### PR TITLE
Skip JAR creation when it would be empty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,18 @@
         </configuration>
       </plugin>
     </plugins>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <skipIfEmpty>true</skipIfEmpty>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <profiles>


### PR DESCRIPTION
Configure skipIfEmpty flag for maven-jar-plugin

Fixes #25 