### PR TITLE
JUnit5 migration/JUnit bom

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -34,7 +34,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>${version.junit}</version>
+        <version>${version.junit4}</version>
       </dependency>
 
       <dependency>

--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -58,7 +58,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>${version.junit}</version>
+        <version>${version.junit4}</version>
       </dependency>
 
       <dependency>

--- a/distro/run/qa/pom.xml
+++ b/distro/run/qa/pom.xml
@@ -20,7 +20,6 @@
     <version.jersey-json>1.15</version.jersey-json>
     <version.jersey-apache-client>1.15</version.jersey-apache-client>
     <version.httpcomponents>4.5.10</version.httpcomponents>
-    <version.junit4>4.13.1</version.junit4>
     <version.chromedriver>112.0.5615.49</version.chromedriver>
   </properties>
 

--- a/distro/run/qa/pom.xml
+++ b/distro/run/qa/pom.xml
@@ -20,7 +20,7 @@
     <version.jersey-json>1.15</version.jersey-json>
     <version.jersey-apache-client>1.15</version.jersey-apache-client>
     <version.httpcomponents>4.5.10</version.httpcomponents>
-    <version.junit>4.13.1</version.junit>
+    <version.junit4>4.13.1</version.junit4>
     <version.chromedriver>112.0.5615.49</version.chromedriver>
   </properties>
 
@@ -59,7 +59,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>${version.junit}</version>
+        <version>${version.junit4}</version>
       </dependency>
 
     </dependencies>

--- a/freemarker-template-engine/pom.xml
+++ b/freemarker-template-engine/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
+      <version>${version.junit4}</version>
       <scope>test</scope>
     </dependency>
 

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -91,13 +91,6 @@
         <version>${version.junit4}</version>
       </dependency>
       <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>${version.junit}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${version.assertj}</version>

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -91,6 +91,13 @@
         <version>${version.junit4}</version>
       </dependency>
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${version.junit}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${version.assertj}</version>

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>${version.junit}</version>
+        <version>${version.junit4}</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,6 +46,7 @@
 
     <version.slf4j>1.7.26</version.slf4j>
     <version.logback>1.2.11</version.logback>
+    <version.junit>5.11.3</version.junit>
     <version.junit4>4.13.1</version.junit4>
     <version.assertj>2.9.1</version.assertj>
     <version.mockito>5.10.0</version.mockito>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
 
     <version.slf4j>1.7.26</version.slf4j>
     <version.logback>1.2.11</version.logback>
-    <version.junit>4.13.1</version.junit>
+    <version.junit4>4.13.1</version.junit4>
     <version.assertj>2.9.1</version.assertj>
     <version.mockito>5.10.0</version.mockito>
     <version.wiremock>2.27.2</version.wiremock>

--- a/spin/dataformat-all/pom.xml
+++ b/spin/dataformat-all/pom.xml
@@ -141,7 +141,7 @@
            <additionalDependency>
              <groupId>junit</groupId>
              <artifactId>junit</artifactId>
-             <version>${version.junit}</version>
+             <version>${version.junit4}</version>
            </additionalDependency>
           </additionalDependencies>
         </configuration>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
@@ -17,7 +17,6 @@
     <version.h2>1.4.199</version.h2>
     <version.jaxb-api>2.3.1</version.jaxb-api>
     <version.jersey-apache-client>1.15</version.jersey-apache-client>
-    <version.junit4>4.12</version.junit4>
     <version.chromedriver>112.0.5615.49</version.chromedriver>
 
     <http.port>58080</http.port>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
@@ -17,7 +17,7 @@
     <version.h2>1.4.199</version.h2>
     <version.jaxb-api>2.3.1</version.jaxb-api>
     <version.jersey-apache-client>1.15</version.jersey-apache-client>
-    <version.junit>4.12</version.junit>
+    <version.junit4>4.12</version.junit4>
     <version.chromedriver>112.0.5615.49</version.chromedriver>
 
     <http.port>58080</http.port>

--- a/test-utils/assert/core/pom.xml
+++ b/test-utils/assert/core/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
+      <version>${version.junit4}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test-utils/assert/qa/pom.xml
+++ b/test-utils/assert/qa/pom.xml
@@ -17,7 +17,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>

--- a/test-utils/junit5-extension-dmn/pom.xml
+++ b/test-utils/junit5-extension-dmn/pom.xml
@@ -22,6 +22,13 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${version.junit}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/test-utils/junit5-extension-dmn/pom.xml
+++ b/test-utils/junit5-extension-dmn/pom.xml
@@ -51,7 +51,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.operaton.bpm.dmn</groupId>

--- a/test-utils/junit5-extension-dmn/pom.xml
+++ b/test-utils/junit5-extension-dmn/pom.xml
@@ -13,23 +13,12 @@
     <relativePath>../../database</relativePath>
   </parent>
 
-  <properties>
-    <version.junit5>5.9.3</version.junit5>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>org.operaton.bpm</groupId>
         <artifactId>operaton-core-internal-dependencies</artifactId>
         <version>${project.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>${version.junit5}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/test-utils/junit5-extension/pom.xml
+++ b/test-utils/junit5-extension/pom.xml
@@ -50,7 +50,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.operaton.bpm</groupId>

--- a/test-utils/junit5-extension/pom.xml
+++ b/test-utils/junit5-extension/pom.xml
@@ -21,6 +21,13 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${version.junit}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   

--- a/test-utils/junit5-extension/pom.xml
+++ b/test-utils/junit5-extension/pom.xml
@@ -12,23 +12,12 @@
     <version>1.0.0-beta-1</version>
   </parent>
 
-  <properties>
-    <version.junit5>5.9.3</version.junit5>
-  </properties>
-  
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>org.operaton.bpm</groupId>
         <artifactId>operaton-core-internal-dependencies</artifactId>
         <version>${project.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>${version.junit5}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
Rename property `version.junit` to `version.junit4` since JUnit 5 becomes the leading JUnit version.

Introduce property `version.junit` with current version of JUnit 5.

This is a preparation step for migrating the test code basis.