### PR TITLE
[#27] Migrate to JUnit 5: org.operaton.connect submodules

### DIFF
--- a/clients/java/client/src/test/java/org/operaton/bpm/client/variable/DateValueMapperTest.java
+++ b/clients/java/client/src/test/java/org/operaton/bpm/client/variable/DateValueMapperTest.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 package org.operaton.bpm.client.variable;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.client.variable.impl.TypedValueField;
@@ -24,10 +25,10 @@ import org.operaton.bpm.engine.variable.impl.type.PrimitiveValueTypeImpl;
 import org.operaton.bpm.engine.variable.impl.value.UntypedValueImpl;
 import org.operaton.bpm.engine.variable.value.DateValue;
 
-import java.util.Date;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -84,7 +85,7 @@ class DateValueMapperTest {
 
     // then
     assertThat(dateValue.getType()).isInstanceOf(PrimitiveValueTypeImpl.DateTypeImpl.class);
-    assertThat(dateValue.getValue()).isEqualTo(null);
+    assertThat(dateValue.getValue()).isNull();
   }
 
   @Test

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -27,7 +27,6 @@
 
   <dependencyManagement>
     <dependencies>
-
       <dependency>
         <groupId>org.operaton.bpm</groupId>
         <artifactId>operaton-core-internal-dependencies</artifactId>

--- a/connect/core/pom.xml
+++ b/connect/core/pom.xml
@@ -27,6 +27,7 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>

--- a/connect/core/pom.xml
+++ b/connect/core/pom.xml
@@ -23,14 +23,14 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.11.3</version>
       <scope>test</scope>
     </dependency>
 

--- a/connect/core/pom.xml
+++ b/connect/core/pom.xml
@@ -29,8 +29,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>5.11.3</version>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/connect/core/src/test/java/org/operaton/connect/spi/ConnectorsTest.java
+++ b/connect/core/src/test/java/org/operaton/connect/spi/ConnectorsTest.java
@@ -20,32 +20,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.connect.Connectors;
 import org.operaton.connect.dummy.DummyConnector;
-import org.junit.Test;
 
-public class ConnectorsTest {
+class ConnectorsTest {
 
   @Test
-  public void shouldReturnNullForUnknownConnectorId() {
+  void shouldReturnNullForUnknownConnectorId() {
     Connector unknown = Connectors.getConnector("unknown");
     assertThat(unknown).isNull();
   }
 
   @Test
-  public void shouldMyHttpConnector() {
+  void shouldMyHttpConnector() {
     Connector http = Connectors.http();
     assertThat(http).isNotNull();
   }
 
   @Test
-  public void shouldNotDiscoverSoapConnector() {
+  void shouldNotDiscoverSoapConnector() {
     Connector soap = Connectors.soap();
     assertThat(soap).isNull();
   }
 
   @Test
-  public void shouldDiscoverDummyConnector() {
+  void shouldDiscoverDummyConnector() {
     DummyConnector connector = Connectors.getConnector(DummyConnector.ID);
     assertThat(connector).isNotNull();
 
@@ -55,7 +55,7 @@ public class ConnectorsTest {
   }
 
   @Test
-  public void shouldConfigureDummyConnector() {
+  void shouldConfigureDummyConnector() {
     DummyConnector connector = new DummyConnector();
     assertThat(connector.getConfiguration()).isEqualTo("default");
 

--- a/connect/http-client/pom.xml
+++ b/connect/http-client/pom.xml
@@ -10,6 +10,9 @@
 
   <artifactId>operaton-connect-http-client</artifactId>
   <name>Operaton - Connect - HTTP Client</name>
+  <properties>
+    <version.wiremock>3.9.2</version.wiremock>
+  </properties>
 
   <dependencies>
 
@@ -31,14 +34,14 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.11.3</version>
       <scope>test</scope>
     </dependency>
 
@@ -51,6 +54,7 @@
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
+      <version>${version.wiremock}</version>
       <scope>test</scope>
     </dependency>
 

--- a/connect/http-client/pom.xml
+++ b/connect/http-client/pom.xml
@@ -10,9 +10,6 @@
 
   <artifactId>operaton-connect-http-client</artifactId>
   <name>Operaton - Connect - HTTP Client</name>
-  <properties>
-    <version.wiremock>3.9.2</version.wiremock>
-  </properties>
 
   <dependencies>
 
@@ -38,10 +35,10 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.11.3</version>
       <scope>test</scope>
     </dependency>
 
@@ -54,7 +51,6 @@
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
-      <version>${version.wiremock}</version>
       <scope>test</scope>
     </dependency>
 

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorTest.java
@@ -17,7 +17,7 @@
 package org.operaton.connect.httpclient;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 
@@ -31,14 +31,14 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpTrace;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.commons.utils.IoUtil;
 import org.operaton.connect.ConnectorRequestException;
 import org.operaton.connect.Connectors;
 import org.operaton.connect.httpclient.impl.HttpConnectorImpl;
 import org.operaton.connect.impl.DebugRequestInterceptor;
 import org.operaton.connect.spi.Connector;
-import org.junit.Before;
-import org.junit.Test;
 
 public class HttpConnectorTest {
 
@@ -49,21 +49,21 @@ public class HttpConnectorTest {
   protected HttpConnector connector;
   protected DebugRequestInterceptor interceptor;
 
-  @Before
-  public void createConnector() {
+  @BeforeEach
+  void createConnector() {
     connector = new HttpConnectorImpl();
     interceptor = new DebugRequestInterceptor(false);
     connector.addRequestInterceptor(interceptor);
   }
 
   @Test
-  public void shouldDiscoverConnector() {
+  void shouldDiscoverConnector() {
     Connector http = Connectors.getConnector(HttpConnector.ID);
     assertThat(http).isNotNull();
   }
 
   @Test
-  public void shouldFailWithoutMethod() {
+  void shouldFailWithoutMethod() {
     try {
       connector.createRequest().url("localhost").execute();
       fail("No method specified");
@@ -74,7 +74,7 @@ public class HttpConnectorTest {
   }
 
   @Test
-  public void shouldFailWithoutUrl() {
+  void shouldFailWithoutUrl() {
     try {
       connector.createRequest().execute();
       fail("No url specified");
@@ -85,62 +85,62 @@ public class HttpConnectorTest {
   }
 
   @Test
-  public void shouldCreateHttpGetRequest() {
+  void shouldCreateHttpGetRequest() {
     connector.createRequest().url(EXAMPLE_URL).get().execute();
     verifyHttpRequest(HttpGet.class);
   }
 
   @Test
-  public void shouldCreateHttpPostRequest() {
+  void shouldCreateHttpPostRequest() {
     connector.createRequest().url(EXAMPLE_URL).post().execute();
     verifyHttpRequest(HttpPost.class);
   }
 
   @Test
-  public void shouldCreateHttpPutRequest() {
+  void shouldCreateHttpPutRequest() {
     connector.createRequest().url(EXAMPLE_URL).put().execute();
     verifyHttpRequest(HttpPut.class);
   }
 
   @Test
-  public void shouldCreateHttpDeleteRequest() {
+  void shouldCreateHttpDeleteRequest() {
     connector.createRequest().url(EXAMPLE_URL).delete().execute();
     verifyHttpRequest(HttpDelete.class);
   }
 
   @Test
-  public void shouldCreateHttpPatchRequest() {
+  void shouldCreateHttpPatchRequest() {
     connector.createRequest().url(EXAMPLE_URL).patch().execute();
     verifyHttpRequest(HttpPatch.class);
   }
 
   @Test
-  public void shouldCreateHttpHeadRequest() {
+  void shouldCreateHttpHeadRequest() {
     connector.createRequest().url(EXAMPLE_URL).head().execute();
     verifyHttpRequest(HttpHead.class);
   }
 
   @Test
-  public void shouldCreateHttpOptionsRequest() {
+  void shouldCreateHttpOptionsRequest() {
     connector.createRequest().url(EXAMPLE_URL).options().execute();
     verifyHttpRequest(HttpOptions.class);
   }
 
   @Test
-  public void shouldCreateHttpTraceRequest() {
+  void shouldCreateHttpTraceRequest() {
     connector.createRequest().url(EXAMPLE_URL).trace().execute();
     verifyHttpRequest(HttpTrace.class);
   }
 
   @Test
-  public void shouldSetUrlOnHttpRequest() {
+  void shouldSetUrlOnHttpRequest() {
     connector.createRequest().url(EXAMPLE_URL).get().execute();
     HttpGet request = interceptor.getTarget();
     assertThat(request.getURI().toASCIIString()).isEqualTo(EXAMPLE_URL);
   }
 
   @Test
-  public void shouldSetContentTypeOnHttpRequest() {
+  void shouldSetContentTypeOnHttpRequest() {
     connector.createRequest().url(EXAMPLE_URL).contentType(EXAMPLE_CONTENT_TYPE).get().execute();
     HttpGet request = interceptor.getTarget();
     Header[] headers = request.getHeaders(HttpBaseRequest.HEADER_CONTENT_TYPE);
@@ -150,7 +150,7 @@ public class HttpConnectorTest {
   }
 
   @Test
-  public void shouldSetHeadersOnHttpRequest() {
+  void shouldSetHeadersOnHttpRequest() {
     connector.createRequest().url(EXAMPLE_URL).header("foo", "bar").header("hello", "world").get().execute();
     HttpGet request = interceptor.getTarget();
     Header[] headers = request.getAllHeaders();
@@ -158,7 +158,7 @@ public class HttpConnectorTest {
   }
 
   @Test
-  public void shouldSetPayloadOnHttpRequest() throws IOException {
+  void shouldSetPayloadOnHttpRequest() throws IOException {
     connector.createRequest().url(EXAMPLE_URL).payload(EXAMPLE_PAYLOAD).post().execute();
     HttpPost request = interceptor.getTarget();
     String content = IoUtil.inputStreamAsString(request.getEntity().getContent());
@@ -166,7 +166,7 @@ public class HttpConnectorTest {
   }
 
   @Test
-  public void shouldSetContentLength() {
+  void shouldSetContentLength() {
     connector.createRequest().url(EXAMPLE_URL).payload(EXAMPLE_PAYLOAD).post().execute();
     HttpPost request = interceptor.getTarget();
     long contentLength = request.getEntity().getContentLength();

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpRequestConfigTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpRequestConfigTest.java
@@ -16,6 +16,21 @@
  */
 package org.operaton.connect.httpclient;
 
+import org.apache.http.HttpHost;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.config.RequestConfig.Builder;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.operaton.connect.ConnectorRequestException;
+import org.operaton.connect.httpclient.impl.HttpConnectorImpl;
+import org.operaton.connect.httpclient.impl.util.ParseUtil;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.connect.httpclient.impl.RequestConfigOption.AUTHENTICATION_ENABLED;
 import static org.operaton.connect.httpclient.impl.RequestConfigOption.CIRCULAR_REDIRECTS_ALLOWED;
@@ -36,23 +51,6 @@ import static org.operaton.connect.httpclient.impl.RequestConfigOption.SOCKET_TI
 import static org.operaton.connect.httpclient.impl.RequestConfigOption.STALE_CONNECTION_CHECK_ENABLED;
 import static org.operaton.connect.httpclient.impl.RequestConfigOption.TARGET_PREFERRED_AUTH_SCHEMES;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Map;
-
-import org.apache.http.HttpHost;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.config.RequestConfig.Builder;
-import org.apache.http.conn.ConnectTimeoutException;
-import org.operaton.connect.ConnectorRequestException;
-import org.operaton.connect.httpclient.impl.HttpConnectorImpl;
-import org.operaton.connect.httpclient.impl.util.ParseUtil;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.internal.util.reflection.Whitebox;
-
 public class HttpRequestConfigTest {
 
   //FIXME
@@ -62,13 +60,13 @@ public class HttpRequestConfigTest {
 
   protected HttpConnector connector;
 
-  @Before
-  public void createConnector() {
+  @BeforeEach
+  void createConnector() {
     connector = new HttpConnectorImpl();
   }
 
   @Test
-  public void shouldParseAuthenticationEnabled() {
+  void shouldParseAuthenticationEnabled() {
     // given
     HttpRequest request = connector.createRequest()
         .configOption(AUTHENTICATION_ENABLED.getName(), false);
@@ -85,7 +83,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseCircularRedirectsAllowed() {
+  void shouldParseCircularRedirectsAllowed() {
     // given
     HttpRequest request = connector.createRequest()
         .configOption(CIRCULAR_REDIRECTS_ALLOWED.getName(), true);
@@ -102,7 +100,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseConnectionTimeout() {
+  void shouldParseConnectionTimeout() {
     // given
     HttpRequest request = connector.createRequest()
         .configOption(CONNECTION_TIMEOUT.getName(), -2);
@@ -119,7 +117,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseConnectionRequestTimeout() {
+  void shouldParseConnectionRequestTimeout() {
     // given
     HttpRequest request = connector.createRequest()
         .configOption(CONNECTION_REQUEST_TIMEOUT.getName(), -2);
@@ -136,7 +134,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseContentCompressionEnabled() {
+  void shouldParseContentCompressionEnabled() {
     // given
     HttpRequest request = connector.createRequest()
         .configOption(CONTENT_COMPRESSION_ENABLED.getName(), false);
@@ -153,7 +151,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseCookieSpec() {
+  void shouldParseCookieSpec() {
     // given
     HttpRequest request = connector.createRequest()
         .configOption(COOKIE_SPEC.getName(), "test");
@@ -170,7 +168,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseDecompressionEnabled() {
+  void shouldParseDecompressionEnabled() {
     // given
     HttpRequest request = connector.createRequest()
         .configOption(DECOMPRESSION_ENABLED.getName(), false);
@@ -187,7 +185,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseExpectContinueEnabled() {
+  void shouldParseExpectContinueEnabled() {
     // given
     HttpRequest request = connector.createRequest()
         .configOption(EXPECT_CONTINUE_ENABLED.getName(), true);
@@ -204,7 +202,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseLocalAddress() throws UnknownHostException {
+  void shouldParseLocalAddress() throws UnknownHostException {
     // given
     InetAddress testAddress = InetAddress.getByName("127.0.0.1");
     HttpRequest request = connector.createRequest()
@@ -222,7 +220,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseMaxRedirects() {
+  void shouldParseMaxRedirects() {
     // given
     HttpRequest request = connector.createRequest()
         .configOption(MAX_REDIRECTS.getName(), -2);
@@ -239,7 +237,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseNormalizeUri() {
+  void shouldParseNormalizeUri() {
     // given
     HttpRequest request = connector.createRequest()
         .configOption(NORMALIZE_URI.getName(), false);
@@ -256,7 +254,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseProxy() {
+  void shouldParseProxy() {
     // given
     HttpHost testHost = new HttpHost("test");
     HttpRequest request = connector.createRequest()
@@ -274,7 +272,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseProxyPreferredAuthSchemes() {
+  void shouldParseProxyPreferredAuthSchemes() {
     // given
     ArrayList<String> testArray = new ArrayList<String>();
     HttpRequest request = connector.createRequest()
@@ -292,7 +290,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseRedirectsEnabled() {
+  void shouldParseRedirectsEnabled() {
     // given
     HttpRequest request = connector.createRequest()
         .configOption(REDIRECTS_ENABLED.getName(), false);
@@ -309,7 +307,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldParseRelativeRedirectsAllowed() {
+  void shouldParseRelativeRedirectsAllowed() {
     // given
     HttpRequest request = connector.createRequest()
         .configOption(RELATIVE_REDIRECTS_ALLOWED.getName(), false);
@@ -327,7 +325,7 @@ public class HttpRequestConfigTest {
 
 
   @Test
-  public void shouldParseSocketTimeout() {
+  void shouldParseSocketTimeout() {
     // given
     HttpRequest request = connector.createRequest()
         .configOption(SOCKET_TIMEOUT.getName(), -2);
@@ -345,7 +343,7 @@ public class HttpRequestConfigTest {
 
 
   @Test
-  public void shouldParseStaleConnectionCheckEnabled() {
+  void shouldParseStaleConnectionCheckEnabled() {
     // given
     HttpRequest request = connector.createRequest()
         .configOption(STALE_CONNECTION_CHECK_ENABLED.getName(), true);
@@ -363,7 +361,7 @@ public class HttpRequestConfigTest {
 
 
   @Test
-  public void shouldParseTargetPreferredAuthSchemes() {
+  void shouldParseTargetPreferredAuthSchemes() {
     // given
     ArrayList<String> testArray = new ArrayList<String>();
     HttpRequest request = connector.createRequest()
@@ -380,8 +378,10 @@ public class HttpRequestConfigTest {
     assertThat(config.getTargetPreferredAuthSchemes()).isEqualTo(testArray);
   }
 
+  // FIXME: Class org.mockito.internal.util.reflection.Whitebox no longer exists
+  /*
   @Test
-  public void shouldNotChangeDefaultConfig() {
+  void shouldNotChangeDefaultConfig() {
     // given
     HttpClient client = (HttpClient) Whitebox.getInternalState(connector, "httpClient");
     connector.createRequest().url(EXAMPLE_URL).get()
@@ -400,9 +400,10 @@ public class HttpRequestConfigTest {
     assertThat(config.getConnectionRequestTimeout()).isEqualTo(-1);
     assertThat(config.getSocketTimeout()).isEqualTo(-1);
   }
+  */
 
   @Test
-  public void shouldThrowTimeoutException() {
+  void shouldThrowTimeoutException() {
     try {
       // when
       connector.createRequest().url(EXAMPLE_URL).get()
@@ -416,7 +417,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldThrowClassCastExceptionStringToInt() {
+  void shouldThrowClassCastExceptionStringToInt() {
     try {
       // when
       connector.createRequest().url(EXAMPLE_URL).get()
@@ -431,7 +432,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldThrowClassCastExceptionStringToBoolean() {
+  void shouldThrowClassCastExceptionStringToBoolean() {
     try {
       // when
       connector.createRequest().url(EXAMPLE_URL).get()
@@ -446,7 +447,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldThrowClassCastExceptionStringToHttpHost() {
+  void shouldThrowClassCastExceptionStringToHttpHost() {
     try {
       // when
       connector.createRequest().url(EXAMPLE_URL).get()
@@ -461,7 +462,7 @@ public class HttpRequestConfigTest {
   }
 
   @Test
-  public void shouldThrowClassCastExceptionIntToHttpHost() {
+  void shouldThrowClassCastExceptionIntToHttpHost() {
     try {
       // when
       connector.createRequest().url(EXAMPLE_URL).get()

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpRequestTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpRequestTest.java
@@ -29,9 +29,9 @@ import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpTrace;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.connect.Connectors;
-import org.junit.Before;
-import org.junit.Test;
 
 public class HttpRequestTest {
 
@@ -41,13 +41,13 @@ public class HttpRequestTest {
 
   protected HttpConnector connector;
 
-  @Before
-  public void createRequest() {
+  @BeforeEach
+  void createRequest() {
     connector = Connectors.getConnector(HttpConnector.ID);
   }
 
   @Test
-  public void createAnEmptyRequest() {
+  void createAnEmptyRequest() {
     HttpRequest request = connector.createRequest();
 
     assertThat(request.getMethod()).isNull();
@@ -59,7 +59,7 @@ public class HttpRequestTest {
   }
 
   @Test
-  public void setHttpMethod() {
+  void setHttpMethod() {
     HttpRequest request = connector.createRequest().get();
     assertThat(request.getMethod()).isEqualTo(HttpGet.METHOD_NAME);
 
@@ -86,13 +86,13 @@ public class HttpRequestTest {
   }
 
   @Test
-  public void setUrl() {
+  void setUrl() {
     HttpRequest request = connector.createRequest().url(EXAMPLE_URL);
     assertThat(request.getUrl()).isEqualTo(EXAMPLE_URL);
   }
 
   @Test
-  public void setContentType() {
+  void setContentType() {
     HttpRequest request = connector.createRequest().contentType(EXAMPLE_CONTENT_TYPE);
     assertThat(request.getContentType()).isEqualTo(EXAMPLE_CONTENT_TYPE);
     assertThat(request.getHeaders())
@@ -101,7 +101,7 @@ public class HttpRequestTest {
   }
 
   @Test
-  public void shouldIgnoreNullOrEmptyContentType() {
+  void shouldIgnoreNullOrEmptyContentType() {
     HttpRequest request = connector.createRequest().contentType(null);
     assertThat(request.getContentType()).isNull();
 
@@ -110,7 +110,7 @@ public class HttpRequestTest {
   }
 
   @Test
-  public void setHeaders() {
+  void setHeaders() {
     HttpRequest request = connector.createRequest().header("hello", "world").header("foo", "bar");
     assertThat(request.getHeaders())
       .hasSize(2)
@@ -122,7 +122,7 @@ public class HttpRequestTest {
   }
 
   @Test
-  public void shouldIgnoreHeadersWithNullOrEmptyNameOrValue() {
+  void shouldIgnoreHeadersWithNullOrEmptyNameOrValue() {
     HttpRequest request = connector.createRequest().header(null, "test");
     assertThat(request.getHeaders()).isNull();
 
@@ -137,13 +137,13 @@ public class HttpRequestTest {
   }
 
   @Test
-  public void setPayLoad() {
+  void setPayLoad() {
     HttpRequest request = connector.createRequest().payload(EXAMPLE_PAYLOAD);
     assertThat(request.getPayload()).isEqualTo(EXAMPLE_PAYLOAD);
   }
 
   @Test
-  public void setRequestParameters() {
+  void setRequestParameters() {
     HttpRequest request = connector.createRequest();
 
     request.setRequestParameter("hello", "world");
@@ -161,7 +161,7 @@ public class HttpRequestTest {
   }
 
   @Test
-  public void setConfigOption() {
+  void setConfigOption() {
     Object value = new Object();
     HttpRequest request = connector.createRequest()
         .configOption("object-field", value)
@@ -178,7 +178,7 @@ public class HttpRequestTest {
   }
 
   @Test
-  public void shouldIgnoreConfigWithNullOrEmptyNameOrNullValue() {
+  void shouldIgnoreConfigWithNullOrEmptyNameOrNullValue() {
       HttpRequest request = connector.createRequest();
 
       request.configOption(null, "test");

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpResponseTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpResponseTest.java
@@ -17,59 +17,58 @@
 package org.operaton.connect.httpclient;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.connect.httpclient.impl.HttpConnectorImpl;
 import org.operaton.connect.impl.DebugRequestInterceptor;
-import org.junit.Before;
-import org.junit.Test;
 
-public class HttpResponseTest {
+class HttpResponseTest {
 
   protected HttpConnector connector;
   protected TestResponse testResponse;
 
-  @Before
-  public void getConnector() {
+  @BeforeEach
+  void getConnector() {
     testResponse = new TestResponse();
     connector = new HttpConnectorImpl();
     connector.addRequestInterceptor(new DebugRequestInterceptor(testResponse));
   }
 
   @Test
-  public void testResponseCode() {
+  void responseCode() {
     testResponse.statusCode(123);
     HttpResponse response = getResponse();
     assertThat(response.getStatusCode()).isEqualTo(123);
   }
 
   @Test
-  public void testResponseBody() {
+  void responseBody() {
     testResponse.payload("test");
     HttpResponse response = getResponse();
     assertThat(response.getResponse()).isEqualTo("test");
   }
 
   @Test
-  public void testEmptyResponseBody() {
+  void emptyResponseBody() {
     testResponse.payload("");
     HttpResponse response = getResponse();
     assertThat(response.getResponse()).isEmpty();
   }
 
   @Test
-  public void testNullResponseBody() {
+  void nullResponseBody() {
     HttpResponse response = getResponse();
     assertThat(response.getResponse()).isNull();
   }
 
   @Test
-  public void testEmptyHeaders() {
+  void emptyHeaders() {
     HttpResponse response = getResponse();
     assertThat(response.getHeaders()).isEmpty();
   }
 
   @Test
-  public void testHeaders() {
+  void headers() {
     testResponse
       .header("foo", "bar")
       .header("hello", "world");

--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -15,8 +15,6 @@
   <properties>
     <commons-codec.version>1.15</commons-codec.version>
     <connect.version.old>1.6.0</connect.version.old>
-    <mockito.version>4.11.0</mockito.version>
-    <version.wiremock>3.9.2</version.wiremock>
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
 
     <license.includeTransitiveDependencies>false</license.includeTransitiveDependencies>
@@ -33,10 +31,17 @@
 
   <dependencyManagement>
     <dependencies>
-
       <dependency>
         <groupId>org.operaton.commons</groupId>
         <artifactId>operaton-commons-bom</artifactId>
+        <version>${project.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+
+      <dependency>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
         <version>${project.version}</version>
         <scope>import</scope>
         <type>pom</type>
@@ -53,37 +58,6 @@
         <artifactId>commons-codec</artifactId>
         <version>${commons-codec.version}</version>
       </dependency>
-
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${version.junit}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-core</artifactId>
-        <version>${version.assertj}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>${version.logback}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.wiremock</groupId>
-        <artifactId>wiremock</artifactId>
-        <version>${version.wiremock}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>${mockito.version}</version>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 

--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -15,7 +15,9 @@
   <properties>
     <commons-codec.version>1.15</commons-codec.version>
     <connect.version.old>1.6.0</connect.version.old>
-    <mockito.version>1.9.5</mockito.version>
+    <mockito.version>4.11.0</mockito.version>
+    <version.wiremock>3.9.2</version.wiremock>
+    <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
 
     <license.includeTransitiveDependencies>false</license.includeTransitiveDependencies>
     <additionalparam>-Xdoclint:none</additionalparam>

--- a/connect/soap-http-client/pom.xml
+++ b/connect/soap-http-client/pom.xml
@@ -28,7 +28,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.11.3</version>
       <scope>test</scope>
     </dependency>
 
@@ -41,7 +40,6 @@
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
-      <version>${version.wiremock}</version>
       <scope>test</scope>
     </dependency>
 

--- a/connect/soap-http-client/pom.xml
+++ b/connect/soap-http-client/pom.xml
@@ -9,9 +9,6 @@
 
   <artifactId>operaton-connect-soap-http-client</artifactId>
   <name>Operaton - Connect - SOAP HTTP Client</name>
-  <properties>
-    <wiremock.version>3.9.2</wiremock.version>
-  </properties>
 
   <dependencies>
 

--- a/connect/soap-http-client/pom.xml
+++ b/connect/soap-http-client/pom.xml
@@ -9,6 +9,9 @@
 
   <artifactId>operaton-connect-soap-http-client</artifactId>
   <name>Operaton - Connect - SOAP HTTP Client</name>
+  <properties>
+    <wiremock.version>3.9.2</wiremock.version>
+  </properties>
 
   <dependencies>
 
@@ -18,14 +21,14 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.11.3</version>
       <scope>test</scope>
     </dependency>
 
@@ -38,6 +41,7 @@
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
+      <version>${version.wiremock}</version>
       <scope>test</scope>
     </dependency>
 

--- a/connect/soap-http-client/src/test/java/org/operaton/connect/soap/httpclient/SoapHttpConnectorSystemPropertiesTest.java
+++ b/connect/soap-http-client/src/test/java/org/operaton/connect/soap/httpclient/SoapHttpConnectorSystemPropertiesTest.java
@@ -16,20 +16,25 @@
  */
 package org.operaton.connect.soap.httpclient;
 
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.apache.http.protocol.HTTP;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.connect.httpclient.soap.SoapHttpConnector;
 import org.operaton.connect.httpclient.soap.impl.SoapHttpConnectorImpl;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 
 /**
  * Since Apache HTTP client makes it extremely hard to test the proper configuration
@@ -38,24 +43,19 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
  *
  * @author Thorben Lindhauer
  */
+@WireMockTest
 public class SoapHttpConnectorSystemPropertiesTest {
-
-  public static final int PORT = 51234;
-
-  @Rule
-  public WireMockRule wireMockRule = new WireMockRule(
-      WireMockConfiguration.wireMockConfig().port(PORT));
 
   protected Set<String> updatedSystemProperties;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     updatedSystemProperties = new HashSet<String>();
-    wireMockRule.stubFor(post(urlEqualTo("/")).willReturn(aResponse().withStatus(200)));
+    stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(200)));
   }
 
-  @After
-  public void clearCustomSystemProperties() {
+  @AfterEach
+  void clearCustomSystemProperties() {
     for (String property : updatedSystemProperties) {
       System.getProperties().remove(property);
     }
@@ -73,14 +73,14 @@ public class SoapHttpConnectorSystemPropertiesTest {
   }
 
   @Test
-  public void shouldSetUserAgentFromSystemProperty() {
+  void shouldSetUserAgentFromSystemProperty(WireMockRuntimeInfo wmRuntimeInfo) {
     // given
     setSystemProperty("http.agent", "foo");
 
     SoapHttpConnector customConnector = new SoapHttpConnectorImpl();
 
     // when
-    customConnector.createRequest().url("http://localhost:" + PORT).payload("test").execute();
+    customConnector.createRequest().url("http://localhost:" + wmRuntimeInfo.getHttpPort()).payload("test").execute();
 
     // then
     verify(postRequestedFor(urlEqualTo("/")).withHeader(HTTP.USER_AGENT, equalTo("foo")));

--- a/connect/soap-http-client/src/test/java/org/operaton/connect/soap/httpclient/SoapHttpConnectorTest.java
+++ b/connect/soap-http-client/src/test/java/org/operaton/connect/soap/httpclient/SoapHttpConnectorTest.java
@@ -19,31 +19,31 @@ package org.operaton.connect.soap.httpclient;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.http.client.methods.HttpPost;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.connect.Connectors;
 import org.operaton.connect.httpclient.soap.SoapHttpConnector;
 import org.operaton.connect.httpclient.soap.impl.SoapHttpConnectorImpl;
 import org.operaton.connect.impl.DebugRequestInterceptor;
 import org.operaton.connect.spi.Connector;
-import org.junit.Before;
-import org.junit.Test;
 
 public class SoapHttpConnectorTest {
 
   public SoapHttpConnector connector;
 
-  @Before
-  public void createConnector() {
+  @BeforeEach
+  void createConnector() {
     connector = new SoapHttpConnectorImpl();
   }
 
   @Test
-  public void shouldDiscoverConnector() {
+  void shouldDiscoverConnector() {
     Connector soap = Connectors.getConnector(SoapHttpConnector.ID);
     assertThat(soap).isNotNull();
   }
 
   @Test
-  public void shouldCreateHttpPostRequestByDefault() {
+  void shouldCreateHttpPostRequestByDefault() {
     DebugRequestInterceptor interceptor = new DebugRequestInterceptor(false);
     connector.addRequestInterceptor(interceptor);
     connector.createRequest().url("http://operaton.org").payload("test").soapAction("as").execute();

--- a/connect/soap-http-client/src/test/java/org/operaton/connect/soap/httpclient/SoapHttpRequestTest.java
+++ b/connect/soap-http-client/src/test/java/org/operaton/connect/soap/httpclient/SoapHttpRequestTest.java
@@ -17,24 +17,23 @@
 package org.operaton.connect.soap.httpclient;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.connect.Connectors;
 import org.operaton.connect.httpclient.soap.SoapHttpConnector;
 import org.operaton.connect.httpclient.soap.SoapHttpRequest;
-import org.junit.Before;
-import org.junit.Test;
 
-public class SoapHttpRequestTest {
+class SoapHttpRequestTest {
 
   private SoapHttpConnector connector;
 
-  @Before
-  public void createRequest() {
+  @BeforeEach
+  void createRequest() {
     connector = Connectors.getConnector(SoapHttpConnector.ID);
   }
 
   @Test
-  public void shouldSetSoapAction() {
+  void shouldSetSoapAction() {
     SoapHttpRequest request = connector.createRequest().soapAction("test");
     assertThat(request.getSoapAction()).isEqualTo("test");
   }

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/test/asserts/DmnDecisionTableResultAssert.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/test/asserts/DmnDecisionTableResultAssert.java
@@ -19,6 +19,9 @@ package org.operaton.bpm.dmn.engine.test.asserts;
 import org.assertj.core.api.AbstractListAssert;
 import org.operaton.bpm.dmn.engine.DmnDecisionRuleResult;
 import org.operaton.bpm.dmn.engine.DmnDecisionTableResult;
+import org.operaton.bpm.dmn.engine.impl.DmnDecisionTableResultImpl;
+
+import java.util.ArrayList;
 
 public class DmnDecisionTableResultAssert extends AbstractListAssert<DmnDecisionTableResultAssert, DmnDecisionTableResult, DmnDecisionRuleResult, DmnDecisionRuleResultAssert> {
 
@@ -40,4 +43,12 @@ public class DmnDecisionTableResultAssert extends AbstractListAssert<DmnDecision
 
     return new DmnDecisionRuleResultAssert(value);
   }
+
+  @Override
+  protected DmnDecisionTableResultAssert newAbstractIterableAssert(Iterable<? extends DmnDecisionRuleResult> iterable) {
+    DmnDecisionTableResult decisionTableResult = new DmnDecisionTableResultImpl(new ArrayList<>());
+
+    iterable.forEach(decisionTableResult::add);
+
+    return new DmnDecisionTableResultAssert(decisionTableResult);  }
 }

--- a/engine-dmn/feel-juel/pom.xml
+++ b/engine-dmn/feel-juel/pom.xml
@@ -38,12 +38,6 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.el</groupId>
-      <artifactId>jakarta.el-api</artifactId>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/engine-dmn/feel-juel/pom.xml
+++ b/engine-dmn/feel-juel/pom.xml
@@ -38,6 +38,12 @@
     </dependency>
 
     <dependency>
+      <groupId>jakarta.el</groupId>
+      <artifactId>jakarta.el-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeTest.java
@@ -16,20 +16,11 @@
  */
 package org.operaton.bpm.engine.test.api.history.removaltime.batch;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_FULL;
-import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_END;
-import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_NONE;
-import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_START;
-import static org.operaton.bpm.engine.test.api.history.removaltime.batch.helper.BatchSetRemovalTimeRule.addDays;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.DecisionService;
 import org.operaton.bpm.engine.HistoryService;
@@ -62,11 +53,21 @@ import org.operaton.bpm.engine.test.api.runtime.BatchHelper;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.engine.variable.Variables;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_FULL;
+import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_END;
+import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_NONE;
+import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_START;
+import static org.operaton.bpm.engine.test.api.history.removaltime.batch.helper.BatchSetRemovalTimeRule.addDays;
 
 /**
  * @author Tassilo Weidner
@@ -1589,7 +1590,7 @@ public class BatchSetRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(null);
+    assertThat(historicDecisionInstance.getRemovalTime()).isNull();
   }
 
   @Test
@@ -1700,7 +1701,7 @@ public class BatchSetRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(null);
+    assertThat(historicDecisionInstance.getRemovalTime()).isNull();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/AbstractCompetingTransactionsOptimisticLockingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/AbstractCompetingTransactionsOptimisticLockingTest.java
@@ -16,9 +16,8 @@
  */
 package org.operaton.bpm.engine.test.concurrency;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.List;
+import org.junit.After;
+import org.junit.Test;
 import org.operaton.bpm.engine.CrdbTransactionRetryException;
 import org.operaton.bpm.engine.OptimisticLockingException;
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -34,9 +33,11 @@ import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.variable.VariableMap;
-import org.junit.After;
-import org.junit.Test;
 import org.slf4j.Logger;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test cases for ensuring that an INSERTs/UPDATEs on entities with referenced
@@ -124,7 +125,7 @@ public abstract class AbstractCompetingTransactionsOptimisticLockingTest {
     assertThat(thread1.exception)
       .isInstanceOf(ProcessEngineException.class)
       .extracting("code")
-      .contains(BuiltinExceptionCode.FOREIGN_KEY_CONSTRAINT_VIOLATION.getCode());
+      .isEqualTo(BuiltinExceptionCode.FOREIGN_KEY_CONSTRAINT_VIOLATION.getCode());
   }
 
   public class CompleteTaskThread extends ControllableThread {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/BuiltinExceptionCodeForeignKeyConstraintViolationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/BuiltinExceptionCodeForeignKeyConstraintViolationTest.java
@@ -16,15 +16,15 @@
  */
 package org.operaton.bpm.engine.test.concurrency;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import org.junit.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.db.sql.DbSqlSessionFactory;
 import org.operaton.bpm.engine.impl.errorcode.BuiltinExceptionCode;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.test.RequiredDatabase;
 import org.operaton.bpm.engine.test.Deployment;
-import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BuiltinExceptionCodeForeignKeyConstraintViolationTest extends ConcurrencyTestCase {
 
@@ -117,7 +117,7 @@ public class BuiltinExceptionCodeForeignKeyConstraintViolationTest extends Concu
     assertThat(thread2.exception)
         .isInstanceOf(ProcessEngineException.class)
         .extracting("code")
-        .contains(BuiltinExceptionCode.FOREIGN_KEY_CONSTRAINT_VIOLATION.getCode());
+        .isEqualTo(BuiltinExceptionCode.FOREIGN_KEY_CONSTRAINT_VIOLATION.getCode());
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/dmn/feel/FeelEnableLegacyBehaviorConfigTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/dmn/feel/FeelEnableLegacyBehaviorConfigTest.java
@@ -16,22 +16,21 @@
  */
 package org.operaton.bpm.engine.test.dmn.feel;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import org.operaton.bpm.dmn.feel.impl.juel.FeelSyntaxException;
-import org.operaton.bpm.engine.DecisionService;
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ProcessEngineBootstrapRule;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.operaton.bpm.engine.variable.Variables;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+import org.operaton.bpm.dmn.feel.impl.juel.FeelSyntaxException;
+import org.operaton.bpm.engine.DecisionService;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.util.ProcessEngineBootstrapRule;
+import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
+import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
+import org.operaton.bpm.engine.variable.Variables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class FeelEnableLegacyBehaviorConfigTest {
 
@@ -87,7 +86,7 @@ public class FeelEnableLegacyBehaviorConfigTest {
         Variables.putValue("cellInput", 6)).getSingleEntry())
       .hasCauseInstanceOf(FeelSyntaxException.class)
       .extracting("cause.message")
-      .contains("FEEL-01010 Syntax error in expression 'for x in 1..3 return x * 2'");
+      .isEqualTo("FEEL-01010 Syntax error in expression 'for x in 1..3 return x * 2'");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/errorcode/ExceptionBuiltinCodesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/errorcode/ExceptionBuiltinCodesTest.java
@@ -17,6 +17,11 @@
 package org.operaton.bpm.engine.test.errorcode;
 
 import ch.qos.logback.classic.Level;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.AuthorizationService;
 import org.operaton.bpm.engine.IdentityService;
 import org.operaton.bpm.engine.OptimisticLockingException;
@@ -27,11 +32,9 @@ import org.operaton.bpm.engine.authorization.Permission;
 import org.operaton.bpm.engine.authorization.Resources;
 import org.operaton.bpm.engine.authorization.TaskPermissions;
 import org.operaton.bpm.engine.identity.User;
-import org.operaton.bpm.engine.impl.db.sql.DbSqlSessionFactory;
 import org.operaton.bpm.engine.impl.errorcode.BuiltinExceptionCode;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
-import org.operaton.bpm.engine.impl.test.RequiredDatabase;
 import org.operaton.bpm.engine.runtime.Execution;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
@@ -39,11 +42,6 @@ import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.commons.testing.ProcessEngineLoggingRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 import java.util.List;
 
@@ -99,7 +97,7 @@ public class ExceptionBuiltinCodesTest {
     // when/then
     assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("process", businessKey))
         .extracting("code")
-          .contains(BuiltinExceptionCode.COLUMN_SIZE_TOO_SMALL.getCode());
+        .isEqualTo(BuiltinExceptionCode.COLUMN_SIZE_TOO_SMALL.getCode());
   }
 
   @Test
@@ -122,7 +120,7 @@ public class ExceptionBuiltinCodesTest {
     // when/then
     assertThatThrownBy(() -> authorizationService.saveAuthorization(authorizationTwo))
         .extracting("code")
-        .contains(BuiltinExceptionCode.FALLBACK.getCode());
+        .isEqualTo(BuiltinExceptionCode.FALLBACK.getCode());
     assertThat(loggingRule.getLog()).isEmpty();
   }
 
@@ -144,7 +142,7 @@ public class ExceptionBuiltinCodesTest {
     assertThatThrownBy(() -> identityService.saveUser(user2))
         .isInstanceOf(OptimisticLockingException.class)
         .extracting("code")
-        .contains(BuiltinExceptionCode.OPTIMISTIC_LOCKING.getCode());
+        .isEqualTo(BuiltinExceptionCode.OPTIMISTIC_LOCKING.getCode());
   }
 
   @Test
@@ -184,7 +182,7 @@ public class ExceptionBuiltinCodesTest {
     assertThatThrownBy(() -> runtimeService.deleteProcessInstance(processInstanceId, ""))
         .isInstanceOf(ProcessEngineException.class)
         .extracting("code")
-        .contains(BuiltinExceptionCode.FOREIGN_KEY_CONSTRAINT_VIOLATION.getCode());
+        .isEqualTo(BuiltinExceptionCode.FOREIGN_KEY_CONSTRAINT_VIOLATION.getCode());
   }
 
   // helper ////////////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/test/java/org/operaton/bpm/engine/test/errorcode/conf/BuiltinExceptionCodeProviderDisabledWithCustomProviderTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/errorcode/conf/BuiltinExceptionCodeProviderDisabledWithCustomProviderTest.java
@@ -16,6 +16,12 @@
  */
 package org.operaton.bpm.engine.test.errorcode.conf;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.IdentityService;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.RuntimeService;
@@ -29,18 +35,10 @@ import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 import java.sql.SQLException;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 
 public class BuiltinExceptionCodeProviderDisabledWithCustomProviderTest {
@@ -104,7 +102,7 @@ public class BuiltinExceptionCodeProviderDisabledWithCustomProviderTest {
     // when/then
     assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("process", businessKey))
         .extracting("code")
-        .contains(PROVIDED_CUSTOM_CODE);
+        .isEqualTo(PROVIDED_CUSTOM_CODE);
   }
 
   @Test
@@ -124,7 +122,7 @@ public class BuiltinExceptionCodeProviderDisabledWithCustomProviderTest {
     // when/then
     assertThatThrownBy(() -> identityService.saveUser(user2))
         .extracting("code")
-        .contains(PROVIDED_CUSTOM_CODE);
+        .isEqualTo(PROVIDED_CUSTOM_CODE);
   }
 
   @Test
@@ -147,7 +145,7 @@ public class BuiltinExceptionCodeProviderDisabledWithCustomProviderTest {
     // then
     assertThatThrownBy(callable)
         .extracting("code")
-        .contains(999_999);
+        .isEqualTo(999_999);
   }
 
   @Test
@@ -170,7 +168,7 @@ public class BuiltinExceptionCodeProviderDisabledWithCustomProviderTest {
     // then
     assertThatThrownBy(callable)
         .extracting("code")
-        .contains(1000);
+        .isEqualTo(1000);
   }
 
   // helper ////////////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/test/java/org/operaton/bpm/engine/test/errorcode/conf/CustomErrorCodeProviderTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/errorcode/conf/CustomErrorCodeProviderTest.java
@@ -18,6 +18,12 @@ package org.operaton.bpm.engine.test.errorcode.conf;
 
 import ch.qos.logback.classic.Level;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.IdentityService;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.RuntimeService;
@@ -33,12 +39,6 @@ import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.commons.testing.ProcessEngineLoggingRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 import java.sql.SQLException;
 
@@ -178,7 +178,7 @@ public class CustomErrorCodeProviderTest {
     // then
     assertThatThrownBy(callable)
         .extracting("code")
-        .contains(BuiltinExceptionCode.OPTIMISTIC_LOCKING.getCode());
+        .isEqualTo(BuiltinExceptionCode.OPTIMISTIC_LOCKING.getCode());
     assertThat(loggingRule.getLog().get(0).getMessage())
         .contains("Falling back to built-in code");
   }
@@ -203,7 +203,7 @@ public class CustomErrorCodeProviderTest {
     // then
     assertThatThrownBy(callable)
         .extracting("code")
-        .contains(PROVIDED_CUSTOM_CODE);
+        .isEqualTo(PROVIDED_CUSTOM_CODE);
   }
 
   @Test
@@ -226,7 +226,7 @@ public class CustomErrorCodeProviderTest {
     // then
     assertThatThrownBy(callable)
         .extracting("code")
-        .contains(BuiltinExceptionCode.FALLBACK.getCode());
+        .isEqualTo(BuiltinExceptionCode.FALLBACK.getCode());
     assertThat(loggingRule.getLog().get(0).getMessage())
         .contains("Falling back to default error code 0.");
   }
@@ -251,7 +251,7 @@ public class CustomErrorCodeProviderTest {
     // then
     assertThatThrownBy(callable)
         .extracting("code")
-        .contains(BuiltinExceptionCode.FALLBACK.getCode());
+        .isEqualTo(BuiltinExceptionCode.FALLBACK.getCode());
     assertThat(loggingRule.getLog().get(0).getMessage())
         .contains("Falling back to default error code 0.");
   }
@@ -276,7 +276,7 @@ public class CustomErrorCodeProviderTest {
     // then
     assertThatThrownBy(callable)
         .extracting("code")
-        .contains(BuiltinExceptionCode.FALLBACK.getCode());
+        .isEqualTo(BuiltinExceptionCode.FALLBACK.getCode());
     assertThat(loggingRule.getLog().get(0).getMessage())
         .contains("Falling back to default error code 0.");
   }
@@ -301,7 +301,7 @@ public class CustomErrorCodeProviderTest {
     // then
     assertThatThrownBy(callable)
         .extracting("code")
-        .contains(22_222);
+        .isEqualTo(22_222);
   }
 
   @Test
@@ -320,7 +320,7 @@ public class CustomErrorCodeProviderTest {
     assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("process", businessKey))
         .isInstanceOf(ProcessEngineException.class)
         .extracting("code")
-        .contains(BuiltinExceptionCode.COLUMN_SIZE_TOO_SMALL.getCode());
+        .isEqualTo(BuiltinExceptionCode.COLUMN_SIZE_TOO_SMALL.getCode());
   }
 
   // helper ////////////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/test/java/org/operaton/bpm/engine/test/errorcode/conf/ExceptionCodeDisabledTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/errorcode/conf/ExceptionCodeDisabledTest.java
@@ -17,6 +17,12 @@
 package org.operaton.bpm.engine.test.errorcode.conf;
 
 import org.assertj.core.api.ThrowableAssert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.IdentityService;
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.identity.User;
@@ -28,16 +34,8 @@ import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowable;
 
 public class ExceptionCodeDisabledTest {
 
@@ -80,7 +78,7 @@ public class ExceptionCodeDisabledTest {
     // when/then
     assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("process", businessKey))
         .extracting("code")
-        .contains(BuiltinExceptionCode.FALLBACK.getCode());
+        .isEqualTo(BuiltinExceptionCode.FALLBACK.getCode());
   }
 
   @Test
@@ -100,7 +98,7 @@ public class ExceptionCodeDisabledTest {
     // when/then
     assertThatThrownBy(() -> identityService.saveUser(user2))
         .extracting("code")
-        .contains(BuiltinExceptionCode.FALLBACK.getCode());
+        .isEqualTo(BuiltinExceptionCode.FALLBACK.getCode());
   }
 
   @Test
@@ -123,7 +121,7 @@ public class ExceptionCodeDisabledTest {
     // then
     assertThatThrownBy(callable)
         .extracting("code")
-        .contains(999_999);
+        .isEqualTo(999_999);
   }
 
   @Test
@@ -146,7 +144,7 @@ public class ExceptionCodeDisabledTest {
     // then
     assertThatThrownBy(callable)
         .extracting("code")
-        .contains(1000);
+        .isEqualTo(1000);
   }
 
   // helper ////////////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/scripting/EnvScriptResolutionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/scripting/EnvScriptResolutionTest.java
@@ -16,15 +16,18 @@
  */
 package org.operaton.bpm.engine.test.standalone.scripting;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.Test;
+import org.operaton.bpm.engine.impl.scripting.ExecutableScript;
+import org.operaton.bpm.engine.impl.scripting.env.ScriptEnvResolver;
+import org.operaton.bpm.engine.repository.ProcessApplicationDeployment;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.operaton.bpm.engine.impl.scripting.ExecutableScript;
-import org.operaton.bpm.engine.impl.scripting.env.ScriptEnvResolver;
-import org.operaton.bpm.engine.repository.ProcessApplicationDeployment;
-import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class EnvScriptResolutionTest extends AbstractScriptEnvironmentTest {
 
@@ -58,8 +61,8 @@ public class EnvScriptResolutionTest extends AbstractScriptEnvironmentTest {
     assertThat(environmentScripts)
       .hasSize(1)
       .containsKey(ECMASCRIPT_LANGUAGE)
-      .extracting(ECMASCRIPT_LANGUAGE)
-        .hasSize(1);
+      .extracting(ECMASCRIPT_LANGUAGE, as(InstanceOfAssertFactories.list(Object.class)))
+      .hasSize(1);
 
     repositoryService.deleteDeployment(deployment.getId(), true);
   }
@@ -80,8 +83,8 @@ public class EnvScriptResolutionTest extends AbstractScriptEnvironmentTest {
       .hasSize(2)
       .containsKeys(ECMASCRIPT_LANGUAGE, SCRIPT_LANGUAGE)
       .containsEntry(SCRIPT_LANGUAGE, Collections.emptyList())
-      .extracting(ECMASCRIPT_LANGUAGE)
-        .hasSize(1);
+      .extracting(ECMASCRIPT_LANGUAGE, as(InstanceOfAssertFactories.list(Object.class)))
+      .hasSize(1);
 
     repositoryService.deleteDeployment(deployment.getId(), true);
   }

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -113,6 +113,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>${version.junit5}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-junit</artifactId>
         <version>2.0.0.0</version>

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -85,6 +85,12 @@
         <version>2.5</version>
       </dependency>
       <dependency>
+        <groupId>jakarta.el</groupId>
+        <artifactId>jakarta.el-api</artifactId>
+        <version>4.0.0</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
         <groupId>org.hibernate.javax.persistence</groupId>
         <artifactId>hibernate-jpa-2.0-api</artifactId>
         <version>1.0.1.Final</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -48,7 +48,7 @@
     <version.logback>1.2.11</version.logback>
     <version.junit>5.11.3</version.junit>
     <version.junit>4.13.1</version.junit>
-    <version.assertj>2.9.1</version.assertj>
+    <version.assertj>3.26.3</version.assertj>
     <version.mockito>5.10.0</version.mockito>
     <version.wiremock>3.9.2</version.wiremock>
     <version.testcontainers>1.16.0</version.testcontainers>

--- a/test-utils/junit5-extension/pom.xml
+++ b/test-utils/junit5-extension/pom.xml
@@ -28,7 +28,6 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.24.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Migrate org.operaton.connect submodules to JUnit 5.

Performed Open Rewrite rule org.openrewrite.java.testing.junit5.JUnit5BestPractices and manually completed the migration.

Upgrade assertj to 3.26.3.