### PR TITLE
[#27] Migrate to JUnit 5: commons

### DIFF
--- a/commons/logging/pom.xml
+++ b/commons/logging/pom.xml
@@ -24,14 +24,20 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/commons/logging/src/test/java/org/operaton/commons/logging/BaseLoggerTest.java
+++ b/commons/logging/src/test/java/org/operaton/commons/logging/BaseLoggerTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.commons.logging;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.*;
@@ -32,7 +32,7 @@ public class BaseLoggerTest {
   public static final String SOME_MESSAGE = "Some message";
 
   @Test
-  public void shouldFormatMessage() {
+  void shouldFormatMessage() {
     ExampleLogger logger = LOG;
 
     String messageTemplate = "Some message '{}'";
@@ -44,7 +44,7 @@ public class BaseLoggerTest {
   }
 
   @Test
-  public void shouldFormatExceptionMessageWithParam() {
+  void shouldFormatExceptionMessageWithParam() {
     ExampleLogger logger = LOG;
 
     String messageTemplate = "Some message '{}'";
@@ -57,7 +57,7 @@ public class BaseLoggerTest {
   }
 
   @Test
-  public void shouldFormatExceptionMessageWithParams() {
+  void shouldFormatExceptionMessageWithParams() {
     ExampleLogger logger = LOG;
 
     String messageTemplate = "Some message '{}' '{}'";
@@ -71,7 +71,7 @@ public class BaseLoggerTest {
   }
 
   @Test
-  public void shouldFormatExceptionMessageWithoutParam() {
+  void shouldFormatExceptionMessageWithoutParam() {
     ExampleLogger logger = LOG;
 
     String formattedMessage = logger.exceptionMessage(ID, SOME_MESSAGE);
@@ -81,49 +81,49 @@ public class BaseLoggerTest {
   }
 
   @Test
-  public void shouldCallLogTrace() {
+  void shouldCallLogTrace() {
     final ExampleLogger logger = Mockito.spy(LOG);
     logger.log("TRACE", ID, SOME_MESSAGE);
     Mockito.verify(logger).logTrace(ID, SOME_MESSAGE);
   }
 
   @Test
-  public void shouldCallLogInfo() {
+  void shouldCallLogInfo() {
     final ExampleLogger logger = Mockito.spy(LOG);
     logger.log("INFO", ID, SOME_MESSAGE);
     Mockito.verify(logger).logInfo(ID, SOME_MESSAGE);
   }
 
   @Test
-  public void shouldCallLogDebug() {
+  void shouldCallLogDebug() {
     final ExampleLogger logger = Mockito.spy(LOG);
     logger.log("DEBUG", ID, SOME_MESSAGE);
     Mockito.verify(logger).logDebug(ID, SOME_MESSAGE);
   }
 
   @Test
-  public void shouldCallLogError() {
+  void shouldCallLogError() {
     final ExampleLogger logger = Mockito.spy(LOG);
     logger.log("ERROR", ID, SOME_MESSAGE);
     Mockito.verify(logger).logError(ID, SOME_MESSAGE);
   }
 
   @Test
-  public void shouldCallLogWarn() {
+  void shouldCallLogWarn() {
     final ExampleLogger logger = Mockito.spy(LOG);
     logger.log(" warn ", ID, SOME_MESSAGE);
     Mockito.verify(logger).logWarn(ID, SOME_MESSAGE);
   }
 
   @Test
-  public void shouldCallLogDebugWhenNotMatched() {
+  void shouldCallLogDebugWhenNotMatched() {
     final ExampleLogger logger = Mockito.spy(LOG);
     logger.log("FATAL", ID, SOME_MESSAGE);
     Mockito.verify(logger).logDebug(ID, SOME_MESSAGE);
   }
 
   @Test
-  public void shouldCallLogWarnWhenNotMatched() {
+  void shouldCallLogWarnWhenNotMatched() {
     final ExampleLogger logger = Mockito.spy(LOG);
     logger.log("FATAL", Level.WARN, ID, SOME_MESSAGE);
     Mockito.verify(logger).logWarn(ID, SOME_MESSAGE);

--- a/commons/logging/src/test/java/org/operaton/commons/logging/MdcAccessTest.java
+++ b/commons/logging/src/test/java/org/operaton/commons/logging/MdcAccessTest.java
@@ -17,31 +17,27 @@
 package org.operaton.commons.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 
-public class MdcAccessTest {
+class MdcAccessTest {
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     MDC.clear();
   }
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
     MDC.clear();
   }
 
   @Test
-  public void shouldPutValueToMdc() {
+  void shouldPutValueToMdc() {
     // when
     MdcAccess.put("foo", "bar");
     // then
@@ -50,7 +46,7 @@ public class MdcAccessTest {
   }
 
   @Test
-  public void shouldPutNullValueToMdc() {
+  void shouldPutNullValueToMdc() {
     // given
     MDC.put("foo", "bar");
     // when
@@ -60,15 +56,14 @@ public class MdcAccessTest {
   }
 
   @Test
-  public void shouldNotPutNullKeyToMdc() {
-    // then
-    thrown.expect(IllegalArgumentException.class);
-    // when
-    MdcAccess.put(null, "bar");
+  void shouldNotPutNullKeyToMdc() {
+    assertThrows(IllegalArgumentException.class, () ->
+      // when
+      MdcAccess.put(null, "bar"));
   }
 
   @Test
-  public void shouldGetValueFromMdc() {
+  void shouldGetValueFromMdc() {
     // given
     MDC.put("foo", "bar");
     // when
@@ -78,15 +73,14 @@ public class MdcAccessTest {
   }
 
   @Test
-  public void shouldNotGetNullKeyFromMdc() {
-    // then
-    thrown.expect(IllegalArgumentException.class);
-    // when
-    MdcAccess.get(null);
+  void shouldNotGetNullKeyFromMdc() {
+    assertThrows(IllegalArgumentException.class, () ->
+      // when
+      MdcAccess.get(null));
   }
 
   @Test
-  public void shouldRemoveFromMdc() {
+  void shouldRemoveFromMdc() {
     // given
     MDC.put("foo", "bar");
     MDC.put("baz", "fooz");
@@ -98,11 +92,10 @@ public class MdcAccessTest {
   }
 
   @Test
-  public void shouldNotRemoveNullKeyFromMdc() {
-    // then
-    thrown.expect(IllegalArgumentException.class);
-    // when
-    MdcAccess.remove(null);
+  void shouldNotRemoveNullKeyFromMdc() {
+    assertThrows(IllegalArgumentException.class, () ->
+      // when
+      MdcAccess.remove(null));
   }
 
 }

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -31,41 +31,12 @@
     <dependencies>
 
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${version.junit4}</version>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
+        <version>${project.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
-
-      <dependency>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-core</artifactId>
-        <version>${version.assertj}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${version.slf4j}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>ch.qos.logback</groupId>
-        <artifactId>logback-classic</artifactId>
-        <version>${version.logback}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-library</artifactId>
-        <version>1.3</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>4.6.0</version>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 

--- a/commons/typed-values/pom.xml
+++ b/commons/typed-values/pom.xml
@@ -39,15 +39,18 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-junit</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
 
     <dependency>

--- a/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/api/variable/PrimitiveValueTest.java
+++ b/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/api/variable/PrimitiveValueTest.java
@@ -16,44 +16,25 @@
  */
 package org.operaton.bpm.engine.test.api.variable;
 
-import static org.operaton.bpm.engine.variable.Variables.booleanValue;
-import static org.operaton.bpm.engine.variable.Variables.byteArrayValue;
-import static org.operaton.bpm.engine.variable.Variables.createVariables;
-import static org.operaton.bpm.engine.variable.Variables.dateValue;
-import static org.operaton.bpm.engine.variable.Variables.doubleValue;
-import static org.operaton.bpm.engine.variable.Variables.integerValue;
-import static org.operaton.bpm.engine.variable.Variables.shortValue;
-import static org.operaton.bpm.engine.variable.Variables.stringValue;
-import static org.operaton.bpm.engine.variable.Variables.untypedNullValue;
-import static org.operaton.bpm.engine.variable.type.ValueType.BOOLEAN;
-import static org.operaton.bpm.engine.variable.type.ValueType.BYTES;
-import static org.operaton.bpm.engine.variable.type.ValueType.DATE;
-import static org.operaton.bpm.engine.variable.type.ValueType.DOUBLE;
-import static org.operaton.bpm.engine.variable.type.ValueType.INTEGER;
-import static org.operaton.bpm.engine.variable.type.ValueType.NULL;
-import static org.operaton.bpm.engine.variable.type.ValueType.SHORT;
-import static org.operaton.bpm.engine.variable.type.ValueType.STRING;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.operaton.bpm.engine.variable.VariableMap;
+import org.operaton.bpm.engine.variable.impl.value.NullValueImpl;
+import org.operaton.bpm.engine.variable.type.ValueType;
+import org.operaton.bpm.engine.variable.value.TypedValue;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 
-import org.operaton.bpm.engine.variable.VariableMap;
-import org.operaton.bpm.engine.variable.impl.value.NullValueImpl;
-import org.operaton.bpm.engine.variable.type.ValueType;
-import org.operaton.bpm.engine.variable.value.TypedValue;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.operaton.bpm.engine.variable.Variables.*;
+import static org.operaton.bpm.engine.variable.type.ValueType.*;
 
 /**
  * @author Philipp Ossler *
  */
-@RunWith(Parameterized.class)
 public class PrimitiveValueTest {
 
   protected static final Date DATE_VALUE = new Date();
@@ -62,7 +43,6 @@ public class PrimitiveValueTest {
   protected static final String PERIOD_VALUE = "P14D";
   protected static final byte[] BYTES_VALUE = "a".getBytes();
 
-  @Parameters(name = "{index}: {0} = {1}")
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][] {
         { STRING, "someString", stringValue("someString"), stringValue(null) },
@@ -75,27 +55,21 @@ public class PrimitiveValueTest {
         { BYTES, BYTES_VALUE, byteArrayValue(BYTES_VALUE), byteArrayValue(null) }
       });
   }
-
-  @Parameter(0)
   public ValueType valueType;
-
-  @Parameter(1)
   public Object value;
-
-  @Parameter(2)
   public TypedValue typedValue;
-
-  @Parameter(3)
   public TypedValue nullValue;
 
   protected String variableName = "variable";
 
-  @Test
-  public void testCreatePrimitiveVariableUntyped() {
-    VariableMap variables = createVariables().putValue(variableName, value);
+  @MethodSource("data")
+  @ParameterizedTest(name = "{index}: {0} = {1}")
+  public void createPrimitiveVariableUntyped(ValueType initValueType, Object initValue, TypedValue initTypedValue, TypedValue initNullValue) {
+    initPrimitiveValueTest(initValueType, initValue, initTypedValue, initNullValue);
+    VariableMap variables = createVariables().putValue(variableName, initValue);
 
-    assertEquals(value, variables.get(variableName));
-    assertEquals(value, variables.getValueTyped(variableName).getValue());
+    assertEquals(initValue, variables.get(variableName));
+    assertEquals(initValue, variables.getValueTyped(variableName).getValue());
 
     // no type information present
     TypedValue typedValue = variables.getValueTyped(variableName);
@@ -107,8 +81,10 @@ public class PrimitiveValueTest {
     }
   }
 
-  @Test
-  public void testCreatePrimitiveVariableTyped() {
+  @MethodSource("data")
+  @ParameterizedTest(name = "{index}: {0} = {1}")
+  public void createPrimitiveVariableTyped(ValueType valueType, Object value, TypedValue typedValue, TypedValue nullValue) {
+    initPrimitiveValueTest(valueType, value, typedValue, nullValue);
     VariableMap variables = createVariables().putValue(variableName, typedValue);
 
     // get return value
@@ -122,19 +98,28 @@ public class PrimitiveValueTest {
     assertEquals(value, stringValue);
   }
 
-  @Test
-  public void testCreatePrimitiveVariableNull() {
+  @MethodSource("data")
+  @ParameterizedTest(name = "{index}: {0} = {1}")
+  public void createPrimitiveVariableNull(ValueType valueType, Object value, TypedValue typedValue, TypedValue nullValue) {
+    initPrimitiveValueTest(valueType, value, typedValue, nullValue);
     VariableMap variables = createVariables().putValue(variableName, nullValue);
 
     // get return value
-    assertEquals(null, variables.get(variableName));
+    assertNull(variables.get(variableName));
 
     // type is not lost
     assertEquals(valueType, variables.getValueTyped(variableName).getType());
 
     // get wrapper
     Object stringValue = variables.getValueTyped(variableName).getValue();
-    assertEquals(null, stringValue);
+    assertNull(stringValue);
+  }
+
+  public void initPrimitiveValueTest(ValueType valueType, Object value, TypedValue typedValue, TypedValue nullValue) {
+    this.valueType = valueType;
+    this.value = value;
+    this.typedValue = typedValue;
+    this.nullValue = nullValue;
   }
 
 }

--- a/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/api/variable/VariableApiTest.java
+++ b/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/api/variable/VariableApiTest.java
@@ -15,12 +15,8 @@
  * limitations under the License.
  */
 package org.operaton.bpm.engine.test.api.variable;
-
+import static org.junit.jupiter.api.Assertions.*;
 import static org.operaton.bpm.engine.variable.Variables.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 
 import java.io.File;
 import java.math.BigDecimal;
@@ -31,19 +27,19 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.variable.context.VariableContext;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.Variables.SerializationDataFormats;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
 import org.operaton.bpm.engine.variable.value.TypedValue;
-import org.junit.Test;
 
 /**
  * @author Daniel Meyer
  *
  */
-public class VariableApiTest {
+class VariableApiTest {
 
   private static final String DESERIALIZED_OBJECT_VAR_NAME = "deserializedObject";
   private static final ExampleObject DESERIALIZED_OBJECT_VAR_VALUE = new ExampleObject();
@@ -51,7 +47,7 @@ public class VariableApiTest {
   private static final String SERIALIZATION_DATA_FORMAT_NAME = "data-format-name";
 
   @Test
-  public void testCreateObjectVariables() {
+  void createObjectVariables() {
 
     VariableMap variables = createVariables()
       .putValue(DESERIALIZED_OBJECT_VAR_NAME, objectValue(DESERIALIZED_OBJECT_VAR_VALUE));
@@ -78,7 +74,7 @@ public class VariableApiTest {
   }
 
   @Test
-  public void testVariableMapWithoutCreateVariables() {
+  void variableMapWithoutCreateVariables() {
     VariableMap map1 = putValue("foo", true).putValue("bar", 20);
     VariableMap map2 = putValueTyped("foo", booleanValue(true)).putValue("bar", integerValue(20));
 
@@ -87,7 +83,7 @@ public class VariableApiTest {
   }
 
   @Test
-  public void testVariableMapCompatibility() {
+  void variableMapCompatibility() {
 
     // test compatibility with Map<String, Object>
     VariableMap map1 = createVariables()
@@ -131,7 +127,7 @@ public class VariableApiTest {
   }
 
   @Test
-  public void testSerializationDataFormats() {
+  void serializationDataFormats() {
     ObjectValue objectValue = objectValue(DESERIALIZED_OBJECT_VAR_VALUE).serializationDataFormat(SerializationDataFormats.JAVA).create();
     assertEquals(SerializationDataFormats.JAVA.getName(), objectValue.getSerializationDataFormat());
 
@@ -143,27 +139,27 @@ public class VariableApiTest {
   }
 
   @Test
-  public void testEmptyVariableMapAsVariableContext() {
+  void emptyVariableMapAsVariableContext() {
     VariableContext varContext = createVariables().asVariableContext();
-    assertTrue(varContext.keySet().size() == 0);
+    assertEquals(0, varContext.keySet().size());
     assertNull(varContext.resolve("nonExisting"));
     assertFalse(varContext.containsVariable("nonExisting"));
   }
 
   @Test
-  public void testEmptyVariableContext() {
+  void testEmptyVariableContext() {
     VariableContext varContext = emptyVariableContext();
-    assertTrue(varContext.keySet().size() == 0);
+    assertEquals(0, varContext.keySet().size());
     assertNull(varContext.resolve("nonExisting"));
     assertFalse(varContext.containsVariable("nonExisting"));
   }
 
   @Test
-  public void testVariableMapAsVariableContext() {
+  void variableMapAsVariableContext() {
     VariableContext varContext = createVariables()
         .putValueTyped("someValue", integerValue(1)).asVariableContext();
 
-    assertTrue(varContext.keySet().size() == 1);
+    assertEquals(1, varContext.keySet().size());
 
     assertNull(varContext.resolve("nonExisting"));
     assertFalse(varContext.containsVariable("nonExisting"));
@@ -173,7 +169,7 @@ public class VariableApiTest {
   }
 
   @Test
-  public void testTransientVariables() throws URISyntaxException {
+  void transientVariables() throws URISyntaxException {
     VariableMap variableMap = createVariables().putValueTyped("foo", doubleValue(10.0, true))
                      .putValueTyped("bar", integerValue(10, true))
                      .putValueTyped("aa", booleanValue(true, true))
@@ -191,12 +187,12 @@ public class VariableApiTest {
 
     for (Entry<String, Object> e : variableMap.entrySet()) {
       TypedValue value = (TypedValue) variableMap.getValueTyped(e.getKey());
-      assertTrue("Variable '" + e.getKey() + "' is not transient: " + value, value.isTransient());
+      assertTrue(value.isTransient(), "Variable '" + e.getKey() + "' is not transient: " + value);
     }
   }
-  
+
   @Test
-  public void testTransientVariablesRaw() throws URISyntaxException {
+  void transientVariablesRaw() throws URISyntaxException {
     VariableMap variableMap = createVariables().putValueTyped("foo", doubleValue(10.0, true))
                      .putValue("bar", integerValue(10, true))
                      .putValue("aa", booleanValue(true, true))
@@ -216,7 +212,7 @@ public class VariableApiTest {
 
     for (Entry<String, Object> e : variableMap.entrySet()) {
       TypedValue value = (TypedValue) variableMap.getValueTyped(e.getKey());
-      assertTrue("Variable '" + e.getKey() + "' is not transient: " + value, value.isTransient());
+      assertTrue(value.isTransient(), "Variable '" + e.getKey() + "' is not transient: " + value);
     }
   }
 }

--- a/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
+++ b/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
@@ -20,10 +20,11 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -35,61 +36,61 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Scanner;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.impl.type.FileValueTypeImpl;
 import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 import org.operaton.commons.utils.IoUtil;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Ronny Bräunlich
  *
  */
-public class FileValueTypeImplTest {
+class FileValueTypeImplTest {
 
   private FileValueTypeImpl type;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     type = new FileValueTypeImpl();
   }
 
   @Test
-  public void nameShouldBeFile() {
+  void nameShouldBeFile() {
     assertThat(type.getName(), is("file"));
   }
 
   @Test
-  public void shouldNotHaveParent() {
+  void shouldNotHaveParent() {
     assertThat(type.getParent(), is(nullValue()));
   }
 
   @Test
-  public void isPrimitiveValue() {
+  void isPrimitiveValue() {
     assertThat(type.isPrimitiveValueType(), is(true));
   }
 
   @Test
-  public void isNotAnAbstractType() {
+  void isNotAnAbstractType() {
     assertThat(type.isAbstract(), is(false));
   }
 
   @Test
-  public void canNotConvertFromAnyValue() {
+  void canNotConvertFromAnyValue() {
     // we just use null to make sure false is always returned
     assertThat(type.canConvertFromTypedValue(null), is(false));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void convertingThrowsException() {
-    type.convertFromTypedValue(Variables.untypedNullValue());
+  @Test
+  void convertingThrowsException() {
+    assertThrows(IllegalArgumentException.class, () ->
+      type.convertFromTypedValue(Variables.untypedNullValue()));
   }
 
   @Test
-  public void createValueFromFile() throws URISyntaxException {
+  void createValueFromFile() throws URISyntaxException {
     File file = new File(this.getClass().getClassLoader().getResource("org/operaton/bpm/engine/test/variables/simpleFile.txt").toURI());
     TypedValue value = type.createValue(file, Collections.<String, Object> singletonMap(FileValueTypeImpl.VALUE_INFO_FILE_NAME, "simpleFile.txt"));
     assertThat(value, is(instanceOf(FileValue.class)));
@@ -98,7 +99,7 @@ public class FileValueTypeImplTest {
   }
 
   @Test
-  public void createValueFromStream() {
+  void createValueFromStream() {
     InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
     TypedValue value = type.createValue(file, Collections.<String, Object> singletonMap(FileValueTypeImpl.VALUE_INFO_FILE_NAME, "simpleFile.txt"));
     assertThat(value, is(instanceOf(FileValue.class)));
@@ -107,7 +108,7 @@ public class FileValueTypeImplTest {
   }
 
   @Test
-  public void createValueFromBytes() throws IOException, URISyntaxException {
+  void createValueFromBytes() throws IOException, URISyntaxException {
     File file = new File(this.getClass().getClassLoader().getResource("org/operaton/bpm/engine/test/variables/simpleFile.txt").toURI());
     TypedValue value = type.createValue(file, Collections.<String, Object> singletonMap(FileValueTypeImpl.VALUE_INFO_FILE_NAME, "simpleFile.txt"));
     assertThat(value, is(instanceOf(FileValue.class)));
@@ -115,13 +116,14 @@ public class FileValueTypeImplTest {
     checkStreamFromValue(value, "text");
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void createValueFromObject() throws IOException, URISyntaxException {
-    type.createValue(new Object(), Collections.<String, Object> singletonMap(FileValueTypeImpl.VALUE_INFO_FILE_NAME, "simpleFile.txt"));
+  @Test
+  void createValueFromObject() {
+    assertThrows(IllegalArgumentException.class, () ->
+      type.createValue(new Object(), Collections.<String, Object>singletonMap(FileValueTypeImpl.VALUE_INFO_FILE_NAME, "simpleFile.txt")));
   }
 
   @Test
-  public void createValueWithProperties() {
+  void createValueWithProperties() {
     // given
     InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
     Map<String, Object> properties = new HashMap<String, Object>();
@@ -140,7 +142,7 @@ public class FileValueTypeImplTest {
 
 
   @Test
-  public void createValueWithNullProperties() {
+  void createValueWithNullProperties() {
     // given
     InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
     Map<String, Object> properties = new HashMap<String, Object>();
@@ -173,20 +175,22 @@ public class FileValueTypeImplTest {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void cannotCreateFileWithoutName() {
+  @Test
+  void cannotCreateFileWithoutName() {
     InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
-    type.createValue(file, Collections.<String, Object> emptyMap());
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void cannotCreateFileWithoutValueInfo() {
-    InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
-    type.createValue(file, null);
+    assertThrows(IllegalArgumentException.class, () ->
+      type.createValue(file, Collections.<String, Object>emptyMap()));
   }
 
   @Test
-  public void cannotCreateFileWithInvalidTransientFlag() {
+  void cannotCreateFileWithoutValueInfo() {
+    InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
+    assertThrows(IllegalArgumentException.class, () ->
+      type.createValue(file, null));
+  }
+
+  @Test
+  void cannotCreateFileWithInvalidTransientFlag() {
     InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
     Map<String, Object> info = new HashMap<String, Object>();
     info.put("filename", "bar");
@@ -200,7 +204,7 @@ public class FileValueTypeImplTest {
   }
 
   @Test
-  public void valueInfoContainsFileTypeNameTransientFlagAndCharsetEncoding() {
+  void valueInfoContainsFileTypeNameTransientFlagAndCharsetEncoding() {
     InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
     String fileName = "simpleFile.txt";
     String fileType = "text/plain";
@@ -215,7 +219,7 @@ public class FileValueTypeImplTest {
   }
 
   @Test
-  public void valueInfoContainsFileTypeNameAndStringEncoding() {
+  void valueInfoContainsFileTypeNameAndStringEncoding() {
     InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
     String fileName = "simpleFile.txt";
     String fileType = "text/plain";
@@ -229,7 +233,7 @@ public class FileValueTypeImplTest {
   }
 
   @Test
-  public void fileByteArrayIsEqualToFileValueContent() throws IOException {
+  void fileByteArrayIsEqualToFileValueContent() throws IOException {
     InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
     String fileName = "simpleFile.txt";
 
@@ -239,7 +243,7 @@ public class FileValueTypeImplTest {
   }
 
   @Test
-  public void fileByteArrayIsEqualToFileValueContentCase2() throws IOException {
+  void fileByteArrayIsEqualToFileValueContentCase2() throws IOException {
 
     byte[] bytes = new byte[]{ -16, -128, -128, -128 };
     InputStream byteStream = new ByteArrayInputStream(bytes);
@@ -251,7 +255,7 @@ public class FileValueTypeImplTest {
   }
 
   @Test
-  public void doesNotHaveParent(){
+  void doesNotHaveParent(){
     assertThat(type.getParent(), is(nullValue()));
   }
 

--- a/commons/utils/pom.xml
+++ b/commons/utils/pom.xml
@@ -19,15 +19,19 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-junit</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
 
     <dependency>

--- a/commons/utils/src/test/java/org/operaton/commons/utils/EnsureUtilTest.java
+++ b/commons/utils/src/test/java/org/operaton/commons/utils/EnsureUtilTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.commons.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
@@ -24,10 +24,10 @@ import static org.assertj.core.api.Fail.fail;
 /**
  * @author Stefan Hentschel.
  */
-public class EnsureUtilTest {
+class EnsureUtilTest {
 
   @Test
-  public void ensureNotNull() {
+  void ensureNotNull() {
     String string = "string";
 
     try {
@@ -39,7 +39,7 @@ public class EnsureUtilTest {
   }
 
   @Test
-  public void shouldFailEnsureNotNull() {
+  void shouldFailEnsureNotNull() {
     String string = null;
 
     try {
@@ -52,7 +52,7 @@ public class EnsureUtilTest {
   }
 
   @Test
-  public void ensureParameterInstanceOfClass() {
+  void ensureParameterInstanceOfClass() {
     Object string = "string";
 
     try{
@@ -65,7 +65,7 @@ public class EnsureUtilTest {
   }
 
   @Test
-  public void shouldFailEnsureParameterInstanceOfClass() {
+  void shouldFailEnsureParameterInstanceOfClass() {
     Object string = "string";
 
     try{

--- a/commons/utils/src/test/java/org/operaton/commons/utils/IoUtilTest.java
+++ b/commons/utils/src/test/java/org/operaton/commons/utils/IoUtilTest.java
@@ -16,13 +16,13 @@
  */
 package org.operaton.commons.utils;
 
-import org.junit.Test;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+
+import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -34,21 +34,21 @@ public class IoUtilTest {
   public final static String TEST_FILE_NAME = "org/operaton/commons/utils/testFile.txt";
 
   @Test
-  public void shouldTransformBetweenInputStreamAndString() {
+  void shouldTransformBetweenInputStreamAndString() {
     InputStream inputStream = IoUtil.stringAsInputStream("test");
     String string = IoUtil.inputStreamAsString(inputStream);
     assertThat(string).isEqualTo("test");
   }
-  
+
   @Test
-  public void shouldTransformFromInputStreamToByteArray() {
+  void shouldTransformFromInputStreamToByteArray() {
     String testString = "Test String";
     InputStream inputStream = IoUtil.stringAsInputStream(testString);
     assertThat(IoUtil.inputStreamAsByteArray(inputStream)).isEqualTo(testString.getBytes(IoUtil.ENCODING_CHARSET));
-  }  
-  
+  }
+
   @Test
-  public void shouldTransformFromStringToInputStreamToByteArray() {
+  void shouldTransformFromStringToInputStreamToByteArray() {
     String testString = "Test String";
     InputStream inputStream = IoUtil.stringAsInputStream(testString);
     
@@ -58,16 +58,16 @@ public class IoUtilTest {
     inputStream = IoUtil.stringAsInputStream(testString);
     byte[] newBytes = newString.getBytes(IoUtil.ENCODING_CHARSET);
     assertThat(IoUtil.inputStreamAsByteArray(inputStream)).isEqualTo(newBytes);
-  }  
-  
-  
+  }
+
+
   @Test
-  public void getFileContentAsString() {
+  void getFileContentAsString() {
     assertThat(IoUtil.fileAsString(TEST_FILE_NAME)).isEqualTo("This is a Test!");
   }
 
   @Test
-  public void shouldFailGetFileContentAsStringWithGarbageAsFilename() {
+  void shouldFailGetFileContentAsStringWithGarbageAsFilename() {
     try {
       IoUtil.fileAsString("asd123");
       fail("Expected: IoUtilException");
@@ -77,7 +77,7 @@ public class IoUtilTest {
   }
 
   @Test
-  public void getFileContentAsStream() {
+  void getFileContentAsStream() {
     InputStream stream = IoUtil.fileAsStream(TEST_FILE_NAME);
     BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
     StringBuilder output = new StringBuilder();
@@ -93,7 +93,7 @@ public class IoUtilTest {
   }
 
   @Test
-  public void shouldFailGetFileContentAsStreamWithGarbageAsFilename() {
+  void shouldFailGetFileContentAsStreamWithGarbageAsFilename() {
     try {
       IoUtil.fileAsStream("asd123");
       fail("Expected: IoUtilException");
@@ -103,7 +103,7 @@ public class IoUtilTest {
   }
 
   @Test
-  public void getFileFromClassPath() {
+  void getFileFromClassPath() {
     File file = IoUtil.getClasspathFile(TEST_FILE_NAME);
 
     assertThat(file).isNotNull();
@@ -111,7 +111,7 @@ public class IoUtilTest {
   }
 
   @Test
-  public void shouldFailGetFileFromClassPathWithGarbage() {
+  void shouldFailGetFileFromClassPathWithGarbage() {
     try {
       IoUtil.getClasspathFile("asd123");
       fail("Expected: IoUtilException");
@@ -121,7 +121,7 @@ public class IoUtilTest {
   }
 
   @Test
-  public void shouldFailGetFileFromClassPathWithNull() {
+  void shouldFailGetFileFromClassPathWithNull() {
     try {
       IoUtil.getClasspathFile(null);
       fail("Expected: IoUtilException");
@@ -131,7 +131,7 @@ public class IoUtilTest {
   }
 
   @Test
-  public void shouldUseFallBackWhenCustomClassLoaderIsWrong() {
+  void shouldUseFallBackWhenCustomClassLoaderIsWrong() {
     File file = IoUtil.getClasspathFile(TEST_FILE_NAME, new ClassLoader() {
       @Override
       public URL getResource(String name) {
@@ -143,7 +143,7 @@ public class IoUtilTest {
   }
 
   @Test
-  public void shouldUseFallBackWhenCustomClassLoaderIsNull() {
+  void shouldUseFallBackWhenCustomClassLoaderIsNull() {
     File file = IoUtil.getClasspathFile(TEST_FILE_NAME, null);
     assertThat(file).isNotNull();
     assertThat(file.getName()).isEqualTo("testFile.txt");

--- a/commons/utils/src/test/java/org/operaton/commons/utils/StringUtilTest.java
+++ b/commons/utils/src/test/java/org/operaton/commons/utils/StringUtilTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.commons.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.commons.utils.StringUtil.isExpression;
@@ -28,10 +28,10 @@ import static org.operaton.commons.utils.StringUtil.getStackTrace;
 /**
  * @author Sebastian Menski
  */
-public class StringUtilTest {
+class StringUtilTest {
 
   @Test
-  public void testExpressionDetection() {
+  void expressionDetection() {
     assertThat(isExpression("${test}")).isTrue();
     assertThat(isExpression("${a(b,c)}")).isTrue();
     assertThat(isExpression("${ test }")).isTrue();
@@ -53,7 +53,7 @@ public class StringUtilTest {
   }
 
   @Test
-  public void testStringSplit() {
+  void stringSplit() {
     assertThat(split("a,b,c", ",")).hasSize(3).containsExactly("a", "b", "c");
     assertThat(split("aaaxbaaxc", "a{2}x")).hasSize(3).containsExactly("a", "b", "c");
     assertThat(split(null, ",")).isNull();
@@ -62,7 +62,7 @@ public class StringUtilTest {
   }
 
   @Test
-  public void testStringJoin() {
+  void stringJoin() {
     assertThat(join(",", "a", "b", "c")).isEqualTo("a,b,c");
     assertThat(join(", ", "a", "b", "c")).isEqualTo("a, b, c");
     assertThat(join(null, "a", "b", "c")).isEqualTo("abc");
@@ -72,17 +72,17 @@ public class StringUtilTest {
   }
 
   @Test
-  public void testDefaultString() {
+  void testDefaultString() {
     assertThat(defaultString(null)).isEqualTo("");
     assertThat(defaultString("")).isEqualTo("");
     assertThat(defaultString("bat")).isEqualTo("bat");
   }
 
   @Test
-  public void testGetStacktrace() {
+  void getStacktrace() {
     Throwable th = new IllegalArgumentException("Wrong argument!", new NullPointerException("This shouldn't have been empty"));
     assertThat(getStackTrace(th)).containsSubsequence("java.lang.IllegalArgumentException: Wrong argument!",
-      "at org.operaton.commons.utils.StringUtilTest.testGetStacktrace(StringUtilTest.java:",
+      "at org.operaton.commons.utils.StringUtilTest.getStacktrace(StringUtilTest.java:",
       "Caused by: java.lang.NullPointerException: This shouldn't have been empty");
   }
 

--- a/commons/utils/src/test/java/org/operaton/commons/utils/cache/ConcurrentLruCacheTest.java
+++ b/commons/utils/src/test/java/org/operaton/commons/utils/cache/ConcurrentLruCacheTest.java
@@ -16,32 +16,28 @@
  */
 package org.operaton.commons.utils.cache;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class ConcurrentLruCacheTest {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
+class ConcurrentLruCacheTest {
 
   private ConcurrentLruCache<String, String> cache;
 
-  @Before
-  public void createCache() {
+  @BeforeEach
+  void createCache() {
     cache = new ConcurrentLruCache<String, String>(3);
   }
 
   @Test
-  public void getEntryWithNotExistingKey() {
+  void getEntryWithNotExistingKey() {
     assertThat(cache.get("not existing")).isNull();
   }
 
   @Test
-  public void getEntry() {
+  void getEntry() {
     cache.put("a", "1");
 
     assertThat(cache.size()).isEqualTo(1);
@@ -49,7 +45,7 @@ public class ConcurrentLruCacheTest {
   }
 
   @Test
-  public void overrideEntry() {
+  void overrideEntry() {
     cache.put("a", "1");
     cache.put("a", "2");
 
@@ -58,7 +54,7 @@ public class ConcurrentLruCacheTest {
   }
 
   @Test
-  public void removeLeastRecentlyInsertedEntry() {
+  void removeLeastRecentlyInsertedEntry() {
     cache.put("a", "1");
     cache.put("b", "2");
     cache.put("c", "3");
@@ -72,7 +68,7 @@ public class ConcurrentLruCacheTest {
   }
 
   @Test
-  public void removeLeastRecentlyUsedEntry() {
+  void removeLeastRecentlyUsedEntry() {
     cache.put("a", "1");
     cache.put("b", "2");
     cache.put("c", "3");
@@ -90,7 +86,7 @@ public class ConcurrentLruCacheTest {
   }
 
   @Test
-  public void clearCache() {
+  void clearCache() {
     cache.put("a", "1");
 
     cache.clear();
@@ -99,28 +95,29 @@ public class ConcurrentLruCacheTest {
   }
 
   @Test
-  public void failToInsertInvalidKey() {
-    thrown.expect(NullPointerException.class);
+  void failToInsertInvalidKey() {
+    assertThrows(NullPointerException.class, () ->
 
-    cache.put(null, "1");
+      cache.put(null, "1"));
   }
 
   @Test
-  public void failToInsertInvalidValue() {
-    thrown.expect(NullPointerException.class);
+  void failToInsertInvalidValue() {
+    assertThrows(NullPointerException.class, () ->
 
-    cache.put("a", null);
+      cache.put("a", null));
   }
 
   @Test
-  public void failToCreateCacheWithInvalidCapacity() {
-    thrown.expect(IllegalArgumentException.class);
+  void failToCreateCacheWithInvalidCapacity() {
+    assertThrows(IllegalArgumentException.class, () -> {
 
-    new ConcurrentLruCache<String, String>(-1);
+      new ConcurrentLruCache<String, String>(-1);
+    });
   }
 
   @Test
-  public void removeElementInEmptyCache() {
+  void removeElementInEmptyCache() {
 
     // given
     cache.clear();
@@ -133,7 +130,7 @@ public class ConcurrentLruCacheTest {
   }
 
   @Test
-  public void removeNoneExistingKeyInCache(){
+  void removeNoneExistingKeyInCache(){
     //given
     cache.put("a", "1");
     cache.put("b", "2");
@@ -149,7 +146,7 @@ public class ConcurrentLruCacheTest {
   }
 
   @Test
-  public void removeAllElements() {
+  void removeAllElements() {
     // given
     cache.put("a", "1");
     cache.put("b", "2");

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -15,6 +15,10 @@
 
   <description>Operaton core internal bill of material for dependencies</description>
 
+  <properties>
+    <version.junit5>5.11.3</version.junit5>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -91,6 +95,24 @@
         <version>${version.junit4}</version>
       </dependency>
       <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${version.junit5}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-junit</artifactId>
+        <version>2.0.0.0</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${version.assertj}</version>
@@ -99,6 +121,11 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${version.logback}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${version.slf4j}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/test-utils/junit5-extension-dmn/pom.xml
+++ b/test-utils/junit5-extension-dmn/pom.xml
@@ -47,6 +47,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.operaton.bpm.dmn</groupId>

--- a/test-utils/junit5-extension/pom.xml
+++ b/test-utils/junit5-extension/pom.xml
@@ -46,6 +46,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.operaton.bpm</groupId>


### PR DESCRIPTION
Migrated with Open Rewrite recipe org.openrewrite.java.testing.junit5.JUnit5BestPractices.

Added required dependencies to internal-dependencies/pom.xml.

commons-testing stays with JUnit 4 since downstream testing classes use ProcessEngineLoggingRule.