### PR TITLE
Migrate to JUnit 5: freemarker-template-engine

### DIFF
--- a/freemarker-template-engine/pom.xml
+++ b/freemarker-template-engine/pom.xml
@@ -19,25 +19,38 @@
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
+        <version>${project.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
-      <version>2.3.31</version>
     </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit4}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>${version.assertj}</version>
-      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
   </dependencies>
 
@@ -46,7 +59,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.17</version>
+        <version>3.1.2</version>
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
         </configuration>

--- a/freemarker-template-engine/src/test/java/org/operaton/templateengines/engine/FreeMarkerScriptEngineTest.java
+++ b/freemarker-template-engine/src/test/java/org/operaton/templateengines/engine/FreeMarkerScriptEngineTest.java
@@ -20,12 +20,11 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import javax.script.*;
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.templateengines.engine.util.Greeter;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -33,7 +32,7 @@ import static org.assertj.core.api.Assertions.fail;
 /**
  * @author Sebastian Menski
  */
-public class FreeMarkerScriptEngineTest {
+class FreeMarkerScriptEngineTest {
 
   protected static ScriptEngine scriptEngine;
   protected Bindings bindings;
@@ -41,19 +40,19 @@ public class FreeMarkerScriptEngineTest {
   protected String template;
   protected String expected;
 
-  @BeforeClass
-  public static void getScriptEngine() {
+  @BeforeAll
+  static void getScriptEngine() {
     ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
     scriptEngine = scriptEngineManager.getEngineByName("freemarker");
   }
 
-  @Before
-  public void createBindings() {
+  @BeforeEach
+  void createBindings() {
     bindings = new SimpleBindings();
   }
 
-  @After
-  public void checkResult() throws ScriptException {
+  @AfterEach
+  void checkResult() throws ScriptException {
     if (template != null) {
       assertThat(evaluate(template)).isEqualTo(expected);
     }
@@ -64,54 +63,54 @@ public class FreeMarkerScriptEngineTest {
   }
 
   @Test
-  public void testScriptEngineExists() {
+  void scriptEngineExists() {
     assertThat(scriptEngine).isNotNull();
   }
 
   @Test
-  public void testVariableExpansion() {
+  void variableExpansion() {
     bindings.put("name", "world");
     expected = "Hello world!";
     template = "Hello ${name}!";
   }
 
   @Test
-  public void testJavaProperties() {
+  void javaProperties() {
     bindings.put("greeter", new Greeter());
     expected = "!";
     template = "${greeter.suffix}";
   }
 
   @Test
-  public void testJavaMethodCall() throws ScriptException {
+  void javaMethodCall() throws ScriptException {
     bindings.put("greeter", new Greeter());
     expected = "Hello world!";
     template = "${greeter.hello('world')}";
   }
 
   @Test
-  public void testJavaArrays() throws ScriptException {
+  void javaArrays() throws ScriptException {
     bindings.put("myarray", new String[]{"hello", "foo", "world", "bar"});
     expected = "4 hello world!";
     template = "${myarray?size} ${myarray[0]} ${myarray[2]}!";
   }
 
   @Test
-  public void testJavaBoolean() throws ScriptException {
+  void javaBoolean() throws ScriptException {
     bindings.put("mybool", false);
     expected = "Hello world!";
     template = "<#if mybool>okey<#else>Hello world!</#if>";
   }
 
   @Test
-  public void testJavaInteger() throws ScriptException {
+  void javaInteger() throws ScriptException {
     bindings.put("myint", 6);
     expected = "42";
     template = "<#assign myint = myint + 36>${myint}";
   }
 
   @Test
-  public void testJavaCollection() throws ScriptException {
+  void javaCollection() throws ScriptException {
     Collection names = Arrays.asList("tweety", "duffy", "tom");
     bindings.put("names", names);
     expected = "tweety, duffy, tom";
@@ -119,14 +118,14 @@ public class FreeMarkerScriptEngineTest {
   }
 
   @Test
-  public void testDefineBlock() throws ScriptException {
+  void defineBlock() throws ScriptException {
     bindings.put("who", "world");
     expected = "Hello world!";
     template = "<#macro block>Hello ${who}!</#macro><@block/>";
   }
-  
+
   @Test
-  public void testFailingEvaluation() {
+  void failingEvaluation() {
     try {
       String invalidTemplate = "${}";
       evaluate(invalidTemplate);

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -15,6 +15,10 @@
 
   <description>Operaton core internal bill of material for dependencies</description>
 
+  <properties>
+    <version.junit5>5.11.3</version.junit5>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -91,6 +95,24 @@
         <version>${version.junit4}</version>
       </dependency>
       <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${version.junit5}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-junit</artifactId>
+        <version>2.0.0.0</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${version.assertj}</version>
@@ -99,6 +121,11 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${version.logback}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${version.slf4j}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/test-utils/junit5-extension-dmn/pom.xml
+++ b/test-utils/junit5-extension-dmn/pom.xml
@@ -47,6 +47,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.operaton.bpm.dmn</groupId>

--- a/test-utils/junit5-extension/pom.xml
+++ b/test-utils/junit5-extension/pom.xml
@@ -46,6 +46,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.operaton.bpm</groupId>


### PR DESCRIPTION
Migrated with Open Rewrite recipe org.openrewrite.java.testing.junit5.JUnit5BestPractices.

Added required dependencies to internal-dependencies/pom.xml.

Use operaton-core-internal-dependencies BOM.