### PR TITLE
[deps] Upgrade Wiremock to version 3.9.2

### DIFF
--- a/connect/http-client/pom.xml
+++ b/connect/http-client/pom.xml
@@ -49,7 +49,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
+      <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>

--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -17,7 +17,7 @@
     <commons-codec.version>1.15</commons-codec.version>
     <connect.version.old>1.6.0</connect.version.old>
     <mockito.version>1.9.5</mockito.version>
-    <wiremock.version>1.58</wiremock.version>
+    <wiremock.version>3.9.2</wiremock.version>
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
 
     <license.includeTransitiveDependencies>false</license.includeTransitiveDependencies>
@@ -74,7 +74,7 @@
       </dependency>
 
       <dependency>
-        <groupId>com.github.tomakehurst</groupId>
+        <groupId>org.wiremock</groupId>
         <artifactId>wiremock</artifactId>
         <version>${wiremock.version}</version>
       </dependency>

--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -17,7 +17,6 @@
     <commons-codec.version>1.15</commons-codec.version>
     <connect.version.old>1.6.0</connect.version.old>
     <mockito.version>1.9.5</mockito.version>
-    <wiremock.version>3.9.2</wiremock.version>
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
 
     <license.includeTransitiveDependencies>false</license.includeTransitiveDependencies>
@@ -76,7 +75,7 @@
       <dependency>
         <groupId>org.wiremock</groupId>
         <artifactId>wiremock</artifactId>
-        <version>${wiremock.version}</version>
+        <version>${version.wiremock}</version>
       </dependency>
 
       <dependency>

--- a/connect/soap-http-client/pom.xml
+++ b/connect/soap-http-client/pom.xml
@@ -36,7 +36,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
+      <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>

--- a/connect/soap-http-client/src/test/java/org/operaton/connect/soap/httpclient/SoapHttpConnectorSystemPropertiesTest.java
+++ b/connect/soap-http-client/src/test/java/org/operaton/connect/soap/httpclient/SoapHttpConnectorSystemPropertiesTest.java
@@ -16,29 +16,20 @@
  */
 package org.operaton.connect.soap.httpclient;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-
-import java.util.HashSet;
-import java.util.Set;
-
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.http.protocol.HTTP;
-import org.operaton.connect.httpclient.HttpConnector;
-import org.operaton.connect.httpclient.impl.HttpConnectorImpl;
-import org.operaton.connect.httpclient.soap.SoapHttpConnector;
-import org.operaton.connect.httpclient.soap.impl.SoapHttpConnectorImpl;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.operaton.connect.httpclient.soap.SoapHttpConnector;
+import org.operaton.connect.httpclient.soap.impl.SoapHttpConnectorImpl;
 
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 /**
  * Since Apache HTTP client makes it extremely hard to test the proper configuration
@@ -60,7 +51,7 @@ public class SoapHttpConnectorSystemPropertiesTest {
   @Before
   public void setUp() {
     updatedSystemProperties = new HashSet<String>();
-    wireMockRule.stubFor(get(urlEqualTo("/")).willReturn(aResponse().withStatus(200)));
+    wireMockRule.stubFor(post(urlEqualTo("/")).willReturn(aResponse().withStatus(200)));
   }
 
   @After

--- a/engine-rest/engine-rest-openapi/pom.xml
+++ b/engine-rest/engine-rest-openapi/pom.xml
@@ -44,7 +44,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
+      <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
       <version>${version.wiremock}</version>
       <scope>test</scope>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -278,7 +278,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
+      <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -342,7 +342,7 @@
       </dependency>
 
       <dependency>
-        <groupId>com.github.tomakehurst</groupId>
+        <groupId>org.wiremock</groupId>
         <artifactId>wiremock</artifactId>
         <version>${version.wiremock}</version>
         <scope>test</scope>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -49,7 +49,7 @@
     <version.junit>4.13.1</version.junit>
     <version.assertj>2.9.1</version.assertj>
     <version.mockito>5.10.0</version.mockito>
-    <version.wiremock>2.27.2</version.wiremock>
+    <version.wiremock>3.9.2</version.wiremock>
     <version.testcontainers>1.16.0</version.testcontainers>
 
     <version.commonj>1.1.0</version.commonj>

--- a/qa/integration-tests-engine-jakarta/pom.xml
+++ b/qa/integration-tests-engine-jakarta/pom.xml
@@ -278,6 +278,12 @@
       <artifactId>spring-web</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- required for TestWarDeploymentWithProcessEnginePlugin -->
     <dependency>
       <groupId>org.codehaus.groovy</groupId>

--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -232,7 +232,7 @@
         </dependency>
 
         <dependency>
-          <groupId>com.github.tomakehurst</groupId>
+          <groupId>org.wiremock</groupId>
           <artifactId>wiremock</artifactId>
           <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Upgrade from `com.github.tomakehurst:wiremock:2.27.2` to `org.wiremock:wiremock:3.9.2`.

Fixes #46 