### PR TITLE
[#27] JUnit 5 migration: submodule clients

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,6 +1,5 @@
 --batch-mode
 --errors
---fail-at-end
 --show-version
 --no-transfer-progress
 -DinstallAtEnd=true

--- a/clients/java/client/pom.xml
+++ b/clients/java/client/pom.xml
@@ -74,14 +74,6 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
-
-    <!-- test dependencies -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
@@ -91,6 +83,11 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/rule/ClientRule.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/rule/ClientRule.java
@@ -16,19 +16,23 @@
  */
 package org.operaton.bpm.client.rule;
 
-import static org.operaton.bpm.client.util.PropertyUtil.*;
-import static org.operaton.bpm.client.util.TestUtil.waitUntil;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.operaton.bpm.client.ExternalTaskClient;
+import org.operaton.bpm.client.ExternalTaskClientBuilder;
+import org.operaton.bpm.client.util.PropertyUtil;
 
 import java.util.Properties;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
-import org.operaton.bpm.client.ExternalTaskClient;
-import org.operaton.bpm.client.ExternalTaskClientBuilder;
-import org.operaton.bpm.client.util.PropertyUtil;
-import org.junit.rules.ExternalResource;
+import static org.operaton.bpm.client.util.PropertyUtil.CAMUNDA_ENGINE_NAME;
+import static org.operaton.bpm.client.util.PropertyUtil.CAMUNDA_ENGINE_REST;
+import static org.operaton.bpm.client.util.PropertyUtil.DEFAULT_PROPERTIES_PATH;
+import static org.operaton.bpm.client.util.TestUtil.waitUntil;
 
-public class ClientRule extends ExternalResource {
+public class ClientRule implements BeforeEachCallback, AfterEachCallback {
 
   public static final long LOCK_DURATION = 1000 * 60 * 5;
 
@@ -44,8 +48,8 @@ public class ClientRule extends ExternalResource {
       String endpoint = properties.getProperty(CAMUNDA_ENGINE_REST);
       String engine = properties.getProperty(CAMUNDA_ENGINE_NAME);
       return ExternalTaskClient.create()
-          .baseUrl(endpoint + engine)
-          .lockDuration(LOCK_DURATION);
+              .baseUrl(endpoint + engine)
+              .lockDuration(LOCK_DURATION);
     });
   }
 
@@ -53,9 +57,19 @@ public class ClientRule extends ExternalResource {
     this.builder = builderSupplier.get();
   }
 
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    before();
+  }
+
   public void before() {
     builder.disableAutoFetching();
     client = builder.build();
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    after();
   }
 
   public void after() {
@@ -76,6 +90,5 @@ public class ClientRule extends ExternalResource {
     finally {
       client.stop();
     }
-
   }
 }

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
@@ -118,9 +118,7 @@ public class EngineRule implements BeforeEachCallback, AfterEachCallback  {
     parameters.put("skipCustomListeners", true);
     parameters.put("skipIoMappings", true);
 
-    deployments.forEach(deployment -> {
-      deleteDeployment(deployment, parameters);
-    });
+    deployments.forEach(deployment -> deleteDeployment(deployment, parameters));
   }
 
 

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
@@ -24,52 +24,35 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Supplier;
 
+import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.client5.http.ClientProtocolException;
-import org.apache.hc.client5.http.classic.methods.HttpDelete;
-import org.apache.hc.client5.http.classic.methods.HttpGet;
-import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
-import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.client5.http.classic.methods.*;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
-import org.apache.hc.core5.http.io.entity.StringEntity;
-import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
-import org.apache.hc.client5.http.impl.classic.AbstractHttpClientResponseHandler;
-import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
-import org.operaton.bpm.client.dto.HistoricProcessInstanceDto;
-import org.operaton.bpm.client.dto.IncidentDto;
-import org.operaton.bpm.client.dto.ProcessDefinitionDto;
-import org.operaton.bpm.client.dto.ProcessInstanceDto;
-import org.operaton.bpm.client.dto.TaskDto;
-import org.operaton.bpm.client.dto.VariableInstanceDto;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+import org.apache.hc.client5.http.impl.classic.*;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import com.fasterxml.jackson.databind.*;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.operaton.bpm.client.dto.*;
 import org.operaton.bpm.client.task.ExternalTask;
 import org.operaton.bpm.client.task.impl.ExternalTaskImpl;
 import org.operaton.bpm.client.variable.impl.TypedValueField;
 import org.operaton.bpm.engine.variable.impl.value.FileValueImpl;
 import org.operaton.bpm.engine.variable.type.ValueType;
-import org.operaton.bpm.engine.variable.value.SerializableValue;
-import org.operaton.bpm.engine.variable.value.TypedValue;
-import org.operaton.bpm.model.bpmn.Bpmn;
-import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.rules.ExternalResource;
+import org.operaton.bpm.engine.variable.value.*;
+import org.operaton.bpm.model.bpmn.*;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-
-public class EngineRule extends ExternalResource {
+public class EngineRule implements BeforeEachCallback, AfterEachCallback  {
 
   protected static final String URI_DEPLOYMEN_CREATE = "%s/deployment/create";
   protected static final String URI_DEPLOYMENT_DELETE = "%s/deployment/%s";
@@ -86,7 +69,6 @@ public class EngineRule extends ExternalResource {
   protected Properties properties;
   protected CloseableHttpClient httpClient;
   protected ObjectMapper objectMapper;
-
   protected Set<String> deployments = new HashSet<>();
 
   public EngineRule() {
@@ -101,18 +83,19 @@ public class EngineRule extends ExternalResource {
     this.properties = properties.get();
   }
 
-  @Override
-  protected void before() throws Throwable {
-    deployments.clear();
 
-    initializeHttpClient();
-    initializeObjectMapper();
-  }
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        deployments.clear();
+        initializeHttpClient();
+        initializeObjectMapper();
 
-  @Override
-  protected void after() {
-    cleanEngine();
-  }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        cleanEngine();
+    }
 
   protected void initializeHttpClient() {
     if (httpClient == null) {
@@ -135,10 +118,11 @@ public class EngineRule extends ExternalResource {
     parameters.put("skipCustomListeners", true);
     parameters.put("skipIoMappings", true);
 
-    deployments.forEach((deployment) -> {
+    deployments.forEach(deployment -> {
       deleteDeployment(deployment, parameters);
     });
   }
+
 
   public List<ProcessDefinitionDto> deploy(BpmnModelInstance... processes) {
     return deploy(null, processes);

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/task/ExternalTaskCustomExtensionPropertiesIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/task/ExternalTaskCustomExtensionPropertiesIT.java
@@ -16,9 +16,9 @@
  */
 package org.operaton.bpm.client.task;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.operaton.bpm.client.ExternalTaskClient;
 import org.operaton.bpm.client.dto.ProcessDefinitionDto;
 import org.operaton.bpm.client.dto.ProcessInstanceDto;
@@ -28,20 +28,18 @@ import org.operaton.bpm.client.util.ProcessModels;
 import org.operaton.bpm.client.util.RecordingExternalTaskHandler;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+@ExtendWith(EngineRule.class)
+@ExtendWith(ClientRule.class)
 public class ExternalTaskCustomExtensionPropertiesIT {
 
   protected BpmnModelInstance externalTaskProcess;
 
   protected ClientRule clientRule = new ClientRule();
   protected EngineRule engineRule = new EngineRule();
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(clientRule);
 
   protected ExternalTaskClient client;
 
@@ -50,7 +48,7 @@ public class ExternalTaskCustomExtensionPropertiesIT {
 
   protected RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler();
 
-  @Before
+  @BeforeEach
   public void setup() {
     client = clientRule.client();
     handler.clear();

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/task/ExternalTaskHandlerIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/task/ExternalTaskHandlerIT.java
@@ -16,24 +16,9 @@
  */
 package org.operaton.bpm.client.task;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.client.rule.ClientRule.LOCK_DURATION;
-import static org.operaton.bpm.client.util.ProcessModels.BPMN_ERROR_EXTERNAL_TASK_PROCESS;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_ID;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_PRIORITY;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
-import static org.operaton.bpm.client.util.ProcessModels.PROCESS_KEY;
-import static org.operaton.bpm.client.util.ProcessModels.PROCESS_KEY_2;
-import static org.operaton.bpm.client.util.ProcessModels.USER_TASK_AFTER_BPMN_ERROR;
-import static org.operaton.bpm.client.util.ProcessModels.USER_TASK_ID;
-import static org.operaton.bpm.client.util.ProcessModels.createProcessWithExclusiveGateway;
-
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.operaton.bpm.client.ExternalTaskClient;
 import org.operaton.bpm.client.dto.IncidentDto;
 import org.operaton.bpm.client.dto.ProcessDefinitionDto;
@@ -48,26 +33,39 @@ import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.bpmn.instance.BoundaryEvent;
 import org.operaton.bpm.model.bpmn.instance.ErrorEventDefinition;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.client.rule.ClientRule.LOCK_DURATION;
+import static org.operaton.bpm.client.util.ProcessModels.BPMN_ERROR_EXTERNAL_TASK_PROCESS;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_ID;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_PRIORITY;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
+import static org.operaton.bpm.client.util.ProcessModels.PROCESS_KEY;
+import static org.operaton.bpm.client.util.ProcessModels.PROCESS_KEY_2;
+import static org.operaton.bpm.client.util.ProcessModels.USER_TASK_AFTER_BPMN_ERROR;
+import static org.operaton.bpm.client.util.ProcessModels.USER_TASK_ID;
+import static org.operaton.bpm.client.util.ProcessModels.createProcessWithExclusiveGateway;
+
+@ExtendWith(EngineRule.class)
+@ExtendWith(ClientRule.class)
 public class ExternalTaskHandlerIT {
 
   private static final String BUSINESS_KEY = "aBusinessKey";
   protected ClientRule clientRule = new ClientRule();
   protected EngineRule engineRule = new EngineRule();
 
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(clientRule);
-
   protected ExternalTaskClient client;
 
   protected ProcessDefinitionDto processDefinition;
   protected ProcessInstanceDto processInstance;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     client = clientRule.client();
 

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/topic/TopicSubscriptionIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/topic/TopicSubscriptionIT.java
@@ -16,6 +16,9 @@
  */
 package org.operaton.bpm.client.topic;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.operaton.bpm.client.ExternalTaskClient;
 import org.operaton.bpm.client.dto.ProcessDefinitionDto;
 import org.operaton.bpm.client.dto.ProcessInstanceDto;
@@ -26,23 +29,27 @@ import org.operaton.bpm.client.task.ExternalTask;
 import org.operaton.bpm.client.util.RecordingExternalTaskHandler;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.TypedValue;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.RuleChain;
 
-import java.util.HashMap;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.client.util.ProcessModels.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.operaton.bpm.client.util.ProcessModels.BPMN_ERROR_EXTERNAL_TASK_PROCESS;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
+import static org.operaton.bpm.client.util.ProcessModels.ONE_EXTERNAL_TASK_WITH_OUTPUT_PARAM_PROCESS;
+import static org.operaton.bpm.client.util.ProcessModels.ONE_EXTERNAL_TASK_WITH_VERSION_TAG;
+import static org.operaton.bpm.client.util.ProcessModels.PROCESS_DEFINITION_VERSION_TAG;
+import static org.operaton.bpm.client.util.ProcessModels.PROCESS_KEY;
+import static org.operaton.bpm.client.util.ProcessModels.PROCESS_KEY_2;
 
 /**
  * @author Tassilo Weidner
  */
+@ExtendWith(EngineRule.class)
+@ExtendWith(ClientRule.class)
 public class TopicSubscriptionIT {
 
   protected static final String BUSINESS_KEY = "aBusinessKey";
@@ -55,10 +62,6 @@ public class TopicSubscriptionIT {
 
   protected ClientRule clientRule = new ClientRule();
   protected EngineRule engineRule = new EngineRule();
-  protected ExpectedException thrown = ExpectedException.none();
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(clientRule).around(thrown);
 
   protected ExternalTaskClient client;
 
@@ -66,7 +69,7 @@ public class TopicSubscriptionIT {
   protected ProcessDefinitionDto processDefinition2;
   protected RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     client = clientRule.client();
     handler.clear();
@@ -475,13 +478,12 @@ public class TopicSubscriptionIT {
     // given
     engineRule.startProcessInstance(processDefinition.getId());
 
-    // then
-    thrown.expect(ExternalTaskClientException.class);
-
-    // when
-    client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
-      .lockDuration(0)
-      .open();
+    // when + then
+    assertThatThrownBy(() ->
+      client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
+        .lockDuration(0)
+        .open()
+    ).isInstanceOf(ExternalTaskClientException.class);
   }
 
   @Test
@@ -489,12 +491,8 @@ public class TopicSubscriptionIT {
     // given
     engineRule.startProcessInstance(processDefinition.getId());
 
-    // then
-    thrown.expect(ExternalTaskClientException.class);
-
-    // when
-    client.subscribe(null)
-      .open();
+    // when + then
+    assertThatThrownBy(() -> client.subscribe(null).open()).isInstanceOf(ExternalTaskClientException.class);
   }
 
   @Test
@@ -502,12 +500,8 @@ public class TopicSubscriptionIT {
     // given
     engineRule.startProcessInstance(processDefinition.getId());
 
-    // then
-    thrown.expect(ExternalTaskClientException.class);
-
-    // when
-    client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
-      .open();
+    // when + then
+    assertThatThrownBy(() -> client.subscribe(EXTERNAL_TASK_TOPIC_FOO).open()).isInstanceOf(ExternalTaskClientException.class);
   }
 
   @Test
@@ -515,13 +509,11 @@ public class TopicSubscriptionIT {
     // given
     engineRule.startProcessInstance(processDefinition.getId());
 
-    // then
-    thrown.expect(ExternalTaskClientException.class);
-
-    // when
-    client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
+    // when + then
+    assertThatThrownBy(() -> client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
       .handler(null)
-      .open();
+      .open())
+            .isInstanceOf(ExternalTaskClientException.class);
   }
 
   @Test
@@ -547,13 +539,12 @@ public class TopicSubscriptionIT {
       .handler(handler)
       .open();
 
-    // then
-    thrown.expect(ExternalTaskClientException.class);
-
-    // when
-    client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
-      .handler(handler)
-      .open();
+    // when + then
+    assertThatThrownBy(() ->
+      client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
+        .handler(handler)
+        .open()
+    ).isInstanceOf(ExternalTaskClientException.class);
   }
 
   @Test

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/FileSerializationIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/FileSerializationIT.java
@@ -16,23 +16,9 @@
  */
 package org.operaton.bpm.client.variable;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_BAR;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
-import static org.operaton.bpm.client.util.ProcessModels.PROCESS_KEY_2;
-import static org.operaton.bpm.client.util.ProcessModels.TWO_EXTERNAL_TASK_PROCESS;
-import static org.operaton.bpm.client.util.ProcessModels.USER_TASK_ID;
-import static org.operaton.bpm.client.util.ProcessModels.createProcessWithExclusiveGateway;
-import static org.operaton.bpm.engine.variable.type.ValueType.FILE;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.operaton.bpm.client.ExternalTaskClient;
 import org.operaton.bpm.client.dto.ProcessDefinitionDto;
 import org.operaton.bpm.client.dto.ProcessInstanceDto;
@@ -52,12 +38,27 @@ import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.commons.utils.IoUtil;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.RuleChain;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_BAR;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
+import static org.operaton.bpm.client.util.ProcessModels.PROCESS_KEY_2;
+import static org.operaton.bpm.client.util.ProcessModels.TWO_EXTERNAL_TASK_PROCESS;
+import static org.operaton.bpm.client.util.ProcessModels.USER_TASK_ID;
+import static org.operaton.bpm.client.util.ProcessModels.createProcessWithExclusiveGateway;
+import static org.operaton.bpm.engine.variable.type.ValueType.FILE;
+
+@ExtendWith(EngineRule.class)
+@ExtendWith(ClientRule.class)
 public class FileSerializationIT {
 
   protected static final String VARIABLE_NAME_FILE = "fileVariable";
@@ -76,10 +77,6 @@ public class FileSerializationIT {
 
   protected ClientRule clientRule = new ClientRule();
   protected EngineRule engineRule = new EngineRule();
-  protected ExpectedException thrown = ExpectedException.none();
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(clientRule).around(thrown);
 
   protected ExternalTaskClient client;
 
@@ -88,7 +85,7 @@ public class FileSerializationIT {
   protected RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler();
   protected RecordingInvocationHandler invocationHandler = new RecordingInvocationHandler();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     client = clientRule.client();
     processDefinition = engineRule.deploy(TWO_EXTERNAL_TASK_PROCESS).get(0);
@@ -487,12 +484,12 @@ public class FileSerializationIT {
     ExternalTask fooTask = invocation.getExternalTask();
     ExternalTaskService fooService = invocation.getExternalTaskService();
 
-    client.subscribe(EXTERNAL_TASK_TOPIC_BAR)
-      .handler(handler)
-      .open();
 
     // then
-    thrown.expect(ValueMapperException.class);
+    assertThatThrownBy(() ->
+            client.subscribe(EXTERNAL_TASK_TOPIC_BAR)
+                    .handler(handler)
+                    .open()).isInstanceOf(ValueMapperException.class);
 
     // when
     Map<String, Object> variables = new HashMap<>();

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/JavaSerializationIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/JavaSerializationIT.java
@@ -16,21 +16,9 @@
  */
 package org.operaton.bpm.client.variable;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.client.rule.ClientRule.LOCK_DURATION;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_BAR;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
-import static org.operaton.bpm.client.util.ProcessModels.TWO_EXTERNAL_TASK_PROCESS;
-import static org.operaton.bpm.client.util.PropertyUtil.CAMUNDA_ENGINE_NAME;
-import static org.operaton.bpm.client.util.PropertyUtil.CAMUNDA_ENGINE_REST;
-import static org.operaton.bpm.client.util.PropertyUtil.DEFAULT_PROPERTIES_PATH;
-import static org.operaton.bpm.client.util.PropertyUtil.loadProperties;
-import static org.operaton.bpm.engine.variable.Variables.SerializationDataFormats.JAVA;
-import static org.operaton.bpm.engine.variable.type.ValueType.OBJECT;
-
-import java.util.Map;
-import java.util.Properties;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.operaton.bpm.client.ExternalTaskClient;
 import org.operaton.bpm.client.dto.ProcessDefinitionDto;
 import org.operaton.bpm.client.dto.ProcessInstanceDto;
@@ -43,12 +31,24 @@ import org.operaton.bpm.client.util.RecordingInvocationHandler;
 import org.operaton.bpm.client.util.RecordingInvocationHandler.RecordedInvocation;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.RuleChain;
 
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.client.rule.ClientRule.LOCK_DURATION;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_BAR;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
+import static org.operaton.bpm.client.util.ProcessModels.TWO_EXTERNAL_TASK_PROCESS;
+import static org.operaton.bpm.client.util.PropertyUtil.CAMUNDA_ENGINE_NAME;
+import static org.operaton.bpm.client.util.PropertyUtil.CAMUNDA_ENGINE_REST;
+import static org.operaton.bpm.client.util.PropertyUtil.DEFAULT_PROPERTIES_PATH;
+import static org.operaton.bpm.client.util.PropertyUtil.loadProperties;
+import static org.operaton.bpm.engine.variable.Variables.SerializationDataFormats.JAVA;
+import static org.operaton.bpm.engine.variable.type.ValueType.OBJECT;
+
+@ExtendWith(EngineRule.class)
+@ExtendWith(ClientRule.class)
 public class JavaSerializationIT {
 
   protected static final String ENGINE_NAME = "/engine/another-engine";
@@ -79,11 +79,6 @@ public class JavaSerializationIT {
     return properties;
   });
 
-  protected ExpectedException thrown = ExpectedException.none();
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(clientRule).around(thrown);
-
   protected ExternalTaskClient client;
 
   protected ProcessDefinitionDto processDefinition;
@@ -92,7 +87,7 @@ public class JavaSerializationIT {
   protected RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler();
   protected RecordingInvocationHandler invocationHandler = new RecordingInvocationHandler();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     client = clientRule.client();
     processDefinition = engineRule.deploy(TWO_EXTERNAL_TASK_PROCESS).get(0);

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/JsonSerializationIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/JsonSerializationIT.java
@@ -16,18 +16,10 @@
  */
 package org.operaton.bpm.client.variable;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_BAR;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
-import static org.operaton.bpm.client.util.ProcessModels.TWO_EXTERNAL_TASK_PROCESS;
-import static org.operaton.bpm.engine.variable.Variables.SerializationDataFormats.JSON;
-import static org.operaton.bpm.engine.variable.type.ValueType.OBJECT;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.operaton.bpm.client.ExternalTaskClient;
 import org.operaton.bpm.client.dto.ProcessDefinitionDto;
 import org.operaton.bpm.client.dto.ProcessInstanceDto;
@@ -41,14 +33,23 @@ import org.operaton.bpm.client.util.RecordingInvocationHandler;
 import org.operaton.bpm.client.util.RecordingInvocationHandler.RecordedInvocation;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
-import org.json.JSONException;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.RuleChain;
 import org.skyscreamer.jsonassert.JSONAssert;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_BAR;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
+import static org.operaton.bpm.client.util.ProcessModels.TWO_EXTERNAL_TASK_PROCESS;
+import static org.operaton.bpm.engine.variable.Variables.SerializationDataFormats.JSON;
+import static org.operaton.bpm.engine.variable.type.ValueType.OBJECT;
+
+@ExtendWith(EngineRule.class)
+@ExtendWith(ClientRule.class)
 public class JsonSerializationIT {
 
   protected static final String VARIABLE_NAME_JSON = "jsonVariable";
@@ -73,10 +74,6 @@ public class JsonSerializationIT {
 
   protected ClientRule clientRule = new ClientRule();
   protected EngineRule engineRule = new EngineRule();
-  protected ExpectedException thrown = ExpectedException.none();
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(clientRule).around(thrown);
 
   protected ExternalTaskClient client;
 
@@ -86,7 +83,7 @@ public class JsonSerializationIT {
   protected RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler();
   protected RecordingInvocationHandler invocationHandler = new RecordingInvocationHandler();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     client = clientRule.client();
     processDefinition = engineRule.deploy(TWO_EXTERNAL_TASK_PROCESS).get(0);
@@ -232,13 +229,12 @@ public class JsonSerializationIT {
 
     engineRule.startProcessInstance(processDefinition.getId(), VARIABLE_NAME_JSON, objectValue);
 
-    // then
-    thrown.expect(ValueMapperException.class);
-
-    // when
-    client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
-      .handler(handler)
-      .open();
+    // when + then
+    assertThatThrownBy(() ->
+      client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
+        .handler(handler)
+        .open()
+    ).isInstanceOf(ValueMapperException.class);
 
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
@@ -256,13 +252,12 @@ public class JsonSerializationIT {
 
     engineRule.startProcessInstance(processDefinition.getId(), VARIABLE_NAME_JSON, objectValue);
 
-    // then
-    thrown.expect(ValueMapperException.class);
-
-    // when
-    client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
-      .handler(handler)
-      .open();
+    // when + then
+    assertThatThrownBy(() ->
+      client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
+        .handler(handler)
+        .open()
+    ).isInstanceOf(ValueMapperException.class);
 
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
@@ -337,13 +332,12 @@ public class JsonSerializationIT {
 
     engineRule.startProcessInstance(processDefinition.getId(), VARIABLE_NAME_JSON, serializedValue);
 
-    // then
-    thrown.expect(ValueMapperException.class);
-
-    // when
-    client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
-      .handler(handler)
-      .open();
+    // when + then
+    assertThatThrownBy(() ->
+      client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
+        .handler(handler)
+        .open()
+    ).isInstanceOf(ValueMapperException.class);
 
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
@@ -361,13 +355,12 @@ public class JsonSerializationIT {
 
     engineRule.startProcessInstance(processDefinition.getId(), VARIABLE_NAME_JSON, serializedValue);
 
-    // then
-    thrown.expect(ValueMapperException.class);
-
-    // when
-    client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
-      .handler(handler)
-      .open();
+    // when + then
+    assertThatThrownBy(() ->
+      client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
+        .handler(handler)
+        .open()
+    ).isInstanceOf(ValueMapperException.class);
 
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
@@ -774,16 +767,14 @@ public class JsonSerializationIT {
       .handler(handler)
       .open();
 
-    // then
-    thrown.expect(ValueMapperException.class);
-
-    // when
+    // when + then
     Map<String, Object> variables = Variables.createVariables();
     ObjectValue objectValue = Variables.objectValue(VARIABLE_VALUE_JSON_DESERIALIZED)
         .serializationDataFormat("not existing data format")
         .create();
     variables.put(VARIABLE_NAME_JSON, objectValue);
-    fooService.complete(fooTask, variables);
+    assertThatThrownBy(() -> fooService.complete(fooTask, variables))
+            .isInstanceOf(ValueMapperException.class);
   }
 
 }

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/JsonValueIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/JsonValueIT.java
@@ -16,19 +16,10 @@
  */
 package org.operaton.bpm.client.variable;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_BAR;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
-import static org.operaton.bpm.client.util.ProcessModels.PROCESS_KEY_2;
-import static org.operaton.bpm.client.util.ProcessModels.TWO_EXTERNAL_TASK_PROCESS;
-import static org.operaton.bpm.client.util.ProcessModels.USER_TASK_ID;
-import static org.operaton.bpm.client.util.ProcessModels.createProcessWithExclusiveGateway;
-import static org.operaton.bpm.client.variable.ClientValues.JSON;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.operaton.bpm.client.ExternalTaskClient;
 import org.operaton.bpm.client.dto.ProcessDefinitionDto;
 import org.operaton.bpm.client.dto.ProcessInstanceDto;
@@ -45,14 +36,23 @@ import org.operaton.bpm.client.variable.value.JsonValue;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.json.JSONException;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 import org.skyscreamer.jsonassert.JSONAssert;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_BAR;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
+import static org.operaton.bpm.client.util.ProcessModels.PROCESS_KEY_2;
+import static org.operaton.bpm.client.util.ProcessModels.TWO_EXTERNAL_TASK_PROCESS;
+import static org.operaton.bpm.client.util.ProcessModels.USER_TASK_ID;
+import static org.operaton.bpm.client.util.ProcessModels.createProcessWithExclusiveGateway;
+import static org.operaton.bpm.client.variable.ClientValues.JSON;
+
+@ExtendWith(EngineRule.class)
+@ExtendWith(ClientRule.class)
 public class JsonValueIT {
 
   protected static final String VARIABLE_NAME_JSON = "jsonVariable";
@@ -67,9 +67,6 @@ public class JsonValueIT {
   protected ClientRule clientRule = new ClientRule();
   protected EngineRule engineRule = new EngineRule();
 
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(clientRule);
-
   protected ExternalTaskClient client;
 
   protected ProcessDefinitionDto processDefinition;
@@ -78,7 +75,7 @@ public class JsonValueIT {
   protected RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler();
   protected RecordingInvocationHandler invocationHandler = new RecordingInvocationHandler();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     client = clientRule.client();
     processDefinition = engineRule.deploy(TWO_EXTERNAL_TASK_PROCESS).get(0);

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/LocalVariableIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/LocalVariableIT.java
@@ -19,6 +19,9 @@ package org.operaton.bpm.client.variable;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.operaton.bpm.client.ExternalTaskClient;
 import org.operaton.bpm.client.dto.ProcessDefinitionDto;
 import org.operaton.bpm.client.dto.ProcessInstanceDto;
@@ -29,11 +32,9 @@ import org.operaton.bpm.client.util.RecordingExternalTaskHandler;
 import org.operaton.bpm.engine.variable.value.StringValue;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
+@ExtendWith(EngineRule.class)
+@ExtendWith(ClientRule.class)
 public class LocalVariableIT {
 
   private static final String GLOBAL_VARIABLE_NAME = "globalVariable";
@@ -52,9 +53,6 @@ public class LocalVariableIT {
   protected ClientRule clientRule = new ClientRule();
   protected EngineRule engineRule = new EngineRule();
 
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(clientRule);
-
   protected ExternalTaskClient client;
 
   protected ProcessDefinitionDto processDefinition;
@@ -62,7 +60,7 @@ public class LocalVariableIT {
 
   protected RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     client = clientRule.client();
     processDefinition = engineRule.deploy(EXTERNAL_TASK_PROCESS).get(0);

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/PrimitiveVariableIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/PrimitiveVariableIT.java
@@ -16,6 +16,29 @@
  */
 package org.operaton.bpm.client.variable;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.operaton.bpm.client.ExternalTaskClient;
+import org.operaton.bpm.client.dto.ProcessDefinitionDto;
+import org.operaton.bpm.client.dto.ProcessInstanceDto;
+import org.operaton.bpm.client.rule.ClientRule;
+import org.operaton.bpm.client.rule.EngineRule;
+import org.operaton.bpm.client.task.ExternalTask;
+import org.operaton.bpm.client.task.ExternalTaskService;
+import org.operaton.bpm.client.util.RecordingExternalTaskHandler;
+import org.operaton.bpm.client.util.RecordingInvocationHandler;
+import org.operaton.bpm.client.util.RecordingInvocationHandler.RecordedInvocation;
+import org.operaton.bpm.engine.variable.VariableMap;
+import org.operaton.bpm.engine.variable.Variables;
+import org.operaton.bpm.engine.variable.value.TypedValue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_BAR;
 import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
@@ -30,30 +53,8 @@ import static org.operaton.bpm.engine.variable.type.ValueType.NULL;
 import static org.operaton.bpm.engine.variable.type.ValueType.SHORT;
 import static org.operaton.bpm.engine.variable.type.ValueType.STRING;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.operaton.bpm.client.ExternalTaskClient;
-import org.operaton.bpm.client.dto.ProcessDefinitionDto;
-import org.operaton.bpm.client.dto.ProcessInstanceDto;
-import org.operaton.bpm.client.rule.ClientRule;
-import org.operaton.bpm.client.rule.EngineRule;
-import org.operaton.bpm.client.task.ExternalTask;
-import org.operaton.bpm.client.task.ExternalTaskService;
-import org.operaton.bpm.client.util.RecordingExternalTaskHandler;
-import org.operaton.bpm.client.util.RecordingInvocationHandler;
-import org.operaton.bpm.client.util.RecordingInvocationHandler.RecordedInvocation;
-import org.operaton.bpm.engine.variable.VariableMap;
-import org.operaton.bpm.engine.variable.Variables;
-import org.operaton.bpm.engine.variable.value.TypedValue;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-
+@ExtendWith(EngineRule.class)
+@ExtendWith(ClientRule.class)
 public class PrimitiveVariableIT {
 
   protected static final String VARIABLE_NAME = "foo";
@@ -81,9 +82,6 @@ public class PrimitiveVariableIT {
   protected ClientRule clientRule = new ClientRule();
   protected EngineRule engineRule = new EngineRule();
 
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(clientRule);
-
   protected ExternalTaskClient client;
 
   protected ProcessDefinitionDto processDefinition;
@@ -92,7 +90,7 @@ public class PrimitiveVariableIT {
   protected RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler();
   protected RecordingInvocationHandler invocationHandler = new RecordingInvocationHandler();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     client = clientRule.client();
     processDefinition = engineRule.deploy(TWO_EXTERNAL_TASK_PROCESS).get(0);

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/XmlSerializationIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/XmlSerializationIT.java
@@ -16,17 +16,9 @@
  */
 package org.operaton.bpm.client.variable;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_BAR;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
-import static org.operaton.bpm.client.util.ProcessModels.TWO_EXTERNAL_TASK_PROCESS;
-import static org.operaton.bpm.engine.variable.Variables.SerializationDataFormats.XML;
-import static org.operaton.bpm.engine.variable.type.ValueType.OBJECT;
-
-import java.util.Arrays;
-import java.util.Map;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.operaton.bpm.client.ExternalTaskClient;
 import org.operaton.bpm.client.dto.ProcessDefinitionDto;
 import org.operaton.bpm.client.dto.ProcessInstanceDto;
@@ -43,12 +35,21 @@ import org.operaton.bpm.engine.variable.value.ObjectValue;
 import org.operaton.spin.Spin;
 import org.operaton.spin.SpinList;
 import org.operaton.spin.xml.SpinXmlElement;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.RuleChain;
 
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_BAR;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
+import static org.operaton.bpm.client.util.ProcessModels.TWO_EXTERNAL_TASK_PROCESS;
+import static org.operaton.bpm.engine.variable.Variables.SerializationDataFormats.XML;
+import static org.operaton.bpm.engine.variable.type.ValueType.OBJECT;
+
+@ExtendWith(EngineRule.class)
+@ExtendWith(ClientRule.class)
 public class XmlSerializationIT {
 
   protected static final String VARIABLE_NAME_XML = "xmlVariable";
@@ -82,10 +83,6 @@ public class XmlSerializationIT {
 
   protected ClientRule clientRule = new ClientRule();
   protected EngineRule engineRule = new EngineRule();
-  protected ExpectedException thrown = ExpectedException.none();
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(clientRule).around(thrown);
 
   protected ExternalTaskClient client;
 
@@ -95,7 +92,7 @@ public class XmlSerializationIT {
   protected RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler();
   protected RecordingInvocationHandler invocationHandler = new RecordingInvocationHandler();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     client = clientRule.client();
     processDefinition = engineRule.deploy(TWO_EXTERNAL_TASK_PROCESS).get(0);
@@ -272,13 +269,12 @@ public class XmlSerializationIT {
 
     engineRule.startProcessInstance(processDefinition.getId(), VARIABLE_NAME_XML, objectValue);
 
-    // then
-    thrown.expect(ValueMapperException.class);
-
-    // when
+    // when + then
+    assertThatThrownBy(() ->
     client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
       .handler(handler)
-      .open();
+      .open()
+    ).isInstanceOf(ValueMapperException.class);
 
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
@@ -296,13 +292,12 @@ public class XmlSerializationIT {
 
     engineRule.startProcessInstance(processDefinition.getId(), VARIABLE_NAME_XML, objectValue);
 
-    // then
-    thrown.expect(ValueMapperException.class);
-
-    // when
-    client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
-      .handler(handler)
-      .open();
+    // when + then
+    assertThatThrownBy(() ->
+      client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
+        .handler(handler)
+        .open()
+    ).isInstanceOf(ValueMapperException.class);
 
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
@@ -381,13 +376,12 @@ public class XmlSerializationIT {
 
     engineRule.startProcessInstance(processDefinition.getId(), VARIABLE_NAME_XML, serializedValue);
 
-    // then
-    thrown.expect(ValueMapperException.class);
-
-    // when
-    client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
-      .handler(handler)
-      .open();
+    // when + then
+    assertThatThrownBy(() ->
+      client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
+        .handler(handler)
+        .open()
+    ).isInstanceOf(ValueMapperException.class);
 
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
@@ -409,13 +403,12 @@ public class XmlSerializationIT {
 
     engineRule.startProcessInstance(processDefinition.getId(), VARIABLE_NAME_XML, serializedValue);
 
-    // then
-    thrown.expect(ValueMapperException.class);
-
-    // when
-    client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
-      .handler(handler)
-      .open();
+    // when + then
+    assertThatThrownBy(() ->
+      client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
+        .handler(handler)
+        .open()
+    ).isInstanceOf(ValueMapperException.class);
 
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/XmlValueIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/XmlValueIT.java
@@ -16,19 +16,9 @@
  */
 package org.operaton.bpm.client.variable;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_BAR;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
-import static org.operaton.bpm.client.util.ProcessModels.PROCESS_KEY_2;
-import static org.operaton.bpm.client.util.ProcessModels.TWO_EXTERNAL_TASK_PROCESS;
-import static org.operaton.bpm.client.util.ProcessModels.USER_TASK_ID;
-import static org.operaton.bpm.client.util.ProcessModels.createProcessWithExclusiveGateway;
-import static org.operaton.bpm.client.variable.ClientValues.XML;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.operaton.bpm.client.ExternalTaskClient;
 import org.operaton.bpm.client.dto.ProcessDefinitionDto;
 import org.operaton.bpm.client.dto.ProcessInstanceDto;
@@ -45,12 +35,22 @@ import org.operaton.bpm.client.variable.value.XmlValue;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_BAR;
+import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
+import static org.operaton.bpm.client.util.ProcessModels.PROCESS_KEY_2;
+import static org.operaton.bpm.client.util.ProcessModels.TWO_EXTERNAL_TASK_PROCESS;
+import static org.operaton.bpm.client.util.ProcessModels.USER_TASK_ID;
+import static org.operaton.bpm.client.util.ProcessModels.createProcessWithExclusiveGateway;
+import static org.operaton.bpm.client.variable.ClientValues.XML;
+
+@ExtendWith(EngineRule.class)
+@ExtendWith(ClientRule.class)
 public class XmlValueIT {
 
   protected static final String VARIABLE_NAME_XML = "xmlVariable";
@@ -65,9 +65,6 @@ public class XmlValueIT {
   protected ClientRule clientRule = new ClientRule();
   protected EngineRule engineRule = new EngineRule();
 
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(clientRule);
-
   protected ExternalTaskClient client;
 
   protected ProcessDefinitionDto processDefinition;
@@ -76,7 +73,7 @@ public class XmlValueIT {
   protected RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler();
   protected RecordingInvocationHandler invocationHandler = new RecordingInvocationHandler();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     client = clientRule.client();
     processDefinition = engineRule.deploy(TWO_EXTERNAL_TASK_PROCESS).get(0);

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/pa/PaExceptionIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/pa/PaExceptionIT.java
@@ -16,6 +16,10 @@
  */
 package org.operaton.bpm.client.variable.pa;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.operaton.bpm.client.ExternalTaskClient;
 import org.operaton.bpm.client.dto.HistoricProcessInstanceDto;
 import org.operaton.bpm.client.dto.ProcessInstanceDto;
@@ -31,11 +35,6 @@ import org.operaton.bpm.client.task.impl.ExternalTaskImpl;
 import org.operaton.bpm.client.util.RecordingExternalTaskHandler;
 import org.operaton.bpm.client.util.RecordingInvocationHandler;
 import org.operaton.bpm.client.util.RecordingInvocationHandler.RecordedInvocation;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,6 +47,8 @@ import static org.operaton.bpm.client.util.PropertyUtil.CAMUNDA_ENGINE_REST;
 import static org.operaton.bpm.client.util.PropertyUtil.DEFAULT_PROPERTIES_PATH;
 import static org.operaton.bpm.client.util.PropertyUtil.loadProperties;
 
+@ExtendWith(EngineRule.class)
+@ExtendWith(ClientRule.class)
 public class PaExceptionIT {
 
   protected static final String ENGINE_NAME = "/engine/another-engine";
@@ -69,9 +70,6 @@ public class PaExceptionIT {
     return properties;
   });
 
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(clientRule);
-
   protected ExternalTaskClient client;
 
   protected List<ProcessInstanceDto> processInstances = new ArrayList<>();
@@ -79,7 +77,7 @@ public class PaExceptionIT {
   protected RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler();
   protected RecordingInvocationHandler invocationHandler = new RecordingInvocationHandler();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     client = clientRule.client();
 
@@ -90,7 +88,7 @@ public class PaExceptionIT {
     invocationHandler.clear();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     processInstances.forEach(processInstance -> {
       String processInstanceId = processInstance.getId();

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/pa/PaSerializationIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/pa/PaSerializationIT.java
@@ -16,6 +16,10 @@
  */
 package org.operaton.bpm.client.variable.pa;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.operaton.bpm.client.ExternalTaskClient;
 import org.operaton.bpm.client.dto.HistoricProcessInstanceDto;
 import org.operaton.bpm.client.dto.ProcessInstanceDto;
@@ -29,11 +33,6 @@ import org.operaton.bpm.client.util.RecordingInvocationHandler.RecordedInvocatio
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
 import org.operaton.qa.Bean;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 import java.util.Collections;
 import java.util.Properties;
@@ -47,6 +46,8 @@ import static org.operaton.bpm.client.util.PropertyUtil.loadProperties;
 /**
  * @author Tassilo Weidner
  */
+@ExtendWith(EngineRule.class)
+@ExtendWith(ClientRule.class)
 public class PaSerializationIT {
 
   protected static final String ENGINE_NAME = "/engine/another-engine";
@@ -76,9 +77,6 @@ public class PaSerializationIT {
     return properties;
   });
 
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(clientRule);
-
   protected ExternalTaskClient client;
 
   protected ProcessInstanceDto processInstance;
@@ -86,7 +84,7 @@ public class PaSerializationIT {
   protected RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler();
   protected RecordingInvocationHandler invocationHandler = new RecordingInvocationHandler();
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     client = clientRule.client();
 
@@ -96,7 +94,7 @@ public class PaSerializationIT {
     invocationHandler.clear();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     HistoricProcessInstanceDto historicProcessInstance = engineRule.getHistoricProcessInstanceById(processInstance.getId());
     if (historicProcessInstance.getEndTime() == null) {

--- a/clients/java/client/src/test/java/org/operaton/bpm/client/backoff/ExponentialBackoffStrategyTest.java
+++ b/clients/java/client/src/test/java/org/operaton/bpm/client/backoff/ExponentialBackoffStrategyTest.java
@@ -17,26 +17,26 @@
 package org.operaton.bpm.client.backoff;
 
 import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.client.task.impl.ExternalTaskImpl;
-import org.junit.Before;
-import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Nikola Koevski
  */
-public class ExponentialBackoffStrategyTest {
+class ExponentialBackoffStrategyTest {
 
   protected ExponentialBackoffStrategy backoffStrategy;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     backoffStrategy = new ExponentialBackoffStrategy();
   }
 
   @Test
-  public void shouldAdvanceBackoffStrategy() {
+  void shouldAdvanceBackoffStrategy() {
     // given
     long initialWaitingTime = backoffStrategy.calculateBackoffTime();
     assertThat(initialWaitingTime).isEqualTo(0L);
@@ -54,7 +54,7 @@ public class ExponentialBackoffStrategyTest {
   }
 
   @Test
-  public void shouldResetBackoffStrategy() {
+  void shouldResetBackoffStrategy() {
     // given
     backoffStrategy.reconfigure(Lists.emptyList());
     long waitingTime1 = backoffStrategy.calculateBackoffTime();
@@ -70,7 +70,7 @@ public class ExponentialBackoffStrategyTest {
   }
 
   @Test
-  public void shouldCapWaitingTime() {
+  void shouldCapWaitingTime() {
     // given
     long waitingTime = backoffStrategy.calculateBackoffTime();
     assertThat(waitingTime).isEqualTo(0L);

--- a/clients/java/client/src/test/java/org/operaton/bpm/client/backoff/ExponentialErrorBackoffStrategyTest.java
+++ b/clients/java/client/src/test/java/org/operaton/bpm/client/backoff/ExponentialErrorBackoffStrategyTest.java
@@ -17,27 +17,27 @@
 package org.operaton.bpm.client.backoff;
 
 import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.client.exception.ExternalTaskClientException;
 import org.operaton.bpm.client.task.ExternalTask;
 import org.operaton.bpm.client.task.impl.ExternalTaskImpl;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ExponentialErrorBackoffStrategyTest {
+class ExponentialErrorBackoffStrategyTest {
 
   protected ExponentialErrorBackoffStrategy backoffStrategy;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     backoffStrategy = new ExponentialErrorBackoffStrategy();
   }
 
   @Test
-  public void shouldAdvanceBackoffStrategy() {
+  void shouldAdvanceBackoffStrategy() {
     // given
     long initialWaitingTime = backoffStrategy.calculateBackoffTime();
     assertThat(initialWaitingTime).isEqualTo(0L);
@@ -57,7 +57,7 @@ public class ExponentialErrorBackoffStrategyTest {
   }
 
   @Test
-  public void shouldResetBackoffStrategy() {
+  void shouldResetBackoffStrategy() {
     // given
     List<ExternalTask> tasks = Lists.newArrayList(new ExternalTaskImpl());
     ExternalTaskClientException error = new ExternalTaskClientException();
@@ -75,7 +75,7 @@ public class ExponentialErrorBackoffStrategyTest {
   }
 
   @Test
-  public void shouldCapWaitingTime() {
+  void shouldCapWaitingTime() {
     // given
     long waitingTime = backoffStrategy.calculateBackoffTime();
     assertThat(waitingTime).isEqualTo(0L);
@@ -94,7 +94,7 @@ public class ExponentialErrorBackoffStrategyTest {
   }
 
   @Test
-  public void shouldCapWaitingTime2() {
+  void shouldCapWaitingTime2() {
     // given
     long waitingTime = backoffStrategy.calculateBackoffTime();
     assertThat(waitingTime).isEqualTo(0L);

--- a/clients/java/client/src/test/java/org/operaton/bpm/client/impl/ExternalTaskClientBuilderImplTest.java
+++ b/clients/java/client/src/test/java/org/operaton/bpm/client/impl/ExternalTaskClientBuilderImplTest.java
@@ -19,19 +19,19 @@ package org.operaton.bpm.client.impl;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.util.Timeout;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.client.ExternalTaskClient;
 import org.operaton.bpm.engine.impl.util.ReflectUtil;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-public class ExternalTaskClientBuilderImplTest {
+class ExternalTaskClientBuilderImplTest {
 
   @Test
-  public void testCustomizeHttpClientExposesInternalHttpClientBuilder() {
+  void customizeHttpClientExposesInternalHttpClientBuilder() {
     // given
     var clientBuilder = new ExternalTaskClientBuilderImpl();
     var requestConfigArgumentCaptor = ArgumentCaptor.forClass(RequestConfig.class);

--- a/clients/java/client/src/test/java/org/operaton/bpm/client/task/ExternalTaskImplTest.java
+++ b/clients/java/client/src/test/java/org/operaton/bpm/client/task/ExternalTaskImplTest.java
@@ -16,13 +16,14 @@
  */
 package org.operaton.bpm.client.task;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.client.task.impl.ExternalTaskImpl;
 import org.operaton.bpm.client.variable.impl.DefaultValueMappers;
 import org.operaton.bpm.client.variable.impl.TypedValueField;
@@ -30,16 +31,15 @@ import org.operaton.bpm.client.variable.impl.ValueMappers;
 import org.operaton.bpm.client.variable.impl.VariableValue;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.type.ValueType;
-import org.junit.Test;
 
 /**
  * @author Tobias Metzke
  *
  */
-public class ExternalTaskImplTest {
+class ExternalTaskImplTest {
 
   @Test
-  public void shouldDisplayAttributesEmptyInToString() {
+  void shouldDisplayAttributesEmptyInToString() {
     // no attributes set, only priority initialized as 0
     ExternalTaskImpl task = new ExternalTaskImpl();
     assertEquals("ExternalTaskImpl [activityId=null, "
@@ -65,7 +65,7 @@ public class ExternalTaskImplTest {
   }
 
   @Test
-  public void shouldDisplayAttributesFilledInToString() {
+  void shouldDisplayAttributesFilledInToString() {
     // with basic attributes set, attributes should be displayed and separated by comma
     ExternalTaskImpl task = new ExternalTaskImpl();
     
@@ -111,10 +111,10 @@ public class ExternalTaskImplTest {
         + "workerId=wi]", 
         task.toString());
   }
-  
+
   @SuppressWarnings("rawtypes")
   @Test
-  public void shouldDisplayAttributesIncludingMapsInToString() {
+  void shouldDisplayAttributesIncludingMapsInToString() {
     // variables map entries should be displayed as well
     ExternalTaskImpl task = new ExternalTaskImpl();
 

--- a/clients/java/client/src/test/java/org/operaton/bpm/client/variable/DateValueMapperTest.java
+++ b/clients/java/client/src/test/java/org/operaton/bpm/client/variable/DateValueMapperTest.java
@@ -15,15 +15,14 @@
  * limitations under the License.
  */
 package org.operaton.bpm.client.variable;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.client.variable.impl.TypedValueField;
 import org.operaton.bpm.client.variable.impl.mapper.DateValueMapper;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.impl.type.PrimitiveValueTypeImpl;
 import org.operaton.bpm.engine.variable.impl.value.UntypedValueImpl;
 import org.operaton.bpm.engine.variable.value.DateValue;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.Date;
 import java.util.Calendar;
@@ -32,7 +31,7 @@ import java.text.SimpleDateFormat;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DateValueMapperTest {
+class DateValueMapperTest {
 
   protected final static String DATE_FORMAT = "dd.MM.yyyy - HH:mm:ss.SSSZ";
   protected final Date VARIABLE_VALUE_DATE = new GregorianCalendar(2018, Calendar.JANUARY, 1, 8, 0, 0).getTime();
@@ -40,13 +39,13 @@ public class DateValueMapperTest {
 
   protected DateValueMapper dateValueMapper;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     dateValueMapper = new DateValueMapper(DATE_FORMAT);
   }
 
   @Test
-  public void shouldConvertToTypedValue() {
+  void shouldConvertToTypedValue() {
     // given
     UntypedValueImpl untypedValue = (UntypedValueImpl) Variables.untypedValue(VARIABLE_VALUE_DATE);
 
@@ -59,7 +58,7 @@ public class DateValueMapperTest {
   }
 
   @Test
-  public void shouldReadValue() {
+  void shouldReadValue() {
     // given
     TypedValueField typedValueField = new TypedValueField();
     typedValueField.setValue(VARIABLE_VALUE_DATE_SERIALIZED);
@@ -74,7 +73,7 @@ public class DateValueMapperTest {
   }
 
   @Test
-  public void shouldReadValue_Null() {
+  void shouldReadValue_Null() {
     // given
     TypedValueField typedValueField = new TypedValueField();
     typedValueField.setValue(null);
@@ -89,7 +88,7 @@ public class DateValueMapperTest {
   }
 
   @Test
-  public void shouldWriteValue() {
+  void shouldWriteValue() {
     // given
     DateValue dateValue = Variables.dateValue(VARIABLE_VALUE_DATE);
     TypedValueField typedValueField = new TypedValueField();

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -5,6 +5,7 @@
   <name>Operaton - Java External Task Client - Root</name>
 
   <artifactId>operaton-external-task-client-root</artifactId>
+  <inceptionYear>2018</inceptionYear>
 
   <packaging>pom</packaging>
 
@@ -29,8 +30,22 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
+        <version>${project.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+    </dependency>
+  </dependencies>
 
   <scm>
     <url>http://github.com/operaton/operaton-external-task-client-java</url>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -5,7 +5,6 @@
   <name>Operaton - Java External Task Client - Root</name>
 
   <artifactId>operaton-external-task-client-root</artifactId>
-  <inceptionYear>2018</inceptionYear>
 
   <packaging>pom</packaging>
 


### PR DESCRIPTION
This PR migrates the code from `clients` to JUnit 5.

The initial migration has been performed with Open Rewrite recipe `org.openrewrite.java.testing.junit5.JUnit5BestPractices`. Remaining gaps have been adopted manually.