### PR TITLE
Prevent shallow clone in Git

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Prevent Shallow Clone to satisfy Sonarqube
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/db85e54c-076e-4722-9c56-16a577dbcccb)

The SonarQube analysis is incomplete when using shallow clone