### PR TITLE
[#78] Perform code coverage with JaCoCo on test execution 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         path: ${{ github.workspace }}/**/target/surefire-reports/**
         retention-days: 30
     - name: Sonarqube Analysis
-      if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request' && github.repository_owner == 'operaton'
+      if: env.SONAR_TOKEN && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/distro/wildfly/subsystem/pom.xml
+++ b/distro/wildfly/subsystem/pom.xml
@@ -93,7 +93,7 @@
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <enableAssertions>true</enableAssertions>
-          <argLine>-Xmx512m</argLine>
+          <argLine>${jacoco.argLine} -Xmx512m</argLine>
           <systemProperties>
             <property>
               <name>jboss.home</name>

--- a/distro/wildfly26/subsystem/pom.xml
+++ b/distro/wildfly26/subsystem/pom.xml
@@ -91,7 +91,7 @@
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <enableAssertions>true</enableAssertions>
-          <argLine>-Xmx512m</argLine>
+          <argLine>${jacoco.argLine} -Xmx512m</argLine>
           <systemProperties>
             <property>
               <name>jboss.home</name>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -294,7 +294,7 @@
           <systemPropertyVariables>
             <restEasyVersion>${version.resteasy}</restEasyVersion>
           </systemPropertyVariables>
-          <argLine>-Xmx2g</argLine>
+          <argLine>${jacoco.argLine} -Xmx2g</argLine>
         </configuration>
       </plugin>
 
@@ -390,7 +390,7 @@
                 </goals>
                 <configuration>
                   <!-- Ensures that endpoints work with other encodings than UTF-8 (cf. CAM-6983) -->
-                  <argLine>-Dfile.encoding=ISO-8859-1</argLine>
+                  <argLine>${jacoco.argLine} -Dfile.encoding=ISO-8859-1</argLine>
                   <includes>
                     <include>**/ProcessDefinitionRestServiceInteractionTest.java</include>
                     <include>**/TaskRestServiceInteractionTest.java</include>
@@ -488,7 +488,7 @@
                 </goals>
                 <configuration>
                   <!-- Ensures that endpoints work with other encodings than UTF-8 (cf. CAM-6983) -->
-                  <argLine>-Dfile.encoding=ISO-8859-1</argLine>
+                  <argLine>${jacoco.argLine} -Dfile.encoding=ISO-8859-1</argLine>
                   <includes>
                     <include>**/ProcessDefinitionRestServiceInteractionTest.java</include>
                     <include>**/TaskRestServiceInteractionTest.java</include>
@@ -591,7 +591,7 @@
                 </goals>
                 <configuration>
                   <!-- Ensures that endpoints work with other encodings than UTF-8 (cf. CAM-6983) -->
-                  <argLine>-Dfile.encoding=ISO-8859-1</argLine>
+                  <argLine>${jacoco.argLine} -Dfile.encoding=ISO-8859-1</argLine>
                   <includes>
                     <include>**/ProcessDefinitionRestServiceInteractionTest.java</include>
                     <include>**/TaskRestServiceInteractionTest.java</include>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -827,7 +827,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>-Xmx968m</argLine>
+              <argLine>${jacoco.argLine} -Xmx968m</argLine>
             </configuration>
           </plugin>
         </plugins>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -141,7 +141,8 @@
             <systemPropertyVariables>
               <myWorkingDir>${project.build.directory}</myWorkingDir>
             </systemPropertyVariables>
-            <argLine>-Xmx968m -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${project.build.directory}/heap_dump.hprof</argLine>
+            <!-- when configuring argLine in submodules, don't forget to prepend ${jacoco.argLine} -->
+            <argLine>${jacoco.argLine} -Xmx968m -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${project.build.directory}/heap_dump.hprof</argLine>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
           </configuration>
         </plugin>
@@ -149,7 +150,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <configuration>
-            <argLine>-Xmx968m</argLine>
+            <argLine>${jacoco.argLine} -Xmx968m</argLine>
             <runOrder>hourly</runOrder>
           </configuration>
           <executions>
@@ -263,9 +264,33 @@
             <wait>750</wait>
           </configuration>
         </plugin>
-
       </plugins>
     </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <propertyName>jacoco.argLine</propertyName>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>
@@ -303,6 +328,7 @@
   </organization>
 
   <url>http://www.operaton.org</url>
+
 </project>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,11 @@
           <version>1.0.0</version>
         </plugin>
         <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.12</version>
+        </plugin>
+        <plugin>
           <groupId>org.jboss.shrinkwrap.resolver</groupId>
           <artifactId>shrinkwrap-resolver-maven-plugin</artifactId>
           <version>${version.shrinkwrap.resolvers}</version>
@@ -534,7 +539,6 @@
         </plugins>
       </build>
     </profile>
-
   </profiles>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,19 @@
           <excludedScopes>test</excludedScopes>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>report</id>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
     <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <sonar.organization>operaton</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+    <C>**/target/jacoco/jacoco.xml</C>
   </properties>
 
   <build>
@@ -399,8 +400,14 @@
       <modules>
         <module>qa</module>
 
+        <module>model-api</module>
+        <module>test-utils/archunit</module>
+        <module>test-utils/testcontainers</module>
+        <module>commons</module>
+        <module>juel</module>
         <module>engine</module>
         <module>engine-cdi</module>
+        <module>engine-dmn</module>
         <module>engine-spring</module>
         <module>engine-rest</module>
 

--- a/qa/large-data-tests/pom.xml
+++ b/qa/large-data-tests/pom.xml
@@ -119,7 +119,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <skipTests>${skipTests}</skipTests>
-              <argLine>-Xmx2048m</argLine>
+              <argLine>${jacoco.argLine} -Xmx2048m</argLine>
             </configuration>
           </plugin>
         </plugins>

--- a/qa/performance-tests-engine/pom.xml
+++ b/qa/performance-tests-engine/pom.xml
@@ -119,7 +119,7 @@
             <configuration>
               <runOrder>alphabetical</runOrder>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>
-              <argLine>-Xmx1024m</argLine>
+              <argLine>${jacoco.argLine} -Xmx1024m</argLine>
               <includes>
                  <include>%regex[.*(${test.includes}).*Test.*.class]</include>
               </includes>
@@ -189,7 +189,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>
-              <argLine>-Xmx1024m</argLine>
+              <argLine>${jacoco.argLine} -Xmx1024m</argLine>
               <includes>
                  <include>%regex[.*(${test.includes}).*Test.*.class]</include>
               </includes>
@@ -257,7 +257,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>
-              <argLine>-Xmx1024m</argLine>
+              <argLine>${jacoco.argLine} -Xmx1024m</argLine>
               <includes>
                  <include>%regex[.*(${test.includes}).*Test.*.class]</include>
               </includes>
@@ -374,7 +374,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>
-              <argLine>-Xmx1024m</argLine>
+              <argLine>${jacoco.argLine} -Xmx1024m</argLine>
               <includes>
                  <include>%regex[.*(${test.includes}).*Test.*.class]</include>
               </includes>
@@ -440,7 +440,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>
-              <argLine>-Xmx1024m</argLine>
+              <argLine>${jacoco.argLine} -Xmx1024m</argLine>
               <includes>
                  <include>%regex[.*(${test.includes}).*Test.*.class]</include>
               </includes>

--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -413,7 +413,7 @@
               </excludes>
               <testFailureIgnore>false</testFailureIgnore>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>
-              <argLine>-Xmx2g -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${project.build.directory}/heap_dump.hprof</argLine>
+              <argLine>${jacoco.argLine} -Xmx2g -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${project.build.directory}/heap_dump.hprof</argLine>
             </configuration>
           </plugin>
 

--- a/quarkus-extension/engine/pom.xml
+++ b/quarkus-extension/engine/pom.xml
@@ -29,7 +29,7 @@
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <trimStackTrace>false</trimStackTrace>
-          <argLine>-Xmx2048m</argLine>
+          <argLine>${jacoco.argLine} -Xmx2048m</argLine>
         </configuration>
       </plugin>
     </plugins>

--- a/spin/core/pom.xml
+++ b/spin/core/pom.xml
@@ -102,7 +102,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>-XX:PermSize=128m</argLine>
+              <argLine>${jacoco.argLine} -XX:PermSize=128m</argLine>
               <excludes>
                 <exclude>**/javascript/**</exclude>
               </excludes>
@@ -123,7 +123,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>-XX:PermSize=128m</argLine>
+              <argLine>${jacoco.argLine} -XX:PermSize=128m</argLine>
               <excludes>
                 <exclude>**/DataFormatLoadingTest.java</exclude>
               </excludes>
@@ -163,9 +163,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>
-                -XX:MetaspaceSize=128m
-              </argLine>
+              <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
               <excludes combine.children="append">
                 <exclude>**/*NashornTest.java</exclude>
               </excludes>

--- a/spin/dataformat-json-jackson/pom.xml
+++ b/spin/dataformat-json-jackson/pom.xml
@@ -133,7 +133,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>-XX:PermSize=128m -XX:MaxPermSize=256m</argLine>
+              <argLine>${jacoco.argLine} -XX:PermSize=128m -XX:MaxPermSize=256m</argLine>
               <excludes>
                 <exclude>**/javascript/**</exclude>
               </excludes>
@@ -174,9 +174,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>
-                -XX:MetaspaceSize=128m
-              </argLine>
+              <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
               <excludes combine.children="append">
                 <exclude>**/nashorn/**</exclude>
               </excludes>

--- a/spin/dataformat-xml-dom-jakarta/pom.xml
+++ b/spin/dataformat-xml-dom-jakarta/pom.xml
@@ -144,9 +144,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>
-                -XX:MetaspaceSize=128m
-              </argLine>
+              <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
               <excludes combine.children="append">
                 <exclude>**/nashorn/**</exclude>
               </excludes>

--- a/spin/dataformat-xml-dom/pom.xml
+++ b/spin/dataformat-xml-dom/pom.xml
@@ -126,7 +126,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>-XX:PermSize=128m -Duser.timezone=GMT+02:00</argLine>
+              <argLine>${jacoco.argLine} -XX:PermSize=128m -Duser.timezone=GMT+02:00</argLine>
               <excludes>
                 <exclude>**/javascript/**</exclude>
               </excludes>
@@ -167,9 +167,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <argLine>
-                -XX:MetaspaceSize=128m
-              </argLine>
+              <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
               <excludes combine.children="append">
                 <exclude>**/nashorn/**</exclude>
               </excludes>

--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -217,7 +217,7 @@
             <systemPropertyVariables>
               <myWorkingDir>${project.build.directory}</myWorkingDir>
             </systemPropertyVariables>
-            <argLine>-XX:MaxMetaspaceSize=128m</argLine>
+            <argLine>${jacoco.argLine} -XX:MaxMetaspaceSize=128m</argLine>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
Adds configuration of the jacoco-maven-plugin
- plugin version management in root pom.xml
- plugin configuration in parent pom.xml
Configure `argLine` properties of `maven-surefire-configurations` to prepend jacoco args