### PR TITLE
fix(identity/ldap): adjust ldap error handling (#4536)

### DIFF
--- a/engine-plugins/identity-ldap/src/main/java/org/operaton/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
+++ b/engine-plugins/identity-ldap/src/main/java/org/operaton/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
@@ -412,20 +412,21 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
           E entity = transformEntity.apply(result);
 
           String id = entity.getId();
-          if (id != null && resultCountPredicate.test(id)) {
-            if (resultCount >= firstResult || ignorePagination) {
-              if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
-                resultLogger.append(entity);
-                resultLogger.append(" based on ");
-                resultLogger.append(result);
-                resultLogger.append(", ");
-              }
-              entities.add((T) entity);
-            }
-            resultCount++;
-          } else {
+          if (id == null) {
             LdapPluginLogger.INSTANCE.invalidLdapEntityReturned(entity, result);
-
+          } else {
+            if (resultCountPredicate.test(id)) {
+              if (resultCount >= firstResult || ignorePagination) {
+                if (LdapPluginLogger.INSTANCE.isDebugEnabled()) {
+                  resultLogger.append(entity);
+                  resultLogger.append(" based on ");
+                  resultLogger.append(result);
+                  resultLogger.append(", ");
+                }
+                entities.add((T) entity);
+              }
+              resultCount++;
+            }
           }
         }
       }


### PR DESCRIPTION
* thrown an error only if id is null, do nothing if an authorization is missing

https://github.com/camunda/camunda-bpm-platform/issues/4293

Backported commit f1c8c6065c from the camunda-bpm-platform repository.
Original author: yanavasileva <yanavasileva@users.noreply.github.com>