### PR TITLE
remove(tests): remove telemetry configuration property  (#4544)

### DIFF
--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -410,6 +410,9 @@
 
                 <exclude>**/ManagementServiceTableCountTest.java</exclude>
 
+                <!-- The test is not relevant in `old-engine` setup since the feature has been removed -->
+                <!-- See https://github.com/camunda/camunda-bpm-platform/pull/4544#discussion_r1728748399 -->
+                <exclude>**/ConcurrentTelemetryConfigurationTest.java</exclude>
               </excludes>
               <testFailureIgnore>false</testFailureIgnore>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>

--- a/quarkus-extension/README.md
+++ b/quarkus-extension/README.md
@@ -29,7 +29,6 @@ can look like the following:
 quarkus.operaton.cmmn-enabled=false
 quarkus.operaton.dmn-enabled=false
 quarkus.operaton.history=none
-quarkus.operaton.initialize-telemetry=false
 
 # job executor configuration
 quarkus.operaton.job-executor.thread-pool.max-pool-size=12

--- a/quarkus-extension/engine/deployment/src/test/resources/org/operaton/bpm/quarkus/engine/test/config/mixed-application.properties
+++ b/quarkus-extension/engine/deployment/src/test/resources/org/operaton/bpm/quarkus/engine/test/config/mixed-application.properties
@@ -2,7 +2,6 @@ quarkus.operaton.cmmn-enabled=false
 quarkus.operaton.dmn-enabled=false
 quarkus.operaton.history=none
 quarkus.operaton.enforce-history-time-to-live=false
-quarkus.operaton.initialize-telemetry=false
 
 quarkus.operaton.job-executor.thread-pool.max-pool-size=12
 quarkus.operaton.job-executor.thread-pool.queue-size=5

--- a/quarkus-extension/engine/deployment/src/test/resources/org/operaton/bpm/quarkus/engine/test/config/process-engine-config-application.properties
+++ b/quarkus-extension/engine/deployment/src/test/resources/org/operaton/bpm/quarkus/engine/test/config/process-engine-config-application.properties
@@ -2,6 +2,5 @@ quarkus.operaton.cmmn-enabled=false
 quarkus.operaton.dmn-enabled=false
 quarkus.operaton.history=none
 quarkus.operaton.enforce-history-time-to-live=false
-quarkus.operaton.initialize-telemetry=false
 
 quarkus.datasource.jdbc.url=jdbc:h2:mem:operaton;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE


### PR DESCRIPTION
* remove telemetry configuration property from `quarkus-extension` as it no longer exist
* exclude telemetry test in `old-engine` setup as telemetry feature is removed in newer versions; during rolling update users run old engine and data with new schema, so the test is not relevant for the scenario

https://github.com/camunda/camunda-bpm-platform/issues/4483

Backported commit abf8f55857 from the camunda-bpm-platform repository.
Original author: yanavasileva <yanavasileva@users.noreply.github.com>