### PR TITLE
[#105] Extend ProcessEngineExtension to enable injection of engine services

### DIFF
--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionServiceInjectionTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionServiceInjectionTest.java
@@ -1,0 +1,52 @@
+package org.operaton.bpm.engine.test.junit5;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.operaton.bpm.engine.*;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(ProcessEngineExtension.class)
+class ProcessEngineExtensionServiceInjectionTest {
+    ProcessEngine processEngine;
+    // this is to check that injection will set _all_ fields with the target type
+    ProcessEngine processEngine2;
+    ProcessEngineConfiguration processEngineConfiguration;
+    ProcessEngineConfigurationImpl processEngineConfigurationImpl;
+    RepositoryService repositoryService;
+    RuntimeService runtimeService;
+    TaskService taskService;
+    HistoryService historyService;
+    IdentityService identityService;
+    ManagementService managementService;
+    FormService formService;
+    FilterService filterService;
+    AuthorizationService authorizationService;
+    CaseService caseService;
+    ExternalTaskService externalTaskService;
+    DecisionService decisionService;
+
+    @Test
+    void extensionInjectsServiceInstances () {
+        assertThat(processEngine).isNotNull();
+        assertThat(processEngine2).isNotNull();
+        assertThat(processEngine).isSameAs(processEngine2);
+
+        assertThat(processEngineConfiguration).isNotNull();
+        assertThat(processEngineConfigurationImpl).isNotNull();
+
+        assertThat(repositoryService).isNotNull();
+        assertThat(runtimeService).isNotNull();
+        assertThat(taskService).isNotNull();
+        assertThat(historyService).isNotNull();
+        assertThat(identityService).isNotNull();
+        assertThat(managementService).isNotNull();
+        assertThat(formService).isNotNull();
+        assertThat(filterService).isNotNull();
+        assertThat(authorizationService).isNotNull();
+        assertThat(caseService).isNotNull();
+        assertThat(externalTaskService).isNotNull();
+        assertThat(decisionService).isNotNull();
+    }
+}


### PR DESCRIPTION
This extends ProcessEngineExtension to be able to inject engine services into fields of the test class. By doing this, tests can be cleaner and just declare a fields of engine services that the test is using.

Fixes #105 