### PR TITLE
chore(distro/tomcat/assembly): Add Juel to distro/lib Folder

### DIFF
--- a/distro/tomcat/assembly/assembly.xml
+++ b/distro/tomcat/assembly/assembly.xml
@@ -106,6 +106,7 @@
         <include>org.operaton.bpm.model:*:jar</include>
 
         <include>org.operaton.bpm.dmn:*:jar</include>
+        <include>org.operaton.bpm.juel:*:jar</include>
 
         <include>org.camunda.feel:*:jar</include>
 


### PR DESCRIPTION
Context: This fix adds juel to distro/lib folder.
Fixes: NoClassDefFound errors that users who copy distro/lib dependencies experience when starting with a Manual Installation of Tomcat 10

Related-to: https://github.com/camunda/camunda-bpm-platform/issues/4573

Backported commit 2fa8c6324c from the camunda-bpm-platform repository.
Original author: psavidis <69160690+psavidis@users.noreply.github.com>