### PR TITLE
chore(docs): Fix sortOrder case in fetch and lock rest api example

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/fetchAndLock/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/external-task/fetchAndLock/post.ftl
@@ -70,7 +70,7 @@
                          "sorting": [
                              {
                                 "sortBy":"createTime",
-                                "sortOrder":"ASC"
+                                "sortOrder":"asc"
                              }
                          ]
                        }


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/4608

Backported commit 16f5002bdf from the camunda-bpm-platform repository.
Original author: Joaquín <joaquin.felici@camunda.com>