### PR TITLE
feat(core): task API enhancement to include attachment/comments info …

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/task-query-params.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/task-query-params.ftl
@@ -657,5 +657,15 @@
   <@lib.parameter name = "parentTaskId"
       location = "query"
       type = "string"
-      last = last
       desc = "Restrict query to all tasks that are sub tasks of the given task. Takes a task id." />
+
+  <@lib.parameter name = "withCommentAttachmentInfo"
+      location = "query"
+      type = "boolean"
+      defaultValue = "false"
+      last = last
+      desc = "Check if task has attachments and/or comments. Value may only be `true`, as
+             `false` is the default behavior.
+             Adding the filter will do additional attachment and comments queries to the database,
+             it might slow down the query in case of tables having high volume of data.
+             This param is not considered for count queries" />

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/task/TaskWithAttachmentAndCommentDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/task/TaskWithAttachmentAndCommentDto.ftl
@@ -1,0 +1,17 @@
+<#macro dto_macro docsUrl="">
+<@lib.dto
+    extends = "TaskDto" >
+
+        <@lib.property
+        name = "attachment"
+        type = "boolean"
+        desc = "Specifies if an attachment exists for the task." />
+
+        <@lib.property
+        name = "comment"
+        type = "boolean"
+        last = true
+        desc = "Specifies if an comment exists for the task." />
+
+</@lib.dto>
+</#macro>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/get.ftl
@@ -34,11 +34,11 @@
 
     <@lib.response
         code = "200"
-        dto = "TaskDto"
+        dto = "TaskWithAttachmentAndCommentDto"
         array = true
         desc = "Request successful."
         examples = ['"example-1": {
-                       "summary": "Status 200 response",
+                       "summary": "Status 200 response 1",
                        "description": "Response for GET `/task?assignee=anAssignee&delegationState=RESOLVED&maxPriority=50`",
                        "value": [
                          {
@@ -70,6 +70,43 @@
                            },
                            "tenantId": "aTenantId",
                            "taskState": "aTaskState"
+                         }
+                       ]
+                     }',
+        '"example-2": {
+                       "summary": "Status 200 response 2",
+                       "description": "Response for GET `/task?assignee=anAssignee&withCommentAttachmentInfo=true`",
+                       "value": [
+                         {
+                           "id":"anId",
+                           "name":"aName",
+                           "assignee":"anAssignee",
+                           "created":"2013-01-23T13:42:42.657+0200",
+                           "due":"2013-01-23T13:49:42.323+0200",
+                           "followUp:":"2013-01-23T13:44:42.987+0200",
+                           "lastUpdated:":"2013-01-23T13:44:42.987+0200",
+                           "delegationState":"RESOLVED",
+                           "description":"aDescription",
+                           "executionId":"anExecution",
+                           "owner":"anOwner",
+                           "parentTaskId":"aParentId",
+                           "priority":42,
+                           "processDefinitionId":"aProcDefId",
+                           "processInstanceId":"aProcInstId",
+                           "caseDefinitionId":"aCaseDefId",
+                           "caseInstanceId":"aCaseInstId",
+                           "caseExecutionId":"aCaseExecution",
+                           "taskDefinitionKey":"aTaskDefinitionKey",
+                           "suspended": false,
+                           "formKey":"aFormKey",
+                           "operatonFormRef":{
+                             "key": "aOperatonFormKey",
+                             "binding": "version",
+                             "version": 2
+                           },
+                           "tenantId": "aTenantId",
+                           "attachment":false,
+                           "comment":false
                          }
                        ]
                      }'] />

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/post.ftl
@@ -68,6 +68,7 @@
                      "description": "Logical query: assignee = \\"John Munda\\" AND (name = \\"Approve Invoice\\" OR priority = 5) AND (suspended = false OR taskDefinitionKey = \\"approveInvoice\\")",
                      "value": {
                        "assignee": "John Munda",
+                       "withCommentAttachmentInfo": "true",
                        "orQueries": [
                          {
                            "name": "Approve Invoice",
@@ -86,7 +87,7 @@
 
     <@lib.response
         code = "200"
-        dto = "TaskDto"
+        dto = "TaskWithAttachmentAndCommentDto"
         array = true
         desc = "Request successful."
         examples = ['"example-1": {
@@ -150,7 +151,9 @@
                            "suspended": false,
                            "formKey": "embedded:app:develop/invoice-forms/approve-invoice.html",
                            "tenantId": null,
-                           "taskState": "aTaskState"
+                           "taskState": "aTaskState",
+                           "attachment":false,
+                           "comment":false
                          }
                        ]
                      }'

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/get.ftl
@@ -23,7 +23,7 @@
 
     <@lib.response
         code = "200"
-        dto = "TaskDto"
+        dto = "TaskWithAttachmentAndCommentDto"
         desc = "Request successful."
         examples = ['"example-1": {
                        "summary": "GET /task/anId Response",
@@ -56,6 +56,38 @@
                          "tenantId":"aTenantId",
 			 "taskState": "aTaskState"
                        }
+                     }',
+        '"example-2": {
+                       "summary": "GET /task/anId?withCommentAttachmentInfo=true Response",
+                       "value": [
+                         {
+                           "id": "349fffa8-6571-11e7-9a44-d6940f5ef88d",
+                           "name": "Approve Invoice",
+                           "assignee": "John Munda",
+                           "created": "2017-07-10T15:10:54.670+0200",
+                           "due": "2017-07-17T15:10:54.670+0200",
+                           "followUp": null,
+                           "lastUpdated": "2017-07-17T15:10:54.670+0200",
+                           "delegationState": null,
+                           "description": "Approve the invoice (or not).",
+                           "executionId": "349f8a5c-6571-11e7-9a44-d6940f5ef88d",
+                           "owner": null,
+                           "parentTaskId": null,
+                           "priority": 50,
+                           "processDefinitionId": "invoice:1:2c8d8057-6571-11e7-9a44-d6940f5ef88d",
+                           "processInstanceId": "349f8a5c-6571-11e7-9a44-d6940f5ef88d",
+                           "taskDefinitionKey": "approveInvoice",
+                           "caseExecutionId": null,
+                           "caseInstanceId": null,
+                           "caseDefinitionId": null,
+                           "suspended": false,
+                           "formKey": "embedded:app:develop/invoice-forms/approve-invoice.html",
+                           "tenantId": null,
+                           "taskState": "aTaskState",
+                           "attachment":false,
+                           "comment":false
+                         }
+                       ]
                      }'] />
 
     <@lib.response

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/TaskRestService.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/TaskRestService.java
@@ -36,7 +36,7 @@ public interface TaskRestService {
   public static final String PATH = "/task";
 
   @Path("/{id}")
-  TaskResource getTask(@PathParam("id") String id);
+  TaskResource getTask(@PathParam("id") String id, @QueryParam("withCommentAttachmentInfo") boolean withCommentAttachmentInfo);
 
   @GET
   @Produces({MediaType.APPLICATION_JSON, Hal.APPLICATION_HAL_JSON})

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskDto.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.form.OperatonFormRef;
 import org.operaton.bpm.engine.rest.dto.converter.DelegationStateConverter;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.DelegationState;
 import org.operaton.bpm.engine.task.Task;
 
@@ -54,6 +55,44 @@ public class TaskDto {
    */
   private String taskState;
 
+  public TaskDto() {
+  }
+
+  public TaskDto(Task task) {
+    this.id = task.getId();
+    this.name = task.getName();
+    this.assignee = task.getAssignee();
+    this.created = task.getCreateTime();
+    this.lastUpdated = task.getLastUpdated();
+    this.due = task.getDueDate();
+    this.followUp = task.getFollowUpDate();
+
+    if (task.getDelegationState() != null) {
+      this.delegationState = task.getDelegationState().toString();
+    }
+
+    this.description = task.getDescription();
+    this.executionId = task.getExecutionId();
+    this.owner = task.getOwner();
+    this.parentTaskId = task.getParentTaskId();
+    this.priority = task.getPriority();
+    this.processDefinitionId = task.getProcessDefinitionId();
+    this.processInstanceId = task.getProcessInstanceId();
+    this.taskDefinitionKey = task.getTaskDefinitionKey();
+    this.caseDefinitionId = task.getCaseDefinitionId();
+    this.caseExecutionId = task.getCaseExecutionId();
+    this.caseInstanceId = task.getCaseInstanceId();
+    this.suspended = task.isSuspended();
+    this.tenantId = task.getTenantId();
+    this.taskState = task.getTaskState();
+    try {
+      this.formKey = task.getFormKey();
+      this.operatonFormRef = task.getOperatonFormRef();
+    }
+    catch (BadUserRequestException e) {
+      // ignore (initializeFormKeys was not called)
+    }
+  }
   public String getId() {
     return id;
   }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskQueryDto.java
@@ -212,6 +212,8 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
 
   private List<TaskQueryDto> orQueries;
 
+  private Boolean withCommentAttachmentInfo;
+
   public TaskQueryDto() {
 
   }
@@ -708,6 +710,11 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     this.variableValuesIgnoreCase = variableValuesCaseInsensitive;
   }
 
+  @OperatonQueryParam(value = "withCommentAttachmentInfo", converter = BooleanConverter.class)
+  public void setWithCommentAttachmentInfo(Boolean withCommentAttachmentInfo) {
+    this.withCommentAttachmentInfo = withCommentAttachmentInfo;
+  }
+
   @Override
   protected boolean isValidSortByValue(String value) {
     return VALID_SORT_BY_VALUES.contains(value);
@@ -1078,6 +1085,8 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     return variableValuesIgnoreCase;
   }
 
+  public Boolean getWithCommentAttachmentInfo() { return withCommentAttachmentInfo;}
+
   @Override
   protected void applyFilters(TaskQuery query) {
     if (orQueries != null) {
@@ -1441,6 +1450,9 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
           throw new InvalidRequestException(Status.BAD_REQUEST, "Invalid case variable comparator specified: " + op);
         }
       }
+    }
+    if (withCommentAttachmentInfo != null && withCommentAttachmentInfo) {
+      query.withCommentAttachmentInfo();
     }
   }
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskWithAttachmentAndCommentDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskWithAttachmentAndCommentDto.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.dto.task;
+
+import org.operaton.bpm.engine.task.Task;
+
+public class TaskWithAttachmentAndCommentDto extends TaskDto {
+
+  private boolean hasAttachment;
+  private boolean hasComment;
+
+  public TaskWithAttachmentAndCommentDto() {
+  }
+
+  public TaskWithAttachmentAndCommentDto(Task task) {
+    super(task);
+  }
+  public boolean getAttachment() {
+    return hasAttachment;
+  }
+  public void setAttachment(boolean hasAttachment) {
+    this.hasAttachment = hasAttachment;
+  }
+
+  public boolean getComment() {
+    return hasComment;
+  }
+
+  public void setComment(boolean hasComment) {
+    this.hasComment = hasComment;
+  }
+
+  public static TaskDto fromEntity(Task task) {
+    TaskWithAttachmentAndCommentDto result = new TaskWithAttachmentAndCommentDto(task);
+
+    result.hasAttachment = task.hasAttachment();
+    result.hasComment = task.hasComment();
+    return result;
+  }
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/TaskRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/TaskRestServiceImpl.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.rest.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
@@ -32,6 +33,7 @@ import org.operaton.bpm.engine.rest.TaskRestService;
 import org.operaton.bpm.engine.rest.dto.CountResultDto;
 import org.operaton.bpm.engine.rest.dto.task.TaskDto;
 import org.operaton.bpm.engine.rest.dto.task.TaskQueryDto;
+import org.operaton.bpm.engine.rest.dto.task.TaskWithAttachmentAndCommentDto;
 import org.operaton.bpm.engine.rest.exception.InvalidRequestException;
 import org.operaton.bpm.engine.rest.hal.Hal;
 import org.operaton.bpm.engine.rest.hal.task.HalTaskList;
@@ -66,6 +68,7 @@ public class TaskRestServiceImpl extends AbstractRestProcessEngineAware implemen
   }
 
   public List<TaskDto> getJsonTasks(UriInfo uriInfo, Integer firstResult, Integer maxResults) {
+    // get list of tasks
     TaskQueryDto queryDto = new TaskQueryDto(getObjectMapper(), uriInfo.getQueryParameters());
     return queryTasks(queryDto, firstResult, maxResults);
   }
@@ -95,11 +98,12 @@ public class TaskRestServiceImpl extends AbstractRestProcessEngineAware implemen
     List<Task> matchingTasks = executeTaskQuery(firstResult, maxResults, query);
 
     List<TaskDto> tasks = new ArrayList<TaskDto>();
-    for (Task task : matchingTasks) {
-      TaskDto returnTask = TaskDto.fromEntity(task);
-      tasks.add(returnTask);
+    if (Boolean.TRUE.equals(queryDto.getWithCommentAttachmentInfo())) {
+      tasks = matchingTasks.stream().map(TaskWithAttachmentAndCommentDto::fromEntity).collect(Collectors.toList());
     }
-
+    else {
+      tasks = matchingTasks.stream().map(TaskDto::fromEntity).collect(Collectors.toList());
+    }
     return tasks;
   }
 
@@ -130,8 +134,8 @@ public class TaskRestServiceImpl extends AbstractRestProcessEngineAware implemen
   }
 
   @Override
-  public TaskResource getTask(String id) {
-    return new TaskResourceImpl(getProcessEngine(), id, relativeRootResourcePath, getObjectMapper());
+  public TaskResource getTask(String id, boolean withCommentAttachmentInfo) {
+    return new TaskResourceImpl(getProcessEngine(), id, relativeRootResourcePath, getObjectMapper(), withCommentAttachmentInfo);
   }
 
   @Override

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/task/impl/TaskResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/task/impl/TaskResourceImpl.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import javax.ws.rs.core.MediaType;
@@ -46,13 +47,7 @@ import org.operaton.bpm.engine.impl.form.validator.FormFieldValidationException;
 import org.operaton.bpm.engine.impl.identity.Authentication;
 import org.operaton.bpm.engine.rest.dto.VariableValueDto;
 import org.operaton.bpm.engine.rest.dto.converter.StringListConverter;
-import org.operaton.bpm.engine.rest.dto.task.CompleteTaskDto;
-import org.operaton.bpm.engine.rest.dto.task.FormDto;
-import org.operaton.bpm.engine.rest.dto.task.IdentityLinkDto;
-import org.operaton.bpm.engine.rest.dto.task.TaskBpmnErrorDto;
-import org.operaton.bpm.engine.rest.dto.task.TaskDto;
-import org.operaton.bpm.engine.rest.dto.task.TaskEscalationDto;
-import org.operaton.bpm.engine.rest.dto.task.UserIdDto;
+import org.operaton.bpm.engine.rest.dto.task.*;
 import org.operaton.bpm.engine.rest.exception.InvalidRequestException;
 import org.operaton.bpm.engine.rest.exception.RestException;
 import org.operaton.bpm.engine.rest.hal.Hal;
@@ -78,12 +73,14 @@ public class TaskResourceImpl implements TaskResource {
   protected String taskId;
   protected String rootResourcePath;
   protected ObjectMapper objectMapper;
+  protected boolean withCommentAttachmentInfo;
 
-  public TaskResourceImpl(ProcessEngine engine, String taskId, String rootResourcePath, ObjectMapper objectMapper) {
+  public TaskResourceImpl(ProcessEngine engine, String taskId, String rootResourcePath, ObjectMapper objectMapper, boolean withCommentAttachmentInfo) {
     this.engine = engine;
     this.taskId = taskId;
     this.rootResourcePath = rootResourcePath;
     this.objectMapper = objectMapper;
+    this.withCommentAttachmentInfo = withCommentAttachmentInfo;
   }
 
   @Override
@@ -192,16 +189,20 @@ public class TaskResourceImpl implements TaskResource {
   }
 
   public TaskDto getJsonTask() {
-    Task task = getTaskById(taskId);
+    Task task = getTaskById(taskId, withCommentAttachmentInfo);
     if (task == null) {
       throw new InvalidRequestException(Status.NOT_FOUND, "No matching task with id " + taskId);
     }
-
-    return TaskDto.fromEntity(task);
+    if (withCommentAttachmentInfo) {
+      return TaskWithAttachmentAndCommentDto.fromEntity(task);
+    }
+    else {
+      return TaskDto.fromEntity(task);
+    }
   }
 
   public HalTask getHalTask() {
-    Task task = getTaskById(taskId);
+    Task task = getTaskById(taskId, withCommentAttachmentInfo);
     if (task == null) {
       throw new InvalidRequestException(Status.NOT_FOUND, "No matching task with id " + taskId);
     }
@@ -212,7 +213,7 @@ public class TaskResourceImpl implements TaskResource {
   @Override
   public FormDto getForm() {
     FormService formService = engine.getFormService();
-    Task task = getTaskById(taskId);
+    Task task = getTaskById(taskId, withCommentAttachmentInfo);
     FormData formData;
     try {
       formData = formService.getTaskFormData(taskId);
@@ -368,7 +369,7 @@ public class TaskResourceImpl implements TaskResource {
   public void updateTask(TaskDto taskDto) {
     TaskService taskService = engine.getTaskService();
 
-    Task task = getTaskById(taskId);
+    Task task = getTaskById(taskId, withCommentAttachmentInfo);
 
     if (task == null) {
       throw new InvalidRequestException(Status.NOT_FOUND, "No matching task with id " + taskId);
@@ -433,8 +434,13 @@ public class TaskResourceImpl implements TaskResource {
     }
   }
 
-  protected Task getTaskById(String id) {
-    return engine.getTaskService().createTaskQuery().taskId(id).initializeFormKeys().singleResult();
+  protected Task getTaskById(String id, boolean withCommentAttachmentInfo) {
+    if (withCommentAttachmentInfo) {
+      return engine.getTaskService().createTaskQuery().taskId(id).withCommentAttachmentInfo().initializeFormKeys().singleResult();
+    }
+    else{
+      return engine.getTaskService().createTaskQuery().taskId(id).initializeFormKeys().singleResult();
+    }
   }
 
   protected String getTaskFormMediaType(String taskId) {

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceInteractionTest.java
@@ -146,6 +146,8 @@ import org.mockito.Mockito;
 import io.restassured.http.ContentType;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TaskRestServiceInteractionTest extends
     AbstractRestServiceTest {
@@ -214,6 +216,7 @@ public class TaskRestServiceInteractionTest extends
     mockQuery = mock(TaskQuery.class);
     when(mockQuery.initializeFormKeys()).thenReturn(mockQuery);
     when(mockQuery.taskId(any())).thenReturn(mockQuery);
+    when(mockQuery.withCommentAttachmentInfo()).thenReturn(mockQuery);
     when(mockQuery.singleResult()).thenReturn(mockTask);
     when(taskServiceMock.createTaskQuery()).thenReturn(mockQuery);
 
@@ -314,6 +317,36 @@ public class TaskRestServiceInteractionTest extends
       .body("tenantId", equalTo(MockProvider.EXAMPLE_TENANT_ID))
       .body("lastUpdated", equalTo(MockProvider.EXAMPLE_TASK_LAST_UPDATED))
       .body("taskState", equalTo(MockProvider.EXAMPLE_HISTORIC_TASK_STATE))
+      .when().get(SINGLE_TASK_URL);
+  }
+  @Test
+  public void testGetSingleTaskWithQueryParam() {
+    given().pathParam("id", EXAMPLE_TASK_ID)
+      .queryParam("withCommentAttachmentInfo", true)
+      .header("accept", MediaType.APPLICATION_JSON)
+      .then().expect().statusCode(Status.OK.getStatusCode())
+      .body("id", equalTo(EXAMPLE_TASK_ID))
+      .body("name", equalTo(MockProvider.EXAMPLE_TASK_NAME))
+      .body("assignee", equalTo(MockProvider.EXAMPLE_TASK_ASSIGNEE_NAME))
+      .body("created", equalTo(MockProvider.EXAMPLE_TASK_CREATE_TIME))
+      .body("due", equalTo(MockProvider.EXAMPLE_TASK_DUE_DATE))
+      .body("delegationState", equalTo(MockProvider.EXAMPLE_TASK_DELEGATION_STATE.toString()))
+      .body("description", equalTo(MockProvider.EXAMPLE_TASK_DESCRIPTION))
+      .body("executionId", equalTo(MockProvider.EXAMPLE_TASK_EXECUTION_ID))
+      .body("owner", equalTo(MockProvider.EXAMPLE_TASK_OWNER))
+      .body("parentTaskId", equalTo(MockProvider.EXAMPLE_TASK_PARENT_TASK_ID))
+      .body("priority", equalTo(MockProvider.EXAMPLE_TASK_PRIORITY))
+      .body("processDefinitionId", equalTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))
+      .body("processInstanceId", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
+      .body("taskDefinitionKey", equalTo(MockProvider.EXAMPLE_TASK_DEFINITION_KEY))
+      .body("suspended", equalTo(MockProvider.EXAMPLE_TASK_SUSPENSION_STATE))
+      .body("caseExecutionId", equalTo(MockProvider.EXAMPLE_CASE_EXECUTION_ID))
+      .body("caseInstanceId", equalTo(MockProvider.EXAMPLE_CASE_INSTANCE_ID))
+      .body("caseDefinitionId", equalTo(MockProvider.EXAMPLE_CASE_DEFINITION_ID))
+      .body("tenantId", equalTo(MockProvider.EXAMPLE_TENANT_ID))
+      .body("lastUpdated", equalTo(MockProvider.EXAMPLE_TASK_LAST_UPDATED))
+      .body("attachment", equalTo(MockProvider.EXAMPLE_TASK_ATTACHMENT_STATE))
+      .body("comment", equalTo(MockProvider.EXAMPLE_TASK_COMMENT_STATE))
       .when().get(SINGLE_TASK_URL);
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
@@ -212,6 +212,32 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     assertThat(MockProvider.EXAMPLE_TENANT_ID).isEqualTo(returnedTenantId);
 
   }
+  @Test
+  public void testTaskQueryWithAttachmentAndComment() {
+    String queryName = "name";
+
+    Response response = given().queryParam("name", queryName)
+            .queryParam("withCommentAttachmentInfo","true")
+            .header("accept", MediaType.APPLICATION_JSON)
+            .then().expect().statusCode(Status.OK.getStatusCode())
+            .when().get(TASK_QUERY_URL);
+
+    InOrder inOrder = inOrder(mockQuery);
+    inOrder.verify(mockQuery).taskName(queryName);
+    inOrder.verify(mockQuery).list();
+
+    String content = response.asString();
+    List<LinkedHashMap<String, String>> instances = from(content).getList("");
+    assertThat(instances).hasSize(1).as("There should be one task returned.");
+    assertThat(instances.get(0)).isNotNull().as("The returned task should not be null.");
+
+    boolean returnedAttachmentsInfo = from(content).getBoolean("[0].attachment");
+    boolean returnedCommentsInfo = from(content).getBoolean("[0].comment");
+
+    assertThat(MockProvider.EXAMPLE_TASK_ATTACHMENT_STATE).isEqualTo(returnedAttachmentsInfo);
+    assertThat(MockProvider.EXAMPLE_TASK_COMMENT_STATE).isEqualTo(returnedCommentsInfo);
+
+  }
 
   @Test
   public void testSimpleHalTaskQuery() {
@@ -521,6 +547,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     parameters.put("withCandidateUsers", true);
     parameters.put("withoutCandidateUsers", true);
     parameters.put("withoutDueDate", true);
+    parameters.put("withCommentAttachmentInfo", true);
 
     return parameters;
   }
@@ -586,6 +613,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     verify(mockQuery).withCandidateUsers();
     verify(mockQuery).withoutCandidateUsers();
     verify(mockQuery).withoutDueDate();
+    verify(mockQuery).withCommentAttachmentInfo();
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/MockProvider.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/MockProvider.java
@@ -198,6 +198,10 @@ public abstract class MockProvider {
   public static final String EXAMPLE_TASK_DEFINITION_KEY = "aTaskDefinitionKey";
   public static final boolean EXAMPLE_TASK_SUSPENSION_STATE = false;
 
+  public static final boolean EXAMPLE_TASK_ATTACHMENT_STATE = false;
+
+  public static final boolean EXAMPLE_TASK_COMMENT_STATE = false;
+
   // task comment
   public static final String EXAMPLE_TASK_COMMENT_ID = "aTaskCommentId";
   public static final String EXAMPLE_TASK_COMMENT_FULL_MESSAGE = "aTaskCommentFullMessage";
@@ -1057,7 +1061,11 @@ public abstract class MockProvider {
       .caseExecutionId(EXAMPLE_CASE_EXECUTION_ID)
       .formKey(EXAMPLE_FORM_KEY)
       .operatonFormRef(EXAMPLE_FORM_KEY, EXAMPLE_FORM_REF_BINDING, EXAMPLE_FORM_REF_VERSION)
-      .tenantId(EXAMPLE_TENANT_ID).taskState(EXAMPLE_HISTORIC_TASK_STATE);
+      .tenantId(EXAMPLE_TENANT_ID)
+      .taskState(EXAMPLE_HISTORIC_TASK_STATE)
+      .tenantId(EXAMPLE_TENANT_ID)
+      .hasAttachment(EXAMPLE_TASK_ATTACHMENT_STATE)
+      .hasComment(EXAMPLE_TASK_COMMENT_STATE);
   }
 
   public static List<Task> createMockTasks() {

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/MockTaskBuilder.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/MockTaskBuilder.java
@@ -50,6 +50,11 @@ public class MockTaskBuilder {
   private String formKey;
   private OperatonFormRef operatonFormRef;
   private String tenantId;
+  private boolean hasAttachment;
+
+  private boolean hasComment;
+
+
 
   private String taskState;
 
@@ -170,6 +175,16 @@ public class MockTaskBuilder {
     return this;
   }
 
+  public MockTaskBuilder hasAttachment(boolean hasAttachment) {
+    this.hasAttachment = hasAttachment;
+    return this;
+  }
+
+  public MockTaskBuilder hasComment(boolean hasComment) {
+    this.hasComment = hasComment;
+    return this;
+  }
+
   public Task build() {
     Task mockTask = mock(Task.class);
     when(mockTask.getId()).thenReturn(id);
@@ -195,6 +210,8 @@ public class MockTaskBuilder {
     when(mockTask.getOperatonFormRef()).thenReturn(operatonFormRef);
     when(mockTask.getTenantId()).thenReturn(tenantId);
     when(mockTask.getTaskState()).thenReturn(taskState);
+    when(mockTask.hasAttachment()).thenReturn(hasAttachment);
+    when(mockTask.hasComment()).thenReturn(hasComment);
     return mockTask;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/TaskQueryImpl.java
@@ -44,6 +44,7 @@ import org.operaton.bpm.engine.task.DelegationState;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.task.TaskQuery;
 import org.operaton.bpm.engine.variable.type.ValueType;
+import org.operaton.bpm.engine.impl.history.HistoryLevel;
 
 /**
  * @author Joram Barrez
@@ -175,6 +176,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   // or query /////////////////////////////
   protected List<TaskQueryImpl> queries = new ArrayList<>(Arrays.asList(this));
   protected boolean isOrQueryActive = false;
+  protected boolean withCommentAttachmentInfo;
 
   public TaskQueryImpl() {
   }
@@ -1088,6 +1090,12 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
       || CompareUtil.elementIsNotContainedInArray(processInstanceBusinessKey, processInstanceBusinessKeys);
   }
 
+  @Override
+  public TaskQuery withCommentAttachmentInfo() {
+    this.withCommentAttachmentInfo = true;
+    return this;
+  }
+
   public List<String> getCandidateGroups() {
     if (cachedCandidateGroups != null) {
       return cachedCandidateGroups;
@@ -1438,6 +1446,13 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
       for (Task task : taskList) {
         // initialize the form keys of the tasks
         ((TaskEntity) task).initializeFormKey();
+      }
+    }
+
+    if (withCommentAttachmentInfo && !Context.getProcessEngineConfiguration().getHistoryLevel().equals(HistoryLevel.HISTORY_LEVEL_NONE)) {
+      for (Task task : taskList) {
+        // verify attachment and comments exists for the task
+        ((TaskEntity) task).initializeAttachmentAndComments();
       }
     }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -162,6 +162,8 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
   protected boolean isFormKeyInitialized = false;
   protected String formKey;
   protected OperatonFormRef operatonFormRef;
+  protected boolean attachmentExists;
+  protected boolean commentExists;
 
   @SuppressWarnings({ "unchecked" })
   protected transient VariableStore<VariableInstanceEntity> variableStore
@@ -1462,6 +1464,10 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
       }
     }
   }
+  public void initializeAttachmentAndComments(){
+    this.attachmentExists = !Context.getCommandContext().getAttachmentManager().findAttachmentsByTaskId(id).isEmpty();
+    this.commentExists = !Context.getCommandContext().getCommentManager().findCommentsByTaskId(id).isEmpty();
+  }
 
   @Override
   public String getFormKey() {
@@ -1780,7 +1786,14 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
       throw ProcessEngineLogger.CMD_LOGGER.exceptionBpmnErrorPropagationFailed(errorCode, ex);
     }
   }
-
+  @Override
+  public boolean hasAttachment() {
+    return attachmentExists;
+  }
+  @Override
+  public boolean hasComment() {
+    return commentExists;
+  }
   public void escalation(String escalationCode, Map<String, Object> variables) {
     ensureTaskActive();
     ActivityExecution activityExecution = getExecution();

--- a/engine/src/main/java/org/operaton/bpm/engine/task/Task.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/task/Task.java
@@ -202,4 +202,9 @@ public interface Task {
    * @param taskState the taskState to set
    */
   void setTaskState(String taskState);
+  /** Returns if an attachment exists for the task */
+  boolean hasAttachment();
+  /** Signifies if a comment exists for the task */
+  boolean hasComment();
+
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/task/TaskQuery.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/task/TaskQuery.java
@@ -1104,4 +1104,11 @@ public interface TaskQuery extends Query<TaskQuery, Task> {
    *                                this exception, {@link #or()} must be invoked first.
    */
   TaskQuery endOr();
+
+  /**
+   * Evaluates existence of attachment and comments associated with the task, defaults to false.
+   * Adding the filter will do additional attachment and comments queries to the database,
+   * it might slow down the query in case of tables having high volume of data.
+   */
+  TaskQuery withCommentAttachmentInfo();
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
@@ -33,6 +33,7 @@ import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.taskByPr
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.taskByProcessInstanceId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySortingAndCount;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -55,6 +56,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.operaton.bpm.engine.BadUserRequestException;
+import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.exception.NullValueException;
 import org.operaton.bpm.engine.filter.Filter;
@@ -72,6 +74,7 @@ import org.operaton.bpm.engine.task.DelegationState;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.task.TaskQuery;
 import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.type.ValueType;
@@ -5602,7 +5605,39 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     assertThat(taskResult.getLastUpdated()).isAfter(beforeSave);
     assertThat(taskResult.getLastUpdated()).isAfter(taskResult.getCreateTime());
   }
-
+  @Test
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_ACTIVITY)
+  @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
+  public void shouldNotFindAttachmentAndCommentInfoWithoutQueryParam() {
+    // given
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    task.setAssignee("myself");
+    // when
+    taskService.createComment(task.getId(), processInstance.getId(), "testComment");
+    taskService.createAttachment("foo", task.getId(), processInstance.getId(), "testAttachment", "testDesc", "http://operaton.org");
+    // then
+    Task taskResult = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    assertThat(taskResult).isNotNull();
+    assertFalse(taskResult.hasComment());
+    assertFalse(taskResult.hasAttachment());
+  }
+  @Test
+  @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_ACTIVITY)
+  @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
+  public void shouldFindAttachmentAndCommentInfoWithQueryParam() {
+    // given
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    // when
+    taskService.createComment(task.getId(), processInstance.getId(), "testComment");
+    taskService.createAttachment("foo", task.getId(), processInstance.getId(), "testAttachment",  "testDesc", "http://operaton.org");
+    // then
+    Task taskResult = taskService.createTaskQuery().processInstanceId(processInstance.getId()).withCommentAttachmentInfo().singleResult();
+    assertThat(taskResult).isNotNull();
+    assertTrue(taskResult.hasComment());
+    assertTrue(taskResult.hasAttachment());
+  }
   // ---------------------- HELPER ------------------------------
 
   // make sure that time passes between two fast operations


### PR DESCRIPTION
…(#4306)

* task API response include attachments and comments info
  * when `withCommentAttachmentInfo` is enabled
  * additional queries if a attachment/comment  is present
  * count query is not affected

related to https://github.com/camunda/camunda-bpm-platform/issues/2404

---------

Signed-off-by: Kumar Pani, Suman <Suman.KumarPani@fmr.com>

Backported commit ddf039c4f3 from the camunda-bpm-platform repository.
Original author: sumankumarpani <sumankumarpani@gmail.com>