### PR TITLE
feat(engine): add historicProcInsQuery to executeModificationAsync

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/ModificationDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/ModificationDto.ftl
@@ -38,6 +38,14 @@
     />
 
     <@lib.property
+        name = "historicProcessInstanceQuery"
+        type = "ref"
+        dto = "HistoricProcessInstanceQueryDto"
+        desc = "A historic process instance query. It is advised to include the `unfinished` filter in the
+                historic process instance query as finished instances cause failures for the modification."
+    />
+
+    <@lib.property
         name = "instructions"
         type = "array"
         dto = "MultipleProcessInstanceModificationInstructionDto"

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/ModificationDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/ModificationDto.java
@@ -19,6 +19,8 @@ package org.operaton.bpm.engine.rest.dto;
 import java.util.List;
 
 import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.history.HistoricProcessInstanceQuery;
+import org.operaton.bpm.engine.rest.dto.history.HistoricProcessInstanceQueryDto;
 import org.operaton.bpm.engine.rest.dto.runtime.ProcessInstanceQueryDto;
 import org.operaton.bpm.engine.rest.dto.runtime.modification.ProcessInstanceModificationInstructionDto;
 import org.operaton.bpm.engine.runtime.ModificationBuilder;
@@ -30,6 +32,7 @@ public class ModificationDto {
   protected List<ProcessInstanceModificationInstructionDto> instructions;
   protected List<String> processInstanceIds;
   protected ProcessInstanceQueryDto processInstanceQuery;
+  protected HistoricProcessInstanceQueryDto historicProcessInstanceQuery;
   protected String processDefinitionId;
   protected boolean skipIoMappings;
   protected boolean skipCustomListeners;
@@ -99,4 +102,11 @@ public class ModificationDto {
     this.annotation = annotation;
   }
 
+  public HistoricProcessInstanceQueryDto getHistoricProcessInstanceQuery() {
+    return historicProcessInstanceQuery;
+  }
+
+  public void setHistoricProcessInstanceQuery(HistoricProcessInstanceQueryDto historicProcessInstanceQuery) {
+    this.historicProcessInstanceQuery = historicProcessInstanceQuery;
+  }
 }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/ModificationRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/ModificationRestServiceImpl.java
@@ -22,9 +22,11 @@ import javax.ws.rs.core.Response.Status;
 
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.batch.Batch;
+import org.operaton.bpm.engine.history.HistoricProcessInstanceQuery;
 import org.operaton.bpm.engine.rest.ModificationRestService;
 import org.operaton.bpm.engine.rest.dto.ModificationDto;
 import org.operaton.bpm.engine.rest.dto.batch.BatchDto;
+import org.operaton.bpm.engine.rest.dto.history.HistoricProcessInstanceQueryDto;
 import org.operaton.bpm.engine.rest.dto.runtime.ProcessInstanceQueryDto;
 import org.operaton.bpm.engine.rest.exception.InvalidRequestException;
 import org.operaton.bpm.engine.runtime.ModificationBuilder;
@@ -72,6 +74,12 @@ public class ModificationRestServiceImpl extends AbstractRestProcessEngineAware 
     if (processInstanceQueryDto != null) {
       ProcessInstanceQuery processInstanceQuery = processInstanceQueryDto.toQuery(getProcessEngine());
       builder.processInstanceQuery(processInstanceQuery);
+    }
+
+    HistoricProcessInstanceQueryDto historicProcessInstanceQueryDto = dto.getHistoricProcessInstanceQuery();
+    if(historicProcessInstanceQueryDto != null) {
+      HistoricProcessInstanceQuery historicProcessInstanceQuery = historicProcessInstanceQueryDto.toQuery(getProcessEngine());
+      builder.historicProcessInstanceQuery(historicProcessInstanceQuery);
     }
 
     if (dto.isSkipCustomListeners()) {

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ModificationRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ModificationRestServiceInteractionTest.java
@@ -32,9 +32,12 @@ import javax.ws.rs.core.Response.Status;
 
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.BadUserRequestException;
+import org.operaton.bpm.engine.HistoryService;
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.batch.Batch;
+import org.operaton.bpm.engine.impl.HistoricProcessInstanceQueryImpl;
 import org.operaton.bpm.engine.impl.ProcessInstanceQueryImpl;
+import org.operaton.bpm.engine.rest.dto.history.HistoricProcessInstanceQueryDto;
 import org.operaton.bpm.engine.rest.dto.runtime.ProcessInstanceQueryDto;
 import org.operaton.bpm.engine.rest.exception.InvalidRequestException;
 import org.operaton.bpm.engine.rest.util.ModificationInstructionBuilder;
@@ -57,12 +60,16 @@ public class ModificationRestServiceInteractionTest extends AbstractRestServiceT
   protected static final String EXECUTE_MODIFICATION_ASYNC_URL = PROCESS_INSTANCE_URL + "/executeAsync";
 
   protected RuntimeService runtimeServiceMock;
+  protected HistoryService historyServiceMock;
   protected ModificationBuilder modificationBuilderMock;
 
   @Before
   public void setUpRuntimeData() {
     runtimeServiceMock = mock(RuntimeService.class);
     when(processEngine.getRuntimeService()).thenReturn(runtimeServiceMock);
+
+    historyServiceMock = mock(HistoryService.class);
+    when(processEngine.getHistoryService()).thenReturn(historyServiceMock);
 
     modificationBuilderMock = mock(ModificationBuilder.class);
     when(modificationBuilderMock.cancelAllForActivity(any())).thenReturn(modificationBuilderMock);
@@ -300,6 +307,39 @@ public class ModificationRestServiceInteractionTest extends AbstractRestServiceT
   }
 
   @Test
+  public void executeModificationWithValidHistoricProcessInstanceQuerySync() {
+
+    when(historyServiceMock.createHistoricProcessInstanceQuery()).thenReturn(new HistoricProcessInstanceQueryImpl());
+    Map<String, Object> json = new HashMap<String, Object>();
+
+    List<Map<String, Object>> instructions = new ArrayList<Map<String, Object>>();
+    instructions.add(ModificationInstructionBuilder.startAfter().activityId("activityId").getJson());
+    json.put("processDefinitionId", "processDefinitionId");
+
+    HistoricProcessInstanceQueryDto historicProcessInstanceQueryDto = new HistoricProcessInstanceQueryDto();
+    historicProcessInstanceQueryDto.setProcessInstanceBusinessKey("foo");
+
+    json.put("historicProcessInstanceQuery", historicProcessInstanceQueryDto);
+
+    json.put("instructions", instructions);
+
+    given()
+        .contentType(ContentType.JSON)
+        .body(json)
+        .then()
+        .expect()
+        .statusCode(Status.NO_CONTENT.getStatusCode())
+        .when()
+        .post(EXECUTE_MODIFICATION_SYNC_URL);
+
+    verify(historyServiceMock, times(1)).createHistoricProcessInstanceQuery();
+    verify(modificationBuilderMock).startAfterActivity("activityId");
+    verify(modificationBuilderMock).historicProcessInstanceQuery(historicProcessInstanceQueryDto.toQuery(processEngine));
+    verify(modificationBuilderMock).execute();
+  }
+
+
+  @Test
   public void executeModificationWithValidProcessInstanceQueryAsync() {
 
     when(runtimeServiceMock.createProcessInstanceQuery()).thenReturn(new ProcessInstanceQueryImpl());
@@ -326,6 +366,74 @@ public class ModificationRestServiceInteractionTest extends AbstractRestServiceT
 
     verify(runtimeServiceMock, times(1)).createProcessInstanceQuery();
     verify(modificationBuilderMock).startAfterActivity("activityId");
+    verify(modificationBuilderMock).processInstanceQuery(processInstanceQueryDto.toQuery(processEngine));
+    verify(modificationBuilderMock).executeAsync();
+  }
+
+  @Test
+  public void executeModificationWithValidHistoricProcessInstanceQueryAsync() {
+    when(historyServiceMock.createHistoricProcessInstanceQuery()).thenReturn(new HistoricProcessInstanceQueryImpl());
+    Map<String, Object> json = new HashMap<String, Object>();
+
+    List<Map<String, Object>> instructions = new ArrayList<Map<String, Object>>();
+    instructions.add(ModificationInstructionBuilder.startAfter().activityId("activityId").getJson());
+
+    HistoricProcessInstanceQueryDto historicProcessInstanceQueryDto = new HistoricProcessInstanceQueryDto();
+    historicProcessInstanceQueryDto.setProcessInstanceBusinessKey("foo");
+
+    json.put("historicProcessInstanceQuery", historicProcessInstanceQueryDto);
+    json.put("instructions", instructions);
+    json.put("processDefinitionId", "processDefinitionId");
+
+    given()
+        .contentType(ContentType.JSON)
+        .body(json)
+        .then()
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .post(EXECUTE_MODIFICATION_ASYNC_URL);
+
+    verify(historyServiceMock, times(1)).createHistoricProcessInstanceQuery();
+    verify(modificationBuilderMock).startAfterActivity("activityId");
+    verify(modificationBuilderMock).historicProcessInstanceQuery(historicProcessInstanceQueryDto.toQuery(processEngine));
+    verify(modificationBuilderMock).executeAsync();
+  }
+
+  @Test
+  public void executeModificationWithBothProcessInstanceQueries() {
+    when(historyServiceMock.createHistoricProcessInstanceQuery()).thenReturn(new HistoricProcessInstanceQueryImpl());
+    when(runtimeServiceMock.createProcessInstanceQuery()).thenReturn(new ProcessInstanceQueryImpl());
+
+    Map<String, Object> json = new HashMap<String, Object>();
+
+    List<Map<String, Object>> instructions = new ArrayList<Map<String, Object>>();
+    instructions.add(ModificationInstructionBuilder.startAfter().activityId("activityId").getJson());
+
+    HistoricProcessInstanceQueryDto historicProcessInstanceQueryDto = new HistoricProcessInstanceQueryDto();
+    historicProcessInstanceQueryDto.setProcessInstanceBusinessKey("foo");
+
+    ProcessInstanceQueryDto processInstanceQueryDto = new ProcessInstanceQueryDto();
+    processInstanceQueryDto.setBusinessKey("foo");
+
+    json.put("processInstanceQuery", processInstanceQueryDto);
+    json.put("historicProcessInstanceQuery", historicProcessInstanceQueryDto);
+    json.put("instructions", instructions);
+    json.put("processDefinitionId", "processDefinitionId");
+
+    given()
+        .contentType(ContentType.JSON)
+        .body(json)
+        .then()
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .post(EXECUTE_MODIFICATION_ASYNC_URL);
+
+    verify(historyServiceMock, times(1)).createHistoricProcessInstanceQuery();
+    verify(modificationBuilderMock).startAfterActivity("activityId");
+    verify(modificationBuilderMock).historicProcessInstanceQuery(historicProcessInstanceQueryDto.toQuery(processEngine));
+    verify(runtimeServiceMock, times(1)).createProcessInstanceQuery();
     verify(modificationBuilderMock).processInstanceQuery(processInstanceQueryDto.toQuery(processEngine));
     verify(modificationBuilderMock).executeAsync();
   }
@@ -360,6 +468,35 @@ public class ModificationRestServiceInteractionTest extends AbstractRestServiceT
   }
 
   @Test
+  public void executeModificationWithInvalidHistoricProcessInstanceQuerySync() {
+    when(historyServiceMock.createHistoricProcessInstanceQuery()).thenReturn(new HistoricProcessInstanceQueryImpl());
+
+    Map<String, Object> json = new HashMap<String, Object>();
+
+    String message = "Process instance ids is null";
+    doThrow(new BadUserRequestException(message)).when(modificationBuilderMock).execute();
+
+    List<Map<String, Object>> instructions = new ArrayList<Map<String, Object>>();
+    instructions.add(ModificationInstructionBuilder.startAfter().activityId("acivityId").getJson());
+
+    HistoricProcessInstanceQueryDto historicProcessInstanceQueryDto = new HistoricProcessInstanceQueryDto();
+    historicProcessInstanceQueryDto.setProcessInstanceBusinessKey("foo");
+
+    json.put("historicProcessInstanceQuery", historicProcessInstanceQueryDto);
+    json.put("instructions", instructions);
+    json.put("processDefinitionId", "processDefinitionId");
+
+    given()
+        .contentType(ContentType.JSON)
+        .body(json)
+        .then()
+        .expect()
+        .statusCode(Status.BAD_REQUEST.getStatusCode())
+        .when()
+        .post(EXECUTE_MODIFICATION_SYNC_URL);
+  }
+
+  @Test
   public void executeModificationWithInvalidProcessInstanceQueryAsync() {
 
     when(runtimeServiceMock.createProcessInstanceQuery()).thenReturn(new ProcessInstanceQueryImpl());
@@ -382,6 +519,31 @@ public class ModificationRestServiceInteractionTest extends AbstractRestServiceT
       .statusCode(Status.OK.getStatusCode())
     .when()
       .post(EXECUTE_MODIFICATION_ASYNC_URL);
+  }
+
+  @Test
+  public void executeModificationWithInvalidHistoricProcessInstanceQueryAsync() {
+    when(historyServiceMock.createHistoricProcessInstanceQuery()).thenReturn(new HistoricProcessInstanceQueryImpl());
+    Map<String, Object> json = new HashMap<String, Object>();
+
+    List<Map<String, Object>> instructions = new ArrayList<Map<String, Object>>();
+    instructions.add(ModificationInstructionBuilder.startAfter().activityId("acivityId").getJson());
+
+    HistoricProcessInstanceQueryDto historicProcessInstanceQueryDto = new HistoricProcessInstanceQueryDto();
+    historicProcessInstanceQueryDto.setProcessInstanceBusinessKey("foo");
+
+    json.put("historicProcessInstanceQuery", historicProcessInstanceQueryDto);
+    json.put("instructions", instructions);
+    json.put("processDefinitionId", "processDefinitionId");
+
+    given()
+        .contentType(ContentType.JSON)
+        .body(json)
+        .then()
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .post(EXECUTE_MODIFICATION_ASYNC_URL);
   }
 
   @Test

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ModificationBuilderImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ModificationBuilderImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.exception.NotValidException;
+import org.operaton.bpm.engine.history.HistoricProcessInstanceQuery;
 import org.operaton.bpm.engine.impl.cmd.AbstractProcessInstanceModificationCommand;
 import org.operaton.bpm.engine.impl.cmd.ActivityAfterInstantiationCmd;
 import org.operaton.bpm.engine.impl.cmd.ActivityBeforeInstantiationCmd;
@@ -40,6 +41,7 @@ public class ModificationBuilderImpl implements ModificationBuilder {
 
   protected CommandExecutor commandExecutor;
   protected ProcessInstanceQuery processInstanceQuery;
+  protected HistoricProcessInstanceQuery historicProcessInstanceQuery;
   protected List<String> processInstanceIds;
   protected List<AbstractProcessInstanceModificationCommand> instructions;
   protected String processDefinitionId;
@@ -115,6 +117,12 @@ public class ModificationBuilderImpl implements ModificationBuilder {
   }
 
   @Override
+  public ModificationBuilder historicProcessInstanceQuery(HistoricProcessInstanceQuery historicProcessInstanceQuery) {
+    this.historicProcessInstanceQuery = historicProcessInstanceQuery;
+    return this;
+  }
+
+  @Override
   public ModificationBuilder skipCustomListeners() {
     this.skipCustomListeners = true;
     return this;
@@ -151,6 +159,10 @@ public class ModificationBuilderImpl implements ModificationBuilder {
 
   public ProcessInstanceQuery getProcessInstanceQuery() {
     return processInstanceQuery;
+  }
+
+  public HistoricProcessInstanceQuery getHistoricProcessInstanceQuery() {
+    return historicProcessInstanceQuery;
   }
 
   public List<String> getProcessInstanceIds() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractModificationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractModificationCmd.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
+import org.operaton.bpm.engine.impl.HistoricProcessInstanceQueryImpl;
 import org.operaton.bpm.engine.impl.ModificationBuilderImpl;
 import org.operaton.bpm.engine.impl.ProcessInstanceQueryImpl;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -51,6 +52,12 @@ public abstract class AbstractModificationCmd <T> implements Command<T> {
     final ProcessInstanceQueryImpl processInstanceQuery = (ProcessInstanceQueryImpl) builder.getProcessInstanceQuery();
     if (processInstanceQuery != null) {
       collectedProcessInstanceIds.addAll(processInstanceQuery.listIds());
+    }
+
+    final HistoricProcessInstanceQueryImpl historicProcessInstanceQuery =
+        (HistoricProcessInstanceQueryImpl) builder.getHistoricProcessInstanceQuery();
+    if(historicProcessInstanceQuery != null) {
+      collectedProcessInstanceIds.addAll(historicProcessInstanceQuery.listIds());
     }
 
     return collectedProcessInstanceIds;

--- a/engine/src/main/java/org/operaton/bpm/engine/runtime/ModificationBuilder.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/runtime/ModificationBuilder.java
@@ -24,6 +24,7 @@ import org.operaton.bpm.engine.authorization.BatchPermissions;
 import org.operaton.bpm.engine.authorization.Permissions;
 import org.operaton.bpm.engine.authorization.Resources;
 import org.operaton.bpm.engine.batch.Batch;
+import org.operaton.bpm.engine.history.HistoricProcessInstanceQuery;
 
 public interface ModificationBuilder extends InstantiationBuilder<ModificationBuilder>{
 
@@ -116,5 +117,12 @@ public interface ModificationBuilder extends InstantiationBuilder<ModificationBu
    *   </ul>
    */
   Batch executeAsync();
+
+  /**
+   * @param historicProcessInstanceQuery a query which selects the process instances to modify.
+   *   It is advised to include the `unfinished` filter in the historicProcessInstanceQuery as finished instances cause failures for the modification.
+   *   Query results are restricted to process instances for which the user has {@link Permissions#READ_HISTORY} permission.
+   */
+  ModificationBuilder historicProcessInstanceQuery(HistoricProcessInstanceQuery historicProcessInstanceQuery);
 }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionAsyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionAsyncTest.java
@@ -35,12 +35,15 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
+import org.operaton.bpm.engine.HistoryService;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.RuntimeService;
+import org.operaton.bpm.engine.TaskService;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.batch.history.HistoricBatch;
 import org.operaton.bpm.engine.delegate.ExecutionListener;
+import org.operaton.bpm.engine.history.HistoricProcessInstanceQuery;
 import org.operaton.bpm.engine.impl.batch.BatchSeedJobHandler;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
@@ -55,6 +58,7 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstanceQuery;
 import org.operaton.bpm.engine.runtime.VariableInstance;
 import org.operaton.bpm.engine.task.Task;
+import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.bpmn.multiinstance.DelegateEvent;
@@ -86,6 +90,7 @@ public class ModificationExecutionAsyncTest {
 
   protected ProcessEngineConfigurationImpl configuration;
   protected RuntimeService runtimeService;
+  protected HistoryService historyService;
 
   protected BpmnModelInstance instance;
 
@@ -110,6 +115,7 @@ public class ModificationExecutionAsyncTest {
   @Before
   public void initServices() {
     runtimeService = rule.getRuntimeService();
+    historyService = rule.getHistoryService();
   }
 
   @Before
@@ -239,6 +245,17 @@ public class ModificationExecutionAsyncTest {
 
     try {
       runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceQuery(null).executeAsync();
+      fail("Should not succeed");
+    } catch (ProcessEngineException e) {
+      assertThat(e.getMessage()).contains("Process instance ids is empty");
+    }
+  }
+
+  @Test
+  public void testNullHistoricProcessInstanceQueryAsync() {
+
+    try {
+      runtimeService.createModification("processDefinitionId").startAfterActivity("user1").historicProcessInstanceQuery(null).executeAsync();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids is empty");
@@ -842,6 +859,114 @@ public class ModificationExecutionAsyncTest {
   }
 
   @Test
+  public void testBatchExecutionFailureWithHistoricQueryThatMatchesDeletedInstance() {
+    DeploymentWithDefinitions deployment = testRule.deploy(instance);
+    ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
+
+    List<String> startedInstances = helper.startInstances("process1", 3);
+    RuntimeService runtimeService = rule.getRuntimeService();
+
+    String deletedProcessInstanceId = startedInstances.get(0);
+
+    runtimeService.deleteProcessInstance(deletedProcessInstanceId, "test");
+
+    HistoricProcessInstanceQuery historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery().processDefinitionId(processDefinition.getId());
+
+    Batch batch = runtimeService
+        .createModification(processDefinition.getId())
+        .startAfterActivity("user1")
+        .historicProcessInstanceQuery(historicProcessInstanceQuery)
+        .executeAsync();
+
+    helper.completeSeedJobs(batch);
+
+    // when
+    helper.executeJobs(batch);
+
+    // then the remaining process instance was modified
+    for (String processInstanceId : startedInstances) {
+      if (processInstanceId.equals(deletedProcessInstanceId)) {
+        ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
+        assertNull(updatedTree);
+        continue;
+      }
+
+      ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
+      assertNotNull(updatedTree);
+      assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
+
+      assertThat(updatedTree).hasStructure(
+          describeActivityInstanceTree(
+              processDefinition.getId())
+              .activity("user1")
+              .activity("user2")
+              .done());
+    }
+
+    // and one batch job failed and has 2 retries left
+    List<Job> modificationJobs = helper.getExecutionJobs(batch);
+    assertEquals(1, modificationJobs.size());
+
+    Job failedJob = modificationJobs.get(0);
+    assertEquals(2, failedJob.getRetries());
+    assertThat(failedJob.getExceptionMessage()).startsWith("ENGINE-13036");
+    assertThat(failedJob.getExceptionMessage()).contains("Process instance '" + deletedProcessInstanceId + "' cannot be modified");
+  }
+
+  @Test
+  @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationTest.syncAfterOneTaskProcess.bpmn20.xml" })
+  public void testBatchExecutionWithHistoricQueryUnfinished() {
+    // given
+    List<String> startedInstances = helper.startInstances("oneTaskProcess", 3);
+
+    TaskService taskService = rule.getTaskService();
+    Task task = taskService.createTaskQuery().processInstanceId(startedInstances.get(0)).singleResult();
+    String processDefinitionId = task.getProcessDefinitionId();
+    String completedProcessInstanceId = task.getProcessInstanceId();
+    assertNotNull(task);
+    taskService.complete(task.getId());
+
+    HistoricProcessInstanceQuery historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery().unfinished().processDefinitionId(processDefinitionId);
+    assertEquals(2, historicProcessInstanceQuery.count());
+
+    // then
+    Batch batch = runtimeService
+        .createModification(processDefinitionId)
+        .startAfterActivity("theStart")
+        .historicProcessInstanceQuery(historicProcessInstanceQuery)
+        .executeAsync();
+
+    helper.completeSeedJobs(batch);
+
+    // when
+    helper.executeJobs(batch);
+
+    //     then the remaining process instance was modified
+    for (String processInstanceId : startedInstances) {
+      if (processInstanceId.equals(completedProcessInstanceId)) {
+        ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
+        assertNull(updatedTree);
+        continue;
+      }
+
+      ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
+      assertNotNull(updatedTree);
+      assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
+
+      assertThat(updatedTree).hasStructure(
+          describeActivityInstanceTree(
+              processDefinitionId)
+              .activity("theTask")
+              .activity("theTask")
+              .done());
+    }
+
+    // and one batch job failed and has 2 retries left
+    List<Job> modificationJobs = helper.getExecutionJobs(batch);
+    assertEquals(0, modificationJobs.size());
+  }
+
+  @Test
   public void testBatchCreationWithProcessInstanceQuery() {
     int processInstanceCount = 15;
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
@@ -863,6 +988,142 @@ public class ModificationExecutionAsyncTest {
   }
 
   @Test
+  public void testBatchCreationWithHistoricProcessInstanceQuery() {
+    int processInstanceCount = 15;
+    DeploymentWithDefinitions deployment = testRule.deploy(instance);
+    ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
+    helper.startInstances("process1", 15);
+
+    HistoricProcessInstanceQuery historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery().processDefinitionId(processDefinition.getId());
+    assertEquals(processInstanceCount, historicProcessInstanceQuery.count());
+
+    // when
+    Batch batch = runtimeService
+        .createModification(processDefinition.getId())
+        .startAfterActivity("user1")
+        .historicProcessInstanceQuery(historicProcessInstanceQuery)
+        .executeAsync();
+
+    // then a batch is created
+    assertBatchCreated(batch, processInstanceCount);
+  }
+
+  @Test
+  @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationTest.syncAfterOneTaskProcess.bpmn20.xml" })
+  public void testBatchExecutionFailureWithFinishedInstanceId() {
+    // given
+    List<String> startedInstances = helper.startInstances("oneTaskProcess", 3);
+
+    TaskService taskService = rule.getTaskService();
+    Task task = taskService.createTaskQuery().processInstanceId(startedInstances.get(0)).singleResult();
+    String processDefinitionId = task.getProcessDefinitionId();
+    String completedProcessInstanceId = task.getProcessInstanceId();
+    assertNotNull(task);
+    taskService.complete(task.getId());
+
+    // then
+    Batch batch = runtimeService
+        .createModification(processDefinitionId)
+        .startAfterActivity("theStart")
+        .processInstanceIds(startedInstances)
+        .executeAsync();
+
+    helper.completeSeedJobs(batch);
+
+    // when
+    helper.executeJobs(batch);
+
+    //     then the remaining process instance was modified
+    for (String processInstanceId : startedInstances) {
+      if (processInstanceId.equals(completedProcessInstanceId)) {
+        ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
+        assertNull(updatedTree);
+        continue;
+      }
+
+      ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
+      assertNotNull(updatedTree);
+      assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
+
+      assertThat(updatedTree).hasStructure(
+          describeActivityInstanceTree(
+              processDefinitionId)
+              .activity("theTask")
+              .activity("theTask")
+              .done());
+    }
+
+    //    and one batch job failed and has 2 retries left
+    List<Job> modificationJobs = helper.getExecutionJobs(batch);
+    assertEquals(1, modificationJobs.size());
+
+    Job failedJob = modificationJobs.get(0);
+    assertEquals(2, failedJob.getRetries());
+    assertThat(failedJob.getExceptionMessage()).startsWith("ENGINE-13036");
+    assertThat(failedJob.getExceptionMessage()).contains("Process instance '" + completedProcessInstanceId + "' cannot be modified");
+  }
+
+
+  @Test
+  @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationTest.syncAfterOneTaskProcess.bpmn20.xml" })
+  public void testBatchExecutionFailureWithHistoricQueryThatMatchesFinishedInstance() {
+    // given
+    List<String> startedInstances = helper.startInstances("oneTaskProcess", 3);
+
+    TaskService taskService = rule.getTaskService();
+    Task task = taskService.createTaskQuery().processInstanceId(startedInstances.get(0)).singleResult();
+    String processDefinitionId = task.getProcessDefinitionId();
+    String completedProcessInstanceId = task.getProcessInstanceId();
+    assertNotNull(task);
+    taskService.complete(task.getId());
+
+    HistoricProcessInstanceQuery historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery().processDefinitionId(processDefinitionId);
+    assertEquals(3, historicProcessInstanceQuery.count());
+
+    // then
+    Batch batch = runtimeService
+        .createModification(processDefinitionId)
+        .startAfterActivity("theStart")
+        .historicProcessInstanceQuery(historicProcessInstanceQuery)
+        .executeAsync();
+
+    helper.completeSeedJobs(batch);
+
+    // when
+    helper.executeJobs(batch);
+
+    //     then the remaining process instance was modified
+    for (String processInstanceId : startedInstances) {
+      if (processInstanceId.equals(completedProcessInstanceId)) {
+        ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
+        assertNull(updatedTree);
+        continue;
+      }
+
+      ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
+      assertNotNull(updatedTree);
+      assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
+
+      assertThat(updatedTree).hasStructure(
+          describeActivityInstanceTree(
+              processDefinitionId)
+              .activity("theTask")
+              .activity("theTask")
+              .done());
+    }
+
+    // and one batch job failed and has 2 retries left
+    List<Job> modificationJobs = helper.getExecutionJobs(batch);
+    assertEquals(1, modificationJobs.size());
+
+    Job failedJob = modificationJobs.get(0);
+    assertEquals(2, failedJob.getRetries());
+    assertThat(failedJob.getExceptionMessage()).startsWith("ENGINE-13036");
+    assertThat(failedJob.getExceptionMessage()).contains("Process instance '" + completedProcessInstanceId + "' cannot be modified");
+  }
+
+
+  @Test
   public void testBatchCreationWithOverlappingProcessInstanceIdsAndQuery() {
     int processInstanceCount = 15;
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
@@ -879,6 +1140,53 @@ public class ModificationExecutionAsyncTest {
       .processInstanceIds(processInstanceIds)
       .processInstanceQuery(processInstanceQuery)
       .executeAsync();
+
+    // then a batch is created
+    assertBatchCreated(batch, processInstanceCount);
+  }
+
+  @Test
+  public void testBatchCreationWithOverlappingProcessInstanceIdsAndHistoricQuery() {
+    int processInstanceCount = 15;
+    DeploymentWithDefinitions deployment = testRule.deploy(instance);
+    ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
+    List<String> processInstanceIds = helper.startInstances("process1", 15);
+
+    HistoricProcessInstanceQuery historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery().processDefinitionId(processDefinition.getId());
+    assertEquals(processInstanceCount, historicProcessInstanceQuery.count());
+
+    // when
+    Batch batch = runtimeService
+        .createModification(processDefinition.getId())
+        .startTransition("seq")
+        .processInstanceIds(processInstanceIds)
+        .historicProcessInstanceQuery(historicProcessInstanceQuery)
+        .executeAsync();
+
+    // then a batch is created
+    assertBatchCreated(batch, processInstanceCount);
+  }
+
+  @Test
+  public void testBatchCreationWithOverlappingHistoricQueryAndQuery() {
+    // given
+    int processInstanceCount = 15;
+    DeploymentWithDefinitions deployment = testRule.deploy(instance);
+    ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
+    helper.startInstances("process1", processInstanceCount);
+
+    ProcessInstanceQuery processInstanceQuery = runtimeService.createProcessInstanceQuery().processDefinitionId(processDefinition.getId());
+    assertEquals(processInstanceCount, processInstanceQuery.count());
+    HistoricProcessInstanceQuery historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery().processDefinitionId(processDefinition.getId());
+    assertEquals(processInstanceCount, historicProcessInstanceQuery.count());
+
+    // when
+    Batch batch = runtimeService
+        .createModification(processDefinition.getId())
+        .startTransition("seq")
+        .processInstanceQuery(processInstanceQuery)
+        .historicProcessInstanceQuery(historicProcessInstanceQuery)
+        .executeAsync();
 
     // then a batch is created
     assertBatchCreated(batch, processInstanceCount);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionSyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionSyncTest.java
@@ -29,13 +29,16 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.operaton.bpm.engine.HistoryService;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.RuntimeService;
+import org.operaton.bpm.engine.history.HistoricProcessInstanceQuery;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.repository.DeploymentWithDefinitions;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.runtime.ActivityInstance;
 import org.operaton.bpm.engine.runtime.Execution;
+import org.operaton.bpm.engine.runtime.ProcessInstanceQuery;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
@@ -59,6 +62,7 @@ public class ModificationExecutionSyncTest {
   public RuleChain ruleChain = RuleChain.outerRule(rule).around(testRule);
 
   protected RuntimeService runtimeService;
+  protected HistoryService historyService;
   protected BpmnModelInstance instance;
 
   @Before
@@ -76,6 +80,7 @@ public class ModificationExecutionSyncTest {
   @Before
   public void initServices() {
     runtimeService = rule.getRuntimeService();
+    historyService = rule.getHistoryService();
   }
 
   @After
@@ -95,6 +100,78 @@ public class ModificationExecutionSyncTest {
       assertEquals(1, activeActivityIds.size());
       assertEquals(activeActivityIds.iterator().next(), "user2");
     }
+  }
+
+  @Test
+  public void createSimpleModificationPlanWithHistoricQuery() {
+    ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
+    List<String> instances = helper.startInstances("process1", 2);
+    HistoricProcessInstanceQuery historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
+    historicProcessInstanceQuery.processDefinitionId(processDefinition.getId());
+
+    runtimeService.createModification(processDefinition.getId()).startBeforeActivity("user2")
+        .cancelAllForActivity("user1").historicProcessInstanceQuery(historicProcessInstanceQuery).execute();
+
+    for (String instanceId : instances) {
+      List<String> activeActivityIds = runtimeService.getActiveActivityIds(instanceId);
+      assertEquals(1, activeActivityIds.size());
+      assertEquals(activeActivityIds.iterator().next(), "user2");
+    }
+  }
+
+  @Test
+  public void createSimpleModificationPlanWithIdenticalRuntimeAndHistoryQuery() {
+    ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
+    List<String> instances = helper.startInstances("process1", 2);
+    HistoricProcessInstanceQuery historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
+    historicProcessInstanceQuery.processDefinitionId(processDefinition.getId());
+    ProcessInstanceQuery processInstanceQuery = runtimeService.createProcessInstanceQuery();
+    processInstanceQuery.processDefinitionId(processDefinition.getId());
+
+    runtimeService.createModification(processDefinition.getId()).startBeforeActivity("user2")
+        .cancelAllForActivity("user1").historicProcessInstanceQuery(historicProcessInstanceQuery).processInstanceQuery(processInstanceQuery).execute();
+
+    for (String instanceId : instances) {
+      List<String> activeActivityIds = runtimeService.getActiveActivityIds(instanceId);
+      assertEquals(1, activeActivityIds.size());
+      assertEquals(activeActivityIds.iterator().next(), "user2");
+    }
+  }
+
+  @Test
+  public void createSimpleModificationPlanWithComplementaryRuntimeAndHistoryQueries() {
+    ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
+    List<String> instances = helper.startInstances("process1", 2);
+    HistoricProcessInstanceQuery historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
+    historicProcessInstanceQuery.processInstanceId(instances.get(0));
+    ProcessInstanceQuery processInstanceQuery = runtimeService.createProcessInstanceQuery();
+    processInstanceQuery.processInstanceId(instances.get(1));
+
+    runtimeService.createModification(processDefinition.getId()).startBeforeActivity("user2")
+        .cancelAllForActivity("user1").historicProcessInstanceQuery(historicProcessInstanceQuery).processInstanceQuery(processInstanceQuery).execute();
+
+    for (String instanceId : instances) {
+      List<String> activeActivityIds = runtimeService.getActiveActivityIds(instanceId);
+      assertEquals(1, activeActivityIds.size());
+      assertEquals(activeActivityIds.iterator().next(), "user2");
+    }
+  }
+
+  @Test
+  public void createSimpleModificationPlanWithHistoricQueryUnfinished() {
+    ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
+    List<String> instances = helper.startInstances("process1", 2);
+    HistoricProcessInstanceQuery historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
+    historicProcessInstanceQuery.processDefinitionId(processDefinition.getId()).unfinished();
+
+    runtimeService.deleteProcessInstance(instances.get(0), "test");
+
+    runtimeService.createModification(processDefinition.getId()).startBeforeActivity("user2")
+        .cancelAllForActivity("user1").historicProcessInstanceQuery(historicProcessInstanceQuery).execute();
+
+    List<String> activeActivityIds = runtimeService.getActiveActivityIds(instances.get(1));
+    assertEquals(1, activeActivityIds.size());
+    assertEquals(activeActivityIds.iterator().next(), "user2");
   }
 
   @Test
@@ -168,6 +245,16 @@ public class ModificationExecutionSyncTest {
   public void testNullProcessInstanceQuery() {
     try {
       runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceQuery(null).execute();
+      fail("Should not succeed");
+    } catch (ProcessEngineException e) {
+      assertThat(e.getMessage()).contains("Process instance ids is empty");
+    }
+  }
+
+  @Test
+  public void testNullHistoricProcessInstanceQuery() {
+    try {
+      runtimeService.createModification("processDefinitionId").startAfterActivity("user1").historicProcessInstanceQuery(null).execute();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids is empty");

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationTest.syncAfterOneTaskProcess.bpmn20.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationTest.syncAfterOneTaskProcess.bpmn20.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:operaton="http://operaton.org/schema/1.0/bpmn"
+  targetNamespace="org.operaton.bpm.engine.test.enginge.test.api.runtime">
+
+  <process id="oneTaskProcess" isExecutable="true">
+
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+    <userTask id="theTask" name="my task" operaton:asyncAfter="false"/>    
+    <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
related to: #4620

Backported commit 1b9de30e4c from the camunda-bpm-platform repository.
Original author: Gergely Juhasz <gergely.juhasz@camunda.com>