### PR TITLE
(chore)JUnit5 migration: example submodule (#27)

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -2,6 +2,5 @@
 --errors
 --show-version
 --no-transfer-progress
--DinstallAtEnd=true
 -DdeployAtEnd=true
 -Duser.timezone=Europe/Berlin

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/test/ProcessEngineAssert.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/test/ProcessEngineAssert.java
@@ -16,8 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.test;
 
-import junit.framework.AssertionFailedError;
-
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 
@@ -31,7 +29,7 @@ public class ProcessEngineAssert {
       .singleResult();
     
     if (processInstance!=null) {
-      throw new AssertionFailedError("expected finished process instance '"+processInstanceId+"' but it was still in the db"); 
+      throw new AssertionError("expected finished process instance '"+processInstanceId+"' but it was still in the db");
     }
   }
 }

--- a/examples/invoice/src/test/java/org/operaton/bpm/example/invoice/InvoiceTestCase.java
+++ b/examples/invoice/src/test/java/org/operaton/bpm/example/invoice/InvoiceTestCase.java
@@ -16,7 +16,20 @@
  */
 package org.operaton.bpm.example.invoice;
 
-import static org.operaton.bpm.engine.variable.Variables.fileValue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.operaton.bpm.engine.ManagementService;
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.RuntimeService;
+import org.operaton.bpm.engine.TaskService;
+import org.operaton.bpm.engine.runtime.Job;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.task.IdentityLink;
+import org.operaton.bpm.engine.task.Task;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.bpm.engine.variable.VariableMap;
+import org.operaton.bpm.engine.variable.Variables;
 
 import java.io.InputStream;
 import java.util.Arrays;
@@ -24,19 +37,19 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.operaton.bpm.engine.runtime.Job;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.task.IdentityLink;
-import org.operaton.bpm.engine.task.Task;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineTestCase;
-import org.operaton.bpm.engine.variable.VariableMap;
-import org.operaton.bpm.engine.variable.Variables;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.operaton.bpm.engine.impl.test.ProcessEngineAssert.assertProcessEnded;
+import static org.operaton.bpm.engine.variable.Variables.fileValue;
 
-public class InvoiceTestCase extends ProcessEngineTestCase {
-
-  @Deployment(resources= {"invoice.v1.bpmn", "invoiceBusinessDecisions.dmn"})
-  public void testHappyPathV1() {
+@ExtendWith(ProcessEngineExtension.class)
+public class InvoiceTestCase {
+   ProcessEngine processEngine;
+   RuntimeService runtimeService;
+   TaskService taskService;
+   ManagementService managementService;
+   @Deployment(resources = {"invoice.v1.bpmn", "invoiceBusinessDecisions.dmn"})
+   @Test
+   public void testHappyPathV1() {
     InputStream invoiceInputStream = InvoiceProcessApplication.class.getClassLoader().getResourceAsStream("invoice.pdf");
     VariableMap variables = Variables.createVariables()
       .putValue("creditor", "Great Pizza for Everyone Inc.")
@@ -75,11 +88,12 @@ public class InvoiceTestCase extends ProcessEngineTestCase {
     assertNotNull(archiveInvoiceJob);
     managementService.executeJob(archiveInvoiceJob.getId());
 
-    assertProcessEnded(pi.getId());
+    assertProcessEnded(processEngine, pi.getId());
   }
 
-  @Deployment(resources= {"invoice.v2.bpmn", "invoiceBusinessDecisions.dmn"})
-  public void testHappyPathV2() {
+   @Deployment(resources = {"invoice.v2.bpmn", "invoiceBusinessDecisions.dmn"})
+   @Test
+   public void testHappyPathV2() {
     InputStream invoiceInputStream = InvoiceProcessApplication.class.getClassLoader().getResourceAsStream("invoice.pdf");
     VariableMap variables = Variables.createVariables()
       .putValue("creditor", "Great Pizza for Everyone Inc.")
@@ -118,11 +132,12 @@ public class InvoiceTestCase extends ProcessEngineTestCase {
     assertNotNull(archiveInvoiceJob);
     managementService.executeJob(archiveInvoiceJob.getId());
 
-    assertProcessEnded(pi.getId());
+    assertProcessEnded(processEngine, pi.getId());
   }
 
-  @Deployment(resources= {"invoice.v2.bpmn", "invoiceBusinessDecisions.dmn"})
-  public void testApproveInvoiceAssignment() {
+   @Deployment(resources = {"invoice.v2.bpmn", "invoiceBusinessDecisions.dmn"})
+   @Test
+   public void testApproveInvoiceAssignment() {
     InputStream invoiceInputStream = InvoiceProcessApplication.class.getClassLoader().getResourceAsStream("invoice.pdf");
 
     VariableMap variables = Variables.createVariables()
@@ -165,8 +180,9 @@ public class InvoiceTestCase extends ProcessEngineTestCase {
     assertEquals("mary", taskService.getVariable(task.getId(), "approver"));
   }
 
-  @Deployment(resources= {"invoice.v2.bpmn", "reviewInvoice.bpmn", "invoiceBusinessDecisions.dmn"})
-  public void testNonSuccessfulPath() {
+   @Deployment(resources = {"invoice.v2.bpmn", "reviewInvoice.bpmn", "invoiceBusinessDecisions.dmn"})
+   @Test
+   public void testNonSuccessfulPath() {
     InputStream invoiceInputStream = InvoiceProcessApplication.class.getClassLoader().getResourceAsStream("invoice.pdf");
     VariableMap variables = Variables.createVariables()
       .putValue("creditor", "Great Pizza for Everyone Inc.")
@@ -210,9 +226,11 @@ public class InvoiceTestCase extends ProcessEngineTestCase {
     variables.put("clarified", Boolean.FALSE);
     taskService.complete(task.getId(), variables);
 
-    assertProcessEnded(task.getProcessInstanceId());
-    assertProcessEnded(pi.getId());
+    assertProcessEnded(processEngine, task.getProcessInstanceId());
+    assertProcessEnded(processEngine, pi.getId());
   }
 
 
 }
+
+

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -34,12 +34,6 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>
@@ -54,6 +48,12 @@
     <dependency>
       <groupId>org.graalvm.js</groupId>
       <artifactId>js-scriptengine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.operaton.bpm</groupId>
+      <artifactId>operaton-bpm-junit5</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Migrate the examples module to JUnit 5.

The code uses now ProcessEngineAssert, but this class dependet on JUnit 4's AssertionFailedError. This caused this error:
```
java.lang.NoClassDefFoundError: junit/framework/AssertionFailedError
        at org.operaton.bpm.example.invoice.InvoiceTestCase.testHappyPathV1(InvoiceTestCase.java:91)
```

To avoid this JU4 dependency replaced by its supertype java.lang.AssertionError. The ProcessEngineAssert will be used also in other migrated test cases.

Removed "installAtEnd" from maven.config. Sometimes I need to have some modules like installed, and a full build takes long and may fail.