### PR TITLE
chore(distro/run): Add Config for Disabling WADL

### DIFF
--- a/distro/run/assembly/resources/default.yml
+++ b/distro/run/assembly/resources/default.yml
@@ -13,6 +13,8 @@ operaton.bpm:
     cors:
       enabled: true
       allowed-origins: "*"
+    rest:
+      disable-wadl: false
 # https://docs.operaton.org/manual/latest/user-guide/operaton-bpm-run/#example-application
     example:
       enabled: true

--- a/distro/run/assembly/resources/production.yml
+++ b/distro/run/assembly/resources/production.yml
@@ -29,6 +29,7 @@ operaton.bpm:
 # https://docs.operaton.org/manual/latest/user-guide/security/#authentication
 # https://docs.operaton.org/manual/latest/user-guide/operaton-bpm-run/#authentication
     auth.enabled: true
+    rest.disable-wadl: true
 # https://docs.operaton.org/manual/latest/user-guide/process-engine/identity-service/#configuration-properties-of-the-ldap-plugin
 # https://docs.operaton.org/manual/latest/user-guide/operaton-bpm-run/#ldap-identity-service
 # Uncomment this section to enable LDAP support for Operaton Run

--- a/distro/run/core/src/main/java/org/operaton/bpm/run/OperatonBpmRunRestConfiguration.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/OperatonBpmRunRestConfiguration.java
@@ -24,6 +24,7 @@ import org.operaton.bpm.run.property.OperatonBpmRunCorsProperty;
 import org.operaton.bpm.run.property.OperatonBpmRunProperties;
 import org.operaton.bpm.spring.boot.starter.OperatonBpmAutoConfiguration;
 import org.operaton.bpm.spring.boot.starter.rest.OperatonBpmRestInitializer;
+import org.operaton.bpm.spring.boot.starter.rest.OperatonJerseyResourceConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -33,6 +34,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Collections;
 
 @EnableConfigurationProperties(OperatonBpmRunProperties.class)
 @Configuration
@@ -104,6 +107,13 @@ public class OperatonBpmRunRestConfiguration {
                                   operatonBpmRunProperties.getCors().getPreflightMaxAge());
 
     return registration;
+  }
+
+  @Bean
+  public OperatonJerseyResourceConfig operatonRunJerseyResourceConfig() {
+    OperatonJerseyResourceConfig operatonJerseyResourceConfig = new OperatonJerseyResourceConfig();
+    operatonJerseyResourceConfig.setProperties(Collections.singletonMap("jersey.config.server.wadl.disableWadl", operatonBpmRunProperties.getRest().isDisableWadl()));
+    return operatonJerseyResourceConfig;
   }
 
 }

--- a/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunProperties.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunProperties.java
@@ -42,6 +42,9 @@ public class OperatonBpmRunProperties {
   @NestedConfigurationProperty
   protected List<OperatonBpmRunProcessEnginePluginProperty> processEnginePlugins = new ArrayList<>();
 
+  @NestedConfigurationProperty
+  protected OperatonBpmRunRestProperties rest = new OperatonBpmRunRestProperties();
+
   protected OperatonBpmRunAdministratorAuthorizationProperties adminAuth
       = new OperatonBpmRunAdministratorAuthorizationProperties();
 
@@ -85,6 +88,14 @@ public class OperatonBpmRunProperties {
     this.processEnginePlugins = processEnginePlugins;
   }
 
+  public OperatonBpmRunRestProperties getRest() {
+    return rest;
+  }
+
+  public void setRest(OperatonBpmRunRestProperties rest) {
+    this.rest = rest;
+  }
+
   @Override
   public String toString() {
     return "OperatonBpmRunProperties [" +
@@ -93,6 +104,7 @@ public class OperatonBpmRunProperties {
         ", ldap=" + ldap +
         ", adminAuth=" + adminAuth +
         ", plugins=" + processEnginePlugins +
+        ", rest=" + rest +
         "]";
   }
 }

--- a/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunRestProperties.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunRestProperties.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.run.property;
+
+public class OperatonBpmRunRestProperties {
+
+  public static final String PREFIX = OperatonBpmRunProperties.PREFIX + ".rest";
+
+  protected boolean disableWadl;
+
+  public boolean isDisableWadl() {
+    return disableWadl;
+  }
+
+  public void setDisableWadl(boolean disableWadl) {
+    this.disableWadl = disableWadl;
+  }
+
+  @Override
+  public String toString() {
+    return "OperatonBpmRunRestProperties[" + "disableWadl=" + disableWadl + ']';
+  }
+}

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/rest/WadlDisabledTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/rest/WadlDisabledTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.run.test.config.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import org.operaton.bpm.run.property.OperatonBpmRunRestProperties;
+import org.operaton.bpm.run.test.AbstractRestTest;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = { OperatonBpmRunRestProperties.PREFIX + ".disable-wadl=true" })
+public class WadlDisabledTest extends AbstractRestTest {
+
+  @Test
+  public void shouldReturn404() {
+    // given
+
+    // when
+    ResponseEntity<JsonNode> response = testRestTemplate.getForEntity(CONTEXT_PATH + "/application.wadl", JsonNode.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().get("message").textValue()).isEqualTo("HTTP 404 Not Found");
+    assertThat(response.getBody().get("type").textValue()).isEqualTo("NotFoundException");
+    assertThat(response.getBody().get("code").getNodeType()).isEqualTo(JsonNodeType.NULL);
+  }
+}

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/rest/WadlEnabledTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/rest/WadlEnabledTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.run.test.config.rest;
+
+import org.operaton.bpm.run.property.OperatonBpmRunRestProperties;
+import org.operaton.bpm.run.test.AbstractRestTest;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = { OperatonBpmRunRestProperties.PREFIX + ".disable-wadl=false" })
+public class WadlEnabledTest extends AbstractRestTest {
+
+  @Test
+  public void shouldReturnWadl() {
+    // given
+
+    // when
+    ResponseEntity<String> response = testRestTemplate.getForEntity(CONTEXT_PATH + "/application.wadl", String.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotEmpty();
+  }
+}

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/rest/WadlUnsetTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/rest/WadlUnsetTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.run.test.config.rest;
+
+import org.operaton.bpm.run.test.AbstractRestTest;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WadlUnsetTest extends AbstractRestTest {
+
+  @Test
+  public void shouldReturnWadl() {
+    // given
+
+    // when
+    ResponseEntity<String> response = testRestTemplate.getForEntity(CONTEXT_PATH + "/application.wadl", String.class);
+
+    // then
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isNotEmpty();
+  }
+}


### PR DESCRIPTION
Context: Camunda-Run and Configuration of the WADL REST Endpoint

What: A new property is added that controls the WADL file, exposed via the REST API
Where: `camunda-run`

Endpoint: `/engine-rest/wadl.application`
Property: `camunda.bpm.run.rest.disable-wadl`

Values
- `true` disables the endpoint
- `false` enables the endpoint
- absence of the property has the same effect as the value `false` (endpoint is enabled)

Note: `production.yml` has the feature disabled by default

Co-authored-by: Petros Savvidis <petros.savvidis@camunda.com>
Related-to: https://github.com/camunda/camunda-bpm-platform/issues/4508

Backported commit 56673650f7 from the camunda-bpm-platform repository.
Original author: Jonathan Lukas <jonathan.lukas@camunda.com>