### PR TITLE
feat(tests): Enable ProcessEngineExtension to inject services into the super class of a test case (#27)

### DIFF
--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionSubTypeInjectionTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionSubTypeInjectionTest.java
@@ -1,0 +1,15 @@
+package org.operaton.bpm.engine.test.junit5;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test is checking that a ProcessEngineExtension annotated to the superclass of a test is injecting the
+ * services into the superclass fields.
+ */
+class ProcessEngineExtensionSubTypeInjectionTest extends ProcessEngineExtensionServiceInjectionTest {
+    @Test
+    @Override
+    void extensionInjectsServiceInstances() {
+        super.extensionInjectsServiceInstances();
+    }
+}


### PR DESCRIPTION
This is to allow a class hierarchy where the base class is annotated with @ExtendWith(ProcessEngineExtension.class) and declares (protected/package private) fields for engine services.

Example for this need: `org.operaton.spin.plugin.variables.JsonSerializationWithValidationTest`
This test derives from `JsonSerializationTest` and the subclass would need the services injected into the fields of `JsonSerializationTest`.