### PR TITLE
chore(deps): bump Tomcat to 10.1.29 (#4623)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -64,7 +64,7 @@
     <version.wildfly26.core>18.0.4.Final</version.wildfly26.core>
 
     <version.tomcat9>9.0.90</version.tomcat9>
-    <version.tomcat>10.1.25</version.tomcat>
+    <version.tomcat>10.1.30</version.tomcat>
 
     <version.arquillian>1.1.10.Final</version.arquillian>
     <version.shrinkwrap.resolvers>2.2.2</version.shrinkwrap.resolvers>


### PR DESCRIPTION
related to camunda/camunda-bpm-platform#4622

Backported commit 79ff55d871 from the camunda-bpm-platform repository.
Original author: tasso94 <3015690+tasso94@users.noreply.github.com>