### PR TITLE
feat(engine): like-queries for candidate groups

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/task-query-params.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/task-query-params.ftl
@@ -200,6 +200,11 @@
       type = "string"
       desc = "Only include tasks that are offered to the given group." />
 
+  <@lib.parameter name = "candidateGroupLike"
+  location = "query"
+  type = "string"
+  desc = "Only include tasks that are offered to groups that have the parameter value as a substring." />
+
   <@lib.parameter name = "candidateGroupExpression"
       location = "query"
       type = "string"

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/task/TaskQueryDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/task/TaskQueryDto.ftl
@@ -208,6 +208,11 @@
         name = "candidateGroup"
         type = "string"
         desc = "Only include tasks that are offered to the given group." />
+
+    <@lib.property
+    name = "candidateGroupLike"
+    type = "string"
+    desc = "Only include tasks that are offered to groups that have the parameter value as a substring." />
   
     <@lib.property
         name = "candidateGroupExpression"

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskQueryDto.java
@@ -131,6 +131,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
   private String[] assigneeNotIn;
   private String candidateGroup;
   private String candidateGroupExpression;
+  private String candidateGroupLike;
   private String candidateUser;
   private String candidateUserExpression;
   private Boolean includeAssignedTasks;
@@ -343,6 +344,11 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
   @OperatonQueryParam("candidateGroupExpression")
   public void setCandidateGroupExpression(String candidateGroupExpression) {
     this.candidateGroupExpression = candidateGroupExpression;
+  }
+
+  @OperatonQueryParam("candidateGroupLike")
+  public void setCandidateGroupLike(String candidateGroupLike) {
+    this.candidateGroupLike = candidateGroupLike;
   }
 
   @OperatonQueryParam(value = "withCandidateGroups", converter = BooleanConverter.class)
@@ -814,6 +820,10 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     return candidateGroupExpression;
   }
 
+  public String getCandidateGroupLike() {
+    return candidateGroupLike;
+  }
+
   public String getCandidateUser() {
     return candidateUser;
   }
@@ -1159,6 +1169,9 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     }
     if (candidateGroupExpression != null) {
       query.taskCandidateGroupExpression(candidateGroupExpression);
+    }
+    if (candidateGroupLike != null) {
+      query.taskCandidateGroupLike(candidateGroupLike);
     }
     if (withCandidateGroups != null && withCandidateGroups) {
       query.withCandidateGroups();
@@ -1558,6 +1571,7 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
 
     dto.candidateUser = taskQuery.getCandidateUser();
     dto.candidateGroup = taskQuery.getCandidateGroup();
+    dto.candidateGroupLike = taskQuery.getCandidateGroupLike();
     dto.candidateGroups = taskQuery.getCandidateGroupsInternal();
     dto.includeAssignedTasks = taskQuery.isIncludeAssignedTasksInternal();
     dto.withCandidateGroups = taskQuery.isWithCandidateGroups();

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
@@ -482,6 +482,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     parameters.put("assignee", "anAssignee");
     parameters.put("assigneeLike", "anAssigneeLike");
     parameters.put("candidateGroup", "aCandidateGroup");
+    parameters.put("candidateGroupLike", "aCandidateGroupLike");
     parameters.put("candidateUser", "aCandidate");
     parameters.put("includeAssignedTasks", "false");
     parameters.put("taskId", "aTaskId");
@@ -539,6 +540,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     verify(mockQuery).taskAssignee(stringQueryParameters.get("assignee"));
     verify(mockQuery).taskAssigneeLike(stringQueryParameters.get("assigneeLike"));
     verify(mockQuery).taskCandidateGroup(stringQueryParameters.get("candidateGroup"));
+    verify(mockQuery).taskCandidateGroupLike(stringQueryParameters.get("candidateGroupLike"));
     verify(mockQuery).taskCandidateUser(stringQueryParameters.get("candidateUser"));
     verify(mockQuery).taskDefinitionKey(stringQueryParameters.get("taskDefinitionKey"));
     verify(mockQuery).taskDefinitionKeyLike(stringQueryParameters.get("taskDefinitionKeyLike"));

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/TaskQueryImpl.java
@@ -113,6 +113,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   protected DelegationState delegationState;
   protected String candidateUser;
   protected String candidateGroup;
+  protected String candidateGroupLike;
   protected List<String> candidateGroups;
   protected Boolean withCandidateGroups;
   protected Boolean withoutCandidateGroups;
@@ -450,6 +451,18 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   }
 
   @Override
+  public TaskQuery taskCandidateGroupLike(String candidateGroupLike) {
+    ensureNotNull("Candidate group like", candidateGroupLike);
+
+    if (!isOrQueryActive && (candidateUser != null || expressions.containsKey("taskCandidateUser"))) {
+      throw new ProcessEngineException("Invalid query usage: cannot set both candidateGroupLike and candidateUser");
+    }
+
+    this.candidateGroupLike = candidateGroupLike;
+    return this;
+  }
+
+  @Override
   public TaskQuery taskCandidateGroupIn(List<String> candidateGroups) {
     ensureNotEmpty("Candidate group list", candidateGroups);
 
@@ -480,10 +493,11 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
 
   @Override
   public TaskQuery includeAssignedTasks() {
-    if (candidateUser == null && candidateGroup == null && candidateGroups == null && !isWithCandidateGroups() && !isWithoutCandidateGroups() && !isWithCandidateUsers() && !isWithoutCandidateUsers()
+    if (candidateUser == null && candidateGroup == null && candidateGroupLike == null && candidateGroups == null
+        && !isWithCandidateGroups() && !isWithoutCandidateGroups() && !isWithCandidateUsers() && !isWithoutCandidateUsers()
         && !expressions.containsKey("taskCandidateUser") && !expressions.containsKey("taskCandidateGroup")
         && !expressions.containsKey("taskCandidateGroupIn")) {
-      throw new ProcessEngineException("Invalid query usage: candidateUser, candidateGroup, candidateGroupIn, withCandidateGroups, withoutCandidateGroups, withCandidateUsers, withoutCandidateUsers has to be called before 'includeAssignedTasks'.");
+      throw new ProcessEngineException("Invalid query usage: candidateUser, candidateGroup, candidateGroupLike, candidateGroupIn, withCandidateGroups, withoutCandidateGroups, withCandidateUsers, withoutCandidateUsers has to be called before 'includeAssignedTasks'.");
     }
 
     includeAssignedTasks = true;
@@ -1563,6 +1577,10 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     return candidateGroup;
   }
 
+  public String getCandidateGroupLike() {
+    return candidateGroupLike;
+  }
+
   public boolean isIncludeAssignedTasks() {
     return includeAssignedTasks != null ? includeAssignedTasks : false;
   }
@@ -1912,6 +1930,13 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
     }
     else if (this.getCandidateGroup() != null) {
       extendedQuery.taskCandidateGroup(this.getCandidateGroup());
+    }
+
+    if (extendingQuery.getCandidateGroupLike() != null) {
+      extendedQuery.taskCandidateGroupLike(extendingQuery.getCandidateGroupLike());
+    }
+    else if (this.getCandidateGroupLike() != null) {
+      extendedQuery.taskCandidateGroupLike(this.getCandidateGroupLike());
     }
 
     if (extendingQuery.isWithCandidateGroups() || this.isWithCandidateGroups()) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/json/JsonTaskQueryConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/json/JsonTaskQueryConverter.java
@@ -62,6 +62,7 @@ public class JsonTaskQueryConverter extends JsonObjectConverter<TaskQuery> {
   public static final String DELEGATION_STATE = "delegationState";
   public static final String CANDIDATE_USER = "candidateUser";
   public static final String CANDIDATE_GROUP = "candidateGroup";
+  public static final String CANDIDATE_GROUP_LIKE = "candidateGroupLike";
   public static final String CANDIDATE_GROUPS = "candidateGroups";
   public static final String WITH_CANDIDATE_GROUPS = "withCandidateGroups";
   public static final String WITHOUT_CANDIDATE_GROUPS = "withoutCandidateGroups";
@@ -166,6 +167,7 @@ public class JsonTaskQueryConverter extends JsonObjectConverter<TaskQuery> {
     JsonUtil.addField(json, DELEGATION_STATE, query.getDelegationStateString());
     JsonUtil.addField(json, CANDIDATE_USER, query.getCandidateUser());
     JsonUtil.addField(json, CANDIDATE_GROUP, query.getCandidateGroup());
+    JsonUtil.addField(json, CANDIDATE_GROUP_LIKE, query.getCandidateGroupLike());
     JsonUtil.addListField(json, CANDIDATE_GROUPS, query.getCandidateGroupsInternal());
     JsonUtil.addDefaultField(json, WITH_CANDIDATE_GROUPS, false, query.isWithCandidateGroups());
     JsonUtil.addDefaultField(json, WITHOUT_CANDIDATE_GROUPS, false, query.isWithoutCandidateGroups());
@@ -362,6 +364,9 @@ public class JsonTaskQueryConverter extends JsonObjectConverter<TaskQuery> {
     }
     if (json.has(CANDIDATE_GROUP)) {
       query.taskCandidateGroup(JsonUtil.getString(json, CANDIDATE_GROUP));
+    }
+    if (json.has(CANDIDATE_GROUP_LIKE)) {
+      query.taskCandidateGroupLike(JsonUtil.getString(json, CANDIDATE_GROUP_LIKE));
     }
     if (json.has(CANDIDATE_GROUPS) && !json.has(CANDIDATE_USER) && !json.has(CANDIDATE_GROUP)) {
       query.taskCandidateGroupIn(getList(JsonUtil.getArray(json, CANDIDATE_GROUPS)));

--- a/engine/src/main/java/org/operaton/bpm/engine/task/TaskQuery.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/task/TaskQuery.java
@@ -315,6 +315,25 @@ public interface TaskQuery extends Query<TaskQuery, Task> {
   TaskQuery taskCandidateGroupExpression(String candidateGroupExpression);
 
   /**
+   * Only select tasks whose candidate users belong to groups matching the given parameter.
+   * The syntax is that of SQL: for example usage: nameLike(%operaton%)
+   *
+   * <p>
+   * Per default it only selects tasks which are not already assigned
+   * to a user. To also include assigned task in the result specify
+   * {@link #includeAssignedTasks()} in your query.
+   * </p>
+   *
+   * @throws ProcessEngineException <ul><li>When query is executed and {@link #taskCandidateUser(String)} or
+   *                                {@link #taskCandidateUserExpression(String)} (List)} has been executed on the
+   *                                "and query" instance. <br>
+   *                                No exception is thrown when query is executed and {@link #taskCandidateUser(String)} or
+   *                                {@link #taskCandidateUserExpression(String)} has been executed on the "or query" instance.</li>
+   *                                <li>When passed group is <code>null</code>.</li></ul>
+   */
+  TaskQuery taskCandidateGroupLike(String candidateGroupLike);
+
+  /**
    * Only select tasks for which the 'candidateGroup' is one of the given groups.
    *
    * <p>

--- a/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/Task.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/Task.xml
@@ -250,7 +250,7 @@
       <if test="query.isOrQueryActive">
         <bind name="JOIN_TYPE" value="'left join'" />
       </if>
-      <if test="query != null &amp;&amp; (query.candidateUser != null || query.candidateGroups != null || query.involvedUser != null || query.withCandidateGroups || query.withCandidateUsers)">
+      <if test="query != null &amp;&amp; (query.candidateUser != null || query.candidateGroups != null  || query.candidateGroupLike != null || query.involvedUser != null || query.withCandidateGroups || query.withCandidateUsers)">
         <bind name="I_JOIN" value="true" />
       </if>
       <!-- the process definition table is joined if
@@ -577,14 +577,14 @@
             <if test="query.isWithoutTenantId">
               ${queryType} RES.TENANT_ID_ is null
             </if>
-            <if test="query.candidateUser != null || query.candidateGroups != null || query.withCandidateGroups || query.withCandidateUsers">
+            <if test="query.candidateUser != null || query.candidateGroups != null || query.candidateGroupLike != null || query.withCandidateGroups || query.withCandidateUsers">
               ${queryType}
               <trim prefixOverrides="and" prefix="(" suffix=")">
                 <if test="!query.includeAssignedTasks">
                   and RES.ASSIGNEE_ is null
                 </if>
                 and I.TYPE_ = 'candidate'
-                <if test="query.candidateUser != null || query.candidateGroups != null">
+                <if test="query.candidateUser != null || query.candidateGroups != null || query.candidateGroupLike != null">
                   and
                   (
                   <if test="query.candidateUser != null">
@@ -599,6 +599,14 @@
                              open="(" separator="," close=")">
                       #{group}
                     </foreach>
+                  </if>
+                  <!-- If we need to add the candidateGroupsLike statement and there have been previous statements
+                   in the candidates block, then we need to add an "or" first -->
+                  <if test="query.candidateGroupLike != null &amp;&amp; (query.candidateUser != null || (query.candidateGroups != null &amp;&amp; query.candidateGroups.size &gt; 0))">
+                    or
+                  </if>
+                  <if test="query.candidateGroupLike != null">
+                    I.GROUP_ID_ LIKE #{candidateGroupLike}
                   </if>
                   )
                 </if>

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
@@ -35,6 +35,7 @@ import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySo
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -611,6 +612,70 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
   }
 
   @Test
+  public void testQueryByIncludeAssignedTasksWithoutMissingCandidateUserOrGroup() {
+    // We expect no exceptions when the there is at least 1 candidate user or group present
+    try {
+      taskService.createTaskQuery().taskCandidateUser("user").includeAssignedTasks();
+    } catch (ProcessEngineException e) {
+      fail("We expect no exceptions when a taskCandidateUser is present");
+    }
+
+    try {
+      taskService.createTaskQuery().taskCandidateGroupLike("%group%").includeAssignedTasks();
+    } catch (ProcessEngineException e) {
+      fail("We expect no exceptions when a candidateGroupLike is present");
+    }
+
+    try {
+      taskService.createTaskQuery().taskCandidateGroupIn(List.of("group")).includeAssignedTasks();
+    } catch (ProcessEngineException e) {
+      fail("We expect no exceptions when a taskCandidateGroupIn is present");
+    }
+
+    try {
+      taskService.createTaskQuery().withCandidateGroups().includeAssignedTasks();
+    } catch (ProcessEngineException e) {
+      fail("We expect no exceptions when a withCandidateGroups is present");
+    }
+
+    try {
+      taskService.createTaskQuery().withoutCandidateGroups().includeAssignedTasks();
+    } catch (ProcessEngineException e) {
+      fail("We expect no exceptions when a withoutCandidateGroups is present");
+    }
+
+    try {
+      taskService.createTaskQuery().withCandidateUsers().includeAssignedTasks();
+    } catch (ProcessEngineException e) {
+      fail("We expect no exceptions when a withCandidateUsers is present");
+    }
+
+    try {
+      taskService.createTaskQuery().withoutCandidateUsers().includeAssignedTasks();
+    } catch (ProcessEngineException e) {
+      fail("We expect no exceptions when a withoutCandidateUsers is present");
+    }
+
+    try {
+      taskService.createTaskQuery().taskCandidateUserExpression("expression").includeAssignedTasks();
+    } catch (ProcessEngineException e) {
+      fail("We expect no exceptions when a taskCandidateUserExpression is present");
+    }
+
+    try {
+      taskService.createTaskQuery().taskCandidateGroupExpression("expression").includeAssignedTasks();
+    } catch (ProcessEngineException e) {
+      fail("We expect no exceptions when a taskCandidateGroupExpression is present");
+    }
+
+    try {
+      taskService.createTaskQuery().taskCandidateGroupInExpression("expression").includeAssignedTasks();
+    } catch (ProcessEngineException e) {
+      fail("We expect no exceptions when a taskCandidateGroupInExpression is present");
+    }
+  }
+
+  @Test
   public void testQueryByCandidateGroup() {
     // management group is candidate for 3 tasks, one of them is already assigned
     TaskQuery query = taskService.createTaskQuery().taskCandidateGroup("management");
@@ -648,6 +713,58 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     query = taskService.createTaskQuery().taskCandidateGroup("sales").includeAssignedTasks();
     assertEquals(0, query.count());
     assertEquals(0, query.list().size());
+  }
+
+  @Test
+  public void testQueryByCandidateGroupLike() {
+    // management group is candidate for 3 tasks, one of them is already assigned
+    TaskQuery query = taskService.createTaskQuery().taskCandidateGroupLike("management");
+    assertEquals(2, query.count());
+    assertEquals(2, query.list().size());
+    assertThrows(ProcessEngineException.class, query::singleResult);
+
+    // test with "shortened" group name for like query
+    query = taskService.createTaskQuery().taskCandidateGroupLike("mana%");
+    assertEquals(2, query.count());
+    assertEquals(2, query.list().size());
+    assertThrows(ProcessEngineException.class, query::singleResult);
+
+    // test with "shortened" group name for like query (different part)
+    query = taskService.createTaskQuery().taskCandidateGroupLike("%ment");
+    assertEquals(2, query.count());
+    assertEquals(2, query.list().size());
+    assertThrows(ProcessEngineException.class, query::singleResult);
+
+    // test management candidates group with assigned tasks included
+    query = taskService.createTaskQuery().taskCandidateGroupLike("management").includeAssignedTasks();
+    assertEquals(3, query.count());
+    assertEquals(3, query.list().size());
+    assertThrows(ProcessEngineException.class, query::singleResult);
+
+    // test with "shortened" group name for like query (assigned tasks included)
+    query = taskService.createTaskQuery().taskCandidateGroupLike("mana%").includeAssignedTasks();
+    assertEquals(3, query.count());
+    assertEquals(3, query.list().size());
+    assertThrows(ProcessEngineException.class, query::singleResult);
+
+    // test with "shortened" group name for like query (different part, assigned tasks included)
+    query = taskService.createTaskQuery().taskCandidateGroupLike("%ment").includeAssignedTasks();
+    assertEquals(3, query.count());
+    assertEquals(3, query.list().size());
+    assertThrows(ProcessEngineException.class, query::singleResult);
+
+    // test query that matches tasks with the "management" the "accountancy" candidate groups
+    // accountancy group is candidate for 3 tasks, one of them is already assigned
+    query = taskService.createTaskQuery().taskCandidateGroupLike("%an%");
+    assertEquals(4, query.count());
+    assertEquals(4, query.list().size());
+    assertThrows(ProcessEngineException.class, query::singleResult);
+
+    // test query that matches tasks with the "management" the "accountancy" candidate groups (assigned tasks included)
+    query = taskService.createTaskQuery().taskCandidateGroupLike("%an%").includeAssignedTasks();
+    assertEquals(5, query.count());
+    assertEquals(5, query.list().size());
+    assertThrows(ProcessEngineException.class, query::singleResult);
   }
 
   @Test


### PR DESCRIPTION
- adds functionality to filter tasks on a candidate group using a like-statement

related to #4540

Backported commit 79b001b337 from the camunda-bpm-platform repository.
Original author: Jordy Cantaert <jordy.cantaert@vaph.be>