### PR TITLE
chore(deps-dev): Ensure that everywhere the same JUnit 5 version is used (#155)

### DIFF
--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -15,10 +15,6 @@
 
   <description>Operaton core internal bill of material for dependencies</description>
 
-  <properties>
-    <version.junit5>5.11.3</version.junit5>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -76,6 +76,7 @@
 
     <version.nodejs>20.14.0</version.nodejs>
     <version.npm>10.7.0</version.npm>
+    <version.junit5>5.11.3</version.junit5>
 
     <!-- OSGi bundles properties -->
     <operaton.artifact />

--- a/quarkus-extension/pom.xml
+++ b/quarkus-extension/pom.xml
@@ -19,6 +19,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${version.junit5}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bom</artifactId>
         <version>${version.quarkus}</version>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -17,6 +17,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${version.junit5}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/test-utils/assert/pom.xml
+++ b/test-utils/assert/pom.xml
@@ -14,6 +14,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${version.junit5}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- spring-framework-bom as first element in the list
            ensures to be chosen over spring-boot-dependencies
            to load spring-beans with Spring 5.


### PR DESCRIPTION
JUnit 5 dependencies after this change:

![Screenshot 305](https://github.com/user-attachments/assets/55548450-035a-4872-800d-9b83a43e64cd)

**Testing Instructions**

Execute
```
./mvnw dependency:list | grep org.junit | sort -u
```

Ensure that all tests have run.

Fixes #155 