### PR TITLE
feat(distro/run): Make deployChangedOnly Configurable

### DIFF
--- a/distro/run/assembly/resources/default.yml
+++ b/distro/run/assembly/resources/default.yml
@@ -15,6 +15,8 @@ operaton.bpm:
       allowed-origins: "*"
     rest:
       disable-wadl: false
+    deployment:
+      deploy-changed-only: true
 # https://docs.operaton.org/manual/latest/user-guide/operaton-bpm-run/#example-application
     example:
       enabled: true

--- a/distro/run/assembly/resources/production.yml
+++ b/distro/run/assembly/resources/production.yml
@@ -30,6 +30,7 @@ operaton.bpm:
 # https://docs.operaton.org/manual/latest/user-guide/operaton-bpm-run/#authentication
     auth.enabled: true
     rest.disable-wadl: true
+    deployment.deploy-changed-only: true
 # https://docs.operaton.org/manual/latest/user-guide/process-engine/identity-service/#configuration-properties-of-the-ldap-plugin
 # https://docs.operaton.org/manual/latest/user-guide/operaton-bpm-run/#ldap-identity-service
 # Uncomment this section to enable LDAP support for Operaton Run

--- a/distro/run/core/src/main/java/org/operaton/bpm/run/OperatonBpmRunDeploymentConfiguration.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/OperatonBpmRunDeploymentConfiguration.java
@@ -16,6 +16,12 @@
  */
 package org.operaton.bpm.run;
 
+import org.apache.commons.lang3.StringUtils;
+import org.operaton.bpm.spring.boot.starter.configuration.impl.DefaultDeploymentConfiguration;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,23 +31,16 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.StringUtils;
-import org.operaton.bpm.spring.boot.starter.configuration.impl.DefaultDeploymentConfiguration;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
-
 public class OperatonBpmRunDeploymentConfiguration extends DefaultDeploymentConfiguration {
 
-  public static final String CAMUNDA_DEPLOYMENT_DIR_PROPERTY = "operaton.deploymentDir";
+  private final String deploymentDir;
 
-  @Autowired
-  private Environment env;
+  public OperatonBpmRunDeploymentConfiguration(String deploymentDir) {
+    this.deploymentDir = deploymentDir;
+  }
 
   @Override
   public Set<Resource> getDeploymentResources() {
-    String deploymentDir = env.getProperty(CAMUNDA_DEPLOYMENT_DIR_PROPERTY);
     if (!StringUtils.isEmpty(deploymentDir)) {
       Path resourceDir = Paths.get(deploymentDir);
 
@@ -52,5 +51,14 @@ public class OperatonBpmRunDeploymentConfiguration extends DefaultDeploymentConf
       }
     }
     return Collections.emptySet();
+  }
+
+  protected String getNormalizedDeploymentDir() {
+    String result = deploymentDir;
+
+    if(File.separator.equals("\\")) {
+      result = result.replace("\\", "/");
+    }
+    return result;
   }
 }

--- a/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunDeploymentProperties.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunDeploymentProperties.java
@@ -16,35 +16,22 @@
  */
 package org.operaton.bpm.run.property;
 
-import java.util.Collections;
-import java.util.Map;
+public class OperatonBpmRunDeploymentProperties {
 
-public class OperatonBpmRunProcessEnginePluginProperty {
+  public static final String PREFIX = OperatonBpmRunProperties.PREFIX + ".deployment";
 
-  protected String pluginClass;
-  protected Map<String, Object> pluginParameters = Collections.EMPTY_MAP;
+  protected boolean deployChangedOnly = true;
 
-  public String getPluginClass() {
-    return pluginClass;
+  public boolean isDeployChangedOnly() {
+    return deployChangedOnly;
   }
 
-  public void setPluginClass(String pluginClass) {
-    this.pluginClass = pluginClass;
-  }
-
-  public Map<String, Object> getPluginParameters() {
-    return pluginParameters;
-  }
-
-  public void setPluginParameters(Map<String, Object> pluginParameters) {
-    this.pluginParameters = pluginParameters;
+  public void setDeployChangedOnly(boolean deployChangedOnly) {
+    this.deployChangedOnly = deployChangedOnly;
   }
 
   @Override
   public String toString() {
-    return "OperatonBpmRunProcessEnginePluginProperty [pluginClass=" + pluginClass +
-        ", pluginParameters=" + pluginParameters +
-        "]";
+    return "OperatonBpmRunDeploymentProperties[" + "deployChangedOnly=" + deployChangedOnly + ']';
   }
-
 }

--- a/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunProperties.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunProperties.java
@@ -16,14 +16,12 @@
  */
 package org.operaton.bpm.run.property;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.operaton.bpm.spring.boot.starter.property.OperatonBpmProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @ConfigurationProperties(OperatonBpmRunProperties.PREFIX)
 public class OperatonBpmRunProperties {
@@ -44,6 +42,9 @@ public class OperatonBpmRunProperties {
 
   @NestedConfigurationProperty
   protected OperatonBpmRunRestProperties rest = new OperatonBpmRunRestProperties();
+
+  @NestedConfigurationProperty
+  protected OperatonBpmRunDeploymentProperties deployment = new OperatonBpmRunDeploymentProperties();
 
   protected OperatonBpmRunAdministratorAuthorizationProperties adminAuth
       = new OperatonBpmRunAdministratorAuthorizationProperties();
@@ -96,6 +97,15 @@ public class OperatonBpmRunProperties {
     this.rest = rest;
   }
 
+  public OperatonBpmRunDeploymentProperties getDeployment() {
+    return deployment;
+  }
+
+  public void setDeployment(OperatonBpmRunDeploymentProperties deployment) {
+    this.deployment = deployment;
+  }
+
+
   @Override
   public String toString() {
     return "OperatonBpmRunProperties [" +
@@ -105,6 +115,7 @@ public class OperatonBpmRunProperties {
         ", adminAuth=" + adminAuth +
         ", plugins=" + processEnginePlugins +
         ", rest=" + rest +
+        ", deployment=" + deployment +
         "]";
   }
 }

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/deploy/DeployChangedOnlyDisabledTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/deploy/DeployChangedOnlyDisabledTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.run.test.config.deploy;
+
+import org.operaton.bpm.run.OperatonBpmRunProcessEngineConfiguration;
+import org.operaton.bpm.run.property.OperatonBpmRunDeploymentProperties;
+import org.operaton.bpm.run.test.AbstractRestTest;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = { OperatonBpmRunDeploymentProperties.PREFIX + ".deploy-changed-only=false" })
+public class DeployChangedOnlyDisabledTest extends AbstractRestTest {
+
+  @Autowired
+  private OperatonBpmRunProcessEngineConfiguration engineConfig;
+
+  @Test
+  public void shouldEnableDeployChangedOnlyOnOperatonRunProperty() {
+    assertThat(engineConfig.isDeployChangedOnly()).isEqualTo(false);
+  }
+}

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/deploy/DeployChangedOnlyEnabledTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/deploy/DeployChangedOnlyEnabledTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.run.test.config.deploy;
+
+import org.operaton.bpm.run.OperatonBpmRunProcessEngineConfiguration;
+import org.operaton.bpm.run.property.OperatonBpmRunDeploymentProperties;
+import org.operaton.bpm.run.test.AbstractRestTest;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = { OperatonBpmRunDeploymentProperties.PREFIX + ".deploy-changed-only=true" })
+public class DeployChangedOnlyEnabledTest extends AbstractRestTest {
+
+  @Autowired
+  private OperatonBpmRunProcessEngineConfiguration engineConfig;
+
+  @Test
+  public void shouldEnableDeployChangedOnlyOnOperatonRunProperty() {
+    assertThat(engineConfig.isDeployChangedOnly()).isEqualTo(true);
+  }
+}

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/deploy/DeployChangedOnlyUnsetTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/deploy/DeployChangedOnlyUnsetTest.java
@@ -14,37 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.operaton.bpm.run.property;
+package org.operaton.bpm.run.test.config.deploy;
 
-import java.util.Collections;
-import java.util.Map;
+import org.operaton.bpm.run.OperatonBpmRunProcessEngineConfiguration;
+import org.operaton.bpm.run.test.AbstractRestTest;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
-public class OperatonBpmRunProcessEnginePluginProperty {
+import static org.assertj.core.api.Assertions.assertThat;
 
-  protected String pluginClass;
-  protected Map<String, Object> pluginParameters = Collections.EMPTY_MAP;
+public class DeployChangedOnlyUnsetTest extends AbstractRestTest {
 
-  public String getPluginClass() {
-    return pluginClass;
+  @Autowired
+  private OperatonBpmRunProcessEngineConfiguration engineConfig;
+
+  @Test
+  public void shouldEnableDeployChangedOnlyOnOperatonRunProperty() {
+    assertThat(engineConfig.isDeployChangedOnly()).isEqualTo(true);
   }
-
-  public void setPluginClass(String pluginClass) {
-    this.pluginClass = pluginClass;
-  }
-
-  public Map<String, Object> getPluginParameters() {
-    return pluginParameters;
-  }
-
-  public void setPluginParameters(Map<String, Object> pluginParameters) {
-    this.pluginParameters = pluginParameters;
-  }
-
-  @Override
-  public String toString() {
-    return "OperatonBpmRunProcessEnginePluginProperty [pluginClass=" + pluginClass +
-        ", pluginParameters=" + pluginParameters +
-        "]";
-  }
-
 }


### PR DESCRIPTION
Description: The feature allows camunda-run to parameterise the filtering of duplicate resources via a configurable flag.

Feature-flag: This commit introduces the new feature flag `camunda.bpm.run.deployment.deploy-changed-only`
Default-value: `true` (to be backwards compatible with the previously hardcoded behaviour)

Has-refactoring: This commit also refactors the `@CamundaBpmRunConfiguration` and all its dependencies to be simpler and conforming to spring-boot best practices.

Has-unit-tests: This commit adds three test cases for covering the enabling | Disabling | Absence of the new property.

Related-to: https://github.com/camunda/camunda-bpm-platform/issues/2652

Backported commit e7941a3f50 from the camunda-bpm-platform repository. Original author: psavidis <69160690+psavidis@users.noreply.github.com>"