### PR TITLE
fix(openapi): fix incorrect schema for metrics param (#4555)

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/metrics/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/metrics/get.ftl
@@ -59,7 +59,8 @@
     <@lib.parameter
         name = "interval"
         location = "query"
-        type = "string"
+        type = "integer"
+        format = "int64"
         defaultValue = "900"
         desc = "The interval for which the metrics should be aggregated. Time unit is seconds.
                 Default: The interval is set to 15 minutes (900 seconds)." />


### PR DESCRIPTION
related to https://github.com/camunda/camunda-bpm-platform/issues/4554

Backported commit b1c8dd36919 from the camunda-bpm-platform repository. Original author: Timo Kramer <4785848+TimoKramer@users.noreply.github.com>"