### PR TITLE
chore(build): Set up release workflow (#37)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      next_version:
+        description: 'The next development version to set'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+
+      - name: Maven Build
+        run: mvn clean verify
+
+      - name: Release with JReleaser
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+        run: jreleaser release
+
+      - name: Set next development version
+        run: |
+          mvn versions:set -DnewVersion=${{ github.event.inputs.next_version }}
+          git commit -am "[releng] Prepare for next development iteration ${{ github.event.inputs.next_version }}"
+          git push origin main

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,0 +1,43 @@
+# jreleaser.yml
+project:
+  name: operaton
+  description: Operaton - The open source process engine
+  version: @release.version@
+
+release:
+  github:
+    owner: operaton
+    repo: operaton
+    token: {{ secrets.GITHUB_TOKEN }}
+    draft: false
+    overwrite: true
+    skip_tag: false
+
+distributions:
+  maven:
+    group_id: org.operaton
+    artifact_id: operaton-root
+
+checksum:
+  algorithms: [SHA-256, SHA-512]
+
+packagers:
+  maven:
+    active: release
+    deployer:
+      repository: mavenCentral
+      url: https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/
+      username: {{ secrets.OSSRH_USERNAME }}
+      password: {{ secrets.OSSRH_PASSWORD }}
+
+changelog:
+  enabled: true
+  sort: ASC
+  preset: conventional-commits
+  categories:
+    - title: "Features"
+      labels: ["enhancement", "feature"]
+    - title: "Bug Fixes"
+      labels: ["bug"]
+    - title: "Documentation"
+      labels: ["docs", "documentation"]


### PR DESCRIPTION
Adds a release workflow that uses JReleaser.

The release workflow is manually triggered with the next version as input.

The following secrets have to be configured:
- `OSSRH_USERNAME`
- `OSSRH_PASSWORD`
- `GPG_PRIVATE_KEY`
- `GPG_PASSPHRASE`

Fixes #37 