### PR TITLE
chore(build): Remove Java related profiles (#169)

### DIFF
--- a/engine-rest/engine-rest-jakarta/pom.xml
+++ b/engine-rest/engine-rest-jakarta/pom.xml
@@ -15,6 +15,7 @@
   <properties>
     <rest.http.port>38081</rest.http.port>
     <version.resteasy>6.2.3.Final</version.resteasy>
+    <version.spring.framework>${version.spring.framework6}</version.spring.framework>
   </properties>
 
   <dependencyManagement>
@@ -202,6 +203,19 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>${version.spring.framework}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-jcl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>
@@ -670,53 +684,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-
-    <profile>
-      <id>below-jdk17</id>
-      <activation>
-        <jdk>(,17)</jdk>
-      </activation>
-
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <testExcludes>
-                <exclude>**/AuthenticationFilterPathMatchingTest.java</exclude>
-              </testExcludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>jdk17-and-onwards</id>
-      <activation>
-        <jdk>[17,)</jdk>
-      </activation>
-
-      <properties>
-        <version.spring.framework>${version.spring.framework6}</version.spring.framework>
-      </properties>
-
-      <dependencies>
-        <dependency>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-test</artifactId>
-          <version>${version.spring.framework}</version>
-          <scope>test</scope>
-          <exclusions>
-            <exclusion>
-              <groupId>org.springframework</groupId>
-              <artifactId>spring-jcl</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-      </dependencies>
     </profile>
   </profiles>
 

--- a/engine-spring/core/pom.xml
+++ b/engine-spring/core/pom.xml
@@ -169,6 +169,10 @@
           <dependenciesToScan>
             <dependency>org.operaton.bpm:operaton-bpm-archunit</dependency>
           </dependenciesToScan>
+          <!-- Nashorn is not part of the JDK anymore in Java 15+ -->
+          <excludes>
+            <exclude>**/*NashornTest.java</exclude>
+          </excludes>
         </configuration>
       </plugin>
 
@@ -196,28 +200,4 @@
     </plugins>
   </build>
   
-  <profiles>
-    <profile>
-      <id>java15</id>
-      <activation>
-        <jdk>[15,)</jdk>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <configuration>
-                <!-- Nashorn is not part of the JDK anymore in Java 15+ -->
-                <excludes>
-                  <exclude>**/*NashornTest.java</exclude>
-                </excludes>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/engine-spring/pom.xml
+++ b/engine-spring/pom.xml
@@ -15,19 +15,7 @@
 
   <modules>
     <module>core</module>
+    <module>core-6</module>
   </modules>
 
-  <profiles>
-    <profile>
-      <id>jdk17</id>
-      <activation>
-        <jdk>[17,)</jdk>
-      </activation>
-      <modules>
-        <module>core-6</module>
-      </modules>
-    </profile>
-  </profiles>
-
-  
 </project>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -423,11 +423,13 @@
           <trimStackTrace>false</trimStackTrace>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <includes>
-           <include>%regex[.*(${test.includes}).*Test.*.class]</include>
+            <include>%regex[.*(${test.includes}).*Test.*.class]</include>
           </includes>
-          <excludes>
+          <excludes combine.children="append">
             <exclude>**/*TestCase.java</exclude>
             <exclude>%regex[.*(${test.excludes}).*Test.*.class]</exclude>
+            <!-- Nashorn is not part of the JDK anymore in Java 15+ -->
+            <exclude>**/*NashornTest.java</exclude>
           </excludes>
           <dependenciesToScan>
             <dependency>org.operaton.bpm:operaton-bpm-archunit</dependency>
@@ -877,28 +879,6 @@
             </configuration>
           </plugin>
         </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>java15</id>
-      <activation>
-        <jdk>[15,)</jdk>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <configuration>
-                <!-- Nashorn is not part of the JDK anymore in Java 15+ -->
-                <excludes combine.children="append">
-                  <exclude>**/*NashornTest.java</exclude>
-                </excludes>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
       </build>
     </profile>
 

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -63,6 +63,7 @@
 
   <modules>
     <module>ensure-clean-db-plugin</module>
+    <module>integration-tests-engine-jakarta</module>
   </modules>
 
   <profiles>
@@ -85,16 +86,6 @@
         <!--module>test-old-engine</module-->
         <module>performance-tests-engine</module>
         <module>large-data-tests</module>
-      </modules>
-    </profile>
-
-    <profile>
-      <id>jdk17</id>
-      <activation>
-        <jdk>[17,)</jdk>
-      </activation>
-      <modules>
-        <module>integration-tests-engine-jakarta</module>
       </modules>
     </profile>
 

--- a/quarkus-extension/pom.xml
+++ b/quarkus-extension/pom.xml
@@ -54,17 +54,6 @@
 
   <profiles>
     <profile>
-      <id>jdk17-and-onwards</id>
-      <activation>
-        <jdk>[17,)</jdk>
-      </activation>
-
-      <modules>
-        <module>engine</module>
-      </modules>
-    </profile>
-
-    <profile>
       <id>quarkus-tests</id>
       <build>
         <pluginManagement>
@@ -80,4 +69,8 @@
       </build>
     </profile>
   </profiles>
+
+  <modules>
+    <module>engine</module>
+  </modules>
 </project>

--- a/spin/core/pom.xml
+++ b/spin/core/pom.xml
@@ -111,67 +111,6 @@
         </plugins>
       </build>
     </profile>
-    <!-- exclude the DataFormatProviderTest until PowerMock 2.0 is released: https://app.camunda.com/jira/browse/CAM-9309 -->
-    <profile>
-      <id>jdk-9-and-onwards</id>
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>${jacoco.argLine} -XX:PermSize=128m</argLine>
-              <excludes>
-                <exclude>**/DataFormatLoadingTest.java</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>jdk-15-and-onwards</id>
-      <activation>
-        <jdk>[15,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <excludes combine.children="append">
-                <exclude>**/*NashornTest.java</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>jdk-16-and-onwards</id>
-      <activation>
-        <jdk>[16,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
-              <excludes combine.children="append">
-                <exclude>**/*NashornTest.java</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
 
     <!-- check for api differences between latest minor release -->
     <profile>
@@ -257,6 +196,18 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
+          <excludes combine.children="append">
+            <exclude>**/*NashornTest.java</exclude>
+            <!-- clone not supported -->
+            <exclude>**/DataFormatLoadingTest.java</exclude>
+          </excludes>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/spin/dataformat-json-jackson/pom.xml
+++ b/spin/dataformat-json-jackson/pom.xml
@@ -148,48 +148,7 @@
         </plugins>
       </build>
     </profile>
-    
-    <profile>
-      <id>jdk-15-and-onwards</id>
-      <activation>
-        <jdk>[15,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <excludes combine.children="append">
-                <exclude>**/nashorn/**</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
 
-    <profile>
-      <id>jdk-16-and-onwards</id>
-      <activation>
-        <jdk>[16,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
-              <excludes combine.children="append">
-                <exclude>**/nashorn/**</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    
     <!-- check for api differences between latest minor release -->
     <profile>
       <id>check-api-compatibility</id>
@@ -255,6 +214,16 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
+          <excludes combine.children="append">
+            <exclude>**/nashorn/**</exclude>
+          </excludes>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/spin/dataformat-xml-dom-jakarta/pom.xml
+++ b/spin/dataformat-xml-dom-jakarta/pom.xml
@@ -118,49 +118,6 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>jdk-15-and-onwards</id>
-      <activation>
-        <jdk>[15,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <excludes combine.children="append">
-                <exclude>**/nashorn/**</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>jdk-16-and-onwards</id>
-      <activation>
-        <jdk>[16,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
-              <excludes combine.children="append">
-                <exclude>**/nashorn/**</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
       <plugin>
@@ -362,6 +319,16 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
+          <excludes combine.children="append">
+            <exclude>**/nashorn/**</exclude>
+          </excludes>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/spin/dataformat-xml-dom/pom.xml
+++ b/spin/dataformat-xml-dom/pom.xml
@@ -98,28 +98,21 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>
-    <profile>
-      <id>jdk-9-and-onwards</id>
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>jakarta.xml.bind</groupId>
-          <artifactId>jakarta.xml.bind-api</artifactId>
-          <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-          <groupId>com.sun.xml.bind</groupId>
-          <artifactId>jaxb-impl</artifactId>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
 
     <profile>
       <id>disable-javascript-tests</id>
@@ -141,48 +134,7 @@
         </plugins>
       </build>
     </profile>
-    
-    <profile>
-      <id>jdk-15-and-onwards</id>
-      <activation>
-        <jdk>[15,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <excludes combine.children="append">
-                <exclude>**/nashorn/**</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
 
-    <profile>
-      <id>jdk-16-and-onwards</id>
-      <activation>
-        <jdk>[16,)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
-              <excludes combine.children="append">
-                <exclude>**/nashorn/**</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    
     <!-- check for api differences between latest minor release -->
     <profile>
       <id>check-api-compatibility</id>
@@ -248,6 +200,16 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
+          <excludes combine.children="append">
+            <exclude>**/nashorn/**</exclude>
+          </excludes>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/spin/pom.xml
+++ b/spin/pom.xml
@@ -18,6 +18,7 @@
     <module>core</module>
     <module>dataformat-json-jackson</module>
     <module>dataformat-xml-dom</module>
+    <module>dataformat-xml-dom-jakarta</module>
     <module>dataformat-all</module>
   </modules>
 
@@ -170,15 +171,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>jdk11</id>
-      <activation>
-        <jdk>[11,)</jdk>
-      </activation>
-      <modules>
-        <module>dataformat-xml-dom-jakarta</module>
-      </modules>
     </profile>
   </profiles>
 

--- a/webapps/assembly-jakarta/pom.xml
+++ b/webapps/assembly-jakarta/pom.xml
@@ -21,6 +21,7 @@
     <version.resteasy>6.2.8.Final</version.resteasy>
     <version.jetty>11.0.14</version.jetty>
     <version.jersey2>3.1.1</version.jersey2>
+    <version.spring.framework>${version.spring.framework6}</version.spring.framework>
 
     <web.resources.override>${jakarta.runtime}/default/webapp</web.resources.override>
     <java.resources.override>${jakarta.runtime}/default/resources</java.resources.override>
@@ -120,6 +121,20 @@
       <version>${project.version}</version>
       <scope>test</scope>
       <classifier>tests</classifier>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>${version.spring.framework}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>${version.spring.framework}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -632,57 +647,6 @@
       </build>
     </profile>
 
-    <profile>
-      <id>below-jdk17</id>
-      <activation>
-        <jdk>(,17)</jdk>
-      </activation>
-
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <testExcludes>
-                <exclude>**/AuthCacheTest.java</exclude>
-                <exclude>**/ContainerAuthenticationFilterTest.java</exclude>
-                <exclude>**/CsrfPreventionFilterAppPathTest.java</exclude>
-                <exclude>**/CsrfPreventionFilterTest.java</exclude>
-                <exclude>**/UserAuthenticationResourceTest.java</exclude>
-                <exclude>**/UserAuthenticationResourceLoggingTest.java</exclude>
-              </testExcludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <profile>
-      <id>jdk17-and-onwards</id>
-      <activation>
-        <jdk>[17,)</jdk>
-      </activation>
-
-      <properties>
-        <version.spring.framework>${version.spring.framework6}</version.spring.framework>
-      </properties>
-
-      <dependencies>
-        <dependency>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-test</artifactId>
-          <version>${version.spring.framework}</version>
-          <scope>test</scope>
-        </dependency>
-
-        <dependency>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-web</artifactId>
-          <version>${version.spring.framework}</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
Merged profiles related to Java versions because minimal supported Java version is now 17 and all profiles either targeted versions below or from Java 17.

Fixes #169 