### PR TITLE
chore(build): Reduce build warnings (#176)

### DIFF
--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricBatchRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricBatchRestServiceInteractionTest.java
@@ -206,7 +206,7 @@ public class HistoricBatchRestServiceInteractionTest extends AbstractRestService
     verify(queryMock).batchId(EXAMPLE_BATCH_ID);
 
     verify(builder).calculatedRemovalTime();
-    verify(builder).byIds(null);
+    verify(builder).byIds((String[]) null);
     verify(builder).byQuery(queryMock);
     verify(builder).executeAsync();
     verifyNoMoreInteractions(builder);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDecisionInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDecisionInstanceRestServiceInteractionTest.java
@@ -443,7 +443,7 @@ public class HistoricDecisionInstanceRestServiceInteractionTest extends Abstract
     verify(historicQueryMock).decisionInstanceId(EXAMPLE_DECISION_INSTANCE_ID);
 
     verify(builder).calculatedRemovalTime();
-    verify(builder).byIds(null);
+    verify(builder).byIds((String[]) null);
     verify(builder).byQuery(historicQueryMock);
     verify(builder).executeAsync();
     verifyNoMoreInteractions(builder);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceInteractionTest.java
@@ -348,7 +348,7 @@ public class HistoricProcessInstanceRestServiceInteractionTest extends AbstractR
     verify(query).processDefinitionId(EXAMPLE_PROCESS_DEFINITION_ID);
 
     verify(builder).calculatedRemovalTime();
-    verify(builder).byIds(null);
+    verify(builder).byIds((String[]) null);
     verify(builder).byQuery(query);
     verify(builder).executeAsync();
     verifyNoMoreInteractions(builder);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/EnsureUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/EnsureUtil.java
@@ -62,16 +62,32 @@ public final class EnsureUtil {
     }
   }
 
+  public static void ensureNotNull(String variableName, String... values) {
+    ensureNotNull(variableName, (Object[]) values);
+  }
+
   public static void ensureNotNull(String variableName, Object... values) {
     ensureNotNull("", variableName, values);
+  }
+
+  public static void ensureNotNull(Class<? extends ProcessEngineException> exceptionClass, String variableName, String... values) {
+    ensureNotNull(exceptionClass, variableName, (Object[]) values);
   }
 
   public static void ensureNotNull(Class<? extends ProcessEngineException> exceptionClass, String variableName, Object... values) {
     ensureNotNull(exceptionClass, null, variableName, values);
   }
 
+  public static void ensureNotNull(String message, String variableName, String... values) {
+    ensureNotNull(message, variableName, (Object[]) values);
+  }
+
   public static void ensureNotNull(String message, String variableName, Object... values) {
     ensureNotNull(NullValueException.class, message, variableName, values);
+  }
+
+  public static void ensureNotNull(Class<? extends ProcessEngineException> exceptionClass, String message, String variableName, String... values) {
+    ensureNotNull(exceptionClass, message, variableName, (Object[]) values);
   }
 
   public static void ensureNotNull(Class<? extends ProcessEngineException> exceptionClass, String message, String variableName, Object... values) {
@@ -219,8 +235,16 @@ public final class EnsureUtil {
     }
   }
 
+  public static void ensureOnlyOneNotNull(String message, String... values) {
+    ensureOnlyOneNotNull(message, (Object[]) values);
+  }
+
   public static void ensureOnlyOneNotNull(String message, Object... values) {
     ensureOnlyOneNotNull(NullValueException.class, message, values);
+  }
+
+  public static void ensureOnlyOneNotNull(Class<? extends ProcessEngineException> exceptionClass, String message, String... values) {
+    ensureOnlyOneNotNull(exceptionClass, message, (Object[]) values);
   }
 
   public static void ensureOnlyOneNotNull(Class<? extends ProcessEngineException> exceptionClass, String message, Object... values) {
@@ -238,8 +262,16 @@ public final class EnsureUtil {
     }
   }
 
-  public static void ensureAtLeastOneNotNull(String message, Object... values) {
+  public static void ensureAtLeastOneNotNull(String message, String... values) {
+    ensureAtLeastOneNotNull(message, (Object[]) values);
+  }
+
+    public static void ensureAtLeastOneNotNull(String message, Object... values) {
     ensureAtLeastOneNotNull(NullValueException.class, message, values);
+  }
+
+  public static void ensureAtLeastOneNotNull(Class<? extends ProcessEngineException> exceptionClass, String message, String... values) {
+    ensureAtLeastOneNotNull(exceptionClass, message, (Object[]) values);
   }
 
   public static void ensureAtLeastOneNotNull(Class<? extends ProcessEngineException> exceptionClass, String message, Object... values) {

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -115,12 +115,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${version.junit5}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-junit</artifactId>
         <version>2.0.0.0</version>

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingForJoinTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingForJoinTest.java
@@ -139,7 +139,7 @@ public class ProcessInstanceAssertIsWaitingForJoinTest extends ProcessAssertTest
     expect(new Failure() {
       @Override
       public void when() {
-        assertThat(processInstance).isWaitingAt(null);
+        assertThat(processInstance).isWaitingAt((String[]) null);
       }
     }, "Expecting list of activityIds not to be null, not to be empty");
   }


### PR DESCRIPTION
Reduce build warnings.

Resolved:
```
[WARNING] Some problems were encountered while building the effective model for org.operaton.bpm:operaton-core-internal-dependencies:pom:1.0.0-beta-2
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.junit.jupiter:junit-jupiter-api:jar -> duplicate declaration of version ${version.junit5} @ line 117, column 19
```

Adds overloaded methods to `EnsureUtil` that take a `String...` parameter and call the method with `Object...` parameter. By doing so cases where ensureXXX methods are called with string args the new methods will be taken. This reduces some warnings with message:
```non-varargs call of varargs method with inexact argument type for last parameter```

There are still some in tests of operator-engine, but since they usually try to call methods with once `null` and then `(String)null` this looks a bit intentionally here. Might be refactored later.