### PR TITLE
chore(build): Define property 'surefire.argLine' (#176)

### DIFF
--- a/distro/wildfly/subsystem/pom.xml
+++ b/distro/wildfly/subsystem/pom.xml
@@ -12,6 +12,10 @@
 
   <name>Operaton - Wildfly Subsystem</name>
 
+  <properties>
+    <surefire.memArgs>-Xmx512m</surefire.memArgs>
+  </properties>
+
   <dependencies>
 
     <dependency>
@@ -93,7 +97,6 @@
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <enableAssertions>true</enableAssertions>
-          <argLine>${jacoco.argLine} -Xmx512m</argLine>
           <systemProperties>
             <property>
               <name>jboss.home</name>

--- a/distro/wildfly26/subsystem/pom.xml
+++ b/distro/wildfly26/subsystem/pom.xml
@@ -12,6 +12,10 @@
 
   <name>Operaton - Wildfly 26 Subsystem</name>
 
+  <properties>
+    <surefire.memArgs>-Xmx512m</surefire.memArgs>
+  </properties>
+
   <dependencies>
 
     <dependency>
@@ -91,7 +95,6 @@
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <enableAssertions>true</enableAssertions>
-          <argLine>${jacoco.argLine} -Xmx512m</argLine>
           <systemProperties>
             <property>
               <name>jboss.home</name>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -390,7 +390,7 @@
                 </goals>
                 <configuration>
                   <!-- Ensures that endpoints work with other encodings than UTF-8 (cf. CAM-6983) -->
-                  <argLine>${jacoco.argLine} -Dfile.encoding=ISO-8859-1</argLine>
+                  <argLine>${surefire.argLine} -Dfile.encoding=ISO-8859-1</argLine>
                   <includes>
                     <include>**/ProcessDefinitionRestServiceInteractionTest.java</include>
                     <include>**/TaskRestServiceInteractionTest.java</include>
@@ -488,7 +488,7 @@
                 </goals>
                 <configuration>
                   <!-- Ensures that endpoints work with other encodings than UTF-8 (cf. CAM-6983) -->
-                  <argLine>${jacoco.argLine} -Dfile.encoding=ISO-8859-1</argLine>
+                  <argLine>${surefire.argLine} -Dfile.encoding=ISO-8859-1</argLine>
                   <includes>
                     <include>**/ProcessDefinitionRestServiceInteractionTest.java</include>
                     <include>**/TaskRestServiceInteractionTest.java</include>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -16,6 +16,7 @@
     <version.tomcat>7.0.50</version.tomcat>
     <rest.http.port>38080</rest.http.port>
     <javax.activation.version>1.1.1</javax.activation.version>
+    <surefire.memArgs>-Xmx2g</surefire.memArgs>
   </properties>
 
   <dependencies>
@@ -294,7 +295,6 @@
           <systemPropertyVariables>
             <restEasyVersion>${version.resteasy}</restEasyVersion>
           </systemPropertyVariables>
-          <argLine>${jacoco.argLine} -Xmx2g</argLine>
         </configuration>
       </plugin>
 
@@ -591,7 +591,7 @@
                 </goals>
                 <configuration>
                   <!-- Ensures that endpoints work with other encodings than UTF-8 (cf. CAM-6983) -->
-                  <argLine>${jacoco.argLine} -Dfile.encoding=ISO-8859-1</argLine>
+                  <argLine>${surefire.argLine} -Dfile.encoding=ISO-8859-1</argLine>
                   <includes>
                     <include>**/ProcessDefinitionRestServiceInteractionTest.java</include>
                     <include>**/TaskRestServiceInteractionTest.java</include>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -819,13 +819,6 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>${jacoco.argLine} -Xmx968m</argLine>
-            </configuration>
-          </plugin>
         </plugins>
       </build>
     </profile>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -79,7 +79,9 @@
     <version.npm>10.7.0</version.npm>
     <version.junit5>5.11.3</version.junit5>
 
-    <surefire.argLine>-Xmx968m -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${project.build.directory}/heap_dump.hprof -Xlog:class+load=off</surefire.argLine>
+    <jacoco.argLine/>
+    <surefire.memArgs>-Xmx968m -XX:MetaspaceSize=128m</surefire.memArgs>
+    <surefire.argLine>${jacoco.argLine} ${surefire.memArgs} -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${project.build.directory}/heap_dump.hprof -Xshare:off</surefire.argLine>
 
     <!-- OSGi bundles properties -->
     <operaton.artifact />
@@ -145,8 +147,8 @@
             <systemPropertyVariables>
               <myWorkingDir>${project.build.directory}</myWorkingDir>
             </systemPropertyVariables>
-            <!-- when configuring argLine in submodules, don't forget to prepend ${jacoco.argLine} -->
-            <argLine>${jacoco.argLine} ${surefire.argLine}</argLine>
+            <!-- when configuring argLine in submodules, don't forget to prepend ${surefire.argLine} -->
+            <argLine>${surefire.argLine}</argLine>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
           </configuration>
         </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -80,8 +80,8 @@
     <version.junit5>5.11.3</version.junit5>
 
     <jacoco.argLine/>
-    <surefire.memArgs>-Xmx968m -XX:MetaspaceSize=128m</surefire.memArgs>
-    <surefire.argLine>${jacoco.argLine} ${surefire.memArgs} -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${project.build.directory}/heap_dump.hprof -Xshare:off</surefire.argLine>
+    <surefire.memArgs>-Xmx1024m -XX:MetaspaceSize=128m</surefire.memArgs>
+    <surefire.argLine>${jacoco.argLine} ${surefire.memArgs} -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${project.build.directory}/heap_dump.hprof</surefire.argLine>
 
     <!-- OSGi bundles properties -->
     <operaton.artifact />
@@ -147,8 +147,6 @@
             <systemPropertyVariables>
               <myWorkingDir>${project.build.directory}</myWorkingDir>
             </systemPropertyVariables>
-            <!-- when configuring argLine in submodules, don't forget to prepend ${surefire.argLine} -->
-            <argLine>${surefire.argLine}</argLine>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
           </configuration>
         </plugin>
@@ -156,7 +154,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <configuration>
-            <argLine>${jacoco.argLine} -Xmx968m</argLine>
             <runOrder>hourly</runOrder>
           </configuration>
           <executions>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -79,6 +79,8 @@
     <version.npm>10.7.0</version.npm>
     <version.junit5>5.11.3</version.junit5>
 
+    <surefire.argLine>-Xmx968m -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${project.build.directory}/heap_dump.hprof -Xlog:class+load=off</surefire.argLine>
+
     <!-- OSGi bundles properties -->
     <operaton.artifact />
     <operaton.osgi.import.operaton.spin.version>version="[$(version;==;${operaton.spin.version.clean}),$(version;=+;${operaton.spin.version.clean}))"</operaton.osgi.import.operaton.spin.version>
@@ -144,7 +146,7 @@
               <myWorkingDir>${project.build.directory}</myWorkingDir>
             </systemPropertyVariables>
             <!-- when configuring argLine in submodules, don't forget to prepend ${jacoco.argLine} -->
-            <argLine>${jacoco.argLine} -Xmx968m -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${project.build.directory}/heap_dump.hprof</argLine>
+            <argLine>${jacoco.argLine} ${surefire.argLine}</argLine>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
           </configuration>
         </plugin>

--- a/qa/large-data-tests/pom.xml
+++ b/qa/large-data-tests/pom.xml
@@ -13,6 +13,7 @@
   <properties>
     <skipTests>true</skipTests>
     <jdbcBatchProcessing>true</jdbcBatchProcessing>
+    <surefire.memArgs>-Xmx2048m</surefire.memArgs>
   </properties>
 
   <dependencies>
@@ -130,7 +131,6 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <skipTests>${skipTests}</skipTests>
-              <argLine>${jacoco.argLine} -Xmx2048m</argLine>
             </configuration>
           </plugin>
         </plugins>

--- a/qa/performance-tests-engine/pom.xml
+++ b/qa/performance-tests-engine/pom.xml
@@ -119,7 +119,6 @@
             <configuration>
               <runOrder>alphabetical</runOrder>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>
-              <argLine>${jacoco.argLine} -Xmx1024m</argLine>
               <includes>
                  <include>%regex[.*(${test.includes}).*Test.*.class]</include>
               </includes>
@@ -189,7 +188,6 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>
-              <argLine>${jacoco.argLine} -Xmx1024m</argLine>
               <includes>
                  <include>%regex[.*(${test.includes}).*Test.*.class]</include>
               </includes>
@@ -257,7 +255,6 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>
-              <argLine>${jacoco.argLine} -Xmx1024m</argLine>
               <includes>
                  <include>%regex[.*(${test.includes}).*Test.*.class]</include>
               </includes>
@@ -374,7 +371,6 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>
-              <argLine>${jacoco.argLine} -Xmx1024m</argLine>
               <includes>
                  <include>%regex[.*(${test.includes}).*Test.*.class]</include>
               </includes>
@@ -440,7 +436,6 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>
-              <argLine>${jacoco.argLine} -Xmx1024m</argLine>
               <includes>
                  <include>%regex[.*(${test.includes}).*Test.*.class]</include>
               </includes>

--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <operaton.old.engine.version>7.21.0</operaton.old.engine.version>
+    <surefire.memArgs>-Xmx2g -XX:MetaspaceSize=128m</surefire.memArgs>
   </properties>
 
   <build>
@@ -430,7 +431,6 @@
               </excludes>
               <testFailureIgnore>false</testFailureIgnore>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>
-              <argLine>${jacoco.argLine} -Xmx2g -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${project.build.directory}/heap_dump.hprof</argLine>
             </configuration>
           </plugin>
 

--- a/quarkus-extension/engine/pom.xml
+++ b/quarkus-extension/engine/pom.xml
@@ -15,6 +15,10 @@
 
   <packaging>pom</packaging>
 
+  <properties>
+    <surefire.memArgs>-Xmx2048m</surefire.memArgs>
+  </properties>
+
   <modules>
     <module>deployment</module>
     <module>runtime</module>
@@ -29,7 +33,6 @@
         <configuration>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <trimStackTrace>false</trimStackTrace>
-          <argLine>${jacoco.argLine} -Xmx2048m</argLine>
         </configuration>
       </plugin>
     </plugins>

--- a/spin/core/pom.xml
+++ b/spin/core/pom.xml
@@ -180,7 +180,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
           <excludes combine.children="append">
             <exclude>**/*NashornTest.java</exclude>
             <!-- clone not supported -->

--- a/spin/dataformat-json-jackson/pom.xml
+++ b/spin/dataformat-json-jackson/pom.xml
@@ -198,7 +198,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
           <excludes combine.children="append">
             <exclude>**/nashorn/**</exclude>
           </excludes>

--- a/spin/dataformat-xml-dom-jakarta/pom.xml
+++ b/spin/dataformat-xml-dom-jakarta/pom.xml
@@ -324,7 +324,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
           <excludes combine.children="append">
             <exclude>**/nashorn/**</exclude>
           </excludes>

--- a/spin/dataformat-xml-dom/pom.xml
+++ b/spin/dataformat-xml-dom/pom.xml
@@ -183,7 +183,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>${jacoco.argLine} -XX:MetaspaceSize=128m</argLine>
           <excludes combine.children="append">
             <exclude>**/nashorn/**</exclude>
           </excludes>

--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -217,7 +217,6 @@
             <systemPropertyVariables>
               <myWorkingDir>${project.build.directory}</myWorkingDir>
             </systemPropertyVariables>
-            <argLine>${jacoco.argLine} -XX:MaxMetaspaceSize=128m</argLine>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
This change makes the JVM arguments used by surefire more flexible.

In `parent/pom.xml` a property `surefire.argLine` is defined. This property is now used in any places that require additional customization of the JVM args.

Often customization is required for adjusting memory settings. The memory settings are now defined with a default value in the property `surefire.memArgs` in the parent POM. 

Modules that need customization of memory now just override the `surefire.memArgs` instead of overriding surefire's `argLine` property. This way we make sure that the surefire default arg line is always taken.

The original intent was to get rid off the warning:
```OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended```

Therefore I wanted to append a setting to the default `surefire.argLine`. However, this did not work out (e.g. tried with `-Xshare:off` or `-XX:-PrintWarnings`).

Anyway, IMO this setting cleans it up a bit.

**Testing Instructions**

You can see that the settings are applied by looking at the effective POM, or by enabling debug output with `-X` in the execution.

Example: `engine-rest` sets different memory settings than default and appends `file.encoding`:
```
mvn help:effective-pom -f engine-rest/engine-rest | grep -H -n "<argLine>"
(standard input):2364:              <argLine>-Xmx2g -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/Users/karstenthoms/Development/projects/operaton/engine-rest/engine-rest/target/heap_dump.hprof -Dfile.encoding=ISO-8859-1</argLine>
(standard input):2607:                  <argLine>-Xmx2g -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/Users/karstenthoms/Development/projects/operaton/engine-rest/engine-rest/target/heap_dump.hprof -Dfile.encoding=ISO-8859-1</argLine>
(standard input):2705:                  <argLine>-Xmx2g -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/Users/karstenthoms/Development/projects/operaton/engine-rest/engine-rest/target/heap_dump.hprof -Dfile.encoding=ISO-8859-1</argLine>
(standard input):2795:                  <argLine>-Xmx2g -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/Users/karstenthoms/Development/projects/operaton/engine-rest/engine-rest/target/heap_dump.hprof -Dfile.encoding=ISO-8859-1</argLine>
```