### PR TITLE
chore(build): remove profile 'disable-javascript-tests' (#181)

### DIFF
--- a/spin/core/pom.xml
+++ b/spin/core/pom.xml
@@ -91,27 +91,6 @@
   </dependencies>
 
   <profiles>
-    <profile>
-      <id>disable-javascript-tests</id>
-      <activation>
-        <jdk>(,1.8)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>${jacoco.argLine} -XX:PermSize=128m</argLine>
-              <excludes>
-                <exclude>**/javascript/**</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <!-- check for api differences between latest minor release -->
     <profile>
       <id>check-api-compatibility</id>

--- a/spin/dataformat-json-jackson/pom.xml
+++ b/spin/dataformat-json-jackson/pom.xml
@@ -128,27 +128,6 @@
   </dependencies>
 
   <profiles>
-    <profile>
-      <id>disable-javascript-tests</id>
-      <activation>
-        <jdk>(,1.8)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>${jacoco.argLine} -XX:PermSize=128m -XX:MaxPermSize=256m</argLine>
-              <excludes>
-                <exclude>**/javascript/**</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <!-- check for api differences between latest minor release -->
     <profile>
       <id>check-api-compatibility</id>

--- a/spin/dataformat-xml-dom/pom.xml
+++ b/spin/dataformat-xml-dom/pom.xml
@@ -113,28 +113,6 @@
   </dependencies>
 
   <profiles>
-
-    <profile>
-      <id>disable-javascript-tests</id>
-      <activation>
-        <jdk>(,1.8)</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>${jacoco.argLine} -XX:PermSize=128m -Duser.timezone=GMT+02:00</argLine>
-              <excludes>
-                <exclude>**/javascript/**</exclude>
-              </excludes>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <!-- check for api differences between latest minor release -->
     <profile>
       <id>check-api-compatibility</id>


### PR DESCRIPTION
This change removes the profile from all related pom.xml files.

**Testing Instruction**
Execute: 
```
mvn help:all-profiles | grep 'Active' | awk '{print $3}' | sort -u
```
This should not list the profile anymore.