### PR TITLE
chore(build): remove obsolete enforcer configuration

### DIFF
--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -41,23 +41,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <build>
-    <plugins>
-      <!-- Enforces Java 17 during the build -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <configuration>
-          <rules>
-            <requireJavaVersion>
-              <version>[17,)</version>
-            </requireJavaVersion>
-          </rules>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
   <profiles>
     <profile>
       <id>distro</id>


### PR DESCRIPTION
This configuration of `maven-enforcer-plugin` is obsolete, since minimal Java version is now 17.