### PR TITLE
chore(build): Set skip=true for maven-install-plugin (#179)

### DIFF
--- a/qa/integration-tests-engine-jakarta/pom.xml
+++ b/qa/integration-tests-engine-jakarta/pom.xml
@@ -294,6 +294,18 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -262,6 +262,17 @@
         </excludes>
       </testResource>
     </testResources>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Artifacts
- operaton-qa-integration-tests-engine
- operaton-qa-integration-tests-engine-jakarta only have test sources, but no main sources. Thus it does not produce a jar file to be installed.