### PR TITLE
chore(testing) JUnit5 migration: submodules /model-api

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -139,23 +139,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.spec</groupId>
-      <artifactId>jboss-javaee-web-6.0</artifactId>
-      <type>pom</type>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.spec.javax.xml.bind</groupId>
-          <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jboss.spec.javax.servlet.jsp</groupId>
-          <artifactId>jboss-jsp-api_2.2_spec</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>jakarta.transaction</groupId>
       <artifactId>jakarta.transaction-api</artifactId>
       <scope>provided</scope>
@@ -207,12 +190,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
       <scope>test</scope>
@@ -251,13 +228,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.operaton.bpm</groupId>
-      <artifactId>operaton-test-utils-testcontainers</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
@@ -276,51 +246,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jul-to-slf4j</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.groovy</groupId>
-      <artifactId>groovy-jsr223</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.python</groupId>
-      <artifactId>jython</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>28.2-jre</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jruby</groupId>
-      <artifactId>jruby-complete</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.graalvm.js</groupId>
-      <artifactId>js</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -139,6 +139,23 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jboss.spec</groupId>
+      <artifactId>jboss-javaee-web-6.0</artifactId>
+      <type>pom</type>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.xml.bind</groupId>
+          <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.servlet.jsp</groupId>
+          <artifactId>jboss-jsp-api_2.2_spec</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>jakarta.transaction</groupId>
       <artifactId>jakarta.transaction-api</artifactId>
       <scope>provided</scope>
@@ -190,6 +207,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
       <scope>test</scope>
@@ -228,6 +251,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.operaton.bpm</groupId>
+      <artifactId>operaton-test-utils-testcontainers</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
@@ -246,9 +276,51 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.groovy</groupId>
+      <artifactId>groovy-jsr223</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.python</groupId>
+      <artifactId>jython</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>28.2-jre</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jruby</groupId>
+      <artifactId>jruby-complete</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.graalvm.js</groupId>
+      <artifactId>js</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/model-api/bpmn-model/pom.xml
+++ b/model-api/bpmn-model/pom.xml
@@ -4,7 +4,6 @@
   <parent>
     <groupId>org.operaton.bpm.model</groupId>
     <artifactId>operaton-model-apis</artifactId>
-    <relativePath>../</relativePath>
     <version>1.0.0-beta-2</version>
   </parent>
 
@@ -19,37 +18,12 @@
       ${operaton.osgi.export.pkg};${operaton.osgi.version};-noimport:=true
     </operaton.osgi.export>
   </properties>
-  <dependencies>
 
+  <dependencies>
     <dependency>
       <groupId>org.operaton.bpm.model</groupId>
       <artifactId>operaton-xml-model</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-    <dependency>
-      <groupId>org.operaton.bpm</groupId>
-      <artifactId>operaton-bpm-archunit</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>junit</groupId>
-					<artifactId>junit</artifactId>
-				</exclusion>
-			</exclusions>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/model-api/bpmn-model/pom.xml
+++ b/model-api/bpmn-model/pom.xml
@@ -27,22 +27,27 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-junit</artifactId>
+			<scope>test</scope>
+		</dependency>
 
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-bpm-archunit</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
     </dependency>
 
   </dependencies>

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnDiTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnDiTest.java
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn;
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.*;
 import org.operaton.bpm.model.bpmn.instance.Process;
 import org.operaton.bpm.model.bpmn.instance.bpmndi.*;
@@ -23,9 +25,6 @@ import org.operaton.bpm.model.bpmn.instance.dc.Bounds;
 import org.operaton.bpm.model.bpmn.instance.dc.Font;
 import org.operaton.bpm.model.bpmn.instance.di.DiagramElement;
 import org.operaton.bpm.model.bpmn.instance.di.Waypoint;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.Collection;
 
@@ -50,7 +49,7 @@ public class BpmnDiTest {
   private Association association;
   private EndEvent endEvent;
 
-  @Before
+  @BeforeEach
   public void parseModel() {
     modelInstance = Bpmn.readModelFromStream(getClass().getResourceAsStream(getClass().getSimpleName() + ".xml"));
     collaboration = modelInstance.getModelElementById(COLLABORATION_ID);
@@ -245,7 +244,7 @@ public class BpmnDiTest {
     flowEdge.getWaypoints().add(endWaypoint);
   }
 
-  @After
+  @AfterEach
   public void validateModel() {
     Bpmn.validateModel(modelInstance);
   }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnModelInstanceTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnModelInstanceTest.java
@@ -19,9 +19,7 @@ package org.operaton.bpm.model.bpmn;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.Definitions;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Filip Hrisafov
@@ -40,8 +38,8 @@ public class BpmnModelInstanceTest {
     BpmnModelInstance cloneInstance = modelInstance.clone();
     cloneInstance.getDefinitions().setId("TestId2");
 
-    assertThat(modelInstance.getDefinitions().getId(), is(equalTo("TestId")));
-    assertThat(cloneInstance.getDefinitions().getId(), is(equalTo("TestId2")));
+    assertThat(modelInstance.getDefinitions().getId()).isEqualTo("TestId");
+    assertThat(cloneInstance.getDefinitions().getId()).isEqualTo("TestId2");
   }
 
 }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnModelInstanceTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnModelInstanceTest.java
@@ -16,12 +16,12 @@
  */
 package org.operaton.bpm.model.bpmn;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.Definitions;
-import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Filip Hrisafov

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnModelTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnModelTest.java
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.operaton.bpm.model.bpmn.util.ParseBpmnModelRule;
-import org.junit.Rule;
 
 /**
  * @author Daniel Meyer
@@ -25,7 +26,7 @@ import org.junit.Rule;
  */
 public class BpmnModelTest {
 
-  @Rule
+  @RegisterExtension
   public final ParseBpmnModelRule parseBpmnModelRule = new ParseBpmnModelRule();
 
   protected BpmnModelInstance bpmnModelInstance;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnModelTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnModelTest.java
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn;
-
+import org.junit.jupiter.api.BeforeEach;
 import org.operaton.bpm.model.bpmn.util.ParseBpmnModelRule;
-import org.junit.Before;
 import org.junit.Rule;
 
 /**
@@ -31,7 +30,7 @@ public class BpmnModelTest {
 
   protected BpmnModelInstance bpmnModelInstance;
 
-  @Before
+  @BeforeEach
   public void setup() {
     bpmnModelInstance = parseBpmnModelRule.getBpmnModel();
   }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.model.bpmn;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/CollaborationParserTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/CollaborationParserTest.java
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.*;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import java.util.Collection;
 
@@ -33,7 +32,7 @@ public class CollaborationParserTest {
   private static BpmnModelInstance modelInstance;
   private static Collaboration collaboration;
 
-  @BeforeClass
+  @BeforeAll
   public static void parseModel() {
     modelInstance = Bpmn.readModelFromStream(CollaborationParserTest.class.getResourceAsStream("CollaborationParserTest.bpmn"));
     collaboration = modelInstance.getModelElementById("collaboration1");
@@ -94,7 +93,7 @@ public class CollaborationParserTest {
   }
 
 
-  @AfterClass
+  @AfterAll
   public static void validateModel() {
     Bpmn.validateModel(modelInstance);
   }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ConditionalSequenceFlowTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ConditionalSequenceFlowTest.java
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.ConditionExpression;
 import org.operaton.bpm.model.bpmn.instance.SequenceFlow;
-import org.junit.Before;
-import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,7 +35,7 @@ public class ConditionalSequenceFlowTest {
   protected ConditionExpression conditionExpression2;
   protected ConditionExpression conditionExpression3;
 
-  @Before
+  @BeforeEach
   public void parseModel() {
     modelInstance = Bpmn.readModelFromStream(getClass().getResourceAsStream(getClass().getSimpleName() + ".xml"));
     flow1 = modelInstance.getModelElementById("flow1");

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/CreateModelTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/CreateModelTest.java
@@ -15,12 +15,11 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn;
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.*;
 import org.operaton.bpm.model.bpmn.instance.Process;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Sebastian Menski
@@ -31,7 +30,7 @@ public class CreateModelTest {
   public Definitions definitions;
   public Process process;
 
-  @Before
+  @BeforeEach
   public void createEmptyModel() {
     modelInstance = Bpmn.createEmptyModel();
     definitions = modelInstance.newInstance(Definitions.class);
@@ -93,7 +92,7 @@ public class CreateModelTest {
     createSequenceFlow(process, join, endEvent);
   }
 
-  @After
+  @AfterEach
   public void validateModel() {
     Bpmn.validateModel(modelInstance);
   }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DataObjectsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DataObjectsTest.java
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn;
-
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.*;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import java.util.Collection;
 
@@ -31,7 +30,7 @@ public class DataObjectsTest {
 
   private static BpmnModelInstance modelInstance;
 
-  @BeforeClass
+  @BeforeAll
   public static void parseModel() {
     modelInstance = Bpmn.readModelFromStream(DataObjectsTest.class.getResourceAsStream("DataObjectTest.bpmn"));
   }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DataStoreTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DataStoreTest.java
@@ -17,11 +17,10 @@
 package org.operaton.bpm.model.bpmn;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.DataStore;
 import org.operaton.bpm.model.bpmn.instance.DataStoreReference;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 /**
  * @author Falko Menge
@@ -30,7 +29,7 @@ public class DataStoreTest {
 
   private static BpmnModelInstance modelInstance;
 
-  @BeforeClass
+  @BeforeAll
   public static void parseModel() {
     modelInstance = Bpmn.readModelFromStream(DataStoreTest.class.getResourceAsStream("DataStoreTest.bpmn"));
   }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DefinitionsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DefinitionsTest.java
@@ -15,14 +15,13 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn;
-import org.junit.jupiter.api.Assertions;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.model.bpmn.instance.*;
 import org.operaton.bpm.model.bpmn.instance.Process;
+import org.operaton.bpm.model.bpmn.instance.*;
 import org.operaton.bpm.model.bpmn.util.BpmnModelResource;
 import org.operaton.bpm.model.xml.ModelParseException;
 import org.operaton.bpm.model.xml.ModelReferenceException;
-import org.operaton.bpm.model.xml.ModelValidationException;
 import org.operaton.bpm.model.xml.impl.util.IoUtil;
 
 import java.io.ByteArrayOutputStream;
@@ -106,12 +105,7 @@ public class DefinitionsTest extends BpmnModelTest {
     definitions.getImports().add(importElement);
 
     // validate model
-    try {
-      Bpmn.validateModel(bpmnModelInstance);
-    }
-    catch (ModelValidationException e) {
-      Assertions.fail();
-    }
+    Bpmn.validateModel(bpmnModelInstance);
   }
 
   @Test

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DefinitionsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DefinitionsTest.java
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn;
-
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.*;
 import org.operaton.bpm.model.bpmn.instance.Process;
 import org.operaton.bpm.model.bpmn.util.BpmnModelResource;
@@ -23,8 +24,6 @@ import org.operaton.bpm.model.xml.ModelParseException;
 import org.operaton.bpm.model.xml.ModelReferenceException;
 import org.operaton.bpm.model.xml.ModelValidationException;
 import org.operaton.bpm.model.xml.impl.util.IoUtil;
-import org.junit.Assert;
-import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -69,7 +68,7 @@ public class DefinitionsTest extends BpmnModelTest {
   public void shouldNotImportWrongOrderedSequence() {
     try {
       Bpmn.readModelFromStream(getClass().getResourceAsStream("DefinitionsTest.shouldNotImportWrongOrderedSequence.bpmn"));
-      Assert.fail("Model is invalid and should not pass the validation");
+      Assertions.fail("Model is invalid and should not pass the validation");
     }
     catch (Exception e) {
       assertThat(e).isInstanceOf(ModelParseException.class);
@@ -115,7 +114,7 @@ public class DefinitionsTest extends BpmnModelTest {
       Bpmn.validateModel(bpmnModelInstance);
     }
     catch (ModelValidationException e) {
-      Assert.fail();
+      Assertions.fail();
     }
   }
 
@@ -142,7 +141,7 @@ public class DefinitionsTest extends BpmnModelTest {
       Bpmn.validateModel(bpmnModelInstance);
     }
     catch (ModelValidationException e) {
-      Assert.fail();
+      Assertions.fail();
     }
 
     // convert the model to the XML string representation
@@ -210,7 +209,7 @@ public class DefinitionsTest extends BpmnModelTest {
     MessageEventDefinition anotherMessageEventDefinition = bpmnModelInstance.newInstance(MessageEventDefinition.class);
     try {
       anotherMessageEventDefinition.setMessage(anotherMessage);
-      Assert.fail("Message should not be added to message event definition, cause it is not part of the model");
+      Assertions.fail("Message should not be added to message event definition, cause it is not part of the model");
     }
     catch(Exception e) {
       assertThat(e).isInstanceOf(ModelReferenceException.class);
@@ -230,7 +229,7 @@ public class DefinitionsTest extends BpmnModelTest {
       Bpmn.validateModel(bpmnModelInstance);
     }
     catch (ModelValidationException e) {
-      Assert.fail();
+      Assertions.fail();
     }
   }
 
@@ -277,7 +276,7 @@ public class DefinitionsTest extends BpmnModelTest {
       Bpmn.validateModel(bpmnModelInstance);
     }
     catch (ModelValidationException e) {
-      Assert.fail();
+      Assertions.fail();
     }
   }
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DefinitionsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DefinitionsTest.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.XML_SCHEMA_NS;
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.XPATH_NS;
 
@@ -66,13 +67,8 @@ public class DefinitionsTest extends BpmnModelTest {
 
   @Test
   public void shouldNotImportWrongOrderedSequence() {
-    try {
-      Bpmn.readModelFromStream(getClass().getResourceAsStream("DefinitionsTest.shouldNotImportWrongOrderedSequence.bpmn"));
-      Assertions.fail("Model is invalid and should not pass the validation");
-    }
-    catch (Exception e) {
-      assertThat(e).isInstanceOf(ModelParseException.class);
-    }
+    assertThatThrownBy(() -> Bpmn.readModelFromStream(getClass().getResourceAsStream("DefinitionsTest.shouldNotImportWrongOrderedSequence.bpmn")))
+            .isInstanceOf(ModelParseException.class);
   }
 
   @Test
@@ -137,12 +133,7 @@ public class DefinitionsTest extends BpmnModelTest {
     definitions.getImports().add(importElement);
 
     // validate model
-    try {
-      Bpmn.validateModel(bpmnModelInstance);
-    }
-    catch (ModelValidationException e) {
-      Assertions.fail();
-    }
+    Bpmn.validateModel(bpmnModelInstance);
 
     // convert the model to the XML string representation
     OutputStream outputStream = new ByteArrayOutputStream();
@@ -207,13 +198,10 @@ public class DefinitionsTest extends BpmnModelTest {
 
     // create a message event definition and try to add last create message
     MessageEventDefinition anotherMessageEventDefinition = bpmnModelInstance.newInstance(MessageEventDefinition.class);
-    try {
-      anotherMessageEventDefinition.setMessage(anotherMessage);
-      Assertions.fail("Message should not be added to message event definition, cause it is not part of the model");
-    }
-    catch(Exception e) {
-      assertThat(e).isInstanceOf(ModelReferenceException.class);
-    }
+    final MessageEventDefinition finalMessageEventDefinition = anotherMessageEventDefinition;
+    assertThatThrownBy(() -> finalMessageEventDefinition.setMessage(anotherMessage))
+            .isInstanceOf(ModelReferenceException.class)
+            .withFailMessage("Message should not be added to message event definition, cause it is not part of the model");
 
     // first add message to model than to event definition
     definitions.getRootElements().add(anotherMessage);
@@ -225,12 +213,7 @@ public class DefinitionsTest extends BpmnModelTest {
     startEvent.getEventDefinitions().add(anotherMessageEventDefinition);
 
     // validate model
-    try {
-      Bpmn.validateModel(bpmnModelInstance);
-    }
-    catch (ModelValidationException e) {
-      Assertions.fail();
-    }
+    Bpmn.validateModel(bpmnModelInstance);
   }
 
   @Test
@@ -272,12 +255,6 @@ public class DefinitionsTest extends BpmnModelTest {
     process.setExtensionElements(extensionElements);
 
     // validate model
-    try {
-      Bpmn.validateModel(bpmnModelInstance);
-    }
-    catch (ModelValidationException e) {
-      Assertions.fail();
-    }
+    Bpmn.validateModel(bpmnModelInstance);
   }
-
 }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/GenerateIdTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/GenerateIdTest.java
@@ -18,11 +18,11 @@ package org.operaton.bpm.model.bpmn;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.Definitions;
 import org.operaton.bpm.model.bpmn.instance.Process;
 import org.operaton.bpm.model.bpmn.instance.StartEvent;
 import org.operaton.bpm.model.bpmn.instance.UserTask;
-import org.junit.Test;
 
 public class GenerateIdTest {
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ModelTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ModelTest.java
@@ -16,11 +16,11 @@
  */
 package org.operaton.bpm.model.bpmn;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.*;
 import org.operaton.bpm.model.xml.Model;
 import org.operaton.bpm.model.xml.impl.util.ModelUtil;
 import org.operaton.bpm.model.xml.type.ModelElementType;
-import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
@@ -69,7 +69,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.operaton.bpm.model.bpmn.instance.BaseElement;
 import org.operaton.bpm.model.bpmn.instance.BpmnModelElementInstance;
 import org.operaton.bpm.model.bpmn.instance.BusinessRuleTask;
@@ -111,18 +112,13 @@ import org.operaton.bpm.model.bpmn.instance.operaton.OperatonProperty;
 import org.operaton.bpm.model.bpmn.instance.operaton.OperatonScript;
 import org.operaton.bpm.model.bpmn.instance.operaton.OperatonTaskListener;
 import org.operaton.bpm.model.bpmn.instance.operaton.OperatonValue;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * @author Sebastian Menski
  * @author Ronny Bräunlich
  */
-@RunWith(Parameterized.class)
 public class OperatonExtensionsTest {
 
   private Process process;
@@ -142,7 +138,6 @@ public class OperatonExtensionsTest {
   private BpmnModelInstance modelInstance;
   private Error error;
 
-  @Parameters(name="Namespace: {0}")
   public static Collection<Object[]> parameters(){
     return Arrays.asList(new Object[][]{
         {OPERATON_NS, Bpmn.readModelFromStream(OperatonExtensionsTest.class.getResourceAsStream("OperatonExtensionsTest.xml"))},
@@ -151,12 +146,12 @@ public class OperatonExtensionsTest {
     });
   }
 
-  public OperatonExtensionsTest(String namespace, BpmnModelInstance modelInstance) {
+  public void initOperatonExtensionsTest(String namespace, BpmnModelInstance modelInstance) {
     this.namespace = namespace;
     this.originalModelInstance = modelInstance;
   }
 
-  @Before
+  @BeforeEach
   public void setUp(){
     modelInstance = originalModelInstance.clone();
     process = modelInstance.getModelElementById(PROCESS_ID);
@@ -174,15 +169,19 @@ public class OperatonExtensionsTest {
     error = modelInstance.getModelElementById("error");
   }
 
-  @Test
-  public void testAssignee() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testAssignee(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonAssignee()).isEqualTo(TEST_STRING_XML);
     userTask.setOperatonAssignee(TEST_STRING_API);
     assertThat(userTask.getOperatonAssignee()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testAsync() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testAsync(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.isOperatonAsync()).isFalse();
     assertThat(userTask.isOperatonAsync()).isTrue();
     assertThat(parallelGateway.isOperatonAsync()).isTrue();
@@ -196,8 +195,10 @@ public class OperatonExtensionsTest {
     assertThat(parallelGateway.isOperatonAsync()).isFalse();
   }
 
-  @Test
-  public void testAsyncBefore() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testAsyncBefore(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.isOperatonAsyncBefore()).isTrue();
     assertThat(endEvent.isOperatonAsyncBefore()).isTrue();
     assertThat(userTask.isOperatonAsyncBefore()).isTrue();
@@ -214,8 +215,10 @@ public class OperatonExtensionsTest {
     assertThat(parallelGateway.isOperatonAsyncBefore()).isFalse();
   }
 
-  @Test
-  public void testAsyncAfter() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testAsyncAfter(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.isOperatonAsyncAfter()).isTrue();
     assertThat(endEvent.isOperatonAsyncAfter()).isTrue();
     assertThat(userTask.isOperatonAsyncAfter()).isTrue();
@@ -232,152 +235,198 @@ public class OperatonExtensionsTest {
     assertThat(parallelGateway.isOperatonAsyncAfter()).isFalse();
   }
 
-  @Test
-  public void testFlowNodeJobPriority() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testFlowNodeJobPriority(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.getOperatonJobPriority()).isEqualTo(TEST_FLOW_NODE_JOB_PRIORITY);
     assertThat(endEvent.getOperatonJobPriority()).isEqualTo(TEST_FLOW_NODE_JOB_PRIORITY);
     assertThat(userTask.getOperatonJobPriority()).isEqualTo(TEST_FLOW_NODE_JOB_PRIORITY);
     assertThat(parallelGateway.getOperatonJobPriority()).isEqualTo(TEST_FLOW_NODE_JOB_PRIORITY);
   }
 
-  @Test
-  public void testProcessJobPriority() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testProcessJobPriority(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(process.getOperatonJobPriority()).isEqualTo(TEST_PROCESS_JOB_PRIORITY);
   }
 
-  @Test
-  public void testProcessTaskPriority() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testProcessTaskPriority(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(process.getOperatonTaskPriority()).isEqualTo(TEST_PROCESS_TASK_PRIORITY);
   }
 
-  @Test
-  public void testHistoryTimeToLive() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testHistoryTimeToLive(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(process.getOperatonHistoryTimeToLive()).isEqualTo(TEST_HISTORY_TIME_TO_LIVE);
   }
 
-  @Test
-  public void testIsStartableInTasklist() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testIsStartableInTasklist(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(process.isOperatonStartableInTasklist()).isEqualTo(false);
   }
 
-  @Test
-  public void testVersionTag() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testVersionTag(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(process.getOperatonVersionTag()).isEqualTo("v1.0.0");
   }
 
-  @Test
-  public void testServiceTaskPriority() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testServiceTaskPriority(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(serviceTask.getOperatonTaskPriority()).isEqualTo(TEST_SERVICE_TASK_PRIORITY);
   }
 
-  @Test
-  public void testCalledElementBinding() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testCalledElementBinding(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCalledElementBinding()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCalledElementBinding(TEST_STRING_API);
     assertThat(callActivity.getOperatonCalledElementBinding()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testCalledElementVersion() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testCalledElementVersion(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCalledElementVersion()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCalledElementVersion(TEST_STRING_API);
     assertThat(callActivity.getOperatonCalledElementVersion()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testCalledElementVersionTag() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testCalledElementVersionTag(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCalledElementVersionTag()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCalledElementVersionTag(TEST_STRING_API);
     assertThat(callActivity.getOperatonCalledElementVersionTag()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testCalledElementTenantId() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testCalledElementTenantId(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCalledElementTenantId()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCalledElementTenantId(TEST_STRING_API);
     assertThat(callActivity.getOperatonCalledElementTenantId()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testCaseRef() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testCaseRef(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCaseRef()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCaseRef(TEST_STRING_API);
     assertThat(callActivity.getOperatonCaseRef()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testCaseBinding() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testCaseBinding(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCaseBinding()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCaseBinding(TEST_STRING_API);
     assertThat(callActivity.getOperatonCaseBinding()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testCaseVersion() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testCaseVersion(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCaseVersion()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCaseVersion(TEST_STRING_API);
     assertThat(callActivity.getOperatonCaseVersion()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testCaseTenantId() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testCaseTenantId(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCaseTenantId()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCaseTenantId(TEST_STRING_API);
     assertThat(callActivity.getOperatonCaseTenantId()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testDecisionRef() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testDecisionRef(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(businessRuleTask.getOperatonDecisionRef()).isEqualTo(TEST_STRING_XML);
     businessRuleTask.setOperatonDecisionRef(TEST_STRING_API);
     assertThat(businessRuleTask.getOperatonDecisionRef()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testDecisionRefBinding() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testDecisionRefBinding(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(businessRuleTask.getOperatonDecisionRefBinding()).isEqualTo(TEST_STRING_XML);
     businessRuleTask.setOperatonDecisionRefBinding(TEST_STRING_API);
     assertThat(businessRuleTask.getOperatonDecisionRefBinding()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testDecisionRefVersion() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testDecisionRefVersion(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(businessRuleTask.getOperatonDecisionRefVersion()).isEqualTo(TEST_STRING_XML);
     businessRuleTask.setOperatonDecisionRefVersion(TEST_STRING_API);
     assertThat(businessRuleTask.getOperatonDecisionRefVersion()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testDecisionRefVersionTag() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testDecisionRefVersionTag(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(businessRuleTask.getOperatonDecisionRefVersionTag()).isEqualTo(TEST_STRING_XML);
     businessRuleTask.setOperatonDecisionRefVersionTag(TEST_STRING_API);
     assertThat(businessRuleTask.getOperatonDecisionRefVersionTag()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testDecisionRefTenantId() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testDecisionRefTenantId(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(businessRuleTask.getOperatonDecisionRefTenantId()).isEqualTo(TEST_STRING_XML);
     businessRuleTask.setOperatonDecisionRefTenantId(TEST_STRING_API);
     assertThat(businessRuleTask.getOperatonDecisionRefTenantId()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testMapDecisionResult() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testMapDecisionResult(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(businessRuleTask.getOperatonMapDecisionResult()).isEqualTo(TEST_STRING_XML);
     businessRuleTask.setOperatonMapDecisionResult(TEST_STRING_API);
     assertThat(businessRuleTask.getOperatonMapDecisionResult()).isEqualTo(TEST_STRING_API);
   }
 
 
-  @Test
-  public void testTaskPriority() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testTaskPriority(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(businessRuleTask.getOperatonTaskPriority()).isEqualTo(TEST_STRING_XML);
     businessRuleTask.setOperatonTaskPriority(TEST_SERVICE_TASK_PRIORITY);
     assertThat(businessRuleTask.getOperatonTaskPriority()).isEqualTo(TEST_SERVICE_TASK_PRIORITY);
   }
 
-  @Test
-  public void testCandidateGroups() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testCandidateGroups(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonCandidateGroups()).isEqualTo(TEST_GROUPS_XML);
     assertThat(userTask.getOperatonCandidateGroupsList()).containsAll(TEST_GROUPS_LIST_XML);
     userTask.setOperatonCandidateGroups(TEST_GROUPS_API);
@@ -388,8 +437,10 @@ public class OperatonExtensionsTest {
     assertThat(userTask.getOperatonCandidateGroupsList()).containsAll(TEST_GROUPS_LIST_XML);
   }
 
-  @Test
-  public void testCandidateStarterGroups() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testCandidateStarterGroups(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(process.getOperatonCandidateStarterGroups()).isEqualTo(TEST_GROUPS_XML);
     assertThat(process.getOperatonCandidateStarterGroupsList()).containsAll(TEST_GROUPS_LIST_XML);
     process.setOperatonCandidateStarterGroups(TEST_GROUPS_API);
@@ -400,8 +451,10 @@ public class OperatonExtensionsTest {
     assertThat(process.getOperatonCandidateStarterGroupsList()).containsAll(TEST_GROUPS_LIST_XML);
   }
 
-  @Test
-  public void testCandidateStarterUsers() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testCandidateStarterUsers(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(process.getOperatonCandidateStarterUsers()).isEqualTo(TEST_USERS_XML);
     assertThat(process.getOperatonCandidateStarterUsersList()).containsAll(TEST_USERS_LIST_XML);
     process.setOperatonCandidateStarterUsers(TEST_USERS_API);
@@ -412,8 +465,10 @@ public class OperatonExtensionsTest {
     assertThat(process.getOperatonCandidateStarterUsersList()).containsAll(TEST_USERS_LIST_XML);
   }
 
-  @Test
-  public void testCandidateUsers() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testCandidateUsers(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonCandidateUsers()).isEqualTo(TEST_USERS_XML);
     assertThat(userTask.getOperatonCandidateUsersList()).containsAll(TEST_USERS_LIST_XML);
     userTask.setOperatonCandidateUsers(TEST_USERS_API);
@@ -424,8 +479,10 @@ public class OperatonExtensionsTest {
     assertThat(userTask.getOperatonCandidateUsersList()).containsAll(TEST_USERS_LIST_XML);
   }
 
-  @Test
-  public void testClass() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testClass(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(serviceTask.getOperatonClass()).isEqualTo(TEST_CLASS_XML);
     assertThat(messageEventDefinition.getOperatonClass()).isEqualTo(TEST_CLASS_XML);
 
@@ -436,8 +493,10 @@ public class OperatonExtensionsTest {
     assertThat(messageEventDefinition.getOperatonClass()).isEqualTo(TEST_CLASS_API);
   }
 
-  @Test
-  public void testDelegateExpression() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testDelegateExpression(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(serviceTask.getOperatonDelegateExpression()).isEqualTo(TEST_DELEGATE_EXPRESSION_XML);
     assertThat(messageEventDefinition.getOperatonDelegateExpression()).isEqualTo(TEST_DELEGATE_EXPRESSION_XML);
 
@@ -448,34 +507,44 @@ public class OperatonExtensionsTest {
     assertThat(messageEventDefinition.getOperatonDelegateExpression()).isEqualTo(TEST_DELEGATE_EXPRESSION_API);
   }
 
-  @Test
-  public void testDueDate() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testDueDate(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonDueDate()).isEqualTo(TEST_DUE_DATE_XML);
     userTask.setOperatonDueDate(TEST_DUE_DATE_API);
     assertThat(userTask.getOperatonDueDate()).isEqualTo(TEST_DUE_DATE_API);
   }
 
-  @Test
-  public void testErrorCodeVariable(){
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testErrorCodeVariable(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     ErrorEventDefinition errorEventDefinition = startEvent.getChildElementsByType(ErrorEventDefinition.class).iterator().next();
     assertThat(errorEventDefinition.getAttributeValueNs(namespace, CAMUNDA_ATTRIBUTE_ERROR_CODE_VARIABLE)).isEqualTo("errorVariable");
   }
 
-  @Test
-  public void testErrorMessageVariable(){
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testErrorMessageVariable(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     ErrorEventDefinition errorEventDefinition = startEvent.getChildElementsByType(ErrorEventDefinition.class).iterator().next();
     assertThat(errorEventDefinition.getAttributeValueNs(namespace, CAMUNDA_ATTRIBUTE_ERROR_MESSAGE_VARIABLE)).isEqualTo("errorMessageVariable");
   }
 
-  @Test
-  public void testErrorMessage() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testErrorMessage(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(error.getOperatonErrorMessage()).isEqualTo(TEST_STRING_XML);
     error.setOperatonErrorMessage(TEST_STRING_API);
     assertThat(error.getOperatonErrorMessage()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testExclusive() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testExclusive(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.isOperatonExclusive()).isTrue();
     assertThat(userTask.isOperatonExclusive()).isFalse();
     userTask.setOperatonExclusive(true);
@@ -489,8 +558,10 @@ public class OperatonExtensionsTest {
     assertThat(callActivity.isOperatonExclusive()).isTrue();
   }
 
-  @Test
-  public void testExpression() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testExpression(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(serviceTask.getOperatonExpression()).isEqualTo(TEST_EXPRESSION_XML);
     assertThat(messageEventDefinition.getOperatonExpression()).isEqualTo(TEST_EXPRESSION_XML);
     serviceTask.setOperatonExpression(TEST_EXPRESSION_API);
@@ -499,8 +570,10 @@ public class OperatonExtensionsTest {
     assertThat(messageEventDefinition.getOperatonExpression()).isEqualTo(TEST_EXPRESSION_API);
   }
 
-  @Test
-  public void testFormHandlerClass() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testFormHandlerClass(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.getOperatonFormHandlerClass()).isEqualTo(TEST_CLASS_XML);
     assertThat(userTask.getOperatonFormHandlerClass()).isEqualTo(TEST_CLASS_XML);
     startEvent.setOperatonFormHandlerClass(TEST_CLASS_API);
@@ -509,8 +582,10 @@ public class OperatonExtensionsTest {
     assertThat(userTask.getOperatonFormHandlerClass()).isEqualTo(TEST_CLASS_API);
   }
 
-  @Test
-  public void testFormKey() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testFormKey(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.getOperatonFormKey()).isEqualTo(TEST_STRING_XML);
     assertThat(userTask.getOperatonFormKey()).isEqualTo(TEST_STRING_XML);
     startEvent.setOperatonFormKey(TEST_STRING_API);
@@ -519,22 +594,28 @@ public class OperatonExtensionsTest {
     assertThat(userTask.getOperatonFormKey()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testInitiator() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testInitiator(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.getOperatonInitiator()).isEqualTo(TEST_STRING_XML);
     startEvent.setOperatonInitiator(TEST_STRING_API);
     assertThat(startEvent.getOperatonInitiator()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testPriority() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testPriority(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonPriority()).isEqualTo(TEST_PRIORITY_XML);
     userTask.setOperatonPriority(TEST_PRIORITY_API);
     assertThat(userTask.getOperatonPriority()).isEqualTo(TEST_PRIORITY_API);
   }
 
-  @Test
-  public void testResultVariable() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testResultVariable(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(serviceTask.getOperatonResultVariable()).isEqualTo(TEST_STRING_XML);
     assertThat(messageEventDefinition.getOperatonResultVariable()).isEqualTo(TEST_STRING_XML);
     serviceTask.setOperatonResultVariable(TEST_STRING_API);
@@ -543,8 +624,10 @@ public class OperatonExtensionsTest {
     assertThat(messageEventDefinition.getOperatonResultVariable()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testType() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testType(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(serviceTask.getOperatonType()).isEqualTo(TEST_TYPE_XML);
     assertThat(messageEventDefinition.getOperatonType()).isEqualTo(TEST_STRING_XML);
     serviceTask.setOperatonType(TEST_TYPE_API);
@@ -554,8 +637,10 @@ public class OperatonExtensionsTest {
 
   }
 
-  @Test
-  public void testTopic() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testTopic(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(serviceTask.getOperatonTopic()).isEqualTo(TEST_STRING_XML);
     assertThat(messageEventDefinition.getOperatonTopic()).isEqualTo(TEST_STRING_XML);
     serviceTask.setOperatonTopic(TEST_TYPE_API);
@@ -564,22 +649,28 @@ public class OperatonExtensionsTest {
     assertThat(messageEventDefinition.getOperatonTopic()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testVariableMappingClass() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testVariableMappingClass(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonVariableMappingClass()).isEqualTo(TEST_CLASS_XML);
     callActivity.setOperatonVariableMappingClass(TEST_CLASS_API);
     assertThat(callActivity.getOperatonVariableMappingClass()).isEqualTo(TEST_CLASS_API);
   }
 
-  @Test
-  public void testVariableMappingDelegateExpression() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testVariableMappingDelegateExpression(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonVariableMappingDelegateExpression()).isEqualTo(TEST_DELEGATE_EXPRESSION_XML);
     callActivity.setOperatonVariableMappingDelegateExpression(TEST_DELEGATE_EXPRESSION_API);
     assertThat(callActivity.getOperatonVariableMappingDelegateExpression()).isEqualTo(TEST_DELEGATE_EXPRESSION_API);
   }
 
-  @Test
-  public void testExecutionListenerExtension() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testExecutionListenerExtension(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonExecutionListener processListener = process.getExtensionElements().getElementsQuery().filterByType(OperatonExecutionListener.class).singleResult();
     OperatonExecutionListener startEventListener = startEvent.getExtensionElements().getElementsQuery().filterByType(OperatonExecutionListener.class).singleResult();
     OperatonExecutionListener serviceTaskListener = serviceTask.getExtensionElements().getElementsQuery().filterByType(OperatonExecutionListener.class).singleResult();
@@ -603,8 +694,10 @@ public class OperatonExtensionsTest {
     assertThat(serviceTaskListener.getOperatonEvent()).isEqualTo(TEST_EXECUTION_EVENT_API);
   }
 
-  @Test
-  public void testOperatonScriptExecutionListener() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonScriptExecutionListener(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonExecutionListener sequenceFlowListener = sequenceFlow.getExtensionElements().getElementsQuery().filterByType(OperatonExecutionListener.class).singleResult();
 
     OperatonScript script = sequenceFlowListener.getOperatonScript();
@@ -623,16 +716,20 @@ public class OperatonExtensionsTest {
     assertThat(script.getTextContent()).isEmpty();
   }
 
-  @Test
-  public void testFailedJobRetryTimeCycleExtension() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testFailedJobRetryTimeCycleExtension(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonFailedJobRetryTimeCycle timeCycle = sendTask.getExtensionElements().getElementsQuery().filterByType(OperatonFailedJobRetryTimeCycle.class).singleResult();
     assertThat(timeCycle.getTextContent()).isEqualTo(TEST_STRING_XML);
     timeCycle.setTextContent(TEST_STRING_API);
     assertThat(timeCycle.getTextContent()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testFieldExtension() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testFieldExtension(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonField field = sendTask.getExtensionElements().getElementsQuery().filterByType(OperatonField.class).singleResult();
     assertThat(field.getOperatonName()).isEqualTo(TEST_STRING_XML);
     assertThat(field.getOperatonExpression()).isEqualTo(TEST_EXPRESSION_XML);
@@ -651,8 +748,10 @@ public class OperatonExtensionsTest {
     assertThat(field.getOperatonString().getTextContent()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testFormData() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testFormData(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonFormData formData = userTask.getExtensionElements().getElementsQuery().filterByType(OperatonFormData.class).singleResult();
     OperatonFormField formField = formData.getOperatonFormFields().iterator().next();
     assertThat(formField.getOperatonId()).isEqualTo(TEST_STRING_XML);
@@ -696,8 +795,10 @@ public class OperatonExtensionsTest {
     assertThat(value.getOperatonName()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testFormProperty() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testFormProperty(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonFormProperty formProperty = startEvent.getExtensionElements().getElementsQuery().filterByType(OperatonFormProperty.class).singleResult();
     assertThat(formProperty.getOperatonId()).isEqualTo(TEST_STRING_XML);
     assertThat(formProperty.getOperatonName()).isEqualTo(TEST_STRING_XML);
@@ -731,8 +832,10 @@ public class OperatonExtensionsTest {
     assertThat(formProperty.getOperatonDefault()).isEqualTo(TEST_STRING_API);
   }
 
-  @Test
-  public void testInExtension() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testInExtension(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonIn in = callActivity.getExtensionElements().getElementsQuery().filterByType(OperatonIn.class).singleResult();
     assertThat(in.getOperatonSource()).isEqualTo(TEST_STRING_XML);
     assertThat(in.getOperatonSourceExpression()).isEqualTo(TEST_EXPRESSION_XML);
@@ -754,8 +857,10 @@ public class OperatonExtensionsTest {
     assertThat(in.getOperatonLocal()).isFalse();
   }
 
-  @Test
-  public void testOutExtension() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOutExtension(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonOut out = callActivity.getExtensionElements().getElementsQuery().filterByType(OperatonOut.class).singleResult();
     assertThat(out.getOperatonSource()).isEqualTo(TEST_STRING_XML);
     assertThat(out.getOperatonSourceExpression()).isEqualTo(TEST_EXPRESSION_XML);
@@ -774,8 +879,10 @@ public class OperatonExtensionsTest {
     assertThat(out.getOperatonLocal()).isFalse();
   }
 
-  @Test
-  public void testPotentialStarter() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testPotentialStarter(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonPotentialStarter potentialStarter = startEvent.getExtensionElements().getElementsQuery().filterByType(OperatonPotentialStarter.class).singleResult();
     Expression expression = potentialStarter.getResourceAssignmentExpression().getExpression();
     assertThat(expression.getTextContent()).isEqualTo(TEST_GROUPS_XML);
@@ -783,8 +890,10 @@ public class OperatonExtensionsTest {
     assertThat(expression.getTextContent()).isEqualTo(TEST_GROUPS_API);
   }
 
-  @Test
-  public void testTaskListener() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testTaskListener(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonTaskListener taskListener = userTask.getExtensionElements().getElementsQuery().filterByType(OperatonTaskListener.class).list().get(0);
     assertThat(taskListener.getOperatonEvent()).isEqualTo(TEST_TASK_EVENT_XML);
     assertThat(taskListener.getOperatonClass()).isEqualTo(TEST_CLASS_XML);
@@ -813,8 +922,10 @@ public class OperatonExtensionsTest {
     assertThat(timeout.getTimeDuration().getRawTextContent()).isEqualTo("PT1H");
   }
 
-  @Test
-  public void testOperatonScriptTaskListener() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonScriptTaskListener(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonTaskListener taskListener = userTask.getExtensionElements().getElementsQuery().filterByType(OperatonTaskListener.class).list().get(1);
 
     OperatonScript script = taskListener.getOperatonScript();
@@ -833,8 +944,10 @@ public class OperatonExtensionsTest {
     assertThat(script.getTextContent()).isEqualTo("println 'Hello World'");
   }
 
-  @Test
-  public void testOperatonModelerProperties() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonModelerProperties(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonProperties operatonProperties = endEvent.getExtensionElements().getElementsQuery().filterByType(OperatonProperties.class).singleResult();
     assertThat(operatonProperties).isNotNull();
     assertThat(operatonProperties.getOperatonProperties()).hasSize(2);
@@ -846,15 +959,19 @@ public class OperatonExtensionsTest {
     }
   }
 
-  @Test
-  public void testGetNonExistingOperatonCandidateUsers() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testGetNonExistingOperatonCandidateUsers(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     userTask.removeAttributeNs(namespace, "candidateUsers");
     assertThat(userTask.getOperatonCandidateUsers()).isNull();
     assertThat(userTask.getOperatonCandidateUsersList()).isEmpty();
   }
 
-  @Test
-  public void testSetNullOperatonCandidateUsers() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testSetNullOperatonCandidateUsers(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonCandidateUsers()).isNotEmpty();
     assertThat(userTask.getOperatonCandidateUsersList()).isNotEmpty();
     userTask.setOperatonCandidateUsers(null);
@@ -862,8 +979,10 @@ public class OperatonExtensionsTest {
     assertThat(userTask.getOperatonCandidateUsersList()).isEmpty();
   }
 
-  @Test
-  public void testEmptyOperatonCandidateUsers() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testEmptyOperatonCandidateUsers(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonCandidateUsers()).isNotEmpty();
     assertThat(userTask.getOperatonCandidateUsersList()).isNotEmpty();
     userTask.setOperatonCandidateUsers("");
@@ -871,8 +990,10 @@ public class OperatonExtensionsTest {
     assertThat(userTask.getOperatonCandidateUsersList()).isEmpty();
   }
 
-  @Test
-  public void testSetNullOperatonCandidateUsersList() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testSetNullOperatonCandidateUsersList(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonCandidateUsers()).isNotEmpty();
     assertThat(userTask.getOperatonCandidateUsersList()).isNotEmpty();
     userTask.setOperatonCandidateUsersList(null);
@@ -880,8 +1001,10 @@ public class OperatonExtensionsTest {
     assertThat(userTask.getOperatonCandidateUsersList()).isEmpty();
   }
 
-  @Test
-  public void testEmptyOperatonCandidateUsersList() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testEmptyOperatonCandidateUsersList(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonCandidateUsers()).isNotEmpty();
     assertThat(userTask.getOperatonCandidateUsersList()).isNotEmpty();
     userTask.setOperatonCandidateUsersList(Collections.<String>emptyList());
@@ -889,14 +1012,18 @@ public class OperatonExtensionsTest {
     assertThat(userTask.getOperatonCandidateUsersList()).isEmpty();
   }
 
-  @Test
-  public void testScriptResource() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testScriptResource(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(scriptTask.getScriptFormat()).isEqualTo("groovy");
     assertThat(scriptTask.getOperatonResource()).isEqualTo("test.groovy");
   }
 
-  @Test
-  public void testOperatonConnector() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonConnector(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonConnector operatonConnector = serviceTask.getExtensionElements().getElementsQuery().filterByType(OperatonConnector.class).singleResult();
     assertThat(operatonConnector).isNotNull();
 
@@ -921,16 +1048,20 @@ public class OperatonExtensionsTest {
     assertThat(outputParameter.getTextContent()).isEqualTo("output");
   }
 
-  @Test
-  public void testOperatonInputOutput() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonInputOutput(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonInputOutput operatonInputOutput = serviceTask.getExtensionElements().getElementsQuery().filterByType(OperatonInputOutput.class).singleResult();
     assertThat(operatonInputOutput).isNotNull();
     assertThat(operatonInputOutput.getOperatonInputParameters()).hasSize(6);
     assertThat(operatonInputOutput.getOperatonOutputParameters()).hasSize(1);
   }
 
-  @Test
-  public void testOperatonInputParameter() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonInputParameter(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     // find existing
     OperatonInputParameter inputParameter = findInputParameterByName(serviceTask, "shouldBeConstant");
 
@@ -953,29 +1084,37 @@ public class OperatonExtensionsTest {
     assertThat(inputParameter.getTextContent()).isEqualTo("def");
   }
 
-  @Test
-  public void testOperatonNullInputParameter() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonNullInputParameter(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonInputParameter inputParameter = findInputParameterByName(serviceTask, "shouldBeNull");
     assertThat(inputParameter.getOperatonName()).isEqualTo("shouldBeNull");
     assertThat(inputParameter.getTextContent()).isEmpty();
   }
 
-  @Test
-  public void testOperatonConstantInputParameter() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonConstantInputParameter(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonInputParameter inputParameter = findInputParameterByName(serviceTask, "shouldBeConstant");
     assertThat(inputParameter.getOperatonName()).isEqualTo("shouldBeConstant");
     assertThat(inputParameter.getTextContent()).isEqualTo("foo");
   }
 
-  @Test
-  public void testOperatonExpressionInputParameter() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonExpressionInputParameter(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonInputParameter inputParameter = findInputParameterByName(serviceTask, "shouldBeExpression");
     assertThat(inputParameter.getOperatonName()).isEqualTo("shouldBeExpression");
     assertThat(inputParameter.getTextContent()).isEqualTo("${1 + 1}");
   }
 
-  @Test
-  public void testOperatonListInputParameter() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonListInputParameter(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonInputParameter inputParameter = findInputParameterByName(serviceTask, "shouldBeList");
     assertThat(inputParameter.getOperatonName()).isEqualTo("shouldBeList");
     assertThat(inputParameter.getTextContent()).isNotEmpty();
@@ -1048,8 +1187,10 @@ public class OperatonExtensionsTest {
 
   }
 
-  @Test
-  public void testOperatonMapInputParameter() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonMapInputParameter(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonInputParameter inputParameter = findInputParameterByName(serviceTask, "shouldBeMap");
     assertThat(inputParameter.getOperatonName()).isEqualTo("shouldBeMap");
     assertThat(inputParameter.getTextContent()).isNotEmpty();
@@ -1088,8 +1229,10 @@ public class OperatonExtensionsTest {
     assertThat((Object) inputParameter.getValue()).isNull();
   }
 
-  @Test
-  public void testOperatonScriptInputParameter() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonScriptInputParameter(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonInputParameter inputParameter = findInputParameterByName(serviceTask, "shouldBeScript");
     assertThat(inputParameter.getOperatonName()).isEqualTo("shouldBeScript");
     assertThat(inputParameter.getTextContent()).isNotEmpty();
@@ -1116,8 +1259,10 @@ public class OperatonExtensionsTest {
     assertThat((Object) inputParameter.getValue()).isNull();
   }
 
-  @Test
-  public void testOperatonNestedOutputParameter() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonNestedOutputParameter(String namespace, BpmnModelInstance modelInstance) {
+    initOperatonExtensionsTest(namespace, modelInstance);
     OperatonOutputParameter operatonOutputParameter = serviceTask.getExtensionElements().getElementsQuery().filterByType(OperatonInputOutput.class).singleResult().getOperatonOutputParameters().iterator().next();
 
     assertThat(operatonOutputParameter).isNotNull();
@@ -1171,7 +1316,7 @@ public class OperatonExtensionsTest {
     throw new BpmnModelException("Unable to find operaton:inputParameter with name '" + name + "' for element with id '" + baseElement.getId() + "'");
   }
 
-  @After
+  @AfterEach
   public void validateModel() {
     Bpmn.validateModel(modelInstance);
   }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
@@ -149,9 +149,9 @@ public class OperatonExtensionsTest {
   public void initOperatonExtensionsTest(String namespace, BpmnModelInstance modelInstance) {
     this.namespace = namespace;
     this.originalModelInstance = modelInstance;
+    setUp();
   }
 
-  @BeforeEach
   public void setUp(){
     modelInstance = originalModelInstance.clone();
     process = modelInstance.getModelElementById(PROCESS_ID);
@@ -705,7 +705,7 @@ public class OperatonExtensionsTest {
     assertThat(script.getOperatonResource()).isNull();
     assertThat(script.getTextContent()).isEqualTo("println 'Hello World'");
 
-    OperatonScript newScript = modelInstance.newInstance(OperatonScript.class);
+    OperatonScript newScript = this.modelInstance.newInstance(OperatonScript.class);
     newScript.setOperatonScriptFormat("groovy");
     newScript.setOperatonResource("test.groovy");
     sequenceFlowListener.setOperatonScript(newScript);
@@ -933,7 +933,7 @@ public class OperatonExtensionsTest {
     assertThat(script.getOperatonResource()).isEqualTo("test.groovy");
     assertThat(script.getTextContent()).isEmpty();
 
-    OperatonScript newScript = modelInstance.newInstance(OperatonScript.class);
+    OperatonScript newScript = this.modelInstance.newInstance(OperatonScript.class);
     newScript.setOperatonScriptFormat("groovy");
     newScript.setTextContent("println 'Hello World'");
     taskListener.setOperatonScript(newScript);
@@ -1072,7 +1072,7 @@ public class OperatonExtensionsTest {
     assertThat(inputParameter.getTextContent()).isEqualTo("world");
 
     // add new one
-    inputParameter = modelInstance.newInstance(OperatonInputParameter.class);
+    inputParameter = this.modelInstance.newInstance(OperatonInputParameter.class);
     inputParameter.setOperatonName("abc");
     inputParameter.setTextContent("def");
     serviceTask.getExtensionElements().getElementsQuery().filterByType(OperatonInputOutput.class).singleResult()
@@ -1126,13 +1126,13 @@ public class OperatonExtensionsTest {
       assertThat(values.getTextContent()).isIn("a", "b", "c");
     }
 
-    list = modelInstance.newInstance(OperatonList.class);
+    list = this.modelInstance.newInstance(OperatonList.class);
     for (int i = 0; i < 4; i++) {
-      OperatonValue value = modelInstance.newInstance(OperatonValue.class);
+      OperatonValue value = this.modelInstance.newInstance(OperatonValue.class);
       value.setTextContent("test");
       list.getValues().add(value);
     }
-    Collection<OperatonValue> testValues = Arrays.asList(modelInstance.newInstance(OperatonValue.class), modelInstance.newInstance(OperatonValue.class));
+    Collection<OperatonValue> testValues = Arrays.asList(this.modelInstance.newInstance(OperatonValue.class), this.modelInstance.newInstance(OperatonValue.class));
     list.getValues().addAll(testValues);
     inputParameter.setValue(list);
 
@@ -1157,19 +1157,19 @@ public class OperatonExtensionsTest {
     // test standard list interactions
     Collection<BpmnModelElementInstance> elements = list.getValues();
 
-    OperatonValue value = modelInstance.newInstance(OperatonValue.class);
+    OperatonValue value = this.modelInstance.newInstance(OperatonValue.class);
     elements.add(value);
 
     List<OperatonValue> newValues = new ArrayList<OperatonValue>();
-    newValues.add(modelInstance.newInstance(OperatonValue.class));
-    newValues.add(modelInstance.newInstance(OperatonValue.class));
+    newValues.add(this.modelInstance.newInstance(OperatonValue.class));
+    newValues.add(this.modelInstance.newInstance(OperatonValue.class));
     elements.addAll(newValues);
     assertThat(elements).hasSize(3);
 
-    assertThat(elements).doesNotContain(modelInstance.newInstance(OperatonValue.class));
-    assertThat(elements.containsAll(Arrays.asList(modelInstance.newInstance(OperatonValue.class)))).isFalse();
+    assertThat(elements).doesNotContain(this.modelInstance.newInstance(OperatonValue.class));
+    assertThat(elements.containsAll(Arrays.asList(this.modelInstance.newInstance(OperatonValue.class)))).isFalse();
 
-    assertThat(elements.remove(modelInstance.newInstance(OperatonValue.class))).isFalse();
+    assertThat(elements.remove(this.modelInstance.newInstance(OperatonValue.class))).isFalse();
     assertThat(elements).hasSize(3);
 
     assertThat(elements.remove(value)).isTrue();
@@ -1178,7 +1178,7 @@ public class OperatonExtensionsTest {
     assertThat(elements.removeAll(newValues)).isTrue();
     assertThat(elements).isEmpty();
 
-    elements.add(modelInstance.newInstance(OperatonValue.class));
+    elements.add(this.modelInstance.newInstance(OperatonValue.class));
     elements.clear();
     assertThat(elements).isEmpty();
 
@@ -1208,8 +1208,8 @@ public class OperatonExtensionsTest {
       }
     }
 
-    map = modelInstance.newInstance(OperatonMap.class);
-    OperatonEntry entry = modelInstance.newInstance(OperatonEntry.class);
+    map = this.modelInstance.newInstance(OperatonMap.class);
+    OperatonEntry entry = this.modelInstance.newInstance(OperatonEntry.class);
     entry.setOperatonKey("test");
     entry.setTextContent("value");
     map.getOperatonEntries().add(entry);
@@ -1222,7 +1222,7 @@ public class OperatonExtensionsTest {
     assertThat(entry.getTextContent()).isEqualTo("value");
 
     Collection<OperatonEntry> entries = map.getOperatonEntries();
-    entries.add(modelInstance.newInstance(OperatonEntry.class));
+    entries.add(this.modelInstance.newInstance(OperatonEntry.class));
     assertThat(entries).hasSize(2);
 
     inputParameter.removeValue();
@@ -1244,7 +1244,7 @@ public class OperatonExtensionsTest {
     assertThat(script.getOperatonResource()).isNull();
     assertThat(script.getTextContent()).isEqualTo("1 + 1");
 
-    script = modelInstance.newInstance(OperatonScript.class);
+    script = this.modelInstance.newInstance(OperatonScript.class);
     script.setOperatonScriptFormat("python");
     script.setOperatonResource("script.py");
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ProcessTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ProcessTest.java
@@ -16,11 +16,11 @@
  */
 package org.operaton.bpm.model.bpmn;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.Process;
 import org.operaton.bpm.model.bpmn.instance.RootElement;
 import org.operaton.bpm.model.bpmn.util.BpmnModelResource;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
-import org.junit.Test;
 
 import java.util.Collection;
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/QueryTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/QueryTest.java
@@ -15,14 +15,13 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.FlowNode;
 import org.operaton.bpm.model.bpmn.instance.Gateway;
 import org.operaton.bpm.model.bpmn.instance.Task;
 import org.operaton.bpm.model.xml.type.ModelElementType;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -37,7 +36,7 @@ public class QueryTest {
   private static Query<FlowNode> gateway1Succeeding;
   private static Query<FlowNode> gateway2Succeeding;
 
-  @BeforeClass
+  @BeforeAll
   public static void createModelInstance() {
     modelInstance = Bpmn.createProcess()
       .startEvent().id("start")
@@ -63,7 +62,7 @@ public class QueryTest {
 
   }
 
-  @AfterClass
+  @AfterAll
   public static void validateModelInstance() {
     Bpmn.validateModel(modelInstance);
   }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ReferenceTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ReferenceTest.java
@@ -15,12 +15,11 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.*;
 import org.operaton.bpm.model.bpmn.instance.Process;
 import org.operaton.bpm.model.bpmn.util.BpmnModelResource;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.Collection;
 
@@ -37,7 +36,7 @@ public class ReferenceTest extends BpmnModelTest {
   private MessageEventDefinition messageEventDefinition;
   private StartEvent startEvent;
 
-  @Before
+  @BeforeEach
   public void createModel() {
     testBpmnModelInstance = Bpmn.createEmptyModel();
     Definitions definitions = testBpmnModelInstance.newInstance(Definitions.class);

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ResourceRolesTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ResourceRolesTest.java
@@ -19,14 +19,13 @@ package org.operaton.bpm.model.bpmn;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
-
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.HumanPerformer;
 import org.operaton.bpm.model.bpmn.instance.Performer;
 import org.operaton.bpm.model.bpmn.instance.PotentialOwner;
 import org.operaton.bpm.model.bpmn.instance.ResourceRole;
 import org.operaton.bpm.model.bpmn.instance.UserTask;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 /**
  * @author Dario Campagna
@@ -35,7 +34,7 @@ public class ResourceRolesTest {
 
   private static BpmnModelInstance modelInstance;
 
-  @BeforeClass
+  @BeforeAll
   public static void parseModel() {
     modelInstance = Bpmn.readModelFromStream(ResourceRolesTest.class.getResourceAsStream("ResourceRolesTest.bpmn"));
   }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.model.bpmn.builder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Fail.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -62,6 +63,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import org.assertj.core.api.Assertions;
 import org.operaton.bpm.model.bpmn.AssociationDirection;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelException;
@@ -2634,7 +2637,7 @@ public class ProcessBuilderTest {
 
   @Test
   public void testOnlyOneCompensateBoundaryEventAllowed() {
-    Throwable exception = assertThrows(BpmnModelException.class, () -> {
+    assertThatThrownBy(() -> {
       // given
       UserTaskBuilder builder = Bpmn.createProcess()
         .startEvent()
@@ -2646,25 +2649,25 @@ public class ProcessBuilderTest {
 
       // when
       builder.userTask();
-    });
-    assertTrue(exception.getMessage().contains("Only single compensation handler allowed. Call compensationDone() to continue main flow."));
+    }).isInstanceOf(BpmnModelException.class)
+            .hasMessageContaining("Only single compensation handler allowed. Call compensationDone() to continue main flow.");
   }
 
   @Test
   public void testInvalidCompensationStartCall() {
-    Throwable exception = assertThrows(BpmnModelException.class, () -> {
+    assertThatThrownBy(() -> {
       // given
       StartEventBuilder builder = Bpmn.createProcess().startEvent();
 
       // when
       builder.compensationStart();
-    });
-    assertTrue(exception.getMessage().contains("Compensation can only be started on a boundary event with a compensation event definition"));
+    }).isInstanceOf(BpmnModelException.class)
+                    .hasMessageContaining("Compensation can only be started on a boundary event with a compensation event definition");
   }
 
   @Test
   public void testInvalidCompensationDoneCall() {
-    Throwable exception = assertThrows(BpmnModelException.class, () -> {
+    assertThatThrownBy(() -> {
       // given
       AbstractFlowNodeBuilder builder = Bpmn.createProcess()
         .startEvent()
@@ -2674,8 +2677,8 @@ public class ProcessBuilderTest {
 
       // when
       builder.compensationDone();
-    });
-    assertTrue(exception.getMessage().contains("No compensation in progress. Call compensationStart() first."));
+    }).isInstanceOf(BpmnModelException.class)
+            .hasMessageContaining("No compensation in progress. Call compensationStart() first.");
   }
 
   @Test

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.model.bpmn.builder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.BOUNDARY_ID;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.CALL_ACTIVITY_ID;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.CATCH_ID;
@@ -55,7 +57,6 @@ import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_VERSION_TAG;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TRANSACTION_ID;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.USER_TASK_ID;
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.BPMN20_NS;
-import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -124,11 +125,9 @@ import org.operaton.bpm.model.bpmn.instance.operaton.OperatonTaskListener;
 import org.operaton.bpm.model.xml.Model;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 import org.operaton.bpm.model.xml.type.ModelElementType;
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -142,16 +141,13 @@ public class ProcessBuilderTest {
 
   public static final String FAILED_JOB_RETRY_TIME_CYCLE = "R5/PT1M";
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
   private BpmnModelInstance modelInstance;
   private static ModelElementType taskType;
   private static ModelElementType gatewayType;
   private static ModelElementType eventType;
   private static ModelElementType processType;
 
-  @BeforeClass
+  @BeforeAll
   public static void getElementTypes() {
     Model model = Bpmn.createEmptyModel().getModel();
     taskType = model.getType(Task.class);
@@ -160,7 +156,7 @@ public class ProcessBuilderTest {
     processType = model.getType(Process.class);
   }
 
-  @After
+  @AfterEach
   public void validateModel() throws IOException {
     if (modelInstance != null) {
       Bpmn.validateModel(modelInstance);
@@ -2638,51 +2634,48 @@ public class ProcessBuilderTest {
 
   @Test
   public void testOnlyOneCompensateBoundaryEventAllowed() {
-    // given
-    UserTaskBuilder builder = Bpmn.createProcess()
-      .startEvent()
-      .userTask("task")
-      .boundaryEvent("boundary")
-      .compensateEventDefinition().compensateEventDefinitionDone()
-      .compensationStart()
-      .userTask("compensate").name("compensate");
+    Throwable exception = assertThrows(BpmnModelException.class, () -> {
+      // given
+      UserTaskBuilder builder = Bpmn.createProcess()
+        .startEvent()
+        .userTask("task")
+        .boundaryEvent("boundary")
+        .compensateEventDefinition().compensateEventDefinitionDone()
+        .compensationStart()
+        .userTask("compensate").name("compensate");
 
-    // then
-    thrown.expect(BpmnModelException.class);
-    thrown.expectMessage("Only single compensation handler allowed. Call compensationDone() to continue main flow.");
-
-    // when
-    builder.userTask();
+      // when
+      builder.userTask();
+    });
+    assertTrue(exception.getMessage().contains("Only single compensation handler allowed. Call compensationDone() to continue main flow."));
   }
 
   @Test
   public void testInvalidCompensationStartCall() {
-    // given
-    StartEventBuilder builder = Bpmn.createProcess().startEvent();
+    Throwable exception = assertThrows(BpmnModelException.class, () -> {
+      // given
+      StartEventBuilder builder = Bpmn.createProcess().startEvent();
 
-    // then
-    thrown.expect(BpmnModelException.class);
-    thrown.expectMessage("Compensation can only be started on a boundary event with a compensation event definition");
-
-    // when
-    builder.compensationStart();
+      // when
+      builder.compensationStart();
+    });
+    assertTrue(exception.getMessage().contains("Compensation can only be started on a boundary event with a compensation event definition"));
   }
 
   @Test
   public void testInvalidCompensationDoneCall() {
-    // given
-    AbstractFlowNodeBuilder builder = Bpmn.createProcess()
-      .startEvent()
-      .userTask("task")
-      .boundaryEvent("boundary")
-      .compensateEventDefinition().compensateEventDefinitionDone();
+    Throwable exception = assertThrows(BpmnModelException.class, () -> {
+      // given
+      AbstractFlowNodeBuilder builder = Bpmn.createProcess()
+        .startEvent()
+        .userTask("task")
+        .boundaryEvent("boundary")
+        .compensateEventDefinition().compensateEventDefinitionDone();
 
-    // then
-    thrown.expect(BpmnModelException.class);
-    thrown.expectMessage("No compensation in progress. Call compensationStart() first.");
-
-    // when
-    builder.compensationDone();
+      // when
+      builder.compensationDone();
+    });
+    assertTrue(exception.getMessage().contains("No compensation in progress. Call compensationStart() first."));
   }
 
   @Test

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/di/CoordinatesGenerationTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/di/CoordinatesGenerationTest.java
@@ -29,6 +29,7 @@ import static org.operaton.bpm.model.bpmn.BpmnTestConstants.USER_TASK_ID;
 import java.util.Collection;
 import java.util.Iterator;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.bpmn.builder.ProcessBuilder;
@@ -36,7 +37,6 @@ import org.operaton.bpm.model.bpmn.instance.bpmndi.BpmnEdge;
 import org.operaton.bpm.model.bpmn.instance.bpmndi.BpmnShape;
 import org.operaton.bpm.model.bpmn.instance.dc.Bounds;
 import org.operaton.bpm.model.bpmn.instance.di.Waypoint;
-import org.junit.Test;
 
 public class CoordinatesGenerationTest {
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/di/DiGeneratorForFlowNodesTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/di/DiGeneratorForFlowNodesTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.model.bpmn.builder.di;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.BOUNDARY_ID;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.CALL_ACTIVITY_ID;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.CATCH_ID;
@@ -30,27 +31,23 @@ import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TASK_ID;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_CONDITION;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TRANSACTION_ID;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.USER_TASK_ID;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.bpmn.builder.ProcessBuilder;
 import org.operaton.bpm.model.bpmn.instance.bpmndi.BpmnDiagram;
 import org.operaton.bpm.model.bpmn.instance.bpmndi.BpmnShape;
-import org.junit.After;
-import org.junit.Test;
 
 public class DiGeneratorForFlowNodesTest {
 
   private BpmnModelInstance instance;
 
-  @After
+  @AfterEach
   public void validateModel() throws IOException {
     if (instance != null) {
       Bpmn.validateModel(instance);

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/di/DiGeneratorForSequenceFlowsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/di/DiGeneratorForSequenceFlowsTest.java
@@ -15,30 +15,28 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn.builder.di;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.END_EVENT_ID;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.SEQUENCE_FLOW_ID;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.START_EVENT_ID;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.USER_TASK_ID;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.bpmn.builder.ProcessBuilder;
 import org.operaton.bpm.model.bpmn.instance.bpmndi.BpmnEdge;
-import org.junit.After;
-import org.junit.Test;
 
 public class DiGeneratorForSequenceFlowsTest {
 
   private BpmnModelInstance instance;
 
-  @After
+  @AfterEach
   public void validateModel() throws IOException {
     if (instance != null) {
       Bpmn.validateModel(instance);

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/AbstractEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/AbstractEventDefinitionTest.java
@@ -16,11 +16,11 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.Query;
 import org.operaton.bpm.model.bpmn.impl.QueryImpl;
 import org.operaton.bpm.model.xml.impl.util.ReflectUtil;
-import org.junit.Before;
 
 import java.io.InputStream;
 import java.util.Collection;
@@ -41,7 +41,7 @@ public abstract class AbstractEventDefinitionTest extends BpmnModelElementInstan
     return null;
   }
 
-  @Before
+  @BeforeEach
   public void getEvent() {
     InputStream inputStream = ReflectUtil.getResourceAsStream("org/operaton/bpm/model/bpmn/EventDefinitionsTest.xml");
     IntermediateThrowEvent event = Bpmn.readModelFromStream(inputStream).getModelElementById("event");

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/AbstractGatewayTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/AbstractGatewayTest.java
@@ -16,11 +16,11 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.GatewayDirection;
 import org.operaton.bpm.model.xml.impl.util.ReflectUtil;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
-import org.junit.Before;
 
 import java.io.InputStream;
 import java.util.Arrays;
@@ -51,7 +51,7 @@ public abstract class AbstractGatewayTest<G extends Gateway> extends BpmnModelEl
     );
   }
 
-  @Before
+  @BeforeEach
   @SuppressWarnings("unchecked")
   public void getGateway() {
     InputStream inputStream = ReflectUtil.getResourceAsStream("org/operaton/bpm/model/bpmn/GatewaysTest.xml");

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/BaseElementTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/BaseElementTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/BpmnModelElementInstanceTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/BpmnModelElementInstanceTest.java
@@ -15,18 +15,19 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn.instance;
+
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.operaton.bpm.model.bpmn.impl.BpmnModelConstants;
 import org.operaton.bpm.model.bpmn.util.GetBpmnModelElementTypeRule;
 import org.operaton.bpm.model.xml.test.AbstractModelElementInstanceTest;
-import org.junit.ClassRule;
 
 /**
  * @author Sebastian Menski
  */
 public abstract class BpmnModelElementInstanceTest extends AbstractModelElementInstanceTest {
 
-  @ClassRule
+  @RegisterExtension
   public static final GetBpmnModelElementTypeRule modelElementTypeRule = new GetBpmnModelElementTypeRule();
 
   @BeforeAll

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/BpmnModelElementInstanceTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/BpmnModelElementInstanceTest.java
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn.instance;
-
+import org.junit.jupiter.api.BeforeAll;
 import org.operaton.bpm.model.bpmn.impl.BpmnModelConstants;
 import org.operaton.bpm.model.bpmn.util.GetBpmnModelElementTypeRule;
 import org.operaton.bpm.model.xml.test.AbstractModelElementInstanceTest;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 
 /**
@@ -30,7 +29,7 @@ public abstract class BpmnModelElementInstanceTest extends AbstractModelElementI
   @ClassRule
   public static final GetBpmnModelElementTypeRule modelElementTypeRule = new GetBpmnModelElementTypeRule();
 
-  @BeforeClass
+  @BeforeAll
   public static void initModelElementType() {
     initModelElementType(modelElementTypeRule);
   }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/CancelEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/CancelEventDefinitionTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/CompensateEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/CompensateEventDefinitionTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ComplexGatewayTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ComplexGatewayTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ConditionalEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ConditionalEventDefinitionTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ErrorEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ErrorEventDefinitionTest.java
@@ -18,9 +18,9 @@ package org.operaton.bpm.model.bpmn.instance;
 
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
 
-import org.junit.Test;
-
 import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
 import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/EscalationEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/EscalationEventDefinitionTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/EventBasedGatewayTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/EventBasedGatewayTest.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.EventBasedGatewayType;
-import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ExclusiveGatewayTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ExclusiveGatewayTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/FlowNodeTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/FlowNodeTest.java
@@ -16,11 +16,11 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.bpmn.impl.instance.Incoming;
 import org.operaton.bpm.model.bpmn.impl.instance.Outgoing;
-import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/InclusiveGatewayTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/InclusiveGatewayTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/LinkEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/LinkEventDefinitionTest.java
@@ -16,9 +16,9 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.impl.instance.Source;
 import org.operaton.bpm.model.bpmn.impl.instance.Target;
-import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/MessageEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/MessageEventDefinitionTest.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.impl.instance.OperationRef;
-import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ProcessTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ProcessTest.java
@@ -21,11 +21,12 @@ import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
 
 import java.util.Arrays;
 import java.util.Collection;
+
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.BpmnTestConstants;
 
 import org.operaton.bpm.model.bpmn.ProcessType;
 import org.operaton.bpm.model.bpmn.impl.instance.Supports;
-import org.junit.Test;
 
 /**
  * @author Sebastian Menski

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ServiceTaskTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ServiceTaskTest.java
@@ -19,11 +19,11 @@ package org.operaton.bpm.model.bpmn.instance;
 import java.util.Arrays;
 import java.util.Collection;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.BpmnTestConstants;
 
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
-
-import org.junit.Test;
 
 /**
  * @author Sebastian Menski

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/SignalEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/SignalEventDefinitionTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TerminateEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TerminateEventDefinitionTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TextAnnotationTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TextAnnotationTest.java
@@ -17,17 +17,13 @@
 package org.operaton.bpm.model.bpmn.instance;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collection;
-
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 /**
  * @author Filip Hrisafov
@@ -52,7 +48,7 @@ public class TextAnnotationTest extends BpmnModelElementInstanceTest {
     );
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void parseModel() {
     modelInstance = Bpmn.readModelFromStream(TextAnnotationTest.class
       .getResourceAsStream("TextAnnotationTest.bpmn"));

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TimerEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TimerEventDefinitionTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TransactionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TransactionTest.java
@@ -30,11 +30,11 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.bpmn.TransactionMethod;
 import org.operaton.bpm.model.xml.impl.util.ReflectUtil;
-import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/CompatabilityTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/CompatabilityTest.java
@@ -15,20 +15,19 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn.instance.operaton;
-
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.PROCESS_ID;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.Collection;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.bpmn.OperatonExtensionsTest;
 import org.operaton.bpm.model.bpmn.impl.BpmnModelConstants;
 import org.operaton.bpm.model.bpmn.impl.instance.ProcessImpl;
 import org.operaton.bpm.model.bpmn.instance.ExtensionElements;
-import org.junit.Test;
 
 /**
  * Test to check the interoperability when changing elements and attributes with

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/CompatabilityTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/CompatabilityTest.java
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn.instance.operaton;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.operaton.bpm.model.bpmn.BpmnTestConstants.PROCESS_ID;
-import static org.hamcrest.CoreMatchers.is;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
 
@@ -51,7 +51,7 @@ public class CompatabilityTest {
       listener.setOperatonClass(listenerClass);
     }
     for (OperatonExecutionListener listener : listeners) {
-      assertThat(listener.getAttributeValueNs(BpmnModelConstants.CAMUNDA_NS, "class"), is(listenerClass));
+      assertThat(listener.getAttributeValueNs(BpmnModelConstants.CAMUNDA_NS, "class")).isEqualTo(listenerClass);
     }
   }
 
@@ -66,11 +66,11 @@ public class CompatabilityTest {
     process.setOperatonHistoryTimeToLive(historyTimeToLive);
     process.setOperatonIsStartableInTasklist(false);
     process.setOperatonVersionTag("v1.0.0");
-    assertThat(process.getAttributeValueNs(BpmnModelConstants.CAMUNDA_NS, "jobPriority"), is(priority));
-    assertThat(process.getAttributeValueNs(BpmnModelConstants.CAMUNDA_NS, "taskPriority"), is(priority));
-    assertThat(process.getAttributeValueNs(BpmnModelConstants.CAMUNDA_NS, "historyTimeToLive"), is(historyTimeToLive.toString()));
-    assertThat(process.isOperatonStartableInTasklist(), is(false));
-    assertThat(process.getOperatonVersionTag(), is("v1.0.0"));
+    assertThat(process.getAttributeValueNs(BpmnModelConstants.CAMUNDA_NS, "jobPriority")).isEqualTo(priority);
+    assertThat(process.getAttributeValueNs(BpmnModelConstants.CAMUNDA_NS, "taskPriority")).isEqualTo(priority);
+    assertThat(process.getAttributeValueNs(BpmnModelConstants.CAMUNDA_NS, "historyTimeToLive")).isEqualTo(historyTimeToLive.toString());
+    assertThat(process.isOperatonStartableInTasklist()).isEqualTo(false);
+    assertThat(process.getOperatonVersionTag()).isEqualTo("v1.0.0");
   }
 
 }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonInputParameterTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonInputParameterTest.java
@@ -18,12 +18,12 @@ package org.operaton.bpm.model.bpmn.instance.operaton;
 
 import java.util.Arrays;
 import java.util.Collection;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.BpmnModelElementInstanceTest;
-import org.junit.Ignore;
-import org.junit.Test;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
-import static org.junit.Assert.fail;
 
 /**
  * @author Sebastian Menski
@@ -44,7 +44,7 @@ public class OperatonInputParameterTest extends BpmnModelElementInstanceTest {
     );
   }
 
-  @Ignore("Test ignored. CAM-9441: Bug fix needed")
+  @Disabled("Test ignored. CAM-9441: Bug fix needed")
   @Test
   public void testIntputParameterScriptChildAssignment() {
     try {
@@ -61,7 +61,7 @@ public class OperatonInputParameterTest extends BpmnModelElementInstanceTest {
     }
   }
 
-  @Ignore("Test ignored. CAM-9441: Bug fix needed")
+  @Disabled("Test ignored. CAM-9441: Bug fix needed")
   @Test
   public void testInputParameterListChildAssignment() {
     try {
@@ -76,7 +76,7 @@ public class OperatonInputParameterTest extends BpmnModelElementInstanceTest {
     }
   }
 
-  @Ignore("Test ignored. CAM-9441: Bug fix needed")
+  @Disabled("Test ignored. CAM-9441: Bug fix needed")
   @Test
   public void testInputParameterMapChildAssignment() {
     try {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonListTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonListTest.java
@@ -16,14 +16,13 @@
  */
 package org.operaton.bpm.model.bpmn.instance.operaton;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
-import static org.junit.Assert.fail;
 
 import java.util.Collection;
-
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.BpmnModelElementInstanceTest;
-import org.junit.Ignore;
-import org.junit.Test;
 
 public class OperatonListTest extends BpmnModelElementInstanceTest {
 
@@ -39,7 +38,7 @@ public class OperatonListTest extends BpmnModelElementInstanceTest {
     return null;
   }
 
-  @Ignore("Test ignored. CAM-9441: Bug fix needed")
+  @Disabled("Test ignored. CAM-9441: Bug fix needed")
   @Test
   public void testListValueChildAssignment() {
     try {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonOutputParameterTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonOutputParameterTest.java
@@ -18,12 +18,12 @@ package org.operaton.bpm.model.bpmn.instance.operaton;
 
 import java.util.Arrays;
 import java.util.Collection;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.BpmnModelElementInstanceTest;
-import org.junit.Ignore;
-import org.junit.Test;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
-import static org.junit.Assert.fail;
 
 /**
  * @author Sebastian Menski
@@ -44,7 +44,7 @@ public class OperatonOutputParameterTest extends BpmnModelElementInstanceTest {
     );
   }
 
-  @Ignore("Test ignored. CAM-9441: Bug fix needed")
+  @Disabled("Test ignored. CAM-9441: Bug fix needed")
   @Test
   public void testOutputParameterScriptChildAssignment() {
     try {
@@ -61,7 +61,7 @@ public class OperatonOutputParameterTest extends BpmnModelElementInstanceTest {
     }
   }
 
-  @Ignore("Test ignored. CAM-9441: Bug fix needed")
+  @Disabled("Test ignored. CAM-9441: Bug fix needed")
   @Test
   public void testOutputParameterListChildAssignment() {
     try {
@@ -76,7 +76,7 @@ public class OperatonOutputParameterTest extends BpmnModelElementInstanceTest {
     }
   }
 
-  @Ignore("Test ignored. CAM-9441: Bug fix needed")
+  @Disabled("Test ignored. CAM-9441: Bug fix needed")
   @Test
   public void testOutputParameterMapChildAssignment() {
     try {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/util/GetBpmnModelElementTypeRule.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/util/GetBpmnModelElementTypeRule.java
@@ -16,28 +16,28 @@
  */
 package org.operaton.bpm.model.bpmn.util;
 
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.xml.Model;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 import org.operaton.bpm.model.xml.test.GetModelElementTypeRule;
 import org.operaton.bpm.model.xml.type.ModelElementType;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
 
 /**
  * @author Sebastian Menski
  */
-public class GetBpmnModelElementTypeRule extends TestWatcher implements GetModelElementTypeRule {
+public class GetBpmnModelElementTypeRule implements GetModelElementTypeRule, BeforeAllCallback {
 
   private ModelInstance modelInstance;
   private Model model;
   private ModelElementType modelElementType;
 
   @Override
-  @SuppressWarnings("unchecked")
-  protected void starting(Description description) {
-    String className = description.getClassName();
+  public void beforeAll(ExtensionContext context) {
+    String className = context.getTestClass().orElseThrow().getName();
     className =  className.replaceAll("Test", "");
     Class<? extends ModelElementInstance> instanceClass = null;
     try {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/util/ParseBpmnModelRule.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/util/ParseBpmnModelRule.java
@@ -16,11 +16,11 @@
  */
 package org.operaton.bpm.model.bpmn.util;
 
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.xml.impl.util.IoUtil;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
 
 import java.io.InputStream;
 
@@ -28,19 +28,19 @@ import java.io.InputStream;
  * @author Daniel Meyer
  *
  */
-public class ParseBpmnModelRule extends TestWatcher {
+public class ParseBpmnModelRule implements BeforeEachCallback {
 
   protected BpmnModelInstance bpmnModelInstance;
 
   @Override
-  protected void starting(Description description) {
+  public void beforeEach(ExtensionContext context) {
 
-    if(description.getAnnotation(BpmnModelResource.class) != null) {
+    if(context.getTestMethod().orElseThrow().getAnnotation(BpmnModelResource.class) != null) {
 
-      Class<?> testClass = description.getTestClass();
-      String methodName = description.getMethodName();
+      Class<?> testClass = context.getTestClass().orElseThrow();
+      String methodName = context.getTestMethod().orElseThrow().getName();
 
-      String resourceFolderName = testClass.getName().replaceAll("\\.", "/");
+      String resourceFolderName = testClass.getName().replace(".", "/");
       String bpmnResourceName = resourceFolderName + "." + methodName + ".bpmn";
 
       InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream(bpmnResourceName);
@@ -49,9 +49,7 @@ public class ParseBpmnModelRule extends TestWatcher {
       } finally {
         IoUtil.closeSilently(resourceAsStream);
       }
-
     }
-
   }
 
   public BpmnModelInstance getBpmnModel() {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/validation/ValidateProcessTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/validation/ValidateProcessTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
@@ -27,7 +28,6 @@ import org.operaton.bpm.model.xml.validation.ModelElementValidator;
 import org.operaton.bpm.model.xml.validation.ValidationResult;
 import org.operaton.bpm.model.xml.validation.ValidationResultType;
 import org.operaton.bpm.model.xml.validation.ValidationResults;
-import org.junit.Test;
 import org.operaton.bpm.model.bpmn.instance.Process;
 
 import static org.assertj.core.api.Assertions.*;

--- a/model-api/cmmn-model/pom.xml
+++ b/model-api/cmmn-model/pom.xml
@@ -27,22 +27,27 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-junit</artifactId>
+			<scope>test</scope>
+		</dependency>
 
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-bpm-archunit</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
     </dependency>
 
   </dependencies>

--- a/model-api/cmmn-model/pom.xml
+++ b/model-api/cmmn-model/pom.xml
@@ -1,10 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.operaton.bpm.model</groupId>
     <artifactId>operaton-model-apis</artifactId>
-    <relativePath>../</relativePath>
     <version>1.0.0-beta-2</version>
   </parent>
 
@@ -19,37 +19,12 @@
       ${operaton.osgi.export.pkg};${operaton.osgi.version};-noimport:=true
     </operaton.osgi.export>
   </properties>
-  <dependencies>
 
+  <dependencies>
     <dependency>
       <groupId>org.operaton.bpm.model</groupId>
       <artifactId>operaton-xml-model</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-    <dependency>
-      <groupId>org.operaton.bpm</groupId>
-      <artifactId>operaton-bpm-archunit</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>junit</groupId>
-					<artifactId>junit</artifactId>
-				</exclusion>
-			</exclusions>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnModelInstanceTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnModelInstanceTest.java
@@ -16,12 +16,12 @@
  */
 package org.operaton.bpm.model.cmmn;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.cmmn.instance.Definitions;
-import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Filip Hrisafov

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnModelInstanceTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnModelInstanceTest.java
@@ -19,9 +19,7 @@ package org.operaton.bpm.model.cmmn;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.cmmn.instance.Definitions;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Filip Hrisafov
@@ -40,8 +38,8 @@ public class CmmnModelInstanceTest {
     CmmnModelInstance cloneInstance = modelInstance.clone();
     cloneInstance.getDefinitions().setId("TestId2");
 
-    assertThat(modelInstance.getDefinitions().getId(), is(equalTo("TestId")));
-    assertThat(cloneInstance.getDefinitions().getId(), is(equalTo("TestId2")));
+    assertThat(modelInstance.getDefinitions().getId()).isEqualTo("TestId");
+    assertThat(cloneInstance.getDefinitions().getId()).isEqualTo("TestId2");
   }
 
 }

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnModelTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnModelTest.java
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.cmmn;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.operaton.bpm.model.cmmn.util.ParseCmmnModelRule;
-import org.junit.Rule;
 
 /**
  * @author Roman Smirnov
@@ -25,7 +26,7 @@ import org.junit.Rule;
  */
 public abstract class CmmnModelTest {
 
-  @Rule
+  @RegisterExtension
   public final ParseCmmnModelRule parseCmmnModelRule = new ParseCmmnModelRule();
 
   protected CmmnModelInstance cmmnModelInstance;

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnModelTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnModelTest.java
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.cmmn;
-
+import org.junit.jupiter.api.BeforeEach;
 import org.operaton.bpm.model.cmmn.util.ParseCmmnModelRule;
-import org.junit.Before;
 import org.junit.Rule;
 
 /**
@@ -31,7 +30,7 @@ public abstract class CmmnModelTest {
 
   protected CmmnModelInstance cmmnModelInstance;
 
-  @Before
+  @BeforeEach
   public void setup() {
     cmmnModelInstance = parseCmmnModelRule.getCmmnModel();
   }

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnTest.java
@@ -16,9 +16,9 @@
  */
 package org.operaton.bpm.model.cmmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Roman Smirnov

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CreateModelTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CreateModelTest.java
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.cmmn;
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.cmmn.instance.Case;
 import org.operaton.bpm.model.cmmn.instance.CasePlanModel;
 import org.operaton.bpm.model.cmmn.instance.CmmnModelElementInstance;
@@ -23,9 +25,6 @@ import org.operaton.bpm.model.cmmn.instance.Definitions;
 import org.operaton.bpm.model.cmmn.instance.HumanTask;
 import org.operaton.bpm.model.cmmn.instance.PlanItem;
 import org.operaton.bpm.model.cmmn.instance.Stage;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Sebastian Menski
@@ -36,7 +35,7 @@ public class CreateModelTest {
   public Definitions definitions;
   public Process process;
 
-  @Before
+  @BeforeEach
   public void createEmptyModel() {
     modelInstance = Cmmn.createEmptyModel();
     definitions = modelInstance.newInstance(Definitions.class);
@@ -90,7 +89,7 @@ public class CreateModelTest {
     planItem.setDefinition(humanTask);
   }
 
-  @After
+  @AfterEach
   public void validateModel() {
     Cmmn.validateModel(modelInstance);
   }

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/GenerateIdTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/GenerateIdTest.java
@@ -20,13 +20,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.cmmn.impl.instance.CaseFileItemTransitionStandardEventImpl;
 import org.operaton.bpm.model.cmmn.instance.Case;
 import org.operaton.bpm.model.cmmn.instance.CasePlanModel;
 import org.operaton.bpm.model.cmmn.instance.DefaultControl;
 import org.operaton.bpm.model.cmmn.instance.Definitions;
 import org.operaton.bpm.model.cmmn.instance.HumanTask;
-import org.junit.Test;
 
 public class GenerateIdTest {
 

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/SimpleTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/SimpleTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.cmmn.instance.Case;
 import org.operaton.bpm.model.cmmn.instance.CasePlanModel;
 import org.operaton.bpm.model.cmmn.instance.HumanTask;
@@ -27,7 +28,6 @@ import org.operaton.bpm.model.cmmn.instance.PlanItem;
 import org.operaton.bpm.model.cmmn.instance.PlanItemDefinition;
 import org.operaton.bpm.model.cmmn.util.CmmnModelResource;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/instance/CmmnModelElementInstanceTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/instance/CmmnModelElementInstanceTest.java
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.cmmn.instance;
-
+import org.junit.jupiter.api.BeforeAll;
 import org.operaton.bpm.model.cmmn.impl.CmmnModelConstants;
 import org.operaton.bpm.model.cmmn.util.GetCmmnModelElementTypeRule;
 import org.operaton.bpm.model.xml.test.AbstractModelElementInstanceTest;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 
 /**
@@ -31,7 +30,7 @@ public abstract class CmmnModelElementInstanceTest extends AbstractModelElementI
   @ClassRule
   public static final GetCmmnModelElementTypeRule modelElementTypeRule = new GetCmmnModelElementTypeRule();
 
-  @BeforeClass
+  @BeforeAll
   public static void initModelElementType() {
     initModelElementType(modelElementTypeRule);
   }

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/instance/CmmnModelElementInstanceTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/instance/CmmnModelElementInstanceTest.java
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.cmmn.instance;
+
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.operaton.bpm.model.cmmn.impl.CmmnModelConstants;
 import org.operaton.bpm.model.cmmn.util.GetCmmnModelElementTypeRule;
 import org.operaton.bpm.model.xml.test.AbstractModelElementInstanceTest;
-import org.junit.ClassRule;
 
 /**
  * @author Roman Smirnov
@@ -27,7 +28,7 @@ import org.junit.ClassRule;
  */
 public abstract class CmmnModelElementInstanceTest extends AbstractModelElementInstanceTest {
 
-  @ClassRule
+  @RegisterExtension
   public static final GetCmmnModelElementTypeRule modelElementTypeRule = new GetCmmnModelElementTypeRule();
 
   @BeforeAll

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/util/GetCmmnModelElementTypeRule.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/util/GetCmmnModelElementTypeRule.java
@@ -16,29 +16,29 @@
  */
 package org.operaton.bpm.model.cmmn.util;
 
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.operaton.bpm.model.cmmn.Cmmn;
 import org.operaton.bpm.model.xml.Model;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 import org.operaton.bpm.model.xml.test.GetModelElementTypeRule;
 import org.operaton.bpm.model.xml.type.ModelElementType;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
 
 /**
  * @author Sebastian Menski
  * @author Roman Smirnov
  */
-public class GetCmmnModelElementTypeRule extends TestWatcher implements GetModelElementTypeRule {
+public class GetCmmnModelElementTypeRule implements GetModelElementTypeRule, BeforeAllCallback {
 
   private ModelInstance modelInstance;
   private Model model;
   private ModelElementType modelElementType;
 
   @Override
-  @SuppressWarnings("unchecked")
-  protected void starting(Description description) {
-    String className = description.getClassName();
+  public void beforeAll(ExtensionContext context) {
+    String className = context.getTestClass().orElseThrow().getName();
     className =  className.replaceAll("Test", "");
     Class<? extends ModelElementInstance> instanceClass = null;
     try {

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/util/ParseCmmnModelRule.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/util/ParseCmmnModelRule.java
@@ -16,32 +16,32 @@
  */
 package org.operaton.bpm.model.cmmn.util;
 
-import java.io.InputStream;
-
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.operaton.bpm.model.cmmn.Cmmn;
 import org.operaton.bpm.model.cmmn.CmmnModelInstance;
 import org.operaton.bpm.model.xml.impl.util.IoUtil;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
+
+import java.io.InputStream;
 
 /**
  * @author Daniel Meyer
  * @author Roman Smirnov
  *
  */
-public class ParseCmmnModelRule extends TestWatcher {
+public class ParseCmmnModelRule implements BeforeEachCallback {
 
   protected CmmnModelInstance CmmnModelInstance;
 
   @Override
-  protected void starting(Description description) {
+  public void beforeEach(ExtensionContext context){
 
-    if(description.getAnnotation(CmmnModelResource.class) != null) {
+    if(context.getTestMethod().map(method -> method.getAnnotation(CmmnModelResource.class)).isPresent()) {
 
-      Class<?> testClass = description.getTestClass();
-      String methodName = description.getMethodName();
+      Class<?> testClass = context.getTestClass().orElseThrow();
+      String methodName = context.getTestMethod().get().getName();
 
-      String resourceFolderName = testClass.getName().replaceAll("\\.", "/");
+      String resourceFolderName = testClass.getName().replace(".", "/");
       String cmmnResourceName = resourceFolderName + "." + methodName + ".cmmn";
 
       InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream(cmmnResourceName);
@@ -50,9 +50,7 @@ public class ParseCmmnModelRule extends TestWatcher {
       } finally {
         IoUtil.closeSilently(resourceAsStream);
       }
-
     }
-
   }
 
   public CmmnModelInstance getCmmnModel() {

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn10/Cmmn10Test.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn10/Cmmn10Test.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Collection;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.cmmn.Cmmn;
 import org.operaton.bpm.model.cmmn.CmmnModelInstance;
 import org.operaton.bpm.model.cmmn.impl.CmmnModelConstants;
@@ -44,7 +45,6 @@ import org.operaton.bpm.model.cmmn.instance.PlanItem;
 import org.operaton.bpm.model.cmmn.instance.Sentry;
 import org.operaton.bpm.model.cmmn.instance.TimerEvent;
 import org.operaton.bpm.model.cmmn.instance.UserEvent;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov

--- a/model-api/dmn-model/pom.xml
+++ b/model-api/dmn-model/pom.xml
@@ -27,16 +27,15 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-junit</artifactId>
+			<scope>test</scope>
+		</dependency>
 
     <dependency>
       <groupId>org.xmlunit</groupId>
@@ -49,6 +48,12 @@
       <artifactId>operaton-bpm-archunit</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
     </dependency>
 
   </dependencies>

--- a/model-api/dmn-model/pom.xml
+++ b/model-api/dmn-model/pom.xml
@@ -4,7 +4,6 @@
   <parent>
     <groupId>org.operaton.bpm.model</groupId>
     <artifactId>operaton-model-apis</artifactId>
-    <relativePath>../</relativePath>
     <version>1.0.0-beta-2</version>
   </parent>
 
@@ -19,43 +18,18 @@
       ${operaton.osgi.export.pkg};${operaton.osgi.version};-noimport:=true
     </operaton.osgi.export>
   </properties>
-  <dependencies>
 
+  <dependencies>
     <dependency>
       <groupId>org.operaton.bpm.model</groupId>
       <artifactId>operaton-xml-model</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-    <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-core</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.operaton.bpm</groupId>
-      <artifactId>operaton-bpm-archunit</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>junit</groupId>
-					<artifactId>junit</artifactId>
-				</exclusion>
-			</exclusions>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnDiTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnDiTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.model.dmn;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DmnDiTest {
 

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnModelInstanceTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnModelInstanceTest.java
@@ -18,9 +18,9 @@ package org.operaton.bpm.model.dmn;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.dmn.impl.DmnModelConstants;
 import org.operaton.bpm.model.dmn.instance.Definitions;
-import org.junit.Test;
 
 /**
  * @author Filip Hrisafov

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnModelTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnModelTest.java
@@ -23,7 +23,8 @@ import java.io.File;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.operaton.bpm.model.dmn.instance.DmnElement;
 import org.operaton.bpm.model.dmn.instance.DmnModelElementInstance;
 import org.operaton.bpm.model.dmn.instance.NamedElement;
@@ -31,9 +32,7 @@ import org.operaton.bpm.model.dmn.util.Java9CDataWhitespaceFilter;
 import org.operaton.bpm.model.dmn.util.ParseDmnModelRule;
 import org.operaton.bpm.model.xml.impl.util.ReflectUtil;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
-import org.junit.Before;
 import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
 import org.w3c.dom.Document;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
@@ -45,12 +44,12 @@ public abstract class DmnModelTest {
   @Rule
   public final ParseDmnModelRule parseDmnModelRule = new ParseDmnModelRule();
 
-  @Rule
-  public TemporaryFolder tmpFolder = new TemporaryFolder();
+  @TempDir
+  public File tmpFolder;
 
   protected DmnModelInstance modelInstance;
 
-  @Before
+  @BeforeEach
   public void setup() {
     modelInstance = parseDmnModelRule.getDmnModel();
   }
@@ -91,7 +90,7 @@ public abstract class DmnModelTest {
   }
 
   protected void assertModelEqualsFile(String expectedPath) throws Exception {
-    File actualFile = tmpFolder.newFile();
+    File actualFile = File.createTempFile("junit", null, tmpFolder);
     Dmn.writeModelToFile(actualFile, modelInstance);
 
     File expectedFile = ReflectUtil.getResourceAsFile(expectedPath);

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnModelTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnModelTest.java
@@ -16,14 +16,8 @@
  */
 package org.operaton.bpm.model.dmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-
-import java.io.File;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.operaton.bpm.model.dmn.instance.DmnElement;
 import org.operaton.bpm.model.dmn.instance.DmnModelElementInstance;
@@ -32,16 +26,22 @@ import org.operaton.bpm.model.dmn.util.Java9CDataWhitespaceFilter;
 import org.operaton.bpm.model.dmn.util.ParseDmnModelRule;
 import org.operaton.bpm.model.xml.impl.util.ReflectUtil;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
-import org.junit.Rule;
 import org.w3c.dom.Document;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public abstract class DmnModelTest {
 
   public final static String TEST_NAMESPACE = "http://operaton.org/schema/1.0/dmn";
 
-  @Rule
+  @RegisterExtension
   public final ParseDmnModelRule parseDmnModelRule = new ParseDmnModelRule();
 
   @TempDir

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnTest.java
@@ -16,9 +16,9 @@
  */
 package org.operaton.bpm.model.dmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DmnTest {
 

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnWriterTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnWriterTest.java
@@ -18,11 +18,11 @@ package org.operaton.bpm.model.dmn;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.dmn.instance.Decision;
 import org.operaton.bpm.model.dmn.instance.DecisionTable;
 import org.operaton.bpm.model.dmn.instance.InputEntry;
 import org.operaton.bpm.model.dmn.instance.Rule;
-import org.junit.Test;
 
 public class DmnWriterTest extends DmnModelTest {
 

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ExampleCompatibilityTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ExampleCompatibilityTest.java
@@ -23,7 +23,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.operaton.bpm.model.dmn.instance.BusinessContextElement;
 import org.operaton.bpm.model.dmn.instance.Decision;
 import org.operaton.bpm.model.dmn.instance.DecisionTable;
@@ -41,19 +42,14 @@ import org.operaton.bpm.model.dmn.instance.OutputEntry;
 import org.operaton.bpm.model.dmn.instance.OutputValues;
 import org.operaton.bpm.model.dmn.instance.Rule;
 import org.operaton.bpm.model.dmn.instance.Text;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
 
-@RunWith(Parameterized.class)
 public class ExampleCompatibilityTest extends DmnModelTest {
 
   public static final String EXAMPLE_DMN = "org/operaton/bpm/model/dmn/Example.dmn";
 
-  private final DmnModelInstance originalModelInstance;
+  private DmnModelInstance originalModelInstance;
 
-   @Parameterized.Parameters(name="Namespace: {0}")
    public static Collection<Object[]> parameters(){
      return Arrays.asList(new Object[][]{
          {Dmn.readModelFromStream(ExampleCompatibilityTest.class.getResourceAsStream("Example.dmn"))},
@@ -70,17 +66,20 @@ public class ExampleCompatibilityTest extends DmnModelTest {
      });
    }
 
-  public ExampleCompatibilityTest(DmnModelInstance originalModelInstance) {
+  public void initExampleCompatibilityTest(DmnModelInstance originalModelInstance) {
     this.originalModelInstance = originalModelInstance;
   }
 
-  @Before
+  @BeforeEach
   public void parseModel() {
     modelInstance = originalModelInstance.clone();
   }
 
-  @Test
-  public void shouldGetElements() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void shouldGetElements(DmnModelInstance originalModelInstance) {
+
+    initExampleCompatibilityTest(originalModelInstance);
 
     // Definitions
     Definitions definitions = modelInstance.getDefinitions();
@@ -219,8 +218,10 @@ public class ExampleCompatibilityTest extends DmnModelTest {
     assertThat(businessContextElements).isEmpty();
   }
 
-  @Test
-  public void shouldWriteElements() throws Exception {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void shouldWriteElements(DmnModelInstance originalModelInstance) throws Exception {
+    initExampleCompatibilityTest(originalModelInstance);
     modelInstance = Dmn.createEmptyModel();
 
     // Definitions

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ExampleCompatibilityTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ExampleCompatibilityTest.java
@@ -68,11 +68,7 @@ public class ExampleCompatibilityTest extends DmnModelTest {
 
   public void initExampleCompatibilityTest(DmnModelInstance originalModelInstance) {
     this.originalModelInstance = originalModelInstance;
-  }
-
-  @BeforeEach
-  public void parseModel() {
-    modelInstance = originalModelInstance.clone();
+    this.modelInstance = originalModelInstance.clone();
   }
 
   @MethodSource("parameters")

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ExpressionLanguageTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ExpressionLanguageTest.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.model.dmn;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.dmn.instance.Decision;
 import org.operaton.bpm.model.dmn.instance.DecisionTable;
 import org.operaton.bpm.model.dmn.instance.Definitions;
@@ -31,7 +32,6 @@ import org.operaton.bpm.model.dmn.instance.OutputValues;
 import org.operaton.bpm.model.dmn.instance.Rule;
 import org.operaton.bpm.model.dmn.instance.Text;
 import org.operaton.bpm.model.dmn.util.DmnModelResource;
-import org.junit.Test;
 
 public class ExpressionLanguageTest extends DmnModelTest {
 

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/GenerateIdTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/GenerateIdTest.java
@@ -18,11 +18,11 @@ package org.operaton.bpm.model.dmn;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.dmn.instance.Decision;
 import org.operaton.bpm.model.dmn.instance.DecisionTable;
 import org.operaton.bpm.model.dmn.instance.Definitions;
 import org.operaton.bpm.model.dmn.instance.Output;
-import org.junit.Test;
 
 public class GenerateIdTest {
 

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/OperatonExtensionsTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/OperatonExtensionsTest.java
@@ -42,12 +42,7 @@ public class OperatonExtensionsTest {
 
   public void initOperatonExtensionsTest(DmnModelInstance originalModelInstance) {
     this.originalModelInstance = originalModelInstance;
-  }
-
-  @BeforeEach
-  public void parseModel() {
-    modelInstance = originalModelInstance.clone();
-
+    this.modelInstance = originalModelInstance.clone();
   }
 
   @MethodSource("parameters")

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/OperatonExtensionsTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/OperatonExtensionsTest.java
@@ -20,23 +20,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Collection;
-
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.operaton.bpm.model.dmn.instance.Decision;
 import org.operaton.bpm.model.dmn.instance.Input;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
-@RunWith(Parameterized.class)
 public class OperatonExtensionsTest {
 
-  private final DmnModelInstance originalModelInstance;
+  private DmnModelInstance originalModelInstance;
   private DmnModelInstance modelInstance;
 
-   @Parameters(name="Namespace: {0}")
    public static Collection<Object[]> parameters(){
      return Arrays.asList(new Object[][]{
          {Dmn.readModelFromStream(OperatonExtensionsTest.class.getResourceAsStream("OperatonExtensionsTest.dmn"))},
@@ -45,41 +40,47 @@ public class OperatonExtensionsTest {
      });
    }
 
-  public OperatonExtensionsTest(DmnModelInstance originalModelInstance) {
+  public void initOperatonExtensionsTest(DmnModelInstance originalModelInstance) {
     this.originalModelInstance = originalModelInstance;
   }
 
-  @Before
+  @BeforeEach
   public void parseModel() {
     modelInstance = originalModelInstance.clone();
 
   }
 
-  @Test
-  public void testOperatonClauseOutput() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonClauseOutput(DmnModelInstance originalModelInstance) {
+    initOperatonExtensionsTest(originalModelInstance);
     Input input = modelInstance.getModelElementById("input");
     assertThat(input.getOperatonInputVariable()).isEqualTo("myVariable");
     input.setOperatonInputVariable("foo");
     assertThat(input.getOperatonInputVariable()).isEqualTo("foo");
   }
 
-  @Test
-  public void testOperatonHistoryTimeToLive() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonHistoryTimeToLive(DmnModelInstance originalModelInstance) {
+    initOperatonExtensionsTest(originalModelInstance);
     Decision decision = modelInstance.getModelElementById("decision");
     assertThat(decision.getOperatonHistoryTimeToLive()).isEqualTo(5);
     decision.setOperatonHistoryTimeToLive(6);
     assertThat(decision.getOperatonHistoryTimeToLive()).isEqualTo(6);
   }
 
-  @Test
-  public void testOperatonVersionTag() {
+  @MethodSource("parameters")
+  @ParameterizedTest(name = "Namespace: {0}")
+  public void testOperatonVersionTag(DmnModelInstance originalModelInstance) {
+    initOperatonExtensionsTest(originalModelInstance);
     Decision decision = modelInstance.getModelElementById("decision");
     assertThat(decision.getVersionTag()).isEqualTo("1.0.0");
     decision.setVersionTag("1.1.0");
     assertThat(decision.getVersionTag()).isEqualTo("1.1.0");
   }
 
-  @After
+  @AfterEach
   public void validateModel() {
     Dmn.validateModel(modelInstance);
   }

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ReadWriteTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ReadWriteTest.java
@@ -28,10 +28,10 @@ import static org.operaton.bpm.model.dmn.HitPolicy.PRIORITY;
 import static org.operaton.bpm.model.dmn.HitPolicy.RULE_ORDER;
 import static org.operaton.bpm.model.dmn.HitPolicy.UNIQUE;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.dmn.impl.instance.InputDataImpl;
 import org.operaton.bpm.model.dmn.instance.*;
 import org.operaton.bpm.model.dmn.util.DmnModelResource;
-import org.junit.Test;
 
 import java.util.Collection;
 

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/instance/DmnModelElementInstanceTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/instance/DmnModelElementInstanceTest.java
@@ -15,15 +15,16 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.dmn.instance;
+
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.operaton.bpm.model.dmn.impl.DmnModelConstants;
 import org.operaton.bpm.model.dmn.util.GetDmnModelElementTypeRule;
 import org.operaton.bpm.model.xml.test.AbstractModelElementInstanceTest;
-import org.junit.ClassRule;
 
 public abstract class DmnModelElementInstanceTest extends AbstractModelElementInstanceTest {
 
-  @ClassRule
+  @RegisterExtension
   public static final GetDmnModelElementTypeRule modelElementTypeRule = new GetDmnModelElementTypeRule();
 
   @BeforeAll

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/instance/DmnModelElementInstanceTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/instance/DmnModelElementInstanceTest.java
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.dmn.instance;
-
+import org.junit.jupiter.api.BeforeAll;
 import org.operaton.bpm.model.dmn.impl.DmnModelConstants;
 import org.operaton.bpm.model.dmn.util.GetDmnModelElementTypeRule;
 import org.operaton.bpm.model.xml.test.AbstractModelElementInstanceTest;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 
 public abstract class DmnModelElementInstanceTest extends AbstractModelElementInstanceTest {
@@ -27,7 +26,7 @@ public abstract class DmnModelElementInstanceTest extends AbstractModelElementIn
   @ClassRule
   public static final GetDmnModelElementTypeRule modelElementTypeRule = new GetDmnModelElementTypeRule();
 
-  @BeforeClass
+  @BeforeAll
   public static void initModelElementType() {
     initModelElementType(modelElementTypeRule);
   }

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/util/GetDmnModelElementTypeRule.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/util/GetDmnModelElementTypeRule.java
@@ -16,27 +16,27 @@
  */
 package org.operaton.bpm.model.dmn.util;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.operaton.bpm.model.dmn.Dmn;
 import org.operaton.bpm.model.xml.Model;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 import org.operaton.bpm.model.xml.test.GetModelElementTypeRule;
 import org.operaton.bpm.model.xml.type.ModelElementType;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
 
-public class GetDmnModelElementTypeRule extends TestWatcher implements GetModelElementTypeRule {
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GetDmnModelElementTypeRule implements GetModelElementTypeRule, BeforeAllCallback {
 
   private ModelInstance modelInstance;
   private Model model;
   private ModelElementType modelElementType;
 
   @Override
-  @SuppressWarnings("unchecked")
-  protected void starting(Description description) {
-    String className = description.getClassName();
+  public void beforeAll(ExtensionContext context) {
+    String className = context.getTestClass().orElseThrow().getName();
     assertThat(className).endsWith("Test");
     className = className.substring(0, className.length() - "Test".length());
     Class<? extends ModelElementInstance> instanceClass;

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/util/ParseDmnModelRule.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/util/ParseDmnModelRule.java
@@ -16,30 +16,28 @@
  */
 package org.operaton.bpm.model.dmn.util;
 
-import java.io.InputStream;
-
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.operaton.bpm.model.dmn.Dmn;
 import org.operaton.bpm.model.dmn.DmnModelInstance;
 import org.operaton.bpm.model.xml.impl.util.IoUtil;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
 
-public class ParseDmnModelRule extends TestWatcher {
+import java.io.InputStream;
+import java.util.Optional;
+
+public class ParseDmnModelRule implements BeforeEachCallback {
 
   protected DmnModelInstance dmnModelInstance;
 
   @Override
-  protected void starting(Description description) {
-
-    DmnModelResource dmnModelResource = description.getAnnotation(DmnModelResource.class);
-
-    if(dmnModelResource != null) {
-
-      String resourcePath = dmnModelResource.resource();
+  public void beforeEach(ExtensionContext context) {
+    Optional<DmnModelResource> dmnModelResource = context.getTestMethod().map(method -> method.getAnnotation(DmnModelResource.class));
+    if (dmnModelResource.isPresent()) {
+      String resourcePath = dmnModelResource.get().resource();
 
       if (resourcePath.isEmpty()) {
-        Class<?> testClass = description.getTestClass();
-        String methodName = description.getMethodName();
+        Class<?> testClass = context.getTestClass().orElseThrow();
+        String methodName = context.getTestMethod().get().getName();
 
         String resourceFolderName = testClass.getName().replaceAll("\\.", "/");
         resourcePath = resourceFolderName + "." + methodName + ".dmn";
@@ -51,9 +49,7 @@ public class ParseDmnModelRule extends TestWatcher {
       } finally {
         IoUtil.closeSilently(resourceAsStream);
       }
-
     }
-
   }
 
   public DmnModelInstance getDmnModel() {

--- a/model-api/pom.xml
+++ b/model-api/pom.xml
@@ -33,5 +33,17 @@
     <module>dmn-model</module>
     <module>cmmn-model</module>
   </modules>
+	<dependencies>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.operaton.bpm</groupId>
+			<artifactId>operaton-bpm-junit5</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/model-api/pom.xml
+++ b/model-api/pom.xml
@@ -33,17 +33,28 @@
     <module>dmn-model</module>
     <module>cmmn-model</module>
   </modules>
-	<dependencies>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.operaton.bpm</groupId>
-			<artifactId>operaton-bpm-junit5</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.operaton.bpm</groupId>
+      <artifactId>operaton-bpm-archunit</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/model-api/xml-model/pom.xml
+++ b/model-api/xml-model/pom.xml
@@ -22,16 +22,15 @@
   <dependencies>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>provided</scope>
     </dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-junit</artifactId>
+			<scope>test</scope>
+		</dependency>
 
   </dependencies>
 

--- a/model-api/xml-model/pom.xml
+++ b/model-api/xml-model/pom.xml
@@ -4,7 +4,6 @@
   <parent>
     <groupId>org.operaton.bpm.model</groupId>
     <artifactId>operaton-model-apis</artifactId>
-    <relativePath>../</relativePath>
     <version>1.0.0-beta-2</version>
   </parent>
 
@@ -16,22 +15,18 @@
     <operaton.artifact>org.operaton.bpm.model.xml</operaton.artifact>
     <operaton.osgi.import.additional>
       org.assertj.*;resolution:=optional,
-      org.junit.*;resolution:=optional
+      org.junit.jupiter.api.*;resolution:=optional
     </operaton.osgi.import.additional>
   </properties>
+
   <dependencies>
-
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <!-- Required for AbstractModelElementInstanceTest -->
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-
   </dependencies>
 
   <build>

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/AbstractModelElementInstanceTest.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/AbstractModelElementInstanceTest.java
@@ -16,11 +16,12 @@
  */
 package org.operaton.bpm.model.xml.test;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.operaton.bpm.model.xml.test.assertions.ModelAssertions.assertThat;
-import static org.junit.Assert.fail;
 
 import java.util.Collection;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.Model;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.impl.type.ModelElementTypeImpl;
@@ -30,7 +31,6 @@ import org.operaton.bpm.model.xml.test.assertions.AttributeAssert;
 import org.operaton.bpm.model.xml.test.assertions.ChildElementAssert;
 import org.operaton.bpm.model.xml.test.assertions.ModelElementTypeAssert;
 import org.operaton.bpm.model.xml.type.ModelElementType;
-import org.junit.Test;
 import org.w3c.dom.DOMException;
 
 public abstract class AbstractModelElementInstanceTest {

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/AbstractModelElementInstanceTest.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/AbstractModelElementInstanceTest.java
@@ -16,11 +16,6 @@
  */
 package org.operaton.bpm.model.xml.test;
 
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.operaton.bpm.model.xml.test.assertions.ModelAssertions.assertThat;
-
-import java.util.Collection;
-
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.Model;
 import org.operaton.bpm.model.xml.ModelInstance;
@@ -33,6 +28,12 @@ import org.operaton.bpm.model.xml.test.assertions.ModelElementTypeAssert;
 import org.operaton.bpm.model.xml.type.ModelElementType;
 import org.w3c.dom.DOMException;
 
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.operaton.bpm.model.xml.test.assertions.ModelAssertions.assertThat;
+
+// TODO Move class to test sources
 public abstract class AbstractModelElementInstanceTest {
 
 

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/GetModelElementTypeRule.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/GetModelElementTypeRule.java
@@ -19,9 +19,8 @@ package org.operaton.bpm.model.xml.test;
 import org.operaton.bpm.model.xml.Model;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.type.ModelElementType;
-import org.junit.rules.TestRule;
 
-public interface GetModelElementTypeRule extends TestRule {
+public interface GetModelElementTypeRule {
 
   ModelInstance getModelInstance();
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/ModelTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/ModelTest.java
@@ -15,12 +15,11 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.xml;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.testmodel.TestModel;
 import org.operaton.bpm.model.xml.testmodel.instance.*;
 import org.operaton.bpm.model.xml.type.ModelElementType;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.Collection;
 
@@ -34,7 +33,7 @@ public class ModelTest {
 
   private Model model;
 
-  @Before
+  @BeforeEach
   public void createModel() {
     model = TestModel.getTestModel();
   }

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/StringUtilTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/StringUtilTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.model.xml;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/impl/parser/ParserTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/impl/parser/ParserTest.java
@@ -16,17 +16,16 @@
  */
 package org.operaton.bpm.model.xml.impl.parser;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.InputStream;
-
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.ModelParseException;
 import org.operaton.bpm.model.xml.testmodel.TestModelParser;
-import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Test;
-import org.junit.rules.ExpectedException;
+
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ParserTest {
 
@@ -47,8 +46,7 @@ public class ParserTest {
 
   @Test
   public void shouldProhibitExternalSchemaAccessViaSystemProperty() {
-    Throwable exception = assertThrows(ModelParseException.class, () -> {
-
+    Assertions.assertThatThrownBy(() -> {
       // given
       // the external schema access property is not supported on certain
       // IBM JDK versions, in which case schema access cannot be restricted
@@ -61,24 +59,20 @@ public class ParserTest {
         String testXml = "org/operaton/bpm/model/xml/impl/parser/ExternalSchemaAccess.xml";
         InputStream testXmlAsStream = this.getClass().getClassLoader().getResourceAsStream(testXml);
 
-        // then
-        exception.expect(ModelParseException.class);
-        exception.expectMessage("SAXException while parsing input stream");
-
         // when
         modelParser.parseModelFromStream(testXmlAsStream);
       } finally {
         System.clearProperty(ACCESS_EXTERNAL_SCHEMA_PROP);
       }
-    });
-    assertTrue(exception.getMessage().contains("SAXException while parsing input stream"));
+    }) // then
+            .isInstanceOf(ModelParseException.class)
+            .hasMessage("SAXException while parsing input stream");
+
   }
 
   @Test
   public void shouldAllowExternalSchemaAccessViaSystemProperty() {
-
     // given
-
     System.setProperty(ACCESS_EXTERNAL_SCHEMA_PROP, "all");
 
     try {

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/impl/parser/ParserTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/impl/parser/ParserTest.java
@@ -17,23 +17,20 @@
 package org.operaton.bpm.model.xml.impl.parser;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.ModelParseException;
 import org.operaton.bpm.model.xml.testmodel.TestModelParser;
-import org.junit.Assume;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
 import org.junit.rules.ExpectedException;
 
 public class ParserTest {
 
   private static final String ACCESS_EXTERNAL_SCHEMA_PROP = "javax.xml.accessExternalSchema";
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   @Test
   public void shouldThrowExceptionForTooManyAttributes() {
@@ -50,28 +47,31 @@ public class ParserTest {
 
   @Test
   public void shouldProhibitExternalSchemaAccessViaSystemProperty() {
+    Throwable exception = assertThrows(ModelParseException.class, () -> {
 
-    // given
-    // the external schema access property is not supported on certain
-    // IBM JDK versions, in which case schema access cannot be restricted
-    Assume.assumeTrue(doesJdkSupportExternalSchemaAccessProperty());
+      // given
+      // the external schema access property is not supported on certain
+      // IBM JDK versions, in which case schema access cannot be restricted
+      Assumptions.assumeTrue(doesJdkSupportExternalSchemaAccessProperty());
 
-    System.setProperty(ACCESS_EXTERNAL_SCHEMA_PROP, "");
+      System.setProperty(ACCESS_EXTERNAL_SCHEMA_PROP, "");
 
-    try {
-      TestModelParser modelParser = new TestModelParser();
-      String testXml = "org/operaton/bpm/model/xml/impl/parser/ExternalSchemaAccess.xml";
-      InputStream testXmlAsStream = this.getClass().getClassLoader().getResourceAsStream(testXml);
+      try {
+        TestModelParser modelParser = new TestModelParser();
+        String testXml = "org/operaton/bpm/model/xml/impl/parser/ExternalSchemaAccess.xml";
+        InputStream testXmlAsStream = this.getClass().getClassLoader().getResourceAsStream(testXml);
 
-      // then
-      exception.expect(ModelParseException.class);
-      exception.expectMessage("SAXException while parsing input stream");
+        // then
+        exception.expect(ModelParseException.class);
+        exception.expectMessage("SAXException while parsing input stream");
 
-      // when
-      modelParser.parseModelFromStream(testXmlAsStream);
-    } finally {
-      System.clearProperty(ACCESS_EXTERNAL_SCHEMA_PROP);
-    }
+        // when
+        modelParser.parseModelFromStream(testXmlAsStream);
+      } finally {
+        System.clearProperty(ACCESS_EXTERNAL_SCHEMA_PROP);
+      }
+    });
+    assertTrue(exception.getMessage().contains("SAXException while parsing input stream"));
   }
 
   @Test

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/instance/DomTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/instance/DomTest.java
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.xml.instance;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
 import org.operaton.bpm.model.xml.testmodel.Gender;
@@ -23,8 +24,6 @@ import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import org.operaton.bpm.model.xml.testmodel.TestModelTest;
 import org.operaton.bpm.model.xml.testmodel.instance.Animals;
 import org.operaton.bpm.model.xml.testmodel.instance.Description;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -32,7 +31,6 @@ import java.util.Collection;
 import static javax.xml.XMLConstants.XMLNS_ATTRIBUTE_NS_URI;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAMESPACE;
-import static org.junit.runners.Parameterized.Parameters;
 
 /**
  * @author Sebastian Menski
@@ -73,7 +71,7 @@ public class DomTest extends TestModelTest {
     return new Object[]{"created", modelInstance, modelParser};
   }
 
-  @Before
+  @BeforeEach
   public void copyModelInstance() {
     modelInstance = cloneModelInstance();
     document = modelInstance.getDocument();

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/instance/ModelElementInstanceTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/instance/ModelElementInstanceTest.java
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.xml.instance;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
 import org.operaton.bpm.model.xml.testmodel.Gender;
@@ -24,15 +25,12 @@ import org.operaton.bpm.model.xml.testmodel.TestModelTest;
 import org.operaton.bpm.model.xml.testmodel.instance.Animals;
 import org.operaton.bpm.model.xml.testmodel.instance.Bird;
 import org.operaton.bpm.model.xml.type.ModelElementType;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAMESPACE;
-import static org.junit.runners.Parameterized.Parameters;
 
 /**
  * @author Daniel Meyer
@@ -75,7 +73,7 @@ public class ModelElementInstanceTest extends TestModelTest {
     return new Object[]{"created", modelInstance, modelParser};
   }
 
-  @Before
+  @BeforeEach
   public void copyModelInstance() {
     modelInstance = cloneModelInstance();
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/instance/ModelElementInstanceTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/instance/ModelElementInstanceTest.java
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.xml.instance;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.operaton.bpm.model.xml.ModelInstance;
-import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
 import org.operaton.bpm.model.xml.testmodel.Gender;
 import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import org.operaton.bpm.model.xml.testmodel.TestModelTest;
@@ -26,8 +26,7 @@ import org.operaton.bpm.model.xml.testmodel.instance.Animals;
 import org.operaton.bpm.model.xml.testmodel.instance.Bird;
 import org.operaton.bpm.model.xml.type.ModelElementType;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAMESPACE;
@@ -44,17 +43,11 @@ public class ModelElementInstanceTest extends TestModelTest {
   private Bird daisy;
   private Bird hedwig;
 
-  public ModelElementInstanceTest(String testName, ModelInstance testModelInstance, AbstractModelParser modelParser) {
-    super(testName, testModelInstance, modelParser);
+  static Stream<Arguments> models() {
+    return Stream.of(createModel(), parseModel(ModelElementInstanceTest.class)).map(Arguments::of);
   }
 
-  @Parameters(name="Model {0}")
-  public static Collection<Object[]> models() {
-    Object[][] models = {createModel(), parseModel(ModelElementInstanceTest.class)};
-    return Arrays.asList(models);
-  }
-
-  private static Object[] createModel() {
+  private static TestModelArgs createModel() {
     TestModelParser modelParser = new TestModelParser();
     ModelInstance modelInstance = modelParser.getEmptyModel();
 
@@ -70,12 +63,12 @@ public class ModelElementInstanceTest extends TestModelTest {
     daisy.setTextContent("\n        some text content with outer line breaks\n    ");
     hedwig.setTextContent("\n        some text content with inner\n        line breaks\n    ");
 
-    return new Object[]{"created", modelInstance, modelParser};
+    return new TestModelArgs("created", modelInstance, modelParser);
   }
 
-  @BeforeEach
-  public void copyModelInstance() {
-    modelInstance = cloneModelInstance();
+  @Override
+  protected void init(TestModelArgs args) {
+    super.init(args);
 
     animals = (Animals) modelInstance.getDocumentElement();
     tweety = modelInstance.getModelElementById("tweety");
@@ -84,8 +77,10 @@ public class ModelElementInstanceTest extends TestModelTest {
     hedwig = modelInstance.getModelElementById("hedwig");
   }
 
-  @Test
-  public void testAttribute() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testAttribute(TestModelArgs args) {
+    init(args);
     String tweetyName = tweety.getId() + "-name";
     tweety.setAttributeValue("name", tweetyName);
     assertThat(tweety.getAttributeValue("name")).isEqualTo(tweetyName);
@@ -93,8 +88,10 @@ public class ModelElementInstanceTest extends TestModelTest {
     assertThat(tweety.getAttributeValue("name")).isNull();
   }
 
-  @Test
-  public void testAttributeWithNamespace() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testAttributeWithNamespace(TestModelArgs args) {
+    init(args);
     String tweetyName = tweety.getId() + "-name";
     tweety.setAttributeValueNs(MODEL_NAMESPACE, "name", tweetyName);
     assertThat(tweety.getAttributeValue("name")).isEqualTo(tweetyName);
@@ -104,8 +101,10 @@ public class ModelElementInstanceTest extends TestModelTest {
     assertThat(tweety.getAttributeValueNs(MODEL_NAMESPACE, "name")).isNull();
   }
 
-  @Test
-  public void TestElementType() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void TestElementType(TestModelArgs args) {
+    init(args);
     ModelElementType birdType = modelInstance.getModel().getType(Bird.class);
     assertThat(tweety.getElementType()).isEqualTo(birdType);
     assertThat(donald.getElementType()).isEqualTo(birdType);
@@ -113,8 +112,10 @@ public class ModelElementInstanceTest extends TestModelTest {
     assertThat(hedwig.getElementType()).isEqualTo(birdType);
   }
 
-  @Test
-  public void TestParentElement() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void TestParentElement(TestModelArgs args) {
+    init(args);
     assertThat(tweety.getParentElement()).isEqualTo(animals);
     assertThat(donald.getParentElement()).isEqualTo(animals);
     assertThat(daisy.getParentElement()).isEqualTo(animals);
@@ -126,16 +127,20 @@ public class ModelElementInstanceTest extends TestModelTest {
     assertThat(timmy.getParentElement()).isNull();
   }
 
-  @Test
-  public void TestModelInstance() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void TestModelInstance(TestModelArgs args) {
+    init(args);
     assertThat(tweety.getModelInstance()).isEqualTo(modelInstance);
     assertThat(donald.getModelInstance()).isEqualTo(modelInstance);
     assertThat(daisy.getModelInstance()).isEqualTo(modelInstance);
     assertThat(hedwig.getModelInstance()).isEqualTo(modelInstance);
   }
 
-  @Test
-  public void testReplaceWithElement() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testReplaceWithElement(TestModelArgs args) {
+    init(args);
     Bird timmy = modelInstance.newInstance(Bird.class);
     timmy.setId("timmy");
     timmy.setGender(Gender.Male);
@@ -151,16 +156,20 @@ public class ModelElementInstanceTest extends TestModelTest {
       .doesNotContain(tweety);
   }
 
-  @Test
-  public void testReplaceRootElement() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testReplaceRootElement(TestModelArgs args) {
+    init(args);
     assertThat(((Animals) modelInstance.getDocumentElement()).getAnimals()).isNotEmpty();
     Animals newAnimals = modelInstance.newInstance(Animals.class);
     modelInstance.setDocumentElement(newAnimals);
     assertThat(((Animals) modelInstance.getDocumentElement()).getAnimals()).isEmpty();
   }
 
-  @Test
-  public void testTextContent() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testTextContent(TestModelArgs args) {
+    init(args);
     assertThat(tweety.getTextContent()).isEqualTo("");
     assertThat(donald.getTextContent()).isEqualTo("some text content");
     assertThat(daisy.getTextContent()).isEqualTo("some text content with outer line breaks");
@@ -171,8 +180,10 @@ public class ModelElementInstanceTest extends TestModelTest {
     assertThat(tweety.getTextContent()).isEqualTo(testContent.trim());
   }
 
-  @Test
-  public void testRawTextContent() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testRawTextContent(TestModelArgs args) {
+    init(args);
     assertThat(tweety.getRawTextContent()).isEqualTo("");
     assertThat(donald.getRawTextContent()).isEqualTo("some text content");
     assertThat(daisy.getRawTextContent()).isEqualTo("\n        some text content with outer line breaks\n    ");

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/ModelBuilderTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/ModelBuilderTest.java
@@ -16,9 +16,9 @@
  */
 package org.operaton.bpm.model.xml.testmodel;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.Model;
 import org.operaton.bpm.model.xml.ModelBuilder;
-import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAME;

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelInstanceTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelInstanceTest.java
@@ -18,13 +18,13 @@ package org.operaton.bpm.model.xml.testmodel;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.testmodel.instance.Animal;
 import org.operaton.bpm.model.xml.testmodel.instance.Animals;
 import org.operaton.bpm.model.xml.testmodel.instance.Bird;
-import org.junit.Test;
 
 public class TestModelInstanceTest {
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelInstanceTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelInstanceTest.java
@@ -16,9 +16,7 @@
  */
 package org.operaton.bpm.model.xml.testmodel;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelInstance;
@@ -42,8 +40,8 @@ public class TestModelInstanceTest {
     ModelInstance cloneInstance = modelInstance.clone();
     getFirstAnimal(cloneInstance).setId("TestId2");
 
-    assertThat(getFirstAnimal(modelInstance).getId(), is(equalTo("TestId")));
-    assertThat(getFirstAnimal(cloneInstance).getId(), is(equalTo("TestId2")));
+    assertThat(getFirstAnimal(modelInstance).getId()).isEqualTo("TestId");
+    assertThat(getFirstAnimal(cloneInstance).getId()).isEqualTo("TestId2");
   }
 
   protected Animal getFirstAnimal(ModelInstance modelInstance) {

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelTest.java
@@ -20,7 +20,7 @@ import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.impl.ModelInstanceImpl;
 import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
 import org.operaton.bpm.model.xml.testmodel.instance.*;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -82,7 +82,7 @@ public abstract class TestModelTest {
     return egg;
   }
 
-  @After
+  @AfterEach
   public void validateModel() {
     modelParser.validateModel(modelInstance.getDocument());
   }

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelTest.java
@@ -16,45 +16,27 @@
  */
 package org.operaton.bpm.model.xml.testmodel;
 
-import org.operaton.bpm.model.xml.ModelInstance;
-import org.operaton.bpm.model.xml.impl.ModelInstanceImpl;
-import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
-import org.operaton.bpm.model.xml.testmodel.instance.*;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.operaton.bpm.model.xml.ModelInstance;
+import org.operaton.bpm.model.xml.testmodel.instance.*;
 
 import java.io.InputStream;
 
 /**
  * @author Sebastian Menski
  */
-@RunWith(Parameterized.class)
 public abstract class TestModelTest {
-
-  protected final String testName;
-  private final ModelInstance testModelInstance;
-  private final AbstractModelParser modelParser;
-
-  // cloned model instance for every test method (see subclasses)
   protected ModelInstance modelInstance;
+  protected TestModelParser modelParser;
 
-  public TestModelTest(String testName, ModelInstance testModelInstance, AbstractModelParser modelParser) {
-    this.testName = testName;
-    this.testModelInstance = testModelInstance;
-    this.modelParser = modelParser;
-  }
+  public record TestModelArgs (String name, ModelInstance modelInstance, TestModelParser modelParser) {}
 
-  public ModelInstance cloneModelInstance() {
-    return testModelInstance.clone();
-  }
-
-  protected static Object[] parseModel(Class<?> test) {
+  protected static TestModelArgs parseModel(Class<?> test) {
     TestModelParser modelParser = new TestModelParser();
     String testXml = test.getSimpleName() + ".xml";
     InputStream testXmlAsStream = test.getResourceAsStream(testXml);
     ModelInstance modelInstance = modelParser.parseModelFromStream(testXmlAsStream);
-    return new Object[]{"parsed", modelInstance, modelParser};
+    return new TestModelArgs ("parsed", modelInstance, modelParser);
   }
 
   public static Bird createBird(ModelInstance modelInstance, String id, Gender gender) {
@@ -82,8 +64,17 @@ public abstract class TestModelTest {
     return egg;
   }
 
+  protected void init (TestModelArgs args) {
+    this.modelInstance = args.modelInstance.clone();
+    this.modelParser = args.modelParser;
+  }
+
   @AfterEach
-  public void validateModel() {
-    modelParser.validateModel(modelInstance.getDocument());
+  protected void validateModel() {
+    if (modelParser != null && modelInstance != null) {
+      modelParser.validateModel(modelInstance.getDocument());
+      modelParser = null;
+      modelInstance = null;
+    }
   }
 }

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
@@ -18,9 +18,9 @@ package org.operaton.bpm.model.xml.testmodel.instance;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -34,9 +34,9 @@ import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 import org.operaton.bpm.model.xml.testmodel.Gender;
 import org.operaton.bpm.model.xml.testmodel.TestModelConstants;
 import org.operaton.bpm.model.xml.testmodel.TestModelTest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runners.Parameterized.Parameters;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -58,7 +58,7 @@ public class AlternativeNsTest extends TestModelTest {
     return Collections.singleton(parseModel(AlternativeNsTest.class));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     modelInstance = cloneModelInstance();
     ModelImpl modelImpl = (ModelImpl) modelInstance.getModel();
@@ -66,7 +66,7 @@ public class AlternativeNsTest extends TestModelTest {
     modelImpl.declareAlternativeNamespace(YET_ANOTHER_NS, TestModelConstants.NEWER_NAMESPACE);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     ModelImpl modelImpl = (ModelImpl) modelInstance.getModel();
     modelImpl.undeclareAlternativeNamespace(MECHANICAL_NS);
@@ -229,7 +229,7 @@ public class AlternativeNsTest extends TestModelTest {
     for (int i = 0; i < attributes.getLength(); i++) {
       Node item = attributes.item(i);
       String nodeValue = item.getNodeValue();
-      assertNotEquals("Found newer namespace url which shouldn't exist", TestModelConstants.NEWER_NAMESPACE, nodeValue);
+      assertNotEquals(TestModelConstants.NEWER_NAMESPACE, nodeValue, "Found newer namespace url which shouldn't exist");
     }
   }
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
@@ -16,30 +16,29 @@
  */
 package org.operaton.bpm.model.xml.testmodel.instance;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.impl.ModelImpl;
-import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
 import org.operaton.bpm.model.xml.instance.DomElement;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
+import org.operaton.bpm.model.xml.instance.ModelElementInstanceTest;
 import org.operaton.bpm.model.xml.testmodel.Gender;
 import org.operaton.bpm.model.xml.testmodel.TestModelConstants;
 import org.operaton.bpm.model.xml.testmodel.TestModelTest;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.runners.Parameterized.Parameters;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Ronny Bräunlich
@@ -49,18 +48,13 @@ public class AlternativeNsTest extends TestModelTest {
   private static final String MECHANICAL_NS = "http://operaton.org/mechanical";
   private static final String YET_ANOTHER_NS = "http://operaton.org/yans";
 
-  public AlternativeNsTest(String testName, ModelInstance testModelInstance, AbstractModelParser modelParser) {
-    super(testName, testModelInstance, modelParser);
+  static Stream<Arguments> models() {
+    return Stream.of(parseModel(AlternativeNsTest.class)).map(Arguments::of);
   }
 
-  @Parameters(name = "Model {0}")
-  public static Collection<Object[]> models() {
-    return Collections.singleton(parseModel(AlternativeNsTest.class));
-  }
-
-  @BeforeEach
-  public void setUp() {
-    modelInstance = cloneModelInstance();
+  @Override
+  public void init(TestModelArgs args) {
+    super.init(args);
     ModelImpl modelImpl = (ModelImpl) modelInstance.getModel();
     modelImpl.declareAlternativeNamespace(MECHANICAL_NS, TestModelConstants.NEWER_NAMESPACE);
     modelImpl.declareAlternativeNamespace(YET_ANOTHER_NS, TestModelConstants.NEWER_NAMESPACE);
@@ -68,22 +62,28 @@ public class AlternativeNsTest extends TestModelTest {
 
   @AfterEach
   public void tearDown() {
-    ModelImpl modelImpl = (ModelImpl) modelInstance.getModel();
-    modelImpl.undeclareAlternativeNamespace(MECHANICAL_NS);
-    modelImpl.undeclareAlternativeNamespace(YET_ANOTHER_NS);
+    if (modelInstance != null) {
+      ModelImpl modelImpl = (ModelImpl) modelInstance.getModel();
+      modelImpl.undeclareAlternativeNamespace(MECHANICAL_NS);
+      modelImpl.undeclareAlternativeNamespace(YET_ANOTHER_NS);
+    }
   }
 
-  @Test
-  public void getUniqueChildElementByNameNsForAlternativeNs() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void getUniqueChildElementByNameNsForAlternativeNs(TestModelArgs args) {
+    init(args);
     ModelElementInstance hedwig = modelInstance.getModelElementById("hedwig");
-    assertThat(hedwig, is(notNullValue()));
+    assertThat(hedwig).isNotNull();
     ModelElementInstance childElementByNameNs = hedwig.getUniqueChildElementByNameNs(TestModelConstants.NEWER_NAMESPACE, "wings");
-    assertThat(childElementByNameNs, is(notNullValue()));
-    assertThat(childElementByNameNs.getTextContent(), is("wusch"));
+    assertThat(childElementByNameNs).isNotNull();
+    assertThat(childElementByNameNs.getTextContent()).isEqualTo("wusch");
   }
 
-  @Test
-  public void getUniqueChildElementByNameNsForSecondAlternativeNs() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void getUniqueChildElementByNameNsForSecondAlternativeNs(TestModelArgs args) {
+    init(args);
     // givne
     ModelElementInstance donald = modelInstance.getModelElementById("donald");
 
@@ -91,21 +91,25 @@ public class AlternativeNsTest extends TestModelTest {
     ModelElementInstance childElementByNameNs = donald.getUniqueChildElementByNameNs(TestModelConstants.NEWER_NAMESPACE, "wings");
 
     // then
-    assertThat(childElementByNameNs, is(notNullValue()));
-    assertThat(childElementByNameNs.getTextContent(), is("flappy"));
+    assertThat(childElementByNameNs).isNotNull();
+    assertThat(childElementByNameNs.getTextContent()).isEqualTo("flappy");
   }
 
-  @Test
-  public void getChildElementsByTypeForAlternativeNs() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void getChildElementsByTypeForAlternativeNs(TestModelArgs args) {
+    init(args);
     ModelElementInstance birdo = modelInstance.getModelElementById("birdo");
-    assertThat(birdo, is(notNullValue()));
+    assertThat(birdo).isNotNull();
     Collection<Wings> elements = birdo.getChildElementsByType(Wings.class);
-    assertThat(elements.size(), is(1));
-    assertThat(elements.iterator().next().getTextContent(), is("zisch"));
+    assertThat(elements.size()).isEqualTo(1);
+    assertThat(elements.iterator().next().getTextContent()).isEqualTo("zisch");
   }
 
-  @Test
-  public void getChildElementsByTypeForSecondAlternativeNs() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void getChildElementsByTypeForSecondAlternativeNs(TestModelArgs args) {
+    init(args);
     // given
     ModelElementInstance donald = modelInstance.getModelElementById("donald");
 
@@ -113,20 +117,24 @@ public class AlternativeNsTest extends TestModelTest {
     Collection<Wings> elements = donald.getChildElementsByType(Wings.class);
 
     // then
-    assertThat(elements.size(), is(1));
-    assertThat(elements.iterator().next().getTextContent(), is("flappy"));
+    assertThat(elements.size()).isEqualTo(1);
+    assertThat(elements.iterator().next().getTextContent()).isEqualTo("flappy");
   }
 
-  @Test
-  public void getAttributeValueNsForAlternativeNs() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void getAttributeValueNsForAlternativeNs(TestModelArgs args) {
+    init(args);
     Bird plucky = modelInstance.getModelElementById("plucky");
-    assertThat(plucky, is(notNullValue()));
+    assertThat(plucky).isNotNull();
     Boolean extendedWings = plucky.canHazExtendedWings();
-    assertThat(extendedWings, is(false));
+    assertThat(extendedWings).isEqualTo(false);
   }
 
-  @Test
-  public void getAttributeValueNsForSecondAlternativeNs() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void getAttributeValueNsForSecondAlternativeNs(TestModelArgs args) {
+    init(args);
     // given
     Bird donald = modelInstance.getModelElementById("donald");
 
@@ -134,24 +142,28 @@ public class AlternativeNsTest extends TestModelTest {
     Boolean extendedWings = donald.canHazExtendedWings();
 
     // then
-    assertThat(extendedWings, is(true));
+    assertThat(extendedWings).isEqualTo(true);
   }
 
-  @Test
-  public void modifyingAttributeWithAlternativeNamespaceKeepsAlternativeNamespace(){
+  @ParameterizedTest
+  @MethodSource("models")
+  public void modifyingAttributeWithAlternativeNamespaceKeepsAlternativeNamespace(TestModelArgs args) {
+    init(args);
     Bird plucky = modelInstance.getModelElementById("plucky");
-    assertThat(plucky, is(notNullValue()));
+    assertThat(plucky).isNotNull();
     //validate old value
     Boolean extendedWings = plucky.canHazExtendedWings();
-    assertThat(extendedWings, is(false));
+    assertThat(extendedWings).isEqualTo(false);
     //change it
     plucky.setCanHazExtendedWings(true);
     String attributeValueNs = plucky.getAttributeValueNs(MECHANICAL_NS, "canHazExtendedWings");
-    assertThat(attributeValueNs, is("true"));
+    assertThat(attributeValueNs).isEqualTo("true");
   }
 
-  @Test
-  public void modifyingAttributeWithSecondAlternativeNamespaceKeepsSecondAlternativeNamespace(){
+  @ParameterizedTest
+  @MethodSource("models")
+  public void modifyingAttributeWithSecondAlternativeNamespaceKeepsSecondAlternativeNamespace(TestModelArgs args) {
+    init(args);
     // given
     Bird donald = modelInstance.getModelElementById("donald");
 
@@ -160,32 +172,38 @@ public class AlternativeNsTest extends TestModelTest {
 
     // then
     String attributeValueNs = donald.getAttributeValueNs(YET_ANOTHER_NS, "canHazExtendedWings");
-    assertThat(attributeValueNs, is("false"));
+    assertThat(attributeValueNs).isEqualTo("false");
   }
 
-  @Test
-  public void modifyingAttributeWithNewNamespaceKeepsNewNamespace(){
+  @ParameterizedTest
+  @MethodSource("models")
+  public void modifyingAttributeWithNewNamespaceKeepsNewNamespace(TestModelArgs args) {
+    init(args);
     Bird bird = createBird(modelInstance, "waldo", Gender.Male);
     bird.setCanHazExtendedWings(true);
     String attributeValueNs = bird.getAttributeValueNs(TestModelConstants.NEWER_NAMESPACE, "canHazExtendedWings");
-    assertThat(attributeValueNs, is("true"));
+    assertThat(attributeValueNs).isEqualTo("true");
   }
 
-  @Test
-  public void modifyingElementWithAlternativeNamespaceKeepsAlternativeNamespace(){
+  @ParameterizedTest
+  @MethodSource("models")
+  public void modifyingElementWithAlternativeNamespaceKeepsAlternativeNamespace(TestModelArgs args) {
+    init(args);
     Bird birdo = modelInstance.getModelElementById("birdo");
-    assertThat(birdo, is(notNullValue()));
+    assertThat(birdo).isNotNull();
     Wings wings = birdo.getWings();
-    assertThat(wings, is(notNullValue()));
+    assertThat(wings).isNotNull();
     wings.setTextContent("kawusch");
 
     List<DomElement> childElementsByNameNs = birdo.getDomElement().getChildElementsByNameNs(MECHANICAL_NS, "wings");
-    assertThat(childElementsByNameNs.size(), is(1));
-    assertThat(childElementsByNameNs.get(0).getTextContent(), is("kawusch"));
+    assertThat(childElementsByNameNs.size()).isEqualTo(1);
+    assertThat(childElementsByNameNs.get(0).getTextContent()).isEqualTo("kawusch");
   }
 
-  @Test
-  public void modifyingElementWithSecondAlternativeNamespaceKeepsSecondAlternativeNamespace(){
+  @ParameterizedTest
+  @MethodSource("models")
+  public void modifyingElementWithSecondAlternativeNamespaceKeepsSecondAlternativeNamespace(TestModelArgs args) {
+    init(args);
     // given
     Bird donald = modelInstance.getModelElementById("donald");
     Wings wings = donald.getWings();
@@ -195,35 +213,39 @@ public class AlternativeNsTest extends TestModelTest {
 
     // then
     List<DomElement> childElementsByNameNs = donald.getDomElement().getChildElementsByNameNs(YET_ANOTHER_NS, "wings");
-    assertThat(childElementsByNameNs.size(), is(1));
-    assertThat(childElementsByNameNs.get(0).getTextContent(), is("kawusch"));
+    assertThat(childElementsByNameNs.size()).isEqualTo(1);
+    assertThat(childElementsByNameNs.get(0).getTextContent()).isEqualTo("kawusch");
   }
 
-  @Test
-  public void modifyingElementWithNewNamespaceKeepsNewNamespace(){
+  @ParameterizedTest
+  @MethodSource("models")
+  public void modifyingElementWithNewNamespaceKeepsNewNamespace(TestModelArgs args) {
+    init(args);
     Bird bird = createBird(modelInstance, "waldo", Gender.Male);
     bird.setWings(modelInstance.newInstance(Wings.class));
 
     List<DomElement> childElementsByNameNs = bird.getDomElement().getChildElementsByNameNs(TestModelConstants.NEWER_NAMESPACE, "wings");
-    assertThat(childElementsByNameNs.size(), is(1));
+    assertThat(childElementsByNameNs.size()).isEqualTo(1);
   }
 
-  @Test
-  public void useExistingNamespace() {
-    assertThatThereIsNoNewerNamespaceUrl();
+  @ParameterizedTest
+  @MethodSource("models")
+  void useExistingNamespace(TestModelArgs args) {
+    init(args);
+    assertThatThereIsNoNewerNamespaceUrl(modelInstance);
 
     Bird plucky = modelInstance.getModelElementById("plucky");
     plucky.setAttributeValueNs(MECHANICAL_NS, "canHazExtendedWings", "true");
 
     Bird donald = modelInstance.getModelElementById("donald");
     donald.setAttributeValueNs(YET_ANOTHER_NS, "canHazExtendedWings", "false");
-    assertThatThereIsNoNewerNamespaceUrl();
+    assertThatThereIsNoNewerNamespaceUrl(modelInstance);
 
     assertTrue(plucky.canHazExtendedWings());
-    assertThatThereIsNoNewerNamespaceUrl();
+    assertThatThereIsNoNewerNamespaceUrl(modelInstance);
   }
 
-  protected void assertThatThereIsNoNewerNamespaceUrl() {
+  protected void assertThatThereIsNoNewerNamespaceUrl(ModelInstance modelInstance) {
     Node rootElement = modelInstance.getDocument().getDomSource().getNode().getFirstChild();
     NamedNodeMap attributes = rootElement.getAttributes();
     for (int i = 0; i < attributes.getLength(); i++) {

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AnimalTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AnimalTest.java
@@ -16,24 +16,23 @@
  */
 package org.operaton.bpm.model.xml.testmodel.instance;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAMESPACE;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.ModelValidationException;
-import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
 import org.operaton.bpm.model.xml.testmodel.Gender;
 import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import org.operaton.bpm.model.xml.testmodel.TestModelTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.runners.Parameterized.Parameters;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAMESPACE;
 
 /**
  * @author Sebastian Menski
@@ -54,18 +53,11 @@ public class AnimalTest extends TestModelTest {
   private RelationshipDefinition timmyRelationship;
   private RelationshipDefinition daisyRelationship;
 
-  public AnimalTest(String testName, ModelInstance testModelInstance, AbstractModelParser modelParser) {
-    super(testName, testModelInstance, modelParser);
+  static Stream<Arguments> models() {
+    return Stream.of(createModel(), parseModel(AnimalTest.class)).map(Arguments::of);
   }
 
-
-  @Parameters(name="Model {0}")
-  public static Collection<Object[]> models() {
-    Object[][] models = {createModel(), parseModel(AnimalTest.class)};
-    return Arrays.asList(models);
-  }
-
-  public static Object[] createModel() {
+  public static TestModelArgs createModel() {
     TestModelParser modelParser = new TestModelParser();
     ModelInstance modelInstance = modelParser.getEmptyModel();
 
@@ -101,12 +93,12 @@ public class AnimalTest extends TestModelTest {
     tweety.getBestFriends().add(birdo);
     tweety.getBestFriends().add(plucky);
 
-    return new Object[]{"created", modelInstance, modelParser};
+    return new TestModelArgs("created", modelInstance, modelParser);
   }
 
-  @BeforeEach
-  public void copyModelInstance() {
-    modelInstance = cloneModelInstance();
+  @Override
+  protected void init(TestModelArgs args) {
+    super.init(args);
 
     tweety = modelInstance.getModelElementById("tweety");
     hedwig = modelInstance.getModelElementById("hedwig");
@@ -125,155 +117,200 @@ public class AnimalTest extends TestModelTest {
     daisyRelationship = createRelationshipDefinition(modelInstance, daisy, ChildRelationshipDefinition.class);
   }
 
-  @Test
-  public void testSetIdAttributeByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetIdAttributeByHelper(TestModelArgs args) {
+    init(args);
     String newId = "new-" + tweety.getId();
     tweety.setId(newId);
     assertThat(tweety.getId()).isEqualTo(newId);
   }
 
-  @Test
-  public void testSetIdAttributeByAttributeName() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetIdAttributeByAttributeName(TestModelArgs args) {
+    init(args);
     tweety.setAttributeValue("id", "duffy", true);
     assertThat(tweety.getId()).isEqualTo("duffy");
   }
 
-  @Test
-  public void testRemoveIdAttribute() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testRemoveIdAttribute(TestModelArgs args) {
+    init(args);
     tweety.removeAttribute("id");
     assertThat(tweety.getId()).isNull();
   }
 
-  @Test
-  public void testSetNameAttributeByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetNameAttributeByHelper(TestModelArgs args) {
+    init(args);
     tweety.setName("tweety");
     assertThat(tweety.getName()).isEqualTo("tweety");
   }
 
-  @Test
-  public void testSetNameAttributeByAttributeName() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetNameAttributeByAttributeName(TestModelArgs args) {
+    init(args);
     tweety.setAttributeValue("name", "daisy");
     assertThat(tweety.getName()).isEqualTo("daisy");
   }
 
-  @Test
-  public void testRemoveNameAttribute() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testRemoveNameAttribute(TestModelArgs args) {
+    init(args);
     tweety.removeAttribute("name");
     assertThat(tweety.getName()).isNull();
   }
 
-  @Test
-  public void testSetFatherAttributeByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetFatherAttributeByHelper(TestModelArgs args) {
+    init(args);
     tweety.setFather(timmy);
     assertThat(tweety.getFather()).isEqualTo(timmy);
   }
 
-  @Test
-  public void testSetFatherAttributeByAttributeName() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetFatherAttributeByAttributeName(TestModelArgs args) {
+    init(args);
     tweety.setAttributeValue("father", timmy.getId());
     assertThat(tweety.getFather()).isEqualTo(timmy);
   }
 
-  @Test
-  public void testSetFatherAttributeByAttributeNameWithNamespace() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetFatherAttributeByAttributeNameWithNamespace(TestModelArgs args) {
+    init(args);
     tweety.setAttributeValue("father", "tns:hedwig");
     assertThat(tweety.getFather()).isEqualTo(hedwig);
   }
 
-  @Test
-  public void testRemoveFatherAttribute() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testRemoveFatherAttribute(TestModelArgs args) {
+    init(args);
     tweety.setFather(timmy);
     assertThat(tweety.getFather()).isEqualTo(timmy);
     tweety.removeAttribute("father");
     assertThat(tweety.getFather()).isNull();
   }
 
-  @Test
-  public void testChangeIdAttributeOfFatherReference() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testChangeIdAttributeOfFatherReference(TestModelArgs args) {
+    init(args);
     tweety.setFather(timmy);
     assertThat(tweety.getFather()).isEqualTo(timmy);
     timmy.setId("new-" + timmy.getId());
     assertThat(tweety.getFather()).isEqualTo(timmy);
   }
 
-  @Test
-  public void testReplaceFatherReferenceWithNewAnimal() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testReplaceFatherReferenceWithNewAnimal(TestModelArgs args) {
+    init(args);
     tweety.setFather(timmy);
     assertThat(tweety.getFather()).isEqualTo(timmy);
     timmy.replaceWithElement(plucky);
     assertThat(tweety.getFather()).isEqualTo(plucky);
   }
 
-  @Test
-  public void testSetMotherAttributeByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetMotherAttributeByHelper(TestModelArgs args) {
+    init(args);
     tweety.setMother(daisy);
     assertThat(tweety.getMother()).isEqualTo(daisy);
   }
 
-  @Test
-  public void testSetMotherAttributeByAttributeName() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetMotherAttributeByAttributeName(TestModelArgs args) {
+    init(args);
     tweety.setAttributeValue("mother", fiffy.getId());
     assertThat(tweety.getMother()).isEqualTo(fiffy);
   }
 
-  @Test
-  public void testRemoveMotherAttribute() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testRemoveMotherAttribute(TestModelArgs args) {
+    init(args);
     tweety.setMother(daisy);
     assertThat(tweety.getMother()).isEqualTo(daisy);
     tweety.removeAttribute("mother");
     assertThat(tweety.getMother()).isNull();
   }
 
-  @Test
-  public void testReplaceMotherReferenceWithNewAnimal() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testReplaceMotherReferenceWithNewAnimal(TestModelArgs args) {
+    init(args);
     tweety.setMother(daisy);
     assertThat(tweety.getMother()).isEqualTo(daisy);
     daisy.replaceWithElement(birdo);
     assertThat(tweety.getMother()).isEqualTo(birdo);
   }
 
-  @Test
-  public void testChangeIdAttributeOfMotherReference() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testChangeIdAttributeOfMotherReference(TestModelArgs args) {
+    init(args);
     tweety.setMother(daisy);
     assertThat(tweety.getMother()).isEqualTo(daisy);
     daisy.setId("new-" + daisy.getId());
     assertThat(tweety.getMother()).isEqualTo(daisy);
   }
 
-  @Test
-  public void testSetIsEndangeredAttributeByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetIsEndangeredAttributeByHelper(TestModelArgs args) {
+    init(args);
     tweety.setIsEndangered(true);
     assertThat(tweety.isEndangered()).isTrue();
   }
 
-  @Test
-  public void testSetIsEndangeredAttributeByAttributeName() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetIsEndangeredAttributeByAttributeName(TestModelArgs args) {
+    init(args);
     tweety.setAttributeValue("isEndangered", "false");
     assertThat(tweety.isEndangered()).isFalse();
   }
 
-  @Test
-  public void testRemoveIsEndangeredAttribute() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testRemoveIsEndangeredAttribute(TestModelArgs args) {
+    init(args);
     tweety.removeAttribute("isEndangered");
     // default value of isEndangered: false
     assertThat(tweety.isEndangered()).isFalse();
   }
 
-  @Test
-  public void testSetGenderAttributeByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetGenderAttributeByHelper(TestModelArgs args) {
+    init(args);
     tweety.setGender(Gender.Male);
     assertThat(tweety.getGender()).isEqualTo(Gender.Male);
   }
 
-  @Test
-  public void testSetGenderAttributeByAttributeName() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetGenderAttributeByAttributeName(TestModelArgs args) {
+    init(args);
     tweety.setAttributeValue("gender", Gender.Unknown.toString());
     assertThat(tweety.getGender()).isEqualTo(Gender.Unknown);
   }
 
-  @Test
-  public void testRemoveGenderAttribute() {
-    tweety.removeAttribute("gender");
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testRemoveGenderAttribute(TestModelArgs args) {
+    init(args);tweety.removeAttribute("gender");
     assertThat(tweety.getGender()).isNull();
 
     // gender is required, so the model is invalid without
@@ -289,26 +326,34 @@ public class AnimalTest extends TestModelTest {
     tweety.setGender(Gender.Female);
   }
 
-  @Test
-  public void testSetAgeAttributeByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetAgeAttributeByHelper(TestModelArgs args) {
+    init(args);
     tweety.setAge(13);
     assertThat(tweety.getAge()).isEqualTo(13);
   }
 
-  @Test
-  public void testSetAgeAttributeByAttributeName() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetAgeAttributeByAttributeName(TestModelArgs args) {
+    init(args);
     tweety.setAttributeValue("age", "23");
     assertThat(tweety.getAge()).isEqualTo(23);
   }
 
-  @Test
-  public void testRemoveAgeAttribute() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testRemoveAgeAttribute(TestModelArgs args) {
+    init(args);
     tweety.removeAttribute("age");
     assertThat(tweety.getAge()).isNull();
   }
 
-  @Test
-  public void testAddRelationshipDefinitionsByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testAddRelationshipDefinitionsByHelper(TestModelArgs args) {
+    init(args);
     assertThat(tweety.getRelationshipDefinitions())
       .isNotEmpty()
       .hasSize(4)
@@ -322,8 +367,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(hedwigRelationship, birdoRelationship, pluckyRelationship, fiffyRelationship, timmyRelationship, daisyRelationship);
   }
 
-  @Test
-  public void testUpdateRelationshipDefinitionsByIdByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateRelationshipDefinitionsByIdByHelper(TestModelArgs args) {
+    init(args);
     hedwigRelationship.setId("new-" + hedwigRelationship.getId());
     pluckyRelationship.setId("new-" + pluckyRelationship.getId());
     assertThat(tweety.getRelationshipDefinitions())
@@ -331,8 +378,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(hedwigRelationship, birdoRelationship, pluckyRelationship, fiffyRelationship);
   }
 
-  @Test
-  public void testUpdateRelationshipDefinitionsByIdByAttributeName() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateRelationshipDefinitionsByIdByAttributeName(TestModelArgs args) {
+    init(args);
     birdoRelationship.setAttributeValue("id", "new-" + birdoRelationship.getId(), true);
     fiffyRelationship.setAttributeValue("id", "new-" + fiffyRelationship.getId(), true);
     assertThat(tweety.getRelationshipDefinitions())
@@ -340,8 +389,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(hedwigRelationship, birdoRelationship, pluckyRelationship, fiffyRelationship);
   }
 
-  @Test
-  public void testUpdateRelationshipDefinitionsByReplaceElements() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateRelationshipDefinitionsByReplaceElements(TestModelArgs args) {
+    init(args);
     hedwigRelationship.replaceWithElement(timmyRelationship);
     pluckyRelationship.replaceWithElement(daisyRelationship);
     assertThat(tweety.getRelationshipDefinitions())
@@ -349,8 +400,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(birdoRelationship, fiffyRelationship, timmyRelationship, daisyRelationship);
   }
 
-  @Test
-  public void testUpdateRelationshipDefinitionsByRemoveElements() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateRelationshipDefinitionsByRemoveElements(TestModelArgs args) {
+    init(args);
     tweety.getRelationshipDefinitions().remove(birdoRelationship);
     tweety.getRelationshipDefinitions().remove(fiffyRelationship);
     assertThat(tweety.getRelationshipDefinitions())
@@ -358,14 +411,18 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(hedwigRelationship, pluckyRelationship);
   }
 
-  @Test
-  public void testClearRelationshipDefinitions() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testClearRelationshipDefinitions(TestModelArgs args) {
+    init(args);
     tweety.getRelationshipDefinitions().clear();
     assertThat(tweety.getRelationshipDefinitions()).isEmpty();
   }
 
-  @Test
-  public void testAddRelationsDefinitionRefsByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testAddRelationsDefinitionRefsByHelper(TestModelArgs args) {
+    init(args);
     assertThat(tweety.getRelationshipDefinitionRefs())
       .isNotEmpty()
       .hasSize(4)
@@ -382,8 +439,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(hedwigRelationship, birdoRelationship, pluckyRelationship, fiffyRelationship, timmyRelationship, daisyRelationship);
   }
 
-  @Test
-  public void testUpdateRelationshipDefinitionRefsByIdByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateRelationshipDefinitionRefsByIdByHelper(TestModelArgs args) {
+    init(args);
     hedwigRelationship.setId("child-relationship");
     pluckyRelationship.setId("friend-relationship");
     assertThat(tweety.getRelationshipDefinitionRefs())
@@ -391,8 +450,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(hedwigRelationship, birdoRelationship, pluckyRelationship, fiffyRelationship);
   }
 
-  @Test
-  public void testUpdateRelationshipDefinitionRefsByIdByAttributeName() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateRelationshipDefinitionRefsByIdByAttributeName(TestModelArgs args) {
+    init(args);
     birdoRelationship.setAttributeValue("id", "birdo-relationship", true);
     fiffyRelationship.setAttributeValue("id", "fiffy-relationship", true);
     assertThat(tweety.getRelationshipDefinitionRefs())
@@ -400,8 +461,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(hedwigRelationship, birdoRelationship, pluckyRelationship, fiffyRelationship);
   }
 
-  @Test
-  public void testUpdateRelationshipDefinitionRefsByReplaceElements() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateRelationshipDefinitionRefsByReplaceElements(TestModelArgs args) {
+    init(args);
     hedwigRelationship.replaceWithElement(timmyRelationship);
     pluckyRelationship.replaceWithElement(daisyRelationship);
     assertThat(tweety.getRelationshipDefinitionRefs())
@@ -409,8 +472,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(birdoRelationship, fiffyRelationship, timmyRelationship, daisyRelationship);
   }
 
-  @Test
-  public void testUpdateRelationshipDefinitionRefsByRemoveElements() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateRelationshipDefinitionRefsByRemoveElements(TestModelArgs args) {
+    init(args);
     tweety.getRelationshipDefinitions().remove(birdoRelationship);
     tweety.getRelationshipDefinitions().remove(fiffyRelationship);
     assertThat(tweety.getRelationshipDefinitionRefs())
@@ -418,8 +483,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(hedwigRelationship, pluckyRelationship);
   }
 
-  @Test
-  public void testUpdateRelationshipDefinitionRefsByRemoveIdAttribute() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateRelationshipDefinitionRefsByRemoveIdAttribute(TestModelArgs args) {
+    init(args);
     birdoRelationship.removeAttribute("id");
     pluckyRelationship.removeAttribute("id");
     assertThat(tweety.getRelationshipDefinitionRefs())
@@ -427,16 +494,20 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(hedwigRelationship, fiffyRelationship);
   }
 
-  @Test
-  public void testClearRelationshipDefinitionsRefs() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testClearRelationshipDefinitionsRefs(TestModelArgs args) {
+    init(args);
     tweety.getRelationshipDefinitionRefs().clear();
     assertThat(tweety.getRelationshipDefinitionRefs()).isEmpty();
     // should not affect animal relationship definitions
     assertThat(tweety.getRelationshipDefinitions()).hasSize(4);
   }
 
-  @Test
-  public void testClearRelationshipDefinitionRefsByClearRelationshipDefinitions() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testClearRelationshipDefinitionRefsByClearRelationshipDefinitions(TestModelArgs args) {
+    init(args);
     assertThat(tweety.getRelationshipDefinitionRefs()).isNotEmpty();
     tweety.getRelationshipDefinitions().clear();
     assertThat(tweety.getRelationshipDefinitions()).isEmpty();
@@ -444,8 +515,10 @@ public class AnimalTest extends TestModelTest {
     assertThat(tweety.getRelationshipDefinitionRefs()).isEmpty();
   }
 
-  @Test
-  public void testAddRelationshipDefinitionRefElementsByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testAddRelationshipDefinitionRefElementsByHelper(TestModelArgs args) {
+    init(args);
     assertThat(tweety.getRelationshipDefinitionRefElements())
       .isNotEmpty()
       .hasSize(4);
@@ -466,8 +539,10 @@ public class AnimalTest extends TestModelTest {
       .contains(timmyRelationshipDefinitionRef, daisyRelationshipDefinitionRef);
   }
 
-  @Test
-  public void testRelationshipDefinitionRefElementsByTextContent() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testRelationshipDefinitionRefElementsByTextContent(TestModelArgs args) {
+    init(args);
     Collection<RelationshipDefinitionRef> relationshipDefinitionRefElements = tweety.getRelationshipDefinitionRefElements();
     Collection<String> textContents = new ArrayList<String>();
     for (RelationshipDefinitionRef relationshipDefinitionRef : relationshipDefinitionRefElements) {
@@ -481,8 +556,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(hedwigRelationship.getId(), birdoRelationship.getId(), pluckyRelationship.getId(), fiffyRelationship.getId());
   }
 
-  @Test
-  public void testUpdateRelationshipDefinitionRefElementsByTextContent() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateRelationshipDefinitionRefElementsByTextContent(TestModelArgs args) {
+    init(args);
     List<RelationshipDefinitionRef> relationshipDefinitionRefs = new ArrayList<RelationshipDefinitionRef>(tweety.getRelationshipDefinitionRefElements());
 
     addRelationshipDefinition(tweety, timmyRelationship);
@@ -496,8 +573,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(birdoRelationship, fiffyRelationship, timmyRelationship, daisyRelationship);
   }
 
-  @Test
-  public void testUpdateRelationshipDefinitionRefElementsByTextContentWithNamespace() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateRelationshipDefinitionRefElementsByTextContentWithNamespace(TestModelArgs args) {
+    init(args);
     List<RelationshipDefinitionRef> relationshipDefinitionRefs = new ArrayList<RelationshipDefinitionRef>(tweety.getRelationshipDefinitionRefElements());
 
     addRelationshipDefinition(tweety, timmyRelationship);
@@ -511,8 +590,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(birdoRelationship, fiffyRelationship, timmyRelationship, daisyRelationship);
   }
 
-  @Test
-  public void testUpdateRelationshipDefinitionRefElementsByRemoveElements() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateRelationshipDefinitionRefElementsByRemoveElements(TestModelArgs args) {
+    init(args);
     List<RelationshipDefinitionRef> relationshipDefinitionRefs = new ArrayList<RelationshipDefinitionRef>(tweety.getRelationshipDefinitionRefElements());
     tweety.getRelationshipDefinitionRefElements().remove(relationshipDefinitionRefs.get(1));
     tweety.getRelationshipDefinitionRefElements().remove(relationshipDefinitionRefs.get(3));
@@ -521,8 +602,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(hedwigRelationship, pluckyRelationship);
   }
 
-  @Test
-  public void testClearRelationshipDefinitionRefElements() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testClearRelationshipDefinitionRefElements(TestModelArgs args) {
+    init(args);
     tweety.getRelationshipDefinitionRefElements().clear();
     assertThat(tweety.getRelationshipDefinitionRefElements()).isEmpty();
     assertThat(tweety.getRelationshipDefinitionRefs()).isEmpty();
@@ -532,8 +615,10 @@ public class AnimalTest extends TestModelTest {
       .hasSize(4);
   }
 
-  @Test
-  public void testClearRelationshipDefinitionRefElementsByClearRelationshipDefinitionRefs() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testClearRelationshipDefinitionRefElementsByClearRelationshipDefinitionRefs(TestModelArgs args) {
+    init(args);
     tweety.getRelationshipDefinitionRefs().clear();
     assertThat(tweety.getRelationshipDefinitionRefs()).isEmpty();
     assertThat(tweety.getRelationshipDefinitionRefElements()).isEmpty();
@@ -543,8 +628,10 @@ public class AnimalTest extends TestModelTest {
       .hasSize(4);
   }
 
-  @Test
-  public void testClearRelationshipDefinitionRefElementsByClearRelationshipDefinitions() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testClearRelationshipDefinitionRefElementsByClearRelationshipDefinitions(TestModelArgs args) {
+    init(args);
     tweety.getRelationshipDefinitions().clear();
     assertThat(tweety.getRelationshipDefinitionRefs()).isEmpty();
     assertThat(tweety.getRelationshipDefinitionRefElements()).isEmpty();
@@ -552,8 +639,10 @@ public class AnimalTest extends TestModelTest {
     assertThat(tweety.getRelationshipDefinitions()).isEmpty();
   }
 
-  @Test
-  public void testGetBestFriends() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testGetBestFriends(TestModelArgs args) {
+    init(args);
     Collection<Animal> bestFriends = tweety.getBestFriends();
 
     assertThat(bestFriends)
@@ -562,8 +651,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(birdo, plucky);
   }
 
-  @Test
-  public void testAddBestFriend() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testAddBestFriend(TestModelArgs args) {
+    init(args);
     tweety.getBestFriends().add(daisy);
 
     Collection<Animal> bestFriends = tweety.getBestFriends();
@@ -574,8 +665,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(birdo, plucky, daisy);
   }
 
-  @Test
-  public void testRemoveBestFriendRef() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testRemoveBestFriendRef(TestModelArgs args) {
+    init(args);
     tweety.getBestFriends().remove(plucky);
 
     Collection<Animal> bestFriends = tweety.getBestFriends();
@@ -586,8 +679,10 @@ public class AnimalTest extends TestModelTest {
       .containsOnly(birdo);
   }
 
-  @Test
-  public void testClearBestFriendRef() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testClearBestFriendRef(TestModelArgs args) {
+    init(args);
     tweety.getBestFriends().clear();
 
     Collection<Animal> bestFriends = tweety.getBestFriends();
@@ -596,8 +691,10 @@ public class AnimalTest extends TestModelTest {
       .isEmpty();
   }
 
-  @Test
-  public void testClearAndAddBestFriendRef() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testClearAndAddBestFriendRef(TestModelArgs args) {
+    init(args);
     tweety.getBestFriends().clear();
 
     Collection<Animal> bestFriends = tweety.getBestFriends();

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AnimalTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AnimalTest.java
@@ -17,8 +17,8 @@
 package org.operaton.bpm.model.xml.testmodel.instance;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAMESPACE;
-import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,8 +31,8 @@ import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
 import org.operaton.bpm.model.xml.testmodel.Gender;
 import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import org.operaton.bpm.model.xml.testmodel.TestModelTest;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
@@ -104,7 +104,7 @@ public class AnimalTest extends TestModelTest {
     return new Object[]{"created", modelInstance, modelParser};
   }
 
-  @Before
+  @BeforeEach
   public void copyModelInstance() {
     modelInstance = cloneModelInstance();
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/BirdTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/BirdTest.java
@@ -15,19 +15,20 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.xml.testmodel.instance;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.operaton.bpm.model.xml.ModelInstance;
-import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
 import org.operaton.bpm.model.xml.impl.util.StringUtil;
 import org.operaton.bpm.model.xml.testmodel.Gender;
 import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import org.operaton.bpm.model.xml.testmodel.TestModelTest;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAMESPACE;
@@ -44,17 +45,11 @@ public class BirdTest extends TestModelTest {
   private Egg egg2;
   private Egg egg3;
 
-  public BirdTest(String testName, ModelInstance testModelInstance, AbstractModelParser modelParser) {
-    super(testName, testModelInstance, modelParser);
+  public static Stream<Arguments> models() {
+    return Stream.of(createModel(), parseModel(BirdTest.class)).map(Arguments::of);
   }
 
-  @Parameters(name="Model {0}")
-  public static Collection<Object[]> models() {
-    Object[][] models = {createModel(), parseModel(BirdTest.class)};
-    return Arrays.asList(models);
-  }
-
-  public static Object[] createModel() {
+  public static TestModelArgs createModel() {
     TestModelParser modelParser = new TestModelParser();
     ModelInstance modelInstance = modelParser.getEmptyModel();
 
@@ -95,12 +90,12 @@ public class BirdTest extends TestModelTest {
     timmy.getGuardedEggRefs().add(guardEgg);
     timmy.getGuardedEggs().add(egg3);
 
-    return new Object[]{"created", modelInstance, modelParser};
+    return new TestModelArgs("created", modelInstance, modelParser);
   }
 
-  @BeforeEach
-  public void copyModelInstance() {
-    modelInstance = cloneModelInstance();
+  @Override
+  protected void init(TestModelArgs args) {
+    super.init(args);
     tweety = modelInstance.getModelElementById("tweety");
     hedwig = modelInstance.getModelElementById("hedwig");
     timmy = modelInstance.getModelElementById("timmy");
@@ -109,134 +104,178 @@ public class BirdTest extends TestModelTest {
     egg3 = modelInstance.getModelElementById("egg3");
   }
 
-  @Test
-  public void testAddEggsByHelper() {
-    assertThat(tweety.getEggs())
-      .isNotEmpty()
-      .hasSize(3)
-      .containsOnly(egg1, egg2, egg3);
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testAddEggsByHelper(TestModelArgs args) {
+    init(args);
+    assertThat(tweety.getEggs()).isNotEmpty().hasSize(3).containsOnly(egg1, egg2, egg3);
 
     Egg egg4 = createEgg(modelInstance, "egg4");
     tweety.getEggs().add(egg4);
     Egg egg5 = createEgg(modelInstance, "egg5");
     tweety.getEggs().add(egg5);
 
-    assertThat(tweety.getEggs())
-      .hasSize(5)
-      .containsOnly(egg1, egg2, egg3, egg4, egg5);
+    assertThat(tweety.getEggs()).hasSize(5).containsOnly(egg1, egg2, egg3, egg4, egg5);
   }
 
-  @Test
-  public void testUpdateEggsByIdByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateEggsByIdByHelper(TestModelArgs args) {
+
+    init(args);
+
     egg1.setId("new-" + egg1.getId());
     egg2.setId("new-" + egg2.getId());
-    assertThat(tweety.getEggs())
-      .hasSize(3)
-      .containsOnly(egg1, egg2, egg3);
+    assertThat(tweety.getEggs()).hasSize(3).containsOnly(egg1, egg2, egg3);
   }
 
-  @Test
-  public void testUpdateEggsByIdByAttributeName() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateEggsByIdByAttributeName(TestModelArgs args) {
+    init(args);
     egg1.setAttributeValue("id", "new-" + egg1.getId(), true);
     egg2.setAttributeValue("id", "new-" + egg2.getId(), true);
-    assertThat(tweety.getEggs())
-      .hasSize(3)
-      .containsOnly(egg1, egg2, egg3);
+    assertThat(tweety.getEggs()).hasSize(3).containsOnly(egg1, egg2, egg3);
   }
 
-  @Test
-  public void testUpdateEggsByReplaceElements() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateEggsByReplaceElements(TestModelArgs args) {
+    init(args);
     Egg egg4 = createEgg(modelInstance, "egg4");
     Egg egg5 = createEgg(modelInstance, "egg5");
     egg1.replaceWithElement(egg4);
     egg2.replaceWithElement(egg5);
-    assertThat(tweety.getEggs())
-      .hasSize(3)
-      .containsOnly(egg3, egg4, egg5);
+    assertThat(tweety.getEggs()).hasSize(3).containsOnly(egg3, egg4, egg5);
   }
 
-  @Test
-  public void testUpdateEggsByRemoveElement() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateEggsByRemoveElement(TestModelArgs args) {
+
+    init(args);
+
     tweety.getEggs().remove(egg1);
-    assertThat(tweety.getEggs())
-      .hasSize(2)
-      .containsOnly(egg2, egg3);
+    assertThat(tweety.getEggs()).hasSize(2).containsOnly(egg2, egg3);
   }
 
-  @Test
-  public void testClearEggs() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testClearEggs(TestModelArgs args) {
+
+    init(args);
+
     tweety.getEggs().clear();
-    assertThat(tweety.getEggs())
-      .isEmpty();
+    assertThat(tweety.getEggs()).isEmpty();
   }
 
-  @Test
-  public void testSetSpouseRefByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetSpouseRefByHelper(TestModelArgs args) {
+
+    init(args);
+
     tweety.setSpouse(timmy);
     assertThat(tweety.getSpouse()).isEqualTo(timmy);
   }
 
-  @Test
-  public void testUpdateSpouseByIdHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateSpouseByIdHelper(TestModelArgs args) {
+
+    init(args);
+
     hedwig.setId("new-" + hedwig.getId());
     assertThat(tweety.getSpouse()).isEqualTo(hedwig);
   }
 
-  @Test
-  public void testUpdateSpouseByIdByAttributeName() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateSpouseByIdByAttributeName(TestModelArgs args) {
+
+    init(args);
+
     hedwig.setAttributeValue("id", "new-" + hedwig.getId(), true);
     assertThat(tweety.getSpouse()).isEqualTo(hedwig);
   }
 
-  @Test
-  public void testUpdateSpouseByReplaceElement() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateSpouseByReplaceElement(TestModelArgs args) {
+
+    init(args);
+
     hedwig.replaceWithElement(timmy);
     assertThat(tweety.getSpouse()).isEqualTo(timmy);
   }
 
-  @Test
-  public void testUpdateSpouseByRemoveElement() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateSpouseByRemoveElement(TestModelArgs args) {
+    init(args);
     Animals animals = (Animals) modelInstance.getDocumentElement();
     animals.getAnimals().remove(hedwig);
     assertThat(tweety.getSpouse()).isNull();
   }
 
-  @Test
-  public void testClearSpouse() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testClearSpouse(TestModelArgs args) {
+
+    init(args);
+
     tweety.removeSpouse();
     assertThat(tweety.getSpouse()).isNull();
   }
 
-  @Test
-  public void testSetSpouseRefsByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetSpouseRefsByHelper(TestModelArgs args) {
+    init(args);
     SpouseRef spouseRef = modelInstance.newInstance(SpouseRef.class);
     spouseRef.setTextContent(timmy.getId());
     tweety.getSpouseRef().replaceWithElement(spouseRef);
     assertThat(tweety.getSpouse()).isEqualTo(timmy);
   }
 
-  @Test
-  public void testSpouseRefsByTextContent() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSpouseRefsByTextContent(TestModelArgs args) {
+
+    init(args);
+
     SpouseRef spouseRef = tweety.getSpouseRef();
     assertThat(spouseRef.getTextContent()).isEqualTo(hedwig.getId());
   }
 
-  @Test
-  public void testUpdateSpouseRefsByTextContent() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateSpouseRefsByTextContent(TestModelArgs args) {
+
+    init(args);
+
     SpouseRef spouseRef = tweety.getSpouseRef();
     spouseRef.setTextContent(timmy.getId());
     assertThat(tweety.getSpouse()).isEqualTo(timmy);
   }
 
-  @Test
-  public void testUpdateSpouseRefsByTextContentWithNamespace() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateSpouseRefsByTextContentWithNamespace(TestModelArgs args) {
+
+    init(args);
+
     SpouseRef spouseRef = tweety.getSpouseRef();
     spouseRef.setTextContent("tns:" + timmy.getId());
     assertThat(tweety.getSpouse()).isEqualTo(timmy);
   }
 
-  @Test
-  public void testGetMother() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testGetMother(TestModelArgs args) {
+
+    init(args);
+
     Animal mother = egg1.getMother();
     assertThat(mother).isEqualTo(tweety);
 
@@ -244,67 +283,99 @@ public class BirdTest extends TestModelTest {
     assertThat(mother).isEqualTo(tweety);
   }
 
-  @Test
-  public void testSetMotherRefByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetMotherRefByHelper(TestModelArgs args) {
+
+    init(args);
+
     egg1.setMother(timmy);
     assertThat(egg1.getMother()).isEqualTo(timmy);
   }
 
-  @Test
-  public void testUpdateMotherByIdHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateMotherByIdHelper(TestModelArgs args) {
+
+    init(args);
+
     tweety.setId("new-" + tweety.getId());
     assertThat(egg1.getMother()).isEqualTo(tweety);
   }
 
-  @Test
-  public void testUpdateMotherByIdByAttributeName() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateMotherByIdByAttributeName(TestModelArgs args) {
+
+    init(args);
+
     tweety.setAttributeValue("id", "new-" + tweety.getId(), true);
     assertThat(egg1.getMother()).isEqualTo(tweety);
   }
 
-  @Test
-  public void testUpdateMotherByReplaceElement() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateMotherByReplaceElement(TestModelArgs args) {
+    init(args);
     tweety.replaceWithElement(timmy);
     assertThat(egg1.getMother()).isEqualTo(timmy);
   }
 
-  @Test
-  public void testUpdateMotherByRemoveElement() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateMotherByRemoveElement(TestModelArgs args) {
+    init(args);
     egg1.setMother(hedwig);
     Animals animals = (Animals) modelInstance.getDocumentElement();
     animals.getAnimals().remove(hedwig);
     assertThat(egg1.getMother()).isNull();
   }
 
-  @Test
-  public void testClearMother() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testClearMother(TestModelArgs args) {
+
+    init(args);
+
     egg1.removeMother();
     assertThat(egg1.getMother()).isNull();
   }
 
-  @Test
-  public void testSetMotherRefsByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testSetMotherRefsByHelper(TestModelArgs args) {
+    init(args);
     Mother mother = modelInstance.newInstance(Mother.class);
     mother.setHref("#" + timmy.getId());
     egg1.getMotherRef().replaceWithElement(mother);
     assertThat(egg1.getMother()).isEqualTo(timmy);
   }
 
-  @Test
-  public void testMotherRefsByTextContent() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testMotherRefsByTextContent(TestModelArgs args) {
+
+    init(args);
+
     Mother mother = egg1.getMotherRef();
     assertThat(mother.getHref()).isEqualTo("#" + tweety.getId());
   }
 
-  @Test
-  public void testUpdateMotherRefsByTextContent() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateMotherRefsByTextContent(TestModelArgs args) {
+
+    init(args);
+
     Mother mother = egg1.getMotherRef();
     mother.setHref("#" + timmy.getId());
     assertThat(egg1.getMother()).isEqualTo(timmy);
   }
 
-  @Test
-  public void testGetGuards() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testGetGuards(TestModelArgs args) {
+    init(args);
     Collection<Animal> guards = egg1.getGuardians();
     assertThat(guards).isNotEmpty().hasSize(2);
     assertThat(guards).contains(hedwig, timmy);
@@ -314,24 +385,23 @@ public class BirdTest extends TestModelTest {
     assertThat(guards).contains(hedwig, timmy);
   }
 
-  @Test
-  public void testAddGuardianRefsByHelper() {
-    assertThat(egg1.getGuardianRefs())
-      .isNotEmpty()
-      .hasSize(2);
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testAddGuardianRefsByHelper(TestModelArgs args) {
+    init(args);
+    assertThat(egg1.getGuardianRefs()).isNotEmpty().hasSize(2);
 
     Guardian tweetyGuardian = modelInstance.newInstance(Guardian.class);
     tweetyGuardian.setHref("#" + tweety.getId());
     egg1.getGuardianRefs().add(tweetyGuardian);
 
-    assertThat(egg1.getGuardianRefs())
-      .isNotEmpty()
-      .hasSize(3)
-      .contains(tweetyGuardian);
+    assertThat(egg1.getGuardianRefs()).isNotEmpty().hasSize(3).contains(tweetyGuardian);
   }
 
-  @Test
-  public void testGuardianRefsByTextContent() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testGuardianRefsByTextContent(TestModelArgs args) {
+    init(args);
     Collection<Guardian> guardianRefs = egg1.getGuardianRefs();
     Collection<String> hrefs = new ArrayList<String>();
     for (Guardian guardianRef : guardianRefs) {
@@ -339,77 +409,73 @@ public class BirdTest extends TestModelTest {
       assertThat(href).isNotEmpty();
       hrefs.add(href);
     }
-    assertThat(hrefs)
-      .isNotEmpty()
-      .hasSize(2)
-      .containsOnly("#" + hedwig.getId(), "#" + timmy.getId());
+    assertThat(hrefs).isNotEmpty().hasSize(2).containsOnly("#" + hedwig.getId(), "#" + timmy.getId());
   }
 
-  @Test
-  public void testUpdateGuardianRefsByTextContent() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateGuardianRefsByTextContent(TestModelArgs args) {
+    init(args);
     List<Guardian> guardianRefs = new ArrayList<Guardian>(egg1.getGuardianRefs());
 
     guardianRefs.get(0).setHref("#" + tweety.getId());
 
-    assertThat(egg1.getGuardians())
-      .hasSize(2)
-      .containsOnly(tweety, timmy);
+    assertThat(egg1.getGuardians()).hasSize(2).containsOnly(tweety, timmy);
   }
 
-  @Test
-  public void testUpdateGuardianRefsByRemoveElements() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateGuardianRefsByRemoveElements(TestModelArgs args) {
+    init(args);
     List<Guardian> guardianRefs = new ArrayList<Guardian>(egg1.getGuardianRefs());
     egg1.getGuardianRefs().remove(guardianRefs.get(1));
-    assertThat(egg1.getGuardians())
-      .hasSize(1)
-      .containsOnly(hedwig);
+    assertThat(egg1.getGuardians()).hasSize(1).containsOnly(hedwig);
   }
 
-  @Test
-  public void testClearGuardianRefs() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testClearGuardianRefs(TestModelArgs args) {
+    init(args);
     egg1.getGuardianRefs().clear();
     assertThat(egg1.getGuardianRefs()).isEmpty();
 
     // should not affect animals collection
     Animals animals = (Animals) modelInstance.getDocumentElement();
-    assertThat(animals.getAnimals())
-      .isNotEmpty()
-      .hasSize(3);
+    assertThat(animals.getAnimals()).isNotEmpty().hasSize(3);
   }
 
-  @Test
-  public void testGetGuardedEggs() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testGetGuardedEggs(TestModelArgs args) {
+
+    init(args);
+
     Collection<Egg> guardedEggs = hedwig.getGuardedEggs();
-    assertThat(guardedEggs)
-      .isNotEmpty()
-      .hasSize(2)
-      .contains(egg1, egg2);
+    assertThat(guardedEggs).isNotEmpty().hasSize(2).contains(egg1, egg2);
 
     guardedEggs = timmy.getGuardedEggs();
-    assertThat(guardedEggs)
-      .isNotEmpty()
-      .hasSize(3)
-      .contains(egg1, egg2);
+    assertThat(guardedEggs).isNotEmpty().hasSize(3).contains(egg1, egg2);
   }
 
-  @Test
-  public void testAddGuardedEggRefsByHelper() {
-    assertThat(hedwig.getGuardedEggRefs())
-      .isNotEmpty()
-      .hasSize(2);
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testAddGuardedEggRefsByHelper(TestModelArgs args) {
+    init(args);
+    assertThat(hedwig.getGuardedEggRefs()).isNotEmpty().hasSize(2);
 
     GuardEgg egg3GuardedEgg = modelInstance.newInstance(GuardEgg.class);
     egg3GuardedEgg.setTextContent(egg3.getId());
     hedwig.getGuardedEggRefs().add(egg3GuardedEgg);
 
-    assertThat(hedwig.getGuardedEggRefs())
-      .isNotEmpty()
-      .hasSize(3)
-      .contains(egg3GuardedEgg);
+    assertThat(hedwig.getGuardedEggRefs()).isNotEmpty().hasSize(3).contains(egg3GuardedEgg);
   }
 
-  @Test
-  public void testGuardedEggRefsByTextContent() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testGuardedEggRefsByTextContent(TestModelArgs args) {
+
+    init(args);
+
     Collection<GuardEgg> guardianRefs = timmy.getGuardedEggRefs();
     Collection<String> textContents = new ArrayList<String>();
     for (GuardEgg guardianRef : guardianRefs) {
@@ -417,42 +483,41 @@ public class BirdTest extends TestModelTest {
       assertThat(textContent).isNotEmpty();
       textContents.addAll(StringUtil.splitListBySeparator(textContent, " "));
     }
-    assertThat(textContents)
-      .isNotEmpty()
-      .hasSize(3)
-      .containsOnly(egg1.getId(), egg2.getId(), egg3.getId());
+    assertThat(textContents).isNotEmpty().hasSize(3).containsOnly(egg1.getId(), egg2.getId(), egg3.getId());
   }
 
-  @Test
-  public void testUpdateGuardedEggRefsByTextContent() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateGuardedEggRefsByTextContent(TestModelArgs args) {
+    init(args);
     List<GuardEgg> guardianRefs = new ArrayList<GuardEgg>(hedwig.getGuardedEggRefs());
 
     guardianRefs.get(0).setTextContent(egg1.getId() + " " + egg3.getId());
 
-    assertThat(hedwig.getGuardedEggs())
-      .hasSize(3)
-      .containsOnly(egg1, egg2, egg3);
+    assertThat(hedwig.getGuardedEggs()).hasSize(3).containsOnly(egg1, egg2, egg3);
   }
 
-  @Test
-  public void testUpdateGuardedEggRefsByRemoveElements() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testUpdateGuardedEggRefsByRemoveElements(TestModelArgs args) {
+
+    init(args);
+
     List<GuardEgg> guardianRefs = new ArrayList<GuardEgg>(timmy.getGuardedEggRefs());
     timmy.getGuardedEggRefs().remove(guardianRefs.get(0));
-    assertThat(timmy.getGuardedEggs())
-      .hasSize(1)
-      .containsOnly(egg3);
+    assertThat(timmy.getGuardedEggs()).hasSize(1).containsOnly(egg3);
   }
 
-  @Test
-  public void testClearGuardedEggRefs() {
+  @ParameterizedTest
+  @MethodSource("models")
+  public void testClearGuardedEggRefs(TestModelArgs args) {
+    init(args);
     timmy.getGuardedEggRefs().clear();
     assertThat(timmy.getGuardedEggRefs()).isEmpty();
 
     // should not affect animals collection
     Animals animals = (Animals) modelInstance.getDocumentElement();
-    assertThat(animals.getAnimals())
-      .isNotEmpty()
-      .hasSize(3);
+    assertThat(animals.getAnimals()).isNotEmpty().hasSize(3);
   }
 
 }

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/BirdTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/BirdTest.java
@@ -15,15 +15,14 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.xml.testmodel.instance;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
 import org.operaton.bpm.model.xml.impl.util.StringUtil;
 import org.operaton.bpm.model.xml.testmodel.Gender;
 import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import org.operaton.bpm.model.xml.testmodel.TestModelTest;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,7 +31,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAMESPACE;
-import static org.junit.runners.Parameterized.Parameters;
 
 /**
  * @author Sebastian Menski
@@ -100,7 +98,7 @@ public class BirdTest extends TestModelTest {
     return new Object[]{"created", modelInstance, modelParser};
   }
 
-  @Before
+  @BeforeEach
   public void copyModelInstance() {
     modelInstance = cloneModelInstance();
     tweety = modelInstance.getModelElementById("tweety");

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/FlyingAnimalTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/FlyingAnimalTest.java
@@ -15,14 +15,13 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.xml.testmodel.instance;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
 import org.operaton.bpm.model.xml.testmodel.Gender;
 import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import org.operaton.bpm.model.xml.testmodel.TestModelTest;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,7 +30,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAMESPACE;
-import static org.junit.runners.Parameterized.Parameters;
 
 /**
  * @author Sebastian Menski
@@ -85,7 +83,7 @@ public class FlyingAnimalTest extends TestModelTest {
     return new Object[]{"created", modelInstance, modelParser};
   }
 
-  @Before
+  @BeforeEach
   public void copyModelInstance() {
     modelInstance = cloneModelInstance();
     tweety = modelInstance.getModelElementById("tweety");

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/FlyingAnimalTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/FlyingAnimalTest.java
@@ -15,18 +15,18 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.xml.testmodel.instance;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.operaton.bpm.model.xml.ModelInstance;
-import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
 import org.operaton.bpm.model.xml.testmodel.Gender;
 import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import org.operaton.bpm.model.xml.testmodel.TestModelTest;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAMESPACE;
@@ -44,17 +44,11 @@ public class FlyingAnimalTest extends TestModelTest {
   private FlyingAnimal timmy;
   private FlyingAnimal daisy;
 
-  public FlyingAnimalTest(String testName, ModelInstance testModelInstance, AbstractModelParser modelParser) {
-    super(testName, testModelInstance, modelParser);
+  static Stream<Arguments> models() {
+    return Stream.of(createModel(), parseModel(FlyingAnimalTest.class)).map(Arguments::of);
   }
 
-  @Parameters(name="Model {0}")
-  public static Collection<Object[]> models() {
-    Object[][] models = {createModel(), parseModel(FlyingAnimalTest.class)};
-    return Arrays.asList(models);
-  }
-
-  public static Object[] createModel() {
+  public static TestModelArgs createModel() {
     TestModelParser modelParser = new TestModelParser();
     ModelInstance modelInstance = modelParser.getEmptyModel();
 
@@ -79,13 +73,13 @@ public class FlyingAnimalTest extends TestModelTest {
     tweety.getFlightPartnerRefs().add(plucky);
     tweety.getFlightPartnerRefs().add(fiffy);
 
-
-    return new Object[]{"created", modelInstance, modelParser};
+    return new TestModelArgs("created", modelInstance, modelParser);
   }
 
-  @BeforeEach
-  public void copyModelInstance() {
-    modelInstance = cloneModelInstance();
+  @Override
+  protected void init(TestModelArgs args) {
+    super.init(args);
+    modelInstance = modelInstance.clone();
     tweety = modelInstance.getModelElementById("tweety");
     hedwig = modelInstance.getModelElementById("hedwig");
     birdo = modelInstance.getModelElementById("birdo");
@@ -95,22 +89,28 @@ public class FlyingAnimalTest extends TestModelTest {
     daisy = modelInstance.getModelElementById("daisy");
   }
 
-  @Test
-  public void testSetWingspanAttributeByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testSetWingspanAttributeByHelper(TestModelArgs args) {
+    init(args);
     double wingspan = 2.123;
     tweety.setWingspan(wingspan);
     assertThat(tweety.getWingspan()).isEqualTo(wingspan);
   }
 
-  @Test
-  public void testSetWingspanAttributeByAttributeName() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testSetWingspanAttributeByAttributeName(TestModelArgs args) {
+    init(args);
     Double wingspan = 2.123;
     tweety.setAttributeValue("wingspan", wingspan.toString(), false);
     assertThat(tweety.getWingspan()).isEqualTo(wingspan);
   }
 
-  @Test
-  public void testRemoveWingspanAttribute() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testRemoveWingspanAttribute(TestModelArgs args) {
+    init(args);
     double wingspan = 2.123;
     tweety.setWingspan(wingspan);
     assertThat(tweety.getWingspan()).isEqualTo(wingspan);
@@ -120,45 +120,59 @@ public class FlyingAnimalTest extends TestModelTest {
     assertThat(tweety.getWingspan()).isNull();
   }
 
-  @Test
-  public void testSetFlightInstructorByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testSetFlightInstructorByHelper(TestModelArgs args) {
+    init(args);
     tweety.setFlightInstructor(timmy);
     assertThat(tweety.getFlightInstructor()).isEqualTo(timmy);
   }
 
-  @Test
-  public void testUpdateFlightInstructorByIdHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testUpdateFlightInstructorByIdHelper(TestModelArgs args) {
+    init(args);
     hedwig.setId("new-" + hedwig.getId());
     assertThat(tweety.getFlightInstructor()).isEqualTo(hedwig);
   }
 
-  @Test
-  public void testUpdateFlightInstructorByIdAttributeName() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testUpdateFlightInstructorByIdAttributeName(TestModelArgs args) {
+    init(args);
     hedwig.setAttributeValue("id", "new-" + hedwig.getId(), true);
     assertThat(tweety.getFlightInstructor()).isEqualTo(hedwig);
   }
 
-  @Test
-  public void testUpdateFlightInstructorByReplaceElement() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testUpdateFlightInstructorByReplaceElement(TestModelArgs args) {
+    init(args);
     hedwig.replaceWithElement(timmy);
     assertThat(tweety.getFlightInstructor()).isEqualTo(timmy);
   }
 
-  @Test
-  public void testUpdateFlightInstructorByRemoveElement() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testUpdateFlightInstructorByRemoveElement(TestModelArgs args) {
+    init(args);
     Animals animals = (Animals) modelInstance.getDocumentElement();
     animals.getAnimals().remove(hedwig);
     assertThat(tweety.getFlightInstructor()).isNull();
   }
 
-  @Test
-  public void testClearFlightInstructor() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testClearFlightInstructor(TestModelArgs args) {
+    init(args);
     tweety.removeFlightInstructor();
     assertThat(tweety.getFlightInstructor()).isNull();
   }
 
-  @Test
-  public void testAddFlightPartnerRefsByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testAddFlightPartnerRefsByHelper(TestModelArgs args) {
+    init(args);
     assertThat(tweety.getFlightPartnerRefs())
       .isNotEmpty()
       .hasSize(4)
@@ -173,8 +187,10 @@ public class FlyingAnimalTest extends TestModelTest {
       .containsOnly(hedwig, birdo, plucky, fiffy, timmy, daisy);
   }
 
-  @Test
-  public void testUpdateFlightPartnerRefsByIdByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testUpdateFlightPartnerRefsByIdByHelper(TestModelArgs args) {
+    init(args);
     hedwig.setId("new-" + hedwig.getId());
     plucky.setId("new-" + plucky.getId());
     assertThat(tweety.getFlightPartnerRefs())
@@ -182,8 +198,10 @@ public class FlyingAnimalTest extends TestModelTest {
       .containsOnly(hedwig, birdo, plucky, fiffy);
   }
 
-  @Test
-  public void testUpdateFlightPartnerRefsByIdByAttributeName() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testUpdateFlightPartnerRefsByIdByAttributeName(TestModelArgs args) {
+    init(args);
     birdo.setAttributeValue("id", "new-" + birdo.getId(), true);
     fiffy.setAttributeValue("id", "new-" + fiffy.getId(), true);
     assertThat(tweety.getFlightPartnerRefs())
@@ -191,8 +209,10 @@ public class FlyingAnimalTest extends TestModelTest {
       .containsOnly(hedwig, birdo, plucky, fiffy);
   }
 
-  @Test
-  public void testUpdateFlightPartnerRefsByReplaceElements() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testUpdateFlightPartnerRefsByReplaceElements(TestModelArgs args) {
+    init(args);
     hedwig.replaceWithElement(timmy);
     plucky.replaceWithElement(daisy);
     assertThat(tweety.getFlightPartnerRefs())
@@ -200,8 +220,10 @@ public class FlyingAnimalTest extends TestModelTest {
       .containsOnly(birdo, fiffy, timmy ,daisy);
   }
 
-  @Test
-  public void testUpdateFlightPartnerRefsByRemoveElements() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testUpdateFlightPartnerRefsByRemoveElements(TestModelArgs args) {
+    init(args);
     tweety.getFlightPartnerRefs().remove(birdo);
     tweety.getFlightPartnerRefs().remove(fiffy);
     assertThat(tweety.getFlightPartnerRefs())
@@ -209,14 +231,18 @@ public class FlyingAnimalTest extends TestModelTest {
       .containsOnly(hedwig, plucky);
   }
 
-  @Test
-  public void testClearFlightPartnerRefs() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testClearFlightPartnerRefs(TestModelArgs args) {
+    init(args);
     tweety.getFlightPartnerRefs().clear();
     assertThat(tweety.getFlightPartnerRefs()).isEmpty();
   }
 
-  @Test
-  public void testAddFlightPartnerRefElementsByHelper() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testAddFlightPartnerRefElementsByHelper(TestModelArgs args) {
+    init(args);
     assertThat(tweety.getFlightPartnerRefElements())
       .isNotEmpty()
       .hasSize(4);
@@ -235,8 +261,10 @@ public class FlyingAnimalTest extends TestModelTest {
       .contains(timmyFlightPartnerRef, daisyFlightPartnerRef);
   }
 
-  @Test
-  public void testFlightPartnerRefElementsByTextContent() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testFlightPartnerRefElementsByTextContent(TestModelArgs args) {
+    init(args);
     Collection<FlightPartnerRef> flightPartnerRefElements = tweety.getFlightPartnerRefElements();
     Collection<String> textContents = new ArrayList<String>();
     for (FlightPartnerRef flightPartnerRefElement : flightPartnerRefElements) {
@@ -250,8 +278,10 @@ public class FlyingAnimalTest extends TestModelTest {
       .containsOnly(hedwig.getId(), birdo.getId(), plucky.getId(), fiffy.getId());
   }
 
-  @Test
-  public void testUpdateFlightPartnerRefElementsByTextContent() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testUpdateFlightPartnerRefElementsByTextContent(TestModelArgs args) {
+    init(args);
     List<FlightPartnerRef> flightPartnerRefs = new ArrayList<FlightPartnerRef>(tweety.getFlightPartnerRefElements());
 
     flightPartnerRefs.get(0).setTextContent(timmy.getId());
@@ -262,8 +292,10 @@ public class FlyingAnimalTest extends TestModelTest {
       .containsOnly(birdo, fiffy, timmy, daisy);
   }
 
-  @Test
-  public void testUpdateFlightPartnerRefElementsByRemoveElements() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testUpdateFlightPartnerRefElementsByRemoveElements(TestModelArgs args) {
+    init(args);
     List<FlightPartnerRef> flightPartnerRefs = new ArrayList<FlightPartnerRef>(tweety.getFlightPartnerRefElements());
     tweety.getFlightPartnerRefElements().remove(flightPartnerRefs.get(1));
     tweety.getFlightPartnerRefElements().remove(flightPartnerRefs.get(3));
@@ -272,8 +304,10 @@ public class FlyingAnimalTest extends TestModelTest {
       .containsOnly(hedwig, plucky);
   }
 
-  @Test
-  public void testClearFlightPartnerRefElements() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testClearFlightPartnerRefElements(TestModelArgs args) {
+    init(args);
     tweety.getFlightPartnerRefElements().clear();
     assertThat(tweety.getFlightPartnerRefElements()).isEmpty();
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/UnknownAnimalTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/UnknownAnimalTest.java
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.xml.testmodel.instance;
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelException;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.impl.ModelInstanceImpl;
@@ -24,17 +26,14 @@ import org.operaton.bpm.model.xml.instance.DomDocument;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import org.operaton.bpm.model.xml.type.ModelElementType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAMESPACE;
-import static org.junit.Assert.fail;
 
 /**
  * @author Sebastian Menski
@@ -46,7 +45,7 @@ public class UnknownAnimalTest {
   private ModelElementInstance wanda;
   private ModelElementInstance flipper;
 
-  @Before
+  @BeforeEach
   public void parseModel() {
     modelParser = new TestModelParser();
     String testXml = this.getClass().getSimpleName() + ".xml";
@@ -56,7 +55,7 @@ public class UnknownAnimalTest {
     flipper = modelInstance.getModelElementById("flipper");
   }
 
-  @After
+  @AfterEach
   public void validateModel() {
     DomDocument document = modelInstance.getDocument();
     modelParser.validateModel(document);

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testsupport/CustomParameterResolver.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testsupport/CustomParameterResolver.java
@@ -1,0 +1,86 @@
+package org.operaton.bpm.model.xml.testsupport;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.engine.execution.BeforeEachMethodAdapter;
+import org.junit.jupiter.engine.extension.ExtensionRegistry;
+
+public class CustomParameterResolver implements BeforeEachMethodAdapter, ParameterResolver {
+
+  private ParameterResolver parameterisedTestParameterResolver = null;
+
+  @Override
+  public void invokeBeforeEachMethod(ExtensionContext context, ExtensionRegistry registry)
+      throws Throwable {
+    Optional<ParameterResolver> resolverOptional = registry.getExtensions(ParameterResolver.class)
+        .stream()
+        .filter(parameterResolver ->
+            parameterResolver.getClass().getName()
+                .contains("ParameterizedTestParameterResolver")
+        )
+        .findFirst();
+    if (!resolverOptional.isPresent()) {
+      throw new IllegalStateException(
+          "ParameterizedTestParameterResolver missed in the registry. Probably it's not a Parameterized Test");
+    } else {
+      parameterisedTestParameterResolver = resolverOptional.get();
+    }
+  }
+
+  @Override
+  public boolean supportsParameter(ParameterContext parameterContext,
+      ExtensionContext extensionContext) throws ParameterResolutionException {
+    if (isExecutedOnAfterOrBeforeMethod(parameterContext)) {
+      return getMappedContext(parameterContext, extensionContext).isPresent();
+      /*
+      return getMappedContext(parameterContext, extensionContext).map(pContext -> {
+        return parameterisedTestParameterResolver.supportsParameter(pContext, extensionContext);
+      }).orElse(false);
+
+       */
+    }
+    return false;
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext parameterContext,
+      ExtensionContext extensionContext) throws ParameterResolutionException {
+
+    return parameterisedTestParameterResolver.resolveParameter(
+        getMappedContext(parameterContext, extensionContext).orElseThrow(), extensionContext);
+  }
+
+  private Optional<MappedParameterContext> getMappedContext(ParameterContext parameterContext,
+      ExtensionContext extensionContext) {
+    if (isExecutedOnAfterOrBeforeMethod(parameterContext)) {
+      return Stream.of(parameterContext.getDeclaringExecutable().getParameters())
+              .filter(p -> Objects.equals(p.getType(), parameterContext.getParameter().getType()))
+              .findFirst()
+              .map(p -> new MappedParameterContext(
+                      parameterContext.getIndex(),
+                      p,
+                      Optional.of(parameterContext.getTarget())));
+    }
+    return Optional.empty();
+  }
+
+  private boolean isExecutedOnAfterOrBeforeMethod(ParameterContext parameterContext) {
+    return Arrays.stream(parameterContext.getDeclaringExecutable().getDeclaredAnnotations())
+        .anyMatch(this::isAfterEachOrBeforeEachAnnotation);
+  }
+
+  private boolean isAfterEachOrBeforeEachAnnotation(Annotation annotation) {
+    return annotation.annotationType() == BeforeEach.class
+        || annotation.annotationType() == AfterEach.class;
+  }
+}

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testsupport/MappedParameterContext.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testsupport/MappedParameterContext.java
@@ -1,0 +1,52 @@
+package org.operaton.bpm.model.xml.testsupport;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Parameter;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.platform.commons.util.AnnotationUtils;
+
+public class MappedParameterContext implements ParameterContext {
+
+  private final int index;
+  private final Parameter parameter;
+  private final Optional<Object> target;
+
+  public MappedParameterContext(int index, Parameter parameter,
+      Optional<Object> target) {
+    this.index = index;
+    this.parameter = parameter;
+    this.target = target;
+  }
+
+  @Override
+  public boolean isAnnotated(Class<? extends Annotation> annotationType) {
+    return AnnotationUtils.isAnnotated(parameter, annotationType);
+  }
+
+  @Override
+  public <A extends Annotation> Optional<A> findAnnotation(Class<A> annotationType) {
+    return Optional.empty();
+  }
+
+  @Override
+  public <A extends Annotation> List<A> findRepeatableAnnotations(Class<A> annotationType) {
+    return null;
+  }
+
+  @Override
+  public int getIndex() {
+    return index;
+  }
+
+  @Override
+  public Parameter getParameter() {
+    return parameter;
+  }
+
+  @Override
+  public Optional<Object> getTarget() {
+    return target;
+  }
+}

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/ModelElementTypeTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/ModelElementTypeTest.java
@@ -15,18 +15,17 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.xml.type;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.Model;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.impl.util.ModelTypeException;
 import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import org.operaton.bpm.model.xml.testmodel.instance.*;
-import org.junit.Before;
-import org.junit.Test;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.operaton.bpm.model.xml.test.assertions.ModelAssertions.assertThat;
 import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAMESPACE;
-import static org.junit.Assert.fail;
 
 /**
  * @author Sebastian Menski
@@ -40,7 +39,7 @@ public class ModelElementTypeTest {
   private ModelElementType flyingAnimalType;
   private ModelElementType birdType;
 
-  @Before
+  @BeforeEach
   public void getTypes() {
     TestModelParser modelParser = new TestModelParser();
     modelInstance = modelParser.getEmptyModel();

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/attribute/AttributeTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/attribute/AttributeTest.java
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.xml.type.attribute;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
 import org.operaton.bpm.model.xml.impl.type.attribute.AttributeImpl;
@@ -27,14 +28,11 @@ import org.operaton.bpm.model.xml.testmodel.instance.AnimalTest;
 import org.operaton.bpm.model.xml.testmodel.instance.Animals;
 import org.operaton.bpm.model.xml.testmodel.instance.Bird;
 import org.operaton.bpm.model.xml.type.ModelElementType;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
 
 import static org.operaton.bpm.model.xml.test.assertions.ModelAssertions.assertThat;
-import static org.junit.runners.Parameterized.Parameters;
 
 /**
  * @author Sebastian Menski
@@ -68,7 +66,7 @@ public class AttributeTest extends TestModelTest {
     return new Object[]{"created", modelInstance, modelParser};
   }
 
-  @Before
+  @BeforeEach
   @SuppressWarnings("unchecked")
   public void copyModelInstance() {
     modelInstance = cloneModelInstance();

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/child/ChildElementCollectionTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/child/ChildElementCollectionTest.java
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.xml.type.child;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.UnsupportedModelOperationException;
-import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
 import org.operaton.bpm.model.xml.impl.type.child.ChildElementCollectionImpl;
 import org.operaton.bpm.model.xml.impl.type.child.ChildElementImpl;
 import org.operaton.bpm.model.xml.testmodel.Gender;
@@ -31,6 +31,7 @@ import org.operaton.bpm.model.xml.type.ModelElementType;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.operaton.bpm.model.xml.test.assertions.ModelAssertions.assertThat;
@@ -48,17 +49,12 @@ public class ChildElementCollectionTest extends TestModelTest {
   private ChildElement<FlightInstructor> flightInstructorChild;
   private ChildElementCollection<FlightPartnerRef> flightPartnerRefCollection;
 
-  public ChildElementCollectionTest(String testName, ModelInstance testModelInstance, AbstractModelParser modelParser) {
-    super(testName, testModelInstance, modelParser);
+  static Stream<Arguments> models() {
+    return Stream.of(createModel(), parseModel(ChildElementCollectionTest.class)).map(Arguments::of);
   }
 
-  @Parameters(name="Model {0}")
-  public static Collection<Object[]> models() {
-    Object[][] models = {createModel(), parseModel(ChildElementCollectionTest.class)};
-    return Arrays.asList(models);
-  }
 
-  public static Object[] createModel() {
+  public static TestModelArgs createModel() {
     TestModelParser modelParser = new TestModelParser();
     ModelInstance modelInstance = modelParser.getEmptyModel();
 
@@ -75,13 +71,12 @@ public class ChildElementCollectionTest extends TestModelTest {
     tweety.getFlightPartnerRefs().add(daisy);
     tweety.getFlightPartnerRefs().add(plucky);
 
-    return new Object[]{"created", modelInstance, modelParser};
+    return new TestModelArgs("created", modelInstance, modelParser);
   }
 
-  @BeforeEach
-  public void copyModelInstance() {
-    modelInstance = cloneModelInstance();
-
+  @Override
+  protected void init(TestModelArgs args) {
+    super.init(args);
     tweety = modelInstance.getModelElementById("tweety");
     daffy = modelInstance.getModelElementById("daffy");
     daisy = modelInstance.getModelElementById("daisy");
@@ -92,8 +87,10 @@ public class ChildElementCollectionTest extends TestModelTest {
     flightPartnerRefCollection = FlyingAnimal.flightPartnerRefsColl.getReferenceSourceCollection();
   }
 
-  @Test
-  public void testImmutable() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testImmutable(TestModelArgs args) {
+    init(args);
     assertThat(flightInstructorChild).isMutable();
     assertThat(flightPartnerRefCollection).isMutable();
 
@@ -108,34 +105,44 @@ public class ChildElementCollectionTest extends TestModelTest {
     assertThat(flightPartnerRefCollection).isMutable();
   }
 
-  @Test
-  public void testMinOccurs() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testMinOccurs(TestModelArgs args) {
+    init(args);
     assertThat(flightInstructorChild).isOptional();
     assertThat(flightPartnerRefCollection).isOptional();
   }
 
-  @Test
-  public void testMaxOccurs() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testMaxOccurs(TestModelArgs args) {
+    init(args);
     assertThat(flightInstructorChild).occursMaximal(1);
     assertThat(flightPartnerRefCollection).isUnbounded();
   }
 
-  @Test
-  public void testChildElementType() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testChildElementType(TestModelArgs args) {
+    init(args);
     assertThat(flightInstructorChild).containsType(FlightInstructor.class);
     assertThat(flightPartnerRefCollection).containsType(FlightPartnerRef.class);
   }
 
-  @Test
-  public void testParentElementType() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testParentElementType(TestModelArgs args) {
+    init(args);
     ModelElementType flyingAnimalType = modelInstance.getModel().getType(FlyingAnimal.class);
 
     assertThat(flightInstructorChild).hasParentElementType(flyingAnimalType);
     assertThat(flightPartnerRefCollection).hasParentElementType(flyingAnimalType);
   }
 
-  @Test
-  public void testGetChildElements() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testGetChildElements(TestModelArgs args) {
+    init(args);
     assertThat(flightInstructorChild).hasSize(tweety, 1);
     assertThat(flightPartnerRefCollection).hasSize(tweety, 2);
 
@@ -147,8 +154,10 @@ public class ChildElementCollectionTest extends TestModelTest {
     }
   }
 
-  @Test
-  public void testRemoveChildElements() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testRemoveChildElements(TestModelArgs args) {
+    init(args);
     assertThat(flightInstructorChild).isNotEmpty(tweety);
     assertThat(flightPartnerRefCollection).isNotEmpty(tweety);
 
@@ -159,8 +168,10 @@ public class ChildElementCollectionTest extends TestModelTest {
     assertThat(flightPartnerRefCollection).isEmpty(tweety);
   }
 
-  @Test
-  public void testChildElementsCollection() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testChildElementsCollection(TestModelArgs args) {
+    init(args);
     Collection<FlightPartnerRef> flightPartnerRefs = flightPartnerRefCollection.get(tweety);
 
     Iterator<FlightPartnerRef> iterator = flightPartnerRefs.iterator();

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/child/ChildElementCollectionTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/child/ChildElementCollectionTest.java
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.xml.type.child;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.UnsupportedModelOperationException;
 import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
@@ -26,16 +27,13 @@ import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import org.operaton.bpm.model.xml.testmodel.TestModelTest;
 import org.operaton.bpm.model.xml.testmodel.instance.*;
 import org.operaton.bpm.model.xml.type.ModelElementType;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.operaton.bpm.model.xml.test.assertions.ModelAssertions.assertThat;
-import static org.junit.Assert.fail;
-import static org.junit.runners.Parameterized.Parameters;
 
 /**
  * @author Sebastian Menski
@@ -80,7 +78,7 @@ public class ChildElementCollectionTest extends TestModelTest {
     return new Object[]{"created", modelInstance, modelParser};
   }
 
-  @Before
+  @BeforeEach
   public void copyModelInstance() {
     modelInstance = cloneModelInstance();
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/reference/ReferenceTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/reference/ReferenceTest.java
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.xml.type.reference;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.UnsupportedModelOperationException;
-import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
 import org.operaton.bpm.model.xml.impl.type.reference.AttributeReferenceImpl;
 import org.operaton.bpm.model.xml.impl.type.reference.QNameAttributeReferenceImpl;
 import org.operaton.bpm.model.xml.testmodel.Gender;
@@ -31,6 +31,7 @@ import org.operaton.bpm.model.xml.type.attribute.Attribute;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.operaton.bpm.model.xml.test.assertions.ModelAssertions.assertThat;
@@ -52,17 +53,11 @@ public class ReferenceTest extends TestModelTest {
   private AttributeReferenceImpl<Animal> motherReference;
   private ElementReferenceCollection<FlyingAnimal, FlightPartnerRef> flightPartnerRefsColl;
 
-  public ReferenceTest(String testName, ModelInstance testModelInstance, AbstractModelParser modelParser) {
-    super(testName, testModelInstance, modelParser);
+  static Stream<Arguments> models() {
+    return Stream.of(createModel(), parseModel(ReferenceTest.class)).map(Arguments::of);
   }
 
-  @Parameters(name="Model {0}")
-  public static Collection<Object[]> models() {
-    Object[][] models = {createModel(), parseModel(ReferenceTest.class)};
-    return Arrays.asList(models);
-  }
-
-  public static Object[] createModel() {
+  public static TestModelArgs createModel() {
     TestModelParser modelParser = new TestModelParser();
     ModelInstance modelInstance = modelParser.getEmptyModel();
 
@@ -79,13 +74,12 @@ public class ReferenceTest extends TestModelTest {
 
     tweety.getFlightPartnerRefs().add(daffy);
 
-    return new Object[]{"created", modelInstance, modelParser};
+    return new TestModelArgs("created", modelInstance, modelParser);
   }
 
-  @BeforeEach
-  @SuppressWarnings("unchecked")
-  public void copyModelInstance() {
-    modelInstance = cloneModelInstance();
+  @Override
+  protected void init(TestModelArgs args) {
+    super.init(args);
 
     tweety = modelInstance.getModelElementById("tweety");
     daffy = modelInstance.getModelElementById("daffy");
@@ -108,15 +102,19 @@ public class ReferenceTest extends TestModelTest {
     flightPartnerRef = (FlightPartnerRef) modelInstance.getModelElementsByType(flightPartnerRefType).iterator().next();
   }
 
-  @Test
-  public void testReferenceIdentifier() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testReferenceIdentifier(TestModelArgs args) {
+    init(args);
     assertThat(fatherReference).hasIdentifier(tweety, daffy.getId());
     assertThat(motherReference).hasIdentifier(tweety, daisy.getId());
     assertThat(flightPartnerRefsColl).hasIdentifier(tweety, daffy.getId());
   }
 
-  @Test
-  public void testReferenceTargetElement() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testReferenceTargetElement(TestModelArgs args) {
+    init(args);
     assertThat(fatherReference).hasTargetElement(tweety, daffy);
     assertThat(motherReference).hasTargetElement(tweety, daisy);
     assertThat(flightPartnerRefsColl).hasTargetElement(tweety, daffy);
@@ -130,8 +128,10 @@ public class ReferenceTest extends TestModelTest {
     assertThat(flightPartnerRefsColl).hasTargetElement(tweety, daisy);
   }
 
-  @Test
-  public void testReferenceTargetAttribute() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testReferenceTargetAttribute(TestModelArgs args) {
+    init(args);
     Attribute<?> idAttribute = animalType.getAttribute("id");
     assertThat(idAttribute).hasIncomingReferences(fatherReference, motherReference);
 
@@ -140,8 +140,10 @@ public class ReferenceTest extends TestModelTest {
     assertThat(flightPartnerRefsColl).hasTargetAttribute(idAttribute);
   }
 
-  @Test
-  public void testReferenceSourceAttribute() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testReferenceSourceAttribute(TestModelArgs args) {
+    init(args);
     Attribute<?> fatherAttribute = animalType.getAttribute("father");
     Attribute<?> motherAttribute = animalType.getAttribute("mother");
 
@@ -149,8 +151,10 @@ public class ReferenceTest extends TestModelTest {
     assertThat(motherReference).hasSourceAttribute(motherAttribute);
   }
 
-  @Test
-  public void testRemoveReference() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testRemoveReference(TestModelArgs args) {
+    init(args);
     fatherReference.referencedElementRemoved(daffy, daffy.getId());
 
     assertThat(fatherReference).hasNoTargetElement(tweety);
@@ -161,8 +165,10 @@ public class ReferenceTest extends TestModelTest {
     assertThat(tweety.getMother()).isNull();
   }
 
-  @Test
-  public void testTargetElementsCollection() {
+  @ParameterizedTest
+  @MethodSource("models")
+  void testTargetElementsCollection(TestModelArgs args) {
+    init(args);
     Collection<FlyingAnimal> referenceTargetElements = flightPartnerRefsColl.getReferenceTargetElements(tweety);
     Collection<FlyingAnimal> flightPartners = Arrays.asList(new FlyingAnimal[]{birdo, daffy, daisy, plucky});
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/reference/ReferenceTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/reference/ReferenceTest.java
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.xml.type.reference;
-
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.UnsupportedModelOperationException;
 import org.operaton.bpm.model.xml.impl.parser.AbstractModelParser;
@@ -27,15 +28,12 @@ import org.operaton.bpm.model.xml.testmodel.TestModelTest;
 import org.operaton.bpm.model.xml.testmodel.instance.*;
 import org.operaton.bpm.model.xml.type.ModelElementType;
 import org.operaton.bpm.model.xml.type.attribute.Attribute;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
 
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.operaton.bpm.model.xml.test.assertions.ModelAssertions.assertThat;
-import static org.junit.Assert.fail;
-import static org.junit.runners.Parameterized.Parameters;
 
 /**
  * @author Sebastian Menski
@@ -84,7 +82,7 @@ public class ReferenceTest extends TestModelTest {
     return new Object[]{"created", modelInstance, modelParser};
   }
 
-  @Before
+  @BeforeEach
   @SuppressWarnings("unchecked")
   public void copyModelInstance() {
     modelInstance = cloneModelInstance();

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/validation/ModelValidationTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/validation/ModelValidationTest.java
@@ -21,12 +21,12 @@ import static org.assertj.core.api.Assertions.*;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.impl.validation.ModelValidationResultsImpl;
 import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import org.operaton.bpm.model.xml.testmodel.instance.Bird;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Daniel Meyer
@@ -35,7 +35,7 @@ public class ModelValidationTest {
 
   protected ModelInstance modelInstance;
 
-  @Before
+  @BeforeEach
   public void parseModel() {
     TestModelParser modelParser = new TestModelParser();
     String testXml = "org/operaton/bpm/model/xml/testmodel/instance/UnknownAnimalTest.xml";


### PR DESCRIPTION
This change migrates the test code base of
- `model/bpmn-model`
- `model/bcmn-model`
- `model/dmn-model`
- `model/xml-model`
to JUnit 5.

Changes:
- Performed initial migration with Open Rewrite
- Replaced Hamcrest by AssertJ with Open Rewrite
- Manual migration, especially of used JUnit 4 rules. Some tweaking was required for `TestModelTest` and its subclasses, since this `@Parametrized` test used instance setup before each test execution with parameters, but JUnit 5 does not support `@BeforeEach` with parameters.
- Translated parametrized tests
- Dependency management

