### PR TITLE
chore(internal-dependencies): Bump to commons-io:2.17.0

### DIFF
--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -62,7 +62,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.14.0</version>
+        <version>2.17.0</version>
       </dependency>
       <dependency>
         <groupId>commons-fileupload</groupId>


### PR DESCRIPTION
Related-to: https://github.com/camunda/camunda-bpm-platform/issues/4720

Backported commit 57d462377d3 from the camunda-bpm-platform repository.
Original author: psavidis <69160690+psavidis@users.noreply.github.com>