### PR TITLE
feat(ci): Improve build performance by configure surefire forkCount (#205)

### DIFF
--- a/engine-plugins/identity-ldap/pom.xml
+++ b/engine-plugins/identity-ldap/pom.xml
@@ -15,6 +15,7 @@
   <properties>
     <ldap.server.port>10389</ldap.server.port>
     <ldap.server.port.posix>5027</ldap.server.port.posix>
+    <surefire.forkCount>1</surefire.forkCount>
   </properties>
 
   <dependencies>

--- a/engine-rest/pom.xml
+++ b/engine-rest/pom.xml
@@ -19,6 +19,7 @@
     <version.groovy>3.0.9</version.groovy>
     <version.apache.httpcore>4.4.5</version.apache.httpcore>
     <version.commons-codec>1.15</version.commons-codec>
+    <surefire.forkCount>1</surefire.forkCount>
   </properties>
 
   <dependencyManagement>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -653,9 +653,6 @@
 
     <profile>
       <id>h2-in-memory</id>
-      <properties>
-        <forkCount>0.5C</forkCount>
-      </properties>
       <build>
         <plugins>
           <plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -82,6 +82,7 @@
     <jacoco.argLine/>
     <surefire.memArgs>-Xmx1024m -XX:MetaspaceSize=128m</surefire.memArgs>
     <surefire.argLine>${jacoco.argLine} ${surefire.memArgs} -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${project.build.directory}/heap_dump.hprof</surefire.argLine>
+    <surefire.forkCount>0.5C</surefire.forkCount>
 
     <!-- OSGi bundles properties -->
     <operaton.artifact />
@@ -148,6 +149,7 @@
               <myWorkingDir>${project.build.directory}</myWorkingDir>
             </systemPropertyVariables>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
+            <forkCount>${surefire.forkCount}</forkCount>
           </configuration>
         </plugin>
         <plugin>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -14,6 +14,10 @@
 
   <packaging>pom</packaging>
 
+  <properties>
+    <surefire.forkCount>1</surefire.forkCount>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -41,6 +41,8 @@
     <!-- frontend-sources artifact is for internal use only.
     Artifact generation is skipped when it comes to maven central deployment -->
     <skip-zip-frontend-sources>false</skip-zip-frontend-sources>
+
+    <surefire.forkCount>1</surefire.forkCount>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Defines a property `surefire.forkCount` on `parent/pom.xml` with value `0.5C`, and configure surefire's `forkCount` with this value.

Override the property with value `1` on modules that can't execute multiple tests in parallel, because they need exclusive resource access (e.g. port or directory).

fixes #205 