### PR TITLE
refactor(tests): JUnit5 Migration: Migrate Hamcrest to AssertJ (#27)

### DIFF
--- a/commons/typed-values/pom.xml
+++ b/commons/typed-values/pom.xml
@@ -39,6 +39,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-junit</artifactId>
     </dependency>

--- a/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
+++ b/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
@@ -16,13 +16,7 @@
  */
 package org.operaton.bpm.engine.test.variables;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsMapContaining.hasEntry;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -59,28 +53,28 @@ class FileValueTypeImplTest {
 
   @Test
   void nameShouldBeFile() {
-    assertThat(type.getName(), is("file"));
+    assertThat(type.getName()).isEqualTo("file");
   }
 
   @Test
   void shouldNotHaveParent() {
-    assertThat(type.getParent(), is(nullValue()));
+    assertThat(type.getParent()).isNull();
   }
 
   @Test
   void isPrimitiveValue() {
-    assertThat(type.isPrimitiveValueType(), is(true));
+    assertThat(type.isPrimitiveValueType()).isEqualTo(true);
   }
 
   @Test
   void isNotAnAbstractType() {
-    assertThat(type.isAbstract(), is(false));
+    assertThat(type.isAbstract()).isEqualTo(false);
   }
 
   @Test
   void canNotConvertFromAnyValue() {
     // we just use null to make sure false is always returned
-    assertThat(type.canConvertFromTypedValue(null), is(false));
+    assertThat(type.canConvertFromTypedValue(null)).isEqualTo(false);
   }
 
   @Test
@@ -93,8 +87,8 @@ class FileValueTypeImplTest {
   void createValueFromFile() throws URISyntaxException {
     File file = new File(this.getClass().getClassLoader().getResource("org/operaton/bpm/engine/test/variables/simpleFile.txt").toURI());
     TypedValue value = type.createValue(file, Collections.<String, Object> singletonMap(FileValueTypeImpl.VALUE_INFO_FILE_NAME, "simpleFile.txt"));
-    assertThat(value, is(instanceOf(FileValue.class)));
-    assertThat(value.getType(), is(instanceOf(FileValueTypeImpl.class)));
+    assertThat(value).isInstanceOf(FileValue.class);
+    assertThat(value.getType()).isInstanceOf(FileValueTypeImpl.class);
     checkStreamFromValue(value, "text");
   }
 
@@ -102,8 +96,8 @@ class FileValueTypeImplTest {
   void createValueFromStream() {
     InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
     TypedValue value = type.createValue(file, Collections.<String, Object> singletonMap(FileValueTypeImpl.VALUE_INFO_FILE_NAME, "simpleFile.txt"));
-    assertThat(value, is(instanceOf(FileValue.class)));
-    assertThat(value.getType(), is(instanceOf(FileValueTypeImpl.class)));
+    assertThat(value).isInstanceOf(FileValue.class);
+    assertThat(value.getType()).isInstanceOf(FileValueTypeImpl.class);
     checkStreamFromValue(value, "text");
   }
 
@@ -111,8 +105,8 @@ class FileValueTypeImplTest {
   void createValueFromBytes() throws IOException, URISyntaxException {
     File file = new File(this.getClass().getClassLoader().getResource("org/operaton/bpm/engine/test/variables/simpleFile.txt").toURI());
     TypedValue value = type.createValue(file, Collections.<String, Object> singletonMap(FileValueTypeImpl.VALUE_INFO_FILE_NAME, "simpleFile.txt"));
-    assertThat(value, is(instanceOf(FileValue.class)));
-    assertThat(value.getType(), is(instanceOf(FileValueTypeImpl.class)));
+    assertThat(value).isInstanceOf(FileValue.class);
+    assertThat(value.getType()).isInstanceOf(FileValueTypeImpl.class);
     checkStreamFromValue(value, "text");
   }
 
@@ -133,11 +127,11 @@ class FileValueTypeImplTest {
 
     TypedValue value = type.createValue(file, properties);
 
-    assertThat(value, is(instanceOf(FileValue.class)));
+    assertThat(value).isInstanceOf(FileValue.class);
     FileValue fileValue = (FileValue) value;
-    assertThat(fileValue.getFilename(), is("someFileName"));
-    assertThat(fileValue.getMimeType(), is("someMimeType"));
-    assertThat(fileValue.getEncoding(), is("someEncoding"));
+    assertThat(fileValue.getFilename()).isEqualTo("someFileName");
+    assertThat(fileValue.getMimeType()).isEqualTo("someMimeType");
+    assertThat(fileValue.getEncoding()).isEqualTo("someEncoding");
   }
 
 
@@ -156,7 +150,7 @@ class FileValueTypeImplTest {
       fail("expected exception");
     } catch (IllegalArgumentException e) {
       // then
-      assertThat(e.getMessage(), containsString("The provided mime type is null. Set a non-null value info property with key 'filename'"));
+      assertThat(e.getMessage()).contains("The provided mime type is null. Set a non-null value info property with key 'filename'");
     }
 
     // given
@@ -171,7 +165,7 @@ class FileValueTypeImplTest {
       fail("expected exception");
     } catch (IllegalArgumentException e) {
       // then
-      assertThat(e.getMessage(), containsString("The provided encoding is null. Set a non-null value info property with key 'encoding'"));
+      assertThat(e.getMessage()).contains("The provided encoding is null. Set a non-null value info property with key 'encoding'");
     }
   }
 
@@ -198,7 +192,7 @@ class FileValueTypeImplTest {
     try {
       type.createValue(file, info);
     } catch (IllegalArgumentException e) {
-      assertThat(e.getMessage(), containsString("The property 'transient' should have a value of type 'boolean'."));
+      assertThat(e.getMessage()).contains("The property 'transient' should have a value of type 'boolean'.");
     }
     
   }
@@ -212,10 +206,10 @@ class FileValueTypeImplTest {
     FileValue fileValue = Variables.fileValue(fileName).file(file).mimeType(fileType).encoding(encoding).setTransient(true).create();
     Map<String, Object> info = type.getValueInfo(fileValue);
 
-    assertThat(info, hasEntry(FileValueTypeImpl.VALUE_INFO_FILE_NAME, (Object) fileName));
-    assertThat(info, hasEntry(FileValueTypeImpl.VALUE_INFO_FILE_MIME_TYPE, (Object) fileType));
-    assertThat(info, hasEntry(FileValueTypeImpl.VALUE_INFO_FILE_ENCODING, (Object) encoding.name()));
-    assertThat(info, hasEntry(FileValueTypeImpl.VALUE_INFO_TRANSIENT, (Object) true));
+    assertThat(info).containsEntry(FileValueTypeImpl.VALUE_INFO_FILE_NAME, (Object) fileName);
+    assertThat(info).containsEntry(FileValueTypeImpl.VALUE_INFO_FILE_MIME_TYPE, (Object) fileType);
+    assertThat(info).containsEntry(FileValueTypeImpl.VALUE_INFO_FILE_ENCODING, (Object) encoding.name());
+    assertThat(info).containsEntry(FileValueTypeImpl.VALUE_INFO_TRANSIENT, (Object) true);
   }
 
   @Test
@@ -227,9 +221,9 @@ class FileValueTypeImplTest {
     FileValue fileValue = Variables.fileValue(fileName).file(file).mimeType(fileType).encoding(encoding).create();
     Map<String, Object> info = type.getValueInfo(fileValue);
 
-    assertThat(info, hasEntry(FileValueTypeImpl.VALUE_INFO_FILE_NAME, (Object) fileName));
-    assertThat(info, hasEntry(FileValueTypeImpl.VALUE_INFO_FILE_MIME_TYPE, (Object) fileType));
-    assertThat(info, hasEntry(FileValueTypeImpl.VALUE_INFO_FILE_ENCODING, (Object) encoding));
+    assertThat(info).containsEntry(FileValueTypeImpl.VALUE_INFO_FILE_NAME, (Object) fileName);
+    assertThat(info).containsEntry(FileValueTypeImpl.VALUE_INFO_FILE_MIME_TYPE, (Object) fileType);
+    assertThat(info).containsEntry(FileValueTypeImpl.VALUE_INFO_FILE_ENCODING, (Object) encoding);
   }
 
   @Test
@@ -239,7 +233,7 @@ class FileValueTypeImplTest {
 
     FileValue fileValue = Variables.fileValue(fileName).file(file).create();
     file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
-    assertThat(IoUtil.inputStreamAsByteArray(fileValue.getValue()), equalTo(IoUtil.inputStreamAsByteArray(file)));
+    assertThat(IoUtil.inputStreamAsByteArray(fileValue.getValue())).isEqualTo(IoUtil.inputStreamAsByteArray(file));
   }
 
   @Test
@@ -251,18 +245,18 @@ class FileValueTypeImplTest {
     String fileName = "simpleFile.txt";
 
     FileValue fileValue = Variables.fileValue(fileName).file(byteStream).create();
-    assertThat(IoUtil.inputStreamAsByteArray(fileValue.getValue()), equalTo(bytes));
+    assertThat(IoUtil.inputStreamAsByteArray(fileValue.getValue())).isEqualTo(bytes);
   }
 
   @Test
   void doesNotHaveParent(){
-    assertThat(type.getParent(), is(nullValue()));
+    assertThat(type.getParent()).isNull();
   }
 
 
   private void checkStreamFromValue(TypedValue value, String expected) {
     InputStream stream = (InputStream) value.getValue();
     Scanner scanner = new Scanner(stream);
-    assertThat(scanner.nextLine(), is(expected));
+    assertThat(scanner.nextLine()).isEqualTo(expected);
   }
 }

--- a/engine-cdi/core/src/test/java/org/operaton/bpm/engine/cdi/test/impl/util/ProgrammaticBeanLookupTest.java
+++ b/engine-cdi/core/src/test/java/org/operaton/bpm/engine/cdi/test/impl/util/ProgrammaticBeanLookupTest.java
@@ -16,16 +16,10 @@
  */
 package org.operaton.bpm.engine.cdi.test.impl.util;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.enterprise.inject.Alternative;
 import javax.inject.Named;
-
-import org.operaton.bpm.engine.cdi.impl.ProcessEngineServicesProducer;
-import org.operaton.bpm.engine.cdi.impl.util.ProgrammaticBeanLookup;
-import org.operaton.bpm.engine.cdi.test.impl.beans.SpecializedTestBean;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -34,6 +28,9 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.operaton.bpm.engine.cdi.impl.ProcessEngineServicesProducer;
+import org.operaton.bpm.engine.cdi.impl.util.ProgrammaticBeanLookup;
+import org.operaton.bpm.engine.cdi.test.impl.beans.SpecializedTestBean;
 
 /**
  *
@@ -88,7 +85,7 @@ public class ProgrammaticBeanLookupTest {
   public void testLookupBean() {
     deployer.deploy("normal");
     Object lookup = ProgrammaticBeanLookup.lookup("testOnly");
-    assertThat(lookup, instanceOf(TestBean.class));
+    assertThat(lookup).isInstanceOf(TestBean.class);
     deployer.undeploy("normal");
   }
 
@@ -96,8 +93,7 @@ public class ProgrammaticBeanLookupTest {
   public void testLookupShouldFindAlternative() {
     deployer.deploy("withAlternative");
     Object lookup = ProgrammaticBeanLookup.lookup("testOnly");
-    assertThat(lookup.getClass().getName(),
-        is(equalTo(AlternativeTestBean.class.getName())));
+    assertThat(lookup.getClass().getName()).isEqualTo(AlternativeTestBean.class.getName());
     deployer.undeploy("withAlternative");
   }
 
@@ -105,15 +101,14 @@ public class ProgrammaticBeanLookupTest {
   public void testLookupShouldFindSpecialization() {
     deployer.deploy("withSpecialization");
     Object lookup = ProgrammaticBeanLookup.lookup("testOnly");
-    assertThat(lookup.getClass().getName(),
-        is(equalTo(SpecializedTestBean.class.getName())));
+    assertThat(lookup.getClass().getName()).isEqualTo(SpecializedTestBean.class.getName());
     deployer.undeploy("withSpecialization");
   }
 
   @Test
   public void testLookupShouldSupportProducerMethods() {
     deployer.deploy("withProducerMethod");
-    assertEquals("exampleString", ProgrammaticBeanLookup.lookup("producedString"));
+    assertThat(ProgrammaticBeanLookup.lookup("producedString")).isEqualTo("exampleString");
     deployer.undeploy("withProducerMethod");
   }
 

--- a/engine-cdi/core/src/test/java/org/operaton/bpm/engine/cdi/test/impl/util/ProgrammaticBeanLookupTest.java
+++ b/engine-cdi/core/src/test/java/org/operaton/bpm/engine/cdi/test/impl/util/ProgrammaticBeanLookupTest.java
@@ -16,9 +16,7 @@
  */
 package org.operaton.bpm.engine.cdi.test.impl.util;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/type/DmnDataTypeTransformerTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/type/DmnDataTypeTransformerTest.java
@@ -16,19 +16,7 @@
  */
 package org.operaton.bpm.dmn.engine.type;
 
-import org.operaton.bpm.dmn.engine.DmnEngineConfiguration;
-import org.operaton.bpm.dmn.engine.DmnEngineException;
-import org.operaton.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
-import org.operaton.bpm.dmn.engine.impl.spi.type.DmnDataTypeTransformer;
-import org.operaton.bpm.dmn.engine.impl.spi.type.DmnDataTypeTransformerRegistry;
-import org.operaton.bpm.dmn.engine.test.DmnEngineTest;
-import org.operaton.bpm.engine.variable.Variables;
-import org.operaton.bpm.engine.variable.value.TypedValue;
-import org.camunda.feel.syntaxtree.ZonedTime;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -40,8 +28,19 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.TimeZone;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.camunda.feel.syntaxtree.ZonedTime;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.operaton.bpm.dmn.engine.DmnEngineConfiguration;
+import org.operaton.bpm.dmn.engine.DmnEngineException;
+import org.operaton.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
+import org.operaton.bpm.dmn.engine.impl.spi.type.DmnDataTypeTransformer;
+import org.operaton.bpm.dmn.engine.impl.spi.type.DmnDataTypeTransformerRegistry;
+import org.operaton.bpm.dmn.engine.test.DmnEngineTest;
+import org.operaton.bpm.engine.variable.Variables;
+import org.operaton.bpm.engine.variable.value.TypedValue;
 
 /**
  * Tests the build-in {@link DmnDataTypeTransformer}s.
@@ -72,22 +71,22 @@ public class DmnDataTypeTransformerTest extends DmnEngineTest {
   public void stringType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("string");
 
-    assertThat(typeTransformer.transform("abc")).isEqualTo((TypedValue) Variables.stringValue("abc"));
-    assertThat(typeTransformer.transform(true)).isEqualTo((TypedValue) Variables.stringValue("true"));
-    assertThat(typeTransformer.transform(4)).isEqualTo((TypedValue) Variables.stringValue("4"));
-    assertThat(typeTransformer.transform(2L)).isEqualTo((TypedValue) Variables.stringValue("2"));
-    assertThat(typeTransformer.transform(4.2)).isEqualTo((TypedValue) Variables.stringValue("4.2"));
+    assertThat(typeTransformer.transform("abc")).isEqualTo(Variables.stringValue("abc"));
+    assertThat(typeTransformer.transform(true)).isEqualTo(Variables.stringValue("true"));
+    assertThat(typeTransformer.transform(4)).isEqualTo(Variables.stringValue("4"));
+    assertThat(typeTransformer.transform(2L)).isEqualTo(Variables.stringValue("2"));
+    assertThat(typeTransformer.transform(4.2)).isEqualTo(Variables.stringValue("4.2"));
   }
 
   @Test
   public void booleanType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("boolean");
 
-    assertThat(typeTransformer.transform(true)).isEqualTo((TypedValue) Variables.booleanValue(true));
-    assertThat(typeTransformer.transform(false)).isEqualTo((TypedValue) Variables.booleanValue(false));
+    assertThat(typeTransformer.transform(true)).isEqualTo(Variables.booleanValue(true));
+    assertThat(typeTransformer.transform(false)).isEqualTo(Variables.booleanValue(false));
 
-    assertThat(typeTransformer.transform("true")).isEqualTo((TypedValue) Variables.booleanValue(true));
-    assertThat(typeTransformer.transform("false")).isEqualTo((TypedValue) Variables.booleanValue(false));
+    assertThat(typeTransformer.transform("true")).isEqualTo(Variables.booleanValue(true));
+    assertThat(typeTransformer.transform("false")).isEqualTo(Variables.booleanValue(false));
   }
 
   @Test
@@ -103,13 +102,13 @@ public class DmnDataTypeTransformerTest extends DmnEngineTest {
   public void integerType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("integer");
 
-    assertThat(typeTransformer.transform(4)).isEqualTo((TypedValue) Variables.integerValue(4));
-    assertThat(typeTransformer.transform("4")).isEqualTo((TypedValue) Variables.integerValue(4));
-    assertThat(typeTransformer.transform(2L)).isEqualTo((TypedValue) Variables.integerValue(2));
-    assertThat(typeTransformer.transform(4.0)).isEqualTo((TypedValue) Variables.integerValue(4));
+    assertThat(typeTransformer.transform(4)).isEqualTo(Variables.integerValue(4));
+    assertThat(typeTransformer.transform("4")).isEqualTo(Variables.integerValue(4));
+    assertThat(typeTransformer.transform(2L)).isEqualTo(Variables.integerValue(2));
+    assertThat(typeTransformer.transform(4.0)).isEqualTo(Variables.integerValue(4));
 
-    assertThat(typeTransformer.transform(Integer.MIN_VALUE)).isEqualTo((TypedValue) Variables.integerValue(Integer.MIN_VALUE));
-    assertThat(typeTransformer.transform(Integer.MAX_VALUE)).isEqualTo((TypedValue) Variables.integerValue(Integer.MAX_VALUE));
+    assertThat(typeTransformer.transform(Integer.MIN_VALUE)).isEqualTo(Variables.integerValue(Integer.MIN_VALUE));
+    assertThat(typeTransformer.transform(Integer.MAX_VALUE)).isEqualTo(Variables.integerValue(Integer.MAX_VALUE));
   }
 
   @Test
@@ -161,13 +160,13 @@ public class DmnDataTypeTransformerTest extends DmnEngineTest {
   public void longType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("long");
 
-    assertThat(typeTransformer.transform(2L)).isEqualTo((TypedValue) Variables.longValue(2L));
-    assertThat(typeTransformer.transform("2")).isEqualTo((TypedValue) Variables.longValue(2L));
-    assertThat(typeTransformer.transform(4)).isEqualTo((TypedValue) Variables.longValue(4L));
-    assertThat(typeTransformer.transform(4.0)).isEqualTo((TypedValue) Variables.longValue(4L));
+    assertThat(typeTransformer.transform(2L)).isEqualTo(Variables.longValue(2L));
+    assertThat(typeTransformer.transform("2")).isEqualTo(Variables.longValue(2L));
+    assertThat(typeTransformer.transform(4)).isEqualTo(Variables.longValue(4L));
+    assertThat(typeTransformer.transform(4.0)).isEqualTo(Variables.longValue(4L));
 
-    assertThat(typeTransformer.transform(Long.MIN_VALUE)).isEqualTo((TypedValue) Variables.longValue(Long.MIN_VALUE));
-    assertThat(typeTransformer.transform(Long.MAX_VALUE)).isEqualTo((TypedValue) Variables.longValue(Long.MAX_VALUE));
+    assertThat(typeTransformer.transform(Long.MIN_VALUE)).isEqualTo(Variables.longValue(Long.MIN_VALUE));
+    assertThat(typeTransformer.transform(Long.MAX_VALUE)).isEqualTo(Variables.longValue(Long.MAX_VALUE));
   }
 
   @Test
@@ -201,15 +200,15 @@ public class DmnDataTypeTransformerTest extends DmnEngineTest {
   public void doubleType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("double");
 
-    assertThat(typeTransformer.transform(4.2)).isEqualTo((TypedValue) Variables.doubleValue(4.2));
-    assertThat(typeTransformer.transform("4.2")).isEqualTo((TypedValue) Variables.doubleValue(4.2));
-    assertThat(typeTransformer.transform(4)).isEqualTo((TypedValue) Variables.doubleValue(4.0));
-    assertThat(typeTransformer.transform(4L)).isEqualTo((TypedValue) Variables.doubleValue(4.0));
+    assertThat(typeTransformer.transform(4.2)).isEqualTo(Variables.doubleValue(4.2));
+    assertThat(typeTransformer.transform("4.2")).isEqualTo(Variables.doubleValue(4.2));
+    assertThat(typeTransformer.transform(4)).isEqualTo(Variables.doubleValue(4.0));
+    assertThat(typeTransformer.transform(4L)).isEqualTo(Variables.doubleValue(4.0));
 
-    assertThat(typeTransformer.transform(Double.MIN_VALUE)).isEqualTo((TypedValue) Variables.doubleValue(Double.MIN_VALUE));
-    assertThat(typeTransformer.transform(Double.MAX_VALUE)).isEqualTo((TypedValue) Variables.doubleValue(Double.MAX_VALUE));
-    assertThat(typeTransformer.transform(-Double.MAX_VALUE)).isEqualTo((TypedValue) Variables.doubleValue(-Double.MAX_VALUE));
-    assertThat(typeTransformer.transform(Long.MAX_VALUE)).isEqualTo((TypedValue) Variables.doubleValue((double) Long.MAX_VALUE));
+    assertThat(typeTransformer.transform(Double.MIN_VALUE)).isEqualTo(Variables.doubleValue(Double.MIN_VALUE));
+    assertThat(typeTransformer.transform(Double.MAX_VALUE)).isEqualTo(Variables.doubleValue(Double.MAX_VALUE));
+    assertThat(typeTransformer.transform(-Double.MAX_VALUE)).isEqualTo(Variables.doubleValue(-Double.MAX_VALUE));
+    assertThat(typeTransformer.transform(Long.MAX_VALUE)).isEqualTo(Variables.doubleValue((double) Long.MAX_VALUE));
   }
 
   @Test

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/type/DmnDataTypeTransformerTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/type/DmnDataTypeTransformerTest.java
@@ -41,8 +41,7 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.TimeZone;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests the build-in {@link DmnDataTypeTransformer}s.
@@ -66,29 +65,29 @@ public class DmnDataTypeTransformerTest extends DmnEngineTest {
   public void customType() {
     // by default, the factory should return a transformer for unsupported type
     // that just box the value into an untyped value
-    assertThat(registry.getTransformer("custom").transform("42"), is(Variables.untypedValue("42")));
+    assertThat(registry.getTransformer("custom").transform("42")).isEqualTo(Variables.untypedValue("42"));
   }
 
   @Test
   public void stringType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("string");
 
-    assertThat(typeTransformer.transform("abc"), is((TypedValue) Variables.stringValue("abc")));
-    assertThat(typeTransformer.transform(true), is((TypedValue) Variables.stringValue("true")));
-    assertThat(typeTransformer.transform(4), is((TypedValue) Variables.stringValue("4")));
-    assertThat(typeTransformer.transform(2L), is((TypedValue) Variables.stringValue("2")));
-    assertThat(typeTransformer.transform(4.2), is((TypedValue) Variables.stringValue("4.2")));
+    assertThat(typeTransformer.transform("abc")).isEqualTo((TypedValue) Variables.stringValue("abc"));
+    assertThat(typeTransformer.transform(true)).isEqualTo((TypedValue) Variables.stringValue("true"));
+    assertThat(typeTransformer.transform(4)).isEqualTo((TypedValue) Variables.stringValue("4"));
+    assertThat(typeTransformer.transform(2L)).isEqualTo((TypedValue) Variables.stringValue("2"));
+    assertThat(typeTransformer.transform(4.2)).isEqualTo((TypedValue) Variables.stringValue("4.2"));
   }
 
   @Test
   public void booleanType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("boolean");
 
-    assertThat(typeTransformer.transform(true), is((TypedValue) Variables.booleanValue(true)));
-    assertThat(typeTransformer.transform(false), is((TypedValue) Variables.booleanValue(false)));
+    assertThat(typeTransformer.transform(true)).isEqualTo((TypedValue) Variables.booleanValue(true));
+    assertThat(typeTransformer.transform(false)).isEqualTo((TypedValue) Variables.booleanValue(false));
 
-    assertThat(typeTransformer.transform("true"), is((TypedValue) Variables.booleanValue(true)));
-    assertThat(typeTransformer.transform("false"), is((TypedValue) Variables.booleanValue(false)));
+    assertThat(typeTransformer.transform("true")).isEqualTo((TypedValue) Variables.booleanValue(true));
+    assertThat(typeTransformer.transform("false")).isEqualTo((TypedValue) Variables.booleanValue(false));
   }
 
   @Test
@@ -104,13 +103,13 @@ public class DmnDataTypeTransformerTest extends DmnEngineTest {
   public void integerType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("integer");
 
-    assertThat(typeTransformer.transform(4), is((TypedValue) Variables.integerValue(4)));
-    assertThat(typeTransformer.transform("4"), is((TypedValue) Variables.integerValue(4)));
-    assertThat(typeTransformer.transform(2L), is((TypedValue) Variables.integerValue(2)));
-    assertThat(typeTransformer.transform(4.0), is((TypedValue) Variables.integerValue(4)));
+    assertThat(typeTransformer.transform(4)).isEqualTo((TypedValue) Variables.integerValue(4));
+    assertThat(typeTransformer.transform("4")).isEqualTo((TypedValue) Variables.integerValue(4));
+    assertThat(typeTransformer.transform(2L)).isEqualTo((TypedValue) Variables.integerValue(2));
+    assertThat(typeTransformer.transform(4.0)).isEqualTo((TypedValue) Variables.integerValue(4));
 
-    assertThat(typeTransformer.transform(Integer.MIN_VALUE), is((TypedValue) Variables.integerValue(Integer.MIN_VALUE)));
-    assertThat(typeTransformer.transform(Integer.MAX_VALUE), is((TypedValue) Variables.integerValue(Integer.MAX_VALUE)));
+    assertThat(typeTransformer.transform(Integer.MIN_VALUE)).isEqualTo((TypedValue) Variables.integerValue(Integer.MIN_VALUE));
+    assertThat(typeTransformer.transform(Integer.MAX_VALUE)).isEqualTo((TypedValue) Variables.integerValue(Integer.MAX_VALUE));
   }
 
   @Test
@@ -162,13 +161,13 @@ public class DmnDataTypeTransformerTest extends DmnEngineTest {
   public void longType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("long");
 
-    assertThat(typeTransformer.transform(2L), is((TypedValue) Variables.longValue(2L)));
-    assertThat(typeTransformer.transform("2"), is((TypedValue) Variables.longValue(2L)));
-    assertThat(typeTransformer.transform(4), is((TypedValue) Variables.longValue(4L)));
-    assertThat(typeTransformer.transform(4.0), is((TypedValue) Variables.longValue(4L)));
+    assertThat(typeTransformer.transform(2L)).isEqualTo((TypedValue) Variables.longValue(2L));
+    assertThat(typeTransformer.transform("2")).isEqualTo((TypedValue) Variables.longValue(2L));
+    assertThat(typeTransformer.transform(4)).isEqualTo((TypedValue) Variables.longValue(4L));
+    assertThat(typeTransformer.transform(4.0)).isEqualTo((TypedValue) Variables.longValue(4L));
 
-    assertThat(typeTransformer.transform(Long.MIN_VALUE), is((TypedValue) Variables.longValue(Long.MIN_VALUE)));
-    assertThat(typeTransformer.transform(Long.MAX_VALUE), is((TypedValue) Variables.longValue(Long.MAX_VALUE)));
+    assertThat(typeTransformer.transform(Long.MIN_VALUE)).isEqualTo((TypedValue) Variables.longValue(Long.MIN_VALUE));
+    assertThat(typeTransformer.transform(Long.MAX_VALUE)).isEqualTo((TypedValue) Variables.longValue(Long.MAX_VALUE));
   }
 
   @Test
@@ -202,15 +201,15 @@ public class DmnDataTypeTransformerTest extends DmnEngineTest {
   public void doubleType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("double");
 
-    assertThat(typeTransformer.transform(4.2), is((TypedValue) Variables.doubleValue(4.2)));
-    assertThat(typeTransformer.transform("4.2"), is((TypedValue) Variables.doubleValue(4.2)));
-    assertThat(typeTransformer.transform(4), is((TypedValue) Variables.doubleValue(4.0)));
-    assertThat(typeTransformer.transform(4L), is((TypedValue) Variables.doubleValue(4.0)));
+    assertThat(typeTransformer.transform(4.2)).isEqualTo((TypedValue) Variables.doubleValue(4.2));
+    assertThat(typeTransformer.transform("4.2")).isEqualTo((TypedValue) Variables.doubleValue(4.2));
+    assertThat(typeTransformer.transform(4)).isEqualTo((TypedValue) Variables.doubleValue(4.0));
+    assertThat(typeTransformer.transform(4L)).isEqualTo((TypedValue) Variables.doubleValue(4.0));
 
-    assertThat(typeTransformer.transform(Double.MIN_VALUE), is((TypedValue) Variables.doubleValue(Double.MIN_VALUE)));
-    assertThat(typeTransformer.transform(Double.MAX_VALUE), is((TypedValue) Variables.doubleValue(Double.MAX_VALUE)));
-    assertThat(typeTransformer.transform(-Double.MAX_VALUE), is((TypedValue) Variables.doubleValue(-Double.MAX_VALUE)));
-    assertThat(typeTransformer.transform(Long.MAX_VALUE), is((TypedValue) Variables.doubleValue((double) Long.MAX_VALUE)));
+    assertThat(typeTransformer.transform(Double.MIN_VALUE)).isEqualTo((TypedValue) Variables.doubleValue(Double.MIN_VALUE));
+    assertThat(typeTransformer.transform(Double.MAX_VALUE)).isEqualTo((TypedValue) Variables.doubleValue(Double.MAX_VALUE));
+    assertThat(typeTransformer.transform(-Double.MAX_VALUE)).isEqualTo((TypedValue) Variables.doubleValue(-Double.MAX_VALUE));
+    assertThat(typeTransformer.transform(Long.MAX_VALUE)).isEqualTo((TypedValue) Variables.doubleValue((double) Long.MAX_VALUE));
   }
 
   @Test
@@ -229,8 +228,8 @@ public class DmnDataTypeTransformerTest extends DmnEngineTest {
     Date date = toDate("2015-09-18T12:00:00", null);
     TypedValue dateValue = Variables.dateValue(date);
 
-    assertThat(typeTransformer.transform("2015-09-18T12:00:00"), is(dateValue));
-    assertThat(typeTransformer.transform(date), is(dateValue));
+    assertThat(typeTransformer.transform("2015-09-18T12:00:00")).isEqualTo(dateValue);
+    assertThat(typeTransformer.transform(date)).isEqualTo(dateValue);
   }
 
   @Test
@@ -246,7 +245,7 @@ public class DmnDataTypeTransformerTest extends DmnEngineTest {
     TypedValue transformedFromZonedDateTime = typeTransformer.transform(zonedDateTime);
 
     // then
-    assertThat(transformedFromZonedDateTime, is(dateValue));
+    assertThat(transformedFromZonedDateTime).isEqualTo(dateValue);
   }
 
   @Test
@@ -262,7 +261,7 @@ public class DmnDataTypeTransformerTest extends DmnEngineTest {
     TypedValue transformedFromLocalDateTime = typeTransformer.transform(localDateTime);
 
     // then
-    assertThat(transformedFromLocalDateTime, is(dateValue));
+    assertThat(transformedFromLocalDateTime).isEqualTo(dateValue);
   }
 
   @Test

--- a/engine-plugins/connect-plugin/src/test/java/org/operaton/connect/plugin/ConnectProcessEnginePluginTest.java
+++ b/engine-plugins/connect-plugin/src/test/java/org/operaton/connect/plugin/ConnectProcessEnginePluginTest.java
@@ -16,9 +16,7 @@
  */
 package org.operaton.connect.plugin;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.operaton.bpm.engine.impl.test.ProcessEngineAssert.assertProcessEnded;
 
@@ -164,7 +162,7 @@ class ConnectProcessEnginePluginTest {
     runtimeService.startProcessInstanceByKey("testProcess", variables);
     //we will only reach the user task if the BPMNError from the script was handled by the boundary event
     Task task = taskService.createTaskQuery().singleResult();
-    assertThat(task.getName(), is("User Task"));
+    assertThat(task.getName()).isEqualTo("User Task");
   }
 
   @Deployment(resources = "org/operaton/connect/plugin/ConnectProcessEnginePluginTest.connectorWithThrownExceptionInScriptInputOutputMapping.bpmn")
@@ -177,7 +175,7 @@ class ConnectProcessEnginePluginTest {
     try {
       runtimeService.startProcessInstanceByKey("testProcess", variables);
     } catch(RuntimeException re){
-      assertThat(re.getMessage(), containsString(exceptionMessage));
+      assertThat(re.getMessage()).contains(exceptionMessage);
     }
   }
 
@@ -190,7 +188,7 @@ class ConnectProcessEnginePluginTest {
     runtimeService.startProcessInstanceByKey("testProcess", variables);
     //we will only reach the user task if the BPMNError from the script was handled by the boundary event
     Task task = taskService.createTaskQuery().singleResult();
-    assertThat(task.getName(), is("User Task"));
+    assertThat(task.getName()).isEqualTo("User Task");
   }
 
   @Deployment(resources = "org/operaton/connect/plugin/ConnectProcessEnginePluginTest.connectorWithThrownExceptionInScriptInputOutputMapping.bpmn")
@@ -203,7 +201,7 @@ class ConnectProcessEnginePluginTest {
     try {
       runtimeService.startProcessInstanceByKey("testProcess", variables);
     } catch(RuntimeException re){
-      assertThat(re.getMessage(), containsString(exceptionMessage));
+      assertThat(re.getMessage()).contains(exceptionMessage);
     }
   }
 
@@ -216,7 +214,7 @@ class ConnectProcessEnginePluginTest {
     runtimeService.startProcessInstanceByKey("testProcess", variables);
     //we will only reach the user task if the BPMNError from the script was handled by the boundary event
     Task task = taskService.createTaskQuery().singleResult();
-    assertThat(task.getName(), is("User Task"));
+    assertThat(task.getName()).isEqualTo("User Task");
   }
 
   @Deployment(resources = "org/operaton/connect/plugin/ConnectProcessEnginePluginTest.connectorWithThrownExceptionInScriptResourceInputOutputMapping.bpmn")
@@ -229,7 +227,7 @@ class ConnectProcessEnginePluginTest {
     try {
       runtimeService.startProcessInstanceByKey("testProcess", variables);
     } catch(RuntimeException re){
-      assertThat(re.getMessage(), containsString(exceptionMessage));
+      assertThat(re.getMessage()).contains(exceptionMessage);
     }
   }
 
@@ -242,7 +240,7 @@ class ConnectProcessEnginePluginTest {
     runtimeService.startProcessInstanceByKey("testProcess", variables);
     //we will only reach the user task if the BPMNError from the script was handled by the boundary event
     Task task = taskService.createTaskQuery().singleResult();
-    assertThat(task.getName(), is("User Task"));
+    assertThat(task.getName()).isEqualTo("User Task");
   }
 
   @Deployment(resources = "org/operaton/connect/plugin/ConnectProcessEnginePluginTest.connectorWithThrownExceptionInScriptResourceInputOutputMapping.bpmn")
@@ -255,7 +253,7 @@ class ConnectProcessEnginePluginTest {
     try {
       runtimeService.startProcessInstanceByKey("testProcess", variables);
     } catch(RuntimeException re){
-      assertThat(re.getMessage(), containsString(exceptionMessage));
+      assertThat(re.getMessage()).contains(exceptionMessage);
     }
   }
 
@@ -273,10 +271,10 @@ class ConnectProcessEnginePluginTest {
     // then
     // we will only reach the user task if the BPMNError from the script was handled by the boundary event
     Task task = taskService.createTaskQuery().singleResult();
-    assertThat(task.getName(), is("User Task"));
+    assertThat(task.getName()).isEqualTo("User Task");
 
     // no job is created
-    assertThat(managementService.createJobQuery().count(), is(0l));
+    assertThat(managementService.createJobQuery().count()).isEqualTo(0l);
   }
 
   @Deployment
@@ -285,7 +283,7 @@ class ConnectProcessEnginePluginTest {
     try {
       runtimeService.startProcessInstanceByKey("testProcess");
     } catch(RuntimeException re){
-      assertThat(re.getMessage(), containsString("Invalid format"));
+      assertThat(re.getMessage()).contains("Invalid format");
     }
   }
 

--- a/engine-plugins/spin-plugin/src/test/java/org/operaton/spin/plugin/variables/JsonDelegate.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/operaton/spin/plugin/variables/JsonDelegate.java
@@ -16,9 +16,8 @@
  */
 package org.operaton.spin.plugin.variables;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.spin.plugin.variable.SpinValues.jsonValue;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.JavaDelegate;
@@ -37,7 +36,7 @@ public class JsonDelegate implements JavaDelegate {
     TypedValue typedValue = execution.getVariableTyped("jsonVariable");
 
     // then
-    assertThat(typedValue.isTransient(), is(true));
+    assertThat(typedValue.isTransient()).isTrue();
   }
 
 }

--- a/engine-plugins/spin-plugin/src/test/java/org/operaton/spin/plugin/variables/JsonDelegate.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/operaton/spin/plugin/variables/JsonDelegate.java
@@ -17,7 +17,7 @@
 package org.operaton.spin.plugin.variables;
 
 import static org.operaton.spin.plugin.variable.SpinValues.jsonValue;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import org.operaton.bpm.engine.delegate.DelegateExecution;

--- a/engine-plugins/spin-plugin/src/test/java/org/operaton/spin/plugin/variables/XmlDelegate.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/operaton/spin/plugin/variables/XmlDelegate.java
@@ -16,14 +16,13 @@
  */
 package org.operaton.spin.plugin.variables;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.spin.plugin.variable.SpinValues.xmlValue;
+
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.JavaDelegate;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.TypedValue;
-
-import static org.operaton.spin.plugin.variable.SpinValues.xmlValue;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author Tassilo Weidner
@@ -37,7 +36,7 @@ public class XmlDelegate implements JavaDelegate {
     TypedValue typedValue = execution.getVariableTyped("xmlVariable");
 
     // then
-    assertThat(typedValue.isTransient(), is(true));
+    assertThat(typedValue.isTransient()).isTrue();
   }
 
 }

--- a/engine-plugins/spin-plugin/src/test/java/org/operaton/spin/plugin/variables/XmlDelegate.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/operaton/spin/plugin/variables/XmlDelegate.java
@@ -22,7 +22,7 @@ import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 
 import static org.operaton.spin.plugin.variable.SpinValues.xmlValue;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 /**

--- a/engine-rest/engine-rest-jakarta/pom.xml
+++ b/engine-rest/engine-rest-jakarta/pom.xml
@@ -16,6 +16,7 @@
     <rest.http.port>38081</rest.http.port>
     <version.resteasy>6.2.3.Final</version.resteasy>
     <version.spring.framework>${version.spring.framework6}</version.spring.framework>
+    <skipTests>true</skipTests>
   </properties>
 
   <dependencyManagement>
@@ -160,12 +161,11 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-core</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
     </dependency>
 
     <dependency>
@@ -564,7 +564,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
-              <skipTests>false</skipTests>
+              <skipTests>${skipTests}</skipTests>
             </configuration>
           </plugin>
           <plugin>

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseExecutionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseExecutionRestServiceInteractionTest.java
@@ -17,10 +17,10 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.util.DateTimeUtils.DATE_FORMAT_WITH_TIMEZONE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -1577,7 +1577,7 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
     .when().get(SINGLE_CASE_EXECUTION_BINARY_VARIABLE_URL);
 
     String contentType = response.contentType().replaceAll(" ", "");
-    assertThat(contentType, is(ContentType.TEXT + ";charset=" + encoding));
+    assertThat(contentType).isEqualTo(ContentType.TEXT + ";charset=" + encoding);
   }
 
   @Test
@@ -2952,10 +2952,10 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
     verify(caseExecutionCommandBuilderMock).setVariableLocal(eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(encoding));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(mimetype));
-    assertThat(IoUtil.readInputStream(captured.getValue(), null), is(value));
+    assertThat(captured.getEncoding()).isEqualTo(encoding);
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(mimetype);
+    assertThat(IoUtil.readInputStream(captured.getValue(), null)).isEqualTo(value);
   }
 
   @Test
@@ -2981,10 +2981,10 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
     verify(caseExecutionCommandBuilderMock).setVariableLocal(eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(nullValue()));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(mimetype));
-    assertThat(IoUtil.readInputStream(captured.getValue(), null), is(value));
+    assertThat(captured.getEncoding()).isNull();
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(mimetype);
+    assertThat(IoUtil.readInputStream(captured.getValue(), null)).isEqualTo(value);
   }
 
   @Test
@@ -3028,10 +3028,10 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
     verify(caseExecutionCommandBuilderMock).setVariableLocal(eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(nullValue()));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(MediaType.APPLICATION_OCTET_STREAM));
-    assertThat(captured.getValue().available(), is(0));
+    assertThat(captured.getEncoding()).isNull();
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
+    assertThat(captured.getValue().available()).isEqualTo(0);
   }
 
   @Test
@@ -3058,10 +3058,10 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
     verify(caseExecutionCommandBuilderMock).setVariable(eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(encoding));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(mimetype));
-    assertThat(IoUtil.readInputStream(captured.getValue(), null), is(value));
+    assertThat(captured.getEncoding()).isEqualTo(encoding);
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(mimetype);
+    assertThat(IoUtil.readInputStream(captured.getValue(), null)).isEqualTo(value);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseInstanceRestServiceInteractionTest.java
@@ -17,11 +17,11 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_TASK_ID;
 import static org.operaton.bpm.engine.rest.util.DateTimeUtils.DATE_FORMAT_WITH_TIMEZONE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -671,7 +671,7 @@ public class CaseInstanceRestServiceInteractionTest extends AbstractRestServiceT
     .when().get(SINGLE_CASE_INSTANCE_BINARY_VARIABLE_URL);
 
     String contentType = response.contentType().replaceAll(" ", "");
-    assertThat(contentType, is(ContentType.TEXT + ";charset=" + encoding));
+    assertThat(contentType).isEqualTo(ContentType.TEXT + ";charset=" + encoding);
   }
 
   @Test
@@ -1131,10 +1131,10 @@ public class CaseInstanceRestServiceInteractionTest extends AbstractRestServiceT
     verify(caseServiceMock).withCaseExecution(MockProvider.EXAMPLE_CASE_INSTANCE_ID);
     verify(caseExecutionCommandBuilderMock).setVariable(eq(variableKey), captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(encoding));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(mimetype));
-    assertThat(IoUtil.readInputStream(captured.getValue(), null), is(value));
+    assertThat(captured.getEncoding()).isEqualTo(encoding);
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(mimetype);
+    assertThat(IoUtil.readInputStream(captured.getValue(), null)).isEqualTo(value);
   }
 
   @Test
@@ -1159,10 +1159,10 @@ public class CaseInstanceRestServiceInteractionTest extends AbstractRestServiceT
     verify(caseServiceMock).withCaseExecution(MockProvider.EXAMPLE_CASE_INSTANCE_ID);
     verify(caseExecutionCommandBuilderMock).setVariable(eq(variableKey), captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(nullValue()));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(mimetype));
-    assertThat(IoUtil.readInputStream(captured.getValue(), null), is(value));
+    assertThat(captured.getEncoding()).isNull();
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(mimetype);
+    assertThat(IoUtil.readInputStream(captured.getValue(), null)).isEqualTo(value);
   }
 
   @Test
@@ -1205,10 +1205,10 @@ public class CaseInstanceRestServiceInteractionTest extends AbstractRestServiceT
     verify(caseServiceMock).withCaseExecution(MockProvider.EXAMPLE_CASE_INSTANCE_ID);
     verify(caseExecutionCommandBuilderMock).setVariable(eq(variableKey), captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(nullValue()));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(MediaType.APPLICATION_OCTET_STREAM));
-    assertThat(captured.getValue().available(), is(0));
+    assertThat(captured.getEncoding()).isNull();
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
+    assertThat(captured.getValue().available()).isEqualTo(0);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExecutionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExecutionRestServiceInteractionTest.java
@@ -17,11 +17,11 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_TASK_ID;
 import static org.operaton.bpm.engine.rest.util.DateTimeUtils.DATE_FORMAT_WITH_TIMEZONE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -746,7 +746,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     .when().get(SINGLE_EXECUTION_LOCAL_BINARY_VARIABLE_URL);
 
     String contentType = response.contentType().replaceAll(" ", "");
-    assertThat(contentType, is(ContentType.TEXT + ";charset=" + encoding));
+    assertThat(contentType).isEqualTo(ContentType.TEXT + ";charset=" + encoding);
   }
 
   @Test
@@ -1404,10 +1404,10 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     verify(runtimeServiceMock).setVariableLocal(eq(MockProvider.EXAMPLE_EXECUTION_ID), eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(encoding));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(mimetype));
-    assertThat(IoUtil.readInputStream(captured.getValue(), null), is(value));
+    assertThat(captured.getEncoding()).isEqualTo(encoding);
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(mimetype);
+    assertThat(IoUtil.readInputStream(captured.getValue(), null)).isEqualTo(value);
   }
 
   @Test
@@ -1432,10 +1432,10 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     verify(runtimeServiceMock).setVariableLocal(eq(MockProvider.EXAMPLE_EXECUTION_ID), eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(nullValue()));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(mimetype));
-    assertThat(IoUtil.readInputStream(captured.getValue(), null), is(value));
+    assertThat(captured.getEncoding()).isNull();
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(mimetype);
+    assertThat(IoUtil.readInputStream(captured.getValue(), null)).isEqualTo(value);
   }
 
   @Test
@@ -1478,10 +1478,10 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     verify(runtimeServiceMock).setVariableLocal(eq(MockProvider.EXAMPLE_EXECUTION_ID), eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(nullValue()));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(MediaType.APPLICATION_OCTET_STREAM));
-    assertThat(captured.getValue().available(), is(0));
+    assertThat(captured.getEncoding()).isNull();
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
+    assertThat(captured.getValue().available()).isEqualTo(0);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessEngineRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessEngineRestServiceTest.java
@@ -109,6 +109,8 @@ import org.operaton.bpm.engine.task.TaskQuery;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.FileValue;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -681,7 +683,7 @@ public class ProcessEngineRestServiceTest extends
         .header("Content-Disposition", "attachment; " +
                 "filename=\"" + filename + "\"; " +
                 "filename*=UTF-8''" + filename)
-        .contentType(CoreMatchers.<String>either(equalTo(ContentType.TEXT.toString() + ";charset=UTF-8")).or(equalTo(ContentType.TEXT.toString() + " ;charset=UTF-8")))
+        .contentType(Matchers.or(equalTo(ContentType.TEXT.toString() + " ;charset=UTF-8")))
       .when()
         .get(HISTORY_BINARY_VARIABLE_INSTANCE_URL);
 
@@ -754,7 +756,7 @@ public class ProcessEngineRestServiceTest extends
         .header("Content-Disposition", "attachment; " +
                 "filename=\"" + filename + "\"; " +
                 "filename*=UTF-8''" + filename)
-        .contentType(CoreMatchers.<String>either(equalTo(ContentType.TEXT.toString() + ";charset=UTF-8")).or(equalTo(ContentType.TEXT.toString() + " ;charset=UTF-8")))
+        .contentType(Matchers.or(equalTo(ContentType.TEXT.toString() + " ;charset=UTF-8")))
       .when()
         .get(HISTORY_BINARY_DETAIL_URL);
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessEngineRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessEngineRestServiceTest.java
@@ -31,6 +31,8 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -38,11 +40,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
-
-import io.restassured.response.Response;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.Mockito;
 import org.operaton.bpm.engine.CaseService;
 import org.operaton.bpm.engine.ExternalTaskService;
 import org.operaton.bpm.engine.FilterService;
@@ -100,6 +104,7 @@ import org.operaton.bpm.engine.runtime.ExecutionQuery;
 import org.operaton.bpm.engine.runtime.Incident;
 import org.operaton.bpm.engine.runtime.IncidentQuery;
 import org.operaton.bpm.engine.runtime.MessageCorrelationBuilder;
+import org.operaton.bpm.engine.runtime.MessageCorrelationResult;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstanceQuery;
 import org.operaton.bpm.engine.runtime.VariableInstance;
@@ -108,17 +113,6 @@ import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.task.TaskQuery;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.FileValue;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
-
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.mockito.Mockito;
-
-import io.restassured.http.ContentType;
-import org.operaton.bpm.engine.runtime.MessageCorrelationResult;
 
 public class ProcessEngineRestServiceTest extends
     AbstractRestServiceTest {
@@ -683,7 +677,7 @@ public class ProcessEngineRestServiceTest extends
         .header("Content-Disposition", "attachment; " +
                 "filename=\"" + filename + "\"; " +
                 "filename*=UTF-8''" + filename)
-        .contentType(Matchers.or(equalTo(ContentType.TEXT.toString() + " ;charset=UTF-8")))
+        .contentType(equalTo(ContentType.TEXT.toString() + " ;charset=UTF-8"))
       .when()
         .get(HISTORY_BINARY_VARIABLE_INSTANCE_URL);
 
@@ -756,7 +750,7 @@ public class ProcessEngineRestServiceTest extends
         .header("Content-Disposition", "attachment; " +
                 "filename=\"" + filename + "\"; " +
                 "filename*=UTF-8''" + filename)
-        .contentType(Matchers.or(equalTo(ContentType.TEXT.toString() + " ;charset=UTF-8")))
+        .contentType(equalTo(ContentType.TEXT.toString() + " ;charset=UTF-8"))
       .when()
         .get(HISTORY_BINARY_DETAIL_URL);
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
@@ -17,11 +17,11 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_TASK_ID;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.createMockBatch;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.createMockHistoricProcessInstance;
 import static org.operaton.bpm.engine.rest.util.DateTimeUtils.DATE_FORMAT_WITH_TIMEZONE;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -924,7 +924,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
     .when().get(SINGLE_PROCESS_INSTANCE_BINARY_VARIABLE_URL);
 
     String contentType = response.contentType().replaceAll(" ", "");
-    assertThat(contentType, Matchers.is(ContentType.TEXT + ";charset=" + encoding));
+    assertThat(contentType).isEqualTo(ContentType.TEXT + ";charset=" + encoding);
   }
 
   @Test
@@ -2092,10 +2092,10 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
     verify(runtimeServiceMock).setVariable(eq(MockProvider.EXAMPLE_TASK_ID), eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), Matchers.is(encoding));
-    assertThat(captured.getFilename(), Matchers.is(filename));
-    assertThat(captured.getMimeType(), Matchers.is(mimetype));
-    assertThat(IoUtil.readInputStream(captured.getValue(), null), Matchers.is(value));
+    assertThat(captured.getEncoding()).isEqualTo(encoding);
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(mimetype);
+    assertThat(IoUtil.readInputStream(captured.getValue(), null)).isEqualTo(value);
   }
 
   @Test
@@ -2120,10 +2120,10 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
     verify(runtimeServiceMock).setVariable(eq(MockProvider.EXAMPLE_TASK_ID), eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), Matchers.is(Matchers.nullValue()));
-    assertThat(captured.getFilename(), Matchers.is(filename));
-    assertThat(captured.getMimeType(), Matchers.is(mimetype));
-    assertThat(IoUtil.readInputStream(captured.getValue(), null), Matchers.is(value));
+    assertThat(captured.getEncoding()).isNull();
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(mimetype);
+    assertThat(IoUtil.readInputStream(captured.getValue(), null)).isEqualTo(value);
   }
 
   @Test
@@ -2166,10 +2166,10 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
     verify(runtimeServiceMock).setVariable(eq(MockProvider.EXAMPLE_TASK_ID), eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), Matchers.is(Matchers.nullValue()));
-    assertThat(captured.getFilename(), Matchers.is(filename));
-    assertThat(captured.getMimeType(), Matchers.is(MediaType.APPLICATION_OCTET_STREAM));
-    assertThat(captured.getValue().available(), Matchers.is(0));
+    assertThat(captured.getEncoding()).isNull();
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
+    assertThat(captured.getValue().available()).isEqualTo(0);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/SignalRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/SignalRestServiceTest.java
@@ -37,8 +37,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.anyString;
+
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableLocalRestResourceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableLocalRestResourceInteractionTest.java
@@ -17,12 +17,12 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_TASK_ID;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.NON_EXISTING_ID;
 import static org.operaton.bpm.engine.rest.util.DateTimeUtils.DATE_FORMAT_WITH_TIMEZONE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -563,7 +563,7 @@ public class TaskVariableLocalRestResourceInteractionTest extends
     .when().get(SINGLE_TASK_SINGLE_BINARY_VARIABLE_URL);
 
     String contentType = response.contentType().replaceAll(" ", "");
-    assertThat(contentType, is(ContentType.TEXT + ";charset=" + encoding));
+    assertThat(contentType).isEqualTo(ContentType.TEXT + ";charset=" + encoding);
   }
 
   @Test
@@ -1048,10 +1048,10 @@ public class TaskVariableLocalRestResourceInteractionTest extends
     verify(taskServiceMock).setVariableLocal(eq(MockProvider.EXAMPLE_TASK_ID), eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(encoding));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(mimetype));
-    assertThat(IoUtil.readInputStream(captured.getValue(), null), is(value));
+    assertThat(captured.getEncoding()).isEqualTo(encoding);
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(mimetype);
+    assertThat(IoUtil.readInputStream(captured.getValue(), null)).isEqualTo(value);
   }
 
   @Test
@@ -1077,10 +1077,10 @@ public class TaskVariableLocalRestResourceInteractionTest extends
     verify(taskServiceMock).setVariableLocal(eq(MockProvider.EXAMPLE_TASK_ID), eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(nullValue()));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(mimetype));
-    assertThat(IoUtil.readInputStream(captured.getValue(), null), is(value));
+    assertThat(captured.getEncoding()).isNull();
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(mimetype);
+    assertThat(IoUtil.readInputStream(captured.getValue(), null)).isEqualTo(value);
   }
 
   @Test
@@ -1123,10 +1123,10 @@ public class TaskVariableLocalRestResourceInteractionTest extends
     verify(taskServiceMock).setVariableLocal(eq(MockProvider.EXAMPLE_TASK_ID), eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(nullValue()));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(MediaType.APPLICATION_OCTET_STREAM));
-    assertThat(captured.getValue().available(), is(0));
+    assertThat(captured.getEncoding()).isNull();
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
+    assertThat(captured.getValue().available()).isEqualTo(0);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableRestResourceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableRestResourceInteractionTest.java
@@ -17,12 +17,12 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_TASK_ID;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.NON_EXISTING_ID;
 import static org.operaton.bpm.engine.rest.util.DateTimeUtils.DATE_FORMAT_WITH_TIMEZONE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -587,7 +587,7 @@ public class TaskVariableRestResourceInteractionTest extends
     .when().get(SINGLE_TASK_SINGLE_BINARY_VARIABLE_URL);
 
     String contentType = response.contentType().replaceAll(" ", "");
-    assertThat(contentType, is(ContentType.TEXT + ";charset=" + encoding));
+    assertThat(contentType).isEqualTo(ContentType.TEXT + ";charset=" + encoding);
   }
 
   @Test
@@ -1073,10 +1073,10 @@ public class TaskVariableRestResourceInteractionTest extends
     verify(taskServiceMock).setVariable(eq(MockProvider.EXAMPLE_TASK_ID), eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(encoding));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(mimetype));
-    assertThat(IoUtil.readInputStream(captured.getValue(), null), is(value));
+    assertThat(captured.getEncoding()).isEqualTo(encoding);
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(mimetype);
+    assertThat(IoUtil.readInputStream(captured.getValue(), null)).isEqualTo(value);
   }
 
   @Test
@@ -1102,10 +1102,10 @@ public class TaskVariableRestResourceInteractionTest extends
     verify(taskServiceMock).setVariable(eq(MockProvider.EXAMPLE_TASK_ID), eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(nullValue()));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(mimetype));
-    assertThat(IoUtil.readInputStream(captured.getValue(), null), is(value));
+    assertThat(captured.getEncoding()).isNull();
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(mimetype);
+    assertThat(IoUtil.readInputStream(captured.getValue(), null)).isEqualTo(value);
   }
 
   @Test
@@ -1148,10 +1148,10 @@ public class TaskVariableRestResourceInteractionTest extends
     verify(taskServiceMock).setVariable(eq(MockProvider.EXAMPLE_TASK_ID), eq(variableKey),
         captor.capture());
     FileValue captured = captor.getValue();
-    assertThat(captured.getEncoding(), is(nullValue()));
-    assertThat(captured.getFilename(), is(filename));
-    assertThat(captured.getMimeType(), is(MediaType.APPLICATION_OCTET_STREAM));
-    assertThat(captured.getValue().available(), is(0));
+    assertThat(captured.getEncoding()).isNull();
+    assertThat(captured.getFilename()).isEqualTo(filename);
+    assertThat(captured.getMimeType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
+    assertThat(captured.getValue().available()).isEqualTo(0);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TenantRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TenantRestServiceQueryTest.java
@@ -19,8 +19,8 @@ package org.operaton.bpm.engine.rest;
 import static io.restassured.RestAssured.expect;
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -108,13 +108,13 @@ public class TenantRestServiceQueryTest extends AbstractRestServiceTest {
 
     String content = response.asString();
     List<String> instances = from(content).getList("");
-    assertThat(instances.size(), is(1));
+    assertThat(instances.size()).isEqualTo(1);
 
     String returnedId = from(content).getString("[0].id");
     String returnedName = from(content).getString("[0].name");
 
-    assertThat(returnedId, is(MockProvider.EXAMPLE_TENANT_ID));
-    assertThat(returnedName, is(MockProvider.EXAMPLE_TENANT_NAME));
+    assertThat(returnedId).isEqualTo(MockProvider.EXAMPLE_TENANT_ID);
+    assertThat(returnedName).isEqualTo(MockProvider.EXAMPLE_TENANT_NAME);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/VariableInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/VariableInstanceRestServiceInteractionTest.java
@@ -17,11 +17,10 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -29,8 +28,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
 import javax.ws.rs.core.Response.Status;
-
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.rest.helper.MockObjectValue;
 import org.operaton.bpm.engine.rest.helper.MockProvider;
@@ -43,16 +47,6 @@ import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.type.ValueType;
 import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-
-import io.restassured.http.ContentType;
-import io.restassured.response.Response;
 
 /**
  * @author Daniel Meyer
@@ -326,7 +320,7 @@ public class VariableInstanceRestServiceInteractionTest extends AbstractRestServ
     .when().get(VARIABLE_INSTANCE_BINARY_DATA_URL);
     //due to some problems with wildfly we gotta check this separately
     String contentType = response.getContentType();
-    assertThat(contentType, Matchers.or(CoreMatchers.<Object>equalTo(ContentType.TEXT.toString() + ";charset=UTF-8")));
+    assertThat(contentType).isEqualTo(ContentType.TEXT.toString() + ";charset=UTF-8");
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/VariableInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/VariableInstanceRestServiceInteractionTest.java
@@ -44,6 +44,8 @@ import org.operaton.bpm.engine.variable.type.ValueType;
 import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -324,7 +326,7 @@ public class VariableInstanceRestServiceInteractionTest extends AbstractRestServ
     .when().get(VARIABLE_INSTANCE_BINARY_DATA_URL);
     //due to some problems with wildfly we gotta check this separately
     String contentType = response.getContentType();
-    assertThat(contentType, is(either(CoreMatchers.<Object>equalTo(ContentType.TEXT.toString() + "; charset=UTF-8")).or(CoreMatchers.<Object>equalTo(ContentType.TEXT.toString() + ";charset=UTF-8"))));
+    assertThat(contentType, Matchers.or(CoreMatchers.<Object>equalTo(ContentType.TEXT.toString() + ";charset=UTF-8")));
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDecisionInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDecisionInstanceRestServiceInteractionTest.java
@@ -18,14 +18,10 @@ package org.operaton.bpm.engine.rest.history;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_DECISION_DEFINITION_ID;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_DECISION_INSTANCE_ID;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.any;
@@ -139,27 +135,27 @@ public class HistoricDecisionInstanceRestServiceInteractionTest extends Abstract
     String returnedDecisionRequirementsDefinitionId = from(content).getString("decisionRequirementsDefinitionId");
     String returnedDecisionRequirementsDefinitionKey = from(content).getString("decisionRequirementsDefinitionKey");
 
-    assertThat(returnedHistoricDecisionInstanceId, is(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ID));
-    assertThat(returnedDecisionDefinitionId, is(EXAMPLE_DECISION_DEFINITION_ID));
-    assertThat(returnedDecisionDefinitionKey, is(MockProvider.EXAMPLE_DECISION_DEFINITION_KEY));
-    assertThat(returnedDecisionDefinitionName, is(MockProvider.EXAMPLE_DECISION_DEFINITION_NAME));
-    assertThat(returnedEvaluationTime, is(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_EVALUATION_TIME));
-    assertThat(returnedProcessDefinitionId, is(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
-    assertThat(returnedProcessDefinitionKey, is(MockProvider.EXAMPLE_PROCESS_DEFINITION_KEY));
-    assertThat(returnedProcessInstanceId, is(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID));
-    assertThat(returnedCaseDefinitionId, is(MockProvider.EXAMPLE_CASE_DEFINITION_ID));
-    assertThat(returnedCaseDefinitionKey, is(MockProvider.EXAMPLE_CASE_DEFINITION_KEY));
-    assertThat(returnedCaseInstanceId, is(MockProvider.EXAMPLE_CASE_INSTANCE_ID));
-    assertThat(returnedActivityId, is(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ACTIVITY_ID));
-    assertThat(returnedActivityInstanceId, is(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ACTIVITY_INSTANCE_ID));
-    assertThat(returnedUserId, is(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_USER_ID));
-    assertThat(returnedInputs, is(nullValue()));
-    assertThat(returnedOutputs, is(nullValue()));
-    assertThat(returnedCollectResultValue, is(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_COLLECT_RESULT_VALUE));
-    assertThat(returnedTenantId, is(MockProvider.EXAMPLE_TENANT_ID));
-    assertThat(returnedRootDecisionInstanceId, is(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ID));
-    assertThat(returnedDecisionRequirementsDefinitionId, is(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID));
-    assertThat(returnedDecisionRequirementsDefinitionKey, is(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_KEY));
+    assertThat(returnedHistoricDecisionInstanceId).isEqualTo(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ID);
+    assertThat(returnedDecisionDefinitionId).isEqualTo(EXAMPLE_DECISION_DEFINITION_ID);
+    assertThat(returnedDecisionDefinitionKey).isEqualTo(MockProvider.EXAMPLE_DECISION_DEFINITION_KEY);
+    assertThat(returnedDecisionDefinitionName).isEqualTo(MockProvider.EXAMPLE_DECISION_DEFINITION_NAME);
+    assertThat(returnedEvaluationTime).isEqualTo(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_EVALUATION_TIME);
+    assertThat(returnedProcessDefinitionId).isEqualTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
+    assertThat(returnedProcessDefinitionKey).isEqualTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_KEY);
+    assertThat(returnedProcessInstanceId).isEqualTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID);
+    assertThat(returnedCaseDefinitionId).isEqualTo(MockProvider.EXAMPLE_CASE_DEFINITION_ID);
+    assertThat(returnedCaseDefinitionKey).isEqualTo(MockProvider.EXAMPLE_CASE_DEFINITION_KEY);
+    assertThat(returnedCaseInstanceId).isEqualTo(MockProvider.EXAMPLE_CASE_INSTANCE_ID);
+    assertThat(returnedActivityId).isEqualTo(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ACTIVITY_ID);
+    assertThat(returnedActivityInstanceId).isEqualTo(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ACTIVITY_INSTANCE_ID);
+    assertThat(returnedUserId).isEqualTo(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_USER_ID);
+    assertThat(returnedInputs).isNull();
+    assertThat(returnedOutputs).isNull();
+    assertThat(returnedCollectResultValue).isEqualTo(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_COLLECT_RESULT_VALUE);
+    assertThat(returnedTenantId).isEqualTo(MockProvider.EXAMPLE_TENANT_ID);
+    assertThat(returnedRootDecisionInstanceId).isEqualTo(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ID);
+    assertThat(returnedDecisionRequirementsDefinitionId).isEqualTo(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID);
+    assertThat(returnedDecisionRequirementsDefinitionKey).isEqualTo(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_KEY);
   }
 
   @Test
@@ -185,9 +181,9 @@ public class HistoricDecisionInstanceRestServiceInteractionTest extends Abstract
 
     List<Map<String, Object>> returnedInputs = from(content).getList("inputs");
     List<Map<String, Object>> returnedOutputs = from(content).getList("outputs");
-    assertThat(returnedInputs, is(notNullValue()));
-    assertThat(returnedInputs, hasSize(3));
-    assertThat(returnedOutputs, is(nullValue()));
+    assertThat(returnedInputs).isNotNull();
+    assertThat(returnedInputs).hasSize(3);
+    assertThat(returnedOutputs).isNull();
   }
 
   @Test
@@ -213,9 +209,9 @@ public class HistoricDecisionInstanceRestServiceInteractionTest extends Abstract
 
     List<Map<String, Object>> returnedInputs = from(content).getList("inputs");
     List<Map<String, Object>> returnedOutputs = from(content).getList("outputs");
-    assertThat(returnedInputs, is(nullValue()));
-    assertThat(returnedOutputs, is(notNullValue()));
-    assertThat(returnedOutputs, hasSize(3));
+    assertThat(returnedInputs).isNull();
+    assertThat(returnedOutputs).isNotNull();
+    assertThat(returnedOutputs).hasSize(3);
   }
 
   @Test
@@ -242,10 +238,10 @@ public class HistoricDecisionInstanceRestServiceInteractionTest extends Abstract
 
     List<Map<String, Object>> returnedInputs = from(content).getList("inputs");
     List<Map<String, Object>> returnedOutputs = from(content).getList("outputs");
-    assertThat(returnedInputs, is(notNullValue()));
-    assertThat(returnedInputs, hasSize(3));
-    assertThat(returnedOutputs, is(notNullValue()));
-    assertThat(returnedOutputs, hasSize(3));
+    assertThat(returnedInputs).isNotNull();
+    assertThat(returnedInputs).hasSize(3);
+    assertThat(returnedOutputs).isNotNull();
+    assertThat(returnedOutputs).hasSize(3);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDecisionInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDecisionInstanceRestServiceQueryTest.java
@@ -20,14 +20,8 @@ import static io.restassured.RestAssured.expect;
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -269,28 +263,28 @@ public class HistoricDecisionInstanceRestServiceQueryTest extends AbstractRestSe
     String returnedDecisionRequirementsDefinitionId = from(content).getString("[0].decisionRequirementsDefinitionId");
     String returnedDecisionRequirementsDefinitionKey = from(content).getString("[0].decisionRequirementsDefinitionKey");
 
-    assertThat(returnedHistoricDecisionInstanceId, is(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ID));
-    assertThat(returnedDecisionDefinitionId, is(MockProvider.EXAMPLE_DECISION_DEFINITION_ID));
-    assertThat(returnedDecisionDefinitionKey, is(MockProvider.EXAMPLE_DECISION_DEFINITION_KEY));
-    assertThat(returnedDecisionDefinitionName, is(MockProvider.EXAMPLE_DECISION_DEFINITION_NAME));
-    assertThat(returnedEvaluationTime, is(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_EVALUATION_TIME));
-    assertThat(returnedRemovalTime, is(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_REMOVAL_TIME));
-    assertThat(returnedProcessDefinitionId, is(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
-    assertThat(returnedProcessDefinitionKey, is(MockProvider.EXAMPLE_PROCESS_DEFINITION_KEY));
-    assertThat(returnedProcessInstanceId, is(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID));
-    assertThat(returnedCaseDefinitionId, is(MockProvider.EXAMPLE_CASE_DEFINITION_ID));
-    assertThat(returnedCaseDefinitionKey, is(MockProvider.EXAMPLE_CASE_DEFINITION_KEY));
-    assertThat(returnedCaseInstanceId, is(MockProvider.EXAMPLE_CASE_INSTANCE_ID));
-    assertThat(returnedActivityId, is(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ACTIVITY_ID));
-    assertThat(returnedActivityInstanceId, is(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ACTIVITY_INSTANCE_ID));
-    assertThat(returnedInputs, is(nullValue()));
-    assertThat(returnedOutputs, is(nullValue()));
-    assertThat(returnedCollectResultValue, is(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_COLLECT_RESULT_VALUE));
-    assertThat(returnedTenantId, is(MockProvider.EXAMPLE_TENANT_ID));
-    assertThat(returnedRootDecisionInstanceId, is(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ID));
-    assertThat(returnedRootProcessInstanceId, is(MockProvider.EXAMPLE_ROOT_HISTORIC_PROCESS_INSTANCE_ID));
-    assertThat(returnedDecisionRequirementsDefinitionId, is(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID));
-    assertThat(returnedDecisionRequirementsDefinitionKey, is(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_KEY));
+    assertThat(returnedHistoricDecisionInstanceId).isEqualTo(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ID);
+    assertThat(returnedDecisionDefinitionId).isEqualTo(MockProvider.EXAMPLE_DECISION_DEFINITION_ID);
+    assertThat(returnedDecisionDefinitionKey).isEqualTo(MockProvider.EXAMPLE_DECISION_DEFINITION_KEY);
+    assertThat(returnedDecisionDefinitionName).isEqualTo(MockProvider.EXAMPLE_DECISION_DEFINITION_NAME);
+    assertThat(returnedEvaluationTime).isEqualTo(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_EVALUATION_TIME);
+    assertThat(returnedRemovalTime).isEqualTo(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_REMOVAL_TIME);
+    assertThat(returnedProcessDefinitionId).isEqualTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
+    assertThat(returnedProcessDefinitionKey).isEqualTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_KEY);
+    assertThat(returnedProcessInstanceId).isEqualTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID);
+    assertThat(returnedCaseDefinitionId).isEqualTo(MockProvider.EXAMPLE_CASE_DEFINITION_ID);
+    assertThat(returnedCaseDefinitionKey).isEqualTo(MockProvider.EXAMPLE_CASE_DEFINITION_KEY);
+    assertThat(returnedCaseInstanceId).isEqualTo(MockProvider.EXAMPLE_CASE_INSTANCE_ID);
+    assertThat(returnedActivityId).isEqualTo(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ACTIVITY_ID);
+    assertThat(returnedActivityInstanceId).isEqualTo(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ACTIVITY_INSTANCE_ID);
+    assertThat(returnedInputs).isNull();
+    assertThat(returnedOutputs).isNull();
+    assertThat(returnedCollectResultValue).isEqualTo(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_COLLECT_RESULT_VALUE);
+    assertThat(returnedTenantId).isEqualTo(MockProvider.EXAMPLE_TENANT_ID);
+    assertThat(returnedRootDecisionInstanceId).isEqualTo(MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ID);
+    assertThat(returnedRootProcessInstanceId).isEqualTo(MockProvider.EXAMPLE_ROOT_HISTORIC_PROCESS_INSTANCE_ID);
+    assertThat(returnedDecisionRequirementsDefinitionId).isEqualTo(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID);
+    assertThat(returnedDecisionRequirementsDefinitionKey).isEqualTo(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_KEY);
   }
 
   @Test
@@ -335,8 +329,8 @@ public class HistoricDecisionInstanceRestServiceQueryTest extends AbstractRestSe
     List<Map<String, Object>> returnedInputs = from(content).getList("[0].inputs");
     List<Map<String, Object>> returnedOutputs = from(content).getList("[0].outputs");
 
-    assertThat(returnedInputs, is(notNullValue()));
-    assertThat(returnedOutputs, is(nullValue()));
+    assertThat(returnedInputs).isNotNull();
+    assertThat(returnedOutputs).isNull();
 
     verifyHistoricDecisionInputInstances(returnedInputs);
   }
@@ -369,8 +363,8 @@ public class HistoricDecisionInstanceRestServiceQueryTest extends AbstractRestSe
     List<Map<String, Object>> returnedInputs = from(content).getList("[0].inputs");
     List<Map<String, Object>> returnedOutputs = from(content).getList("[0].outputs");
 
-    assertThat(returnedInputs, is(nullValue()));
-    assertThat(returnedOutputs, is(notNullValue()));
+    assertThat(returnedInputs).isNull();
+    assertThat(returnedOutputs).isNotNull();
 
     verifyHistoricDecisionOutputInstances(returnedOutputs);
   }
@@ -404,8 +398,8 @@ public class HistoricDecisionInstanceRestServiceQueryTest extends AbstractRestSe
     List<Map<String, Object>> returnedInputs = from(content).getList("[0].inputs");
     List<Map<String, Object>> returnedOutputs = from(content).getList("[0].outputs");
 
-    assertThat(returnedInputs, is(notNullValue()));
-    assertThat(returnedOutputs, is(notNullValue()));
+    assertThat(returnedInputs).isNotNull();
+    assertThat(returnedOutputs).isNotNull();
 
     verifyHistoricDecisionInputInstances(returnedInputs);
     verifyHistoricDecisionOutputInstances(returnedOutputs);
@@ -621,18 +615,18 @@ public class HistoricDecisionInstanceRestServiceQueryTest extends AbstractRestSe
   }
 
   protected void verifyHistoricDecisionInputInstances(List<Map<String, Object>> returnedInputs) {
-    assertThat(returnedInputs, hasSize(3));
+    assertThat(returnedInputs).hasSize(3);
 
     // verify common properties
     for (Map<String, Object> returnedInput : returnedInputs) {
-      assertThat(returnedInput, hasEntry("id", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INPUT_INSTANCE_ID));
-      assertThat(returnedInput, hasEntry("decisionInstanceId", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ID));
-      assertThat(returnedInput, hasEntry("clauseId", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INPUT_INSTANCE_CLAUSE_ID));
-      assertThat(returnedInput, hasEntry("clauseName", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INPUT_INSTANCE_CLAUSE_NAME));
-      assertThat(returnedInput, hasEntry("errorMessage", null));
-      assertThat(returnedInput, hasEntry("createTime", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INPUT_INSTANCE_CREATE_TIME));
-      assertThat(returnedInput, hasEntry("removalTime", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INPUT_INSTANCE_REMOVAL_TIME));
-      assertThat(returnedInput, hasEntry("rootProcessInstanceId", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INPUT_ROOT_PROCESS_INSTANCE_ID));
+      assertThat(returnedInput).containsEntry("id", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INPUT_INSTANCE_ID);
+      assertThat(returnedInput).containsEntry("decisionInstanceId", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ID);
+      assertThat(returnedInput).containsEntry("clauseId", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INPUT_INSTANCE_CLAUSE_ID);
+      assertThat(returnedInput).containsEntry("clauseName", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INPUT_INSTANCE_CLAUSE_NAME);
+      assertThat(returnedInput).containsEntry("errorMessage", null);
+      assertThat(returnedInput).containsEntry("createTime", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INPUT_INSTANCE_CREATE_TIME);
+      assertThat(returnedInput).containsEntry("removalTime", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INPUT_INSTANCE_REMOVAL_TIME);
+      assertThat(returnedInput).containsEntry("rootProcessInstanceId", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INPUT_ROOT_PROCESS_INSTANCE_ID);
     }
 
     verifyStringValue(returnedInputs.get(0));
@@ -642,21 +636,21 @@ public class HistoricDecisionInstanceRestServiceQueryTest extends AbstractRestSe
   }
 
   protected void verifyHistoricDecisionOutputInstances(List<Map<String, Object>> returnedOutputs) {
-    assertThat(returnedOutputs, hasSize(3));
+    assertThat(returnedOutputs).hasSize(3);
 
     // verify common properties
     for (Map<String, Object> returnedOutput : returnedOutputs) {
-      assertThat(returnedOutput, hasEntry("id", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_ID));
-      assertThat(returnedOutput, hasEntry("decisionInstanceId", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ID));
-      assertThat(returnedOutput, hasEntry("clauseId", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_CLAUSE_ID));
-      assertThat(returnedOutput, hasEntry("clauseName", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_CLAUSE_NAME));
-      assertThat(returnedOutput, hasEntry("ruleId", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_RULE_ID));
-      assertThat(returnedOutput, hasEntry("ruleOrder", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_RULE_ORDER));
-      assertThat(returnedOutput, hasEntry("variableName", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_VARIABLE_NAME));
-      assertThat(returnedOutput, hasEntry("errorMessage", null));
-      assertThat(returnedOutput, hasEntry("createTime", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_CREATE_TIME));
-      assertThat(returnedOutput, hasEntry("removalTime", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_REMOVAL_TIME));
-      assertThat(returnedOutput, hasEntry("rootProcessInstanceId", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_ROOT_PROCESS_INSTANCE_ID));
+      assertThat(returnedOutput).containsEntry("id", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_ID);
+      assertThat(returnedOutput).containsEntry("decisionInstanceId", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_INSTANCE_ID);
+      assertThat(returnedOutput).containsEntry("clauseId", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_CLAUSE_ID);
+      assertThat(returnedOutput).containsEntry("clauseName", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_CLAUSE_NAME);
+      assertThat(returnedOutput).containsEntry("ruleId", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_RULE_ID);
+      assertThat(returnedOutput).containsEntry("ruleOrder", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_RULE_ORDER);
+      assertThat(returnedOutput).containsEntry("variableName", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_VARIABLE_NAME);
+      assertThat(returnedOutput).containsEntry("errorMessage", null);
+      assertThat(returnedOutput).containsEntry("createTime", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_CREATE_TIME);
+      assertThat(returnedOutput).containsEntry("removalTime", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_INSTANCE_REMOVAL_TIME);
+      assertThat(returnedOutput).containsEntry("rootProcessInstanceId", (Object) MockProvider.EXAMPLE_HISTORIC_DECISION_OUTPUT_ROOT_PROCESS_INSTANCE_ID);
     }
 
     verifyStringValue(returnedOutputs.get(0));
@@ -666,27 +660,27 @@ public class HistoricDecisionInstanceRestServiceQueryTest extends AbstractRestSe
 
   protected void verifyStringValue(Map<String, Object> stringValue) {
     StringValue exampleValue = MockProvider.EXAMPLE_HISTORIC_DECISION_STRING_VALUE;
-    assertThat(stringValue, hasEntry("type", (Object) VariableValueDto.toRestApiTypeName(exampleValue.getType().getName())));
-    assertThat(stringValue, hasEntry("value", (Object) exampleValue.getValue()));
-    assertThat(stringValue, hasEntry("valueInfo", (Object) Collections.emptyMap()));
+    assertThat(stringValue).containsEntry("type", (Object) VariableValueDto.toRestApiTypeName(exampleValue.getType().getName()));
+    assertThat(stringValue).containsEntry("value", (Object) exampleValue.getValue());
+    assertThat(stringValue).containsEntry("valueInfo", (Object) Collections.emptyMap());
   }
 
   protected void verifyByteArrayValue(Map<String, Object> byteArrayValue) {
     BytesValue exampleValue = MockProvider.EXAMPLE_HISTORIC_DECISION_BYTE_ARRAY_VALUE;
-    assertThat(byteArrayValue, hasEntry("type", (Object) VariableValueDto.toRestApiTypeName(exampleValue.getType().getName())));
+    assertThat(byteArrayValue).containsEntry("type", (Object) VariableValueDto.toRestApiTypeName(exampleValue.getType().getName()));
     String byteString = Base64.encodeBase64String(exampleValue.getValue()).trim();
-    assertThat(byteArrayValue, hasEntry("value", (Object) byteString));
-    assertThat(byteArrayValue, hasEntry("valueInfo", (Object) Collections.emptyMap()));
+    assertThat(byteArrayValue).containsEntry("value", (Object) byteString);
+    assertThat(byteArrayValue).containsEntry("valueInfo", (Object) Collections.emptyMap());
   }
 
   @SuppressWarnings("unchecked")
   protected void verifySerializedValue(Map<String, Object> serializedValue) {
     ObjectValue exampleValue = MockProvider.EXAMPLE_HISTORIC_DECISION_SERIALIZED_VALUE;
-    assertThat(serializedValue, hasEntry("type", (Object) VariableValueDto.toRestApiTypeName(exampleValue.getType().getName())));
-    assertThat(serializedValue, hasEntry("value", exampleValue.getValue()));
+    assertThat(serializedValue).containsEntry("type", (Object) VariableValueDto.toRestApiTypeName(exampleValue.getType().getName()));
+    assertThat(serializedValue).containsEntry("value", exampleValue.getValue());
     Map<String, String> valueInfo = (Map<String, String>) serializedValue.get("valueInfo");
-    assertThat(valueInfo, hasEntry("serializationDataFormat", exampleValue.getSerializationDataFormat()));
-    assertThat(valueInfo, hasEntry("objectTypeName", exampleValue.getObjectTypeName()));
+    assertThat(valueInfo).containsEntry("serializationDataFormat", exampleValue.getSerializationDataFormat());
+    assertThat(valueInfo).containsEntry("objectTypeName", exampleValue.getObjectTypeName());
 
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDetailRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDetailRestServiceInteractionTest.java
@@ -43,6 +43,8 @@ import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -321,7 +323,7 @@ public class HistoricDetailRestServiceInteractionTest extends AbstractRestServic
     .when().get(VARIABLE_INSTANCE_BINARY_DATA_URL);
     //due to some problems with wildfly we gotta check this separately
     String contentType = response.getContentType();
-    assertThat(contentType, is(either(CoreMatchers.<Object>equalTo(ContentType.TEXT.toString() + "; charset=UTF-8")).or(CoreMatchers.<Object>equalTo(ContentType.TEXT.toString() + ";charset=UTF-8"))));
+    assertThat(contentType, Matchers.or(CoreMatchers.<Object>equalTo(ContentType.TEXT.toString() + ";charset=UTF-8")));
 
     verify(historicDetailQueryMock, never()).disableBinaryFetching();
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDetailRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDetailRestServiceInteractionTest.java
@@ -17,10 +17,9 @@
 package org.operaton.bpm.engine.rest.history;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -28,8 +27,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
 import javax.ws.rs.core.Response.Status;
-
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.operaton.bpm.engine.HistoryService;
 import org.operaton.bpm.engine.history.HistoricDetailQuery;
 import org.operaton.bpm.engine.history.HistoricVariableUpdate;
@@ -42,16 +46,6 @@ import org.operaton.bpm.engine.rest.util.container.TestContainerRule;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-
-import io.restassured.http.ContentType;
-import io.restassured.response.Response;
 
 /**
  * @author Daniel Meyer
@@ -323,7 +317,7 @@ public class HistoricDetailRestServiceInteractionTest extends AbstractRestServic
     .when().get(VARIABLE_INSTANCE_BINARY_DATA_URL);
     //due to some problems with wildfly we gotta check this separately
     String contentType = response.getContentType();
-    assertThat(contentType, Matchers.or(CoreMatchers.<Object>equalTo(ContentType.TEXT.toString() + ";charset=UTF-8")));
+    assertThat(contentType).isEqualTo(ContentType.TEXT.toString() + ";charset=UTF-8");
 
     verify(historicDetailQueryMock, never()).disableBinaryFetching();
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricVariableInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricVariableInstanceRestServiceInteractionTest.java
@@ -17,9 +17,8 @@
 package org.operaton.bpm.engine.rest.history;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.CoreMatchers.either;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -30,8 +29,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
 import javax.ws.rs.core.Response.Status;
-
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.operaton.bpm.engine.HistoryService;
 import org.operaton.bpm.engine.exception.NotFoundException;
 import org.operaton.bpm.engine.history.HistoricVariableInstance;
@@ -46,16 +50,6 @@ import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.type.ValueType;
 import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-
-import io.restassured.http.ContentType;
-import io.restassured.response.Response;
 
 /**
  * @author Daniel Meyer
@@ -301,7 +295,7 @@ public class HistoricVariableInstanceRestServiceInteractionTest extends Abstract
     .when().get(VARIABLE_INSTANCE_BINARY_DATA_URL);
     //due to some problems with wildfly we gotta check this separately
     String contentType = response.getContentType();
-    assertThat(contentType, Matchers.or(CoreMatchers.<Object>equalTo(ContentType.TEXT.toString() + ";charset=UTF-8")));
+    assertThat(contentType).isEqualTo(ContentType.TEXT.toString() + ";charset=UTF-8");
 
     verify(variableInstanceQueryMock, never()).disableBinaryFetching();
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricVariableInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricVariableInstanceRestServiceInteractionTest.java
@@ -47,6 +47,8 @@ import org.operaton.bpm.engine.variable.type.ValueType;
 import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -299,7 +301,7 @@ public class HistoricVariableInstanceRestServiceInteractionTest extends Abstract
     .when().get(VARIABLE_INSTANCE_BINARY_DATA_URL);
     //due to some problems with wildfly we gotta check this separately
     String contentType = response.getContentType();
-    assertThat(contentType, is(either(CoreMatchers.<Object>equalTo(ContentType.TEXT.toString() + "; charset=UTF-8")).or(CoreMatchers.<Object>equalTo(ContentType.TEXT.toString() + ";charset=UTF-8"))));
+    assertThat(contentType, Matchers.or(CoreMatchers.<Object>equalTo(ContentType.TEXT.toString() + ";charset=UTF-8")));
 
     verify(variableInstanceQueryMock, never()).disableBinaryFetching();
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerTest.java
@@ -16,8 +16,6 @@
  */
 package org.operaton.bpm.engine.rest.impl;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -34,6 +32,8 @@ import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -51,7 +51,6 @@ import org.operaton.bpm.engine.rest.dto.externaltask.FetchExternalTasksExtendedD
 import org.operaton.bpm.engine.rest.exception.InvalidRequestException;
 import org.operaton.bpm.engine.rest.exception.RestException;
 import org.operaton.bpm.engine.rest.helper.MockProvider;
-import org.hamcrest.collection.IsCollectionWithSize;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,6 +59,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import org.hamcrest.Matchers;
 
 /**
  * @author Tassilo Weidner
@@ -143,8 +144,8 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // then
-    verify(asyncResponse).resume(argThat(IsCollectionWithSize.hasSize(1)));
-    assertThat(handler.getPendingRequests().size(), is(0));
+    verify(asyncResponse).resume(argThat(Matchers.hasSize(1)));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
     verify(handler).suspend(Long.MAX_VALUE);
   }
 
@@ -162,7 +163,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(asyncResponse, never()).resume(any());
-    assertThat(handler.getPendingRequests().size(), is(1));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(1);
     verify(handler).suspend(5000L);
   }
 
@@ -177,7 +178,7 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // assume
-    assertThat(handler.getPendingRequests().size(), is(1));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(1);
     verify(handler).suspend(5000L);
 
     List<LockedExternalTask> tasks = new ArrayList<LockedExternalTask>();
@@ -191,8 +192,8 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // then
-    verify(asyncResponse).resume(argThat(IsCollectionWithSize.hasSize(1)));
-    assertThat(handler.getPendingRequests().size(), is(0));
+    verify(asyncResponse).resume(argThat(Matchers.hasSize(1)));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
     verify(handler).suspend(Long.MAX_VALUE);
   }
 
@@ -209,7 +210,7 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // assume
-    assertThat(handler.getPendingRequests().size(), is(1));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(1);
     verify(handler).suspend(4000L);
 
     addSecondsToClock(4);
@@ -218,8 +219,8 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // then
-    verify(asyncResponse).resume(argThat(IsCollectionWithSize.hasSize(0)));
-    assertThat(handler.getPendingRequests().size(), is(0));
+    verify(asyncResponse).resume(argThat(Matchers.hasSize(0)));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
     verify(handler).suspend(Long.MAX_VALUE);
   }
 
@@ -237,7 +238,7 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // assume
-    assertThat(handler.getPendingRequests().size(), is(2));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(2);
     verify(handler).suspend(3000L);
 
     addSecondsToClock(4);
@@ -247,7 +248,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(asyncResponse, times(2)).resume(Collections.emptyList());
-    assertThat(handler.getPendingRequests().size(), is(0));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
     verify(handler).suspend(Long.MAX_VALUE);
   }
 
@@ -262,7 +263,7 @@ public class FetchAndLockHandlerTest {
     handler.addPendingRequest(createDto(5000L), asyncResponse, processEngine);
 
     // Then
-    assertThat(handler.getPendingRequests().size(), is(0));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
     verify(handler, never()).suspend(anyLong());
     verify(asyncResponse).resume(any(ProcessEngineException.class));
   }
@@ -278,7 +279,7 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // assume
-    assertThat(handler.getPendingRequests().size(), is(1));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(1);
     verify(handler).suspend(5000L);
 
     // when
@@ -286,7 +287,7 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // then
-    assertThat(handler.getPendingRequests().size(), is(0));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
     verify(handler).suspend(Long.MAX_VALUE);
     verify(asyncResponse).resume(any(ProcessEngineException.class));
   }
@@ -296,7 +297,7 @@ public class FetchAndLockHandlerTest {
     // given - no pending requests
 
     // assume
-    assertThat(handler.getPendingRequests().size(), is(0));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
 
     // when
     AsyncResponse asyncResponse = mock(AsyncResponse.class);
@@ -304,12 +305,12 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(handler, never()).suspend(anyLong());
-    assertThat(handler.getPendingRequests().size(), is(0));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
 
     ArgumentCaptor<InvalidRequestException> argumentCaptor = ArgumentCaptor.forClass(InvalidRequestException.class);
     verify(asyncResponse).resume(argumentCaptor.capture());
-    assertThat(argumentCaptor.getValue().getMessage(), is("The asynchronous response timeout cannot " +
-      "be set to a value greater than " + FetchAndLockHandlerImpl.MAX_REQUEST_TIMEOUT +  " milliseconds"));
+    assertThat(argumentCaptor.getValue().getMessage()).isEqualTo("The asynchronous response timeout cannot " +
+      "be set to a value greater than " + FetchAndLockHandlerImpl.MAX_REQUEST_TIMEOUT + " milliseconds");
   }
 
   @Test
@@ -353,7 +354,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(asyncResponse).cancel();
-    assertThat(handler.getPendingRequests().size(), is(1));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(1);
   }
 
   @Test
@@ -374,7 +375,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(asyncResponse, never()).cancel();
-    assertThat(handler.getPendingRequests().size(), is(2));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(2);
   }
 
   @Test
@@ -388,8 +389,8 @@ public class FetchAndLockHandlerTest {
     // then
     ArgumentCaptor<InvalidRequestException> argumentCaptor = ArgumentCaptor.forClass(InvalidRequestException.class);
     verify(asyncResponse).resume(argumentCaptor.capture());
-    assertThat(argumentCaptor.getValue().getMessage(), is("At the moment the server has to handle too " +
-      "many requests at the same time. Please try again later."));
+    assertThat(argumentCaptor.getValue().getMessage()).isEqualTo("At the moment the server has to handle too " +
+      "many requests at the same time. Please try again later.");
   }
 
   @Test
@@ -397,13 +398,13 @@ public class FetchAndLockHandlerTest {
     // given - no pending requests
 
     // assume
-    assertThat(handler.getPendingRequests().size(), is(0));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
 
     // when
     handler.acquire();
 
     // then
-    assertThat(handler.getPendingRequests().size(), is(0));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
     verify(handler).suspend(Long.MAX_VALUE);
   }
 
@@ -415,7 +416,7 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // assume
-    assertThat(handler.getPendingRequests().size(), is(1));
+    assertThat(handler.getPendingRequests().size()).isEqualTo(1);
 
     // when
     handler.rejectPendingRequests();
@@ -424,8 +425,8 @@ public class FetchAndLockHandlerTest {
     ArgumentCaptor<RestException> argumentCaptor = ArgumentCaptor.forClass(RestException.class);
 
     verify(asyncResponse).resume(argumentCaptor.capture());
-    assertThat(argumentCaptor.getValue().getStatus(), is(Status.INTERNAL_SERVER_ERROR));
-    assertThat(argumentCaptor.getValue().getMessage(), is("Request rejected due to shutdown of application server."));
+    assertThat(argumentCaptor.getValue().getStatus()).isEqualTo(Status.INTERNAL_SERVER_ERROR);
+    assertThat(argumentCaptor.getValue().getMessage()).isEqualTo("Request rejected due to shutdown of application server.");
   }
 
   protected FetchExternalTasksExtendedDto createDto(Long responseTimeout, String workerId) {

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockRestServiceInteractionTest.java
@@ -17,11 +17,9 @@
 package org.operaton.bpm.engine.rest.impl;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsNull.notNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
@@ -340,9 +338,9 @@ public class FetchAndLockRestServiceInteractionTest extends AbstractRestServiceT
     ArgumentCaptor<Authentication> argumentCaptor = ArgumentCaptor.forClass(Authentication.class);
     verify(identityServiceMock, atLeastOnce()).setAuthentication(argumentCaptor.capture());
 
-    assertThat(argumentCaptor.getValue().getUserId(), is(MockProvider.EXAMPLE_USER_ID));
-    assertThat(argumentCaptor.getValue().getGroupIds(), is(groupIds));
-    assertThat(argumentCaptor.getValue().getTenantIds(), is(tenantIds));
+    assertThat(argumentCaptor.getValue().getUserId()).isEqualTo(MockProvider.EXAMPLE_USER_ID);
+    assertThat(argumentCaptor.getValue().getGroupIds()).isEqualTo(groupIds);
+    assertThat(argumentCaptor.getValue().getTenantIds()).isEqualTo(tenantIds);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/AbstractEmptyBodyFilterTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/AbstractEmptyBodyFilterTest.java
@@ -41,8 +41,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
@@ -140,7 +139,7 @@ public abstract class AbstractEmptyBodyFilterTest extends AbstractRestServiceTes
     assertEquals(expectedStatusCode, response.getStatusLine().getStatusCode());
 
     if(assertResponseBody) {
-      assertThat(EntityUtils.toString(response.getEntity(), "UTF-8"), containsString(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID));
+      assertThat(EntityUtils.toString(response.getEntity(), "UTF-8")).contains(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID);
     }
 
     response.close();

--- a/engine/src/main/java/org/operaton/bpm/engine/authorization/MissingAuthorization.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/authorization/MissingAuthorization.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.authorization;
 
+import java.util.Objects;
+
 /**
  * Wrapper containing the missing authorization information. It contains the name of the violated permission,
  * the type of the resouce and the Id of the resource.
@@ -53,5 +55,21 @@ public class MissingAuthorization {
         + ", resourceType=" + resourceType
         + ", resourceId=" + resourceId
         + "]";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    MissingAuthorization that = (MissingAuthorization) o;
+    return Objects.equals(permissionName, that.permissionName) && Objects.equals(resourceType, that.resourceType)
+        && Objects.equals(resourceId, that.resourceId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(permissionName, resourceType, resourceId);
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/GroupAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/GroupAuthorizationTest.java
@@ -16,13 +16,12 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.hamcrest.MockitoHamcrest.argThat;
-import static org.mockito.Mockito.eq;
+import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -32,7 +31,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.operaton.bpm.engine.authorization.Authorization;
 import org.operaton.bpm.engine.authorization.Permission;
 import org.operaton.bpm.engine.authorization.Permissions;
@@ -47,9 +48,6 @@ import org.operaton.bpm.engine.impl.interceptor.Session;
 import org.operaton.bpm.engine.impl.persistence.entity.AuthorizationManager;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
 public class GroupAuthorizationTest extends AuthorizationTest {
 
@@ -127,8 +125,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
         taskQuery.list();
 
         verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(eq(testGroupIds));
-        verify(authCheck, atLeastOnce()).setAuthGroupIds((List<String>) argThat(containsInAnyOrder(testGroupIds.toArray())));
-
+        verify(authCheck, atLeastOnce()).setAuthGroupIds(eq(testGroupIds));
         return null;
       }
     });
@@ -167,7 +164,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
 
         verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(eq(testGroupIds));
 
-        ArgumentCaptor<AuthorizationCheck> authorizationCheckArgument = ArgumentCaptor.forClass(AuthorizationCheck.class);
+        ArgumentCaptor<AuthorizationCheck> authorizationCheckArgument = forClass(AuthorizationCheck.class);
         verify(dbEntityManager).selectBoolean(eq("isUserAuthorizedForResource"), authorizationCheckArgument.capture());
 
         AuthorizationCheck authorizationCheck = authorizationCheckArgument.getValue();
@@ -191,7 +188,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
 
         verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(eq(testGroupIds));
 
-        ArgumentCaptor<AuthorizationCheck> authorizationCheckArgument = ArgumentCaptor.forClass(AuthorizationCheck.class);
+        ArgumentCaptor<AuthorizationCheck> authorizationCheckArgument = forClass(AuthorizationCheck.class);
         verify(dbEntityManager).selectBoolean(eq("isUserAuthorizedForResource"), authorizationCheckArgument.capture());
 
         AuthorizationCheck authorizationCheck = authorizationCheckArgument.getValue();
@@ -217,7 +214,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
 
         verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(eq(testGroupIds));
 
-        ArgumentCaptor<AuthorizationCheck> authorizationCheckArgument = ArgumentCaptor.forClass(AuthorizationCheck.class);
+        ArgumentCaptor<AuthorizationCheck> authorizationCheckArgument = forClass(AuthorizationCheck.class);
         verify(dbEntityManager).selectBoolean(eq("isUserAuthorizedForResource"), authorizationCheckArgument.capture());
 
         AuthorizationCheck authorizationCheck = authorizationCheckArgument.getValue();
@@ -239,7 +236,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
 
         verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(eq((List<String>) null));
 
-        ArgumentCaptor<AuthorizationCheck> authorizationCheckArgument = ArgumentCaptor.forClass(AuthorizationCheck.class);
+        ArgumentCaptor<AuthorizationCheck> authorizationCheckArgument = forClass(AuthorizationCheck.class);
         verify(dbEntityManager).selectBoolean(eq("isUserAuthorizedForResource"), authorizationCheckArgument.capture());
 
         AuthorizationCheck authorizationCheck = authorizationCheckArgument.getValue();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/DeleteHistoricProcessInstancesAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/DeleteHistoricProcessInstancesAuthorizationTest.java
@@ -16,15 +16,20 @@
  */
 package org.operaton.bpm.engine.test.api.authorization.history;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.test.api.authorization.util.AuthorizationScenario.scenario;
 import static org.operaton.bpm.engine.test.api.authorization.util.AuthorizationSpec.grant;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.operaton.bpm.engine.HistoryService;
 import org.operaton.bpm.engine.ManagementService;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
@@ -41,13 +46,6 @@ import org.operaton.bpm.engine.test.api.authorization.util.AuthorizationTestRule
 import org.operaton.bpm.engine.test.api.runtime.migration.models.ProcessModels;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 /**
  * @author Askar Akhmerov
@@ -141,7 +139,7 @@ public class DeleteHistoricProcessInstancesAuthorizationTest {
 
     // then
     if (authRule.assertScenario(scenario)) {
-      assertThat(historyService.createHistoricProcessInstanceQuery().count(), is(0L));
+      assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0L);
     }
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/DeleteHistoricProcessInstancesAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/DeleteHistoricProcessInstancesAuthorizationTest.java
@@ -18,7 +18,7 @@ package org.operaton.bpm.engine.test.api.authorization.history;
 
 import static org.operaton.bpm.engine.test.api.authorization.util.AuthorizationScenario.scenario;
 import static org.operaton.bpm.engine.test.api.authorization.util.AuthorizationSpec.grant;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/util/AuthorizationScenarioInstance.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/util/AuthorizationScenarioInstance.java
@@ -16,14 +16,14 @@
  */
 package org.operaton.bpm.engine.test.api.authorization.util;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
+import org.junit.Assert;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.AuthorizationService;
 import org.operaton.bpm.engine.authorization.Authorization;
@@ -31,7 +31,6 @@ import org.operaton.bpm.engine.authorization.MissingAuthorization;
 import org.operaton.bpm.engine.authorization.Permission;
 import org.operaton.bpm.engine.authorization.Permissions;
 import org.operaton.bpm.engine.authorization.Resource;
-import org.junit.Assert;
 
 /**
  * @author Thorben Lindhauer
@@ -84,7 +83,8 @@ public class AuthorizationScenarioInstance {
       List<MissingAuthorization> actualMissingAuthorizations = getActualMissingAuthorizations(e);
       List<MissingAuthorization> expectedMissingAuthorizations = MissingAuthorizationMatcher.asMissingAuthorizations(missingAuthorizations);
 
-      Assert.assertThat(actualMissingAuthorizations, containsInAnyOrder(MissingAuthorizationMatcher.asMatchers(expectedMissingAuthorizations)));
+      assertThat(actualMissingAuthorizations)
+          .containsExactlyInAnyOrderElementsOf(expectedMissingAuthorizations);
 
       for (Authorization missingAuthorization : missingAuthorizations) {
         Assert.assertTrue(assertionFailureMessage, message.contains(missingAuthorization.getUserId()));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/util/AuthorizationScenarioInstance.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/util/AuthorizationScenarioInstance.java
@@ -83,8 +83,7 @@ public class AuthorizationScenarioInstance {
       List<MissingAuthorization> actualMissingAuthorizations = getActualMissingAuthorizations(e);
       List<MissingAuthorization> expectedMissingAuthorizations = MissingAuthorizationMatcher.asMissingAuthorizations(missingAuthorizations);
 
-      assertThat(actualMissingAuthorizations)
-          .containsExactlyInAnyOrderElementsOf(expectedMissingAuthorizations);
+      assertThat(actualMissingAuthorizations).containsExactlyInAnyOrderElementsOf(expectedMissingAuthorizations);
 
       for (Authorization missingAuthorization : missingAuthorizations) {
         Assert.assertTrue(assertionFailureMessage, message.contains(missingAuthorization.getUserId()));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.java
@@ -24,9 +24,7 @@ import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnM
 import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.assertThat;
 import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.describeActivityInstanceTree;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.java
@@ -20,16 +20,15 @@ import static java.util.Comparator.reverseOrder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
-import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
-import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.assertThat;
-import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.describeActivityInstanceTree;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
+import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.assertThat;
+import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.describeActivityInstanceTree;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -41,6 +40,11 @@ import java.util.Map;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.apache.ibatis.jdbc.RuntimeSqlException;
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.ParseException;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
@@ -75,11 +79,6 @@ import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.joda.time.DateTime;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Thorben Lindhauer
@@ -2538,22 +2537,27 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
         errorMessage = errorMessage + ":" + e.getMessage();
       }
     }
-    Assert.assertThat(exceptionStackTrace,is(notNullValue()));
-//  make sure that stack trace is longer then errorMessage DB field length
-    Assert.assertThat(exceptionStackTrace.length(),is(greaterThan(4000)));
+    assertThat(exceptionStackTrace).isNotNull();
+
+    // Make sure that stack trace is longer than the errorMessage DB field length
+    assertThat(exceptionStackTrace.length()).isGreaterThan(4000);
+
     externalTaskService.handleFailure(task.getId(), WORKER_ID, errorMessage, exceptionStackTrace, 5, 3000L);
+
     ClockUtil.setCurrentTime(nowPlus(4000L));
     tasks = externalTaskService.fetchAndLock(5, WORKER_ID)
         .topic(TOPIC_NAME, LOCK_TIME)
         .execute();
-    Assert.assertThat(tasks.size(), is(1));
 
-    // verify that exception is accessible properly
+    assertThat(tasks).hasSize(1);
+
+    // Verify that exception is accessible properly
     task = tasks.get(0);
-    Assert.assertThat(task.getErrorMessage(),is(errorMessage.substring(0,666)));
-    Assert.assertThat(task.getRetries(),is(5));
-    Assert.assertThat(externalTaskService.getExternalTaskErrorDetails(task.getId()),is(exceptionStackTrace));
-    Assert.assertThat(task.getErrorDetails(),is(exceptionStackTrace));
+
+    assertThat(task.getErrorMessage()).isEqualTo(errorMessage.substring(0, 666));
+    assertThat(task.getRetries()).isEqualTo(5);
+    assertThat(externalTaskService.getExternalTaskErrorDetails(task.getId())).isEqualTo(exceptionStackTrace);
+    assertThat(task.getErrorDetails()).isEqualTo(exceptionStackTrace);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/SetExternalTasksRetriesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/SetExternalTasksRetriesTest.java
@@ -298,10 +298,8 @@ public class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
     // then batch jobs with different deployment ids exist
     List<Job> batchJobs = managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId()).list();
     assertThat(batchJobs).hasSize(2);
-    assertThat(batchJobs.get(0).getDeploymentId())
-        .isIn(firstDeploymentId, secondDeploymentId);
-    assertThat(batchJobs.get(1).getDeploymentId())
-        .isIn(firstDeploymentId, secondDeploymentId);
+    assertThat(batchJobs.get(0).getDeploymentId()).isIn(firstDeploymentId, secondDeploymentId);
+    assertThat(batchJobs.get(1).getDeploymentId()).isIn(firstDeploymentId, secondDeploymentId);
     assertThat(batchJobs.get(0).getDeploymentId()).isNotEqualTo(batchJobs.get(1).getDeploymentId());
 
     // when the batch jobs for the first deployment are executed

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/SetExternalTasksRetriesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/SetExternalTasksRetriesTest.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-
+import org.hamcrest.Matchers;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.ExternalTaskService;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
@@ -42,7 +42,6 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.AbstractAsyncOperationsTest;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.hamcrest.collection.IsIn;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -300,8 +299,8 @@ public class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
     // then batch jobs with different deployment ids exist
     List<Job> batchJobs = managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId()).list();
     assertThat(batchJobs).hasSize(2);
-    Assert.assertThat(batchJobs.get(0).getDeploymentId(), IsIn.isOneOf(firstDeploymentId, secondDeploymentId));
-    Assert.assertThat(batchJobs.get(1).getDeploymentId(), IsIn.isOneOf(firstDeploymentId, secondDeploymentId));
+    Assert.assertThat(batchJobs.get(0).getDeploymentId(), Matchers.isOneOf(firstDeploymentId, secondDeploymentId));
+    Assert.assertThat(batchJobs.get(1).getDeploymentId(), Matchers.isOneOf(firstDeploymentId, secondDeploymentId));
     assertThat(batchJobs.get(0).getDeploymentId()).isNotEqualTo(batchJobs.get(1).getDeploymentId());
 
     // when the batch jobs for the first deployment are executed

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/SetExternalTasksRetriesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/SetExternalTasksRetriesTest.java
@@ -24,7 +24,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.ExternalTaskService;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
@@ -42,12 +47,6 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.AbstractAsyncOperationsTest;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 public class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
 
@@ -299,8 +298,10 @@ public class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
     // then batch jobs with different deployment ids exist
     List<Job> batchJobs = managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId()).list();
     assertThat(batchJobs).hasSize(2);
-    Assert.assertThat(batchJobs.get(0).getDeploymentId(), Matchers.isOneOf(firstDeploymentId, secondDeploymentId));
-    Assert.assertThat(batchJobs.get(1).getDeploymentId(), Matchers.isOneOf(firstDeploymentId, secondDeploymentId));
+    assertThat(batchJobs.get(0).getDeploymentId())
+        .isIn(firstDeploymentId, secondDeploymentId);
+    assertThat(batchJobs.get(1).getDeploymentId())
+        .isIn(firstDeploymentId, secondDeploymentId);
     assertThat(batchJobs.get(0).getDeploymentId()).isNotEqualTo(batchJobs.get(1).getDeploymentId());
 
     // when the batch jobs for the first deployment are executed

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterPropertiesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterPropertiesTest.java
@@ -16,10 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.filter;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -89,7 +86,7 @@ public class FilterPropertiesTest {
         .singleResult();
 
     // then
-    assertThat(noPropsFilterEntity.getPropertiesInternal(), is("{}"));
+    assertThat(noPropsFilterEntity.getPropertiesInternal()).isEqualTo("{}");
   }
 
   @Test
@@ -140,9 +137,9 @@ public class FilterPropertiesTest {
     Object string = list.get(0);
 
     // then
-    assertThat(deserialisedProperties.size(), is(1));
-    assertThat(string, instanceOf(String.class));
-    assertThat(string.toString(), is("bar"));
+    assertThat(deserialisedProperties.size()).isEqualTo(1);
+    assertThat(string).isInstanceOf(String.class);
+    assertThat(string.toString()).isEqualTo("bar");
   }
 
   @Test
@@ -162,8 +159,8 @@ public class FilterPropertiesTest {
     Object string = map.get("bar");
 
     // then
-    assertThat(deserialisedProperties.size(), is(1));
-    assertThat(string.toString(), is("foo"));
+    assertThat(deserialisedProperties.size()).isEqualTo(1);
+    assertThat(string.toString()).isEqualTo("foo");
   }
 
   @Test
@@ -184,8 +181,8 @@ public class FilterPropertiesTest {
     Object string = list.get(0);
 
     // then
-    assertThat(deserialisedProperties.size(), is(1));
-    assertThat(string.toString(), is("foo"));
+    assertThat(deserialisedProperties.size()).isEqualTo(1);
+    assertThat(string.toString()).isEqualTo("foo");
   }
 
   @Test
@@ -214,14 +211,14 @@ public class FilterPropertiesTest {
     Map map = (Map) list.get(0);
 
     // then
-    assertThat(deserialisedProperties.size(), is(1));
-    assertThat(map.get("string"), is("aStringValue"));
-    assertThat(map.get("int"), is(47));
-    assertThat(map.get("intOutOfRange"), is(Integer.MAX_VALUE + 1L));
-    assertThat(map.get("long"), is(Long.MAX_VALUE));
-    assertThat(map.get("double"), is(3.14159265359D));
-    assertThat(map.get("boolean"), is(true));
-    assertThat(map.get("null"), nullValue());
+    assertThat(deserialisedProperties.size()).isEqualTo(1);
+    assertThat(map.get("string")).isEqualTo("aStringValue");
+    assertThat(map.get("int")).isEqualTo(47);
+    assertThat(map.get("intOutOfRange")).isEqualTo(Integer.MAX_VALUE + 1L);
+    assertThat(map.get("long")).isEqualTo(Long.MAX_VALUE);
+    assertThat(map.get("double")).isEqualTo(3.14159265359D);
+    assertThat(map.get("boolean")).isEqualTo(true);
+    assertThat(map.get("null")).isNull();
   }
 
   @Test
@@ -249,15 +246,15 @@ public class FilterPropertiesTest {
     List list = (List) ((Map) deserialisedProperties.get("foo")).get("bar");
 
     // then
-    assertThat(deserialisedProperties.size(), is(1));
+    assertThat(deserialisedProperties.size()).isEqualTo(1);
 
-    assertThat(list.get(0), is("aStringValue"));
-    assertThat(list.get(1), is(47));
-    assertThat(list.get(2), is(Integer.MAX_VALUE + 1L));
-    assertThat(list.get(3), is(Long.MAX_VALUE));
-    assertThat(list.get(4), is(3.14159265359D));
-    assertThat(list.get(5), is(true));
-    assertThat(list.get(6), nullValue());
+    assertThat(list.get(0)).isEqualTo("aStringValue");
+    assertThat(list.get(1)).isEqualTo(47);
+    assertThat(list.get(2)).isEqualTo(Integer.MAX_VALUE + 1L);
+    assertThat(list.get(3)).isEqualTo(Long.MAX_VALUE);
+    assertThat(list.get(4)).isEqualTo(3.14159265359D);
+    assertThat(list.get(5)).isEqualTo(true);
+    assertThat(list.get(6)).isNull();
   }
 
   protected void assertTestProperties() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterQueryTest.java
@@ -16,9 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.filter;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -27,17 +25,15 @@ import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.operaton.bpm.engine.EntityTypes;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.filter.Filter;
 import org.operaton.bpm.engine.filter.FilterQuery;
 import org.operaton.bpm.engine.impl.persistence.entity.FilterEntity;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Sebastian Menski
@@ -221,60 +217,45 @@ public class FilterQueryTest extends PluggableProcessEngineTest {
     List<String> sortedIds = new ArrayList<String>(filterIds);
     Collections.sort(sortedIds);
     assertEquals(4, filterService.createFilterQuery().orderByFilterId().asc().list().size());
-    Assert.assertThat(filterService.createFilterQuery().orderByFilterId().asc().list(),
-        contains(hasProperty("id", equalTo(sortedIds.get(0))),
-            hasProperty("id", equalTo(sortedIds.get(1))),
-            hasProperty("id", equalTo(sortedIds.get(2))),
-            hasProperty("id", equalTo(sortedIds.get(3)))));
 
-    assertEquals(4, filterService.createFilterQuery().orderByFilterResourceType().asc().list().size());
-    Assert.assertThat(filterService.createFilterQuery().orderByFilterResourceType().asc().list(),
-        contains(hasProperty("resourceType", equalTo(EntityTypes.TASK)),
-          hasProperty("resourceType", equalTo(EntityTypes.TASK)),
-          hasProperty("resourceType", equalTo(EntityTypes.TASK)),
-          hasProperty("resourceType", equalTo(EntityTypes.TASK))));
+    assertThat(filterService.createFilterQuery().orderByFilterId().asc().list())
+        .extracting("id")
+        .containsExactly(sortedIds.get(0), sortedIds.get(1), sortedIds.get(2), sortedIds.get(3));
 
-    assertEquals(4, filterService.createFilterQuery().orderByFilterName().asc().list().size());
-    Assert.assertThat(filterService.createFilterQuery().orderByFilterName().asc().list(),
-        contains(hasProperty("name", equalTo("a")),
-            hasProperty("name", equalTo("b")),
-            hasProperty("name", equalTo("c_")),
-            hasProperty("name", equalTo("d"))));
+    assertThat(filterService.createFilterQuery().orderByFilterResourceType().asc().list())
+        .hasSize(4)
+        .extracting("resourceType")
+        .containsExactly(EntityTypes.TASK, EntityTypes.TASK, EntityTypes.TASK, EntityTypes.TASK);
 
-    assertEquals(4, filterService.createFilterQuery().orderByFilterOwner().asc().list().size());
-    Assert.assertThat(filterService.createFilterQuery().orderByFilterOwner().asc().list(),
-        contains(hasProperty("owner", equalTo("a")),
-            hasProperty("owner", equalTo("b")),
-            hasProperty("owner", equalTo("c")),
-            hasProperty("owner", equalTo("d"))));
+    assertThat(filterService.createFilterQuery().orderByFilterName().asc().list())
+        .hasSize(4)
+        .extracting("name")
+        .containsExactly("a", "b", "c_", "d");
 
-    assertEquals(4, filterService.createFilterQuery().orderByFilterId().desc().list().size());
-    Assert.assertThat(filterService.createFilterQuery().orderByFilterId().desc().list(),
-        contains(hasProperty("id", equalTo(sortedIds.get(3))),
-            hasProperty("id", equalTo(sortedIds.get(2))),
-            hasProperty("id", equalTo(sortedIds.get(1))),
-            hasProperty("id", equalTo(sortedIds.get(0)))));
+    assertThat(filterService.createFilterQuery().orderByFilterOwner().asc().list())
+        .hasSize(4)
+        .extracting("owner")
+        .containsExactly("a", "b", "c", "d");
 
-    assertEquals(4, filterService.createFilterQuery().orderByFilterResourceType().desc().list().size());
-    Assert.assertThat(filterService.createFilterQuery().orderByFilterResourceType().desc().list(),
-      contains(hasProperty("resourceType", equalTo(EntityTypes.TASK)),
-        hasProperty("resourceType", equalTo(EntityTypes.TASK)),
-        hasProperty("resourceType", equalTo(EntityTypes.TASK)),
-        hasProperty("resourceType", equalTo(EntityTypes.TASK))));
+    assertThat(filterService.createFilterQuery().orderByFilterId().desc().list())
+        .hasSize(4)
+        .extracting("id")
+        .containsExactly(sortedIds.get(3), sortedIds.get(2), sortedIds.get(1), sortedIds.get(0));
 
-    assertEquals(4, filterService.createFilterQuery().orderByFilterName().desc().list().size());
-    Assert.assertThat(filterService.createFilterQuery().orderByFilterName().desc().list(),
-        contains(hasProperty("name", equalTo("d")),
-            hasProperty("name", equalTo("c_")),
-            hasProperty("name", equalTo("b")),
-            hasProperty("name", equalTo("a"))));
+    assertThat(filterService.createFilterQuery().orderByFilterResourceType().desc().list())
+        .hasSize(4)
+        .extracting("resourceType")
+        .containsExactly(EntityTypes.TASK, EntityTypes.TASK, EntityTypes.TASK, EntityTypes.TASK);
 
-    assertEquals(4, filterService.createFilterQuery().orderByFilterOwner().desc().list().size());
-    Assert.assertThat(filterService.createFilterQuery().orderByFilterOwner().desc().list(),
-        contains(hasProperty("name", equalTo("d")),
-            hasProperty("name", equalTo("c_")),
-            hasProperty("name", equalTo("b")),
-            hasProperty("name", equalTo("a"))));
+    assertThat(filterService.createFilterQuery().orderByFilterName().desc().list())
+        .hasSize(4)
+        .extracting("name")
+        .containsExactly("d", "c_", "b", "a");
+
+    assertThat(filterService.createFilterQuery().orderByFilterOwner().desc().list())
+        .hasSize(4)
+        .extracting("owner")
+        .containsExactly("d", "c", "b", "a");
 
     assertEquals(1, filterService.createFilterQuery().orderByFilterId().filterName("a").asc().list().size());
     assertEquals(1, filterService.createFilterQuery().orderByFilterId().filterName("a").desc().list().size());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceAsyncOperationsTest.java
@@ -18,8 +18,6 @@ package org.operaton.bpm.engine.test.api.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -28,8 +26,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import org.assertj.core.api.Assertions;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.TaskService;
@@ -45,13 +48,6 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.AbstractAsyncOperationsTest;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 /**
  * @author Askar Akhmerov
@@ -136,12 +132,12 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     assertThat(batchJobs.size()).isEqualTo(2);
     assertThat(batchJobs.get(0).getDeploymentId())
         .satisfiesAnyOf(
-            arg -> assertThat(arg, is(firstDeploymentId)),
+            arg -> assertThat(arg).isEqualTo(firstDeploymentId),
             arg -> assertThat(arg).isNull()
         );
     assertThat(batchJobs.get(1).getDeploymentId())
         .satisfiesAnyOf(
-            arg -> assertThat(arg, is(firstDeploymentId)),
+            arg -> assertThat(arg).isEqualTo(firstDeploymentId),
             arg -> assertThat(arg).isNull()
         );
     assertThat(batchJobs.get(0).getDeploymentId()).isNotEqualTo(batchJobs.get(1).getDeploymentId());
@@ -179,8 +175,8 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     // then batch jobs with different deployment ids exist
     List<Job> batchJobs = managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId()).list();
     assertThat(batchJobs.size()).isEqualTo(2);
-    assertThat(batchJobs.get(0).getDeploymentId(), Matchers.isOneOf(firstDeploymentId, secondDeploymentId));
-    assertThat(batchJobs.get(1).getDeploymentId(), Matchers.isOneOf(firstDeploymentId, secondDeploymentId));
+    assertThat(batchJobs.get(0).getDeploymentId()).isIn(firstDeploymentId, secondDeploymentId);
+    assertThat(batchJobs.get(1).getDeploymentId()).isIn(firstDeploymentId, secondDeploymentId);
     assertThat(batchJobs.get(0).getDeploymentId()).isNotEqualTo(batchJobs.get(1).getDeploymentId());
     assertThat(historicProcessInstances.size()).isEqualTo(4);
     assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId)).isEqualTo(2L);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceAsyncOperationsTest.java
@@ -16,12 +16,10 @@
  */
 package org.operaton.bpm.engine.test.api.history;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -48,7 +46,7 @@ import org.operaton.bpm.engine.test.api.AbstractAsyncOperationsTest;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.hamcrest.CoreMatchers;
-import org.hamcrest.collection.IsIn;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -103,7 +101,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions.size(), is(0));
+    assertThat(exceptions.size()).isEqualTo(0);
     assertNoHistoryForTasks();
     assertHistoricBatchExists(testRule);
     assertAllHistoricProcessInstancesAreDeleted();
@@ -135,19 +133,27 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     // then batch jobs with different deployment ids exist
     JobQuery batchJobQuery = managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId());
     List<Job> batchJobs = batchJobQuery.list();
-    assertThat(batchJobs.size(), is(2));
-    assertThat(batchJobs.get(0).getDeploymentId(), anyOf(is(firstDeploymentId), is(nullValue())));
-    assertThat(batchJobs.get(1).getDeploymentId(), anyOf(is(firstDeploymentId), is(nullValue())));
-    assertThat(batchJobs.get(0).getDeploymentId(), is(not(batchJobs.get(1).getDeploymentId())));
-    assertThat(historicProcessInstances.size(), is(4));
-    assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId), is(2L));
+    assertThat(batchJobs.size()).isEqualTo(2);
+    assertThat(batchJobs.get(0).getDeploymentId())
+        .satisfiesAnyOf(
+            arg -> assertThat(arg, is(firstDeploymentId)),
+            arg -> assertThat(arg).isNull()
+        );
+    assertThat(batchJobs.get(1).getDeploymentId())
+        .satisfiesAnyOf(
+            arg -> assertThat(arg, is(firstDeploymentId)),
+            arg -> assertThat(arg).isNull()
+        );
+    assertThat(batchJobs.get(0).getDeploymentId()).isNotEqualTo(batchJobs.get(1).getDeploymentId());
+    assertThat(historicProcessInstances.size()).isEqualTo(4);
+    assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId)).isEqualTo(2L);
 
     // when the batch jobs for the first deployment are executed
     getJobIdsByDeployment(batchJobs, firstDeploymentId).forEach(managementService::executeJob);
     // then the historic process instances related to the first deployment should be deleted
-    assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId), is(0L));
+    assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId)).isEqualTo(0L);
     // and historic process instances related to the second deployment should not be deleted
-    assertThat(historyService.createHistoricProcessInstanceQuery().count(), is(2L));
+    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(2L);
 
     // when the remaining batch jobs are executed
     batchJobQuery.list().forEach(j -> managementService.executeJob(j.getId()));
@@ -172,20 +178,20 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     executeSeedJobs(batch, 2);
     // then batch jobs with different deployment ids exist
     List<Job> batchJobs = managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId()).list();
-    assertThat(batchJobs.size(), is(2));
-    assertThat(batchJobs.get(0).getDeploymentId(), IsIn.isOneOf(firstDeploymentId, secondDeploymentId));
-    assertThat(batchJobs.get(1).getDeploymentId(), IsIn.isOneOf(firstDeploymentId, secondDeploymentId));
-    assertThat(batchJobs.get(0).getDeploymentId(), is(not(batchJobs.get(1).getDeploymentId())));
-    assertThat(historicProcessInstances.size(), is(4));
-    assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId), is(2L));
-    assertThat(getHistoricProcessInstanceCountByDeploymentId(secondDeploymentId), is(2L));
+    assertThat(batchJobs.size()).isEqualTo(2);
+    assertThat(batchJobs.get(0).getDeploymentId(), Matchers.isOneOf(firstDeploymentId, secondDeploymentId));
+    assertThat(batchJobs.get(1).getDeploymentId(), Matchers.isOneOf(firstDeploymentId, secondDeploymentId));
+    assertThat(batchJobs.get(0).getDeploymentId()).isNotEqualTo(batchJobs.get(1).getDeploymentId());
+    assertThat(historicProcessInstances.size()).isEqualTo(4);
+    assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId)).isEqualTo(2L);
+    assertThat(getHistoricProcessInstanceCountByDeploymentId(secondDeploymentId)).isEqualTo(2L);
 
     // when the batch jobs for the first deployment are executed
     getJobIdsByDeployment(batchJobs, firstDeploymentId).forEach(managementService::executeJob);
     // then the historic process instances related to the first deployment should be deleted
-    assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId), is(0L));
+    assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId)).isEqualTo(0L);
     // and historic process instances related to the second deployment should not be deleted
-    assertThat(getHistoricProcessInstanceCountByDeploymentId(secondDeploymentId), is(2L));
+    assertThat(getHistoricProcessInstanceCountByDeploymentId(secondDeploymentId)).isEqualTo(2L);
 
     // when the remaining batch jobs are executed
     getJobIdsByDeployment(batchJobs, secondDeploymentId).forEach(managementService::executeJob);
@@ -215,7 +221,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     List<Exception> exceptions = executeBatchJobs(batch);
 
     //then
-    assertThat(exceptions.size(), is(0));
+    assertThat(exceptions.size()).isEqualTo(0);
     assertHistoricBatchExists(testRule);
   }
 
@@ -232,7 +238,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions.size(), is(0));
+    assertThat(exceptions.size()).isEqualTo(0);
     assertNoHistoryForTasks();
     assertHistoricBatchExists(testRule);
     assertAllHistoricProcessInstancesAreDeleted();
@@ -250,7 +256,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions.size(), is(0));
+    assertThat(exceptions.size()).isEqualTo(0);
     assertNoHistoryForTasks();
     assertHistoricBatchExists(testRule);
     assertAllHistoricProcessInstancesAreDeleted();
@@ -292,7 +298,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     List<Exception> exceptions = executeBatchJobs(batch);
 
     //then
-    assertThat(exceptions.size(), is(0));
+    assertThat(exceptions.size()).isEqualTo(0);
     assertNoHistoryForTasks();
     assertHistoricBatchExists(testRule);
     assertAllHistoricProcessInstancesAreDeleted();
@@ -350,7 +356,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
   }
 
   protected void assertAllHistoricProcessInstancesAreDeleted() {
-    assertThat(historyService.createHistoricProcessInstanceQuery().count(), is(0L));
+    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0L);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceAsyncOperationsTest.java
@@ -130,16 +130,11 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     JobQuery batchJobQuery = managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId());
     List<Job> batchJobs = batchJobQuery.list();
     assertThat(batchJobs.size()).isEqualTo(2);
-    assertThat(batchJobs.get(0).getDeploymentId())
+    batchJobs.stream().forEach(job -> assertThat(job.getDeploymentId())
         .satisfiesAnyOf(
             arg -> assertThat(arg).isEqualTo(firstDeploymentId),
             arg -> assertThat(arg).isNull()
-        );
-    assertThat(batchJobs.get(1).getDeploymentId())
-        .satisfiesAnyOf(
-            arg -> assertThat(arg).isEqualTo(firstDeploymentId),
-            arg -> assertThat(arg).isNull()
-        );
+        ));
     assertThat(batchJobs.get(0).getDeploymentId()).isNotEqualTo(batchJobs.get(1).getDeploymentId());
     assertThat(historicProcessInstances.size()).isEqualTo(4);
     assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId)).isEqualTo(2L);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/HistoricRootProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/HistoricRootProcessInstanceTest.java
@@ -16,10 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.history.removaltime;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.core.IsNull.nullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.util.Date;
@@ -111,12 +108,12 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     List<HistoricDecisionInstance> historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // assume
-    assertThat(historicDecisionInstances.size(), is(3));
+    assertThat(historicDecisionInstances.size()).isEqualTo(3);
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
-    assertThat(historicDecisionInstances.get(1).getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
-    assertThat(historicDecisionInstances.get(2).getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(historicDecisionInstances.get(0).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+    assertThat(historicDecisionInstances.get(1).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+    assertThat(historicDecisionInstances.get(2).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -143,13 +140,13 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     List<HistoricDecisionInputInstance> historicDecisionInputInstances = historicDecisionInstance.getInputs();
 
     // then
-    assertThat(historicDecisionInputInstances.get(0).getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
-    assertThat(historicDecisionInputInstances.get(1).getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(historicDecisionInputInstances.get(0).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+    assertThat(historicDecisionInputInstances.get(1).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -170,13 +167,13 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     List<HistoricDecisionInputInstance> historicDecisionInputInstances = historicDecisionInstance.getInputs();
 
     // then
-    assertThat(historicDecisionInputInstances.get(0).getRootProcessInstanceId(), nullValue());
-    assertThat(historicDecisionInputInstances.get(1).getRootProcessInstanceId(), nullValue());
+    assertThat(historicDecisionInputInstances.get(0).getRootProcessInstanceId()).isNull();
+    assertThat(historicDecisionInputInstances.get(1).getRootProcessInstanceId()).isNull();
   }
 
   @Test
@@ -203,12 +200,12 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     List<HistoricDecisionOutputInstance> historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
 
     // then
-    assertThat(historicDecisionOutputInstances.get(0).getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(historicDecisionOutputInstances.get(0).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -229,12 +226,12 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     List<HistoricDecisionOutputInstance> historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
 
     // then
-    assertThat(historicDecisionOutputInstances.get(0).getRootProcessInstanceId(), nullValue());
+    assertThat(historicDecisionOutputInstances.get(0).getRootProcessInstanceId()).isNull();
   }
 
   @Test
@@ -252,10 +249,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicProcessInstance, notNullValue());
+    assertThat(historicProcessInstance).isNotNull();
 
     // then
-    assertThat(historicProcessInstance.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(historicProcessInstance.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -273,10 +270,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicActivityInstance, notNullValue());
+    assertThat(historicActivityInstance).isNotNull();
 
     // then
-    assertThat(historicActivityInstance.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(historicActivityInstance.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -294,10 +291,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicTaskInstance, notNullValue());
+    assertThat(historicTaskInstance).isNotNull();
 
     // then
-    assertThat(historicTaskInstance.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(historicTaskInstance.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -311,10 +308,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
 
     // assume
-    assertThat(historicTaskInstance, notNullValue());
+    assertThat(historicTaskInstance).isNotNull();
 
     // then
-    assertThat(historicTaskInstance.getRootProcessInstanceId(), nullValue());
+    assertThat(historicTaskInstance.getRootProcessInstanceId()).isNull();
 
     // cleanup
     taskService.deleteTask(task.getId(), true);
@@ -335,10 +332,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery().singleResult();
 
     // assume
-    assertThat(historicVariableInstance, notNullValue());
+    assertThat(historicVariableInstance).isNotNull();
 
     // then
-    assertThat(historicVariableInstance.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(historicVariableInstance.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -360,11 +357,11 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicDetails.size(), is(2));
+    assertThat(historicDetails.size()).isEqualTo(2);
 
     // then
-    assertThat(historicDetails.get(0).getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
-    assertThat(historicDetails.get(1).getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(historicDetails.get(0).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+    assertThat(historicDetails.get(1).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -384,10 +381,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     HistoricDetail historicDetail = historyService.createHistoricDetailQuery().formFields().singleResult();
 
     // assume
-    assertThat(historicDetail, notNullValue());
+    assertThat(historicDetail).isNotNull();
 
     // then
-    assertThat(historicDetail.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(historicDetail.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -414,11 +411,11 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     List<HistoricIncident> historicIncidents = historyService.createHistoricIncidentQuery().list();
 
     // assume
-    assertThat(historicIncidents.size(), is(2));
+    assertThat(historicIncidents.size()).isEqualTo(2);
 
     // then
-    assertThat(historicIncidents.get(0).getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
-    assertThat(historicIncidents.get(1).getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(historicIncidents.get(0).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+    assertThat(historicIncidents.get(1).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -442,10 +439,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     HistoricIncident historicIncident = historyService.createHistoricIncidentQuery().singleResult();
 
     // assume
-    assertThat(historicIncident, notNullValue());
+    assertThat(historicIncident).isNotNull();
 
     // then
-    assertThat(historicIncident.getRootProcessInstanceId(), nullValue());
+    assertThat(historicIncident.getRootProcessInstanceId()).isNull();
 
     // cleanup
     clearJobLog(jobId);
@@ -472,10 +469,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     HistoricExternalTaskLog ExternalTaskLog = historyService.createHistoricExternalTaskLogQuery().singleResult();
 
     // assume
-    assertThat(ExternalTaskLog, notNullValue());
+    assertThat(ExternalTaskLog).isNotNull();
 
     // then
-    assertThat(ExternalTaskLog.getRootProcessInstanceId(), is(processInstance.getRootProcessInstanceId()));
+    assertThat(ExternalTaskLog.getRootProcessInstanceId()).isEqualTo(processInstance.getRootProcessInstanceId());
   }
 
   @Test
@@ -500,11 +497,11 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     List<HistoricJobLog> jobLog = historyService.createHistoricJobLogQuery().list();
 
     // assume
-    assertThat(jobLog.size(), is(2));
+    assertThat(jobLog.size()).isEqualTo(2);
 
     // then
-    assertThat(jobLog.get(0).getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
-    assertThat(jobLog.get(1).getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(jobLog.get(0).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+    assertThat(jobLog.get(1).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -518,10 +515,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     HistoricJobLog jobLog = historyService.createHistoricJobLogQuery().singleResult();
 
     // assume
-    assertThat(jobLog, notNullValue());
+    assertThat(jobLog).isNotNull();
 
     // then
-    assertThat(jobLog.getRootProcessInstanceId(), nullValue());
+    assertThat(jobLog.getRootProcessInstanceId()).isNull();
 
     // cleanup
     managementService.deleteJob(jobLog.getJobId());
@@ -550,10 +547,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // assume
-    assertThat(userOperationLog, notNullValue());
+    assertThat(userOperationLog).isNotNull();
 
     // then
-    assertThat(userOperationLog.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(userOperationLog.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -580,10 +577,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // assume
-    assertThat(userOperationLog, notNullValue());
+    assertThat(userOperationLog).isNotNull();
 
     // then
-    assertThat(userOperationLog.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(userOperationLog.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -605,10 +602,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // assume
-    assertThat(userOperationLog, notNullValue());
+    assertThat(userOperationLog).isNotNull();
 
     // then
-    assertThat(userOperationLog.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(userOperationLog.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -628,10 +625,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // assume
-    assertThat(userOperationLog, notNullValue());
+    assertThat(userOperationLog).isNotNull();
 
     // then
-    assertThat(userOperationLog.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(userOperationLog.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -654,10 +651,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
             .singleResult();
 
     // assume
-    assertThat(historicIdentityLinkLog, notNullValue());
+    assertThat(historicIdentityLinkLog).isNotNull();
 
     // then
-    assertThat(historicIdentityLinkLog.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(historicIdentityLinkLog.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -672,10 +669,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     HistoricIdentityLinkLog historicIdentityLinkLog = historyService.createHistoricIdentityLinkLogQuery().singleResult();
 
     // assume
-    assertThat(historicIdentityLinkLog, notNullValue());
+    assertThat(historicIdentityLinkLog).isNotNull();
 
     // then
-    assertThat(historicIdentityLinkLog.getRootProcessInstanceId(), nullValue());
+    assertThat(historicIdentityLinkLog.getRootProcessInstanceId()).isNull();
 
     // cleanup
     taskService.complete(aTask.getId());
@@ -702,10 +699,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     Comment comment = taskService.getProcessInstanceComments(processInstanceId).get(0);
 
     // assume
-    assertThat(comment, notNullValue());
+    assertThat(comment).isNotNull();
 
     // then
-    assertThat(comment.getRootProcessInstanceId(), is(processInstance.getRootProcessInstanceId()));
+    assertThat(comment.getRootProcessInstanceId()).isEqualTo(processInstance.getRootProcessInstanceId());
   }
 
   @Test
@@ -725,10 +722,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     Comment comment = taskService.getTaskComments(taskId).get(0);
 
     // assume
-    assertThat(comment, notNullValue());
+    assertThat(comment).isNotNull();
 
     // then
-    assertThat(comment.getRootProcessInstanceId(), is(processInstance.getRootProcessInstanceId()));
+    assertThat(comment.getRootProcessInstanceId()).isEqualTo(processInstance.getRootProcessInstanceId());
   }
 
   @Test
@@ -751,10 +748,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     Comment comment = taskService.getProcessInstanceComments(processInstanceId).get(0);
 
     // assume
-    assertThat(comment, notNullValue());
+    assertThat(comment).isNotNull();
 
     // then
-    assertThat(comment.getRootProcessInstanceId(), nullValue());
+    assertThat(comment.getRootProcessInstanceId()).isNull();
   }
 
   @Test
@@ -774,10 +771,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     Comment comment = taskService.getTaskComments(taskId).get(0);
 
     // assume
-    assertThat(comment, notNullValue());
+    assertThat(comment).isNotNull();
 
     // then
-    assertThat(comment.getRootProcessInstanceId(), is(processInstance.getRootProcessInstanceId()));
+    assertThat(comment.getRootProcessInstanceId()).isEqualTo(processInstance.getRootProcessInstanceId());
   }
 
   @Test
@@ -790,10 +787,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     Comment comment = taskService.getProcessInstanceComments("aNonExistentProcessInstanceId").get(0);
 
     // assume
-    assertThat(comment, notNullValue());
+    assertThat(comment).isNotNull();
 
     // then
-    assertThat(comment.getRootProcessInstanceId(), nullValue());
+    assertThat(comment.getRootProcessInstanceId()).isNull();
 
     // cleanup
     clearCommentByProcessInstanceId("aNonExistentProcessInstanceId");
@@ -809,10 +806,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     Comment comment = taskService.getTaskComments("aNonExistentTaskId").get(0);
 
     // assume
-    assertThat(comment, notNullValue());
+    assertThat(comment).isNotNull();
 
     // then
-    assertThat(comment.getRootProcessInstanceId(), nullValue());
+    assertThat(comment.getRootProcessInstanceId()).isNull();
 
     // cleanup
     clearCommentByTaskId("aNonExistentTaskId");
@@ -838,10 +835,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     Attachment attachment = taskService.getAttachment(attachmentId);
 
     // assume
-    assertThat(attachment, notNullValue());
+    assertThat(attachment).isNotNull();
 
     // then
-    assertThat(attachment.getRootProcessInstanceId(), is(processInstance.getRootProcessInstanceId()));
+    assertThat(attachment.getRootProcessInstanceId()).isEqualTo(processInstance.getRootProcessInstanceId());
   }
 
   @Test
@@ -861,10 +858,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     Attachment attachment = taskService.getAttachment(attachmentId);
 
     // assume
-    assertThat(attachment, notNullValue());
+    assertThat(attachment).isNotNull();
 
     // then
-    assertThat(attachment.getRootProcessInstanceId(), is(processInstance.getRootProcessInstanceId()));
+    assertThat(attachment.getRootProcessInstanceId()).isEqualTo(processInstance.getRootProcessInstanceId());
   }
 
   @Test
@@ -887,10 +884,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     Attachment attachment = taskService.getAttachment(attachmentId);
 
     // assume
-    assertThat(attachment, notNullValue());
+    assertThat(attachment).isNotNull();
 
     // then
-    assertThat(attachment.getRootProcessInstanceId(), nullValue());
+    assertThat(attachment.getRootProcessInstanceId()).isNull();
   }
 
   @Test
@@ -912,10 +909,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     Attachment attachment = taskService.getAttachment(attachmentId);
 
     // assume
-    assertThat(attachment, notNullValue());
+    assertThat(attachment).isNotNull();
 
     // then
-    assertThat(attachment.getRootProcessInstanceId(), is(processInstance.getRootProcessInstanceId()));
+    assertThat(attachment.getRootProcessInstanceId()).isEqualTo(processInstance.getRootProcessInstanceId());
   }
 
   @Test
@@ -928,10 +925,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     Attachment attachment = taskService.getAttachment(attachmentId);
 
     // assume
-    assertThat(attachment, notNullValue());
+    assertThat(attachment).isNotNull();
 
     // then
-    assertThat(attachment.getRootProcessInstanceId(), nullValue());
+    assertThat(attachment.getRootProcessInstanceId()).isNull();
 
     // cleanup
     clearAttachment(attachment);
@@ -954,10 +951,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArray = findByteArrayById(attachment.getContentId());
 
     // assume
-    assertThat(byteArray, notNullValue());
+    assertThat(byteArray).isNotNull();
 
     // then
-    assertThat(byteArray.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(byteArray.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -980,10 +977,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArray = findByteArrayById(attachment.getContentId());
 
     // assume
-    assertThat(byteArray, notNullValue());
+    assertThat(byteArray).isNotNull();
 
     // then
-    assertThat(byteArray.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(byteArray.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -1003,10 +1000,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArray = findByteArrayById(historicVariableInstance.getByteArrayId());
 
     // assume
-    assertThat(byteArray, notNullValue());
+    assertThat(byteArray).isNotNull();
 
     // then
-    assertThat(byteArray.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(byteArray.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -1032,7 +1029,7 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArray = findByteArrayById(historicDetails.getByteArrayValueId());
 
     // then
-    assertThat(byteArray.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(byteArray.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -1060,12 +1057,12 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(jobLog, notNullValue());
+    assertThat(jobLog).isNotNull();
 
     ByteArrayEntity byteArray = findByteArrayById(jobLog.getExceptionByteArrayId());
 
     // then
-    assertThat(byteArray.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(byteArray.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -1096,12 +1093,12 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(externalTaskLog, notNullValue());
+    assertThat(externalTaskLog).isNotNull();
 
     ByteArrayEntity byteArrayEntity = findByteArrayById(externalTaskLog.getErrorDetailsByteArrayId());
 
     // then
-    assertThat(byteArrayEntity.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(byteArrayEntity.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -1126,14 +1123,14 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     HistoricDecisionInputInstanceEntity historicDecisionInputInstanceEntity = (HistoricDecisionInputInstanceEntity) historicDecisionInstance.getInputs().get(0);
 
     ByteArrayEntity byteArrayEntity = findByteArrayById(historicDecisionInputInstanceEntity.getByteArrayValueId());
 
     // then
-    assertThat(byteArrayEntity.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(byteArrayEntity.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -1158,14 +1155,14 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     HistoricDecisionOutputInstanceEntity historicDecisionOutputInstanceEntity = (HistoricDecisionOutputInstanceEntity) historicDecisionInstance.getOutputs().get(0);
 
     ByteArrayEntity byteArrayEntity = findByteArrayById(historicDecisionOutputInstanceEntity.getByteArrayValueId());
 
     // then
-    assertThat(byteArrayEntity.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(byteArrayEntity.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -1188,14 +1185,14 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     HistoricDecisionOutputInstanceEntity historicDecisionOutputInstanceEntity = (HistoricDecisionOutputInstanceEntity) historicDecisionInstance.getOutputs().get(0);
 
     ByteArrayEntity byteArrayEntity = findByteArrayById(historicDecisionOutputInstanceEntity.getByteArrayValueId());
 
     // then
-    assertThat(byteArrayEntity.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(byteArrayEntity.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -1217,10 +1214,10 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
         .singleResult();
 
     // assume
-    assertThat(authorization, notNullValue());
+    assertThat(authorization).isNotNull();
 
     // then
-    assertThat(authorization.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(authorization.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
 
     // clear
     clearAuthorization();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/RemovalTimeStrategyConfigurationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/RemovalTimeStrategyConfigurationTest.java
@@ -16,13 +16,11 @@
  */
 package org.operaton.bpm.engine.test.api.history.removaltime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_END;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_NONE;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_START;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.Is.isA;
 import static org.mockito.Mockito.mock;
 
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -80,8 +78,8 @@ public class RemovalTimeStrategyConfigurationTest {
     processEngineConfiguration.initHistoryRemovalTime();
 
     // then
-    assertThat(processEngineConfiguration.getHistoryRemovalTimeStrategy(), is(HISTORY_REMOVAL_TIME_STRATEGY_END));
-    assertThat(processEngineConfiguration.getHistoryRemovalTimeProvider(), isA(HistoryRemovalTimeProvider.class));
+    assertThat(processEngineConfiguration.getHistoryRemovalTimeStrategy()).isEqualTo(HISTORY_REMOVAL_TIME_STRATEGY_END);
+    assertThat(processEngineConfiguration.getHistoryRemovalTimeProvider()).isInstanceOf(HistoryRemovalTimeProvider.class);
   }
 
   @Test
@@ -96,8 +94,8 @@ public class RemovalTimeStrategyConfigurationTest {
     processEngineConfiguration.initHistoryRemovalTime();
 
     // then
-    assertThat(processEngineConfiguration.getHistoryRemovalTimeStrategy(), is(HISTORY_REMOVAL_TIME_STRATEGY_START));
-    assertThat(processEngineConfiguration.getHistoryRemovalTimeProvider(), isA(HistoryRemovalTimeProvider.class));
+    assertThat(processEngineConfiguration.getHistoryRemovalTimeStrategy()).isEqualTo(HISTORY_REMOVAL_TIME_STRATEGY_START);
+    assertThat(processEngineConfiguration.getHistoryRemovalTimeProvider()).isInstanceOf(HistoryRemovalTimeProvider.class);
   }
 
   @Test
@@ -112,8 +110,8 @@ public class RemovalTimeStrategyConfigurationTest {
     processEngineConfiguration.initHistoryRemovalTime();
 
     // then
-    assertThat(processEngineConfiguration.getHistoryRemovalTimeStrategy(), is(HISTORY_REMOVAL_TIME_STRATEGY_END));
-    assertThat(processEngineConfiguration.getHistoryRemovalTimeProvider(), isA(HistoryRemovalTimeProvider.class));
+    assertThat(processEngineConfiguration.getHistoryRemovalTimeStrategy()).isEqualTo(HISTORY_REMOVAL_TIME_STRATEGY_END);
+    assertThat(processEngineConfiguration.getHistoryRemovalTimeProvider()).isInstanceOf(HistoryRemovalTimeProvider.class);
   }
 
   @Test
@@ -128,8 +126,8 @@ public class RemovalTimeStrategyConfigurationTest {
     processEngineConfiguration.initHistoryRemovalTime();
 
     // then
-    assertThat(processEngineConfiguration.getHistoryRemovalTimeStrategy(), is(HISTORY_REMOVAL_TIME_STRATEGY_NONE));
-    assertThat(processEngineConfiguration.getHistoryRemovalTimeProvider(), isA(HistoryRemovalTimeProvider.class));
+    assertThat(processEngineConfiguration.getHistoryRemovalTimeStrategy()).isEqualTo(HISTORY_REMOVAL_TIME_STRATEGY_NONE);
+    assertThat(processEngineConfiguration.getHistoryRemovalTimeProvider()).isInstanceOf(HistoryRemovalTimeProvider.class);
   }
 
   @Test
@@ -144,8 +142,8 @@ public class RemovalTimeStrategyConfigurationTest {
     processEngineConfiguration.initHistoryRemovalTime();
 
     // then
-    assertThat(processEngineConfiguration.getHistoryRemovalTimeStrategy(), is(HISTORY_REMOVAL_TIME_STRATEGY_END));
-    assertThat(processEngineConfiguration.getHistoryRemovalTimeProvider(), isA(HistoryRemovalTimeProvider.class));
+    assertThat(processEngineConfiguration.getHistoryRemovalTimeStrategy()).isEqualTo(HISTORY_REMOVAL_TIME_STRATEGY_END);
+    assertThat(processEngineConfiguration.getHistoryRemovalTimeProvider()).isInstanceOf(HistoryRemovalTimeProvider.class);
   }
 
   @Test
@@ -159,7 +157,7 @@ public class RemovalTimeStrategyConfigurationTest {
       .hasMessageContaining("history removal time strategy must be set to 'start', 'end' or 'none'");
 
     // assume
-    assertThat(processEngineConfiguration.getHistoryRemovalTimeProvider(), isA(HistoryRemovalTimeProvider.class));
+    assertThat(processEngineConfiguration.getHistoryRemovalTimeProvider()).isInstanceOf(HistoryRemovalTimeProvider.class);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/RemovalTimeStrategyEndTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/RemovalTimeStrategyEndTest.java
@@ -16,12 +16,9 @@
  */
 package org.operaton.bpm.engine.test.api.history.removaltime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_END;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
@@ -146,9 +143,9 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     List<HistoricDecisionInstance> historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // assume
-    assertThat(historicDecisionInstances.get(0).getRemovalTime(), nullValue());
-    assertThat(historicDecisionInstances.get(1).getRemovalTime(), nullValue());
-    assertThat(historicDecisionInstances.get(2).getRemovalTime(), nullValue());
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isNull();
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isNull();
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isNull();
 
     String jobId = managementService.createJobQuery().singleResult().getId();
 
@@ -160,9 +157,9 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRemovalTime(), is(removalTime));
-    assertThat(historicDecisionInstances.get(1).getRemovalTime(), is(removalTime));
-    assertThat(historicDecisionInstances.get(2).getRemovalTime(), is(removalTime));
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -196,8 +193,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     List<HistoricDecisionInputInstance> historicDecisionInputInstances = historicDecisionInstance.getInputs();
 
     // assume
-    assertThat(historicDecisionInputInstances.get(0).getRemovalTime(), nullValue());
-    assertThat(historicDecisionInputInstances.get(1).getRemovalTime(), nullValue());
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isNull();
+    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isNull();
 
     String jobId = managementService.createJobQuery().singleResult().getId();
 
@@ -214,8 +211,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(historicDecisionInputInstances.get(0).getRemovalTime(), is(removalTime));
-    assertThat(historicDecisionInputInstances.get(1).getRemovalTime(), is(removalTime));
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -249,7 +246,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     List<HistoricDecisionOutputInstance> historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
 
     // assume
-    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime(), nullValue());
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isNull();
 
     String jobId = managementService.createJobQuery().singleResult().getId();
 
@@ -266,7 +263,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime(), is(removalTime));
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -285,7 +282,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicProcessInstance.getRemovalTime(), nullValue());
+    assertThat(historicProcessInstance.getRemovalTime()).isNull();
 
     String taskId = historyService.createHistoricTaskInstanceQuery().singleResult().getId();
 
@@ -301,7 +298,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(historicProcessInstance.getRemovalTime(), is(removalTime));
+    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -324,7 +321,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicActivityInstance.getRemovalTime(), nullValue());
+    assertThat(historicActivityInstance.getRemovalTime()).isNull();
 
     // when
     taskService.complete(taskId);
@@ -336,7 +333,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(historicActivityInstance.getRemovalTime(), is(removalTime));
+    assertThat(historicActivityInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   /**
@@ -381,7 +378,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
 
     // assume
-    assertThat(historicTaskInstance.getRemovalTime(), nullValue());
+    assertThat(historicTaskInstance.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -395,7 +392,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(historicTaskInstance.getRemovalTime(), is(removalTime));
+    assertThat(historicTaskInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -428,7 +425,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
         .singleResult();
 
     // assume
-    assertThat(authorization.getRemovalTime(), nullValue());
+    assertThat(authorization.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -442,7 +439,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
         .singleResult();
 
     // then
-    assertThat(authorization.getRemovalTime(), is(removalTime));
+    assertThat(authorization.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -473,8 +470,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // assume
-    assertThat(authorization.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
-    assertThat(authorization.getRemovalTime(), is(removalTime));
+    assertThat(authorization.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+    assertThat(authorization.getRemovalTime()).isEqualTo(removalTime);
 
     authorization.setResourceId("*");
 
@@ -486,8 +483,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
         .singleResult();
 
     // then
-    assertThat(authorization.getRootProcessInstanceId(), nullValue());
-    assertThat(authorization.getRemovalTime(), nullValue());
+    assertThat(authorization.getRootProcessInstanceId()).isNull();
+    assertThat(authorization.getRemovalTime()).isNull();
   }
 
   @Test
@@ -521,8 +518,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
         .singleResult();
 
     // assume
-    assertThat(authorization.getRootProcessInstanceId(), nullValue());
-    assertThat(authorization.getRemovalTime(), nullValue());
+    assertThat(authorization.getRootProcessInstanceId()).isNull();
+    assertThat(authorization.getRemovalTime()).isNull();
 
     taskId = historyService.createHistoricTaskInstanceQuery().singleResult().getId();
 
@@ -538,8 +535,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(authorization.getRootProcessInstanceId(), is(processInstance.getRootProcessInstanceId()));
-    assertThat(authorization.getRemovalTime(), is(removalTime));
+    assertThat(authorization.getRootProcessInstanceId()).isEqualTo(processInstance.getRootProcessInstanceId());
+    assertThat(authorization.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -737,7 +734,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
         .singleResult();
 
     // assume
-    assertThat(authorization.getRemovalTime(), nullValue());
+    assertThat(authorization.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -751,7 +748,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(authorization.getRemovalTime(), is(removalTime));
+    assertThat(authorization.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -776,7 +773,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
         .singleResult();
 
     // assume
-    assertThat(authorization.getRemovalTime(), nullValue());
+    assertThat(authorization.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -790,7 +787,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(authorization.getRemovalTime(), is(removalTime));
+    assertThat(authorization.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -811,7 +808,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery().singleResult();
 
     // assume
-    assertThat(historicVariableInstance.getRemovalTime(), nullValue());
+    assertThat(historicVariableInstance.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -825,7 +822,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(historicVariableInstance.getRemovalTime(), is(removalTime));
+    assertThat(historicVariableInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -848,8 +845,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicDetails.get(0).getRemovalTime(), nullValue());
-    assertThat(historicDetails.get(1).getRemovalTime(), nullValue());
+    assertThat(historicDetails.get(0).getRemovalTime()).isNull();
+    assertThat(historicDetails.get(1).getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -865,8 +862,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(historicDetails.get(0).getRemovalTime(), is(removalTime));
-    assertThat(historicDetails.get(1).getRemovalTime(), is(removalTime));
+    assertThat(historicDetails.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDetails.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -887,7 +884,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     HistoricDetail historicDetail = historyService.createHistoricDetailQuery().formFields().singleResult();
 
     // assume
-    assertThat(historicDetail.getRemovalTime(), nullValue());
+    assertThat(historicDetail.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -901,7 +898,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(historicDetail.getRemovalTime(), is(removalTime));
+    assertThat(historicDetail.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -933,8 +930,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     List<HistoricIncident> historicIncidents = historyService.createHistoricIncidentQuery().list();
 
     // assume
-    assertThat(historicIncidents.get(0).getRemovalTime(), nullValue());
-    assertThat(historicIncidents.get(1).getRemovalTime(), nullValue());
+    assertThat(historicIncidents.get(0).getRemovalTime()).isNull();
+    assertThat(historicIncidents.get(1).getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -948,8 +945,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(historicIncidents.get(0).getRemovalTime(), is(removalTime));
-    assertThat(historicIncidents.get(1).getRemovalTime(), is(removalTime));
+    assertThat(historicIncidents.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicIncidents.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   /**
@@ -989,8 +986,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     List<HistoricIncident> historicIncidents = historyService.createHistoricIncidentQuery().list();
 
     // then
-    assertThat(historicIncidents.get(0).getCreateTime(), is(START_DATE));
-    assertThat(historicIncidents.get(1).getCreateTime(), is(START_DATE));
+    assertThat(historicIncidents.get(0).getCreateTime()).isEqualTo(START_DATE);
+    assertThat(historicIncidents.get(1).getCreateTime()).isEqualTo(START_DATE);
   }
 
   @Test
@@ -1014,10 +1011,10 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     HistoricIncident historicIncident = historyService.createHistoricIncidentQuery().singleResult();
 
     // assume
-    assertThat(historicIncident, notNullValue());
+    assertThat(historicIncident).isNotNull();
 
     // then
-    assertThat(historicIncident.getRemovalTime(), nullValue());
+    assertThat(historicIncident.getRemovalTime()).isNull();
 
     // cleanup
     clearJobLog(jobId);
@@ -1051,7 +1048,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     HistoricExternalTaskLog externalTaskLog = historyService.createHistoricExternalTaskLogQuery().singleResult();
 
     // assume
-    assertThat(externalTaskLog.getRemovalTime(), nullValue());
+    assertThat(externalTaskLog.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -1063,8 +1060,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     List<HistoricExternalTaskLog> externalTaskLogs = historyService.createHistoricExternalTaskLogQuery().list();
 
     // then
-    assertThat(externalTaskLogs.get(0).getRemovalTime(), is(removalTime));
-    assertThat(externalTaskLogs.get(1).getRemovalTime(), is(removalTime));
+    assertThat(externalTaskLogs.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(externalTaskLogs.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   /**
@@ -1100,8 +1097,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     List<HistoricExternalTaskLog> externalTaskLogs = historyService.createHistoricExternalTaskLogQuery().list();
 
     // then
-    assertThat(externalTaskLogs.get(0).getTimestamp(), is(START_DATE));
-    assertThat(externalTaskLogs.get(1).getTimestamp(), is(START_DATE));
+    assertThat(externalTaskLogs.get(0).getTimestamp()).isEqualTo(START_DATE);
+    assertThat(externalTaskLogs.get(1).getTimestamp()).isEqualTo(START_DATE);
   }
 
   @Test
@@ -1129,8 +1126,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     List<HistoricJobLog> jobLog = historyService.createHistoricJobLogQuery().list();
 
     // assume
-    assertThat(jobLog.get(0).getRemovalTime(), nullValue());
-    assertThat(jobLog.get(1).getRemovalTime(), nullValue());
+    assertThat(jobLog.get(0).getRemovalTime()).isNull();
+    assertThat(jobLog.get(1).getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -1144,8 +1141,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(jobLog.get(0).getRemovalTime(), is(removalTime));
-    assertThat(jobLog.get(1).getRemovalTime(), is(removalTime));
+    assertThat(jobLog.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(jobLog.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   /**
@@ -1181,8 +1178,8 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     List<HistoricJobLog> jobLog = historyService.createHistoricJobLogQuery().list();
 
     // then
-    assertThat(jobLog.get(0).getTimestamp(), is(START_DATE));
-    assertThat(jobLog.get(1).getTimestamp(), is(START_DATE));
+    assertThat(jobLog.get(0).getTimestamp()).isEqualTo(START_DATE);
+    assertThat(jobLog.get(1).getTimestamp()).isEqualTo(START_DATE);
   }
 
   @Test
@@ -1210,7 +1207,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // assume
-    assertThat(userOperationLog.getRemovalTime(), nullValue());
+    assertThat(userOperationLog.getRemovalTime()).isNull();
 
     managementService.executeJob(jobId);
 
@@ -1226,7 +1223,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(userOperationLog.getRemovalTime(), is(removalTime));
+    assertThat(userOperationLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1257,7 +1254,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // assume
-    assertThat(userOperationLog.getRemovalTime(), nullValue());
+    assertThat(userOperationLog.getRemovalTime()).isNull();
 
     LockedExternalTask externalTask = externalTaskService.fetchAndLock(1, "aWorkerId")
       .topic("anExternalTaskTopic", 2000)
@@ -1274,7 +1271,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // then
-    assertThat(userOperationLog.getRemovalTime(), is(removalTime));
+    assertThat(userOperationLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1297,7 +1294,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // assume
-    assertThat(userOperationLog.getRemovalTime(), nullValue());
+    assertThat(userOperationLog.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -1309,7 +1306,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(userOperationLog.getRemovalTime(), is(removalTime));
+    assertThat(userOperationLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1332,7 +1329,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // assume
-    assertThat(userOperationLog.getRemovalTime(), nullValue());
+    assertThat(userOperationLog.getRemovalTime()).isNull();
 
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
@@ -1346,7 +1343,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(userOperationLog.getRemovalTime(), is(removalTime));
+    assertThat(userOperationLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   /**
@@ -1377,7 +1374,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // then
-    assertThat(userOperationLog.getTimestamp(), is(START_DATE));
+    assertThat(userOperationLog.getTimestamp()).isEqualTo(START_DATE);
   }
 
   @Test
@@ -1401,7 +1398,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
             .singleResult();
 
     // assume
-    assertThat(historicIdentityLinkLog.getRemovalTime(), nullValue());
+    assertThat(historicIdentityLinkLog.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -1415,7 +1412,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(historicIdentityLinkLog.getRemovalTime(), is(removalTime));
+    assertThat(historicIdentityLinkLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   /**
@@ -1445,7 +1442,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
             .singleResult();
 
     // then
-    assertThat(historicIdentityLinkLog.getTime(), is(START_DATE));
+    assertThat(historicIdentityLinkLog.getTime()).isEqualTo(START_DATE);
   }
 
   @Test
@@ -1462,10 +1459,10 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     HistoricIdentityLinkLog historicIdentityLinkLog = historyService.createHistoricIdentityLinkLogQuery().singleResult();
 
     // assume
-    assertThat(historicIdentityLinkLog, notNullValue());
+    assertThat(historicIdentityLinkLog).isNotNull();
 
     // then
-    assertThat(historicIdentityLinkLog.getRemovalTime(), nullValue());
+    assertThat(historicIdentityLinkLog.getRemovalTime()).isNull();
 
     // cleanup
     taskService.complete(aTask.getId());
@@ -1493,7 +1490,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Comment comment = taskService.getProcessInstanceComments(processInstanceId).get(0);
 
     // assume
-    assertThat(comment.getRemovalTime(), nullValue());
+    assertThat(comment.getRemovalTime()).isNull();
 
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
@@ -1507,7 +1504,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(comment.getRemovalTime(), is(removalTime));
+    assertThat(comment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1528,7 +1525,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Comment comment = taskService.getTaskComments(taskId).get(0);
 
     // assume
-    assertThat(comment.getRemovalTime(), nullValue());
+    assertThat(comment.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -1540,7 +1537,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(comment.getRemovalTime(), is(removalTime));
+    assertThat(comment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1571,7 +1568,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     taskService.complete(taskId);
 
     // then
-    assertThat(comment.getRemovalTime(), nullValue());
+    assertThat(comment.getRemovalTime()).isNull();
   }
 
   @Test
@@ -1592,7 +1589,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Comment comment = taskService.getTaskComments(taskId).get(0);
 
     // assume
-    assertThat(comment.getRemovalTime(), nullValue());
+    assertThat(comment.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -1604,7 +1601,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(comment.getRemovalTime(), is(removalTime));
+    assertThat(comment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1628,7 +1625,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Attachment attachment = taskService.getAttachment(attachmentId);
 
     // assume
-    assertThat(attachment.getRemovalTime(), nullValue());
+    assertThat(attachment.getRemovalTime()).isNull();
 
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
@@ -1642,7 +1639,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     attachment = taskService.getAttachment(attachmentId);
 
     // then
-    assertThat(attachment.getRemovalTime(), is(removalTime));
+    assertThat(attachment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1663,7 +1660,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Attachment attachment = taskService.getAttachment(attachmentId);
 
     // assume
-    assertThat(attachment.getRemovalTime(), nullValue());
+    assertThat(attachment.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -1675,7 +1672,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(attachment.getRemovalTime(), is(removalTime));
+    assertThat(attachment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1706,7 +1703,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     taskService.complete(taskId);
 
     // then
-    assertThat(attachment.getRemovalTime(), nullValue());
+    assertThat(attachment.getRemovalTime()).isNull();
   }
 
   @Test
@@ -1729,7 +1726,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Attachment attachment = taskService.getAttachment(attachmentId);
 
     // assume
-    assertThat(attachment.getRemovalTime(), nullValue());
+    assertThat(attachment.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -1741,7 +1738,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(attachment.getRemovalTime(), is(removalTime));
+    assertThat(attachment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1762,7 +1759,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArray = findByteArrayById(attachment.getContentId());
 
     // assume
-    assertThat(byteArray.getRemovalTime(), nullValue());
+    assertThat(byteArray.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -1774,7 +1771,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(byteArray.getRemovalTime(), is(removalTime));
+    assertThat(byteArray.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1798,7 +1795,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArray = findByteArrayById(attachment.getContentId());
 
     // assume
-    assertThat(byteArray.getRemovalTime(), nullValue());
+    assertThat(byteArray.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -1812,7 +1809,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(byteArray.getRemovalTime(), is(removalTime));
+    assertThat(byteArray.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1833,7 +1830,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArray = findByteArrayById(historicVariableInstance.getByteArrayId());
 
     // assume
-    assertThat(byteArray.getRemovalTime(), nullValue());
+    assertThat(byteArray.getRemovalTime()).isNull();
 
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
@@ -1847,7 +1844,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(byteArray.getRemovalTime(), is(removalTime));
+    assertThat(byteArray.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1873,7 +1870,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArray = findByteArrayById(historicDetails.getByteArrayValueId());
 
     // assume
-    assertThat(byteArray.getRemovalTime(), nullValue());
+    assertThat(byteArray.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -1887,7 +1884,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(byteArray.getRemovalTime(), is(removalTime));
+    assertThat(byteArray.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1922,7 +1919,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArray = findByteArrayById(jobLog.getExceptionByteArrayId());
 
     // assume
-    assertThat(byteArray.getRemovalTime(), nullValue());
+    assertThat(byteArray.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -1938,7 +1935,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     byteArray = findByteArrayById(jobLog.getExceptionByteArrayId());
 
     // then
-    assertThat(byteArray.getRemovalTime(), is(removalTime));
+    assertThat(byteArray.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1975,7 +1972,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArrayEntity = findByteArrayById(externalTaskLog.getErrorDetailsByteArrayId());
 
     // assume
-    assertThat(byteArrayEntity.getRemovalTime(), nullValue());
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -1987,7 +1984,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime(), is(removalTime));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -2019,7 +2016,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArrayEntity = findByteArrayById(historicDecisionInputInstanceEntity.getByteArrayValueId());
 
     // assume
-    assertThat(byteArrayEntity.getRemovalTime(), nullValue());
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
 
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
@@ -2033,7 +2030,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime(), is(removalTime));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -2065,7 +2062,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArrayEntity = findByteArrayById(historicDecisionOutputInstanceEntity.getByteArrayValueId());
 
     // assume
-    assertThat(byteArrayEntity.getRemovalTime(), nullValue());
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -2079,7 +2076,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime(), is(removalTime));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -2111,7 +2108,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArrayEntity = findByteArrayById(historicDecisionOutputInstanceEntity.getByteArrayValueId());
 
     // assume
-    assertThat(byteArrayEntity.getRemovalTime(), nullValue());
+    assertThat(byteArrayEntity.getRemovalTime()).isNull();
 
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
@@ -2125,7 +2122,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(END_DATE, 5);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime(), is(removalTime));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -2155,7 +2152,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery().singleResult();
 
     // then
-    assertThat(historicBatch.getRemovalTime(), is(addDays(END_DATE, 5)));
+    assertThat(historicBatch.getRemovalTime()).isEqualTo(addDays(END_DATE, 5));
 
     // cleanup
     historyService.deleteHistoricBatch(batch.getId());
@@ -2188,9 +2185,9 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     List<HistoricJobLog> jobLogs = historyService.createHistoricJobLogQuery().list();
 
     // then
-    assertThat(jobLogs.get(0).getRemovalTime(), is(addDays(END_DATE, 5)));
-    assertThat(jobLogs.get(1).getRemovalTime(), is(addDays(END_DATE, 5)));
-    assertThat(jobLogs.get(2).getRemovalTime(), is(addDays(END_DATE, 5)));
+    assertThat(jobLogs.get(0).getRemovalTime()).isEqualTo(addDays(END_DATE, 5));
+    assertThat(jobLogs.get(1).getRemovalTime()).isEqualTo(addDays(END_DATE, 5));
+    assertThat(jobLogs.get(2).getRemovalTime()).isEqualTo(addDays(END_DATE, 5));
 
     // cleanup
     historyService.deleteHistoricBatch(batch.getId());
@@ -2244,7 +2241,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArray = findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArray.getRemovalTime(), is(addDays(END_DATE, 5)));
+    assertThat(byteArray.getRemovalTime()).isEqualTo(addDays(END_DATE, 5));
 
     // cleanup
     historyService.deleteHistoricBatch(batch.getId());
@@ -2283,9 +2280,9 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     List<HistoricJobLog> jobLogs = historyService.createHistoricJobLogQuery().list();
 
     // then
-    assertThat(jobLogs.get(0).getTimestamp(), is(START_DATE));
-    assertThat(jobLogs.get(1).getTimestamp(), is(START_DATE));
-    assertThat(jobLogs.get(2).getTimestamp(), is(START_DATE));
+    assertThat(jobLogs.get(0).getTimestamp()).isEqualTo(START_DATE);
+    assertThat(jobLogs.get(1).getTimestamp()).isEqualTo(START_DATE);
+    assertThat(jobLogs.get(2).getTimestamp()).isEqualTo(START_DATE);
 
     // cleanup
     historyService.deleteHistoricBatch(batch.getId());
@@ -2309,7 +2306,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     HistoricJobLog jobLog = historyService.createHistoricJobLogQuery().singleResult();
 
     // assume
-    assertThat(jobLog.getRemovalTime(), nullValue());
+    assertThat(jobLog.getRemovalTime()).isNull();
 
     managementService.setJobRetries(jobLog.getJobId(), 0);
 
@@ -2322,7 +2319,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     HistoricIncident historicIncident = historyService.createHistoricIncidentQuery().singleResult();
 
     // then
-    assertThat(historicIncident.getRemovalTime(), is(addDays(START_DATE, 5)));
+    assertThat(historicIncident.getRemovalTime()).isEqualTo(addDays(START_DATE, 5));
 
     // cleanup
     historyService.deleteHistoricBatch(batch.getId());
@@ -2346,7 +2343,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     HistoricJobLog jobLog = historyService.createHistoricJobLogQuery().singleResult();
 
     // assume
-    assertThat(jobLog.getRemovalTime(), nullValue());
+    assertThat(jobLog.getRemovalTime()).isNull();
 
     // when
     runtimeService.deleteProcessInstance(processInstanceId, "aDeleteReason");
@@ -2372,7 +2369,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     HistoricIncident historicIncident = historyService.createHistoricIncidentQuery().singleResult();
 
     // then
-    assertThat(historicIncident.getRemovalTime(), is(addDays(START_DATE, 5)));
+    assertThat(historicIncident.getRemovalTime()).isEqualTo(addDays(START_DATE, 5));
 
     // cleanup
     historyService.deleteHistoricBatch(batch.getId());
@@ -2396,7 +2393,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     HistoricJobLog jobLog = historyService.createHistoricJobLogQuery().singleResult();
 
     // assume
-    assertThat(jobLog.getRemovalTime(), nullValue());
+    assertThat(jobLog.getRemovalTime()).isNull();
 
     managementService.executeJob(jobLog.getJobId());
 
@@ -2416,7 +2413,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     HistoricIncident historicIncident = historyService.createHistoricIncidentQuery().singleResult();
 
     // then
-    assertThat(historicIncident.getRemovalTime(), is(addDays(START_DATE, 5)));
+    assertThat(historicIncident.getRemovalTime()).isEqualTo(addDays(START_DATE, 5));
 
     // cleanup
     historyService.deleteHistoricBatch(batch.getId());
@@ -2443,7 +2440,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     HistoricJobLog jobLog = historyService.createHistoricJobLogQuery().singleResult();
 
     // assume
-    assertThat(jobLog.getRemovalTime(), nullValue());
+    assertThat(jobLog.getRemovalTime()).isNull();
 
     managementService.setJobRetries(jobLog.getJobId(), 0);
 
@@ -2456,7 +2453,7 @@ public class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     HistoricIncident historicIncident = historyService.createHistoricIncidentQuery().singleResult();
 
     // then
-    assertThat(historicIncident.getCreateTime(), is(START_DATE));
+    assertThat(historicIncident.getCreateTime()).isEqualTo(START_DATE);
 
     // cleanup
     historyService.deleteHistoricBatch(batch.getId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/RemovalTimeStrategyStartTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/RemovalTimeStrategyStartTest.java
@@ -16,12 +16,9 @@
  */
 package org.operaton.bpm.engine.test.api.history.removaltime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_START;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.core.IsNull.nullValue;
 
 import java.io.ByteArrayInputStream;
 import java.util.Calendar;
@@ -145,14 +142,14 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     List<HistoricDecisionInstance> historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // assume
-    assertThat(historicDecisionInstances.size(), is(3));
+    assertThat(historicDecisionInstances.size()).isEqualTo(3);
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRemovalTime(), is(removalTime));
-    assertThat(historicDecisionInstances.get(1).getRemovalTime(), is(removalTime));
-    assertThat(historicDecisionInstances.get(2).getRemovalTime(), is(removalTime));
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -175,14 +172,14 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     List<HistoricDecisionInstance> historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // assume
-    assertThat(historicDecisionInstances.size(), is(3));
+    assertThat(historicDecisionInstances.size()).isEqualTo(3);
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRemovalTime(), is(removalTime));
-    assertThat(historicDecisionInstances.get(1).getRemovalTime(), is(removalTime));
-    assertThat(historicDecisionInstances.get(2).getRemovalTime(), is(removalTime));
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -212,15 +209,15 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     List<HistoricDecisionInputInstance> historicDecisionInputInstances = historicDecisionInstance.getInputs();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(historicDecisionInputInstances.get(0).getRemovalTime(), is(removalTime));
-    assertThat(historicDecisionInputInstances.get(1).getRemovalTime(), is(removalTime));
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -246,15 +243,15 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     List<HistoricDecisionInputInstance> historicDecisionInputInstances = historicDecisionInstance.getInputs();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(historicDecisionInputInstances.get(0).getRemovalTime(), is(removalTime));
-    assertThat(historicDecisionInputInstances.get(1).getRemovalTime(), is(removalTime));
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -275,13 +272,13 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     List<HistoricDecisionInputInstance> historicDecisionInputInstances = historicDecisionInstance.getInputs();
 
     // then
-    assertThat(historicDecisionInputInstances.get(0).getRemovalTime(), nullValue());
-    assertThat(historicDecisionInputInstances.get(1).getRemovalTime(), nullValue());
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isNull();
+    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isNull();
   }
 
   @Test
@@ -311,14 +308,14 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     List<HistoricDecisionOutputInstance> historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime(), is(removalTime));
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -348,14 +345,14 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     List<HistoricDecisionOutputInstance> historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime(), is(removalTime));
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -376,12 +373,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     List<HistoricDecisionOutputInstance> historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
 
     // then
-    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime(), nullValue());
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isNull();
   }
 
   @Test
@@ -401,12 +398,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicProcessInstance, notNullValue());
+    assertThat(historicProcessInstance).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(historicProcessInstance.getRemovalTime(), is(removalTime));
+    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -426,12 +423,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicActivityInstance, notNullValue());
+    assertThat(historicActivityInstance).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(historicActivityInstance.getRemovalTime(), is(removalTime));
+    assertThat(historicActivityInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -451,12 +448,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicTaskInstance, notNullValue());
+    assertThat(historicTaskInstance).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(historicTaskInstance.getRemovalTime(), is(removalTime));
+    assertThat(historicTaskInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -489,12 +486,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
         .singleResult();
 
     // assume
-    assertThat(authorization, notNullValue());
+    assertThat(authorization).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(authorization.getRemovalTime(), is(removalTime));
+    assertThat(authorization.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -519,8 +516,8 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(START_DATE, 5);
 
     // assume
-    assertThat(authorization.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
-    assertThat(authorization.getRemovalTime(), is(removalTime));
+    assertThat(authorization.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
+    assertThat(authorization.getRemovalTime()).isEqualTo(removalTime);
 
     authorization.setResourceId("*");
 
@@ -532,8 +529,8 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
         .singleResult();
 
     // then
-    assertThat(authorization.getRootProcessInstanceId(), nullValue());
-    assertThat(authorization.getRemovalTime(), nullValue());
+    assertThat(authorization.getRootProcessInstanceId()).isNull();
+    assertThat(authorization.getRemovalTime()).isNull();
   }
 
   @Test
@@ -561,8 +558,8 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
         .singleResult();
 
     // assume
-    assertThat(authorization.getRootProcessInstanceId(), nullValue());
-    assertThat(authorization.getRemovalTime(), nullValue());
+    assertThat(authorization.getRootProcessInstanceId()).isNull();
+    assertThat(authorization.getRemovalTime()).isNull();
 
     String taskId = historyService.createHistoricTaskInstanceQuery().singleResult().getId();
 
@@ -578,8 +575,8 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(authorization.getRootProcessInstanceId(), is(processInstance.getRootProcessInstanceId()));
-    assertThat(authorization.getRemovalTime(), is(removalTime));
+    assertThat(authorization.getRootProcessInstanceId()).isEqualTo(processInstance.getRootProcessInstanceId());
+    assertThat(authorization.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -752,12 +749,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
         .singleResult();
 
     // assume
-    assertThat(authorization, notNullValue());
+    assertThat(authorization).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(authorization.getRemovalTime(), is(removalTime));
+    assertThat(authorization.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -785,12 +782,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
         .singleResult();
 
     // assume
-    assertThat(authorization, notNullValue());
+    assertThat(authorization).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(authorization.getRemovalTime(), is(removalTime));
+    assertThat(authorization.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -804,10 +801,10 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
 
     // assume
-    assertThat(historicTaskInstance, notNullValue());
+    assertThat(historicTaskInstance).isNotNull();
 
     // then
-    assertThat(historicTaskInstance.getRemovalTime(), nullValue());
+    assertThat(historicTaskInstance.getRemovalTime()).isNull();
 
     // cleanup
     taskService.deleteTask(task.getId(), true);
@@ -834,7 +831,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(historicVariableInstance.getRemovalTime(), is(removalTime));
+    assertThat(historicVariableInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -858,13 +855,13 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicDetails.size(), is(2));
+    assertThat(historicDetails.size()).isEqualTo(2);
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(historicDetails.get(0).getRemovalTime(), is(removalTime));
-    assertThat(historicDetails.get(1).getRemovalTime(), is(removalTime));
+    assertThat(historicDetails.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDetails.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -886,12 +883,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     HistoricDetail historicDetail = historyService.createHistoricDetailQuery().formFields().singleResult();
 
     // assume
-    assertThat(historicDetail, notNullValue());
+    assertThat(historicDetail).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(historicDetail.getRemovalTime(), is(removalTime));
+    assertThat(historicDetail.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -920,13 +917,13 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     List<HistoricIncident> historicIncidents = historyService.createHistoricIncidentQuery().list();
 
     // assume
-    assertThat(historicIncidents.size(), is(2));
+    assertThat(historicIncidents.size()).isEqualTo(2);
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(historicIncidents.get(0).getRemovalTime(), is(removalTime));
-    assertThat(historicIncidents.get(1).getRemovalTime(), is(removalTime));
+    assertThat(historicIncidents.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicIncidents.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -952,12 +949,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     HistoricIncident historicIncident = historyService.createHistoricIncidentQuery().singleResult();
 
     // assume
-    assertThat(historicIncident, notNullValue());
+    assertThat(historicIncident).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(historicIncident.getRemovalTime(), nullValue());
+    assertThat(historicIncident.getRemovalTime()).isNull();
 
     // cleanup
     clearJobLog(jobId);
@@ -987,12 +984,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     HistoricExternalTaskLog externalTaskLog = historyService.createHistoricExternalTaskLogQuery().singleResult();
 
     // assume
-    assertThat(externalTaskLog, notNullValue());
+    assertThat(externalTaskLog).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(externalTaskLog.getRemovalTime(), is(removalTime));
+    assertThat(externalTaskLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1019,13 +1016,13 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     List<HistoricJobLog> jobLog = historyService.createHistoricJobLogQuery().list();
 
     // assume
-    assertThat(jobLog.size(), is(2));
+    assertThat(jobLog.size()).isEqualTo(2);
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(jobLog.get(0).getRemovalTime(), is(removalTime));
-    assertThat(jobLog.get(1).getRemovalTime(), is(removalTime));
+    assertThat(jobLog.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(jobLog.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1041,10 +1038,10 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     HistoricJobLog jobLog = historyService.createHistoricJobLogQuery().singleResult();
 
     // assume
-    assertThat(jobLog, notNullValue());
+    assertThat(jobLog).isNotNull();
 
     // then
-    assertThat(jobLog.getRemovalTime(), nullValue());
+    assertThat(jobLog.getRemovalTime()).isNull();
 
     // cleanup
     managementService.deleteJob(jobLog.getJobId());
@@ -1075,12 +1072,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // assume
-    assertThat(userOperationLog, notNullValue());
+    assertThat(userOperationLog).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(userOperationLog.getRemovalTime(), is(removalTime));
+    assertThat(userOperationLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1110,12 +1107,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // assume
-    assertThat(userOperationLog, notNullValue());
+    assertThat(userOperationLog).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(userOperationLog.getRemovalTime(), is(removalTime));
+    assertThat(userOperationLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1137,12 +1134,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // assume
-    assertThat(userOperationLog, notNullValue());
+    assertThat(userOperationLog).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(userOperationLog.getRemovalTime(), is(removalTime));
+    assertThat(userOperationLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1164,12 +1161,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     UserOperationLogEntry userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // assume
-    assertThat(userOperationLog, notNullValue());
+    assertThat(userOperationLog).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(userOperationLog.getRemovalTime(), is(removalTime));
+    assertThat(userOperationLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1193,12 +1190,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
         .singleResult();
 
     // assume
-    assertThat(historicIdentityLinkLog, notNullValue());
+    assertThat(historicIdentityLinkLog).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(historicIdentityLinkLog.getRemovalTime(), is(removalTime));
+    assertThat(historicIdentityLinkLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1215,10 +1212,10 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     HistoricIdentityLinkLog historicIdentityLinkLog = historyService.createHistoricIdentityLinkLogQuery().singleResult();
 
     // assume
-    assertThat(historicIdentityLinkLog, notNullValue());
+    assertThat(historicIdentityLinkLog).isNotNull();
 
     // then
-    assertThat(historicIdentityLinkLog.getRemovalTime(), nullValue());
+    assertThat(historicIdentityLinkLog.getRemovalTime()).isNull();
 
     // cleanup
     taskService.complete(aTask.getId());
@@ -1247,12 +1244,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Comment comment = taskService.getProcessInstanceComments(processInstanceId).get(0);
 
     // assume
-    assertThat(comment, notNullValue());
+    assertThat(comment).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(comment.getRemovalTime(), is(removalTime));
+    assertThat(comment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1274,12 +1271,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Comment comment = taskService.getTaskComments(taskId).get(0);
 
     // assume
-    assertThat(comment, notNullValue());
+    assertThat(comment).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(comment.getRemovalTime(), is(removalTime));
+    assertThat(comment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1304,10 +1301,10 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Comment comment = taskService.getProcessInstanceComments(processInstanceId).get(0);
 
     // assume
-    assertThat(comment, notNullValue());
+    assertThat(comment).isNotNull();
 
     // then
-    assertThat(comment.getRemovalTime(), nullValue());
+    assertThat(comment.getRemovalTime()).isNull();
   }
 
   @Test
@@ -1329,12 +1326,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Comment comment = taskService.getTaskComments(taskId).get(0);
 
     // assume
-    assertThat(comment, notNullValue());
+    assertThat(comment).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(comment.getRemovalTime(), is(removalTime));
+    assertThat(comment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1347,10 +1344,10 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Comment comment = taskService.getProcessInstanceComments("aNonExistentProcessInstanceId").get(0);
 
     // assume
-    assertThat(comment, notNullValue());
+    assertThat(comment).isNotNull();
 
     // then
-    assertThat(comment.getRemovalTime(), nullValue());
+    assertThat(comment.getRemovalTime()).isNull();
 
     // cleanup
     clearCommentByProcessInstanceId("aNonExistentProcessInstanceId");
@@ -1366,10 +1363,10 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Comment comment = taskService.getTaskComments("aNonExistentTaskId").get(0);
 
     // assume
-    assertThat(comment, notNullValue());
+    assertThat(comment).isNotNull();
 
     // then
-    assertThat(comment.getRemovalTime(), nullValue());
+    assertThat(comment.getRemovalTime()).isNull();
 
     // cleanup
     clearCommentByTaskId("aNonExistentTaskId");
@@ -1397,12 +1394,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Attachment attachment = taskService.getAttachment(attachmentId);
 
     // assume
-    assertThat(attachment, notNullValue());
+    assertThat(attachment).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(attachment.getRemovalTime(), is(removalTime));
+    assertThat(attachment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1424,12 +1421,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Attachment attachment = taskService.getAttachment(attachmentId);
 
     // assume
-    assertThat(attachment, notNullValue());
+    assertThat(attachment).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(attachment.getRemovalTime(), is(removalTime));
+    assertThat(attachment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1452,10 +1449,10 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Attachment attachment = taskService.getAttachment(attachmentId);
 
     // assume
-    assertThat(attachment, notNullValue());
+    assertThat(attachment).isNotNull();
 
     // then
-    assertThat(attachment.getRemovalTime(), nullValue());
+    assertThat(attachment.getRemovalTime()).isNull();
   }
 
   @Test
@@ -1479,12 +1476,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Attachment attachment = taskService.getAttachment(attachmentId);
 
     // assume
-    assertThat(attachment, notNullValue());
+    assertThat(attachment).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(attachment.getRemovalTime(), is(removalTime));
+    assertThat(attachment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1497,10 +1494,10 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Attachment attachment = taskService.getAttachment(attachmentId);
 
     // assume
-    assertThat(attachment, notNullValue());
+    assertThat(attachment).isNotNull();
 
     // then
-    assertThat(attachment.getRemovalTime(), nullValue());
+    assertThat(attachment.getRemovalTime()).isNull();
 
     // cleanup
     clearAttachment(attachment);
@@ -1525,12 +1522,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArray = findByteArrayById(attachment.getContentId());
 
     // assume
-    assertThat(byteArray, notNullValue());
+    assertThat(byteArray).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(byteArray.getRemovalTime(), is(removalTime));
+    assertThat(byteArray.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1555,12 +1552,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArray = findByteArrayById(attachment.getContentId());
 
     // assume
-    assertThat(byteArray, notNullValue());
+    assertThat(byteArray).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(byteArray.getRemovalTime(), is(removalTime));
+    assertThat(byteArray.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1582,12 +1579,12 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArray = findByteArrayById(historicVariableInstance.getByteArrayId());
 
     // assume
-    assertThat(byteArray, notNullValue());
+    assertThat(byteArray).isNotNull();
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(byteArray.getRemovalTime(), is(removalTime));
+    assertThat(byteArray.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1617,7 +1614,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(byteArray.getRemovalTime(), is(removalTime));
+    assertThat(byteArray.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1647,14 +1644,14 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(jobLog, notNullValue());
+    assertThat(jobLog).isNotNull();
 
     ByteArrayEntity byteArray = findByteArrayById(jobLog.getExceptionByteArrayId());
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(byteArray.getRemovalTime(), is(removalTime));
+    assertThat(byteArray.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1688,14 +1685,14 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(externalTaskLog, notNullValue());
+    assertThat(externalTaskLog).isNotNull();
 
     ByteArrayEntity byteArrayEntity = findByteArrayById(externalTaskLog.getErrorDetailsByteArrayId());
 
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime(), is(removalTime));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1723,7 +1720,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     HistoricDecisionInputInstanceEntity historicDecisionInputInstanceEntity = (HistoricDecisionInputInstanceEntity) historicDecisionInstance.getInputs().get(0);
 
@@ -1732,7 +1729,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime(), is(removalTime));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1757,7 +1754,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     HistoricDecisionInputInstanceEntity historicDecisionInputInstanceEntity = (HistoricDecisionInputInstanceEntity) historicDecisionInstance.getInputs().get(0);
 
@@ -1766,7 +1763,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime(), is(removalTime));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1794,7 +1791,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     HistoricDecisionOutputInstanceEntity historicDecisionOutputInstanceEntity = (HistoricDecisionOutputInstanceEntity) historicDecisionInstance.getOutputs().get(0);
 
@@ -1803,7 +1800,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime(), is(removalTime));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
   @Test
   @Deployment(resources = {
@@ -1827,7 +1824,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     HistoricDecisionOutputInstanceEntity historicDecisionOutputInstanceEntity = (HistoricDecisionOutputInstanceEntity) historicDecisionInstance.getOutputs().get(0);
 
@@ -1836,7 +1833,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime(), is(removalTime));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1864,7 +1861,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     HistoricDecisionOutputInstanceEntity historicDecisionOutputInstanceEntity = (HistoricDecisionOutputInstanceEntity) historicDecisionInstance.getOutputs().get(0);
 
@@ -1873,7 +1870,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime(), is(removalTime));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1898,7 +1895,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance, notNullValue());
+    assertThat(historicDecisionInstance).isNotNull();
 
     HistoricDecisionOutputInstanceEntity historicDecisionOutputInstanceEntity = (HistoricDecisionOutputInstanceEntity) historicDecisionInstance.getOutputs().get(0);
 
@@ -1907,7 +1904,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     Date removalTime = addDays(START_DATE, 5);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime(), is(removalTime));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1930,7 +1927,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery().singleResult();
 
     // then removal time is set
-    assertThat(historicBatch.getRemovalTime(), is(addDays(START_DATE, 5)));
+    assertThat(historicBatch.getRemovalTime()).isEqualTo(addDays(START_DATE, 5));
 
     String seedJobId = managementService.createJobQuery().singleResult().getId();
     managementService.executeJob(seedJobId);
@@ -1946,7 +1943,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     historicBatch = historyService.createHistoricBatchQuery().singleResult();
 
     // then removal time is still set
-    assertThat(historicBatch.getRemovalTime(), is(addDays(START_DATE, 5)));
+    assertThat(historicBatch.getRemovalTime()).isEqualTo(addDays(START_DATE, 5));
 
     // cleanup
     historyService.deleteHistoricBatch(batch.getId());
@@ -1971,7 +1968,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     HistoricJobLog jobLog = historyService.createHistoricJobLogQuery().singleResult();
 
     // assume
-    assertThat(jobLog.getRemovalTime(), is(addDays(START_DATE, 5)));
+    assertThat(jobLog.getRemovalTime()).isEqualTo(addDays(START_DATE, 5));
 
     // when
     managementService.executeJob(jobLog.getJobId());
@@ -1979,8 +1976,8 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     List<HistoricJobLog> jobLogs = historyService.createHistoricJobLogQuery().list();
 
     // then
-    assertThat(jobLogs.get(0).getRemovalTime(), is(addDays(START_DATE, 5)));
-    assertThat(jobLogs.get(1).getRemovalTime(), is(addDays(START_DATE, 5)));
+    assertThat(jobLogs.get(0).getRemovalTime()).isEqualTo(addDays(START_DATE, 5));
+    assertThat(jobLogs.get(1).getRemovalTime()).isEqualTo(addDays(START_DATE, 5));
 
     // cleanup
     managementService.deleteBatch(batch.getId(), true);
@@ -2028,7 +2025,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     ByteArrayEntity byteArray = findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArray.getRemovalTime(), is(addDays(START_DATE, 5)));
+    assertThat(byteArray.getRemovalTime()).isEqualTo(addDays(START_DATE, 5));
 
     // cleanup
     managementService.deleteBatch(batch.getId(), true);
@@ -2053,7 +2050,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     HistoricJobLog jobLog = historyService.createHistoricJobLogQuery().singleResult();
 
     // assume
-    assertThat(jobLog.getRemovalTime(), is(addDays(START_DATE, 5)));
+    assertThat(jobLog.getRemovalTime()).isEqualTo(addDays(START_DATE, 5));
 
     // when
     managementService.setJobRetries(jobLog.getJobId(), 0);
@@ -2061,7 +2058,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     HistoricIncident historicIncident = historyService.createHistoricIncidentQuery().singleResult();
 
     // then
-    assertThat(historicIncident.getRemovalTime(), is(addDays(START_DATE, 5)));
+    assertThat(historicIncident.getRemovalTime()).isEqualTo(addDays(START_DATE, 5));
 
     // cleanup
     managementService.deleteBatch(batch.getId(), true);
@@ -2085,7 +2082,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     HistoricJobLog jobLog = historyService.createHistoricJobLogQuery().singleResult();
 
     // assume
-    assertThat(jobLog.getRemovalTime(), is(addDays(START_DATE, 5)));
+    assertThat(jobLog.getRemovalTime()).isEqualTo(addDays(START_DATE, 5));
 
     runtimeService.deleteProcessInstance(processInstanceId, "aDeleteReason");
 
@@ -2102,7 +2099,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     HistoricIncident historicIncident = historyService.createHistoricIncidentQuery().singleResult();
 
     // then
-    assertThat(historicIncident.getRemovalTime(), is(addDays(START_DATE, 5)));
+    assertThat(historicIncident.getRemovalTime()).isEqualTo(addDays(START_DATE, 5));
 
     // cleanup
     managementService.deleteBatch(batch.getId(), true);
@@ -2126,7 +2123,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     HistoricJobLog jobLog = historyService.createHistoricJobLogQuery().singleResult();
 
     // assume
-    assertThat(jobLog.getRemovalTime(), is(addDays(START_DATE, 5)));
+    assertThat(jobLog.getRemovalTime()).isEqualTo(addDays(START_DATE, 5));
 
     managementService.executeJob(jobLog.getJobId());
 
@@ -2147,7 +2144,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     HistoricIncident historicIncident = historyService.createHistoricIncidentQuery().singleResult();
 
     // then
-    assertThat(historicIncident.getRemovalTime(), is(addDays(START_DATE, 5)));
+    assertThat(historicIncident.getRemovalTime()).isEqualTo(addDays(START_DATE, 5));
 
     // cleanup
     managementService.deleteBatch(batch.getId(), true);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
@@ -24,10 +24,6 @@ import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_FULL;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_END;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_START;
 import static org.operaton.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupHandler.MAX_BATCH_SIZE;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
-import static org.hamcrest.core.IsNull.nullValue;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -287,7 +283,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricDecisionInstance> historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // assume
-    assertThat(historicDecisionInstances.size(), is(3));
+    assertThat(historicDecisionInstances.size()).isEqualTo(3);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
 
@@ -297,7 +293,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // then
-    assertThat(historicDecisionInstances.size(), is(0));
+    assertThat(historicDecisionInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -325,7 +321,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicDecisionInstances.size(), is(3));
+    assertThat(historicDecisionInstances.size()).isEqualTo(3);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 6));
 
@@ -338,7 +334,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicDecisionInstances.size(), is(0));
+    assertThat(historicDecisionInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -370,7 +366,7 @@ public class HistoryCleanupRemovalTimeTest {
       .sum();
 
     // then
-    assertThat(removedDecisionInstancesSum, is(3L));
+    assertThat(removedDecisionInstancesSum).isEqualTo(3L);
   }
 
   @Test
@@ -397,7 +393,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicDecisionInstances.size(), is(3));
+    assertThat(historicDecisionInstances.size()).isEqualTo(3);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
 
@@ -409,7 +405,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicDecisionInstances.size(), is(0));
+    assertThat(historicDecisionInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -436,7 +432,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicDecisionInstances.size(), is(3));
+    assertThat(historicDecisionInstances.size()).isEqualTo(3);
 
     Date removalTime = addDays(END_DATE, 5);
     ClockUtil.setCurrentTime(removalTime);
@@ -449,7 +445,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicDecisionInstances.size(), is(0));
+    assertThat(historicDecisionInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -472,7 +468,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicProcessInstances.size(), is(1));
+    assertThat(historicProcessInstances.size()).isEqualTo(1);
 
     Date removalTime = addDays(END_DATE, 5);
     ClockUtil.setCurrentTime(removalTime);
@@ -485,7 +481,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicProcessInstances.size(), is(0));
+    assertThat(historicProcessInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -508,7 +504,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicProcessInstances.size(), is(1));
+    assertThat(historicProcessInstances.size()).isEqualTo(1);
 
     Date removalTime = addDays(END_DATE, 5);
     ClockUtil.setCurrentTime(removalTime);
@@ -521,7 +517,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicProcessInstances.size(), is(1));
+    assertThat(historicProcessInstances.size()).isEqualTo(1);
   }
 
   @Test
@@ -545,7 +541,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicProcessInstances.size(), is(1));
+    assertThat(historicProcessInstances.size()).isEqualTo(1);
 
     Date removalTime = addDays(END_DATE, 5);
     ClockUtil.setCurrentTime(removalTime);
@@ -558,7 +554,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicProcessInstances.size(), is(0));
+    assertThat(historicProcessInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -586,7 +582,7 @@ public class HistoryCleanupRemovalTimeTest {
       .sum();
 
     // then
-    assertThat(removedProcessInstancesSum, is(2L));
+    assertThat(removedProcessInstancesSum).isEqualTo(2L);
   }
 
   @Test
@@ -607,7 +603,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().list();
 
     // assume
-    assertThat(historicActivityInstances.size(), is(6));
+    assertThat(historicActivityInstances.size()).isEqualTo(6);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
 
@@ -617,7 +613,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicActivityInstances = historyService.createHistoricActivityInstanceQuery().list();
 
     // then
-    assertThat(historicActivityInstances.size(), is(0));
+    assertThat(historicActivityInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -638,7 +634,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery().list();
 
     // assume
-    assertThat(historicTaskInstances.size(), is(1));
+    assertThat(historicTaskInstances.size()).isEqualTo(1);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
 
@@ -648,7 +644,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicTaskInstances = historyService.createHistoricTaskInstanceQuery().list();
 
     // then
-    assertThat(historicTaskInstances.size(), is(0));
+    assertThat(historicTaskInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -677,7 +673,7 @@ public class HistoryCleanupRemovalTimeTest {
         .list();
 
     // assume
-    assertThat(authorizations.size(), is(1));
+    assertThat(authorizations.size()).isEqualTo(1);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
 
@@ -689,7 +685,7 @@ public class HistoryCleanupRemovalTimeTest {
         .list();
 
     // then
-    assertThat(authorizations.size(), is(0));
+    assertThat(authorizations.size()).isEqualTo(0);
 
     // clear
     clearAuthorization();
@@ -715,7 +711,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricVariableInstance> historicVariableInstances = historyService.createHistoricVariableInstanceQuery().list();
 
     // assume
-    assertThat(historicVariableInstances.size(), is(1));
+    assertThat(historicVariableInstances.size()).isEqualTo(1);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
 
@@ -725,7 +721,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicVariableInstances = historyService.createHistoricVariableInstanceQuery().list();
 
     // then
-    assertThat(historicVariableInstances.size(), is(0));
+    assertThat(historicVariableInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -746,7 +742,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicDetails.size(), is(2));
+    assertThat(historicDetails.size()).isEqualTo(2);
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -764,7 +760,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicDetails.size(), is(0));
+    assertThat(historicDetails.size()).isEqualTo(0);
   }
 
   @Test
@@ -787,7 +783,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricIncident> historicIncidents = historyService.createHistoricIncidentQuery().list();
 
     // assume
-    assertThat(historicIncidents.size(), is(2));
+    assertThat(historicIncidents.size()).isEqualTo(2);
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -803,7 +799,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicIncidents = historyService.createHistoricIncidentQuery().list();
 
     // then
-    assertThat(historicIncidents.size(), is(0));
+    assertThat(historicIncidents.size()).isEqualTo(0);
   }
 
   @Test
@@ -831,7 +827,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricExternalTaskLog> externalTaskLogs = historyService.createHistoricExternalTaskLogQuery().list();
 
     // assume
-    assertThat(externalTaskLogs.size(), is(1));
+    assertThat(externalTaskLogs.size()).isEqualTo(1);
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -845,7 +841,7 @@ public class HistoryCleanupRemovalTimeTest {
     externalTaskLogs = historyService.createHistoricExternalTaskLogQuery().list();
 
     // then
-    assertThat(externalTaskLogs.size(), is(0));
+    assertThat(externalTaskLogs.size()).isEqualTo(0);
   }
 
   @Test
@@ -873,7 +869,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(jobLogs.size(), is(2));
+    assertThat(jobLogs.size()).isEqualTo(2);
 
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
@@ -889,7 +885,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(jobLogs.size(), is(0));
+    assertThat(jobLogs.size()).isEqualTo(0);
   }
 
   @Test
@@ -952,7 +948,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<UserOperationLogEntry> userOperationLogs = historyService.createUserOperationLogQuery().list();
 
     // assume
-    assertThat(userOperationLogs.size(), is(1));
+    assertThat(userOperationLogs.size()).isEqualTo(1);
 
     managementService.executeJob(jobId);
 
@@ -970,7 +966,7 @@ public class HistoryCleanupRemovalTimeTest {
     userOperationLogs = historyService.createUserOperationLogQuery().list();
 
     // then
-    assertThat(userOperationLogs.size(), is(0));
+    assertThat(userOperationLogs.size()).isEqualTo(0);
   }
 
   @Test
@@ -989,7 +985,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricIdentityLinkLog> historicIdentityLinkLogs = historyService.createHistoricIdentityLinkLogQuery().list();
 
     // assume
-    assertThat(historicIdentityLinkLogs.size(), is(1));
+    assertThat(historicIdentityLinkLogs.size()).isEqualTo(1);
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -1003,7 +999,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicIdentityLinkLogs = historyService.createHistoricIdentityLinkLogQuery().list();
 
     // then
-    assertThat(historicIdentityLinkLogs.size(), is(0));
+    assertThat(historicIdentityLinkLogs.size()).isEqualTo(0);
   }
 
   @Test
@@ -1025,7 +1021,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<Comment> comments = taskService.getProcessInstanceComments(processInstanceId);
 
     // assume
-    assertThat(comments.size(), is(1));
+    assertThat(comments.size()).isEqualTo(1);
 
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
@@ -1041,7 +1037,7 @@ public class HistoryCleanupRemovalTimeTest {
     comments = taskService.getProcessInstanceComments(processInstanceId);
 
     // then
-    assertThat(comments.size(), is(0));
+    assertThat(comments.size()).isEqualTo(0);
   }
 
   @Test
@@ -1063,7 +1059,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<Attachment> attachments = taskService.getProcessInstanceAttachments(processInstanceId);
 
     // assume
-    assertThat(attachments.size(), is(1));
+    assertThat(attachments.size()).isEqualTo(1);
 
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
@@ -1079,7 +1075,7 @@ public class HistoryCleanupRemovalTimeTest {
     attachments = taskService.getProcessInstanceAttachments(processInstanceId);
 
     // then
-    assertThat(attachments.size(), is(0));
+    assertThat(attachments.size()).isEqualTo(0);
   }
 
   @Test
@@ -1106,7 +1102,7 @@ public class HistoryCleanupRemovalTimeTest {
     ByteArrayEntity byteArray = findByteArrayById(jobLog.getExceptionByteArrayId());
 
     // assume
-    assertThat(byteArray, notNullValue());
+    assertThat(byteArray).isNotNull();
 
     managementService.setJobRetries(jobId, 0);
 
@@ -1125,7 +1121,7 @@ public class HistoryCleanupRemovalTimeTest {
     byteArray = findByteArrayById(jobLog.getExceptionByteArrayId());
 
     // then
-    assertThat(byteArray, nullValue());
+    assertThat(byteArray).isNull();
   }
 
   @Test
@@ -1157,14 +1153,14 @@ public class HistoryCleanupRemovalTimeTest {
     // assume
     List<HistoricBatch> historicBatches = historyService.createHistoricBatchQuery().list();
 
-    assertThat(historicBatches.size(), is(1));
+    assertThat(historicBatches.size()).isEqualTo(1);
 
     // assume
     List<HistoricJobLog> historicJobLogs = historyService.createHistoricJobLogQuery()
       .jobDefinitionConfiguration(batchId)
       .list();
 
-    assertThat(historicJobLogs.size(), is(6));
+    assertThat(historicJobLogs.size()).isEqualTo(6);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
 
@@ -1177,8 +1173,8 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicBatches.size(), is(0));
-    assertThat(historicJobLogs.size(), is(0));
+    assertThat(historicBatches.size()).isEqualTo(0);
+    assertThat(historicJobLogs.size()).isEqualTo(0);
   }
 
   @Test
@@ -1212,7 +1208,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricBatch> historicBatches = historyService.createHistoricBatchQuery().list();
 
     // assume
-    assertThat(historicBatches.size(), is(1));
+    assertThat(historicBatches.size()).isEqualTo(1);
 
     // when
     runHistoryCleanup();
@@ -1222,7 +1218,7 @@ public class HistoryCleanupRemovalTimeTest {
       .sum();
 
     // then
-    assertThat(removedBatchesSum, is(1L));
+    assertThat(removedBatchesSum).isEqualTo(1L);
   }
 
   @Test
@@ -1285,7 +1281,7 @@ public class HistoryCleanupRemovalTimeTest {
       .sum();
 
     // then
-    assertThat(removedMetricsSum, is(1L));
+    assertThat(removedMetricsSum).isEqualTo(1L);
   }
 
   // parallelism test cases ////////////////////////////////////////////////////////////////////////////////////////////
@@ -1984,8 +1980,8 @@ public class HistoryCleanupRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(report.getCleanableProcessInstanceCount(), is(5L));
-    assertThat(report.getFinishedProcessInstanceCount(), is(0L));
+    assertThat(report.getCleanableProcessInstanceCount()).isEqualTo(5L);
+    assertThat(report.getFinishedProcessInstanceCount()).isEqualTo(0L);
   }
 
   @Test
@@ -2012,8 +2008,8 @@ public class HistoryCleanupRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(report.getFinishedProcessInstanceCount(), is(5L));
-    assertThat(report.getCleanableProcessInstanceCount(), is(0L));
+    assertThat(report.getFinishedProcessInstanceCount()).isEqualTo(5L);
+    assertThat(report.getCleanableProcessInstanceCount()).isEqualTo(0L);
   }
 
   @Test
@@ -2039,7 +2035,7 @@ public class HistoryCleanupRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(report, nullValue());
+    assertThat(report).isNull();
   }
 
   @Test
@@ -2072,8 +2068,8 @@ public class HistoryCleanupRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(report.getCleanableDecisionInstanceCount(), is(5L));
-    assertThat(report.getFinishedDecisionInstanceCount(), is(5L));
+    assertThat(report.getCleanableDecisionInstanceCount()).isEqualTo(5L);
+    assertThat(report.getFinishedDecisionInstanceCount()).isEqualTo(5L);
   }
 
   @Test
@@ -2106,8 +2102,8 @@ public class HistoryCleanupRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(report.getCleanableDecisionInstanceCount(), is(0L));
-    assertThat(report.getFinishedDecisionInstanceCount(), is(5L));
+    assertThat(report.getCleanableDecisionInstanceCount()).isEqualTo(0L);
+    assertThat(report.getFinishedDecisionInstanceCount()).isEqualTo(5L);
   }
 
   @Test
@@ -2134,8 +2130,8 @@ public class HistoryCleanupRemovalTimeTest {
     CleanableHistoricBatchReportResult report = historyService.createCleanableHistoricBatchReport().singleResult();
 
     // then
-    assertThat(report.getCleanableBatchesCount(), is(1L));
-    assertThat(report.getFinishedBatchesCount(), is(0L));
+    assertThat(report.getCleanableBatchesCount()).isEqualTo(1L);
+    assertThat(report.getFinishedBatchesCount()).isEqualTo(0L);
 
     // cleanup
     managementService.deleteBatch(batch.getId(), true);
@@ -2165,8 +2161,8 @@ public class HistoryCleanupRemovalTimeTest {
     CleanableHistoricBatchReportResult report = historyService.createCleanableHistoricBatchReport().singleResult();
 
     // then
-    assertThat(report.getCleanableBatchesCount(), is(0L));
-    assertThat(report.getFinishedBatchesCount(), is(0L));
+    assertThat(report.getCleanableBatchesCount()).isEqualTo(0L);
+    assertThat(report.getFinishedBatchesCount()).isEqualTo(0L);
 
     // cleanup
     managementService.deleteBatch(batch.getId(), true);
@@ -2177,8 +2173,8 @@ public class HistoryCleanupRemovalTimeTest {
   protected void assumeWhenThenParallelizedCleanup(List<Job> jobs, Supplier<Long> supplier,
                                                    long initialInstanceCount) {
     // assume
-    assertThat(jobs.size(), is(3));
-    assertThat(supplier.get(), is(initialInstanceCount));
+    assertThat(jobs.size()).isEqualTo(3);
+    assertThat(supplier.get()).isEqualTo(initialInstanceCount);
 
     long expectedInstanceCount = initialInstanceCount-(initialInstanceCount/3);
 
@@ -2190,7 +2186,7 @@ public class HistoryCleanupRemovalTimeTest {
       managementService.executeJob(jobId);
 
       // then
-      assertThat(supplier.get(), is(expectedInstanceCount));
+      assertThat(supplier.get()).isEqualTo(expectedInstanceCount);
 
       expectedInstanceCount = expectedInstanceCount - (initialInstanceCount / 3);
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupStrategyConfigurationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupStrategyConfigurationTest.java
@@ -16,14 +16,13 @@
  */
 package org.operaton.bpm.engine.test.api.history.removaltime.cleanup;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_CLEANUP_STRATEGY_END_TIME_BASED;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_END;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_NONE;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_START;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -80,7 +79,7 @@ public class HistoryCleanupStrategyConfigurationTest {
     engineConfiguration.initHistoryCleanup();
 
     // then
-    assertThat(engineConfiguration.getHistoryCleanupStrategy(), is(HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED));
+    assertThat(engineConfiguration.getHistoryCleanupStrategy()).isEqualTo(HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED);
   }
 
   @Test
@@ -94,7 +93,7 @@ public class HistoryCleanupStrategyConfigurationTest {
     engineConfiguration.initHistoryCleanup();
 
     // then
-    assertThat(engineConfiguration.getHistoryCleanupStrategy(), is(HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED));
+    assertThat(engineConfiguration.getHistoryCleanupStrategy()).isEqualTo(HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED);
   }
 
   @Test
@@ -109,8 +108,8 @@ public class HistoryCleanupStrategyConfigurationTest {
     engineConfiguration.initHistoryCleanup();
 
     // then
-    assertThat(engineConfiguration.getHistoryCleanupStrategy(), is(HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED));
-    assertThat(engineConfiguration.getHistoryRemovalTimeStrategy(), is(HISTORY_REMOVAL_TIME_STRATEGY_END));
+    assertThat(engineConfiguration.getHistoryCleanupStrategy()).isEqualTo(HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED);
+    assertThat(engineConfiguration.getHistoryRemovalTimeStrategy()).isEqualTo(HISTORY_REMOVAL_TIME_STRATEGY_END);
   }
 
   @Test
@@ -125,8 +124,8 @@ public class HistoryCleanupStrategyConfigurationTest {
     engineConfiguration.initHistoryCleanup();
 
     // then
-    assertThat(engineConfiguration.getHistoryCleanupStrategy(), is(HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED));
-    assertThat(engineConfiguration.getHistoryRemovalTimeStrategy(), is(HISTORY_REMOVAL_TIME_STRATEGY_START));
+    assertThat(engineConfiguration.getHistoryCleanupStrategy()).isEqualTo(HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED);
+    assertThat(engineConfiguration.getHistoryRemovalTimeStrategy()).isEqualTo(HISTORY_REMOVAL_TIME_STRATEGY_START);
   }
 
 
@@ -141,7 +140,7 @@ public class HistoryCleanupStrategyConfigurationTest {
     engineConfiguration.initHistoryCleanup();
 
     // then
-    assertThat(engineConfiguration.getHistoryCleanupStrategy(), is(HISTORY_CLEANUP_STRATEGY_END_TIME_BASED));
+    assertThat(engineConfiguration.getHistoryCleanupStrategy()).isEqualTo(HISTORY_CLEANUP_STRATEGY_END_TIME_BASED);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/DatabasePrefixHandlerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/DatabasePrefixHandlerTest.java
@@ -16,9 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.identity;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.operaton.bpm.engine.impl.digest.DatabasePrefixHandler;
 import org.junit.Before;
@@ -43,7 +41,7 @@ public class DatabasePrefixHandlerTest {
     String prefix = prefixHandler.generatePrefix(algorithmName);
 
     // then
-    assertThat(prefix, is("{test}"));
+    assertThat(prefix).isEqualTo("{test}");
   }
 
   @Test
@@ -56,7 +54,7 @@ public class DatabasePrefixHandlerTest {
     String algorithmName = prefixHandler.retrieveAlgorithmName(encryptedPasswordWithPrefix);
 
     // then
-    assertThat(algorithmName, is("SHA"));
+    assertThat(algorithmName).isEqualTo("SHA");
   }
 
   @Test
@@ -69,7 +67,7 @@ public class DatabasePrefixHandlerTest {
     String algorithmName = prefixHandler.retrieveAlgorithmName(encryptedPasswordWithPrefix);
 
     // then
-    assertThat(algorithmName, is(nullValue()));
+    assertThat(algorithmName).isNull();
   }
 
   @Test
@@ -82,7 +80,7 @@ public class DatabasePrefixHandlerTest {
     String algorithmName = prefixHandler.retrieveAlgorithmName(encryptedPasswordWithPrefix);
 
     // then
-    assertThat(algorithmName, is(nullValue()));
+    assertThat(algorithmName).isNull();
   }
 
   @Test
@@ -95,7 +93,7 @@ public class DatabasePrefixHandlerTest {
     String algorithmName = prefixHandler.retrieveAlgorithmName(encryptedPasswordWithPrefix);
 
     // then
-    assertThat(algorithmName, is(nullValue()));
+    assertThat(algorithmName).isNull();
   }
 
   @Test
@@ -108,7 +106,7 @@ public class DatabasePrefixHandlerTest {
     String encryptedPassword = prefixHandler.removePrefix(encryptedPasswordWithPrefix);
 
     // then
-    assertThat(encryptedPassword, is("n3fE9/7XOmgD3BkeJlC+JLyb/Qg="));
+    assertThat(encryptedPassword).isEqualTo("n3fE9/7XOmgD3BkeJlC+JLyb/Qg=");
 
   }
 
@@ -122,7 +120,7 @@ public class DatabasePrefixHandlerTest {
     String encryptedPassword = prefixHandler.removePrefix(encryptedPasswordWithPrefix);
 
     // then
-    assertThat(encryptedPassword, is(nullValue()));
+    assertThat(encryptedPassword).isNull();
 
   }
 
@@ -136,7 +134,7 @@ public class DatabasePrefixHandlerTest {
     String encryptedPassword = prefixHandler.removePrefix(encryptedPasswordWithPrefix);
 
     // then
-    assertThat(encryptedPassword, is(nullValue()));
+    assertThat(encryptedPassword).isNull();
 
   }
 
@@ -150,7 +148,7 @@ public class DatabasePrefixHandlerTest {
     String encryptedPassword = prefixHandler.removePrefix(encryptedPasswordWithPrefix);
 
     // then
-    assertThat(encryptedPassword, is(nullValue()));
+    assertThat(encryptedPassword).isNull();
   }
 
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/PasswordHashingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/PasswordHashingTest.java
@@ -16,10 +16,8 @@
  */
 package org.operaton.bpm.engine.test.api.identity;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -105,7 +103,7 @@ public class PasswordHashingTest {
     identityService.saveUser(user);
 
     // then
-    assertThat(identityService.checkPassword(USER_NAME, PASSWORD), is(true));
+    assertThat(identityService.checkPassword(USER_NAME, PASSWORD)).isEqualTo(true);
   }
 
   @Test
@@ -121,7 +119,7 @@ public class PasswordHashingTest {
     identityService.saveUser(user2);
 
     // then
-    assertThat(user1.getPassword(), is(not(user2.getPassword())));
+    assertThat(user1.getPassword()).isNotEqualTo(user2.getPassword());
   }
 
   @Test
@@ -138,7 +136,7 @@ public class PasswordHashingTest {
 
     // then
     // obtain the expected value on the command line like so: echo -n password12345678910 | openssl dgst -binary -sha1 | openssl base64
-    assertThat(user.getPassword(), is("{SHA}n3fE9/7XOmgD3BkeJlC+JLyb/Qg="));
+    assertThat(user.getPassword()).isEqualTo("{SHA}n3fE9/7XOmgD3BkeJlC+JLyb/Qg=");
   }
 
   @Test
@@ -154,8 +152,8 @@ public class PasswordHashingTest {
 
     // then
     // obtain the expected value on the command line like so: echo -n password12345678910 | openssl dgst -binary -sha512 | openssl base64
-    assertThat(user.getPassword(), is("{SHA-512}sM1U4nCzoDbdUugvJ7dJ6rLc7t1ZPPsnAbUpTqi5nXCYp7PTZCHExuzjoxLLYoUK" +
-      "Gd637jKqT8d9tpsZs3K5+g=="));
+    assertThat(user.getPassword()).isEqualTo("{SHA-512}sM1U4nCzoDbdUugvJ7dJ6rLc7t1ZPPsnAbUpTqi5nXCYp7PTZCHExuzjoxLLYoUK" +
+        "Gd637jKqT8d9tpsZs3K5+g==");
   }
 
   @Test
@@ -199,7 +197,7 @@ public class PasswordHashingTest {
     user = identityService.createUserQuery().userId(USER_NAME).singleResult();
 
     // then
-    assertThat(user.getPassword(), is("{" + ALGORITHM_NAME + "}xxx"));
+    assertThat(user.getPassword()).isEqualTo("{" + ALGORITHM_NAME + "}xxx");
   }
 
   @Test
@@ -230,9 +228,9 @@ public class PasswordHashingTest {
     User user3 = identityService.createUserQuery().userId(userName3).singleResult();
 
     // then
-    assertThat(user1.getPassword(), is("{" + ALGORITHM_NAME + "}xxx"));
-    assertThat(user2.getPassword(), is("{" + anotherAlgorithmName + "}xxx"));
-    assertThat(user3.getPassword(), is("{SHA}n3fE9/7XOmgD3BkeJlC+JLyb/Qg="));
+    assertThat(user1.getPassword()).isEqualTo("{" + ALGORITHM_NAME + "}xxx");
+    assertThat(user2.getPassword()).isEqualTo("{" + anotherAlgorithmName + "}xxx");
+    assertThat(user3.getPassword()).isEqualTo("{SHA}n3fE9/7XOmgD3BkeJlC+JLyb/Qg=");
   }
 
   protected void createUserWithEncryptor(String userName, PasswordEncryptor encryptor) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/PasswordPolicyConfigurationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/PasswordPolicyConfigurationTest.java
@@ -16,10 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.identity;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.hamcrest.core.IsNull.nullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.identity.DefaultPasswordPolicyImpl;
@@ -61,8 +58,8 @@ public class PasswordPolicyConfigurationTest {
     processEngineConfiguration.initPasswordPolicy();
 
     // then
-    assertThat(processEngineConfiguration.getPasswordPolicy(), nullValue());
-    assertThat(processEngineConfiguration.isEnablePasswordPolicy(), is(false));
+    assertThat(processEngineConfiguration.getPasswordPolicy()).isNull();
+    assertThat(processEngineConfiguration.isEnablePasswordPolicy()).isEqualTo(false);
   }
 
   @Test
@@ -75,8 +72,8 @@ public class PasswordPolicyConfigurationTest {
     processEngineConfiguration.initPasswordPolicy();
 
     // then
-    assertThat(processEngineConfiguration.isEnablePasswordPolicy(), is(true));
-    assertThat(processEngineConfiguration.getPasswordPolicy(), is(instanceOf(DefaultPasswordPolicyImpl.class)));
+    assertThat(processEngineConfiguration.isEnablePasswordPolicy()).isEqualTo(true);
+    assertThat(processEngineConfiguration.getPasswordPolicy()).isInstanceOf(DefaultPasswordPolicyImpl.class);
   }
 
   @Test
@@ -89,7 +86,7 @@ public class PasswordPolicyConfigurationTest {
     processEngineConfiguration.initPasswordPolicy();
 
     // then
-    assertThat(processEngineConfiguration.isEnablePasswordPolicy(), is(true));
-    assertThat(processEngineConfiguration.getPasswordPolicy(), is(instanceOf(DefaultPasswordPolicyImpl.class)));
+    assertThat(processEngineConfiguration.isEnablePasswordPolicy()).isEqualTo(true);
+    assertThat(processEngineConfiguration.getPasswordPolicy()).isInstanceOf(DefaultPasswordPolicyImpl.class);
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobEntityTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobEntityTest.java
@@ -16,8 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.mgmt;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
@@ -115,8 +114,8 @@ public class JobEntityTest {
     Job messageJob = managementService.createJobQuery().singleResult();
 
     // then
-    assertThat(messageJob.getCreateTime(), is(CREATE_DATE));
-    assertThat(messageJob.getClass().getSimpleName(), is("MessageEntity"));
+    assertThat(messageJob.getCreateTime()).isEqualTo(CREATE_DATE);
+    assertThat(messageJob.getClass().getSimpleName()).isEqualTo("MessageEntity");
 
     // cleanup
     jobIds.add(messageJob.getId());
@@ -138,8 +137,8 @@ public class JobEntityTest {
     Job timerJob = managementService.createJobQuery().singleResult();
 
     // then
-    assertThat(timerJob.getCreateTime(), is(CREATE_DATE));
-    assertThat(timerJob.getClass().getSimpleName(), is("TimerEntity"));
+    assertThat(timerJob.getCreateTime()).isEqualTo(CREATE_DATE);
+    assertThat(timerJob.getClass().getSimpleName()).isEqualTo("TimerEntity");
 
     // cleanup
     jobIds.add(timerJob.getId());
@@ -154,8 +153,8 @@ public class JobEntityTest {
     Job everLivingJob = managementService.createJobQuery().singleResult();
 
     // then
-    assertThat(everLivingJob.getCreateTime(), is(CREATE_DATE));
-    assertThat(everLivingJob.getClass().getSimpleName(), is("EverLivingJobEntity"));
+    assertThat(everLivingJob.getCreateTime()).isEqualTo(CREATE_DATE);
+    assertThat(everLivingJob.getClass().getSimpleName()).isEqualTo("EverLivingJobEntity");
 
     // cleanup
     jobIds.add(everLivingJob.getId());
@@ -186,7 +185,7 @@ public class JobEntityTest {
 
     // then
     job = (JobEntity) managementService.createJobQuery().jobId(job.getId()).singleResult();
-    assertThat(job.getFailedActivityId(), is("theTask"));
+    assertThat(job.getFailedActivityId()).isEqualTo("theTask");
   }
 
   @Test
@@ -216,7 +215,7 @@ public class JobEntityTest {
 
     // then
     job = (JobEntity) managementService.createJobQuery().jobId(job.getId()).singleResult();
-    assertThat(job.getFailedActivityId(), is("theTask"));
+    assertThat(job.getFailedActivityId()).isEqualTo("theTask");
   }
 
   @Test
@@ -248,7 +247,7 @@ public class JobEntityTest {
 
     // then
     job = (JobEntity) managementService.createJobQuery().jobId(job.getId()).singleResult();
-    assertThat(job.getFailedActivityId(), is("theTask3"));
+    assertThat(job.getFailedActivityId()).isEqualTo("theTask3");
   }
 
   // helper ////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceAsyncOperationsTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
+import org.hamcrest.Matchers;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.batch.Batch;
@@ -38,7 +39,6 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.AbstractAsyncOperationsTest;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.hamcrest.collection.IsIn;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -149,8 +149,8 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     // then batch jobs with different deployment ids exist
     List<Job> batchJobs = managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId()).list();
     assertThat(batchJobs).hasSize(2);
-    Assert.assertThat(batchJobs.get(0).getDeploymentId(), IsIn.isOneOf(firstDeploymentId, secondDeploymentId));
-    Assert.assertThat(batchJobs.get(1).getDeploymentId(), IsIn.isOneOf(firstDeploymentId, secondDeploymentId));
+    Assert.assertThat(batchJobs.get(0).getDeploymentId(), Matchers.isOneOf(firstDeploymentId, secondDeploymentId));
+    Assert.assertThat(batchJobs.get(1).getDeploymentId(), Matchers.isOneOf(firstDeploymentId, secondDeploymentId));
     assertThat(batchJobs.get(0).getDeploymentId()).isNotEqualTo(batchJobs.get(1).getDeploymentId());
 
     // when the batch jobs for the first deployment are executed

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceAsyncOperationsTest.java
@@ -24,9 +24,11 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import org.assertj.core.api.Assertions;
-import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.batch.Batch;
@@ -39,12 +41,6 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.AbstractAsyncOperationsTest;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 /**
  * @author Askar Akhmerov
@@ -113,7 +109,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     Batch batch = managementService.setJobRetriesAsync(ids, RETRIES);
 
     // then
-    Assertions.assertThat(batch.getInvocationsPerBatchJob()).isEqualTo(42);
+    assertThat(batch.getInvocationsPerBatchJob()).isEqualTo(42);
 
     // clear
     engineRule.getProcessEngineConfiguration()
@@ -149,8 +145,8 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     // then batch jobs with different deployment ids exist
     List<Job> batchJobs = managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId()).list();
     assertThat(batchJobs).hasSize(2);
-    Assert.assertThat(batchJobs.get(0).getDeploymentId(), Matchers.isOneOf(firstDeploymentId, secondDeploymentId));
-    Assert.assertThat(batchJobs.get(1).getDeploymentId(), Matchers.isOneOf(firstDeploymentId, secondDeploymentId));
+    assertThat(batchJobs.get(0).getDeploymentId()).isIn(firstDeploymentId, secondDeploymentId);
+    assertThat(batchJobs.get(1).getDeploymentId()).isIn(firstDeploymentId, secondDeploymentId);
     assertThat(batchJobs.get(0).getDeploymentId()).isNotEqualTo(batchJobs.get(1).getDeploymentId());
 
     // when the batch jobs for the first deployment are executed
@@ -563,7 +559,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
         historicProcessInstanceQuery, RETRIES);
 
     // then
-    Assertions.assertThat(batch.getInvocationsPerBatchJob()).isEqualTo(42);
+    assertThat(batch.getInvocationsPerBatchJob()).isEqualTo(42);
 
     // clear
     engineRule.getProcessEngineConfiguration()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricActivityInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricActivityInstancesForOptimizeTest.java
@@ -17,10 +17,8 @@
 package org.operaton.bpm.engine.test.api.optimize;
 
 import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.delegate.ExecutionListener.EVENTNAME_START;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -120,7 +118,7 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricActivityInstances(pastDate(), null, 10);
 
     // then
-    assertThat(completedHistoricActivityInstances.size(), is(2));
+    assertThat(completedHistoricActivityInstances.size()).isEqualTo(2);
     assertThatActivitiesHaveAllImportantInformation(completedHistoricActivityInstances);
   }
 
@@ -146,7 +144,7 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
 
     // then
     Set<String> allowedActivityIds = new HashSet<>(Arrays.asList("userTask", "endEvent"));
-    assertThat(completedHistoricActivityInstances.size(), is(2));
+    assertThat(completedHistoricActivityInstances.size()).isEqualTo(2);
     assertTrue(allowedActivityIds.contains(completedHistoricActivityInstances.get(0).getActivityId()));
     assertTrue(allowedActivityIds.contains(completedHistoricActivityInstances.get(1).getActivityId()));
   }
@@ -172,8 +170,8 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricActivityInstances(null, now, 10);
 
     // then
-    assertThat(completedHistoricActivityInstances.size(), is(1));
-    assertThat(completedHistoricActivityInstances.get(0).getActivityId(), is("startEvent"));
+    assertThat(completedHistoricActivityInstances.size()).isEqualTo(1);
+    assertThat(completedHistoricActivityInstances.get(0).getActivityId()).isEqualTo("startEvent");
   }
 
   @Test
@@ -197,7 +195,7 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricActivityInstances(now, now, 10);
 
     // then
-    assertThat(completedHistoricActivityInstances.size(), is(0));
+    assertThat(completedHistoricActivityInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -223,7 +221,7 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricActivityInstances(pastDate(), null, 3);
 
     // then
-    assertThat(completedHistoricActivityInstances.size(), is(3));
+    assertThat(completedHistoricActivityInstances.size()).isEqualTo(3);
   }
 
   @Test
@@ -253,11 +251,11 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricActivityInstances(pastDate(), null, 4);
 
     // then
-    assertThat(completedHistoricActivityInstances.size(), is(4));
-    assertThat(completedHistoricActivityInstances.get(0).getActivityId(), is("startEvent"));
-    assertThat(completedHistoricActivityInstances.get(1).getActivityId(), is("ServiceTask1"));
-    assertThat(completedHistoricActivityInstances.get(2).getActivityId(), is("ServiceTask2"));
-    assertThat(completedHistoricActivityInstances.get(3).getActivityId(), is("ServiceTask3"));
+    assertThat(completedHistoricActivityInstances.size()).isEqualTo(4);
+    assertThat(completedHistoricActivityInstances.get(0).getActivityId()).isEqualTo("startEvent");
+    assertThat(completedHistoricActivityInstances.get(1).getActivityId()).isEqualTo("ServiceTask1");
+    assertThat(completedHistoricActivityInstances.get(2).getActivityId()).isEqualTo("ServiceTask2");
+    assertThat(completedHistoricActivityInstances.get(3).getActivityId()).isEqualTo("ServiceTask3");
   }
 
   @Test
@@ -276,8 +274,8 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricActivityInstances(pastDate(), null, 10);
 
     // then
-    assertThat(completedHistoricActivityInstances.size(), is(1));
-    assertThat(completedHistoricActivityInstances.get(0).getActivityId(), is("startEvent"));
+    assertThat(completedHistoricActivityInstances.size()).isEqualTo(1);
+    assertThat(completedHistoricActivityInstances.get(0).getActivityId()).isEqualTo("startEvent");
   }
 
 
@@ -307,23 +305,23 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
         endEvent = completedHistoricActivityInstance;
       }
     }
-    assertThat(startEvent, notNullValue());
-    assertThat(startEvent.getActivityName(), is("start"));
-    assertThat(startEvent.getActivityType(), is("startEvent"));
-    assertThat(startEvent.getStartTime(), notNullValue());
-    assertThat(startEvent.getEndTime(), notNullValue());
-    assertThat(startEvent.getProcessDefinitionKey(), is("process"));
-    assertThat(startEvent.getProcessDefinitionId(), notNullValue());
-    assertThat(((HistoryEvent) startEvent).getSequenceCounter(), notNullValue());
+    assertThat(startEvent).isNotNull();
+    assertThat(startEvent.getActivityName()).isEqualTo("start");
+    assertThat(startEvent.getActivityType()).isEqualTo("startEvent");
+    assertThat(startEvent.getStartTime()).isNotNull();
+    assertThat(startEvent.getEndTime()).isNotNull();
+    assertThat(startEvent.getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(startEvent.getProcessDefinitionId()).isNotNull();
+    assertThat(((HistoryEvent) startEvent).getSequenceCounter()).isNotNull();
 
-    assertThat(endEvent, notNullValue());
-    assertThat(endEvent.getActivityName(), is("end"));
-    assertThat(endEvent.getActivityType(), is("noneEndEvent"));
-    assertThat(endEvent.getStartTime(), notNullValue());
-    assertThat(endEvent.getEndTime(), notNullValue());
-    assertThat(endEvent.getProcessDefinitionKey(), is("process"));
-    assertThat(endEvent.getProcessDefinitionId(), notNullValue());
-    assertThat(((HistoryEvent) endEvent).getSequenceCounter(), notNullValue());
+    assertThat(endEvent).isNotNull();
+    assertThat(endEvent.getActivityName()).isEqualTo("end");
+    assertThat(endEvent.getActivityType()).isEqualTo("noneEndEvent");
+    assertThat(endEvent.getStartTime()).isNotNull();
+    assertThat(endEvent.getEndTime()).isNotNull();
+    assertThat(endEvent.getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(endEvent.getProcessDefinitionId()).isNotNull();
+    assertThat(((HistoryEvent) endEvent).getSequenceCounter()).isNotNull();
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricIncidentsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricIncidentsForOptimizeTest.java
@@ -40,10 +40,7 @@ import org.junit.rules.RuleChain;
 import java.util.Date;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
@@ -96,7 +93,7 @@ public class GetCompletedHistoricIncidentsForOptimizeTest {
       optimizeService.getCompletedHistoricIncidents(pastDate(), null, 10);
 
     // then
-    assertThat(completedIncidents.size(), is(1));
+    assertThat(completedIncidents.size()).isEqualTo(1);
     assertThatInstanceHasAllImportantInformation(completedIncidents.get(0));
   }
 
@@ -118,8 +115,8 @@ public class GetCompletedHistoricIncidentsForOptimizeTest {
       optimizeService.getCompletedHistoricIncidents(now, null, 10);
 
     // then
-    assertThat(completedIncidents.size(), is(1));
-    assertThat(completedIncidents.get(0).getProcessInstanceId(), is(processInstance2.getId()));
+    assertThat(completedIncidents.size()).isEqualTo(1);
+    assertThat(completedIncidents.get(0).getProcessInstanceId()).isEqualTo(processInstance2.getId());
   }
 
   @Test
@@ -140,8 +137,8 @@ public class GetCompletedHistoricIncidentsForOptimizeTest {
       optimizeService.getCompletedHistoricIncidents(null, now, 10);
 
     // then
-    assertThat(completedIncidents.size(), is(1));
-    assertThat(completedIncidents.get(0).getProcessInstanceId(), is(processInstance.getId()));
+    assertThat(completedIncidents.size()).isEqualTo(1);
+    assertThat(completedIncidents.get(0).getProcessInstanceId()).isEqualTo(processInstance.getId());
   }
 
   @Test
@@ -162,7 +159,7 @@ public class GetCompletedHistoricIncidentsForOptimizeTest {
       optimizeService.getCompletedHistoricIncidents(now, now, 10);
 
     // then
-    assertThat(completedIncidents.size(), is(0));
+    assertThat(completedIncidents.size()).isEqualTo(0);
   }
 
   @Test
@@ -179,7 +176,7 @@ public class GetCompletedHistoricIncidentsForOptimizeTest {
       optimizeService.getCompletedHistoricIncidents(pastDate(), null, 3);
 
     // then
-    assertThat(completedIncidents.size(), is(3));
+    assertThat(completedIncidents.size()).isEqualTo(3);
   }
 
   @Test
@@ -207,10 +204,10 @@ public class GetCompletedHistoricIncidentsForOptimizeTest {
       optimizeService.getCompletedHistoricIncidents(now, null, 10);
 
     // then
-    assertThat(completedIncidents.size(), is(3));
-    assertThat(completedIncidents.get(0).getProcessInstanceId(), is(processInstance1.getId()));
-    assertThat(completedIncidents.get(1).getProcessInstanceId(), is(processInstance2.getId()));
-    assertThat(completedIncidents.get(2).getProcessInstanceId(), is(processInstance3.getId()));
+    assertThat(completedIncidents.size()).isEqualTo(3);
+    assertThat(completedIncidents.get(0).getProcessInstanceId()).isEqualTo(processInstance1.getId());
+    assertThat(completedIncidents.get(1).getProcessInstanceId()).isEqualTo(processInstance2.getId());
+    assertThat(completedIncidents.get(2).getProcessInstanceId()).isEqualTo(processInstance3.getId());
   }
 
   private Date pastDate() {
@@ -218,13 +215,13 @@ public class GetCompletedHistoricIncidentsForOptimizeTest {
   }
 
   private void assertThatInstanceHasAllImportantInformation(HistoricIncidentEntity historicIncidentEntity) {
-    assertThat(historicIncidentEntity, notNullValue());
-    assertThat(historicIncidentEntity.getId(), notNullValue());
-    assertThat(historicIncidentEntity.getProcessDefinitionKey(), is(PROCESS_DEFINITION_KEY));
-    assertThat(historicIncidentEntity.getProcessDefinitionVersion(), nullValue());
-    assertThat(historicIncidentEntity.getProcessDefinitionId(), notNullValue());
-    assertThat(historicIncidentEntity.getCreateTime(), notNullValue());
-    assertThat(historicIncidentEntity.getEndTime(), notNullValue());
+    assertThat(historicIncidentEntity).isNotNull();
+    assertThat(historicIncidentEntity.getId()).isNotNull();
+    assertThat(historicIncidentEntity.getProcessDefinitionKey()).isEqualTo(PROCESS_DEFINITION_KEY);
+    assertThat(historicIncidentEntity.getProcessDefinitionVersion()).isNull();
+    assertThat(historicIncidentEntity.getProcessDefinitionId()).isNotNull();
+    assertThat(historicIncidentEntity.getCreateTime()).isNotNull();
+    assertThat(historicIncidentEntity.getEndTime()).isNotNull();
   }
 
   private void retryAndSucceed(final ProcessInstance processInstance) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricProcessInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricProcessInstancesForOptimizeTest.java
@@ -16,9 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Date;
 import java.util.List;
@@ -114,7 +112,7 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricProcessInstances(pastDate(), null, 10);
 
     // then
-    assertThat(completedHistoricProcessInstances.size(), is(1));
+    assertThat(completedHistoricProcessInstances.size()).isEqualTo(1);
     assertThatInstanceHasAllImportantInformation(completedHistoricProcessInstances.get(0));
   }
 
@@ -138,7 +136,7 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricProcessInstances(now, null, 10);
 
     // then
-    assertThat(completedHistoricProcessInstances.size(), is(1));
+    assertThat(completedHistoricProcessInstances.size()).isEqualTo(1);
   }
 
   @Test
@@ -162,8 +160,8 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricProcessInstances(null, now, 10);
 
     // then
-    assertThat(completedHistoricProcessInstances.size(), is(1));
-    assertThat(completedHistoricProcessInstances.get(0).getId(), is(processInstance.getId()));
+    assertThat(completedHistoricProcessInstances.size()).isEqualTo(1);
+    assertThat(completedHistoricProcessInstances.get(0).getId()).isEqualTo(processInstance.getId());
   }
 
   @Test
@@ -186,7 +184,7 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricProcessInstances(now, now, 10);
 
     // then
-    assertThat(completedHistoricProcessInstances.size(), is(0));
+    assertThat(completedHistoricProcessInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -208,7 +206,7 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricProcessInstances(pastDate(), null, 3);
 
     // then
-    assertThat(completedHistoricProcessInstances.size(), is(3));
+    assertThat(completedHistoricProcessInstances.size()).isEqualTo(3);
   }
 
   @Test
@@ -238,10 +236,10 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricProcessInstances(now, null, 10);
 
     // then
-    assertThat(completedHistoricProcessInstances.size(), is(3));
-    assertThat(completedHistoricProcessInstances.get(0).getId(), is(processInstance1.getId()));
-    assertThat(completedHistoricProcessInstances.get(1).getId(), is(processInstance2.getId()));
-    assertThat(completedHistoricProcessInstances.get(2).getId(), is(processInstance3.getId()));
+    assertThat(completedHistoricProcessInstances.size()).isEqualTo(3);
+    assertThat(completedHistoricProcessInstances.get(0).getId()).isEqualTo(processInstance1.getId());
+    assertThat(completedHistoricProcessInstances.get(1).getId()).isEqualTo(processInstance2.getId());
+    assertThat(completedHistoricProcessInstances.get(2).getId()).isEqualTo(processInstance3.getId());
   }
 
   @Test
@@ -264,8 +262,8 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricProcessInstances(pastDate(), null, 10);
 
     // then
-    assertThat(completedHistoricProcessInstances.size(), is(1));
-        assertThat(completedHistoricProcessInstances.get(0).getId(), is(processInstanceToComplete.getId()));
+    assertThat(completedHistoricProcessInstances.size()).isEqualTo(1);
+    assertThat(completedHistoricProcessInstances.get(0).getId()).isEqualTo(processInstanceToComplete.getId());
 
   }
 
@@ -287,14 +285,14 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
   }
 
   private void assertThatInstanceHasAllImportantInformation(HistoricProcessInstance historicProcessInstance) {
-    assertThat(historicProcessInstance, notNullValue());
-    assertThat(historicProcessInstance.getId(), notNullValue());
-    assertThat(historicProcessInstance.getProcessDefinitionKey(), is("process"));
-    assertThat(historicProcessInstance.getProcessDefinitionVersion(), notNullValue());
-    assertThat(historicProcessInstance.getProcessDefinitionId(), notNullValue());
-    assertThat(historicProcessInstance.getDurationInMillis(), notNullValue());
-    assertThat(historicProcessInstance.getStartTime(), notNullValue());
-    assertThat(historicProcessInstance.getEndTime(), notNullValue());
+    assertThat(historicProcessInstance).isNotNull();
+    assertThat(historicProcessInstance.getId()).isNotNull();
+    assertThat(historicProcessInstance.getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(historicProcessInstance.getProcessDefinitionVersion()).isNotNull();
+    assertThat(historicProcessInstance.getProcessDefinitionId()).isNotNull();
+    assertThat(historicProcessInstance.getDurationInMillis()).isNotNull();
+    assertThat(historicProcessInstance.getStartTime()).isNotNull();
+    assertThat(historicProcessInstance.getEndTime()).isNotNull();
   }
 
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricTaskInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricTaskInstancesForOptimizeTest.java
@@ -17,9 +17,7 @@
 package org.operaton.bpm.engine.test.api.optimize;
 
 import static junit.framework.TestCase.assertTrue;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -116,7 +114,7 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricTaskInstances(null, null, 10);
 
     // then
-    assertThat(completedHistoricTaskInstances.size(), is(1));
+    assertThat(completedHistoricTaskInstances.size()).isEqualTo(1);
     assertThatTasksHaveAllImportantInformation(completedHistoricTaskInstances.get(0));
   }
 
@@ -150,7 +148,7 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
 
     // then
     Set<String> allowedTaskIds = new HashSet<>(Arrays.asList("userTask2", "userTask3"));
-    assertThat(completedHistoricTaskInstances.size(), is(2));
+    assertThat(completedHistoricTaskInstances.size()).isEqualTo(2);
     assertTrue(allowedTaskIds.contains(completedHistoricTaskInstances.get(0).getTaskDefinitionKey()));
     assertTrue(allowedTaskIds.contains(completedHistoricTaskInstances.get(1).getTaskDefinitionKey()));
   }
@@ -178,8 +176,8 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricTaskInstances(null, now, 10);
 
     // then
-    assertThat(completedHistoricTaskInstances.size(), is(1));
-    assertThat(completedHistoricTaskInstances.get(0).getTaskDefinitionKey(), is("userTask1"));
+    assertThat(completedHistoricTaskInstances.size()).isEqualTo(1);
+    assertThat(completedHistoricTaskInstances.get(0).getTaskDefinitionKey()).isEqualTo("userTask1");
   }
 
   @Test
@@ -205,7 +203,7 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricTaskInstances(now, now, 10);
 
     // then
-    assertThat(completedHistoricTaskInstances.size(), is(0));
+    assertThat(completedHistoricTaskInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -231,7 +229,7 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricTaskInstances(pastDate(), null, 3);
 
     // then
-    assertThat(completedHistoricTaskInstances.size(), is(3));
+    assertThat(completedHistoricTaskInstances.size()).isEqualTo(3);
   }
 
   @Test
@@ -263,10 +261,10 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricTaskInstances(pastDate(), null, 4);
 
     // then
-    assertThat(completedHistoricTaskInstances.size(), is(3));
-    assertThat(completedHistoricTaskInstances.get(0).getTaskDefinitionKey(), is("userTask1"));
-    assertThat(completedHistoricTaskInstances.get(1).getTaskDefinitionKey(), is("userTask2"));
-    assertThat(completedHistoricTaskInstances.get(2).getTaskDefinitionKey(), is("userTask3"));
+    assertThat(completedHistoricTaskInstances.size()).isEqualTo(3);
+    assertThat(completedHistoricTaskInstances.get(0).getTaskDefinitionKey()).isEqualTo("userTask1");
+    assertThat(completedHistoricTaskInstances.get(1).getTaskDefinitionKey()).isEqualTo("userTask2");
+    assertThat(completedHistoricTaskInstances.get(2).getTaskDefinitionKey()).isEqualTo("userTask3");
   }
 
   @Test
@@ -287,8 +285,8 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricTaskInstances(pastDate(), null, 10);
 
     // then
-    assertThat(completedHistoricTaskInstances.size(), is(1));
-    assertThat(completedHistoricTaskInstances.get(0).getTaskDefinitionKey(), is("userTask1"));
+    assertThat(completedHistoricTaskInstances.size()).isEqualTo(1);
+    assertThat(completedHistoricTaskInstances.get(0).getTaskDefinitionKey()).isEqualTo("userTask1");
   }
 
 
@@ -310,15 +308,15 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
   }
 
   private void assertThatTasksHaveAllImportantInformation(HistoricTaskInstance completedHistoricTaskInstance) {
-    assertThat(completedHistoricTaskInstance, notNullValue());
-    assertThat(completedHistoricTaskInstance.getId(), notNullValue());
-    assertThat(completedHistoricTaskInstance.getTaskDefinitionKey(), is("userTask"));
-    assertThat(completedHistoricTaskInstance.getName(), is("task"));
-    assertThat(completedHistoricTaskInstance.getStartTime(), notNullValue());
-    assertThat(completedHistoricTaskInstance.getEndTime(), notNullValue());
-    assertThat(completedHistoricTaskInstance.getProcessDefinitionKey(), is("process"));
-    assertThat(completedHistoricTaskInstance.getProcessDefinitionId(), notNullValue());
-    assertThat(completedHistoricTaskInstance.getAssignee(), is(userId));
+    assertThat(completedHistoricTaskInstance).isNotNull();
+    assertThat(completedHistoricTaskInstance.getId()).isNotNull();
+    assertThat(completedHistoricTaskInstance.getTaskDefinitionKey()).isEqualTo("userTask");
+    assertThat(completedHistoricTaskInstance.getName()).isEqualTo("task");
+    assertThat(completedHistoricTaskInstance.getStartTime()).isNotNull();
+    assertThat(completedHistoricTaskInstance.getEndTime()).isNotNull();
+    assertThat(completedHistoricTaskInstance.getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(completedHistoricTaskInstance.getProcessDefinitionId()).isNotNull();
+    assertThat(completedHistoricTaskInstance.getAssignee()).isEqualTo(userId);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricDecisionInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricDecisionInstancesForOptimizeTest.java
@@ -16,10 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Date;
 import java.util.List;
@@ -138,7 +135,7 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(pastDate(), null, 10);
 
     // then
-    assertThat(decisionInstances.size(), is(1));
+    assertThat(decisionInstances.size()).isEqualTo(1);
     assertThatDecisionsHaveAllImportantInformation(decisionInstances);
   }
 
@@ -155,16 +152,16 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(pastDate(), null, 10);
 
     // then
-    assertThat(decisionInstances.size(), is(1));
+    assertThat(decisionInstances.size()).isEqualTo(1);
     HistoricDecisionInstance decisionInstance = decisionInstances.get(0);
     List<HistoricDecisionInputInstance> inputs = decisionInstance.getInputs();
-    assertThat(inputs, is(notNullValue()));
-    assertThat(inputs.size(), is(1));
+    assertThat(inputs).isNotNull();
+    assertThat(inputs.size()).isEqualTo(1);
 
     HistoricDecisionInputInstance input = inputs.get(0);
-    assertThat(input.getDecisionInstanceId(), is(decisionInstance.getId()));
-    assertThat(input.getClauseId(), is("in"));
-    assertThat(input.getClauseName(), is("input"));
+    assertThat(input.getDecisionInstanceId()).isEqualTo(decisionInstance.getId());
+    assertThat(input.getClauseId()).isEqualTo("in");
+    assertThat(input.getClauseName()).isEqualTo("input");
   }
 
   @Test
@@ -180,21 +177,21 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(pastDate(), null, 10);
 
     // then
-    assertThat(decisionInstances.size(), is(1));
+    assertThat(decisionInstances.size()).isEqualTo(1);
     HistoricDecisionInstance decisionInstance = decisionInstances.get(0);
     List<HistoricDecisionOutputInstance> outputs = decisionInstance.getOutputs();
-    assertThat(outputs, is(notNullValue()));
-    assertThat(outputs.size(), is(1));
+    assertThat(outputs).isNotNull();
+    assertThat(outputs.size()).isEqualTo(1);
 
     HistoricDecisionOutputInstance output = outputs.get(0);
-    assertThat(output.getDecisionInstanceId(), is(decisionInstance.getId()));
-    assertThat(output.getClauseId(), is("out"));
-    assertThat(output.getClauseName(), is("output"));
+    assertThat(output.getDecisionInstanceId()).isEqualTo(decisionInstance.getId());
+    assertThat(output.getClauseId()).isEqualTo("out");
+    assertThat(output.getClauseName()).isEqualTo("output");
 
-    assertThat(output.getRuleId(), is("rule"));
-    assertThat(output.getRuleOrder(), is(1));
+    assertThat(output.getRuleId()).isEqualTo("rule");
+    assertThat(output.getRuleOrder()).isEqualTo(1);
 
-    assertThat(output.getVariableName(), is("result"));
+    assertThat(output.getVariableName()).isEqualTo("result");
   }
 
   @Test
@@ -216,9 +213,9 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(now, null, 10);
 
     // then
-    assertThat(decisionInstances.size(), is(1));
+    assertThat(decisionInstances.size()).isEqualTo(1);
     HistoricDecisionInstance decisionInstance = decisionInstances.get(0);
-    assertThat(decisionInstance.getProcessInstanceId(), is(secondProcessInstance.getId()));
+    assertThat(decisionInstance.getProcessInstanceId()).isEqualTo(secondProcessInstance.getId());
   }
 
   @Test
@@ -240,9 +237,9 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(null, now, 10);
 
     // then
-    assertThat(decisionInstances.size(), is(1));
+    assertThat(decisionInstances.size()).isEqualTo(1);
     HistoricDecisionInstance decisionInstance = decisionInstances.get(0);
-    assertThat(decisionInstance.getProcessInstanceId(), is(firstProcessInstance.getId()));
+    assertThat(decisionInstance.getProcessInstanceId()).isEqualTo(firstProcessInstance.getId());
   }
 
   @Test
@@ -267,7 +264,7 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(now, now, 10);
 
     // then
-    assertThat(decisionInstances.size(), is(0));
+    assertThat(decisionInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -285,7 +282,7 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(null, null, 2);
 
     // then
-    assertThat(decisionInstances.size(), is(2));
+    assertThat(decisionInstances.size()).isEqualTo(2);
   }
 
   @Test
@@ -313,10 +310,10 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(pastDate(), null, 3);
 
     // then
-    assertThat(decisionInstances.size(), is(3));
-    assertThat(decisionInstances.get(0).getProcessInstanceId(), is(firstProcessInstance.getId()));
-    assertThat(decisionInstances.get(1).getProcessInstanceId(), is(secondProcessInstance.getId()));
-    assertThat(decisionInstances.get(2).getProcessInstanceId(), is(thirdProcessInstance.getId()));
+    assertThat(decisionInstances.size()).isEqualTo(3);
+    assertThat(decisionInstances.get(0).getProcessInstanceId()).isEqualTo(firstProcessInstance.getId());
+    assertThat(decisionInstances.get(1).getProcessInstanceId()).isEqualTo(secondProcessInstance.getId());
+    assertThat(decisionInstances.get(2).getProcessInstanceId()).isEqualTo(thirdProcessInstance.getId());
   }
 
   private Date pastDate() {
@@ -329,34 +326,34 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
   }
 
   private void assertThatDecisionsHaveAllImportantInformation(List<HistoricDecisionInstance> decisionInstances) {
-    assertThat(decisionInstances.size(), is(1));
+    assertThat(decisionInstances.size()).isEqualTo(1);
     HistoricDecisionInstance decisionInstance =
       decisionInstances.get(0);
 
 
-    assertThat(decisionInstance, notNullValue());
-    assertThat(decisionInstance.getProcessDefinitionKey(), is("testProcess"));
-    assertThat(decisionInstance.getProcessDefinitionId(), notNullValue());
-    assertThat(decisionInstance.getDecisionDefinitionId(), notNullValue());
-    assertThat(decisionInstance.getDecisionDefinitionKey(), is("testDecision"));
-    assertThat(decisionInstance.getDecisionDefinitionName(), is("sample decision"));
+    assertThat(decisionInstance).isNotNull();
+    assertThat(decisionInstance.getProcessDefinitionKey()).isEqualTo("testProcess");
+    assertThat(decisionInstance.getProcessDefinitionId()).isNotNull();
+    assertThat(decisionInstance.getDecisionDefinitionId()).isNotNull();
+    assertThat(decisionInstance.getDecisionDefinitionKey()).isEqualTo("testDecision");
+    assertThat(decisionInstance.getDecisionDefinitionName()).isEqualTo("sample decision");
 
-    assertThat(decisionInstance.getActivityId(), is("task"));
-    assertThat(decisionInstance.getActivityInstanceId(), notNullValue());
+    assertThat(decisionInstance.getActivityId()).isEqualTo("task");
+    assertThat(decisionInstance.getActivityInstanceId()).isNotNull();
 
-    assertThat(decisionInstance.getProcessInstanceId(), is(notNullValue()));
-    assertThat(decisionInstance.getRootProcessInstanceId(), is(notNullValue()));
+    assertThat(decisionInstance.getProcessInstanceId()).isNotNull();
+    assertThat(decisionInstance.getRootProcessInstanceId()).isNotNull();
 
-    assertThat(decisionInstance.getCaseDefinitionKey(), is(nullValue()));
-    assertThat(decisionInstance.getCaseDefinitionId(), is(nullValue()));
+    assertThat(decisionInstance.getCaseDefinitionKey()).isNull();
+    assertThat(decisionInstance.getCaseDefinitionId()).isNull();
 
-    assertThat(decisionInstance.getCaseInstanceId(), is(nullValue()));
+    assertThat(decisionInstance.getCaseInstanceId()).isNull();
 
-    assertThat(decisionInstance.getRootDecisionInstanceId(), is(nullValue()));
-    assertThat(decisionInstance.getDecisionRequirementsDefinitionId(), is(nullValue()));
-    assertThat(decisionInstance.getDecisionRequirementsDefinitionKey(), is(nullValue()));
+    assertThat(decisionInstance.getRootDecisionInstanceId()).isNull();
+    assertThat(decisionInstance.getDecisionRequirementsDefinitionId()).isNull();
+    assertThat(decisionInstance.getDecisionRequirementsDefinitionKey()).isNull();
 
-    assertThat(decisionInstance.getEvaluationTime(), is(notNullValue()));
+    assertThat(decisionInstance.getEvaluationTime()).isNotNull();
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricIdentityLinkLogsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricIdentityLinkLogsForOptimizeTest.java
@@ -16,10 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Date;
 import java.util.List;
@@ -124,7 +121,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(pastDate(), null, 10);
 
     // then
-    assertThat(identityLinkLogs.size(), is(1));
+    assertThat(identityLinkLogs.size()).isEqualTo(1);
     assertThatIdentityLinksHaveAllImportantInformation(identityLinkLogs.get(0), processInstance);
   }
 
@@ -161,19 +158,19 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(pastDate(), null, 10);
 
     // then
-    assertThat(identityLinkLogs.size(), is(4));
-    assertThat(identityLinkLogs.get(0).getUserId(), is(userId));
-    assertThat(identityLinkLogs.get(0).getOperationType(), is(IDENTITY_LINK_ADD));
-    assertThat(identityLinkLogs.get(0).getType(), is(IdentityLinkType.CANDIDATE));
-    assertThat(identityLinkLogs.get(1).getUserId(), is(userId));
-    assertThat(identityLinkLogs.get(1).getOperationType(), is(IDENTITY_LINK_DELETE));
-    assertThat(identityLinkLogs.get(1).getType(), is(IdentityLinkType.CANDIDATE));
-    assertThat(identityLinkLogs.get(2).getGroupId(), is(groupId));
-    assertThat(identityLinkLogs.get(2).getOperationType(), is(IDENTITY_LINK_ADD));
-    assertThat(identityLinkLogs.get(2).getType(), is(IdentityLinkType.CANDIDATE));
-    assertThat(identityLinkLogs.get(3).getGroupId(), is(groupId));
-    assertThat(identityLinkLogs.get(3).getOperationType(), is(IDENTITY_LINK_DELETE));
-    assertThat(identityLinkLogs.get(3).getType(), is(IdentityLinkType.CANDIDATE));
+    assertThat(identityLinkLogs.size()).isEqualTo(4);
+    assertThat(identityLinkLogs.get(0).getUserId()).isEqualTo(userId);
+    assertThat(identityLinkLogs.get(0).getOperationType()).isEqualTo(IDENTITY_LINK_ADD);
+    assertThat(identityLinkLogs.get(0).getType()).isEqualTo(IdentityLinkType.CANDIDATE);
+    assertThat(identityLinkLogs.get(1).getUserId()).isEqualTo(userId);
+    assertThat(identityLinkLogs.get(1).getOperationType()).isEqualTo(IDENTITY_LINK_DELETE);
+    assertThat(identityLinkLogs.get(1).getType()).isEqualTo(IdentityLinkType.CANDIDATE);
+    assertThat(identityLinkLogs.get(2).getGroupId()).isEqualTo(groupId);
+    assertThat(identityLinkLogs.get(2).getOperationType()).isEqualTo(IDENTITY_LINK_ADD);
+    assertThat(identityLinkLogs.get(2).getType()).isEqualTo(IdentityLinkType.CANDIDATE);
+    assertThat(identityLinkLogs.get(3).getGroupId()).isEqualTo(groupId);
+    assertThat(identityLinkLogs.get(3).getOperationType()).isEqualTo(IDENTITY_LINK_DELETE);
+    assertThat(identityLinkLogs.get(3).getType()).isEqualTo(IdentityLinkType.CANDIDATE);
   }
 
   @Test
@@ -200,13 +197,13 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(pastDate(), null, 10);
 
     // then
-    assertThat(identityLinkLogs.size(), is(2));
-    assertThat(identityLinkLogs.get(0).getUserId(), is(userId));
-    assertThat(identityLinkLogs.get(0).getOperationType(), is(IDENTITY_LINK_ADD));
-    assertThat(identityLinkLogs.get(0).getType(), is(IdentityLinkType.ASSIGNEE));
-    assertThat(identityLinkLogs.get(1).getUserId(), is(userId));
-    assertThat(identityLinkLogs.get(1).getOperationType(), is(IDENTITY_LINK_DELETE));
-    assertThat(identityLinkLogs.get(0).getType(), is(IdentityLinkType.ASSIGNEE));
+    assertThat(identityLinkLogs.size()).isEqualTo(2);
+    assertThat(identityLinkLogs.get(0).getUserId()).isEqualTo(userId);
+    assertThat(identityLinkLogs.get(0).getOperationType()).isEqualTo(IDENTITY_LINK_ADD);
+    assertThat(identityLinkLogs.get(0).getType()).isEqualTo(IdentityLinkType.ASSIGNEE);
+    assertThat(identityLinkLogs.get(1).getUserId()).isEqualTo(userId);
+    assertThat(identityLinkLogs.get(1).getOperationType()).isEqualTo(IDENTITY_LINK_DELETE);
+    assertThat(identityLinkLogs.get(0).getType()).isEqualTo(IdentityLinkType.ASSIGNEE);
   }
 
   @Test
@@ -238,7 +235,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(now, null, 10);
 
     // then
-    assertThat(identityLinkLogs.size(), is(2));
+    assertThat(identityLinkLogs.size()).isEqualTo(2);
   }
 
   @Test
@@ -269,7 +266,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(null, now, 10);
 
     // then
-    assertThat(identityLinkLogs.size(), is(1));
+    assertThat(identityLinkLogs.size()).isEqualTo(1);
   }
 
   @Test
@@ -300,7 +297,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(now, now, 10);
 
     // then
-    assertThat(identityLinkLogs.size(), is(0));
+    assertThat(identityLinkLogs.size()).isEqualTo(0);
   }
 
   @Test
@@ -325,7 +322,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(pastDate(), null, 3);
 
     // then
-    assertThat(identityLinkLogs.size(), is(3));
+    assertThat(identityLinkLogs.size()).isEqualTo(3);
   }
 
   @Test
@@ -356,10 +353,10 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(pastDate(), null, 4);
 
     // then
-    assertThat(identityLinkLogs.size(), is(3));
-    assertThat(identityLinkLogs.get(0).getOperationType(), is(IDENTITY_LINK_ADD));
-    assertThat(identityLinkLogs.get(1).getOperationType(), is(IDENTITY_LINK_DELETE));
-    assertThat(identityLinkLogs.get(2).getOperationType(), is(IDENTITY_LINK_ADD));
+    assertThat(identityLinkLogs.size()).isEqualTo(3);
+    assertThat(identityLinkLogs.get(0).getOperationType()).isEqualTo(IDENTITY_LINK_ADD);
+    assertThat(identityLinkLogs.get(1).getOperationType()).isEqualTo(IDENTITY_LINK_DELETE);
+    assertThat(identityLinkLogs.get(2).getOperationType()).isEqualTo(IDENTITY_LINK_ADD);
   }
 
   private Date pastDate() {
@@ -392,16 +389,16 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
 
   private void assertThatIdentityLinksHaveAllImportantInformation(OptimizeHistoricIdentityLinkLogEntity identityLinkLog,
                                                                   ProcessInstance processInstance) {
-    assertThat(identityLinkLog, notNullValue());
-    assertThat(identityLinkLog.getUserId(), is(userId));
-    assertThat(identityLinkLog.getTaskId(), is(taskService.createTaskQuery().singleResult().getId()));
-    assertThat(identityLinkLog.getType(), is(IdentityLinkType.CANDIDATE));
-    assertThat(identityLinkLog.getAssignerId(), is(assignerId));
-    assertThat(identityLinkLog.getGroupId(), nullValue());
-    assertThat(identityLinkLog.getOperationType(), is(IDENTITY_LINK_ADD));
-    assertThat(identityLinkLog.getProcessDefinitionId(), is(processInstance.getProcessDefinitionId()));
-    assertThat(identityLinkLog.getProcessDefinitionKey(), is("process"));
-    assertThat(identityLinkLog.getProcessInstanceId(), is(processInstance.getId()));
+    assertThat(identityLinkLog).isNotNull();
+    assertThat(identityLinkLog.getUserId()).isEqualTo(userId);
+    assertThat(identityLinkLog.getTaskId()).isEqualTo(taskService.createTaskQuery().singleResult().getId());
+    assertThat(identityLinkLog.getType()).isEqualTo(IdentityLinkType.CANDIDATE);
+    assertThat(identityLinkLog.getAssignerId()).isEqualTo(assignerId);
+    assertThat(identityLinkLog.getGroupId()).isNull();
+    assertThat(identityLinkLog.getOperationType()).isEqualTo(IDENTITY_LINK_ADD);
+    assertThat(identityLinkLog.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+    assertThat(identityLinkLog.getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(identityLinkLog.getProcessInstanceId()).isEqualTo(processInstance.getId());
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricOperationLogsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricOperationLogsForOptimizeTest.java
@@ -23,11 +23,7 @@ import static org.operaton.bpm.engine.history.UserOperationLogEntry.OPERATION_TY
 import static org.operaton.bpm.engine.history.UserOperationLogEntry.OPERATION_TYPE_SUSPEND;
 import static org.operaton.bpm.engine.history.UserOperationLogEntry.OPERATION_TYPE_SUSPEND_JOB;
 import static org.operaton.bpm.engine.history.UserOperationLogEntry.OPERATION_TYPE_SUSPEND_PROCESS_DEFINITION;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -131,30 +127,30 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size(), is(2));
-    assertThat(userOperationsLog.get(0), notNullValue());
-    assertThat(userOperationsLog.get(0).getId(), notNullValue());
-    assertThat(userOperationsLog.get(0).getOperationType(), is(OPERATION_TYPE_SUSPEND));
-    assertThat(userOperationsLog.get(0).getEntityType(), is(EntityTypes.PROCESS_INSTANCE));
-    assertThat(userOperationsLog.get(0).getOrgValue(), nullValue());
-    assertThat(userOperationsLog.get(0).getNewValue(), is(SuspensionState.SUSPENDED.getName()));
-    assertThat(userOperationsLog.get(0).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(0).getProcessDefinitionKey(), is("process"));
-    assertThat(userOperationsLog.get(0).getProcessDefinitionId(), notNullValue());
-    assertThat(userOperationsLog.get(0).getProcessInstanceId(), is(processInstance.getId()));
-    assertThat(userOperationsLog.get(0).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.size()).isEqualTo(2);
+    assertThat(userOperationsLog.get(0)).isNotNull();
+    assertThat(userOperationsLog.get(0).getId()).isNotNull();
+    assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND);
+    assertThat(userOperationsLog.get(0).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
+    assertThat(userOperationsLog.get(0).getOrgValue()).isNull();
+    assertThat(userOperationsLog.get(0).getNewValue()).isEqualTo(SuspensionState.SUSPENDED.getName());
+    assertThat(userOperationsLog.get(0).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(0).getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(userOperationsLog.get(0).getProcessDefinitionId()).isNotNull();
+    assertThat(userOperationsLog.get(0).getProcessInstanceId()).isEqualTo(processInstance.getId());
+    assertThat(userOperationsLog.get(0).getCategory()).isEqualTo(CATEGORY_OPERATOR);
 
-    assertThat(userOperationsLog.get(1), notNullValue());
-    assertThat(userOperationsLog.get(1).getId(), notNullValue());
-    assertThat(userOperationsLog.get(1).getOperationType(), is(OPERATION_TYPE_ACTIVATE));
-    assertThat(userOperationsLog.get(1).getEntityType(), is(EntityTypes.PROCESS_INSTANCE));
-    assertThat(userOperationsLog.get(1).getOrgValue(), nullValue());
-    assertThat(userOperationsLog.get(1).getNewValue(), is(SuspensionState.ACTIVE.getName()));
-    assertThat(userOperationsLog.get(1).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(1).getProcessDefinitionKey(), is("process"));
-    assertThat(userOperationsLog.get(1).getProcessDefinitionId(), notNullValue());
-    assertThat(userOperationsLog.get(1).getProcessInstanceId(), is(processInstance.getId()));
-    assertThat(userOperationsLog.get(1).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.get(1)).isNotNull();
+    assertThat(userOperationsLog.get(1).getId()).isNotNull();
+    assertThat(userOperationsLog.get(1).getOperationType()).isEqualTo(OPERATION_TYPE_ACTIVATE);
+    assertThat(userOperationsLog.get(1).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
+    assertThat(userOperationsLog.get(1).getOrgValue()).isNull();
+    assertThat(userOperationsLog.get(1).getNewValue()).isEqualTo(SuspensionState.ACTIVE.getName());
+    assertThat(userOperationsLog.get(1).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(1).getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(userOperationsLog.get(1).getProcessDefinitionId()).isNotNull();
+    assertThat(userOperationsLog.get(1).getProcessInstanceId()).isEqualTo(processInstance.getId());
+    assertThat(userOperationsLog.get(1).getCategory()).isEqualTo(CATEGORY_OPERATOR);
   }
 
   @Test
@@ -176,30 +172,30 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size(), is(2));
-    assertThat(userOperationsLog.get(0), notNullValue());
-    assertThat(userOperationsLog.get(0).getId(), notNullValue());
-    assertThat(userOperationsLog.get(0).getOperationType(), is(OPERATION_TYPE_SUSPEND));
-    assertThat(userOperationsLog.get(0).getEntityType(), is(EntityTypes.PROCESS_INSTANCE));
-    assertThat(userOperationsLog.get(0).getOrgValue(), nullValue());
-    assertThat(userOperationsLog.get(0).getNewValue(), is(SuspensionState.SUSPENDED.getName()));
-    assertThat(userOperationsLog.get(0).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(0).getProcessDefinitionKey(), is("process"));
-    assertThat(userOperationsLog.get(0).getProcessDefinitionId(), notNullValue());
-    assertThat(userOperationsLog.get(0).getProcessInstanceId(), nullValue());
-    assertThat(userOperationsLog.get(0).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.size()).isEqualTo(2);
+    assertThat(userOperationsLog.get(0)).isNotNull();
+    assertThat(userOperationsLog.get(0).getId()).isNotNull();
+    assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND);
+    assertThat(userOperationsLog.get(0).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
+    assertThat(userOperationsLog.get(0).getOrgValue()).isNull();
+    assertThat(userOperationsLog.get(0).getNewValue()).isEqualTo(SuspensionState.SUSPENDED.getName());
+    assertThat(userOperationsLog.get(0).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(0).getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(userOperationsLog.get(0).getProcessDefinitionId()).isNotNull();
+    assertThat(userOperationsLog.get(0).getProcessInstanceId()).isNull();
+    assertThat(userOperationsLog.get(0).getCategory()).isEqualTo(CATEGORY_OPERATOR);
 
-    assertThat(userOperationsLog.get(1), notNullValue());
-    assertThat(userOperationsLog.get(1).getId(), notNullValue());
-    assertThat(userOperationsLog.get(1).getOperationType(), is(OPERATION_TYPE_ACTIVATE));
-    assertThat(userOperationsLog.get(1).getEntityType(), is(EntityTypes.PROCESS_INSTANCE));
-    assertThat(userOperationsLog.get(1).getOrgValue(), nullValue());
-    assertThat(userOperationsLog.get(1).getNewValue(), is(SuspensionState.ACTIVE.getName()));
-    assertThat(userOperationsLog.get(1).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(1).getProcessDefinitionKey(), is("process"));
-    assertThat(userOperationsLog.get(1).getProcessDefinitionId(), notNullValue());
-    assertThat(userOperationsLog.get(1).getProcessInstanceId(), nullValue());
-    assertThat(userOperationsLog.get(1).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.get(1)).isNotNull();
+    assertThat(userOperationsLog.get(1).getId()).isNotNull();
+    assertThat(userOperationsLog.get(1).getOperationType()).isEqualTo(OPERATION_TYPE_ACTIVATE);
+    assertThat(userOperationsLog.get(1).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
+    assertThat(userOperationsLog.get(1).getOrgValue()).isNull();
+    assertThat(userOperationsLog.get(1).getNewValue()).isEqualTo(SuspensionState.ACTIVE.getName());
+    assertThat(userOperationsLog.get(1).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(1).getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(userOperationsLog.get(1).getProcessDefinitionId()).isNotNull();
+    assertThat(userOperationsLog.get(1).getProcessInstanceId()).isNull();
+    assertThat(userOperationsLog.get(1).getCategory()).isEqualTo(CATEGORY_OPERATOR);
   }
 
   @Test
@@ -221,30 +217,30 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size(), is(2));
-    assertThat(userOperationsLog.get(0), notNullValue());
-    assertThat(userOperationsLog.get(0).getId(), notNullValue());
-    assertThat(userOperationsLog.get(0).getOperationType(), is(OPERATION_TYPE_SUSPEND));
-    assertThat(userOperationsLog.get(0).getEntityType(), is(EntityTypes.PROCESS_INSTANCE));
-    assertThat(userOperationsLog.get(0).getOrgValue(), nullValue());
-    assertThat(userOperationsLog.get(0).getNewValue(), is(SuspensionState.SUSPENDED.getName()));
-    assertThat(userOperationsLog.get(0).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(0).getProcessDefinitionKey(), is("process"));
-    assertThat(userOperationsLog.get(0).getProcessDefinitionId(), nullValue());
-    assertThat(userOperationsLog.get(0).getProcessInstanceId(), nullValue());
-    assertThat(userOperationsLog.get(0).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.size()).isEqualTo(2);
+    assertThat(userOperationsLog.get(0)).isNotNull();
+    assertThat(userOperationsLog.get(0).getId()).isNotNull();
+    assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND);
+    assertThat(userOperationsLog.get(0).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
+    assertThat(userOperationsLog.get(0).getOrgValue()).isNull();
+    assertThat(userOperationsLog.get(0).getNewValue()).isEqualTo(SuspensionState.SUSPENDED.getName());
+    assertThat(userOperationsLog.get(0).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(0).getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(userOperationsLog.get(0).getProcessDefinitionId()).isNull();
+    assertThat(userOperationsLog.get(0).getProcessInstanceId()).isNull();
+    assertThat(userOperationsLog.get(0).getCategory()).isEqualTo(CATEGORY_OPERATOR);
 
-    assertThat(userOperationsLog.get(1), notNullValue());
-    assertThat(userOperationsLog.get(1).getId(), notNullValue());
-    assertThat(userOperationsLog.get(1).getOperationType(), is(OPERATION_TYPE_ACTIVATE));
-    assertThat(userOperationsLog.get(1).getEntityType(), is(EntityTypes.PROCESS_INSTANCE));
-    assertThat(userOperationsLog.get(1).getOrgValue(), nullValue());
-    assertThat(userOperationsLog.get(1).getNewValue(), is(SuspensionState.ACTIVE.getName()));
-    assertThat(userOperationsLog.get(1).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(1).getProcessDefinitionKey(), is("process"));
-    assertThat(userOperationsLog.get(1).getProcessDefinitionId(), nullValue());
-    assertThat(userOperationsLog.get(1).getProcessInstanceId(), nullValue());
-    assertThat(userOperationsLog.get(1).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.get(1)).isNotNull();
+    assertThat(userOperationsLog.get(1).getId()).isNotNull();
+    assertThat(userOperationsLog.get(1).getOperationType()).isEqualTo(OPERATION_TYPE_ACTIVATE);
+    assertThat(userOperationsLog.get(1).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
+    assertThat(userOperationsLog.get(1).getOrgValue()).isNull();
+    assertThat(userOperationsLog.get(1).getNewValue()).isEqualTo(SuspensionState.ACTIVE.getName());
+    assertThat(userOperationsLog.get(1).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(1).getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(userOperationsLog.get(1).getProcessDefinitionId()).isNull();
+    assertThat(userOperationsLog.get(1).getProcessInstanceId()).isNull();
+    assertThat(userOperationsLog.get(1).getCategory()).isEqualTo(CATEGORY_OPERATOR);
   }
 
   @Test
@@ -266,7 +262,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size(), is(4));
+    assertThat(userOperationsLog.size()).isEqualTo(4);
     List<String> newPossibleValue = new ArrayList<>(Arrays.asList(
       SuspensionState.SUSPENDED.getName(),
       SuspensionState.ACTIVE.getName(),
@@ -274,45 +270,45 @@ public class GetHistoricOperationLogsForOptimizeTest {
       "true"
     ));
 
-    assertThat(userOperationsLog.get(0).getOperationType(), is(OPERATION_TYPE_SUSPEND_PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(0).getEntityType(), is(EntityTypes.PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(0).getOrgValue(), nullValue());
+    assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND_PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(0).getEntityType()).isEqualTo(EntityTypes.PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(0).getOrgValue()).isNull();
     assertTrue(newPossibleValue.remove(userOperationsLog.get(0).getNewValue()));
-    assertThat(userOperationsLog.get(0).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(0).getProcessDefinitionKey(), is("process"));
-    assertThat(userOperationsLog.get(0).getProcessDefinitionId(), is(processInstance.getProcessDefinitionId()));
-    assertThat(userOperationsLog.get(0).getProcessInstanceId(), nullValue());
-    assertThat(userOperationsLog.get(0).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.get(0).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(0).getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(userOperationsLog.get(0).getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+    assertThat(userOperationsLog.get(0).getProcessInstanceId()).isNull();
+    assertThat(userOperationsLog.get(0).getCategory()).isEqualTo(CATEGORY_OPERATOR);
 
-    assertThat(userOperationsLog.get(1).getOperationType(), is(OPERATION_TYPE_SUSPEND_PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(1).getEntityType(), is(EntityTypes.PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(1).getOrgValue(), nullValue());
+    assertThat(userOperationsLog.get(1).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND_PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(1).getEntityType()).isEqualTo(EntityTypes.PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(1).getOrgValue()).isNull();
     assertTrue(newPossibleValue.remove(userOperationsLog.get(1).getNewValue()));
-    assertThat(userOperationsLog.get(1).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(1).getProcessDefinitionKey(), is("process"));
-    assertThat(userOperationsLog.get(1).getProcessDefinitionId(), is(processInstance.getProcessDefinitionId()));
-    assertThat(userOperationsLog.get(1).getProcessInstanceId(), nullValue());
-    assertThat(userOperationsLog.get(1).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.get(1).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(1).getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(userOperationsLog.get(1).getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+    assertThat(userOperationsLog.get(1).getProcessInstanceId()).isNull();
+    assertThat(userOperationsLog.get(1).getCategory()).isEqualTo(CATEGORY_OPERATOR);
 
-    assertThat(userOperationsLog.get(2).getOperationType(), is(OPERATION_TYPE_ACTIVATE_PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(2).getEntityType(), is(EntityTypes.PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(2).getOrgValue(), nullValue());
+    assertThat(userOperationsLog.get(2).getOperationType()).isEqualTo(OPERATION_TYPE_ACTIVATE_PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(2).getEntityType()).isEqualTo(EntityTypes.PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(2).getOrgValue()).isNull();
     assertTrue(newPossibleValue.remove(userOperationsLog.get(2).getNewValue()));
-    assertThat(userOperationsLog.get(2).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(2).getProcessDefinitionKey(), is("process"));
-    assertThat(userOperationsLog.get(2).getProcessDefinitionId(), is(processInstance.getProcessDefinitionId()));
-    assertThat(userOperationsLog.get(2).getProcessInstanceId(), nullValue());
-    assertThat(userOperationsLog.get(2).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.get(2).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(2).getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(userOperationsLog.get(2).getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+    assertThat(userOperationsLog.get(2).getProcessInstanceId()).isNull();
+    assertThat(userOperationsLog.get(2).getCategory()).isEqualTo(CATEGORY_OPERATOR);
 
-    assertThat(userOperationsLog.get(3).getOperationType(), is(OPERATION_TYPE_ACTIVATE_PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(3).getEntityType(), is(EntityTypes.PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(3).getOrgValue(), nullValue());
+    assertThat(userOperationsLog.get(3).getOperationType()).isEqualTo(OPERATION_TYPE_ACTIVATE_PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(3).getEntityType()).isEqualTo(EntityTypes.PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(3).getOrgValue()).isNull();
     assertTrue(newPossibleValue.remove(userOperationsLog.get(3).getNewValue()));
-    assertThat(userOperationsLog.get(3).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(3).getProcessDefinitionKey(), is("process"));
-    assertThat(userOperationsLog.get(3).getProcessDefinitionId(), is(processInstance.getProcessDefinitionId()));
-    assertThat(userOperationsLog.get(3).getProcessInstanceId(), nullValue());
-    assertThat(userOperationsLog.get(3).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.get(3).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(3).getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(userOperationsLog.get(3).getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());
+    assertThat(userOperationsLog.get(3).getProcessInstanceId()).isNull();
+    assertThat(userOperationsLog.get(3).getCategory()).isEqualTo(CATEGORY_OPERATOR);
   }
 
   @Test
@@ -334,7 +330,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size(), is(4));
+    assertThat(userOperationsLog.size()).isEqualTo(4);
     List<String> newPossibleValue = new ArrayList<>(Arrays.asList(
       SuspensionState.SUSPENDED.getName(),
       SuspensionState.ACTIVE.getName(),
@@ -342,45 +338,45 @@ public class GetHistoricOperationLogsForOptimizeTest {
       "true"
     ));
 
-    assertThat(userOperationsLog.get(0).getOperationType(), is(OPERATION_TYPE_SUSPEND_PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(0).getEntityType(), is(EntityTypes.PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(0).getOrgValue(), nullValue());
+    assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND_PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(0).getEntityType()).isEqualTo(EntityTypes.PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(0).getOrgValue()).isNull();
     assertTrue(newPossibleValue.remove(userOperationsLog.get(0).getNewValue()));
-    assertThat(userOperationsLog.get(0).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(0).getProcessDefinitionKey(), is("process"));
-    assertThat(userOperationsLog.get(0).getProcessDefinitionId(), nullValue());
-    assertThat(userOperationsLog.get(0).getProcessInstanceId(), nullValue());
-    assertThat(userOperationsLog.get(0).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.get(0).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(0).getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(userOperationsLog.get(0).getProcessDefinitionId()).isNull();
+    assertThat(userOperationsLog.get(0).getProcessInstanceId()).isNull();
+    assertThat(userOperationsLog.get(0).getCategory()).isEqualTo(CATEGORY_OPERATOR);
 
-    assertThat(userOperationsLog.get(1).getOperationType(), is(OPERATION_TYPE_SUSPEND_PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(1).getEntityType(), is(EntityTypes.PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(1).getOrgValue(), nullValue());
+    assertThat(userOperationsLog.get(1).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND_PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(1).getEntityType()).isEqualTo(EntityTypes.PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(1).getOrgValue()).isNull();
     assertTrue(newPossibleValue.remove(userOperationsLog.get(1).getNewValue()));
-    assertThat(userOperationsLog.get(1).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(1).getProcessDefinitionKey(), is("process"));
-    assertThat(userOperationsLog.get(1).getProcessDefinitionId(), nullValue());
-    assertThat(userOperationsLog.get(1).getProcessInstanceId(), nullValue());
-    assertThat(userOperationsLog.get(1).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.get(1).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(1).getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(userOperationsLog.get(1).getProcessDefinitionId()).isNull();
+    assertThat(userOperationsLog.get(1).getProcessInstanceId()).isNull();
+    assertThat(userOperationsLog.get(1).getCategory()).isEqualTo(CATEGORY_OPERATOR);
 
-    assertThat(userOperationsLog.get(2).getOperationType(), is(OPERATION_TYPE_ACTIVATE_PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(2).getEntityType(), is(EntityTypes.PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(2).getOrgValue(), nullValue());
+    assertThat(userOperationsLog.get(2).getOperationType()).isEqualTo(OPERATION_TYPE_ACTIVATE_PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(2).getEntityType()).isEqualTo(EntityTypes.PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(2).getOrgValue()).isNull();
     assertTrue(newPossibleValue.remove(userOperationsLog.get(2).getNewValue()));
-    assertThat(userOperationsLog.get(2).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(2).getProcessDefinitionKey(), is("process"));
-    assertThat(userOperationsLog.get(2).getProcessDefinitionId(), nullValue());
-    assertThat(userOperationsLog.get(2).getProcessInstanceId(), nullValue());
-    assertThat(userOperationsLog.get(2).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.get(2).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(2).getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(userOperationsLog.get(2).getProcessDefinitionId()).isNull();
+    assertThat(userOperationsLog.get(2).getProcessInstanceId()).isNull();
+    assertThat(userOperationsLog.get(2).getCategory()).isEqualTo(CATEGORY_OPERATOR);
 
-    assertThat(userOperationsLog.get(3).getOperationType(), is(OPERATION_TYPE_ACTIVATE_PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(3).getEntityType(), is(EntityTypes.PROCESS_DEFINITION));
-    assertThat(userOperationsLog.get(3).getOrgValue(), nullValue());
+    assertThat(userOperationsLog.get(3).getOperationType()).isEqualTo(OPERATION_TYPE_ACTIVATE_PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(3).getEntityType()).isEqualTo(EntityTypes.PROCESS_DEFINITION);
+    assertThat(userOperationsLog.get(3).getOrgValue()).isNull();
     assertTrue(newPossibleValue.remove(userOperationsLog.get(3).getNewValue()));
-    assertThat(userOperationsLog.get(3).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(3).getProcessDefinitionKey(), is("process"));
-    assertThat(userOperationsLog.get(3).getProcessDefinitionId(), nullValue());
-    assertThat(userOperationsLog.get(3).getProcessInstanceId(), nullValue());
-    assertThat(userOperationsLog.get(3).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.get(3).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(3).getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(userOperationsLog.get(3).getProcessDefinitionId()).isNull();
+    assertThat(userOperationsLog.get(3).getProcessInstanceId()).isNull();
+    assertThat(userOperationsLog.get(3).getCategory()).isEqualTo(CATEGORY_OPERATOR);
   }
 
   @Test
@@ -410,31 +406,31 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size(), is(4));
-    assertThat(userOperationsLog.get(0).getOperationType(), is(OPERATION_TYPE_SUSPEND_JOB));
-    assertThat(userOperationsLog.get(0).getEntityType(), is(EntityTypes.PROCESS_INSTANCE));
-    assertThat(userOperationsLog.get(0).getProcessDefinitionKey(), nullValue());
-    assertThat(userOperationsLog.get(0).getProcessDefinitionId(), nullValue());
-    assertThat(userOperationsLog.get(0).getProcessInstanceId(), nullValue());
+    assertThat(userOperationsLog.size()).isEqualTo(4);
+    assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND_JOB);
+    assertThat(userOperationsLog.get(0).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
+    assertThat(userOperationsLog.get(0).getProcessDefinitionKey()).isNull();
+    assertThat(userOperationsLog.get(0).getProcessDefinitionId()).isNull();
+    assertThat(userOperationsLog.get(0).getProcessInstanceId()).isNull();
 
     // creates two suspend jobs, one for number of process instances affected and one for the async operation
-    assertThat(userOperationsLog.get(1).getOperationType(), is(OPERATION_TYPE_SUSPEND_JOB));
-    assertThat(userOperationsLog.get(1).getEntityType(), is(EntityTypes.PROCESS_INSTANCE));
+    assertThat(userOperationsLog.get(1).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND_JOB);
+    assertThat(userOperationsLog.get(1).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
 
-    assertThat(userOperationsLog.get(2), notNullValue());
-    assertThat(userOperationsLog.get(2).getOperationType(), is(OPERATION_TYPE_ACTIVATE_JOB));
-    assertThat(userOperationsLog.get(2).getEntityType(), is(EntityTypes.PROCESS_INSTANCE));
-    assertThat(userOperationsLog.get(2).getOrgValue(), nullValue());
-    assertThat(userOperationsLog.get(2).getNewValue(), notNullValue());
-    assertThat(userOperationsLog.get(2).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(2).getProcessDefinitionKey(), nullValue());
-    assertThat(userOperationsLog.get(2).getProcessDefinitionId(), nullValue());
-    assertThat(userOperationsLog.get(2).getProcessInstanceId(), nullValue());
-    assertThat(userOperationsLog.get(2).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.get(2)).isNotNull();
+    assertThat(userOperationsLog.get(2).getOperationType()).isEqualTo(OPERATION_TYPE_ACTIVATE_JOB);
+    assertThat(userOperationsLog.get(2).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
+    assertThat(userOperationsLog.get(2).getOrgValue()).isNull();
+    assertThat(userOperationsLog.get(2).getNewValue()).isNotNull();
+    assertThat(userOperationsLog.get(2).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(2).getProcessDefinitionKey()).isNull();
+    assertThat(userOperationsLog.get(2).getProcessDefinitionId()).isNull();
+    assertThat(userOperationsLog.get(2).getProcessInstanceId()).isNull();
+    assertThat(userOperationsLog.get(2).getCategory()).isEqualTo(CATEGORY_OPERATOR);
 
     // creates two activate jobs, one for number of process instances affected and one for the async operation
-    assertThat(userOperationsLog.get(3).getOperationType(), is(OPERATION_TYPE_ACTIVATE_JOB));
-    assertThat(userOperationsLog.get(3).getEntityType(), is(EntityTypes.PROCESS_INSTANCE));
+    assertThat(userOperationsLog.get(3).getOperationType()).isEqualTo(OPERATION_TYPE_ACTIVATE_JOB);
+    assertThat(userOperationsLog.get(3).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
   }
 
   @Test
@@ -464,31 +460,31 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size(), is(4));
-    assertThat(userOperationsLog.get(0).getOperationType(), is(OPERATION_TYPE_SUSPEND_JOB));
-    assertThat(userOperationsLog.get(0).getEntityType(), is(EntityTypes.PROCESS_INSTANCE));
-    assertThat(userOperationsLog.get(0).getProcessDefinitionKey(), nullValue());
-    assertThat(userOperationsLog.get(0).getProcessDefinitionId(), nullValue());
-    assertThat(userOperationsLog.get(0).getProcessInstanceId(), nullValue());
+    assertThat(userOperationsLog.size()).isEqualTo(4);
+    assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND_JOB);
+    assertThat(userOperationsLog.get(0).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
+    assertThat(userOperationsLog.get(0).getProcessDefinitionKey()).isNull();
+    assertThat(userOperationsLog.get(0).getProcessDefinitionId()).isNull();
+    assertThat(userOperationsLog.get(0).getProcessInstanceId()).isNull();
 
     // creates two suspend jobs, one for number of process instances affected and one for the async operation
-    assertThat(userOperationsLog.get(1).getOperationType(), is(OPERATION_TYPE_SUSPEND_JOB));
-    assertThat(userOperationsLog.get(1).getEntityType(), is(EntityTypes.PROCESS_INSTANCE));
+    assertThat(userOperationsLog.get(1).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND_JOB);
+    assertThat(userOperationsLog.get(1).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
 
-    assertThat(userOperationsLog.get(2), notNullValue());
-    assertThat(userOperationsLog.get(2).getOperationType(), is(OPERATION_TYPE_ACTIVATE_JOB));
-    assertThat(userOperationsLog.get(2).getEntityType(), is(EntityTypes.PROCESS_INSTANCE));
-    assertThat(userOperationsLog.get(2).getOrgValue(), nullValue());
-    assertThat(userOperationsLog.get(2).getNewValue(), notNullValue());
-    assertThat(userOperationsLog.get(2).getTimestamp(), notNullValue());
-    assertThat(userOperationsLog.get(2).getProcessDefinitionKey(), nullValue());
-    assertThat(userOperationsLog.get(2).getProcessDefinitionId(), nullValue());
-    assertThat(userOperationsLog.get(2).getProcessInstanceId(), nullValue());
-    assertThat(userOperationsLog.get(2).getCategory(), is(CATEGORY_OPERATOR));
+    assertThat(userOperationsLog.get(2)).isNotNull();
+    assertThat(userOperationsLog.get(2).getOperationType()).isEqualTo(OPERATION_TYPE_ACTIVATE_JOB);
+    assertThat(userOperationsLog.get(2).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
+    assertThat(userOperationsLog.get(2).getOrgValue()).isNull();
+    assertThat(userOperationsLog.get(2).getNewValue()).isNotNull();
+    assertThat(userOperationsLog.get(2).getTimestamp()).isNotNull();
+    assertThat(userOperationsLog.get(2).getProcessDefinitionKey()).isNull();
+    assertThat(userOperationsLog.get(2).getProcessDefinitionId()).isNull();
+    assertThat(userOperationsLog.get(2).getProcessInstanceId()).isNull();
+    assertThat(userOperationsLog.get(2).getCategory()).isEqualTo(CATEGORY_OPERATOR);
 
     // creates two activate jobs, one for number of process instances affected and one for the async operation
-    assertThat(userOperationsLog.get(3).getOperationType(), is(OPERATION_TYPE_ACTIVATE_JOB));
-    assertThat(userOperationsLog.get(3).getEntityType(), is(EntityTypes.PROCESS_INSTANCE));
+    assertThat(userOperationsLog.get(3).getOperationType()).isEqualTo(OPERATION_TYPE_ACTIVATE_JOB);
+    assertThat(userOperationsLog.get(3).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
   }
 
   @Test
@@ -513,7 +509,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
 
     // then
     Set<String> allowedOperationsTypes = new HashSet<>(Arrays.asList(OPERATION_TYPE_SUSPEND, OPERATION_TYPE_ACTIVATE));
-    assertThat(userOperationsLog.size(), is(2));
+    assertThat(userOperationsLog.size()).isEqualTo(2);
     assertTrue(allowedOperationsTypes.contains(userOperationsLog.get(0).getOperationType()));
     assertTrue(allowedOperationsTypes.contains(userOperationsLog.get(1).getOperationType()));
   }
@@ -535,8 +531,8 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(null, now, 10);
 
     // then
-    assertThat(userOperationsLog.size(), is(1));
-    assertThat(userOperationsLog.get(0).getOperationType(), is(OPERATION_TYPE_SUSPEND));
+    assertThat(userOperationsLog.size()).isEqualTo(1);
+    assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND);
   }
 
   @Test
@@ -556,7 +552,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(now, now, 10);
 
     // then
-    assertThat(userOperationsLog.size(), is(0));
+    assertThat(userOperationsLog.size()).isEqualTo(0);
   }
 
   @Test
@@ -573,7 +569,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 3);
 
     // then
-    assertThat(userOperationsLog.size(), is(3));
+    assertThat(userOperationsLog.size()).isEqualTo(3);
   }
 
   @Test
@@ -597,10 +593,10 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 4);
 
     // then
-    assertThat(userOperationsLog.size(), is(3));
-    assertThat(userOperationsLog.get(0).getOperationType(), is(OPERATION_TYPE_SUSPEND));
-    assertThat(userOperationsLog.get(1).getOperationType(), is(OPERATION_TYPE_ACTIVATE));
-    assertThat(userOperationsLog.get(2).getOperationType(), is(OPERATION_TYPE_SUSPEND));
+    assertThat(userOperationsLog.size()).isEqualTo(3);
+    assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND);
+    assertThat(userOperationsLog.get(1).getOperationType()).isEqualTo(OPERATION_TYPE_ACTIVATE);
+    assertThat(userOperationsLog.get(2).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND);
   }
 
   @Test
@@ -608,14 +604,14 @@ public class GetHistoricOperationLogsForOptimizeTest {
     // given
     ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceByKey("process");
     createLogEntriesThatShouldNotBeReturned(processInstance.getId());
-    assertThat(engineRule.getHistoryService().createUserOperationLogQuery().count(), greaterThan(0L));
+    assertThat(engineRule.getHistoryService().createUserOperationLogQuery().count()).isGreaterThan(0L);
 
     // when
     List<UserOperationLogEntry> userOperationsLog =
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size(), is(0));
+    assertThat(userOperationsLog.size()).isEqualTo(0);
   }
 
   private void createLogEntriesThatShouldNotBeReturned(String processInstanceId) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetOpenHistoricIncidentsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetOpenHistoricIncidentsForOptimizeTest.java
@@ -40,10 +40,7 @@ import org.junit.rules.RuleChain;
 import java.util.Date;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
@@ -94,7 +91,7 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
       optimizeService.getOpenHistoricIncidents(pastDate(), null, 10);
 
     // then
-    assertThat(openIncidents.size(), is(1));
+    assertThat(openIncidents.size()).isEqualTo(1);
     assertThatInstanceHasAllImportantInformation(openIncidents.get(0));
   }
 
@@ -115,8 +112,8 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
       optimizeService.getOpenHistoricIncidents(now, null, 10);
 
     // then
-    assertThat(openIncidents.size(), is(1));
-    assertThat(openIncidents.get(0).getProcessInstanceId(), is(processInstance.getId()));
+    assertThat(openIncidents.size()).isEqualTo(1);
+    assertThat(openIncidents.get(0).getProcessInstanceId()).isEqualTo(processInstance.getId());
 
   }
 
@@ -136,8 +133,8 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
       optimizeService.getOpenHistoricIncidents(null, now, 10);
 
     // then
-    assertThat(openIncidents.size(), is(1));
-    assertThat(openIncidents.get(0).getProcessInstanceId(), is(processInstance.getId()));
+    assertThat(openIncidents.size()).isEqualTo(1);
+    assertThat(openIncidents.get(0).getProcessInstanceId()).isEqualTo(processInstance.getId());
   }
 
   @Test
@@ -156,7 +153,7 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
       optimizeService.getOpenHistoricIncidents(now, now, 10);
 
     // then
-    assertThat(openIncidents.size(), is(0));
+    assertThat(openIncidents.size()).isEqualTo(0);
   }
 
   @Test
@@ -172,7 +169,7 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
       optimizeService.getOpenHistoricIncidents(pastDate(), null, 3);
 
     // then
-    assertThat(openIncidents.size(), is(3));
+    assertThat(openIncidents.size()).isEqualTo(3);
   }
 
   @Test
@@ -197,10 +194,10 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
       optimizeService.getOpenHistoricIncidents(now, null, 10);
 
     // then
-    assertThat(openIncidents.size(), is(3));
-    assertThat(openIncidents.get(0).getProcessInstanceId(), is(processInstance1.getId()));
-    assertThat(openIncidents.get(1).getProcessInstanceId(), is(processInstance2.getId()));
-    assertThat(openIncidents.get(2).getProcessInstanceId(), is(processInstance3.getId()));
+    assertThat(openIncidents.size()).isEqualTo(3);
+    assertThat(openIncidents.get(0).getProcessInstanceId()).isEqualTo(processInstance1.getId());
+    assertThat(openIncidents.get(1).getProcessInstanceId()).isEqualTo(processInstance2.getId());
+    assertThat(openIncidents.get(2).getProcessInstanceId()).isEqualTo(processInstance3.getId());
   }
 
   @Test
@@ -216,8 +213,8 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
       optimizeService.getOpenHistoricIncidents(pastDate(), null, 10);
 
     // then
-    assertThat(openIncidents.size(), is(1));
-    assertThat(openIncidents.get(0).getProcessInstanceId(), is(processInstanceWithOpenIncident.getId()));
+    assertThat(openIncidents.size()).isEqualTo(1);
+    assertThat(openIncidents.get(0).getProcessInstanceId()).isEqualTo(processInstanceWithOpenIncident.getId());
   }
 
   private Date pastDate() {
@@ -225,13 +222,13 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
   }
 
   private void assertThatInstanceHasAllImportantInformation(HistoricIncidentEntity historicIncidentEntity) {
-    assertThat(historicIncidentEntity, notNullValue());
-    assertThat(historicIncidentEntity.getId(), notNullValue());
-    assertThat(historicIncidentEntity.getProcessDefinitionKey(), is(PROCESS_DEFINITION_KEY));
-    assertThat(historicIncidentEntity.getProcessDefinitionVersion(), nullValue());
-    assertThat(historicIncidentEntity.getProcessDefinitionId(), notNullValue());
-    assertThat(historicIncidentEntity.getCreateTime(), notNullValue());
-    assertThat(historicIncidentEntity.getEndTime(), nullValue());
+    assertThat(historicIncidentEntity).isNotNull();
+    assertThat(historicIncidentEntity.getId()).isNotNull();
+    assertThat(historicIncidentEntity.getProcessDefinitionKey()).isEqualTo(PROCESS_DEFINITION_KEY);
+    assertThat(historicIncidentEntity.getProcessDefinitionVersion()).isNull();
+    assertThat(historicIncidentEntity.getProcessDefinitionId()).isNotNull();
+    assertThat(historicIncidentEntity.getCreateTime()).isNotNull();
+    assertThat(historicIncidentEntity.getEndTime()).isNull();
   }
 
   private void retryAndSucceed(final ProcessInstance processInstance) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricActivityInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricActivityInstancesForOptimizeTest.java
@@ -16,10 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Date;
 import java.util.List;
@@ -117,7 +114,7 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(pastDate(), null, 10);
 
     // then
-    assertThat(runningHistoricActivityInstances.size(), is(1));
+    assertThat(runningHistoricActivityInstances.size()).isEqualTo(1);
     HistoricActivityInstance activityInstance = runningHistoricActivityInstances.get(0);
     assertThatActivitiesHaveAllImportantInformation(activityInstance);
   }
@@ -144,8 +141,8 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(now, null, 10);
 
     // then
-    assertThat(runningHistoricActivityInstances.size(), is(1));
-    assertThat(runningHistoricActivityInstances.get(0).getProcessInstanceId(), is(secondProcessInstance.getId()));
+    assertThat(runningHistoricActivityInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricActivityInstances.get(0).getProcessInstanceId()).isEqualTo(secondProcessInstance.getId());
   }
 
   @Test
@@ -170,8 +167,8 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(null, now, 10);
 
     // then
-    assertThat(runningHistoricActivityInstances.size(), is(1));
-    assertThat(runningHistoricActivityInstances.get(0).getProcessInstanceId(), is(firstProcessInstance.getId()));
+    assertThat(runningHistoricActivityInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricActivityInstances.get(0).getProcessInstanceId()).isEqualTo(firstProcessInstance.getId());
   }
 
   @Test
@@ -195,7 +192,7 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(now, now, 10);
 
     // then
-    assertThat(runningHistoricActivityInstances.size(), is(0));
+    assertThat(runningHistoricActivityInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -217,7 +214,7 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(pastDate(), null, 3);
 
     // then
-    assertThat(runningHistoricActivityInstances.size(), is(3));
+    assertThat(runningHistoricActivityInstances.size()).isEqualTo(3);
   }
 
   @Test
@@ -244,10 +241,10 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(pastDate(), null, 4);
 
     // then
-    assertThat(runningHistoricActivityInstances.size(), is(3));
-    assertThat(runningHistoricActivityInstances.get(0).getProcessInstanceId(), is(firstProcessInstance.getId()));
-    assertThat(runningHistoricActivityInstances.get(1).getProcessInstanceId(), is(secondProcessInstance.getId()));
-    assertThat(runningHistoricActivityInstances.get(2).getProcessInstanceId(), is(thirdProcessInstance.getId()));
+    assertThat(runningHistoricActivityInstances.size()).isEqualTo(3);
+    assertThat(runningHistoricActivityInstances.get(0).getProcessInstanceId()).isEqualTo(firstProcessInstance.getId());
+    assertThat(runningHistoricActivityInstances.get(1).getProcessInstanceId()).isEqualTo(secondProcessInstance.getId());
+    assertThat(runningHistoricActivityInstances.get(2).getProcessInstanceId()).isEqualTo(thirdProcessInstance.getId());
   }
 
   public void shiftTimeByOneMinute() {
@@ -272,8 +269,8 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(pastDate(), null, 10);
 
     // then
-    assertThat(runningHistoricActivityInstances.size(), is(1));
-    assertThat(runningHistoricActivityInstances.get(0).getActivityId(), is("userTask"));
+    assertThat(runningHistoricActivityInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricActivityInstances.get(0).getActivityId()).isEqualTo("userTask");
 
     // when
     completeAllUserTasks();
@@ -281,7 +278,7 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(pastDate(), null, 10);
 
     // then
-    assertThat(runningHistoricActivityInstances.size(), is(0));
+    assertThat(runningHistoricActivityInstances.size()).isEqualTo(0);
   }
 
   private Date pastDate() {
@@ -304,14 +301,14 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
   }
 
   private void assertThatActivitiesHaveAllImportantInformation(HistoricActivityInstance activityInstance) {
-    assertThat(activityInstance, notNullValue());
-    assertThat(activityInstance.getActivityName(), is("task"));
-    assertThat(activityInstance.getActivityType(), is("userTask"));
-    assertThat(activityInstance.getStartTime(), notNullValue());
-    assertThat(activityInstance.getEndTime(), nullValue());
-    assertThat(activityInstance.getProcessDefinitionKey(), is("process"));
-    assertThat(activityInstance.getProcessDefinitionId(), notNullValue());
-    assertThat(((HistoryEvent) activityInstance).getSequenceCounter(), notNullValue());
+    assertThat(activityInstance).isNotNull();
+    assertThat(activityInstance.getActivityName()).isEqualTo("task");
+    assertThat(activityInstance.getActivityType()).isEqualTo("userTask");
+    assertThat(activityInstance.getStartTime()).isNotNull();
+    assertThat(activityInstance.getEndTime()).isNull();
+    assertThat(activityInstance.getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(activityInstance.getProcessDefinitionId()).isNotNull();
+    assertThat(((HistoryEvent) activityInstance).getSequenceCounter()).isNotNull();
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricProcessInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricProcessInstancesForOptimizeTest.java
@@ -16,10 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Date;
 import java.util.List;
@@ -115,7 +112,7 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
       optimizeService.getRunningHistoricProcessInstances(pastDate(), null, 10);
 
     // then
-    assertThat(runningHistoricProcessInstances.size(), is(1));
+    assertThat(runningHistoricProcessInstances.size()).isEqualTo(1);
     assertThatInstanceHasAllImportantInformation(runningHistoricProcessInstances.get(0));
   }
 
@@ -140,7 +137,7 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
       optimizeService.getRunningHistoricProcessInstances(now, null, 10);
 
     // then
-    assertThat(runningHistoricProcessInstances.size(), is(1));
+    assertThat(runningHistoricProcessInstances.size()).isEqualTo(1);
   }
 
   @Test
@@ -165,8 +162,8 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
       optimizeService.getRunningHistoricProcessInstances(null, now, 10);
 
     // then
-    assertThat(runningHistoricProcessInstances.size(), is(1));
-    assertThat(runningHistoricProcessInstances.get(0).getId(), is(processInstance.getId()));
+    assertThat(runningHistoricProcessInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricProcessInstances.get(0).getId()).isEqualTo(processInstance.getId());
   }
 
   @Test
@@ -191,7 +188,7 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
       optimizeService.getRunningHistoricProcessInstances(now, now, 10);
 
     // then
-    assertThat(runningHistoricProcessInstances.size(), is(0));
+    assertThat(runningHistoricProcessInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -214,7 +211,7 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
       optimizeService.getRunningHistoricProcessInstances(pastDate(), null, 3);
 
     // then
-    assertThat(runningHistoricProcessInstances.size(), is(3));
+    assertThat(runningHistoricProcessInstances.size()).isEqualTo(3);
   }
 
   @Test
@@ -245,10 +242,10 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
       optimizeService.getRunningHistoricProcessInstances(new Date(now.getTime()), null, 10);
 
     // then
-    assertThat(runningHistoricProcessInstances.size(), is(3));
-    assertThat(runningHistoricProcessInstances.get(0).getId(), is(processInstance1.getId()));
-    assertThat(runningHistoricProcessInstances.get(1).getId(), is(processInstance2.getId()));
-    assertThat(runningHistoricProcessInstances.get(2).getId(), is(processInstance3.getId()));
+    assertThat(runningHistoricProcessInstances.size()).isEqualTo(3);
+    assertThat(runningHistoricProcessInstances.get(0).getId()).isEqualTo(processInstance1.getId());
+    assertThat(runningHistoricProcessInstances.get(1).getId()).isEqualTo(processInstance2.getId());
+    assertThat(runningHistoricProcessInstances.get(2).getId()).isEqualTo(processInstance3.getId());
   }
 
   @Test
@@ -270,8 +267,8 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
       optimizeService.getRunningHistoricProcessInstances(pastDate(), null, 10);
 
     // then
-    assertThat(runningHistoricProcessInstances.size(), is(1));
-    assertThat(runningHistoricProcessInstances.get(0).getId(), is(runningProcessInstance.getId()));
+    assertThat(runningHistoricProcessInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricProcessInstances.get(0).getId()).isEqualTo(runningProcessInstance.getId());
   }
 
   private Date pastDate() {
@@ -292,13 +289,13 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
   }
 
   private void assertThatInstanceHasAllImportantInformation(HistoricProcessInstance historicProcessInstance) {
-    assertThat(historicProcessInstance, notNullValue());
-    assertThat(historicProcessInstance.getId(), notNullValue());
-    assertThat(historicProcessInstance.getProcessDefinitionKey(), is("process"));
-    assertThat(historicProcessInstance.getProcessDefinitionVersion(), notNullValue());
-    assertThat(historicProcessInstance.getProcessDefinitionId(), notNullValue());
-    assertThat(historicProcessInstance.getStartTime(), notNullValue());
-    assertThat(historicProcessInstance.getEndTime(), nullValue());
+    assertThat(historicProcessInstance).isNotNull();
+    assertThat(historicProcessInstance.getId()).isNotNull();
+    assertThat(historicProcessInstance.getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(historicProcessInstance.getProcessDefinitionVersion()).isNotNull();
+    assertThat(historicProcessInstance.getProcessDefinitionId()).isNotNull();
+    assertThat(historicProcessInstance.getStartTime()).isNotNull();
+    assertThat(historicProcessInstance.getEndTime()).isNull();
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricTaskInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricTaskInstancesForOptimizeTest.java
@@ -16,10 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Date;
 import java.util.List;
@@ -114,7 +111,7 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
       optimizeService.getRunningHistoricTaskInstances(null, null, 10);
 
     // then
-    assertThat(runningHistoricTaskInstances.size(), is(1));
+    assertThat(runningHistoricTaskInstances.size()).isEqualTo(1);
     assertThatTasksHaveAllImportantInformation(runningHistoricTaskInstances.get(0));
   }
 
@@ -140,8 +137,8 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
       optimizeService.getRunningHistoricTaskInstances(now, null, 10);
 
     // then
-    assertThat(runningHistoricTaskInstances.size(), is(1));
-    assertThat(runningHistoricTaskInstances.get(0).getProcessInstanceId(), is(processInstance2.getId()));
+    assertThat(runningHistoricTaskInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricTaskInstances.get(0).getProcessInstanceId()).isEqualTo(processInstance2.getId());
   }
 
   @Test
@@ -166,8 +163,8 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
       optimizeService.getRunningHistoricTaskInstances(null, now, 10);
 
     // then
-    assertThat(runningHistoricTaskInstances.size(), is(1));
-    assertThat(runningHistoricTaskInstances.get(0).getProcessInstanceId(), is(processInstance1.getId()));
+    assertThat(runningHistoricTaskInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricTaskInstances.get(0).getProcessInstanceId()).isEqualTo(processInstance1.getId());
   }
 
   @Test
@@ -192,7 +189,7 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
       optimizeService.getRunningHistoricTaskInstances(now, now, 10);
 
     // then
-    assertThat(runningHistoricTaskInstances.size(), is(0));
+    assertThat(runningHistoricTaskInstances.size()).isEqualTo(0);
   }
 
   @Test
@@ -214,7 +211,7 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
       optimizeService.getRunningHistoricTaskInstances(pastDate(), null, 3);
 
     // then
-    assertThat(runningHistoricTaskInstances.size(), is(3));
+    assertThat(runningHistoricTaskInstances.size()).isEqualTo(3);
   }
 
   @Test
@@ -243,10 +240,10 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
       optimizeService.getRunningHistoricTaskInstances(pastDate(), null, 10);
 
     // then
-    assertThat(runningHistoricTaskInstances.size(), is(3));
-    assertThat(runningHistoricTaskInstances.get(0).getProcessInstanceId(), is(processInstance1.getId()));
-    assertThat(runningHistoricTaskInstances.get(1).getProcessInstanceId(), is(processInstance2.getId()));
-    assertThat(runningHistoricTaskInstances.get(2).getProcessInstanceId(), is(processInstance3.getId()));
+    assertThat(runningHistoricTaskInstances.size()).isEqualTo(3);
+    assertThat(runningHistoricTaskInstances.get(0).getProcessInstanceId()).isEqualTo(processInstance1.getId());
+    assertThat(runningHistoricTaskInstances.get(1).getProcessInstanceId()).isEqualTo(processInstance2.getId());
+    assertThat(runningHistoricTaskInstances.get(2).getProcessInstanceId()).isEqualTo(processInstance3.getId());
   }
 
   @Test
@@ -268,8 +265,8 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
       optimizeService.getRunningHistoricTaskInstances(pastDate(), null, 10);
 
     // then
-    assertThat(runningHistoricTaskInstances.size(), is(1));
-    assertThat(runningHistoricTaskInstances.get(0).getTaskDefinitionKey(), is("userTask2"));
+    assertThat(runningHistoricTaskInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricTaskInstances.get(0).getTaskDefinitionKey()).isEqualTo("userTask2");
   }
 
   private Date pastDate() {
@@ -290,15 +287,15 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
   }
 
   private void assertThatTasksHaveAllImportantInformation(HistoricTaskInstance completedHistoricTaskInstance) {
-    assertThat(completedHistoricTaskInstance, notNullValue());
-    assertThat(completedHistoricTaskInstance.getId(), notNullValue());
-    assertThat(completedHistoricTaskInstance.getTaskDefinitionKey(), is("userTask"));
-    assertThat(completedHistoricTaskInstance.getName(), is("task"));
-    assertThat(completedHistoricTaskInstance.getStartTime(), notNullValue());
-    assertThat(completedHistoricTaskInstance.getEndTime(), nullValue());
-    assertThat(completedHistoricTaskInstance.getProcessDefinitionKey(), is("process"));
-    assertThat(completedHistoricTaskInstance.getProcessDefinitionId(), notNullValue());
-    assertThat(completedHistoricTaskInstance.getAssignee(), is(userId));
+    assertThat(completedHistoricTaskInstance).isNotNull();
+    assertThat(completedHistoricTaskInstance.getId()).isNotNull();
+    assertThat(completedHistoricTaskInstance.getTaskDefinitionKey()).isEqualTo("userTask");
+    assertThat(completedHistoricTaskInstance.getName()).isEqualTo("task");
+    assertThat(completedHistoricTaskInstance.getStartTime()).isNotNull();
+    assertThat(completedHistoricTaskInstance.getEndTime()).isNull();
+    assertThat(completedHistoricTaskInstance.getProcessDefinitionKey()).isEqualTo("process");
+    assertThat(completedHistoricTaskInstance.getProcessDefinitionId()).isNotNull();
+    assertThat(completedHistoricTaskInstance.getAssignee()).isEqualTo(userId);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationSubProcessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationSubProcessTest.java
@@ -16,9 +16,20 @@
  */
 package org.operaton.bpm.engine.test.api.runtime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
+import static org.operaton.bpm.engine.test.util.ExecutionAssert.describeExecutionTree;
+
 import java.util.ArrayList;
 import java.util.List;
-
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.HistoryService;
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.engine.RuntimeService;
@@ -29,25 +40,12 @@ import org.operaton.bpm.engine.runtime.ActivityInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
+import org.operaton.bpm.engine.test.util.ExecutionAssert;
 import org.operaton.bpm.engine.test.util.ExecutionTree;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-
-import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
-import static org.operaton.bpm.engine.test.util.ExecutionAssert.assertThat;
-import static org.operaton.bpm.engine.test.util.ExecutionAssert.describeExecutionTree;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 /**
  * @author Svetlana Dorokhova.
@@ -151,7 +149,7 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then the process should be finished
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(0L));
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
   }
 
   @Test
@@ -189,10 +187,10 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then the parent process instance is still active
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(1L));
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1L);
 
     Task task = taskService.createTaskQuery().singleResult();
-    assertThat(task.getProcessInstanceId(), is(parentPI.getId()));
+    assertThat(task.getProcessInstanceId()).isEqualTo(parentPI.getId());
   }
 
   @Test
@@ -237,7 +235,7 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then the process should be finished
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(0L));
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
 
   }
 
@@ -284,10 +282,10 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then the parent process instance is still active
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(1L));
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1L);
 
     Task task = taskService.createTaskQuery().singleResult();
-    assertThat(task.getProcessInstanceId(), is(parentPI.getId()));
+    assertThat(task.getProcessInstanceId()).isEqualTo(parentPI.getId());
 
   }
 
@@ -326,7 +324,7 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then the process should be finished
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(0L));
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
 
   }
 
@@ -366,10 +364,10 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then the parent process instance is still active
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(1L));
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1L);
 
     Task task = taskService.createTaskQuery().singleResult();
-    assertThat(task.getProcessInstanceId(), is(parentPI.getId()));
+    assertThat(task.getProcessInstanceId()).isEqualTo(parentPI.getId());
 
   }
 
@@ -416,7 +414,7 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then the process should be finished
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(0L));
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
   }
 
   @Test
@@ -463,10 +461,10 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then the parent process instance is still active
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(1L));
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1L);
 
     Task task = taskService.createTaskQuery().singleResult();
-    assertThat(task.getProcessInstanceId(), is(parentPI.getId()));
+    assertThat(task.getProcessInstanceId()).isEqualTo(parentPI.getId());
   }
 
   @Test
@@ -512,7 +510,7 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then the process should be finished
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(0L));
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
   }
 
   @Test
@@ -559,10 +557,10 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then the parent process instance is still active
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(1L));
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1L);
 
     Task task = taskService.createTaskQuery().singleResult();
-    assertThat(task.getProcessInstanceId(), is(parentPI.getId()));
+    assertThat(task.getProcessInstanceId()).isEqualTo(parentPI.getId());
   }
 
   @Test
@@ -607,7 +605,7 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(0L));
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
   }
 
   @Test
@@ -657,7 +655,7 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(0L));
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
   }
 
   @Test
@@ -703,7 +701,7 @@ public class ProcessInstanceModificationSubProcessTest {
       Assert.assertNull(calledInstanceAfterModification);
 
       ExecutionTree executionTree = ExecutionTree.forExecution(callingInstance.getId(), rule.getProcessEngine());
-      assertThat(executionTree)
+      ExecutionAssert.assertThat(executionTree)
         .matches(
           describeExecutionTree("parentUserTask").scope()
         .done());
@@ -749,11 +747,11 @@ public class ProcessInstanceModificationSubProcessTest {
                   .execute();
 
     // then the parent process instance is still active
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(1L));
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1L);
     assertNotNull(taskService.createTaskQuery().taskName("escalationTask").singleResult());
 
     Task task = taskService.createTaskQuery().singleResult();
-    assertThat(task.getProcessInstanceId(), is(parentPI.getId()));
+    assertThat(task.getProcessInstanceId()).isEqualTo(parentPI.getId());
   }
 
   @Test
@@ -796,11 +794,11 @@ public class ProcessInstanceModificationSubProcessTest {
                   .execute();
 
     // then the parent process instance is still active
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(1L));
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(1L);
     assertNotNull(taskService.createTaskQuery().taskName("errorTask").singleResult());
 
     Task task = taskService.createTaskQuery().singleResult();
-    assertThat(task.getProcessInstanceId(), is(parentPI.getId()));
+    assertThat(task.getProcessInstanceId()).isEqualTo(parentPI.getId());
   }
 
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RootProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RootProcessInstanceTest.java
@@ -16,9 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.runtime;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.List;
@@ -88,10 +86,10 @@ public class RootProcessInstanceTest {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(CALLED_PROCESS_KEY);
 
     // assume
-    assertThat(processInstance.getRootProcessInstanceId(), notNullValue());
+    assertThat(processInstance.getRootProcessInstanceId()).isNotNull();
 
     // then
-    assertThat(processInstance.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(processInstance.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -106,10 +104,10 @@ public class RootProcessInstanceTest {
     ProcessInstance processInstance = formService.submitStartForm(processDefinitionId, properties);
 
     // assume
-    assertThat(processInstance.getRootProcessInstanceId(), notNullValue());
+    assertThat(processInstance.getRootProcessInstanceId()).isNotNull();
 
     // then
-    assertThat(processInstance.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(processInstance.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -123,10 +121,10 @@ public class RootProcessInstanceTest {
       .execute();
 
     // assume
-    assertThat(processInstance.getRootProcessInstanceId(), notNullValue());
+    assertThat(processInstance.getRootProcessInstanceId()).isNotNull();
 
     // then
-    assertThat(processInstance.getRootProcessInstanceId(), is(processInstance.getProcessInstanceId()));
+    assertThat(processInstance.getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
   }
 
   @Test
@@ -152,16 +150,13 @@ public class RootProcessInstanceTest {
       .singleResult();
 
     // assume
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(3L));
-    assertThat(callingProcessInstance.getRootProcessInstanceId(), notNullValue());
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(3L);
+    assertThat(callingProcessInstance.getRootProcessInstanceId()).isNotNull();
 
     // then
-    assertThat(callingProcessInstance.getRootProcessInstanceId(),
-      is(callingProcessInstance.getProcessInstanceId()));
-    assertThat(calledProcessInstance.getRootProcessInstanceId(),
-      is(callingProcessInstance.getProcessInstanceId()));
-    assertThat(calledAndCallingProcessInstance.getRootProcessInstanceId(),
-      is(callingProcessInstance.getProcessInstanceId()));
+    assertThat(callingProcessInstance.getRootProcessInstanceId()).isEqualTo(callingProcessInstance.getProcessInstanceId());
+    assertThat(calledProcessInstance.getRootProcessInstanceId()).isEqualTo(callingProcessInstance.getProcessInstanceId());
+    assertThat(calledAndCallingProcessInstance.getRootProcessInstanceId()).isEqualTo(callingProcessInstance.getProcessInstanceId());
   }
 
   @Test
@@ -197,25 +192,20 @@ public class RootProcessInstanceTest {
       .singleResult();
 
     // assume
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(5L));
-    assertThat(callingProcessInstance.getProcessInstanceId(), notNullValue());
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(5L);
+    assertThat(callingProcessInstance.getProcessInstanceId()).isNotNull();
 
-    assertThat(calledProcessInstances.size(), is(2));
-    assertThat(calledAndCallingProcessInstances.size(), is(2));
+    assertThat(calledProcessInstances.size()).isEqualTo(2);
+    assertThat(calledAndCallingProcessInstances.size()).isEqualTo(2);
 
     // then
-    assertThat(callingProcessInstance.getRootProcessInstanceId(),
-      is(callingProcessInstance.getProcessInstanceId()));
+    assertThat(callingProcessInstance.getRootProcessInstanceId()).isEqualTo(callingProcessInstance.getProcessInstanceId());
 
-    assertThat(calledProcessInstances.get(0).getRootProcessInstanceId(),
-      is(callingProcessInstance.getProcessInstanceId()));
-    assertThat(calledProcessInstances.get(1).getRootProcessInstanceId(),
-      is(callingProcessInstance.getProcessInstanceId()));
+    assertThat(calledProcessInstances.get(0).getRootProcessInstanceId()).isEqualTo(callingProcessInstance.getProcessInstanceId());
+    assertThat(calledProcessInstances.get(1).getRootProcessInstanceId()).isEqualTo(callingProcessInstance.getProcessInstanceId());
 
-    assertThat(calledAndCallingProcessInstances.get(0).getRootProcessInstanceId(),
-      is(callingProcessInstance.getProcessInstanceId()));
-    assertThat(calledAndCallingProcessInstances.get(1).getRootProcessInstanceId(),
-      is(callingProcessInstance.getProcessInstanceId()));
+    assertThat(calledAndCallingProcessInstances.get(0).getRootProcessInstanceId()).isEqualTo(callingProcessInstance.getProcessInstanceId());
+    assertThat(calledAndCallingProcessInstances.get(1).getRootProcessInstanceId()).isEqualTo(callingProcessInstance.getProcessInstanceId());
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationAddMultiInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationAddMultiInstanceTest.java
@@ -16,18 +16,18 @@
  */
 package org.operaton.bpm.engine.test.api.runtime.migration;
 
-import static org.operaton.bpm.engine.test.util.MigrationPlanValidationReportAssert.assertThat;
 import static org.junit.Assert.fail;
+import static org.operaton.bpm.engine.test.util.MigrationPlanValidationReportAssert.assertThat;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.migration.MigrationPlanValidationException;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.api.runtime.migration.models.MultiInstanceProcessModels;
 import org.operaton.bpm.engine.test.api.runtime.migration.models.ProcessModels;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 /**
  * @author Thorben Lindhauer
@@ -58,7 +58,7 @@ public class MigrationAddMultiInstanceTest {
       assertThat(e.getValidationReport())
         .hasInstructionFailures("userTask",
           "Target activity 'userTask' is a descendant of multi-instance body 'userTask#multiInstanceBody' "
-          + "that is not mapped from the source process definition"
+          + "that is not mapped from the source process definition."
         );
     }
   }
@@ -80,7 +80,7 @@ public class MigrationAddMultiInstanceTest {
       assertThat(e.getValidationReport())
         .hasInstructionFailures("userTask",
           "Target activity 'userTask' is a descendant of multi-instance body 'userTask#multiInstanceBody' "
-          + "that is not mapped from the source process definition"
+          + "that is not mapped from the source process definition."
         );
     }
   }
@@ -103,7 +103,7 @@ public class MigrationAddMultiInstanceTest {
       assertThat(e.getValidationReport())
         .hasInstructionFailures("userTask",
           "Target activity 'userTask' is a descendant of multi-instance body 'subProcess#multiInstanceBody' "
-          + "that is not mapped from the source process definition"
+          + "that is not mapped from the source process definition."
         );
     }
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/SkipHistoryOptimisticLockingExceptionsDisabledTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/SkipHistoryOptimisticLockingExceptionsDisabledTest.java
@@ -16,8 +16,7 @@
  */
 package org.operaton.bpm.engine.test.concurrency.partitioning;
 
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
@@ -59,7 +58,7 @@ public class SkipHistoryOptimisticLockingExceptionsDisabledTest extends Abstract
     });
 
     // assume
-    assertThat(historyService.createHistoricVariableInstanceQuery().singleResult(), nullValue());
+    assertThat(historyService.createHistoricVariableInstanceQuery().singleResult()).isNull();
 
     asyncThread.waitUntilDone();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
@@ -16,6 +16,13 @@
  */
 package org.operaton.bpm.engine.test.history;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.ACTIVE;
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.AVAILABLE;
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.COMPLETED;
@@ -23,14 +30,6 @@ import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.DIS
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.ENABLED;
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.SUSPENDED;
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.TERMINATED;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,7 +38,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-
+import org.junit.Test;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.exception.NotValidException;
@@ -64,8 +63,6 @@ import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.cmmn.CmmnTest;
 import org.operaton.bpm.engine.variable.Variables;
-import org.hamcrest.Matcher;
-import org.junit.Test;
 
 /**
  * @author Sebastian Menski
@@ -1068,32 +1065,33 @@ public class HistoricCaseActivityInstanceTest extends CmmnTest {
   protected void assertQuerySorting(String property, Query<?, ?> query, Comparable... items) {
     AbstractQuery<?, ?> queryImpl = (AbstractQuery<?, ?>) query;
 
-    // save order properties to later reverse ordering
+    // Save order properties to later reverse ordering
     List<QueryOrderingProperty> orderProperties = queryImpl.getOrderingProperties();
 
     List<? extends Comparable> sortedList = Arrays.asList(items);
     Collections.sort(sortedList);
 
-    List<Matcher<Object>> matchers = new ArrayList<Matcher<Object>>();
-    for (Comparable comparable : sortedList) {
-      matchers.add(hasProperty(property, equalTo(comparable)));
-    }
-
+    // Assert that the sorted list matches the query result
     List<?> instances = query.asc().list();
-    assertEquals(sortedList.size(), instances.size());
-    assertThat(instances, contains(matchers.toArray(new Matcher[matchers.size()])));
+    assertThat(instances)
+        .hasSize(sortedList.size())
+        .extracting(property)
+        .containsExactlyElementsOf(sortedList);
 
-    // reverse ordering
+    // Reverse ordering
     for (QueryOrderingProperty orderingProperty : orderProperties) {
       orderingProperty.setDirection(Direction.DESCENDING);
     }
 
-    // reverse matchers
-    Collections.reverse(matchers);
+    // Reverse matchers
+    Collections.reverse(sortedList);
 
+    // Assert again with reversed order
     instances = query.list();
-    assertEquals(sortedList.size(), instances.size());
-    assertThat(instances, contains(matchers.toArray(new Matcher[matchers.size()])));
+    assertThat(instances)
+        .hasSize(sortedList.size())
+        .extracting(property)
+        .containsExactlyElementsOf(sortedList);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.oneStageAndOneTaskCaseWithManualActivation.cmmn"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
@@ -23,9 +23,7 @@ import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.DIS
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.ENABLED;
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.SUSPENDED;
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.TERMINATED;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
@@ -1065,28 +1065,28 @@ public class HistoricCaseActivityInstanceTest extends CmmnTest {
   protected void assertQuerySorting(String property, Query<?, ?> query, Comparable... items) {
     AbstractQuery<?, ?> queryImpl = (AbstractQuery<?, ?>) query;
 
-    // Save order properties to later reverse ordering
+    // save order properties to later reverse ordering
     List<QueryOrderingProperty> orderProperties = queryImpl.getOrderingProperties();
 
     List<? extends Comparable> sortedList = Arrays.asList(items);
     Collections.sort(sortedList);
 
-    // Assert that the sorted list matches the query result
+    // assert that the sorted list matches the query result
     List<?> instances = query.asc().list();
     assertThat(instances)
         .hasSize(sortedList.size())
         .extracting(property)
         .containsExactlyElementsOf(sortedList);
 
-    // Reverse ordering
+    // reverse ordering
     for (QueryOrderingProperty orderingProperty : orderProperties) {
       orderingProperty.setDirection(Direction.DESCENDING);
     }
 
-    // Reverse matchers
+    // reverse matchers
     Collections.reverse(sortedList);
 
-    // Assert again with reversed order
+    // assert again with reversed order
     instances = query.list();
     assertThat(instances)
         .hasSize(sortedList.size())

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/PartitioningTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/PartitioningTest.java
@@ -16,9 +16,7 @@
  */
 package org.operaton.bpm.engine.test.history;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -108,13 +106,13 @@ public class PartitioningTest {
     });
 
     // assume
-    assertThat(historyService.createHistoricProcessInstanceQuery().count(), is(0L));
+    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0L);
 
     // when
     runtimeService.deleteProcessInstance(processInstanceId, "aDeleteReason");
 
     // then
-    assertThat(runtimeService.createProcessInstanceQuery().singleResult(), nullValue());
+    assertThat(runtimeService.createProcessInstanceQuery().singleResult()).isNull();
 
     // cleanup
     cleanUp(processInstanceId);
@@ -139,7 +137,7 @@ public class PartitioningTest {
     });
 
     // assume
-    assertThat(historyService.createHistoricTaskInstanceQuery().singleResult(), nullValue());
+    assertThat(historyService.createHistoricTaskInstanceQuery().singleResult()).isNull();
 
     // when
     String taskId = taskService.createTaskQuery()
@@ -149,7 +147,7 @@ public class PartitioningTest {
     taskService.complete(taskId);
 
     // then
-    assertThat(taskService.createTaskQuery().singleResult(), nullValue());
+    assertThat(taskService.createTaskQuery().singleResult()).isNull();
   }
 
   @Test
@@ -168,7 +166,7 @@ public class PartitioningTest {
     });
 
     // assume
-    assertThat(historyService.createHistoricActivityInstanceQuery().count(), is(0L));
+    assertThat(historyService.createHistoricActivityInstanceQuery().count()).isEqualTo(0L);
 
     // when
     String taskId = taskService.createTaskQuery()
@@ -178,7 +176,7 @@ public class PartitioningTest {
     taskService.complete(taskId);
 
     // then
-    assertThat(historyService.createHistoricActivityInstanceQuery().count(), is(1L));
+    assertThat(historyService.createHistoricActivityInstanceQuery().count()).isEqualTo(1L);
   }
 
   @Test
@@ -202,15 +200,15 @@ public class PartitioningTest {
     });
 
     // assume
-    assertThat(historyService.createHistoricIncidentQuery().count(), is(0L));
-    assertThat(runtimeService.createIncidentQuery().count(), is(1L));
+    assertThat(historyService.createHistoricIncidentQuery().count()).isEqualTo(0L);
+    assertThat(runtimeService.createIncidentQuery().count()).isEqualTo(1L);
 
     // when
     runtimeService.resolveIncident(incidentId);
 
     // then
-    assertThat(runtimeService.createIncidentQuery().count(), is(0L));
-    assertThat(historyService.createHistoricIncidentQuery().count(), is(0L));
+    assertThat(runtimeService.createIncidentQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricIncidentQuery().count()).isEqualTo(0L);
   }
 
   @Test
@@ -221,7 +219,7 @@ public class PartitioningTest {
     final Batch batch = runtimeService.deleteProcessInstancesAsync(Collections.singletonList(processInstanceId), "aDeleteReason");
 
     // assume
-    assertThat(historyService.createHistoricBatchQuery().count(), is(1L));
+    assertThat(historyService.createHistoricBatchQuery().count()).isEqualTo(1L);
 
     commandExecutor.execute(new Command<Void>() {
       public Void execute(CommandContext commandContext) {
@@ -237,7 +235,7 @@ public class PartitioningTest {
     });
 
     // assume
-    assertThat(historyService.createHistoricBatchQuery().count(), is(0L));
+    assertThat(historyService.createHistoricBatchQuery().count()).isEqualTo(0L);
 
     // when
     String seedJobDefinitionId = batch.getSeedJobDefinitionId();
@@ -256,8 +254,8 @@ public class PartitioningTest {
     }
 
     // then
-    assertThat(runtimeService.createProcessInstanceQuery().count(), is(0L));
-    assertThat(managementService.createBatchQuery().count(), is(0L));
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
+    assertThat(managementService.createBatchQuery().count()).isEqualTo(0L);
 
     // cleanup
     cleanUp(processInstanceId);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/identity/DefaultPasswordPolicyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/identity/DefaultPasswordPolicyTest.java
@@ -16,11 +16,8 @@
  */
 package org.operaton.bpm.engine.test.standalone.identity;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.hamcrest.core.IsNull.notNullValue;
 
 import org.assertj.core.api.Assertions;
 import org.operaton.bpm.engine.IdentityService;
@@ -76,9 +73,9 @@ public class DefaultPasswordPolicyTest {
   @Test
   public void testGoodPassword() {
     PasswordPolicyResult result = identityService.checkPasswordAgainstPolicy(policy, "LongPas$w0rd");
-    assertThat(result.getViolatedRules().size(), is(0));
-    assertThat(result.getFulfilledRules().size(), is(6));
-    assertThat(result.isValid(), is(true));
+    assertThat(result.getViolatedRules().size()).isEqualTo(0);
+    assertThat(result.getFulfilledRules().size()).isEqualTo(6);
+    assertThat(result.isValid()).isEqualTo(true);
   }
 
   @Test
@@ -89,7 +86,7 @@ public class DefaultPasswordPolicyTest {
     PasswordPolicyResult result = identityService.checkPasswordAgainstPolicy("LongPas$w0rd");
 
     // then
-    assertThat(result, notNullValue());
+    assertThat(result).isNotNull();
   }
 
   @Test
@@ -98,8 +95,8 @@ public class DefaultPasswordPolicyTest {
     checkThatPasswordWasInvalid(result);
 
     PasswordPolicyRule rule = result.getViolatedRules().get(0);
-    assertThat(rule.getPlaceholder(), is(PasswordPolicyLowerCaseRuleImpl.PLACEHOLDER));
-    assertThat(rule, instanceOf(PasswordPolicyLowerCaseRuleImpl.class));
+    assertThat(rule.getPlaceholder()).isEqualTo(PasswordPolicyLowerCaseRuleImpl.PLACEHOLDER);
+    assertThat(rule).isInstanceOf(PasswordPolicyLowerCaseRuleImpl.class);
   }
 
   @Test
@@ -108,8 +105,8 @@ public class DefaultPasswordPolicyTest {
     checkThatPasswordWasInvalid(result);
 
     PasswordPolicyRule rule = result.getViolatedRules().get(0);
-    assertThat(rule.getPlaceholder(), is(PasswordPolicyUpperCaseRuleImpl.PLACEHOLDER));
-    assertThat(rule, instanceOf(PasswordPolicyUpperCaseRuleImpl.class));
+    assertThat(rule.getPlaceholder()).isEqualTo(PasswordPolicyUpperCaseRuleImpl.PLACEHOLDER);
+    assertThat(rule).isInstanceOf(PasswordPolicyUpperCaseRuleImpl.class);
   }
 
   @Test
@@ -118,8 +115,8 @@ public class DefaultPasswordPolicyTest {
     checkThatPasswordWasInvalid(result);
 
     PasswordPolicyRule rule = result.getViolatedRules().get(0);
-    assertThat(rule.getPlaceholder(), is(PasswordPolicySpecialCharacterRuleImpl.PLACEHOLDER));
-    assertThat(rule, instanceOf(PasswordPolicySpecialCharacterRuleImpl.class));
+    assertThat(rule.getPlaceholder()).isEqualTo(PasswordPolicySpecialCharacterRuleImpl.PLACEHOLDER);
+    assertThat(rule).isInstanceOf(PasswordPolicySpecialCharacterRuleImpl.class);
   }
 
   @Test
@@ -128,8 +125,8 @@ public class DefaultPasswordPolicyTest {
     checkThatPasswordWasInvalid(result);
 
     PasswordPolicyRule rule = result.getViolatedRules().get(0);
-    assertThat(rule.getPlaceholder(), is(PasswordPolicyDigitRuleImpl.PLACEHOLDER));
-    assertThat(rule, instanceOf(PasswordPolicyDigitRuleImpl.class));
+    assertThat(rule.getPlaceholder()).isEqualTo(PasswordPolicyDigitRuleImpl.PLACEHOLDER);
+    assertThat(rule).isInstanceOf(PasswordPolicyDigitRuleImpl.class);
   }
 
   @Test
@@ -138,8 +135,8 @@ public class DefaultPasswordPolicyTest {
     checkThatPasswordWasInvalid(result);
 
     PasswordPolicyRule rule = result.getViolatedRules().get(0);
-    assertThat(rule.getPlaceholder(), is(PasswordPolicyLengthRuleImpl.PLACEHOLDER));
-    assertThat(rule, instanceOf(PasswordPolicyLengthRuleImpl.class));
+    assertThat(rule.getPlaceholder()).isEqualTo(PasswordPolicyLengthRuleImpl.PLACEHOLDER);
+    assertThat(rule).isInstanceOf(PasswordPolicyLengthRuleImpl.class);
   }
 
   @Test
@@ -170,7 +167,7 @@ public class DefaultPasswordPolicyTest {
     PasswordPolicy passwordPolicy = identityService.getPasswordPolicy();
 
     // when
-    assertThat(passwordPolicy, notNullValue());
+    assertThat(passwordPolicy).isNotNull();
   }
 
   @Test
@@ -194,10 +191,10 @@ public class DefaultPasswordPolicyTest {
 
     // then
     user = identityService.createUserQuery().userId("johndoe").singleResult();
-    assertThat(user.getFirstName(), is("Jane"));
-    assertThat(user.getLastName(), is("Donnel"));
-    assertThat(user.getEmail(), is("jane@donnel.com"));
-    assertThat(identityService.checkPassword("johndoe", "Passw0rds!"), is(true));
+    assertThat(user.getFirstName()).isEqualTo("Jane");
+    assertThat(user.getLastName()).isEqualTo("Donnel");
+    assertThat(user.getEmail()).isEqualTo("jane@donnel.com");
+    assertThat(identityService.checkPassword("johndoe", "Passw0rds!")).isEqualTo(true);
 
     identityService.deleteUser(user.getId());
   }
@@ -262,8 +259,8 @@ public class DefaultPasswordPolicyTest {
   }
 
   private void checkThatPasswordWasInvalid(PasswordPolicyResult result) {
-    assertThat(result.getViolatedRules().size(), is(1));
-    assertThat(result.getFulfilledRules().size(), is(5));
-    assertThat(result.isValid(), is(false));
+    assertThat(result.getViolatedRules().size()).isEqualTo(1);
+    assertThat(result.getFulfilledRules().size()).isEqualTo(5);
+    assertThat(result.isValid()).isEqualTo(false);
   }
 }

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -127,6 +127,12 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-library</artifactId>
+        <version>2.2</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${version.assertj}</version>
@@ -201,12 +207,6 @@
         <groupId>org.graalvm.js</groupId>
         <artifactId>js-scriptengine</artifactId>
         <version>${version.graal.js}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-library</artifactId>
-        <scope>test</scope>
-        <version>1.3</version>
       </dependency>
       <dependency>
         <groupId>org.xmlunit</groupId>

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/FeelEngineIT.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/FeelEngineIT.java
@@ -30,8 +30,7 @@ import org.junit.runner.RunWith;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Arquillian.class)
 public class FeelEngineIT extends AbstractFoxPlatformIntegrationTest {
@@ -72,8 +71,8 @@ public class FeelEngineIT extends AbstractFoxPlatformIntegrationTest {
         .includeOutputs()
         .singleResult();
 
-    assertThat(hdi.getOutputs().size(), is(1));
-    assertThat(hdi.getOutputs().get(0).getValue(), is(true));
+    assertThat(hdi.getOutputs().size()).isEqualTo(1);
+    assertThat(hdi.getOutputs().get(0).getValue()).isEqualTo(true);
   }
 
   @Test
@@ -90,8 +89,8 @@ public class FeelEngineIT extends AbstractFoxPlatformIntegrationTest {
         .includeOutputs()
         .singleResult();
 
-    assertThat(hdi.getOutputs().size(), is(1));
-    assertThat(hdi.getOutputs().get(0).getValue(), is(true));
+    assertThat(hdi.getOutputs().size()).isEqualTo(1);
+    assertThat(hdi.getOutputs().get(0).getValue()).isEqualTo(true);
   }
 
   // HELPER

--- a/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/optimize/OptimizeApiPageSizeTest.java
+++ b/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/optimize/OptimizeApiPageSizeTest.java
@@ -29,8 +29,7 @@ import org.junit.runner.RunWith;
 import java.util.List;
 import java.util.function.Function;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(JUnitParamsRunner.class)
 public class OptimizeApiPageSizeTest {
@@ -58,7 +57,7 @@ public class OptimizeApiPageSizeTest {
     final List<?> pageOfEntries = scenario.getOptimizeServiceFunction().apply(OPTIMIZE_PAGE_SIZE);
 
     // then
-    assertThat(pageOfEntries.size(), is(OPTIMIZE_PAGE_SIZE));
+    assertThat(pageOfEntries.size()).isEqualTo(OPTIMIZE_PAGE_SIZE);
   }
 
   private Object[] optimizeServiceFunctions() {

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/filter/headersec/ContentTypeOptionsTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/filter/headersec/ContentTypeOptionsTest.java
@@ -20,7 +20,7 @@ import org.operaton.bpm.webapp.impl.util.HeaderRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public class ContentTypeOptionsTest {

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/filter/headersec/ContentTypeOptionsTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/filter/headersec/ContentTypeOptionsTest.java
@@ -16,12 +16,11 @@
  */
 package org.operaton.bpm.webapp.impl.security.filter.headersec;
 
-import org.operaton.bpm.webapp.impl.util.HeaderRule;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.Rule;
 import org.junit.Test;
-
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import org.operaton.bpm.webapp.impl.util.HeaderRule;
 
 public class ContentTypeOptionsTest {
 
@@ -40,7 +39,7 @@ public class ContentTypeOptionsTest {
     headerRule.performRequest();
 
     // then
-    assertThat(headerRule.getHeader(HEADER_NAME), is(HEADER_DEFAULT_VALUE));
+    assertThat(headerRule.getHeader(HEADER_NAME)).isEqualTo(HEADER_DEFAULT_VALUE);
   }
 
   @Test
@@ -52,7 +51,7 @@ public class ContentTypeOptionsTest {
     headerRule.performRequest();
 
     // then
-    assertThat(headerRule.headerExists(HEADER_NAME), is(false));
+    assertThat(headerRule.headerExists(HEADER_NAME)).isFalse();
   }
 
   @Test
@@ -64,7 +63,7 @@ public class ContentTypeOptionsTest {
     headerRule.performRequest();
 
     // then
-    assertThat(headerRule.headerExists(HEADER_NAME), is(false));
+    assertThat(headerRule.headerExists(HEADER_NAME)).isFalse();
   }
 
   @Test
@@ -76,7 +75,7 @@ public class ContentTypeOptionsTest {
     headerRule.performRequest();
 
     // then
-    assertThat(headerRule.getHeader(HEADER_NAME), is("aCustomValue"));
+    assertThat(headerRule.getHeader(HEADER_NAME)).isEqualTo("aCustomValue");
   }
 
 }

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/filter/headersec/XssProtectionTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/filter/headersec/XssProtectionTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 import static org.operaton.bpm.webapp.impl.security.filter.headersec.provider.impl.XssProtectionOption.BLOCK;
 import static org.operaton.bpm.webapp.impl.security.filter.headersec.provider.impl.XssProtectionOption.SANITIZE;
 import static org.operaton.bpm.webapp.impl.security.filter.headersec.provider.impl.XssProtectionProvider.HEADER_NAME;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 /**

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/filter/headersec/XssProtectionTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/filter/headersec/XssProtectionTest.java
@@ -16,17 +16,15 @@
  */
 package org.operaton.bpm.webapp.impl.security.filter.headersec;
 
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.webapp.impl.util.HeaderRule;
-import org.junit.Rule;
-import org.junit.Test;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.webapp.impl.security.filter.headersec.provider.impl.XssProtectionOption.BLOCK;
 import static org.operaton.bpm.webapp.impl.security.filter.headersec.provider.impl.XssProtectionOption.SANITIZE;
 import static org.operaton.bpm.webapp.impl.security.filter.headersec.provider.impl.XssProtectionProvider.HEADER_NAME;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.operaton.bpm.engine.ProcessEngineException;
+import org.operaton.bpm.webapp.impl.util.HeaderRule;
 
 /**
  * @author Tassilo Weidner
@@ -45,7 +43,7 @@ public class XssProtectionTest {
     headerRule.performRequest();
 
     // then
-    assertThat(headerRule.getHeader(HEADER_NAME), is(BLOCK.getHeaderValue()));
+    assertThat(headerRule.getHeader(HEADER_NAME)).isEqualTo(BLOCK.getHeaderValue());
   }
 
   @Test
@@ -57,7 +55,7 @@ public class XssProtectionTest {
     headerRule.performRequest();
 
     // then
-    assertThat(headerRule.headerExists(HEADER_NAME), is(false));
+    assertThat(headerRule.headerExists(HEADER_NAME)).isEqualTo(false);
   }
 
   @Test
@@ -69,7 +67,7 @@ public class XssProtectionTest {
     headerRule.performRequest();
 
     // then
-    assertThat(headerRule.headerExists(HEADER_NAME), is(false));
+    assertThat(headerRule.headerExists(HEADER_NAME)).isEqualTo(false);
   }
 
   @Test
@@ -81,7 +79,7 @@ public class XssProtectionTest {
     headerRule.performRequest();
 
     // then
-    assertThat(headerRule.getHeader(HEADER_NAME), is("aCustomValue"));
+    assertThat(headerRule.getHeader(HEADER_NAME)).isEqualTo("aCustomValue");
   }
 
   @Test
@@ -93,7 +91,7 @@ public class XssProtectionTest {
     headerRule.performRequest();
 
     // then
-    assertThat(headerRule.getHeader(HEADER_NAME), is(SANITIZE.getHeaderValue()));
+    assertThat(headerRule.getHeader(HEADER_NAME)).isEqualTo(SANITIZE.getHeaderValue());
   }
 
   @Test
@@ -105,7 +103,7 @@ public class XssProtectionTest {
     headerRule.performRequest();
 
     // then
-    assertThat(headerRule.getHeader(HEADER_NAME), is(SANITIZE.getHeaderValue()));
+    assertThat(headerRule.getHeader(HEADER_NAME)).isEqualTo(SANITIZE.getHeaderValue());
   }
 
   @Test
@@ -117,7 +115,7 @@ public class XssProtectionTest {
     headerRule.performRequest();
 
     // then
-    assertThat(headerRule.getHeader(HEADER_NAME), is(BLOCK.getHeaderValue()));
+    assertThat(headerRule.getHeader(HEADER_NAME)).isEqualTo(BLOCK.getHeaderValue());
   }
 
   @Test
@@ -131,8 +129,8 @@ public class XssProtectionTest {
     Throwable expectedException = headerRule.getException();
 
     // then
-    assertThat(expectedException, instanceOf(ProcessEngineException.class));
-    assertThat(expectedException.getMessage(), is("XssProtectionProvider: cannot set both xssProtectionValue and xssProtectionOption."));
+    assertThat(expectedException).isInstanceOf(ProcessEngineException.class);
+    assertThat(expectedException.getMessage()).isEqualTo("XssProtectionProvider: cannot set both xssProtectionValue and xssProtectionOption.");
   }
 
   @Test
@@ -143,8 +141,8 @@ public class XssProtectionTest {
     Throwable expectedException = headerRule.getException();
 
     // then
-    assertThat(expectedException, instanceOf(ProcessEngineException.class));
-    assertThat(expectedException.getMessage(), is("XssProtectionProvider: cannot set non-existing option foo for xssProtectionOption."));
+    assertThat(expectedException).isInstanceOf(ProcessEngineException.class);
+    assertThat(expectedException.getMessage()).isEqualTo("XssProtectionProvider: cannot set non-existing option foo for xssProtectionOption.");
   }
 
 }


### PR DESCRIPTION
This change reduces most usages of Hamcrest and replaces it by AssertJ. The goal is to use AssertJ all over the test base.

The initial transition was done with Open Rewrite. Changes to each module have been done with separate commits. 

After that Hamcrest 1.3 was replaced by 2.2 and manual changes have been done on code that came directly along by the dependency change.

Finally code has been polished.

This is an intermediate step and as preparation of further JUnit 5 migrations, as the Open Rewrite migration recipes would do similar. By this the change later will be smaller.

Related to #27 