### PR TITLE
chore(tests): Remove unnecessary public modifiers from tests

### DIFF
--- a/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/api/variable/PrimitiveValueTest.java
+++ b/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/api/variable/PrimitiveValueTest.java
@@ -64,7 +64,7 @@ public class PrimitiveValueTest {
 
   @MethodSource("data")
   @ParameterizedTest(name = "{index}: {0} = {1}")
-  public void createPrimitiveVariableUntyped(ValueType initValueType, Object initValue, TypedValue initTypedValue, TypedValue initNullValue) {
+  void createPrimitiveVariableUntyped(ValueType initValueType, Object initValue, TypedValue initTypedValue, TypedValue initNullValue) {
     initPrimitiveValueTest(initValueType, initValue, initTypedValue, initNullValue);
     VariableMap variables = createVariables().putValue(variableName, initValue);
 
@@ -83,7 +83,7 @@ public class PrimitiveValueTest {
 
   @MethodSource("data")
   @ParameterizedTest(name = "{index}: {0} = {1}")
-  public void createPrimitiveVariableTyped(ValueType valueType, Object value, TypedValue typedValue, TypedValue nullValue) {
+  void createPrimitiveVariableTyped(ValueType valueType, Object value, TypedValue typedValue, TypedValue nullValue) {
     initPrimitiveValueTest(valueType, value, typedValue, nullValue);
     VariableMap variables = createVariables().putValue(variableName, typedValue);
 
@@ -100,7 +100,7 @@ public class PrimitiveValueTest {
 
   @MethodSource("data")
   @ParameterizedTest(name = "{index}: {0} = {1}")
-  public void createPrimitiveVariableNull(ValueType valueType, Object value, TypedValue typedValue, TypedValue nullValue) {
+  void createPrimitiveVariableNull(ValueType valueType, Object value, TypedValue typedValue, TypedValue nullValue) {
     initPrimitiveValueTest(valueType, value, typedValue, nullValue);
     VariableMap variables = createVariables().putValue(variableName, nullValue);
 

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpRequestTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpRequestTest.java
@@ -192,7 +192,7 @@ public class HttpRequestTest {
   }
 
   @Test
-  public void setRequestConfig() {
+  void setRequestConfig() {
     HttpRequest request = connector.createRequest()
         .configOption("throw-http-error", "TRUE")
         .configOption("connection-timeout", "10000")
@@ -209,7 +209,7 @@ public class HttpRequestTest {
   }
 
   @Test
-  public void shouldIgnoreRequestConfigWithNullOrEmptyNameOrValue() {
+  void shouldIgnoreRequestConfigWithNullOrEmptyNameOrValue() {
     HttpRequest request = connector.createRequest().configOption(null, "test");
     assertThat(request.getConfigOptions()).isNull();
 

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpResponseTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpResponseTest.java
@@ -91,7 +91,7 @@ class HttpResponseTest {
   }
 
   @Test
-  public void testSuccessfulResponseCode() {
+  void testSuccessfulResponseCode() {
     // given
     testResponse.statusCode(200);
     // when
@@ -101,7 +101,7 @@ class HttpResponseTest {
   }
 
   @Test
-  public void testResponseErrorCodeForMalformedRequest() {
+  void testResponseErrorCodeForMalformedRequest() {
     // given
     testResponse.statusCode(400);
     // when
@@ -111,7 +111,7 @@ class HttpResponseTest {
   }
 
   @Test
-  public void testResponseErrorCodeForServerError() {
+  void testResponseErrorCodeForServerError() {
     // given
     testResponse.statusCode(500);
     // when
@@ -121,7 +121,7 @@ class HttpResponseTest {
   }
 
   @Test
-  public void testServerErrorResponseWithConfigOptionSet() {
+  void testServerErrorResponseWithConfigOptionSet() {
     // given
     testResponse.statusCode(500);
     try {
@@ -135,7 +135,7 @@ class HttpResponseTest {
   }
 
   @Test
-  public void testMalformedRequestWithConfigOptionSet() {
+  void testMalformedRequestWithConfigOptionSet() {
     // given
     testResponse.statusCode(400);
     try {
@@ -149,7 +149,7 @@ class HttpResponseTest {
   }
 
   @Test
-  public void testSuccessResponseWithConfigOptionSet() {
+  void testSuccessResponseWithConfigOptionSet() {
     // given
     testResponse.statusCode(200);
     // when
@@ -160,7 +160,7 @@ class HttpResponseTest {
   }
 
   @Test
-  public void testMalformedRequestWithConfigOptionSetToFalse() {
+  void testMalformedRequestWithConfigOptionSetToFalse() {
     // given
     testResponse.statusCode(400);
     // when

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnDiTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnDiTest.java
@@ -34,7 +34,7 @@ import static org.operaton.bpm.model.bpmn.BpmnTestConstants.*;
 /**
  * @author Sebastian Menski
  */
-public class BpmnDiTest {
+class BpmnDiTest {
 
   private BpmnModelInstance modelInstance;
   private Collaboration collaboration;
@@ -50,7 +50,7 @@ public class BpmnDiTest {
   private EndEvent endEvent;
 
   @BeforeEach
-  public void parseModel() {
+  void parseModel() {
     modelInstance = Bpmn.readModelFromStream(getClass().getResourceAsStream(getClass().getSimpleName() + ".xml"));
     collaboration = modelInstance.getModelElementById(COLLABORATION_ID);
     participant = modelInstance.getModelElementById(PARTICIPANT_ID + 1);
@@ -66,7 +66,7 @@ public class BpmnDiTest {
   }
 
   @Test
-  public void testBpmnDiagram() {
+  void testBpmnDiagram() {
     Collection<BpmnDiagram> diagrams = modelInstance.getModelElementsByType(BpmnDiagram.class);
     assertThat(diagrams).hasSize(1);
     BpmnDiagram diagram = diagrams.iterator().next();
@@ -76,7 +76,7 @@ public class BpmnDiTest {
   }
 
   @Test
-  public void testBpmnPane() {
+  void testBpmnPane() {
     DiagramElement diagramElement = collaboration.getDiagramElement();
     assertThat(diagramElement)
       .isNotNull()
@@ -87,7 +87,7 @@ public class BpmnDiTest {
   }
 
   @Test
-  public void testBpmnLabelStyle() {
+  void testBpmnLabelStyle() {
     BpmnLabelStyle labelStyle = modelInstance.getModelElementsByType(BpmnLabelStyle.class).iterator().next();
     Font font = labelStyle.getFont();
     assertThat(font).isNotNull();
@@ -100,7 +100,7 @@ public class BpmnDiTest {
   }
 
   @Test
-  public void testBpmnShape() {
+  void testBpmnShape() {
     BpmnShape shape = serviceTask.getDiagramElement();
     assertThat(shape.getBpmnElement()).isEqualTo(serviceTask);
     assertThat(shape.getBpmnLabel()).isNull();
@@ -113,7 +113,7 @@ public class BpmnDiTest {
   }
 
   @Test
-  public void testBpmnLabel() {
+  void testBpmnLabel() {
     BpmnShape shape = startEvent.getDiagramElement();
     assertThat(shape.getBpmnElement()).isEqualTo(startEvent);
     assertThat(shape.getBpmnLabel()).isNotNull();
@@ -124,7 +124,7 @@ public class BpmnDiTest {
   }
 
   @Test
-  public void testBpmnEdge() {
+  void testBpmnEdge() {
     BpmnEdge edge = sequenceFlow.getDiagramElement();
     assertThat(edge.getBpmnElement()).isEqualTo(sequenceFlow);
     assertThat(edge.getBpmnLabel()).isNull();
@@ -136,7 +136,7 @@ public class BpmnDiTest {
   }
 
   @Test
-  public void testDiagramElementTypes() {
+  void testDiagramElementTypes() {
     assertThat(collaboration.getDiagramElement()).isInstanceOf(BpmnPlane.class);
     assertThat(process.getDiagramElement()).isNull();
     assertThat(participant.getDiagramElement()).isInstanceOf(BpmnShape.class);
@@ -152,7 +152,7 @@ public class BpmnDiTest {
   }
 
   @Test
-  public void shouldNotRemoveBpmElementReference() {
+  void shouldNotRemoveBpmElementReference() {
     assertThat(startEvent.getOutgoing()).contains(sequenceFlow);
     assertThat(endEvent.getIncoming()).contains(sequenceFlow);
 
@@ -169,7 +169,7 @@ public class BpmnDiTest {
   }
 
   @Test
-  public void shouldCreateValidBpmnDi() {
+  void shouldCreateValidBpmnDi() {
     modelInstance = Bpmn
       .createProcess("process")
       .startEvent("start")
@@ -245,7 +245,7 @@ public class BpmnDiTest {
   }
 
   @AfterEach
-  public void validateModel() {
+  void validateModel() {
     Bpmn.validateModel(modelInstance);
   }
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnModelInstanceTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnModelInstanceTest.java
@@ -24,10 +24,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Filip Hrisafov
  */
-public class BpmnModelInstanceTest {
+class BpmnModelInstanceTest {
 
   @Test
-  public void testClone() throws Exception {
+  void testClone() throws Exception {
 
     BpmnModelInstance modelInstance = Bpmn.createEmptyModel();
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnModelTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnModelTest.java
@@ -32,7 +32,7 @@ public class BpmnModelTest {
   protected BpmnModelInstance bpmnModelInstance;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     bpmnModelInstance = parseBpmnModelRule.getBpmnModel();
   }
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnTest.java
@@ -23,10 +23,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Sebastian Menski
  */
-public class BpmnTest {
+class BpmnTest {
 
   @Test
-  public void testBpmn() {
+  void testBpmn() {
     assertThat(Bpmn.INSTANCE).isNotNull();
   }
 }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/CollaborationParserTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/CollaborationParserTest.java
@@ -27,19 +27,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Sebastian Menski
  */
-public class CollaborationParserTest {
+class CollaborationParserTest {
 
   private static BpmnModelInstance modelInstance;
   private static Collaboration collaboration;
 
   @BeforeAll
-  public static void parseModel() {
+  static void parseModel() {
     modelInstance = Bpmn.readModelFromStream(CollaborationParserTest.class.getResourceAsStream("CollaborationParserTest.bpmn"));
     collaboration = modelInstance.getModelElementById("collaboration1");
   }
 
   @Test
-  public void testConversations() {
+  void testConversations() {
     assertThat(collaboration.getConversationNodes()).hasSize(1);
 
     ConversationNode conversationNode = collaboration.getConversationNodes().iterator().next();
@@ -50,7 +50,7 @@ public class CollaborationParserTest {
   }
 
   @Test
-  public void testConversationLink() {
+  void testConversationLink() {
     Collection<ConversationLink> conversationLinks = collaboration.getConversationLinks();
     for (ConversationLink conversationLink : conversationLinks) {
       assertThat(conversationLink.getId()).startsWith("conversationLink");
@@ -66,7 +66,7 @@ public class CollaborationParserTest {
   }
 
   @Test
-  public void testMessageFlow() {
+  void testMessageFlow() {
     Collection<MessageFlow> messageFlows = collaboration.getMessageFlows();
     for (MessageFlow messageFlow : messageFlows) {
       assertThat(messageFlow.getId()).startsWith("messageFlow");
@@ -76,7 +76,7 @@ public class CollaborationParserTest {
   }
 
   @Test
-  public void testParticipant() {
+  void testParticipant() {
     Collection<Participant> participants = collaboration.getParticipants();
     for (Participant participant : participants) {
       assertThat(participant.getProcess().getId()).startsWith("process");
@@ -84,7 +84,7 @@ public class CollaborationParserTest {
   }
 
   @Test
-  public void testUnused() {
+  void testUnused() {
     assertThat(collaboration.getCorrelationKeys()).isEmpty();
     assertThat(collaboration.getArtifacts()).isEmpty();
     assertThat(collaboration.getConversationAssociations()).isEmpty();
@@ -94,7 +94,7 @@ public class CollaborationParserTest {
 
 
   @AfterAll
-  public static void validateModel() {
+  static void validateModel() {
     Bpmn.validateModel(modelInstance);
   }
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ConditionalSequenceFlowTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ConditionalSequenceFlowTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Sebastian Menski
  */
-public class ConditionalSequenceFlowTest {
+class ConditionalSequenceFlowTest {
 
   protected BpmnModelInstance modelInstance;
   protected SequenceFlow flow1;
@@ -36,7 +36,7 @@ public class ConditionalSequenceFlowTest {
   protected ConditionExpression conditionExpression3;
 
   @BeforeEach
-  public void parseModel() {
+  void parseModel() {
     modelInstance = Bpmn.readModelFromStream(getClass().getResourceAsStream(getClass().getSimpleName() + ".xml"));
     flow1 = modelInstance.getModelElementById("flow1");
     flow2 = modelInstance.getModelElementById("flow2");
@@ -47,28 +47,28 @@ public class ConditionalSequenceFlowTest {
   }
 
   @Test
-  public void shouldHaveTypeTFormalExpression() {
+  void shouldHaveTypeTFormalExpression() {
     assertThat(conditionExpression1.getType()).isEqualTo("tFormalExpression");
     assertThat(conditionExpression2.getType()).isEqualTo("tFormalExpression");
     assertThat(conditionExpression3.getType()).isEqualTo("tFormalExpression");
   }
 
   @Test
-  public void shouldHaveLanguage() {
+  void shouldHaveLanguage() {
     assertThat(conditionExpression1.getLanguage()).isNull();
     assertThat(conditionExpression2.getLanguage()).isNull();
     assertThat(conditionExpression3.getLanguage()).isEqualTo("groovy");
   }
 
   @Test
-  public void shouldHaveSourceCode() {
+  void shouldHaveSourceCode() {
     assertThat(conditionExpression1.getTextContent()).isEqualTo("test");
     assertThat(conditionExpression2.getTextContent()).isEqualTo("${test}");
     assertThat(conditionExpression3.getTextContent()).isEmpty();
   }
 
   @Test
-  public void shouldHaveResource() {
+  void shouldHaveResource() {
     assertThat(conditionExpression1.getOperatonResource()).isNull();
     assertThat(conditionExpression2.getOperatonResource()).isNull();
     assertThat(conditionExpression3.getOperatonResource()).isEqualTo("test.groovy");

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/CreateModelTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/CreateModelTest.java
@@ -31,7 +31,7 @@ public class CreateModelTest {
   public Process process;
 
   @BeforeEach
-  public void createEmptyModel() {
+  void createEmptyModel() {
     modelInstance = Bpmn.createEmptyModel();
     definitions = modelInstance.newInstance(Definitions.class);
     definitions.setTargetNamespace("http://operaton.org/examples");
@@ -56,7 +56,7 @@ public class CreateModelTest {
   }
 
   @Test
-  public void createProcessWithOneTask() {
+  void createProcessWithOneTask() {
     // create process
     Process process = createElement(definitions, "process-with-one-task", Process.class);
 
@@ -71,7 +71,7 @@ public class CreateModelTest {
   }
 
   @Test
-  public void createProcessWithParallelGateway() {
+  void createProcessWithParallelGateway() {
     // create process
     Process process = createElement(definitions, "process-with-parallel-gateway", Process.class);
 
@@ -93,7 +93,7 @@ public class CreateModelTest {
   }
 
   @AfterEach
-  public void validateModel() {
+  void validateModel() {
     Bpmn.validateModel(modelInstance);
   }
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DataObjectsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DataObjectsTest.java
@@ -26,17 +26,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Dario Campagna
  */
-public class DataObjectsTest {
+class DataObjectsTest {
 
   private static BpmnModelInstance modelInstance;
 
   @BeforeAll
-  public static void parseModel() {
+  static void parseModel() {
     modelInstance = Bpmn.readModelFromStream(DataObjectsTest.class.getResourceAsStream("DataObjectTest.bpmn"));
   }
 
   @Test
-  public void testGetDataObject() {
+  void testGetDataObject() {
     DataObject dataObject = modelInstance.getModelElementById("_21");
     ItemDefinition itemDefinition = modelInstance.getModelElementById("_100");
     assertThat(dataObject).isNotNull();
@@ -46,7 +46,7 @@ public class DataObjectsTest {
   }
 
   @Test
-  public void testGetDataObjectReference() {
+  void testGetDataObjectReference() {
     DataObjectReference dataObjectReference = modelInstance.getModelElementById("_dataRef_7");
     DataObject dataObject = modelInstance.getModelElementById("_7");
     assertThat(dataObjectReference).isNotNull();
@@ -55,7 +55,7 @@ public class DataObjectsTest {
   }
 
   @Test
-  public void testDataObjectReferenceAsDataAssociationSource() {
+  void testDataObjectReferenceAsDataAssociationSource() {
     ScriptTask scriptTask = modelInstance.getModelElementById("_3");
     DataObjectReference dataObjectReference = modelInstance.getModelElementById("_dataRef_11");
     DataInputAssociation dataInputAssociation = scriptTask.getDataInputAssociations().iterator().next();
@@ -65,7 +65,7 @@ public class DataObjectsTest {
   }
 
   @Test
-  public void testDataObjectReferenceAsDataAssociationTarget() {
+  void testDataObjectReferenceAsDataAssociationTarget() {
     ScriptTask scriptTask = modelInstance.getModelElementById("_3");
     DataObjectReference dataObjectReference = modelInstance.getModelElementById("_dataRef_7");
     DataOutputAssociation dataOutputAssociation = scriptTask.getDataOutputAssociations().iterator().next();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DataStoreTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DataStoreTest.java
@@ -25,17 +25,17 @@ import org.operaton.bpm.model.bpmn.instance.DataStoreReference;
 /**
  * @author Falko Menge
  */
-public class DataStoreTest {
+class DataStoreTest {
 
   private static BpmnModelInstance modelInstance;
 
   @BeforeAll
-  public static void parseModel() {
+  static void parseModel() {
     modelInstance = Bpmn.readModelFromStream(DataStoreTest.class.getResourceAsStream("DataStoreTest.bpmn"));
   }
 
   @Test
-  public void testGetDataStore() {
+  void testGetDataStore() {
     DataStore dataStore = modelInstance.getModelElementById("myDataStore");
     assertThat(dataStore).isNotNull();
     assertThat(dataStore.getName()).isEqualTo("My Data Store");
@@ -44,7 +44,7 @@ public class DataStoreTest {
   }
 
   @Test
-  public void testGetDataStoreReference() {
+  void testGetDataStoreReference() {
     DataStoreReference dataStoreReference = modelInstance.getModelElementById("myDataStoreReference");
     DataStore dataStore = modelInstance.getModelElementById("myDataStore");
     assertThat(dataStoreReference).isNotNull();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DefinitionsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DefinitionsTest.java
@@ -38,11 +38,11 @@ import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.XPATH_NS;
  * @author Daniel Meyer
  *
  */
-public class DefinitionsTest extends BpmnModelTest {
+class DefinitionsTest extends BpmnModelTest {
 
   @Test
   @BpmnModelResource
-  public void shouldImportEmptyDefinitions() {
+  void shouldImportEmptyDefinitions() {
 
     Definitions definitions = bpmnModelInstance.getDefinitions();
     assertThat(definitions).isNotNull();
@@ -65,13 +65,13 @@ public class DefinitionsTest extends BpmnModelTest {
   }
 
   @Test
-  public void shouldNotImportWrongOrderedSequence() {
+  void shouldNotImportWrongOrderedSequence() {
     assertThatThrownBy(() -> Bpmn.readModelFromStream(getClass().getResourceAsStream("DefinitionsTest.shouldNotImportWrongOrderedSequence.bpmn")))
             .isInstanceOf(ModelParseException.class);
   }
 
   @Test
-  public void shouldAddChildElementsInCorrectOrder() {
+  void shouldAddChildElementsInCorrectOrder() {
     // create an empty model
     BpmnModelInstance bpmnModelInstance = Bpmn.createEmptyModel();
 
@@ -110,7 +110,7 @@ public class DefinitionsTest extends BpmnModelTest {
 
   @Test
   @BpmnModelResource
-  public void shouldNotAffectComments() throws IOException {
+  void shouldNotAffectComments() throws IOException {
     Definitions definitions = bpmnModelInstance.getDefinitions();
     assertThat(definitions).isNotNull();
 
@@ -147,7 +147,7 @@ public class DefinitionsTest extends BpmnModelTest {
   }
 
   @Test
-  public void shouldAddMessageAndMessageEventDefinition() {
+  void shouldAddMessageAndMessageEventDefinition() {
     // create empty model
     BpmnModelInstance bpmnModelInstance = Bpmn.createEmptyModel();
 
@@ -211,7 +211,7 @@ public class DefinitionsTest extends BpmnModelTest {
   }
 
   @Test
-  public void shouldAddParentChildElementInCorrectOrder() {
+  void shouldAddParentChildElementInCorrectOrder() {
     // create empty model
     BpmnModelInstance bpmnModelInstance = Bpmn.createEmptyModel();
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/GenerateIdTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/GenerateIdTest.java
@@ -24,10 +24,10 @@ import org.operaton.bpm.model.bpmn.instance.Process;
 import org.operaton.bpm.model.bpmn.instance.StartEvent;
 import org.operaton.bpm.model.bpmn.instance.UserTask;
 
-public class GenerateIdTest {
+class GenerateIdTest {
 
   @Test
-  public void shouldNotGenerateIdsOnRead() {
+  void shouldNotGenerateIdsOnRead() {
     BpmnModelInstance modelInstance = Bpmn.readModelFromStream(GenerateIdTest.class.getResourceAsStream("GenerateIdTest.bpmn"));
     Definitions definitions = modelInstance.getDefinitions();
     assertThat(definitions.getId()).isNull();
@@ -43,7 +43,7 @@ public class GenerateIdTest {
   }
 
   @Test
-  public void shouldGenerateIdsOnCreate() {
+  void shouldGenerateIdsOnCreate() {
     BpmnModelInstance modelInstance = Bpmn.createEmptyModel();
     Definitions definitions = modelInstance.newInstance(Definitions.class);
     assertThat(definitions.getId()).isNotNull();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ModelTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ModelTest.java
@@ -28,10 +28,10 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ModelTest {
+class ModelTest {
 
   @Test
-  public void testCreateEmptyModel() {
+  void testCreateEmptyModel() {
     BpmnModelInstance bpmnModelInstance = Bpmn.createEmptyModel();
 
     Definitions definitions = bpmnModelInstance.getDefinitions();
@@ -45,7 +45,7 @@ public class ModelTest {
   }
 
   @Test
-  public void testBaseTypeCalculation() {
+  void testBaseTypeCalculation() {
     BpmnModelInstance bpmnModelInstance = Bpmn.createEmptyModel();
     Model model = bpmnModelInstance.getModel();
     Collection<ModelElementType> allBaseTypes = ModelUtil.calculateAllBaseTypes(model.getType(StartEvent.class));
@@ -59,7 +59,7 @@ public class ModelTest {
   }
 
   @Test
-  public void testExtendingTypeCalculation() {
+  void testExtendingTypeCalculation() {
     BpmnModelInstance bpmnModelInstance = Bpmn.createEmptyModel();
     Model model = bpmnModelInstance.getModel();
     List<ModelElementType> baseInstanceTypes = new ArrayList<ModelElementType>();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
@@ -171,7 +171,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testAssignee(String namespace, BpmnModelInstance modelInstance) {
+  void testAssignee(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonAssignee()).isEqualTo(TEST_STRING_XML);
     userTask.setOperatonAssignee(TEST_STRING_API);
@@ -180,7 +180,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testAsync(String namespace, BpmnModelInstance modelInstance) {
+  void testAsync(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.isOperatonAsync()).isFalse();
     assertThat(userTask.isOperatonAsync()).isTrue();
@@ -197,7 +197,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testAsyncBefore(String namespace, BpmnModelInstance modelInstance) {
+  void testAsyncBefore(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.isOperatonAsyncBefore()).isTrue();
     assertThat(endEvent.isOperatonAsyncBefore()).isTrue();
@@ -217,7 +217,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testAsyncAfter(String namespace, BpmnModelInstance modelInstance) {
+  void testAsyncAfter(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.isOperatonAsyncAfter()).isTrue();
     assertThat(endEvent.isOperatonAsyncAfter()).isTrue();
@@ -237,7 +237,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testFlowNodeJobPriority(String namespace, BpmnModelInstance modelInstance) {
+  void testFlowNodeJobPriority(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.getOperatonJobPriority()).isEqualTo(TEST_FLOW_NODE_JOB_PRIORITY);
     assertThat(endEvent.getOperatonJobPriority()).isEqualTo(TEST_FLOW_NODE_JOB_PRIORITY);
@@ -247,49 +247,49 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testProcessJobPriority(String namespace, BpmnModelInstance modelInstance) {
+  void testProcessJobPriority(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(process.getOperatonJobPriority()).isEqualTo(TEST_PROCESS_JOB_PRIORITY);
   }
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testProcessTaskPriority(String namespace, BpmnModelInstance modelInstance) {
+  void testProcessTaskPriority(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(process.getOperatonTaskPriority()).isEqualTo(TEST_PROCESS_TASK_PRIORITY);
   }
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testHistoryTimeToLive(String namespace, BpmnModelInstance modelInstance) {
+  void testHistoryTimeToLive(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(process.getOperatonHistoryTimeToLive()).isEqualTo(TEST_HISTORY_TIME_TO_LIVE);
   }
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testIsStartableInTasklist(String namespace, BpmnModelInstance modelInstance) {
+  void testIsStartableInTasklist(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(process.isOperatonStartableInTasklist()).isEqualTo(false);
   }
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testVersionTag(String namespace, BpmnModelInstance modelInstance) {
+  void testVersionTag(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(process.getOperatonVersionTag()).isEqualTo("v1.0.0");
   }
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testServiceTaskPriority(String namespace, BpmnModelInstance modelInstance) {
+  void testServiceTaskPriority(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(serviceTask.getOperatonTaskPriority()).isEqualTo(TEST_SERVICE_TASK_PRIORITY);
   }
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testCalledElementBinding(String namespace, BpmnModelInstance modelInstance) {
+  void testCalledElementBinding(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCalledElementBinding()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCalledElementBinding(TEST_STRING_API);
@@ -298,7 +298,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testCalledElementVersion(String namespace, BpmnModelInstance modelInstance) {
+  void testCalledElementVersion(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCalledElementVersion()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCalledElementVersion(TEST_STRING_API);
@@ -307,7 +307,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testCalledElementVersionTag(String namespace, BpmnModelInstance modelInstance) {
+  void testCalledElementVersionTag(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCalledElementVersionTag()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCalledElementVersionTag(TEST_STRING_API);
@@ -316,7 +316,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testCalledElementTenantId(String namespace, BpmnModelInstance modelInstance) {
+  void testCalledElementTenantId(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCalledElementTenantId()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCalledElementTenantId(TEST_STRING_API);
@@ -325,7 +325,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testCaseRef(String namespace, BpmnModelInstance modelInstance) {
+  void testCaseRef(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCaseRef()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCaseRef(TEST_STRING_API);
@@ -334,7 +334,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testCaseBinding(String namespace, BpmnModelInstance modelInstance) {
+  void testCaseBinding(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCaseBinding()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCaseBinding(TEST_STRING_API);
@@ -343,7 +343,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testCaseVersion(String namespace, BpmnModelInstance modelInstance) {
+  void testCaseVersion(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCaseVersion()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCaseVersion(TEST_STRING_API);
@@ -352,7 +352,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testCaseTenantId(String namespace, BpmnModelInstance modelInstance) {
+  void testCaseTenantId(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonCaseTenantId()).isEqualTo(TEST_STRING_XML);
     callActivity.setOperatonCaseTenantId(TEST_STRING_API);
@@ -361,7 +361,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testDecisionRef(String namespace, BpmnModelInstance modelInstance) {
+  void testDecisionRef(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(businessRuleTask.getOperatonDecisionRef()).isEqualTo(TEST_STRING_XML);
     businessRuleTask.setOperatonDecisionRef(TEST_STRING_API);
@@ -370,7 +370,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testDecisionRefBinding(String namespace, BpmnModelInstance modelInstance) {
+  void testDecisionRefBinding(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(businessRuleTask.getOperatonDecisionRefBinding()).isEqualTo(TEST_STRING_XML);
     businessRuleTask.setOperatonDecisionRefBinding(TEST_STRING_API);
@@ -379,7 +379,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testDecisionRefVersion(String namespace, BpmnModelInstance modelInstance) {
+  void testDecisionRefVersion(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(businessRuleTask.getOperatonDecisionRefVersion()).isEqualTo(TEST_STRING_XML);
     businessRuleTask.setOperatonDecisionRefVersion(TEST_STRING_API);
@@ -388,7 +388,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testDecisionRefVersionTag(String namespace, BpmnModelInstance modelInstance) {
+  void testDecisionRefVersionTag(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(businessRuleTask.getOperatonDecisionRefVersionTag()).isEqualTo(TEST_STRING_XML);
     businessRuleTask.setOperatonDecisionRefVersionTag(TEST_STRING_API);
@@ -397,7 +397,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testDecisionRefTenantId(String namespace, BpmnModelInstance modelInstance) {
+  void testDecisionRefTenantId(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(businessRuleTask.getOperatonDecisionRefTenantId()).isEqualTo(TEST_STRING_XML);
     businessRuleTask.setOperatonDecisionRefTenantId(TEST_STRING_API);
@@ -406,7 +406,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testMapDecisionResult(String namespace, BpmnModelInstance modelInstance) {
+  void testMapDecisionResult(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(businessRuleTask.getOperatonMapDecisionResult()).isEqualTo(TEST_STRING_XML);
     businessRuleTask.setOperatonMapDecisionResult(TEST_STRING_API);
@@ -416,7 +416,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testTaskPriority(String namespace, BpmnModelInstance modelInstance) {
+  void testTaskPriority(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(businessRuleTask.getOperatonTaskPriority()).isEqualTo(TEST_STRING_XML);
     businessRuleTask.setOperatonTaskPriority(TEST_SERVICE_TASK_PRIORITY);
@@ -425,7 +425,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testCandidateGroups(String namespace, BpmnModelInstance modelInstance) {
+  void testCandidateGroups(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonCandidateGroups()).isEqualTo(TEST_GROUPS_XML);
     assertThat(userTask.getOperatonCandidateGroupsList()).containsAll(TEST_GROUPS_LIST_XML);
@@ -439,7 +439,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testCandidateStarterGroups(String namespace, BpmnModelInstance modelInstance) {
+  void testCandidateStarterGroups(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(process.getOperatonCandidateStarterGroups()).isEqualTo(TEST_GROUPS_XML);
     assertThat(process.getOperatonCandidateStarterGroupsList()).containsAll(TEST_GROUPS_LIST_XML);
@@ -453,7 +453,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testCandidateStarterUsers(String namespace, BpmnModelInstance modelInstance) {
+  void testCandidateStarterUsers(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(process.getOperatonCandidateStarterUsers()).isEqualTo(TEST_USERS_XML);
     assertThat(process.getOperatonCandidateStarterUsersList()).containsAll(TEST_USERS_LIST_XML);
@@ -467,7 +467,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testCandidateUsers(String namespace, BpmnModelInstance modelInstance) {
+  void testCandidateUsers(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonCandidateUsers()).isEqualTo(TEST_USERS_XML);
     assertThat(userTask.getOperatonCandidateUsersList()).containsAll(TEST_USERS_LIST_XML);
@@ -481,7 +481,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testClass(String namespace, BpmnModelInstance modelInstance) {
+  void testClass(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(serviceTask.getOperatonClass()).isEqualTo(TEST_CLASS_XML);
     assertThat(messageEventDefinition.getOperatonClass()).isEqualTo(TEST_CLASS_XML);
@@ -495,7 +495,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testDelegateExpression(String namespace, BpmnModelInstance modelInstance) {
+  void testDelegateExpression(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(serviceTask.getOperatonDelegateExpression()).isEqualTo(TEST_DELEGATE_EXPRESSION_XML);
     assertThat(messageEventDefinition.getOperatonDelegateExpression()).isEqualTo(TEST_DELEGATE_EXPRESSION_XML);
@@ -509,7 +509,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testDueDate(String namespace, BpmnModelInstance modelInstance) {
+  void testDueDate(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonDueDate()).isEqualTo(TEST_DUE_DATE_XML);
     userTask.setOperatonDueDate(TEST_DUE_DATE_API);
@@ -518,7 +518,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testErrorCodeVariable(String namespace, BpmnModelInstance modelInstance) {
+  void testErrorCodeVariable(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     ErrorEventDefinition errorEventDefinition = startEvent.getChildElementsByType(ErrorEventDefinition.class).iterator().next();
     assertThat(errorEventDefinition.getAttributeValueNs(namespace, CAMUNDA_ATTRIBUTE_ERROR_CODE_VARIABLE)).isEqualTo("errorVariable");
@@ -526,7 +526,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testErrorMessageVariable(String namespace, BpmnModelInstance modelInstance) {
+  void testErrorMessageVariable(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     ErrorEventDefinition errorEventDefinition = startEvent.getChildElementsByType(ErrorEventDefinition.class).iterator().next();
     assertThat(errorEventDefinition.getAttributeValueNs(namespace, CAMUNDA_ATTRIBUTE_ERROR_MESSAGE_VARIABLE)).isEqualTo("errorMessageVariable");
@@ -534,7 +534,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testErrorMessage(String namespace, BpmnModelInstance modelInstance) {
+  void testErrorMessage(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(error.getOperatonErrorMessage()).isEqualTo(TEST_STRING_XML);
     error.setOperatonErrorMessage(TEST_STRING_API);
@@ -543,7 +543,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testExclusive(String namespace, BpmnModelInstance modelInstance) {
+  void testExclusive(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.isOperatonExclusive()).isTrue();
     assertThat(userTask.isOperatonExclusive()).isFalse();
@@ -560,7 +560,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testExpression(String namespace, BpmnModelInstance modelInstance) {
+  void testExpression(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(serviceTask.getOperatonExpression()).isEqualTo(TEST_EXPRESSION_XML);
     assertThat(messageEventDefinition.getOperatonExpression()).isEqualTo(TEST_EXPRESSION_XML);
@@ -572,7 +572,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testFormHandlerClass(String namespace, BpmnModelInstance modelInstance) {
+  void testFormHandlerClass(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.getOperatonFormHandlerClass()).isEqualTo(TEST_CLASS_XML);
     assertThat(userTask.getOperatonFormHandlerClass()).isEqualTo(TEST_CLASS_XML);
@@ -584,7 +584,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testFormKey(String namespace, BpmnModelInstance modelInstance) {
+  void testFormKey(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.getOperatonFormKey()).isEqualTo(TEST_STRING_XML);
     assertThat(userTask.getOperatonFormKey()).isEqualTo(TEST_STRING_XML);
@@ -596,7 +596,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testInitiator(String namespace, BpmnModelInstance modelInstance) {
+  void testInitiator(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(startEvent.getOperatonInitiator()).isEqualTo(TEST_STRING_XML);
     startEvent.setOperatonInitiator(TEST_STRING_API);
@@ -605,7 +605,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testPriority(String namespace, BpmnModelInstance modelInstance) {
+  void testPriority(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonPriority()).isEqualTo(TEST_PRIORITY_XML);
     userTask.setOperatonPriority(TEST_PRIORITY_API);
@@ -614,7 +614,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testResultVariable(String namespace, BpmnModelInstance modelInstance) {
+  void testResultVariable(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(serviceTask.getOperatonResultVariable()).isEqualTo(TEST_STRING_XML);
     assertThat(messageEventDefinition.getOperatonResultVariable()).isEqualTo(TEST_STRING_XML);
@@ -626,7 +626,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testType(String namespace, BpmnModelInstance modelInstance) {
+  void testType(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(serviceTask.getOperatonType()).isEqualTo(TEST_TYPE_XML);
     assertThat(messageEventDefinition.getOperatonType()).isEqualTo(TEST_STRING_XML);
@@ -639,7 +639,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testTopic(String namespace, BpmnModelInstance modelInstance) {
+  void testTopic(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(serviceTask.getOperatonTopic()).isEqualTo(TEST_STRING_XML);
     assertThat(messageEventDefinition.getOperatonTopic()).isEqualTo(TEST_STRING_XML);
@@ -651,7 +651,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testVariableMappingClass(String namespace, BpmnModelInstance modelInstance) {
+  void testVariableMappingClass(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonVariableMappingClass()).isEqualTo(TEST_CLASS_XML);
     callActivity.setOperatonVariableMappingClass(TEST_CLASS_API);
@@ -660,7 +660,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testVariableMappingDelegateExpression(String namespace, BpmnModelInstance modelInstance) {
+  void testVariableMappingDelegateExpression(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(callActivity.getOperatonVariableMappingDelegateExpression()).isEqualTo(TEST_DELEGATE_EXPRESSION_XML);
     callActivity.setOperatonVariableMappingDelegateExpression(TEST_DELEGATE_EXPRESSION_API);
@@ -669,7 +669,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testExecutionListenerExtension(String namespace, BpmnModelInstance modelInstance) {
+  void testExecutionListenerExtension(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonExecutionListener processListener = process.getExtensionElements().getElementsQuery().filterByType(OperatonExecutionListener.class).singleResult();
     OperatonExecutionListener startEventListener = startEvent.getExtensionElements().getElementsQuery().filterByType(OperatonExecutionListener.class).singleResult();
@@ -696,7 +696,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonScriptExecutionListener(String namespace, BpmnModelInstance modelInstance) {
+  void testOperatonScriptExecutionListener(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonExecutionListener sequenceFlowListener = sequenceFlow.getExtensionElements().getElementsQuery().filterByType(OperatonExecutionListener.class).singleResult();
 
@@ -718,7 +718,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testFailedJobRetryTimeCycleExtension(String namespace, BpmnModelInstance modelInstance) {
+  void testFailedJobRetryTimeCycleExtension(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonFailedJobRetryTimeCycle timeCycle = sendTask.getExtensionElements().getElementsQuery().filterByType(OperatonFailedJobRetryTimeCycle.class).singleResult();
     assertThat(timeCycle.getTextContent()).isEqualTo(TEST_STRING_XML);
@@ -728,7 +728,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testFieldExtension(String namespace, BpmnModelInstance modelInstance) {
+  void testFieldExtension(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonField field = sendTask.getExtensionElements().getElementsQuery().filterByType(OperatonField.class).singleResult();
     assertThat(field.getOperatonName()).isEqualTo(TEST_STRING_XML);
@@ -750,7 +750,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testFormData(String namespace, BpmnModelInstance modelInstance) {
+  void testFormData(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonFormData formData = userTask.getExtensionElements().getElementsQuery().filterByType(OperatonFormData.class).singleResult();
     OperatonFormField formField = formData.getOperatonFormFields().iterator().next();
@@ -797,7 +797,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testFormProperty(String namespace, BpmnModelInstance modelInstance) {
+  void testFormProperty(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonFormProperty formProperty = startEvent.getExtensionElements().getElementsQuery().filterByType(OperatonFormProperty.class).singleResult();
     assertThat(formProperty.getOperatonId()).isEqualTo(TEST_STRING_XML);
@@ -834,7 +834,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testInExtension(String namespace, BpmnModelInstance modelInstance) {
+  void testInExtension(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonIn in = callActivity.getExtensionElements().getElementsQuery().filterByType(OperatonIn.class).singleResult();
     assertThat(in.getOperatonSource()).isEqualTo(TEST_STRING_XML);
@@ -859,7 +859,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOutExtension(String namespace, BpmnModelInstance modelInstance) {
+  void testOutExtension(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonOut out = callActivity.getExtensionElements().getElementsQuery().filterByType(OperatonOut.class).singleResult();
     assertThat(out.getOperatonSource()).isEqualTo(TEST_STRING_XML);
@@ -881,7 +881,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testPotentialStarter(String namespace, BpmnModelInstance modelInstance) {
+  void testPotentialStarter(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonPotentialStarter potentialStarter = startEvent.getExtensionElements().getElementsQuery().filterByType(OperatonPotentialStarter.class).singleResult();
     Expression expression = potentialStarter.getResourceAssignmentExpression().getExpression();
@@ -892,7 +892,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testTaskListener(String namespace, BpmnModelInstance modelInstance) {
+  void testTaskListener(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonTaskListener taskListener = userTask.getExtensionElements().getElementsQuery().filterByType(OperatonTaskListener.class).list().get(0);
     assertThat(taskListener.getOperatonEvent()).isEqualTo(TEST_TASK_EVENT_XML);
@@ -924,7 +924,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonScriptTaskListener(String namespace, BpmnModelInstance modelInstance) {
+  void testOperatonScriptTaskListener(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonTaskListener taskListener = userTask.getExtensionElements().getElementsQuery().filterByType(OperatonTaskListener.class).list().get(1);
 
@@ -946,7 +946,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonModelerProperties(String namespace, BpmnModelInstance modelInstance) {
+  void testOperatonModelerProperties(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonProperties operatonProperties = endEvent.getExtensionElements().getElementsQuery().filterByType(OperatonProperties.class).singleResult();
     assertThat(operatonProperties).isNotNull();
@@ -961,7 +961,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testGetNonExistingOperatonCandidateUsers(String namespace, BpmnModelInstance modelInstance) {
+  void testGetNonExistingOperatonCandidateUsers(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     userTask.removeAttributeNs(namespace, "candidateUsers");
     assertThat(userTask.getOperatonCandidateUsers()).isNull();
@@ -970,7 +970,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testSetNullOperatonCandidateUsers(String namespace, BpmnModelInstance modelInstance) {
+  void testSetNullOperatonCandidateUsers(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonCandidateUsers()).isNotEmpty();
     assertThat(userTask.getOperatonCandidateUsersList()).isNotEmpty();
@@ -981,7 +981,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testEmptyOperatonCandidateUsers(String namespace, BpmnModelInstance modelInstance) {
+  void testEmptyOperatonCandidateUsers(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonCandidateUsers()).isNotEmpty();
     assertThat(userTask.getOperatonCandidateUsersList()).isNotEmpty();
@@ -992,7 +992,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testSetNullOperatonCandidateUsersList(String namespace, BpmnModelInstance modelInstance) {
+  void testSetNullOperatonCandidateUsersList(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonCandidateUsers()).isNotEmpty();
     assertThat(userTask.getOperatonCandidateUsersList()).isNotEmpty();
@@ -1003,7 +1003,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testEmptyOperatonCandidateUsersList(String namespace, BpmnModelInstance modelInstance) {
+  void testEmptyOperatonCandidateUsersList(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(userTask.getOperatonCandidateUsers()).isNotEmpty();
     assertThat(userTask.getOperatonCandidateUsersList()).isNotEmpty();
@@ -1014,7 +1014,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testScriptResource(String namespace, BpmnModelInstance modelInstance) {
+  void testScriptResource(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     assertThat(scriptTask.getScriptFormat()).isEqualTo("groovy");
     assertThat(scriptTask.getOperatonResource()).isEqualTo("test.groovy");
@@ -1022,7 +1022,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonConnector(String namespace, BpmnModelInstance modelInstance) {
+  void testOperatonConnector(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonConnector operatonConnector = serviceTask.getExtensionElements().getElementsQuery().filterByType(OperatonConnector.class).singleResult();
     assertThat(operatonConnector).isNotNull();
@@ -1050,7 +1050,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonInputOutput(String namespace, BpmnModelInstance modelInstance) {
+  void testOperatonInputOutput(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonInputOutput operatonInputOutput = serviceTask.getExtensionElements().getElementsQuery().filterByType(OperatonInputOutput.class).singleResult();
     assertThat(operatonInputOutput).isNotNull();
@@ -1060,7 +1060,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonInputParameter(String namespace, BpmnModelInstance modelInstance) {
+  void testOperatonInputParameter(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     // find existing
     OperatonInputParameter inputParameter = findInputParameterByName(serviceTask, "shouldBeConstant");
@@ -1086,7 +1086,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonNullInputParameter(String namespace, BpmnModelInstance modelInstance) {
+  void testOperatonNullInputParameter(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonInputParameter inputParameter = findInputParameterByName(serviceTask, "shouldBeNull");
     assertThat(inputParameter.getOperatonName()).isEqualTo("shouldBeNull");
@@ -1095,7 +1095,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonConstantInputParameter(String namespace, BpmnModelInstance modelInstance) {
+  void testOperatonConstantInputParameter(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonInputParameter inputParameter = findInputParameterByName(serviceTask, "shouldBeConstant");
     assertThat(inputParameter.getOperatonName()).isEqualTo("shouldBeConstant");
@@ -1104,7 +1104,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonExpressionInputParameter(String namespace, BpmnModelInstance modelInstance) {
+  void testOperatonExpressionInputParameter(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonInputParameter inputParameter = findInputParameterByName(serviceTask, "shouldBeExpression");
     assertThat(inputParameter.getOperatonName()).isEqualTo("shouldBeExpression");
@@ -1113,7 +1113,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonListInputParameter(String namespace, BpmnModelInstance modelInstance) {
+  void testOperatonListInputParameter(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonInputParameter inputParameter = findInputParameterByName(serviceTask, "shouldBeList");
     assertThat(inputParameter.getOperatonName()).isEqualTo("shouldBeList");
@@ -1189,7 +1189,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonMapInputParameter(String namespace, BpmnModelInstance modelInstance) {
+  void testOperatonMapInputParameter(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonInputParameter inputParameter = findInputParameterByName(serviceTask, "shouldBeMap");
     assertThat(inputParameter.getOperatonName()).isEqualTo("shouldBeMap");
@@ -1231,7 +1231,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonScriptInputParameter(String namespace, BpmnModelInstance modelInstance) {
+  void testOperatonScriptInputParameter(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonInputParameter inputParameter = findInputParameterByName(serviceTask, "shouldBeScript");
     assertThat(inputParameter.getOperatonName()).isEqualTo("shouldBeScript");
@@ -1261,7 +1261,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonNestedOutputParameter(String namespace, BpmnModelInstance modelInstance) {
+  void testOperatonNestedOutputParameter(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
     OperatonOutputParameter operatonOutputParameter = serviceTask.getExtensionElements().getElementsQuery().filterByType(OperatonInputOutput.class).singleResult().getOperatonOutputParameters().iterator().next();
 
@@ -1317,7 +1317,7 @@ public class OperatonExtensionsTest {
   }
 
   @AfterEach
-  public void validateModel() {
+  void validateModel() {
     Bpmn.validateModel(modelInstance);
   }
 }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ProcessTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ProcessTest.java
@@ -30,11 +30,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Daniel Meyer
  *
  */
-public class ProcessTest extends BpmnModelTest {
+class ProcessTest extends BpmnModelTest {
 
   @Test
   @BpmnModelResource
-  public void shouldImportProcess() {
+  void shouldImportProcess() {
 
     ModelElementInstance modelElementById = bpmnModelInstance.getModelElementById("exampleProcessId");
     assertThat(modelElementById).isNotNull();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/QueryTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/QueryTest.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.fail;
 /**
  * @author Sebastian Menski
  */
-public class QueryTest {
+class QueryTest {
 
   private static BpmnModelInstance modelInstance;
   private static Query<FlowNode> startSucceeding;
@@ -37,7 +37,7 @@ public class QueryTest {
   private static Query<FlowNode> gateway2Succeeding;
 
   @BeforeAll
-  public static void createModelInstance() {
+  static void createModelInstance() {
     modelInstance = Bpmn.createProcess()
       .startEvent().id("start")
       .userTask().id("user")
@@ -63,26 +63,26 @@ public class QueryTest {
   }
 
   @AfterAll
-  public static void validateModelInstance() {
+  static void validateModelInstance() {
     Bpmn.validateModel(modelInstance);
   }
 
   @Test
-  public void testList() {
+  void testList() {
     assertThat(startSucceeding.list()).hasSize(1);
     assertThat(gateway1Succeeding.list()).hasSize(2);
     assertThat(gateway2Succeeding.list()).hasSize(3);
   }
 
   @Test
-  public void testCount() {
+  void testCount() {
     assertThat(startSucceeding.count()).isEqualTo(1);
     assertThat(gateway1Succeeding.count()).isEqualTo(2);
     assertThat(gateway2Succeeding.count()).isEqualTo(3);
   }
 
   @Test
-  public void testFilterByType() {
+  void testFilterByType() {
     ModelElementType taskType = modelInstance.getModel().getType(Task.class);
     ModelElementType gatewayType = modelInstance.getModel().getType(Gateway.class);
 
@@ -97,7 +97,7 @@ public class QueryTest {
   }
 
   @Test
-  public void testSingleResult() {
+  void testSingleResult() {
     assertThat(startSucceeding.singleResult().getId()).isEqualTo("user");
     try {
       gateway1Succeeding.singleResult();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ReferenceTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ReferenceTest.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Sebastian Menski
  *
  */
-public class ReferenceTest extends BpmnModelTest {
+class ReferenceTest extends BpmnModelTest {
 
   private BpmnModelInstance testBpmnModelInstance;
   private Message message;
@@ -37,7 +37,7 @@ public class ReferenceTest extends BpmnModelTest {
   private StartEvent startEvent;
 
   @BeforeEach
-  public void createModel() {
+  void createModel() {
     testBpmnModelInstance = Bpmn.createEmptyModel();
     Definitions definitions = testBpmnModelInstance.newInstance(Definitions.class);
     testBpmnModelInstance.setDefinitions(definitions);
@@ -63,7 +63,7 @@ public class ReferenceTest extends BpmnModelTest {
   }
 
   @Test
-  public void testShouldUpdateReferenceOnIdChange() {
+  void testShouldUpdateReferenceOnIdChange() {
     assertThat(messageEventDefinition.getMessage()).isEqualTo(message);
     message.setId("changed-message-id");
     assertThat(message.getId()).isEqualTo("changed-message-id");
@@ -75,7 +75,7 @@ public class ReferenceTest extends BpmnModelTest {
   }
 
   @Test
-  public void testShouldRemoveReferenceIfReferencingElementIsRemoved() {
+  void testShouldRemoveReferenceIfReferencingElementIsRemoved() {
     assertThat(messageEventDefinition.getMessage()).isEqualTo(message);
 
     Definitions definitions = testBpmnModelInstance.getDefinitions();
@@ -86,7 +86,7 @@ public class ReferenceTest extends BpmnModelTest {
   }
 
   @Test
-  public void testShouldRemoveReferenceIfReferencingAttributeIsRemoved() {
+  void testShouldRemoveReferenceIfReferencingAttributeIsRemoved() {
     assertThat(messageEventDefinition.getMessage()).isEqualTo(message);
 
     message.removeAttribute("id");
@@ -96,7 +96,7 @@ public class ReferenceTest extends BpmnModelTest {
   }
 
   @Test
-  public void testShouldUpdateReferenceIfReferencingElementIsReplaced() {
+  void testShouldUpdateReferenceIfReferencingElementIsReplaced() {
     assertThat(messageEventDefinition.getMessage()).isEqualTo(message);
     Message newMessage = testBpmnModelInstance.newInstance(Message.class);
     newMessage.setId("new-message-id");
@@ -107,14 +107,14 @@ public class ReferenceTest extends BpmnModelTest {
   }
 
   @Test
-  public void testShouldAddMessageEventDefinitionRef() {
+  void testShouldAddMessageEventDefinitionRef() {
     Collection<EventDefinition> eventDefinitionRefs = startEvent.getEventDefinitionRefs();
     assertThat(eventDefinitionRefs).isNotEmpty();
     assertThat(eventDefinitionRefs).contains(messageEventDefinition);
   }
 
   @Test
-  public void testShouldUpdateMessageEventDefinitionRefOnIdChange() {
+  void testShouldUpdateMessageEventDefinitionRefOnIdChange() {
     Collection<EventDefinition> eventDefinitionRefs = startEvent.getEventDefinitionRefs();
     assertThat(eventDefinitionRefs).contains(messageEventDefinition);
     messageEventDefinition.setId("changed-message-event-definition-id");
@@ -123,7 +123,7 @@ public class ReferenceTest extends BpmnModelTest {
   }
 
   @Test
-  public void testShouldRemoveMessageEventDefinitionRefIfMessageEventDefinitionIsRemoved() {
+  void testShouldRemoveMessageEventDefinitionRefIfMessageEventDefinitionIsRemoved() {
     startEvent.getEventDefinitions().remove(messageEventDefinition);
     Collection<EventDefinition> eventDefinitionRefs = startEvent.getEventDefinitionRefs();
     assertThat(eventDefinitionRefs).doesNotContain(messageEventDefinition);
@@ -131,7 +131,7 @@ public class ReferenceTest extends BpmnModelTest {
   }
 
   @Test
-  public void testShouldReplaceMessageEventDefinitionRefIfMessageEventDefinitionIsReplaced() {
+  void testShouldReplaceMessageEventDefinitionRefIfMessageEventDefinitionIsReplaced() {
     MessageEventDefinition otherMessageEventDefinition = testBpmnModelInstance.newInstance(MessageEventDefinition.class);
     otherMessageEventDefinition.setId("other-message-event-definition-id");
     Collection<EventDefinition> eventDefinitionRefs = startEvent.getEventDefinitionRefs();
@@ -142,7 +142,7 @@ public class ReferenceTest extends BpmnModelTest {
   }
 
   @Test
-  public void testShouldRemoveMessageEventDefinitionRefIfIdIsRemovedOfMessageEventDefinition() {
+  void testShouldRemoveMessageEventDefinitionRefIfIdIsRemovedOfMessageEventDefinition() {
     Collection<EventDefinition> eventDefinitionRefs = startEvent.getEventDefinitionRefs();
     assertThat(eventDefinitionRefs).contains(messageEventDefinition);
     messageEventDefinition.removeAttribute("id");
@@ -152,7 +152,7 @@ public class ReferenceTest extends BpmnModelTest {
 
   @Test
   @BpmnModelResource
-  public void shouldFindReferenceWithNamespace() {
+  void shouldFindReferenceWithNamespace() {
     MessageEventDefinition messageEventDefinition = bpmnModelInstance.getModelElementById("message-event-definition");
     Message message = bpmnModelInstance.getModelElementById("message-id");
     assertThat(messageEventDefinition.getMessage()).isNotNull();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ResourceRolesTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ResourceRolesTest.java
@@ -30,17 +30,17 @@ import org.operaton.bpm.model.bpmn.instance.UserTask;
 /**
  * @author Dario Campagna
  */
-public class ResourceRolesTest {
+class ResourceRolesTest {
 
   private static BpmnModelInstance modelInstance;
 
   @BeforeAll
-  public static void parseModel() {
+  static void parseModel() {
     modelInstance = Bpmn.readModelFromStream(ResourceRolesTest.class.getResourceAsStream("ResourceRolesTest.bpmn"));
   }
 
   @Test
-  public void testGetPerformer() {
+  void testGetPerformer() {
     UserTask userTask = modelInstance.getModelElementById("_3");
     Collection<ResourceRole> resourceRoles = userTask.getResourceRoles();
     assertThat(resourceRoles.size()).isEqualTo(1);
@@ -50,7 +50,7 @@ public class ResourceRolesTest {
   }
 
   @Test
-  public void testGetHumanPerformer() {
+  void testGetHumanPerformer() {
     UserTask userTask = modelInstance.getModelElementById("_7");
     Collection<ResourceRole> resourceRoles = userTask.getResourceRoles();
     assertThat(resourceRoles.size()).isEqualTo(1);
@@ -60,7 +60,7 @@ public class ResourceRolesTest {
   }
 
   @Test
-  public void testGetPotentialOwner() {
+  void testGetPotentialOwner() {
     UserTask userTask = modelInstance.getModelElementById("_9");
     Collection<ResourceRole> resourceRoles = userTask.getResourceRoles();
     assertThat(resourceRoles.size()).isEqualTo(1);

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
@@ -151,7 +151,7 @@ public class ProcessBuilderTest {
   private static ModelElementType processType;
 
   @BeforeAll
-  public static void getElementTypes() {
+  static void getElementTypes() {
     Model model = Bpmn.createEmptyModel().getModel();
     taskType = model.getType(Task.class);
     gatewayType = model.getType(Gateway.class);
@@ -160,14 +160,14 @@ public class ProcessBuilderTest {
   }
 
   @AfterEach
-  public void validateModel() throws IOException {
+  void validateModel() throws IOException {
     if (modelInstance != null) {
       Bpmn.validateModel(modelInstance);
     }
   }
 
   @Test
-  public void testCreateEmptyProcess() {
+  void testCreateEmptyProcess() {
     modelInstance = Bpmn.createProcess()
       .done();
 
@@ -185,7 +185,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void emptyProcessShouldHaveDefaultHTTL() {
+  void emptyProcessShouldHaveDefaultHTTL() {
     modelInstance = Bpmn.createProcess().done();
 
     var process = (Process) modelInstance.getModelElementsByType(processType)
@@ -197,7 +197,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void shouldHaveDefaultHTTLValueOnSkipDefaultHistoryTimeToLiveFalse() {
+  void shouldHaveDefaultHTTLValueOnSkipDefaultHistoryTimeToLiveFalse() {
     modelInstance = Bpmn.createProcess().done();
 
     var process = (Process) modelInstance.getModelElementsByType(processType)
@@ -209,7 +209,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void shouldHaveNullHTTLValueOnCreateProcessWithSkipHTTL() {
+  void shouldHaveNullHTTLValueOnCreateProcessWithSkipHTTL() {
     modelInstance = Bpmn.createProcess().operatonHistoryTimeToLive(null).done();
 
     var process = (Process) modelInstance.getModelElementsByType(processType)
@@ -221,7 +221,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void shouldHaveNullHTTLValueOnCreateProcessIdWithoutSkipHTTL(){
+  void shouldHaveNullHTTLValueOnCreateProcessIdWithoutSkipHTTL(){
     modelInstance = Bpmn.createProcess(PROCESS_ID).done();
 
     var process = (Process) modelInstance.getModelElementById(PROCESS_ID);
@@ -231,7 +231,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void shouldHaveNullHTTLValueOnCreateProcessIdWithSkipHTTL(){
+  void shouldHaveNullHTTLValueOnCreateProcessIdWithSkipHTTL(){
     modelInstance = Bpmn.createProcess(PROCESS_ID).operatonHistoryTimeToLive(null).done();
 
     var process = (Process) modelInstance.getModelElementById(PROCESS_ID);
@@ -241,14 +241,14 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testGetElement() {
+  void testGetElement() {
     // Make sure this method is publicly available
     Process process = Bpmn.createProcess().getElement();
     assertThat(process).isNotNull();
   }
 
   @Test
-  public void testCreateProcessWithStartEvent() {
+  void testCreateProcessWithStartEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .done();
@@ -258,7 +258,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateProcessWithEndEvent() {
+  void testCreateProcessWithEndEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .endEvent()
@@ -269,7 +269,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateProcessWithServiceTask() {
+  void testCreateProcessWithServiceTask() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .serviceTask()
@@ -283,7 +283,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateProcessWithSendTask() {
+  void testCreateProcessWithSendTask() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .sendTask()
@@ -297,7 +297,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateProcessWithUserTask() {
+  void testCreateProcessWithUserTask() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask()
@@ -311,7 +311,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateProcessWithBusinessRuleTask() {
+  void testCreateProcessWithBusinessRuleTask() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .businessRuleTask()
@@ -325,7 +325,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateProcessWithScriptTask() {
+  void testCreateProcessWithScriptTask() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .scriptTask()
@@ -339,7 +339,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateProcessWithReceiveTask() {
+  void testCreateProcessWithReceiveTask() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .receiveTask()
@@ -353,7 +353,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateProcessWithManualTask() {
+  void testCreateProcessWithManualTask() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .manualTask()
@@ -367,7 +367,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateProcessWithParallelGateway() {
+  void testCreateProcessWithParallelGateway() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .parallelGateway()
@@ -387,7 +387,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateProcessWithExclusiveGateway() {
+  void testCreateProcessWithExclusiveGateway() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask()
@@ -410,7 +410,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateProcessWithInclusiveGateway() {
+  void testCreateProcessWithInclusiveGateway() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask()
@@ -435,7 +435,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateProcessWithForkAndJoin() {
+  void testCreateProcessWithForkAndJoin() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask()
@@ -459,7 +459,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateProcessWithMultipleParallelTask() {
+  void testCreateProcessWithMultipleParallelTask() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .parallelGateway("fork")
@@ -486,7 +486,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testBaseElementDocumentation() {
+  void testBaseElementDocumentation() {
     modelInstance = Bpmn.createProcess("process")
             .documentation("processDocumentation")
             .startEvent("startEvent")
@@ -519,7 +519,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testExtend() {
+  void testExtend() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask()
@@ -545,7 +545,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateInvoiceProcess() {
+  void testCreateInvoiceProcess() {
     modelInstance = Bpmn.createProcess()
       .executable()
       .startEvent()
@@ -591,7 +591,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testProcessOperatonExtensions() {
+  void testProcessOperatonExtensions() {
     modelInstance = Bpmn.createProcess(PROCESS_ID)
       .operatonJobPriority("${somePriority}")
       .operatonTaskPriority(TEST_PROCESS_TASK_PRIORITY)
@@ -611,7 +611,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testProcessStartableInTasklist() {
+  void testProcessStartableInTasklist() {
     modelInstance = Bpmn.createProcess(PROCESS_ID)
       .startEvent()
       .endEvent()
@@ -622,7 +622,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testTaskOperatonExternalTask() {
+  void testTaskOperatonExternalTask() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
         .serviceTask(EXTERNAL_TASK_ID)
@@ -636,7 +636,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testTaskOperatonExternalTaskErrorEventDefinition() {
+  void testTaskOperatonExternalTaskErrorEventDefinition() {
     modelInstance = Bpmn.createProcess()
     .startEvent()
     .serviceTask(EXTERNAL_TASK_ID)
@@ -660,7 +660,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testTaskOperatonExtensions() {
+  void testTaskOperatonExtensions() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .serviceTask(TASK_ID)
@@ -682,7 +682,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testServiceTaskOperatonExtensions() {
+  void testServiceTaskOperatonExtensions() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .serviceTask(TASK_ID)
@@ -709,7 +709,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testServiceTaskOperatonClass() {
+  void testServiceTaskOperatonClass() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .serviceTask(TASK_ID)
@@ -722,7 +722,7 @@ public class ProcessBuilderTest {
 
 
   @Test
-  public void testSendTaskOperatonExtensions() {
+  void testSendTaskOperatonExtensions() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .sendTask(TASK_ID)
@@ -750,7 +750,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testSendTaskOperatonClass() {
+  void testSendTaskOperatonClass() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .sendTask(TASK_ID)
@@ -763,7 +763,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testUserTaskOperatonExtensions() {
+  void testUserTaskOperatonExtensions() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask(TASK_ID)
@@ -801,7 +801,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testBusinessRuleTaskOperatonExtensions() {
+  void testBusinessRuleTaskOperatonExtensions() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .businessRuleTask(TASK_ID)
@@ -841,7 +841,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testBusinessRuleTaskOperatonClass() {
+  void testBusinessRuleTaskOperatonClass() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .businessRuleTask(TASK_ID)
@@ -854,7 +854,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testScriptTaskOperatonExtensions() {
+  void testScriptTaskOperatonExtensions() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .scriptTask(TASK_ID)
@@ -872,7 +872,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testStartEventOperatonExtensions() {
+  void testStartEventOperatonExtensions() {
     modelInstance = Bpmn.createProcess()
       .startEvent(START_EVENT_ID)
         .operatonAsyncBefore()
@@ -900,7 +900,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testErrorDefinitionsForStartEvent() {
+  void testErrorDefinitionsForStartEvent() {
     modelInstance = Bpmn.createProcess()
     .startEvent("start")
       .errorEventDefinition("event")
@@ -915,7 +915,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testErrorDefinitionsForStartEventWithoutEventDefinitionId() {
+  void testErrorDefinitionsForStartEventWithoutEventDefinitionId() {
     modelInstance = Bpmn.createProcess()
     .startEvent("start")
       .errorEventDefinition()
@@ -930,7 +930,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCallActivityOperatonExtension() {
+  void testCallActivityOperatonExtension() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .callActivity(CALL_ACTIVITY_ID)
@@ -980,7 +980,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCallActivityOperatonBusinessKey() {
+  void testCallActivityOperatonBusinessKey() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .callActivity(CALL_ACTIVITY_ID)
@@ -994,7 +994,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCallActivityOperatonVariableMappingClass() {
+  void testCallActivityOperatonVariableMappingClass() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .callActivity(CALL_ACTIVITY_ID)
@@ -1007,7 +1007,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testSubProcessBuilder() {
+  void testSubProcessBuilder() {
     BpmnModelInstance modelInstance = Bpmn.createProcess()
       .startEvent()
       .subProcess(SUB_PROCESS_ID)
@@ -1032,7 +1032,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testSubProcessBuilderDetached() {
+  void testSubProcessBuilderDetached() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .subProcess(SUB_PROCESS_ID)
@@ -1059,7 +1059,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testSubProcessBuilderNested() {
+  void testSubProcessBuilderNested() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .subProcess(SUB_PROCESS_ID + 1)
@@ -1103,7 +1103,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testSubProcessBuilderWrongScope() {
+  void testSubProcessBuilderWrongScope() {
     try {
       modelInstance = Bpmn.createProcess()
         .startEvent()
@@ -1118,7 +1118,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testTransactionBuilder() {
+  void testTransactionBuilder() {
     BpmnModelInstance modelInstance = Bpmn.createProcess()
       .startEvent()
       .transaction(TRANSACTION_ID)
@@ -1145,7 +1145,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testTransactionBuilderDetached() {
+  void testTransactionBuilderDetached() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .transaction(TRANSACTION_ID)
@@ -1172,7 +1172,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testScriptText() {
+  void testScriptText() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .scriptTask("script")
@@ -1187,7 +1187,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testEventBasedGatewayAsyncAfter() {
+  void testEventBasedGatewayAsyncAfter() {
     try {
       modelInstance = Bpmn.createProcess()
         .startEvent()
@@ -1214,7 +1214,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testMessageStartEvent() {
+  void testMessageStartEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent("start").message("message")
       .done();
@@ -1223,7 +1223,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testMessageStartEventWithExistingMessage() {
+  void testMessageStartEventWithExistingMessage() {
     modelInstance = Bpmn.createProcess()
       .startEvent("start").message("message")
         .subProcess().triggerByEvent()
@@ -1241,7 +1241,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateMessageCatchEvent() {
+  void testIntermediateMessageCatchEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateCatchEvent("catch").message("message")
@@ -1251,7 +1251,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateMessageCatchEventWithExistingMessage() {
+  void testIntermediateMessageCatchEventWithExistingMessage() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateCatchEvent("catch1").message("message")
@@ -1267,7 +1267,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testMessageEndEvent() {
+  void testMessageEndEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .endEvent("end").message("message")
@@ -1277,7 +1277,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testMessageEventDefintionEndEvent() {
+  void testMessageEventDefintionEndEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .endEvent("end")
@@ -1289,7 +1289,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testMessageEndEventWithExistingMessage() {
+  void testMessageEndEventWithExistingMessage() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .parallelGateway()
@@ -1307,7 +1307,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testMessageEventDefinitionEndEventWithExistingMessage() {
+  void testMessageEventDefinitionEndEventWithExistingMessage() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .parallelGateway()
@@ -1330,7 +1330,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateMessageThrowEvent() {
+  void testIntermediateMessageThrowEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateThrowEvent("throw").message("message")
@@ -1340,7 +1340,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateMessageEventDefintionThrowEvent() {
+  void testIntermediateMessageEventDefintionThrowEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateThrowEvent("throw")
@@ -1352,7 +1352,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateMessageThrowEventWithExistingMessage() {
+  void testIntermediateMessageThrowEventWithExistingMessage() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateThrowEvent("throw1").message("message")
@@ -1368,7 +1368,7 @@ public class ProcessBuilderTest {
 
 
   @Test
-  public void testIntermediateMessageEventDefintionThrowEventWithExistingMessage() {
+  void testIntermediateMessageEventDefintionThrowEventWithExistingMessage() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateThrowEvent("throw1")
@@ -1389,7 +1389,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateMessageThrowEventWithMessageDefinition() {
+  void testIntermediateMessageThrowEventWithMessageDefinition() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateThrowEvent("throw1")
@@ -1409,7 +1409,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateMessageThrowEventWithTaskPriority() {
+  void testIntermediateMessageThrowEventWithTaskPriority() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateThrowEvent("throw1")
@@ -1422,7 +1422,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testEndEventWithTaskPriority() {
+  void testEndEventWithTaskPriority() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .endEvent("end")
@@ -1435,7 +1435,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testMessageEventDefinitionWithID() {
+  void testMessageEventDefinitionWithID() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateThrowEvent("throw1")
@@ -1476,7 +1476,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testReceiveTaskMessage() {
+  void testReceiveTaskMessage() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .receiveTask("receive").message("message")
@@ -1490,7 +1490,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testReceiveTaskWithExistingMessage() {
+  void testReceiveTaskWithExistingMessage() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .receiveTask("receive1").message("message")
@@ -1509,7 +1509,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testSendTaskMessage() {
+  void testSendTaskMessage() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .sendTask("send").message("message")
@@ -1523,7 +1523,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testSendTaskWithExistingMessage() {
+  void testSendTaskWithExistingMessage() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .sendTask("send1").message("message")
@@ -1542,7 +1542,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testSignalStartEvent() {
+  void testSignalStartEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent("start").signal("signal")
       .done();
@@ -1551,7 +1551,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testSignalStartEventWithExistingSignal() {
+  void testSignalStartEventWithExistingSignal() {
     modelInstance = Bpmn.createProcess()
       .startEvent("start").signal("signal")
       .subProcess().triggerByEvent()
@@ -1569,7 +1569,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateSignalCatchEvent() {
+  void testIntermediateSignalCatchEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateCatchEvent("catch").signal("signal")
@@ -1579,7 +1579,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateSignalCatchEventWithExistingSignal() {
+  void testIntermediateSignalCatchEventWithExistingSignal() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateCatchEvent("catch1").signal("signal")
@@ -1595,7 +1595,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testSignalEndEvent() {
+  void testSignalEndEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .endEvent("end").signal("signal")
@@ -1605,7 +1605,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testSignalEndEventWithExistingSignal() {
+  void testSignalEndEventWithExistingSignal() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .parallelGateway()
@@ -1623,7 +1623,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateSignalThrowEvent() {
+  void testIntermediateSignalThrowEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateThrowEvent("throw").signal("signal")
@@ -1633,7 +1633,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateSignalThrowEventWithExistingSignal() {
+  void testIntermediateSignalThrowEventWithExistingSignal() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateThrowEvent("throw1").signal("signal")
@@ -1649,7 +1649,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateSignalThrowEventWithPayloadLocalVar() {
+  void testIntermediateSignalThrowEventWithPayloadLocalVar() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateThrowEvent("throw")
@@ -1694,7 +1694,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateSignalThrowEventWithPayload() {
+  void testIntermediateSignalThrowEventWithPayload() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateThrowEvent("throw")
@@ -1713,7 +1713,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testMessageBoundaryEvent() {
+  void testMessageBoundaryEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -1741,7 +1741,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testMultipleBoundaryEvents() {
+  void testMultipleBoundaryEvents() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -1779,7 +1779,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTaskListenerByClassName() {
+  void testOperatonTaskListenerByClassName() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -1798,7 +1798,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTaskListenerByClass() {
+  void testOperatonTaskListenerByClass() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -1817,7 +1817,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTaskListenerByExpression() {
+  void testOperatonTaskListenerByExpression() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -1836,7 +1836,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTaskListenerByDelegateExpression() {
+  void testOperatonTaskListenerByDelegateExpression() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -1855,7 +1855,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTimeoutCycleTaskListenerByClassName() {
+  void testOperatonTimeoutCycleTaskListenerByClassName() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -1883,7 +1883,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTimeoutDateTaskListenerByClassName() {
+  void testOperatonTimeoutDateTaskListenerByClassName() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -1911,7 +1911,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTimeoutDurationTaskListenerByClassName() {
+  void testOperatonTimeoutDurationTaskListenerByClassName() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -1939,7 +1939,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTimeoutDurationTaskListenerByClass() {
+  void testOperatonTimeoutDurationTaskListenerByClass() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -1967,7 +1967,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTimeoutCycleTaskListenerByClass() {
+  void testOperatonTimeoutCycleTaskListenerByClass() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -1995,7 +1995,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTimeoutDateTaskListenerByClass() {
+  void testOperatonTimeoutDateTaskListenerByClass() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -2023,7 +2023,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTimeoutCycleTaskListenerByExpression() {
+  void testOperatonTimeoutCycleTaskListenerByExpression() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -2051,7 +2051,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTimeoutDateTaskListenerByExpression() {
+  void testOperatonTimeoutDateTaskListenerByExpression() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -2079,7 +2079,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTimeoutDurationTaskListenerByExpression() {
+  void testOperatonTimeoutDurationTaskListenerByExpression() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -2107,7 +2107,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTimeoutCycleTaskListenerByDelegateExpression() {
+  void testOperatonTimeoutCycleTaskListenerByDelegateExpression() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -2135,7 +2135,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTimeoutDateTaskListenerByDelegateExpression() {
+  void testOperatonTimeoutDateTaskListenerByDelegateExpression() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -2163,7 +2163,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonTimeoutDurationTaskListenerByDelegateExpression() {
+  void testOperatonTimeoutDurationTaskListenerByDelegateExpression() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
           .userTask("task")
@@ -2191,7 +2191,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonExecutionListenerByClassName() {
+  void testOperatonExecutionListenerByClassName() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2210,7 +2210,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonExecutionListenerByClass() {
+  void testOperatonExecutionListenerByClass() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2229,7 +2229,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonExecutionListenerByExpression() {
+  void testOperatonExecutionListenerByExpression() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2248,7 +2248,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOperatonExecutionListenerByDelegateExpression() {
+  void testOperatonExecutionListenerByDelegateExpression() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2267,7 +2267,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testMultiInstanceLoopCharacteristicsSequential() {
+  void testMultiInstanceLoopCharacteristicsSequential() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2297,7 +2297,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testMultiInstanceLoopCharacteristicsParallel() {
+  void testMultiInstanceLoopCharacteristicsParallel() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2318,7 +2318,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testTaskWithOperatonInputOutput() {
+  void testTaskWithOperatonInputOutput() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2334,7 +2334,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testMultiInstanceLoopCharacteristicsAsynchronousMultiInstanceAsyncBeforeElement() {
+  void testMultiInstanceLoopCharacteristicsAsynchronousMultiInstanceAsyncBeforeElement() {
     modelInstance = Bpmn.createProcess()
             .startEvent()
             .userTask("task")
@@ -2358,7 +2358,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testMultiInstanceLoopCharacteristicsAsynchronousMultiInstanceAsyncAfterElement() {
+  void testMultiInstanceLoopCharacteristicsAsynchronousMultiInstanceAsyncAfterElement() {
     modelInstance = Bpmn.createProcess()
             .startEvent()
             .userTask("task")
@@ -2382,7 +2382,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testTaskWithOperatonInputOutputWithExistingExtensionElements() {
+  void testTaskWithOperatonInputOutputWithExistingExtensionElements() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2399,7 +2399,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testTaskWithOperatonInputOutputWithExistingOperatonInputOutput() {
+  void testTaskWithOperatonInputOutputWithExistingOperatonInputOutput() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2418,7 +2418,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testSubProcessWithOperatonInputOutput() {
+  void testSubProcessWithOperatonInputOutput() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .subProcess("subProcess")
@@ -2438,7 +2438,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testSubProcessWithOperatonInputOutputWithExistingExtensionElements() {
+  void testSubProcessWithOperatonInputOutputWithExistingExtensionElements() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .subProcess("subProcess")
@@ -2459,7 +2459,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testSubProcessWithOperatonInputOutputWithExistingOperatonInputOutput() {
+  void testSubProcessWithOperatonInputOutputWithExistingOperatonInputOutput() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .subProcess("subProcess")
@@ -2482,7 +2482,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testTimerStartEventWithDate() {
+  void testTimerStartEventWithDate() {
     modelInstance = Bpmn.createProcess()
       .startEvent("start").timerWithDate(TIMER_DATE)
       .done();
@@ -2491,7 +2491,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testTimerStartEventWithDuration() {
+  void testTimerStartEventWithDuration() {
     modelInstance = Bpmn.createProcess()
       .startEvent("start").timerWithDuration(TIMER_DURATION)
       .done();
@@ -2500,7 +2500,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testTimerStartEventWithCycle() {
+  void testTimerStartEventWithCycle() {
     modelInstance = Bpmn.createProcess()
       .startEvent("start").timerWithCycle(TIMER_CYCLE)
       .done();
@@ -2509,7 +2509,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateTimerCatchEventWithDate() {
+  void testIntermediateTimerCatchEventWithDate() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateCatchEvent("catch").timerWithDate(TIMER_DATE)
@@ -2519,7 +2519,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateTimerCatchEventWithDuration() {
+  void testIntermediateTimerCatchEventWithDuration() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateCatchEvent("catch").timerWithDuration(TIMER_DURATION)
@@ -2529,7 +2529,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateTimerCatchEventWithCycle() {
+  void testIntermediateTimerCatchEventWithCycle() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateCatchEvent("catch").timerWithCycle(TIMER_CYCLE)
@@ -2539,7 +2539,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testTimerBoundaryEventWithDate() {
+  void testTimerBoundaryEventWithDate() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2552,7 +2552,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testTimerBoundaryEventWithDuration() {
+  void testTimerBoundaryEventWithDuration() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2565,7 +2565,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testTimerBoundaryEventWithCycle() {
+  void testTimerBoundaryEventWithCycle() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2578,7 +2578,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testNotCancelingBoundaryEvent() {
+  void testNotCancelingBoundaryEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask()
@@ -2590,7 +2590,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCatchAllErrorBoundaryEvent() {
+  void testCatchAllErrorBoundaryEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2605,7 +2605,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCompensationTask() {
+  void testCompensationTask() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2636,7 +2636,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testOnlyOneCompensateBoundaryEventAllowed() {
+  void testOnlyOneCompensateBoundaryEventAllowed() {
     assertThatThrownBy(() -> {
       // given
       UserTaskBuilder builder = Bpmn.createProcess()
@@ -2654,7 +2654,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testInvalidCompensationStartCall() {
+  void testInvalidCompensationStartCall() {
     assertThatThrownBy(() -> {
       // given
       StartEventBuilder builder = Bpmn.createProcess().startEvent();
@@ -2666,7 +2666,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testInvalidCompensationDoneCall() {
+  void testInvalidCompensationDoneCall() {
     assertThatThrownBy(() -> {
       // given
       AbstractFlowNodeBuilder builder = Bpmn.createProcess()
@@ -2682,7 +2682,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testErrorBoundaryEvent() {
+  void testErrorBoundaryEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2710,7 +2710,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testErrorBoundaryEventWithoutErrorMessage() {
+  void testErrorBoundaryEventWithoutErrorMessage() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
         .userTask("task")
@@ -2724,7 +2724,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testErrorDefinitionForBoundaryEvent() {
+  void testErrorDefinitionForBoundaryEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2744,7 +2744,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testErrorDefinitionForBoundaryEventWithoutEventDefinitionId() {
+  void testErrorDefinitionForBoundaryEventWithoutEventDefinitionId() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2766,7 +2766,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testErrorEndEvent() {
+  void testErrorEndEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .endEvent("end").error("myErrorCode", "errorMessage")
@@ -2776,7 +2776,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testErrorEndEventWithoutErrorMessage() {
+  void testErrorEndEventWithoutErrorMessage() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
         .endEvent("end").error("myErrorCode")
@@ -2786,7 +2786,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testErrorEndEventWithExistingError() {
+  void testErrorEndEventWithExistingError() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2805,7 +2805,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testErrorStartEvent() {
+  void testErrorStartEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .endEvent()
@@ -2821,7 +2821,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testErrorStartEventWithoutErrorMessage() {
+  void testErrorStartEventWithoutErrorMessage() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
         .endEvent()
@@ -2837,7 +2837,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCatchAllErrorStartEvent() {
+  void testCatchAllErrorStartEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .endEvent()
@@ -2854,7 +2854,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCatchAllEscalationBoundaryEvent() {
+  void testCatchAllEscalationBoundaryEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2869,7 +2869,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testEscalationBoundaryEvent() {
+  void testEscalationBoundaryEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .subProcess("subProcess")
@@ -2897,7 +2897,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testEscalationEndEvent() {
+  void testEscalationEndEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .endEvent("end").escalation("myEscalationCode")
@@ -2907,7 +2907,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testEscalationStartEvent() {
+  void testEscalationStartEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .endEvent()
@@ -2923,7 +2923,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCatchAllEscalationStartEvent() {
+  void testCatchAllEscalationStartEvent() {
     modelInstance = Bpmn.createProcess()
         .startEvent()
         .endEvent()
@@ -2940,7 +2940,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateEscalationThrowEvent() {
+  void testIntermediateEscalationThrowEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateThrowEvent("throw").escalation("myEscalationCode")
@@ -2951,7 +2951,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testEscalationEndEventWithExistingEscalation() {
+  void testEscalationEndEventWithExistingEscalation() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("task")
@@ -2971,7 +2971,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCompensationStartEvent() {
+  void testCompensationStartEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .endEvent()
@@ -2987,7 +2987,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testInterruptingStartEvent() {
+  void testInterruptingStartEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .endEvent()
@@ -3006,7 +3006,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testNonInterruptingStartEvent() {
+  void testNonInterruptingStartEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .endEvent()
@@ -3025,7 +3025,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testUserTaskOperatonFormField() {
+  void testUserTaskOperatonFormField() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask(TASK_ID)
@@ -3049,7 +3049,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testUserTaskOperatonFormFieldWithExistingOperatonFormData() {
+  void testUserTaskOperatonFormFieldWithExistingOperatonFormData() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask(TASK_ID)
@@ -3076,7 +3076,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testStartEventOperatonFormField() {
+  void testStartEventOperatonFormField() {
     modelInstance = Bpmn.createProcess()
       .startEvent(START_EVENT_ID)
         .operatonFormField()
@@ -3099,7 +3099,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testUserTaskOperatonFormRef() {
+  void testUserTaskOperatonFormRef() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask(TASK_ID)
@@ -3116,7 +3116,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testStartEventOperatonFormRef() {
+  void testStartEventOperatonFormRef() {
     modelInstance = Bpmn.createProcess()
         .startEvent(START_EVENT_ID)
           .operatonFormRef(FORM_ID)
@@ -3133,7 +3133,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCompensateEventDefintionCatchStartEvent() {
+  void testCompensateEventDefintionCatchStartEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent("start")
         .compensateEventDefinition()
@@ -3151,7 +3151,7 @@ public class ProcessBuilderTest {
 
 
   @Test
-  public void testCompensateEventDefintionCatchBoundaryEvent() {
+  void testCompensateEventDefintionCatchBoundaryEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("userTask")
@@ -3169,7 +3169,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCompensateEventDefintionCatchBoundaryEventWithId() {
+  void testCompensateEventDefintionCatchBoundaryEventWithId() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("userTask")
@@ -3185,7 +3185,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCompensateEventDefintionThrowEndEvent() {
+  void testCompensateEventDefintionThrowEndEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("userTask")
@@ -3203,7 +3203,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCompensateEventDefintionThrowIntermediateEvent() {
+  void testCompensateEventDefintionThrowIntermediateEvent() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("userTask")
@@ -3222,7 +3222,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCompensateEventDefintionThrowIntermediateEventWithId() {
+  void testCompensateEventDefintionThrowIntermediateEventWithId() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("userTask")
@@ -3239,7 +3239,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCompensateEventDefintionReferencesNonExistingActivity() {
+  void testCompensateEventDefintionReferencesNonExistingActivity() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("userTask")
@@ -3262,7 +3262,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCompensateEventDefintionReferencesActivityInDifferentScope() {
+  void testCompensateEventDefintionReferencesActivityInDifferentScope() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("userTask")
@@ -3291,7 +3291,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testConditionalEventDefinitionOperatonExtensions() {
+  void testConditionalEventDefinitionOperatonExtensions() {
     modelInstance = Bpmn.createProcess()
       .startEvent()
       .intermediateCatchEvent()
@@ -3311,7 +3311,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateConditionalEventDefinition() {
+  void testIntermediateConditionalEventDefinition() {
 
     modelInstance = Bpmn.createProcess()
       .startEvent()
@@ -3328,7 +3328,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testIntermediateConditionalEventDefinitionShortCut() {
+  void testIntermediateConditionalEventDefinitionShortCut() {
 
     modelInstance = Bpmn.createProcess()
       .startEvent()
@@ -3342,7 +3342,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testBoundaryConditionalEventDefinition() {
+  void testBoundaryConditionalEventDefinition() {
 
     modelInstance = Bpmn.createProcess()
       .startEvent()
@@ -3362,7 +3362,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testEventSubProcessConditionalStartEvent() {
+  void testEventSubProcessConditionalStartEvent() {
 
     modelInstance = Bpmn.createProcess()
       .startEvent()
@@ -3549,7 +3549,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateEventSubProcess() {
+  void testCreateEventSubProcess() {
     ProcessBuilder process = Bpmn.createProcess();
     modelInstance = process
       .startEvent()
@@ -3580,7 +3580,7 @@ public class ProcessBuilderTest {
 
 
   @Test
-  public void testCreateEventSubProcessInSubProcess() {
+  void testCreateEventSubProcessInSubProcess() {
     ProcessBuilder process = Bpmn.createProcess();
     modelInstance = process
       .startEvent()
@@ -3620,7 +3620,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testCreateEventSubProcessError() {
+  void testCreateEventSubProcessError() {
     ProcessBuilder process = Bpmn.createProcess();
     modelInstance = process
       .startEvent()
@@ -3644,7 +3644,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
-  public void testSetIdAsDefaultNameForFlowElements() {
+  void testSetIdAsDefaultNameForFlowElements() {
     BpmnModelInstance instance = Bpmn.createExecutableProcess("process")
         .startEvent("start")
         .userTask("user")

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/di/CoordinatesGenerationTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/di/CoordinatesGenerationTest.java
@@ -43,7 +43,7 @@ public class CoordinatesGenerationTest {
   private BpmnModelInstance instance;
 
   @Test
-  public void shouldPlaceStartEvent() {
+  void shouldPlaceStartEvent() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -56,7 +56,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceUserTask() {
+  void shouldPlaceUserTask() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -84,7 +84,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceSendTask() {
+  void shouldPlaceSendTask() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -112,7 +112,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceServiceTask() {
+  void shouldPlaceServiceTask() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -140,7 +140,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceReceiveTask() {
+  void shouldPlaceReceiveTask() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -168,7 +168,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceManualTask() {
+  void shouldPlaceManualTask() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -196,7 +196,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceBusinessRuleTask() {
+  void shouldPlaceBusinessRuleTask() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -224,7 +224,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceScriptTask() {
+  void shouldPlaceScriptTask() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -252,7 +252,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceCatchingIntermediateEvent() {
+  void shouldPlaceCatchingIntermediateEvent() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -280,7 +280,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceThrowingIntermediateEvent() {
+  void shouldPlaceThrowingIntermediateEvent() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -308,7 +308,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceEndEvent() {
+  void shouldPlaceEndEvent() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -336,7 +336,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceCallActivity() {
+  void shouldPlaceCallActivity() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -364,7 +364,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceExclusiveGateway() {
+  void shouldPlaceExclusiveGateway() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -392,7 +392,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceInclusiveGateway() {
+  void shouldPlaceInclusiveGateway() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -420,7 +420,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceParallelGateway() {
+  void shouldPlaceParallelGateway() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -448,7 +448,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceEventBasedGateway() {
+  void shouldPlaceEventBasedGateway() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -477,7 +477,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceBlankSubProcess() {
+  void shouldPlaceBlankSubProcess() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -505,7 +505,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceBoundaryEventForTask() {
+  void shouldPlaceBoundaryEventForTask() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -524,7 +524,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceFollowingFlowNodeProperlyForTask() {
+  void shouldPlaceFollowingFlowNodeProperlyForTask() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -554,7 +554,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceTwoBoundaryEventsForTask() {
+  void shouldPlaceTwoBoundaryEventsForTask() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -578,7 +578,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceThreeBoundaryEventsForTask() {
+  void shouldPlaceThreeBoundaryEventsForTask() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -607,7 +607,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceManyBoundaryEventsForTask() {
+  void shouldPlaceManyBoundaryEventsForTask() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -641,7 +641,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceBoundaryEventForSubProcess() {
+  void shouldPlaceBoundaryEventForSubProcess() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -660,7 +660,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceFollowingFlowNodeForSubProcess() {
+  void shouldPlaceFollowingFlowNodeForSubProcess() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -690,7 +690,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceTwoBoundaryEventsForSubProcess() {
+  void shouldPlaceTwoBoundaryEventsForSubProcess() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -712,7 +712,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceThreeBoundaryEventsForSubProcess() {
+  void shouldPlaceThreeBoundaryEventsForSubProcess() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -738,7 +738,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceManyBoundaryEventsForSubProcess() {
+  void shouldPlaceManyBoundaryEventsForSubProcess() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -769,7 +769,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceTwoBranchesForParallelGateway() {
+  void shouldPlaceTwoBranchesForParallelGateway() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -802,7 +802,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceThreeBranchesForParallelGateway() {
+  void shouldPlaceThreeBranchesForParallelGateway() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -839,7 +839,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceManyBranchesForParallelGateway() {
+  void shouldPlaceManyBranchesForParallelGateway() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -881,7 +881,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceTwoBranchesForExclusiveGateway() {
+  void shouldPlaceTwoBranchesForExclusiveGateway() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -914,7 +914,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceThreeBranchesForExclusiveGateway() {
+  void shouldPlaceThreeBranchesForExclusiveGateway() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -951,7 +951,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceManyBranchesForExclusiveGateway() {
+  void shouldPlaceManyBranchesForExclusiveGateway() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -993,7 +993,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceTwoBranchesForEventBasedGateway() {
+  void shouldPlaceTwoBranchesForEventBasedGateway() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -1027,7 +1027,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceThreeBranchesForEventBasedGateway() {
+  void shouldPlaceThreeBranchesForEventBasedGateway() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -1065,7 +1065,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceManyBranchesForEventBasedGateway() {
+  void shouldPlaceManyBranchesForEventBasedGateway() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -1108,7 +1108,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceTwoBranchesForInclusiveGateway() {
+  void shouldPlaceTwoBranchesForInclusiveGateway() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -1141,7 +1141,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceThreeBranchesForInclusiveGateway() {
+  void shouldPlaceThreeBranchesForInclusiveGateway() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -1178,7 +1178,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceManyBranchesForInclusiveGateway() {
+  void shouldPlaceManyBranchesForInclusiveGateway() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder
@@ -1235,7 +1235,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldAdjustSubProcessWidth() {
+  void shouldAdjustSubProcessWidth() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -1255,7 +1255,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldAdjustSubProcessWidthWithEmbeddedSubProcess() {
+  void shouldAdjustSubProcessWidthWithEmbeddedSubProcess() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -1280,7 +1280,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldAdjustSubProcessHeight() {
+  void shouldAdjustSubProcessHeight() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -1301,7 +1301,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldAdjustSubProcessHeightWithEmbeddedProcess() {
+  void shouldAdjustSubProcessHeightWithEmbeddedProcess() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -1329,7 +1329,7 @@ public class CoordinatesGenerationTest {
   }
 
   @Test
-  public void shouldPlaceCompensation() {
+  void shouldPlaceCompensation() {
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
     instance = builder

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/di/DiGeneratorForFlowNodesTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/di/DiGeneratorForFlowNodesTest.java
@@ -43,19 +43,19 @@ import org.operaton.bpm.model.bpmn.builder.ProcessBuilder;
 import org.operaton.bpm.model.bpmn.instance.bpmndi.BpmnDiagram;
 import org.operaton.bpm.model.bpmn.instance.bpmndi.BpmnShape;
 
-public class DiGeneratorForFlowNodesTest {
+class DiGeneratorForFlowNodesTest {
 
   private BpmnModelInstance instance;
 
   @AfterEach
-  public void validateModel() throws IOException {
+  void validateModel() throws IOException {
     if (instance != null) {
       Bpmn.validateModel(instance);
     }
   }
 
   @Test
-  public void shouldGeneratePlaneForProcess() {
+  void shouldGeneratePlaneForProcess() {
 
     // when
     instance = Bpmn.createExecutableProcess("process").done();
@@ -72,7 +72,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForStartEvent() {
+  void shouldGenerateShapeForStartEvent() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -91,7 +91,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForUserTask() {
+  void shouldGenerateShapeForUserTask() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -110,7 +110,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForSendTask() {
+  void shouldGenerateShapeForSendTask() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -129,7 +129,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForServiceTask() {
+  void shouldGenerateShapeForServiceTask() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -148,7 +148,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForReceiveTask() {
+  void shouldGenerateShapeForReceiveTask() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -167,7 +167,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForManualTask() {
+  void shouldGenerateShapeForManualTask() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -186,7 +186,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForBusinessRuleTask() {
+  void shouldGenerateShapeForBusinessRuleTask() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -205,7 +205,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForScriptTask() {
+  void shouldGenerateShapeForScriptTask() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -224,7 +224,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForCatchingIntermediateEvent() {
+  void shouldGenerateShapeForCatchingIntermediateEvent() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -244,7 +244,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForBoundaryIntermediateEvent() {
+  void shouldGenerateShapeForBoundaryIntermediateEvent() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -270,7 +270,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForThrowingIntermediateEvent() {
+  void shouldGenerateShapeForThrowingIntermediateEvent() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -289,7 +289,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForEndEvent() {
+  void shouldGenerateShapeForEndEvent() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -308,7 +308,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForBlankSubProcess() {
+  void shouldGenerateShapeForBlankSubProcess() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -331,7 +331,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapesForNestedFlowNodes() {
+  void shouldGenerateShapesForNestedFlowNodes() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -362,7 +362,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForEventSubProcess() {
+  void shouldGenerateShapeForEventSubProcess() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -392,7 +392,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForCallActivity() {
+  void shouldGenerateShapeForCallActivity() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -412,7 +412,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForTransaction() {
+  void shouldGenerateShapeForTransaction() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -443,7 +443,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForParallelGateway() {
+  void shouldGenerateShapeForParallelGateway() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -463,7 +463,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForInclusiveGateway() {
+  void shouldGenerateShapeForInclusiveGateway() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -483,7 +483,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForEventBasedGateway() {
+  void shouldGenerateShapeForEventBasedGateway() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
@@ -504,7 +504,7 @@ public class DiGeneratorForFlowNodesTest {
   }
 
   @Test
-  public void shouldGenerateShapeForExclusiveGateway() {
+  void shouldGenerateShapeForExclusiveGateway() {
 
     // given
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/di/DiGeneratorForSequenceFlowsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/di/DiGeneratorForSequenceFlowsTest.java
@@ -32,19 +32,19 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.bpmn.builder.ProcessBuilder;
 import org.operaton.bpm.model.bpmn.instance.bpmndi.BpmnEdge;
 
-public class DiGeneratorForSequenceFlowsTest {
+class DiGeneratorForSequenceFlowsTest {
 
   private BpmnModelInstance instance;
 
   @AfterEach
-  public void validateModel() throws IOException {
+  void validateModel() throws IOException {
     if (instance != null) {
       Bpmn.validateModel(instance);
     }
   }
 
   @Test
-  public void shouldGenerateEdgeForSequenceFlow() {
+  void shouldGenerateEdgeForSequenceFlow() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -61,7 +61,7 @@ public class DiGeneratorForSequenceFlowsTest {
   }
 
   @Test
-  public void shouldGenerateEdgesForSequenceFlowsUsingGateway() {
+  void shouldGenerateEdgesForSequenceFlowsUsingGateway() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -85,7 +85,7 @@ public class DiGeneratorForSequenceFlowsTest {
   }
 
   @Test
-  public void shouldGenerateEdgesWhenUsingMoveToActivity() {
+  void shouldGenerateEdgesWhenUsingMoveToActivity() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -112,7 +112,7 @@ public class DiGeneratorForSequenceFlowsTest {
   }
 
   @Test
-  public void shouldGenerateEdgesWhenUsingMoveToNode() {
+  void shouldGenerateEdgesWhenUsingMoveToNode() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 
@@ -139,7 +139,7 @@ public class DiGeneratorForSequenceFlowsTest {
   }
 
   @Test
-  public void shouldGenerateEdgesWhenUsingConnectTo() {
+  void shouldGenerateEdgesWhenUsingConnectTo() {
 
     ProcessBuilder builder = Bpmn.createExecutableProcess();
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/BaseElementTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/BaseElementTest.java
@@ -46,7 +46,7 @@ public class BaseElementTest extends BpmnModelElementInstanceTest {
   }
 
   @Test
-  public void testId() {
+  void testId() {
     Task task = modelInstance.newInstance(Task.class);
     assertThat(task.getId()).isNotNull().startsWith("task");
     task.setId("test");

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/CancelEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/CancelEventDefinitionTest.java
@@ -20,10 +20,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CancelEventDefinitionTest extends AbstractEventDefinitionTest {
+class CancelEventDefinitionTest extends AbstractEventDefinitionTest {
 
   @Test
-  public void getEventDefinition() {
+  void getEventDefinition() {
     CancelEventDefinition eventDefinition = eventDefinitionQuery.filterByType(CancelEventDefinition.class).singleResult();
     assertThat(eventDefinition).isNotNull();
   }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/CompensateEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/CompensateEventDefinitionTest.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class CompensateEventDefinitionTest extends AbstractEventDefinitionTest {
+class CompensateEventDefinitionTest extends AbstractEventDefinitionTest {
 
   public Collection<AttributeAssumption> getAttributesAssumptions() {
     return Arrays.asList(
@@ -33,7 +33,7 @@ public class CompensateEventDefinitionTest extends AbstractEventDefinitionTest {
   }
 
   @Test
-  public void getEventDefinition() {
+  void getEventDefinition() {
     CompensateEventDefinition eventDefinition = eventDefinitionQuery.filterByType(CompensateEventDefinition.class).singleResult();
     assertThat(eventDefinition).isNotNull();
     assertThat(eventDefinition.isWaitForCompletion()).isTrue();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ComplexGatewayTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ComplexGatewayTest.java
@@ -38,12 +38,12 @@ public class ComplexGatewayTest extends AbstractGatewayTest<ComplexGateway> {
   }
 
   @Test
-  public void getDefault() {
+  void getDefault() {
     assertThat(gateway.getDefault().getId()).isEqualTo("flow");
   }
 
   @Test
-  public void getActivationCondition() {
+  void getActivationCondition() {
     assertThat(gateway.getActivationCondition().getTextContent()).isEqualTo("${test}");
   }
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ConditionalEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ConditionalEventDefinitionTest.java
@@ -44,7 +44,7 @@ public class ConditionalEventDefinitionTest extends AbstractEventDefinitionTest 
   }
 
   @Test
-  public void getEventDefinition() {
+  void getEventDefinition() {
     ConditionalEventDefinition eventDefinition = eventDefinitionQuery.filterByType(ConditionalEventDefinition.class).singleResult();
     assertThat(eventDefinition).isNotNull();
     assertThat(eventDefinition.getOperatonVariableEvents()).isNull();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ErrorEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ErrorEventDefinitionTest.java
@@ -16,16 +16,15 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
-import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
-
-import org.junit.jupiter.api.Test;
 import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
 
-public class ErrorEventDefinitionTest extends AbstractEventDefinitionTest {
+class ErrorEventDefinitionTest extends AbstractEventDefinitionTest {
 
   public Collection<AttributeAssumption> getAttributesAssumptions() {
     return Arrays.asList(
@@ -36,7 +35,7 @@ public class ErrorEventDefinitionTest extends AbstractEventDefinitionTest {
   }
 
   @Test
-  public void getEventDefinition() {
+  void getEventDefinition() {
     ErrorEventDefinition eventDefinition = eventDefinitionQuery.filterByType(ErrorEventDefinition.class).singleResult();
     assertThat(eventDefinition).isNotNull();
     assertThat(eventDefinition.getError().getId()).isEqualTo("error");

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/EscalationEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/EscalationEventDefinitionTest.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class EscalationEventDefinitionTest extends AbstractEventDefinitionTest {
+class EscalationEventDefinitionTest extends AbstractEventDefinitionTest {
 
   public Collection<AttributeAssumption> getAttributesAssumptions() {
     return Arrays.asList(
@@ -32,7 +32,7 @@ public class EscalationEventDefinitionTest extends AbstractEventDefinitionTest {
   }
 
   @Test
-  public void getEventDefinition() {
+  void getEventDefinition() {
     EscalationEventDefinition eventDefinition = eventDefinitionQuery.filterByType(EscalationEventDefinition.class).singleResult();
     assertThat(eventDefinition).isNotNull();
     assertThat(eventDefinition.getEscalation().getName()).isEqualTo("escalation");

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/EventBasedGatewayTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/EventBasedGatewayTest.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-public class EventBasedGatewayTest extends AbstractGatewayTest<EventBasedGateway> {
+class EventBasedGatewayTest extends AbstractGatewayTest<EventBasedGateway> {
 
   public Collection<AttributeAssumption> getAttributesAssumptions() {
     return Arrays.asList(
@@ -35,17 +35,17 @@ public class EventBasedGatewayTest extends AbstractGatewayTest<EventBasedGateway
   }
 
   @Test
-  public void getInstantiate() {
+  void getInstantiate() {
     assertThat(gateway.isInstantiate()).isTrue();
   }
 
   @Test
-  public void getEventGatewayType() {
+  void getEventGatewayType() {
     assertThat(gateway.getEventGatewayType()).isEqualTo(EventBasedGatewayType.Parallel);
   }
 
   @Test
-  public void shouldFailSetAsyncAfterToEventBasedGateway() {
+  void shouldFailSetAsyncAfterToEventBasedGateway() {
     // fetching should fail
     try {
       gateway.isOperatonAsyncAfter();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ExclusiveGatewayTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ExclusiveGatewayTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Sebastian Menski
  */
-public class ExclusiveGatewayTest extends AbstractGatewayTest<ExclusiveGateway> {
+class ExclusiveGatewayTest extends AbstractGatewayTest<ExclusiveGateway> {
 
   public Collection<AttributeAssumption> getAttributesAssumptions() {
     return Arrays.asList(
@@ -35,7 +35,7 @@ public class ExclusiveGatewayTest extends AbstractGatewayTest<ExclusiveGateway> 
   }
 
   @Test
-  public void getDefault() {
+  void getDefault() {
     assertThat(gateway.getDefault().getId()).isEqualTo("flow");
   }
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/FlowNodeTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/FlowNodeTest.java
@@ -31,7 +31,7 @@ import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
 /**
  * @author Sebastian Menski
  */
-public class FlowNodeTest extends BpmnModelElementInstanceTest {
+class FlowNodeTest extends BpmnModelElementInstanceTest {
 
   public TypeAssumption getTypeAssumption() {
     return new TypeAssumption(FlowElement.class, true);
@@ -54,7 +54,7 @@ public class FlowNodeTest extends BpmnModelElementInstanceTest {
   }
 
   @Test
-  public void testUpdateIncomingOutgoingChildElements() {
+  void testUpdateIncomingOutgoingChildElements() {
     BpmnModelInstance modelInstance = Bpmn.createProcess()
       .startEvent()
       .userTask("test")
@@ -79,7 +79,7 @@ public class FlowNodeTest extends BpmnModelElementInstanceTest {
   }
 
   @Test
-    public void testOperatonAsyncBefore() {
+  void testOperatonAsyncBefore() {
     Task task = modelInstance.newInstance(Task.class);
     assertThat(task.isOperatonAsyncBefore()).isFalse();
 
@@ -88,7 +88,7 @@ public class FlowNodeTest extends BpmnModelElementInstanceTest {
   }
 
   @Test
-  public void testOperatonAsyncAfter() {
+  void testOperatonAsyncAfter() {
     Task task = modelInstance.newInstance(Task.class);
     assertThat(task.isOperatonAsyncAfter()).isFalse();
 
@@ -97,7 +97,7 @@ public class FlowNodeTest extends BpmnModelElementInstanceTest {
   }
 
   @Test
-  public void testOperatonAsyncAfterAndBefore() {
+  void testOperatonAsyncAfterAndBefore() {
     Task task = modelInstance.newInstance(Task.class);
 
     assertThat(task.isOperatonAsyncAfter()).isFalse();
@@ -120,7 +120,7 @@ public class FlowNodeTest extends BpmnModelElementInstanceTest {
   }
 
   @Test
-  public void testOperatonExclusive() {
+  void testOperatonExclusive() {
     Task task = modelInstance.newInstance(Task.class);
 
     assertThat(task.isOperatonExclusive()).isTrue();
@@ -131,7 +131,7 @@ public class FlowNodeTest extends BpmnModelElementInstanceTest {
   }
 
   @Test
-  public void testOperatonJobPriority() {
+  void testOperatonJobPriority() {
     Task task = modelInstance.newInstance(Task.class);
     assertThat(task.getOperatonJobPriority()).isNull();
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/InclusiveGatewayTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/InclusiveGatewayTest.java
@@ -32,7 +32,7 @@ public class InclusiveGatewayTest extends AbstractGatewayTest<InclusiveGateway> 
   }
 
   @Test
-  public void getDefault() {
+  void getDefault() {
     assertThat(gateway.getDefault().getId()).isEqualTo("flow");
   }
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/LinkEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/LinkEventDefinitionTest.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class LinkEventDefinitionTest extends AbstractEventDefinitionTest {
+class LinkEventDefinitionTest extends AbstractEventDefinitionTest {
 
   public Collection<ChildElementAssumption> getChildElementAssumptions() {
     return Arrays.asList(
@@ -41,7 +41,7 @@ public class LinkEventDefinitionTest extends AbstractEventDefinitionTest {
   }
 
   @Test
-  public void getEventDefinition() {
+  void getEventDefinition() {
     LinkEventDefinition eventDefinition = eventDefinitionQuery.filterByType(LinkEventDefinition.class).singleResult();
     assertThat(eventDefinition).isNotNull();
     assertThat(eventDefinition.getName()).isEqualTo("link");

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/MessageEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/MessageEventDefinitionTest.java
@@ -51,7 +51,7 @@ public class MessageEventDefinitionTest extends AbstractEventDefinitionTest {
   }
 
   @Test
-  public void getEventDefinition() {
+  void getEventDefinition() {
     MessageEventDefinition eventDefinition = eventDefinitionQuery.filterByType(MessageEventDefinition.class).singleResult();
     assertThat(eventDefinition).isNotNull();
     assertThat(eventDefinition.getMessage().getId()).isEqualTo("message");

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ProcessTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ProcessTest.java
@@ -70,7 +70,7 @@ public class ProcessTest extends BpmnModelElementInstanceTest {
   }
 
   @Test
-  public void testOperatonJobPriority() {
+  void testOperatonJobPriority() {
     Process process = modelInstance.newInstance(Process.class);
     assertThat(process.getOperatonJobPriority()).isNull();
 
@@ -80,7 +80,7 @@ public class ProcessTest extends BpmnModelElementInstanceTest {
   }
 
   @Test
-  public void testOperatonTaskPriority() {
+  void testOperatonTaskPriority() {
     //given
     Process proc = modelInstance.newInstance(Process.class);
     assertThat(proc.getOperatonTaskPriority()).isNull();
@@ -91,7 +91,7 @@ public class ProcessTest extends BpmnModelElementInstanceTest {
   }
 
   @Test
-  public void testOperatonHistoryTimeToLive() {
+  void testOperatonHistoryTimeToLive() {
     //given
     Process proc = modelInstance.newInstance(Process.class);
     assertThat(proc.getOperatonHistoryTimeToLive()).isNull();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ServiceTaskTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ServiceTaskTest.java
@@ -52,10 +52,10 @@ public class ServiceTaskTest extends BpmnModelElementInstanceTest {
       new AttributeAssumption(OPERATON_NS, "taskPriority")
     );
   }
-  
-  
+
+
   @Test
-  public void testOperatonTaskPriority() {
+  void testOperatonTaskPriority() {
     //given
     ServiceTask service = modelInstance.newInstance(ServiceTask.class);    
     assertThat(service.getOperatonTaskPriority()).isNull();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/SignalEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/SignalEventDefinitionTest.java
@@ -34,7 +34,7 @@ public class SignalEventDefinitionTest extends AbstractEventDefinitionTest {
   }
 
   @Test
-  public void getEventDefinition() {
+  void getEventDefinition() {
     SignalEventDefinition eventDefinition = eventDefinitionQuery.filterByType(SignalEventDefinition.class).singleResult();
     assertThat(eventDefinition).isNotNull();
     assertThat(eventDefinition.isOperatonAsync()).isFalse();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TerminateEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TerminateEventDefinitionTest.java
@@ -20,10 +20,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TerminateEventDefinitionTest extends AbstractEventDefinitionTest {
+class TerminateEventDefinitionTest extends AbstractEventDefinitionTest {
 
   @Test
-  public void getEventDefinition() {
+  void getEventDefinition() {
     TerminateEventDefinition eventDefinition = eventDefinitionQuery.filterByType(TerminateEventDefinition.class).singleResult();
     assertThat(eventDefinition).isNotNull();
   }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TextAnnotationTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TextAnnotationTest.java
@@ -16,19 +16,20 @@
  */
 package org.operaton.bpm.model.bpmn.instance;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Arrays;
-import java.util.Collection;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Filip Hrisafov
  */
-public class TextAnnotationTest extends BpmnModelElementInstanceTest {
+class TextAnnotationTest extends BpmnModelElementInstanceTest {
 
   protected static BpmnModelInstance modelInstance;
 
@@ -49,13 +50,13 @@ public class TextAnnotationTest extends BpmnModelElementInstanceTest {
   }
 
   @BeforeAll
-  public static void parseModel() {
+  static void parseModel() {
     modelInstance = Bpmn.readModelFromStream(TextAnnotationTest.class
       .getResourceAsStream("TextAnnotationTest.bpmn"));
   }
 
   @Test
-  public void testGetTextAnnotationsByType() {
+  void testGetTextAnnotationsByType() {
     Collection<TextAnnotation> textAnnotations = modelInstance.getModelElementsByType(TextAnnotation.class);
     assertThat(textAnnotations)
       .isNotNull()
@@ -63,7 +64,7 @@ public class TextAnnotationTest extends BpmnModelElementInstanceTest {
   }
 
   @Test
-  public void testGetTextAnnotationById() {
+  void testGetTextAnnotationById() {
     TextAnnotation textAnnotation = modelInstance.getModelElementById("textAnnotation2");
     assertThat(textAnnotation).isNotNull();
     assertThat(textAnnotation.getTextFormat()).isEqualTo("text/plain");
@@ -72,7 +73,7 @@ public class TextAnnotationTest extends BpmnModelElementInstanceTest {
   }
 
   @Test
-  public void testTextAnnotationAsAssociationSource() {
+  void testTextAnnotationAsAssociationSource() {
     Association association = modelInstance.getModelElementById("Association_1");
     BaseElement source = association.getSource();
     assertThat(source).isInstanceOf(TextAnnotation.class);
@@ -80,7 +81,7 @@ public class TextAnnotationTest extends BpmnModelElementInstanceTest {
   }
 
   @Test
-  public void testTextAnnotationAsAssociationTarget() {
+  void testTextAnnotationAsAssociationTarget() {
     Association association = modelInstance.getModelElementById("Association_2");
     BaseElement target = association.getTarget();
     assertThat(target).isInstanceOf(TextAnnotation.class);

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TimerEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TimerEventDefinitionTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TimerEventDefinitionTest extends AbstractEventDefinitionTest {
+class TimerEventDefinitionTest extends AbstractEventDefinitionTest {
 
   public Collection<ChildElementAssumption> getChildElementAssumptions() {
     return Arrays.asList(
@@ -35,7 +35,7 @@ public class TimerEventDefinitionTest extends AbstractEventDefinitionTest {
   }
 
   @Test
-  public void getElementDefinition() {
+  void getElementDefinition() {
     List<TimerEventDefinition> eventDefinitions = eventDefinitionQuery.filterByType(TimerEventDefinition.class).list();
     assertThat(eventDefinitions).hasSize(3);
     for (TimerEventDefinition eventDefinition : eventDefinitions) {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TransactionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TransactionTest.java
@@ -60,7 +60,7 @@ public class TransactionTest extends BpmnModelElementInstanceTest {
   }
 
   @Test
-  public void shouldReadTransaction() {
+  void shouldReadTransaction() {
     InputStream inputStream = ReflectUtil.getResourceAsStream("org/operaton/bpm/model/bpmn/TransactionTest.xml");
     Transaction transaction = Bpmn.readModelFromStream(inputStream).getModelElementById("transaction");
 
@@ -70,7 +70,7 @@ public class TransactionTest extends BpmnModelElementInstanceTest {
   }
 
   @Test
-  public void shouldWriteTransaction() throws ParserConfigurationException, SAXException, IOException {
+  void shouldWriteTransaction() throws ParserConfigurationException, SAXException, IOException {
     // given a model
     BpmnModelInstance newModel = Bpmn.createProcess("process").done();
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/CompatabilityTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/CompatabilityTest.java
@@ -38,10 +38,10 @@ import org.operaton.bpm.model.bpmn.instance.ExtensionElements;
  * @author Ronny Bräunlich
  *
  */
-public class CompatabilityTest {
+class CompatabilityTest {
 
   @Test
-  public void modifyingElementWithActivitiNsKeepsIt() {
+  void modifyingElementWithActivitiNsKeepsIt() {
     BpmnModelInstance modelInstance = Bpmn.readModelFromStream(OperatonExtensionsTest.class.getResourceAsStream("OperatonExtensionsCompatabilityTest.xml"));
     ProcessImpl process = modelInstance.getModelElementById(PROCESS_ID);
     ExtensionElements extensionElements = process.getExtensionElements();
@@ -56,7 +56,7 @@ public class CompatabilityTest {
   }
 
   @Test
-  public void modifyingAttributeWithActivitiNsKeepsIt() {
+  void modifyingAttributeWithActivitiNsKeepsIt() {
     BpmnModelInstance modelInstance = Bpmn.readModelFromStream(OperatonExtensionsTest.class.getResourceAsStream("OperatonExtensionsCompatabilityTest.xml"));
     ProcessImpl process = modelInstance.getModelElementById(PROCESS_ID);
     String priority = "9000";

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonInputParameterTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonInputParameterTest.java
@@ -46,7 +46,7 @@ public class OperatonInputParameterTest extends BpmnModelElementInstanceTest {
 
   @Disabled("Test ignored. CAM-9441: Bug fix needed")
   @Test
-  public void testIntputParameterScriptChildAssignment() {
+  void testIntputParameterScriptChildAssignment() {
     try {
       OperatonInputParameter inputParamElement = modelInstance.newInstance(OperatonInputParameter.class);
       inputParamElement.setOperatonName("aVariable");
@@ -63,7 +63,7 @@ public class OperatonInputParameterTest extends BpmnModelElementInstanceTest {
 
   @Disabled("Test ignored. CAM-9441: Bug fix needed")
   @Test
-  public void testInputParameterListChildAssignment() {
+  void testInputParameterListChildAssignment() {
     try {
       OperatonInputParameter inputParamElement = modelInstance.newInstance(OperatonInputParameter.class);
       inputParamElement.setOperatonName("aVariable");
@@ -78,7 +78,7 @@ public class OperatonInputParameterTest extends BpmnModelElementInstanceTest {
 
   @Disabled("Test ignored. CAM-9441: Bug fix needed")
   @Test
-  public void testInputParameterMapChildAssignment() {
+  void testInputParameterMapChildAssignment() {
     try {
       OperatonInputParameter inputParamElement = modelInstance.newInstance(OperatonInputParameter.class);
       inputParamElement.setOperatonName("aVariable");

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonListTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonListTest.java
@@ -40,7 +40,7 @@ public class OperatonListTest extends BpmnModelElementInstanceTest {
 
   @Disabled("Test ignored. CAM-9441: Bug fix needed")
   @Test
-  public void testListValueChildAssignment() {
+  void testListValueChildAssignment() {
     try {
       OperatonList listElement = modelInstance.newInstance(OperatonList.class);
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonOutputParameterTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonOutputParameterTest.java
@@ -46,7 +46,7 @@ public class OperatonOutputParameterTest extends BpmnModelElementInstanceTest {
 
   @Disabled("Test ignored. CAM-9441: Bug fix needed")
   @Test
-  public void testOutputParameterScriptChildAssignment() {
+  void testOutputParameterScriptChildAssignment() {
     try {
       OperatonOutputParameter outputParamElement = modelInstance.newInstance(OperatonOutputParameter.class);
       outputParamElement.setOperatonName("aVariable");
@@ -63,7 +63,7 @@ public class OperatonOutputParameterTest extends BpmnModelElementInstanceTest {
 
   @Disabled("Test ignored. CAM-9441: Bug fix needed")
   @Test
-  public void testOutputParameterListChildAssignment() {
+  void testOutputParameterListChildAssignment() {
     try {
       OperatonOutputParameter outputParamElement = modelInstance.newInstance(OperatonOutputParameter.class);
       outputParamElement.setOperatonName("aVariable");
@@ -78,7 +78,7 @@ public class OperatonOutputParameterTest extends BpmnModelElementInstanceTest {
 
   @Disabled("Test ignored. CAM-9441: Bug fix needed")
   @Test
-  public void testOutputParameterMapChildAssignment() {
+  void testOutputParameterMapChildAssignment() {
     try {
       OperatonOutputParameter outputParamElement = modelInstance.newInstance(OperatonOutputParameter.class);
       outputParamElement.setOperatonName("aVariable");

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/validation/ValidateProcessTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/validation/ValidateProcessTest.java
@@ -36,10 +36,10 @@ import static org.assertj.core.api.Assertions.*;
  * @author Daniel Meyer
  *
  */
-public class ValidateProcessTest {
+class ValidateProcessTest {
 
   @Test
-  public void validationFailsIfNoStartEventFound() {
+  void validationFailsIfNoStartEventFound() {
 
     List<ModelElementValidator<?>> validators = new ArrayList<ModelElementValidator<?>>();
     validators.add(new ProcessStartEventValidator());

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnModelInstanceTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnModelInstanceTest.java
@@ -24,10 +24,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Filip Hrisafov
  */
-public class CmmnModelInstanceTest {
+class CmmnModelInstanceTest {
 
   @Test
-  public void testClone() throws Exception {
+  void testClone() throws Exception {
 
     CmmnModelInstance modelInstance = Cmmn.createEmptyModel();
 

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnTest.java
@@ -24,10 +24,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Roman Smirnov
  *
  */
-public class CmmnTest {
+class CmmnTest {
 
   @Test
-  public void testCmmn() {
+  void testCmmn() {
     assertThat(Cmmn.INSTANCE).isNotNull();
   }
 

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CreateModelTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CreateModelTest.java
@@ -36,7 +36,7 @@ public class CreateModelTest {
   public Process process;
 
   @BeforeEach
-  public void createEmptyModel() {
+  void createEmptyModel() {
     modelInstance = Cmmn.createEmptyModel();
     definitions = modelInstance.newInstance(Definitions.class);
     definitions.setTargetNamespace("http://operaton.org/examples");
@@ -51,7 +51,7 @@ public class CreateModelTest {
   }
 
   @Test
-  public void createCaseWithOneHumanTask() {
+  void createCaseWithOneHumanTask() {
     // create process
     Case caseInstance = createElement(definitions, "case-with-one-human-task", Case.class);
 
@@ -69,7 +69,7 @@ public class CreateModelTest {
   }
 
   @Test
-  public void createCaseWithOneStageAndNestedHumanTask() {
+  void createCaseWithOneStageAndNestedHumanTask() {
     // create process
     Case caseInstance = createElement(definitions, "case-with-one-human-task", Case.class);
 
@@ -90,7 +90,7 @@ public class CreateModelTest {
   }
 
   @AfterEach
-  public void validateModel() {
+  void validateModel() {
     Cmmn.validateModel(modelInstance);
   }
 

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/GenerateIdTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/GenerateIdTest.java
@@ -28,10 +28,10 @@ import org.operaton.bpm.model.cmmn.instance.DefaultControl;
 import org.operaton.bpm.model.cmmn.instance.Definitions;
 import org.operaton.bpm.model.cmmn.instance.HumanTask;
 
-public class GenerateIdTest {
+class GenerateIdTest {
 
   @Test
-  public void shouldNotGenerateIdsOnRead() {
+  void shouldNotGenerateIdsOnRead() {
     CmmnModelInstance modelInstance = Cmmn.readModelFromStream(GenerateIdTest.class.getResourceAsStream("GenerateIdTest.cmmn"));
     Definitions definitions = modelInstance.getDefinitions();
     assertThat(definitions.getId()).isNull();
@@ -47,7 +47,7 @@ public class GenerateIdTest {
   }
 
   @Test
-  public void shouldGenerateIdsOnCreate() {
+  void shouldGenerateIdsOnCreate() {
     CmmnModelInstance modelInstance = Cmmn.createEmptyModel();
     Definitions definitions = modelInstance.newInstance(Definitions.class);
     assertThat(definitions.getId()).isNotNull();

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/SimpleTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/SimpleTest.java
@@ -33,11 +33,11 @@ import org.operaton.bpm.model.xml.instance.ModelElementInstance;
  * @author Roman Smirnov
  *
  */
-public class SimpleTest extends CmmnModelTest {
+class SimpleTest extends CmmnModelTest {
 
   @Test
   @CmmnModelResource
-  public void shouldGetElements() {
+  void shouldGetElements() {
 
     ModelElementInstance modelElementById = cmmnModelInstance.getModelElementById("Case_1");
     assertThat(modelElementById).isNotNull();

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn10/Cmmn10Test.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn10/Cmmn10Test.java
@@ -50,10 +50,10 @@ import org.operaton.bpm.model.cmmn.instance.UserEvent;
  * @author Roman Smirnov
  *
  */
-public class Cmmn10Test {
+class Cmmn10Test {
 
   @Test
-  public void shouldGetCasePlanModelExitCriterion() {
+  void shouldGetCasePlanModelExitCriterion() {
     CmmnModelInstance modelInstance = getCmmnModelInstance();
     CasePlanModel casePlanModel = modelInstance.getModelElementsByType(CasePlanModel.class).iterator().next();
 
@@ -68,7 +68,7 @@ public class Cmmn10Test {
   }
 
   @Test
-  public void shouldGetPlanItemExitCriterion() {
+  void shouldGetPlanItemExitCriterion() {
     CmmnModelInstance modelInstance = getCmmnModelInstance();
     PlanItem planItem = modelInstance.getModelElementsByType(PlanItem.class).iterator().next();
 
@@ -83,7 +83,7 @@ public class Cmmn10Test {
   }
 
   @Test
-  public void shouldGetPlanItemEntryCriterion() {
+  void shouldGetPlanItemEntryCriterion() {
     CmmnModelInstance modelInstance = getCmmnModelInstance();
     PlanItem planItem = modelInstance.getModelElementsByType(PlanItem.class).iterator().next();
 
@@ -98,7 +98,7 @@ public class Cmmn10Test {
   }
 
   @Test
-  public void shouldGetTaskInputsOutputs() {
+  void shouldGetTaskInputsOutputs() {
     CmmnModelInstance modelInstance = getCmmnModelInstance();
     HumanTask humanTask = modelInstance.getModelElementsByType(HumanTask.class).iterator().next();
 
@@ -116,7 +116,7 @@ public class Cmmn10Test {
   }
 
   @Test
-  public void shouldGetEvents() {
+  void shouldGetEvents() {
     CmmnModelInstance modelInstance = getCmmnModelInstance();
 
     Event event = modelInstance.getModelElementsByType(Event.class).iterator().next();
@@ -130,7 +130,7 @@ public class Cmmn10Test {
   }
 
   @Test
-  public void shouldGetDescription() {
+  void shouldGetDescription() {
     CmmnModelInstance modelInstance = getCmmnModelInstance();
     CasePlanModel casePlanModel = modelInstance.getModelElementsByType(CasePlanModel.class).iterator().next();
 
@@ -142,7 +142,7 @@ public class Cmmn10Test {
   }
 
   @Test
-  public void shouldGetMultipleIfPartConditions() {
+  void shouldGetMultipleIfPartConditions() {
     CmmnModelInstance modelInstance = getCmmnModelInstance();
     Sentry sentry = modelInstance.getModelElementsByType(Sentry.class).iterator().next();
 
@@ -157,7 +157,7 @@ public class Cmmn10Test {
   }
 
   @Test
-  public void shouldGetCaseRoles() {
+  void shouldGetCaseRoles() {
     CmmnModelInstance modelInstance = getCmmnModelInstance();
     Case _case = modelInstance.getModelElementsByType(Case.class).iterator().next();
 
@@ -169,7 +169,7 @@ public class Cmmn10Test {
   }
 
   @Test
-  public void shouldGetExpressionTextContent() {
+  void shouldGetExpressionTextContent() {
     CmmnModelInstance modelInstance = getCmmnModelInstance();
     ConditionExpression expression = modelInstance.getModelElementsByType(ConditionExpression.class).iterator().next();
 
@@ -178,7 +178,7 @@ public class Cmmn10Test {
   }
 
   @Test
-  public void shouldNotAbleToAddNewElement() {
+  void shouldNotAbleToAddNewElement() {
     CmmnModelInstance modelInstance = getCmmnModelInstance();
     CasePlanModel casePlanModel = modelInstance.getModelElementsByType(CasePlanModel.class).iterator().next();
 
@@ -195,7 +195,7 @@ public class Cmmn10Test {
   }
 
   @Test
-  public void shouldReturnCmmn11Namespace() {
+  void shouldReturnCmmn11Namespace() {
     CmmnModelInstance modelInstance = getCmmnModelInstance();
     CasePlanModel casePlanModel = modelInstance.getModelElementsByType(CasePlanModel.class).iterator().next();
 
@@ -203,7 +203,7 @@ public class Cmmn10Test {
   }
 
   @Test
-  public void shouldNotAbleToAddCmmn10Element() {
+  void shouldNotAbleToAddCmmn10Element() {
     CmmnModelInstance modelInstance = Cmmn.readModelFromStream(Cmmn10Test.class.getResourceAsStream("Cmmn11Test.cmmn"));
     CasePlanModel casePlanModel = modelInstance.getModelElementsByType(CasePlanModel.class).iterator().next();
 

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnDiTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnDiTest.java
@@ -18,10 +18,10 @@ package org.operaton.bpm.model.dmn;
 
 import org.junit.jupiter.api.Test;
 
-public class DmnDiTest {
+class DmnDiTest {
 
   @Test
-  public void validateDmnWithOperatonDi() {
+  void validateDmnWithOperatonDi() {
 
     DmnModelInstance modelInstance = Dmn.readModelFromStream(DmnDiTest.class.getResourceAsStream("ExampleWithOperatonDI.dmn"));
 

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnModelInstanceTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnModelInstanceTest.java
@@ -25,10 +25,10 @@ import org.operaton.bpm.model.dmn.instance.Definitions;
 /**
  * @author Filip Hrisafov
  */
-public class DmnModelInstanceTest {
+class DmnModelInstanceTest {
 
   @Test
-  public void testClone() throws Exception {
+  void testClone() throws Exception {
 
     DmnModelInstance modelInstance = Dmn.createEmptyModel();
 
@@ -44,7 +44,7 @@ public class DmnModelInstanceTest {
   }
 
   @Test
-  public void shouldExportDmnDiagramWithLatestDmnNamespace() {
+  void shouldExportDmnDiagramWithLatestDmnNamespace() {
     // given
     DmnModelInstance modelInstance = Dmn.createEmptyModel();
     Definitions definitions = modelInstance.newInstance(Definitions.class);

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnTest.java
@@ -20,10 +20,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DmnTest {
+class DmnTest {
 
   @Test
-  public void testDmn() {
+  void testDmn() {
     assertThat(Dmn.INSTANCE).isNotNull();
   }
 

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnWriterTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnWriterTest.java
@@ -24,7 +24,7 @@ import org.operaton.bpm.model.dmn.instance.DecisionTable;
 import org.operaton.bpm.model.dmn.instance.InputEntry;
 import org.operaton.bpm.model.dmn.instance.Rule;
 
-public class DmnWriterTest extends DmnModelTest {
+class DmnWriterTest extends DmnModelTest {
 
   /**
    * <p>There is an issue in JDK 9+ that changes how CDATA section are serialized:
@@ -57,7 +57,7 @@ public class DmnWriterTest extends DmnModelTest {
    * and the text content method returns the CDATA value only
    */
   @Test
-  public void shouldReadJDK9StyleModel()
+  void shouldReadJDK9StyleModel()
   {
     DmnModelInstance modelInstance =
         Dmn.readModelFromStream(ExampleCompatibilityTest.class.getResourceAsStream("JDK9-style-CDATA.dmn"));

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ExampleCompatibilityTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ExampleCompatibilityTest.java
@@ -73,7 +73,7 @@ public class ExampleCompatibilityTest extends DmnModelTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void shouldGetElements(DmnModelInstance originalModelInstance) {
+  void shouldGetElements(DmnModelInstance originalModelInstance) {
 
     initExampleCompatibilityTest(originalModelInstance);
 
@@ -216,7 +216,7 @@ public class ExampleCompatibilityTest extends DmnModelTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void shouldWriteElements(DmnModelInstance originalModelInstance) throws Exception {
+  void shouldWriteElements(DmnModelInstance originalModelInstance) throws Exception {
     initExampleCompatibilityTest(originalModelInstance);
     modelInstance = Dmn.createEmptyModel();
 

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ExpressionLanguageTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ExpressionLanguageTest.java
@@ -41,7 +41,7 @@ public class ExpressionLanguageTest extends DmnModelTest {
 
   @Test
   @DmnModelResource(resource = EXPRESSION_LANGUAGE_DMN)
-  public void shouldReadExpressionLanguage() {
+  void shouldReadExpressionLanguage() {
     Definitions definitions = modelInstance.getDefinitions();
     assertThat(definitions.getExpressionLanguage()).isEqualTo(EXPRESSION_LANGUAGE);
 
@@ -60,7 +60,7 @@ public class ExpressionLanguageTest extends DmnModelTest {
   }
 
   @Test
-  public void shouldWriteExpressionLanguage() throws Exception {
+  void shouldWriteExpressionLanguage() throws Exception {
     modelInstance = Dmn.createEmptyModel();
     Definitions definitions = generateNamedElement(Definitions.class, "definitions");
     definitions.setNamespace(TEST_NAMESPACE);

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/GenerateIdTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/GenerateIdTest.java
@@ -24,10 +24,10 @@ import org.operaton.bpm.model.dmn.instance.DecisionTable;
 import org.operaton.bpm.model.dmn.instance.Definitions;
 import org.operaton.bpm.model.dmn.instance.Output;
 
-public class GenerateIdTest {
+class GenerateIdTest {
 
   @Test
-  public void shouldNotGenerateIdsOnRead() {
+  void shouldNotGenerateIdsOnRead() {
     DmnModelInstance modelInstance = Dmn.readModelFromStream(GenerateIdTest.class.getResourceAsStream("GenerateIdTest.dmn"));
     Definitions definitions = modelInstance.getDefinitions();
     assertThat(definitions.getId()).isNull();
@@ -43,7 +43,7 @@ public class GenerateIdTest {
   }
 
   @Test
-  public void shouldGenerateIdsOnCreate() {
+  void shouldGenerateIdsOnCreate() {
     DmnModelInstance modelInstance = Dmn.createEmptyModel();
     Definitions definitions = modelInstance.newInstance(Definitions.class);
     assertThat(definitions.getId()).isNotNull();

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/OperatonExtensionsTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/OperatonExtensionsTest.java
@@ -47,7 +47,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonClauseOutput(DmnModelInstance originalModelInstance) {
+  void testOperatonClauseOutput(DmnModelInstance originalModelInstance) {
     initOperatonExtensionsTest(originalModelInstance);
     Input input = modelInstance.getModelElementById("input");
     assertThat(input.getOperatonInputVariable()).isEqualTo("myVariable");
@@ -57,7 +57,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonHistoryTimeToLive(DmnModelInstance originalModelInstance) {
+  void testOperatonHistoryTimeToLive(DmnModelInstance originalModelInstance) {
     initOperatonExtensionsTest(originalModelInstance);
     Decision decision = modelInstance.getModelElementById("decision");
     assertThat(decision.getOperatonHistoryTimeToLive()).isEqualTo(5);
@@ -67,7 +67,7 @@ public class OperatonExtensionsTest {
 
   @MethodSource("parameters")
   @ParameterizedTest(name = "Namespace: {0}")
-  public void testOperatonVersionTag(DmnModelInstance originalModelInstance) {
+  void testOperatonVersionTag(DmnModelInstance originalModelInstance) {
     initOperatonExtensionsTest(originalModelInstance);
     Decision decision = modelInstance.getModelElementById("decision");
     assertThat(decision.getVersionTag()).isEqualTo("1.0.0");
@@ -76,7 +76,7 @@ public class OperatonExtensionsTest {
   }
 
   @AfterEach
-  public void validateModel() {
+  void validateModel() {
     Dmn.validateModel(modelInstance);
   }
 

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ReadWriteTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ReadWriteTest.java
@@ -43,7 +43,7 @@ public class ReadWriteTest extends DmnModelTest {
 
   @Test
   @DmnModelResource(resource = DECISION_TABLE_ORIENTATION_DMN)
-  public void shouldReadDecisionTableOrientation() {
+  void shouldReadDecisionTableOrientation() {
     // Default
     DecisionTable decisionTable = modelInstance.getModelElementById("decisionTable1");
     assertThat(decisionTable.getPreferredOrientation()).isEqualTo(Rule_as_Row);
@@ -62,7 +62,7 @@ public class ReadWriteTest extends DmnModelTest {
   }
 
   @Test
-  public void shouldWriteDecisionTableOrientation() throws Exception {
+  void shouldWriteDecisionTableOrientation() throws Exception {
     modelInstance = Dmn.createEmptyModel();
     Definitions definitions = generateNamedElement(Definitions.class, "definitions");
     definitions.setNamespace(TEST_NAMESPACE);
@@ -108,7 +108,7 @@ public class ReadWriteTest extends DmnModelTest {
 
   @Test
   @DmnModelResource(resource = HIT_POLICY_DMN)
-  public void shouldReadHitPolicy() {
+  void shouldReadHitPolicy() {
     // Default
     DecisionTable decisionTable = modelInstance.getModelElementById("decisionTable1");
     assertThat(decisionTable.getHitPolicy()).isEqualTo(UNIQUE);
@@ -144,7 +144,7 @@ public class ReadWriteTest extends DmnModelTest {
   }
 
   @Test
-  public void shouldWriteHitPolicy() throws Exception {
+  void shouldWriteHitPolicy() throws Exception {
     modelInstance = Dmn.createEmptyModel();
     Definitions definitions = generateNamedElement(Definitions.class, "definitions");
     definitions.setNamespace(TEST_NAMESPACE);
@@ -227,7 +227,7 @@ public class ReadWriteTest extends DmnModelTest {
 
   @Test
   @DmnModelResource(resource = INPUT_DATA_DMN)
-  public void shouldReadInputData() {
+  void shouldReadInputData() {
 
     Collection<InputData> inputDataCollection = modelInstance.getModelElementsByType(InputData.class);
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/ModelTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/ModelTest.java
@@ -29,17 +29,17 @@ import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.*;
 /**
  * @author Sebastian Menski
  */
-public class ModelTest {
+class ModelTest {
 
   private Model model;
 
   @BeforeEach
-  public void createModel() {
+  void createModel() {
     model = TestModel.getTestModel();
   }
 
   @Test
-  public void testGetTypes() {
+  void testGetTypes() {
     Collection<ModelElementType> types = model.getTypes();
     assertThat(types).isNotEmpty();
     assertThat(types).contains(
@@ -52,13 +52,13 @@ public class ModelTest {
   }
 
   @Test
-  public void testGetType() {
+  void testGetType() {
     ModelElementType flyingAnimalType = model.getType(FlyingAnimal.class);
     assertThat(flyingAnimalType.getInstanceType()).isEqualTo(FlyingAnimal.class);
   }
 
   @Test
-  public void testGetTypeForName() {
+  void testGetTypeForName() {
     ModelElementType birdType = model.getTypeForName(ELEMENT_NAME_BIRD);
     assertThat(birdType).isNull();
     birdType = model.getTypeForName(MODEL_NAMESPACE, ELEMENT_NAME_BIRD);
@@ -66,12 +66,12 @@ public class ModelTest {
   }
 
   @Test
-  public void testGetModelName() {
+  void testGetModelName() {
     assertThat(model.getModelName()).isEqualTo(MODEL_NAME);
   }
 
   @Test
-  public void testEqual() {
+  void testEqual() {
     assertThat(model).isNotEqualTo(null);
     assertThat(model).isNotEqualTo(new Object());
     Model otherModel = ModelBuilder.createInstance("Other Model").build();

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/StringUtilTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/StringUtilTest.java
@@ -28,10 +28,10 @@ import static org.operaton.bpm.model.xml.impl.util.StringUtil.splitCommaSeparate
 /**
  * @author Sebastian Menski
  */
-public class StringUtilTest {
+class StringUtilTest {
 
   @Test
-  public void testStringListSplit() {
+  void testStringListSplit() {
     assertThat(splitCommaSeparatedList("")).isEmpty();
     assertThat(splitCommaSeparatedList("  ")).isEmpty();
     assertThat(splitCommaSeparatedList("a")).containsExactly("a");
@@ -49,7 +49,7 @@ public class StringUtilTest {
   }
 
   @Test
-  public void testStringListJoin() {
+  void testStringListJoin() {
     assertThat(joinCommaSeparatedList(null)).isNull();
     List<String> testList = new ArrayList<String>();
     assertThat(joinCommaSeparatedList(testList)).isEqualTo("");
@@ -68,12 +68,12 @@ public class StringUtilTest {
   }
 
   @Test
-  public void testNullSplit() {
+  void testNullSplit() {
     assertThat(splitCommaSeparatedList(null)).isEmpty();
   }
 
   @Test
-  public void testNullJoin() {
+  void testNullJoin() {
     assertThat(joinCommaSeparatedList(null)).isNull();
   }
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/impl/parser/ParserTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/impl/parser/ParserTest.java
@@ -27,12 +27,12 @@ import java.io.InputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ParserTest {
+class ParserTest {
 
   private static final String ACCESS_EXTERNAL_SCHEMA_PROP = "javax.xml.accessExternalSchema";
 
   @Test
-  public void shouldThrowExceptionForTooManyAttributes() {
+  void shouldThrowExceptionForTooManyAttributes() {
     TestModelParser modelParser = new TestModelParser();
     String testXml = "org/operaton/bpm/model/xml/impl/parser/FeatureSecureProcessing.xml";
     InputStream testXmlAsStream = this.getClass().getClassLoader().getResourceAsStream(testXml);
@@ -45,7 +45,7 @@ public class ParserTest {
   }
 
   @Test
-  public void shouldProhibitExternalSchemaAccessViaSystemProperty() {
+  void shouldProhibitExternalSchemaAccessViaSystemProperty() {
     Assertions.assertThatThrownBy(() -> {
       // given
       // the external schema access property is not supported on certain
@@ -71,7 +71,7 @@ public class ParserTest {
   }
 
   @Test
-  public void shouldAllowExternalSchemaAccessViaSystemProperty() {
+  void shouldAllowExternalSchemaAccessViaSystemProperty() {
     // given
     System.setProperty(ACCESS_EXTERNAL_SCHEMA_PROP, "all");
 
@@ -91,7 +91,7 @@ public class ParserTest {
   }
 
   @Test
-  public void shouldThrowExceptionForDoctype() {
+  void shouldThrowExceptionForDoctype() {
     TestModelParser modelParser = new TestModelParser();
     String testXml = "org/operaton/bpm/model/xml/impl/parser/XxeProcessing.xml";
     InputStream testXmlAsStream = this.getClass().getClassLoader().getResourceAsStream(testXml);

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/ModelBuilderTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/ModelBuilderTest.java
@@ -27,10 +27,10 @@ import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAME
  * @author Daniel Meyer
  *
  */
-public class ModelBuilderTest {
+class ModelBuilderTest {
 
   @Test
-  public void shouldSetModelName() {
+  void shouldSetModelName() {
     Model model = ModelBuilder.createInstance(MODEL_NAME)
       .build();
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelInstanceTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelInstanceTest.java
@@ -24,10 +24,10 @@ import org.operaton.bpm.model.xml.testmodel.instance.Animal;
 import org.operaton.bpm.model.xml.testmodel.instance.Animals;
 import org.operaton.bpm.model.xml.testmodel.instance.Bird;
 
-public class TestModelInstanceTest {
+class TestModelInstanceTest {
 
   @Test
-  public void testClone() throws Exception {
+  void testClone() throws Exception {
     ModelInstance modelInstance = new TestModelParser().getEmptyModel();
 
     Animals animals = modelInstance.newInstance(Animals.class);

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
@@ -61,7 +61,7 @@ public class AlternativeNsTest extends TestModelTest {
   }
 
   @AfterEach
-  public void tearDown() {
+  void tearDown() {
     if (modelInstance != null) {
       ModelImpl modelImpl = (ModelImpl) modelInstance.getModel();
       modelImpl.undeclareAlternativeNamespace(MECHANICAL_NS);
@@ -147,7 +147,7 @@ public class AlternativeNsTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void modifyingAttributeWithAlternativeNamespaceKeepsAlternativeNamespace(TestModelArgs args) {
+  void modifyingAttributeWithAlternativeNamespaceKeepsAlternativeNamespace(TestModelArgs args) {
     init(args);
     Bird plucky = modelInstance.getModelElementById("plucky");
     assertThat(plucky).isNotNull();
@@ -162,7 +162,7 @@ public class AlternativeNsTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void modifyingAttributeWithSecondAlternativeNamespaceKeepsSecondAlternativeNamespace(TestModelArgs args) {
+  void modifyingAttributeWithSecondAlternativeNamespaceKeepsSecondAlternativeNamespace(TestModelArgs args) {
     init(args);
     // given
     Bird donald = modelInstance.getModelElementById("donald");
@@ -177,7 +177,7 @@ public class AlternativeNsTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void modifyingAttributeWithNewNamespaceKeepsNewNamespace(TestModelArgs args) {
+  void modifyingAttributeWithNewNamespaceKeepsNewNamespace(TestModelArgs args) {
     init(args);
     Bird bird = createBird(modelInstance, "waldo", Gender.Male);
     bird.setCanHazExtendedWings(true);
@@ -187,7 +187,7 @@ public class AlternativeNsTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void modifyingElementWithAlternativeNamespaceKeepsAlternativeNamespace(TestModelArgs args) {
+  void modifyingElementWithAlternativeNamespaceKeepsAlternativeNamespace(TestModelArgs args) {
     init(args);
     Bird birdo = modelInstance.getModelElementById("birdo");
     assertThat(birdo).isNotNull();
@@ -202,7 +202,7 @@ public class AlternativeNsTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void modifyingElementWithSecondAlternativeNamespaceKeepsSecondAlternativeNamespace(TestModelArgs args) {
+  void modifyingElementWithSecondAlternativeNamespaceKeepsSecondAlternativeNamespace(TestModelArgs args) {
     init(args);
     // given
     Bird donald = modelInstance.getModelElementById("donald");
@@ -219,7 +219,7 @@ public class AlternativeNsTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void modifyingElementWithNewNamespaceKeepsNewNamespace(TestModelArgs args) {
+  void modifyingElementWithNewNamespaceKeepsNewNamespace(TestModelArgs args) {
     init(args);
     Bird bird = createBird(modelInstance, "waldo", Gender.Male);
     bird.setWings(modelInstance.newInstance(Wings.class));

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AnimalTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AnimalTest.java
@@ -119,7 +119,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetIdAttributeByHelper(TestModelArgs args) {
+  void testSetIdAttributeByHelper(TestModelArgs args) {
     init(args);
     String newId = "new-" + tweety.getId();
     tweety.setId(newId);
@@ -128,7 +128,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetIdAttributeByAttributeName(TestModelArgs args) {
+  void testSetIdAttributeByAttributeName(TestModelArgs args) {
     init(args);
     tweety.setAttributeValue("id", "duffy", true);
     assertThat(tweety.getId()).isEqualTo("duffy");
@@ -136,7 +136,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testRemoveIdAttribute(TestModelArgs args) {
+  void testRemoveIdAttribute(TestModelArgs args) {
     init(args);
     tweety.removeAttribute("id");
     assertThat(tweety.getId()).isNull();
@@ -144,7 +144,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetNameAttributeByHelper(TestModelArgs args) {
+  void testSetNameAttributeByHelper(TestModelArgs args) {
     init(args);
     tweety.setName("tweety");
     assertThat(tweety.getName()).isEqualTo("tweety");
@@ -152,7 +152,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetNameAttributeByAttributeName(TestModelArgs args) {
+  void testSetNameAttributeByAttributeName(TestModelArgs args) {
     init(args);
     tweety.setAttributeValue("name", "daisy");
     assertThat(tweety.getName()).isEqualTo("daisy");
@@ -160,7 +160,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testRemoveNameAttribute(TestModelArgs args) {
+  void testRemoveNameAttribute(TestModelArgs args) {
     init(args);
     tweety.removeAttribute("name");
     assertThat(tweety.getName()).isNull();
@@ -168,7 +168,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetFatherAttributeByHelper(TestModelArgs args) {
+  void testSetFatherAttributeByHelper(TestModelArgs args) {
     init(args);
     tweety.setFather(timmy);
     assertThat(tweety.getFather()).isEqualTo(timmy);
@@ -176,7 +176,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetFatherAttributeByAttributeName(TestModelArgs args) {
+  void testSetFatherAttributeByAttributeName(TestModelArgs args) {
     init(args);
     tweety.setAttributeValue("father", timmy.getId());
     assertThat(tweety.getFather()).isEqualTo(timmy);
@@ -184,7 +184,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetFatherAttributeByAttributeNameWithNamespace(TestModelArgs args) {
+  void testSetFatherAttributeByAttributeNameWithNamespace(TestModelArgs args) {
     init(args);
     tweety.setAttributeValue("father", "tns:hedwig");
     assertThat(tweety.getFather()).isEqualTo(hedwig);
@@ -192,7 +192,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testRemoveFatherAttribute(TestModelArgs args) {
+  void testRemoveFatherAttribute(TestModelArgs args) {
     init(args);
     tweety.setFather(timmy);
     assertThat(tweety.getFather()).isEqualTo(timmy);
@@ -202,7 +202,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testChangeIdAttributeOfFatherReference(TestModelArgs args) {
+  void testChangeIdAttributeOfFatherReference(TestModelArgs args) {
     init(args);
     tweety.setFather(timmy);
     assertThat(tweety.getFather()).isEqualTo(timmy);
@@ -212,7 +212,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testReplaceFatherReferenceWithNewAnimal(TestModelArgs args) {
+  void testReplaceFatherReferenceWithNewAnimal(TestModelArgs args) {
     init(args);
     tweety.setFather(timmy);
     assertThat(tweety.getFather()).isEqualTo(timmy);
@@ -222,7 +222,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetMotherAttributeByHelper(TestModelArgs args) {
+  void testSetMotherAttributeByHelper(TestModelArgs args) {
     init(args);
     tweety.setMother(daisy);
     assertThat(tweety.getMother()).isEqualTo(daisy);
@@ -230,7 +230,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetMotherAttributeByAttributeName(TestModelArgs args) {
+  void testSetMotherAttributeByAttributeName(TestModelArgs args) {
     init(args);
     tweety.setAttributeValue("mother", fiffy.getId());
     assertThat(tweety.getMother()).isEqualTo(fiffy);
@@ -238,7 +238,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testRemoveMotherAttribute(TestModelArgs args) {
+  void testRemoveMotherAttribute(TestModelArgs args) {
     init(args);
     tweety.setMother(daisy);
     assertThat(tweety.getMother()).isEqualTo(daisy);
@@ -248,7 +248,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testReplaceMotherReferenceWithNewAnimal(TestModelArgs args) {
+  void testReplaceMotherReferenceWithNewAnimal(TestModelArgs args) {
     init(args);
     tweety.setMother(daisy);
     assertThat(tweety.getMother()).isEqualTo(daisy);
@@ -258,7 +258,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testChangeIdAttributeOfMotherReference(TestModelArgs args) {
+  void testChangeIdAttributeOfMotherReference(TestModelArgs args) {
     init(args);
     tweety.setMother(daisy);
     assertThat(tweety.getMother()).isEqualTo(daisy);
@@ -268,7 +268,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetIsEndangeredAttributeByHelper(TestModelArgs args) {
+  void testSetIsEndangeredAttributeByHelper(TestModelArgs args) {
     init(args);
     tweety.setIsEndangered(true);
     assertThat(tweety.isEndangered()).isTrue();
@@ -276,7 +276,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetIsEndangeredAttributeByAttributeName(TestModelArgs args) {
+  void testSetIsEndangeredAttributeByAttributeName(TestModelArgs args) {
     init(args);
     tweety.setAttributeValue("isEndangered", "false");
     assertThat(tweety.isEndangered()).isFalse();
@@ -284,7 +284,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testRemoveIsEndangeredAttribute(TestModelArgs args) {
+  void testRemoveIsEndangeredAttribute(TestModelArgs args) {
     init(args);
     tweety.removeAttribute("isEndangered");
     // default value of isEndangered: false
@@ -293,7 +293,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetGenderAttributeByHelper(TestModelArgs args) {
+  void testSetGenderAttributeByHelper(TestModelArgs args) {
     init(args);
     tweety.setGender(Gender.Male);
     assertThat(tweety.getGender()).isEqualTo(Gender.Male);
@@ -301,7 +301,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetGenderAttributeByAttributeName(TestModelArgs args) {
+  void testSetGenderAttributeByAttributeName(TestModelArgs args) {
     init(args);
     tweety.setAttributeValue("gender", Gender.Unknown.toString());
     assertThat(tweety.getGender()).isEqualTo(Gender.Unknown);
@@ -309,7 +309,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testRemoveGenderAttribute(TestModelArgs args) {
+  void testRemoveGenderAttribute(TestModelArgs args) {
     init(args);tweety.removeAttribute("gender");
     assertThat(tweety.getGender()).isNull();
 
@@ -328,7 +328,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetAgeAttributeByHelper(TestModelArgs args) {
+  void testSetAgeAttributeByHelper(TestModelArgs args) {
     init(args);
     tweety.setAge(13);
     assertThat(tweety.getAge()).isEqualTo(13);
@@ -336,7 +336,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetAgeAttributeByAttributeName(TestModelArgs args) {
+  void testSetAgeAttributeByAttributeName(TestModelArgs args) {
     init(args);
     tweety.setAttributeValue("age", "23");
     assertThat(tweety.getAge()).isEqualTo(23);
@@ -344,7 +344,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testRemoveAgeAttribute(TestModelArgs args) {
+  void testRemoveAgeAttribute(TestModelArgs args) {
     init(args);
     tweety.removeAttribute("age");
     assertThat(tweety.getAge()).isNull();
@@ -352,7 +352,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testAddRelationshipDefinitionsByHelper(TestModelArgs args) {
+  void testAddRelationshipDefinitionsByHelper(TestModelArgs args) {
     init(args);
     assertThat(tweety.getRelationshipDefinitions())
       .isNotEmpty()
@@ -369,7 +369,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateRelationshipDefinitionsByIdByHelper(TestModelArgs args) {
+  void testUpdateRelationshipDefinitionsByIdByHelper(TestModelArgs args) {
     init(args);
     hedwigRelationship.setId("new-" + hedwigRelationship.getId());
     pluckyRelationship.setId("new-" + pluckyRelationship.getId());
@@ -380,7 +380,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateRelationshipDefinitionsByIdByAttributeName(TestModelArgs args) {
+  void testUpdateRelationshipDefinitionsByIdByAttributeName(TestModelArgs args) {
     init(args);
     birdoRelationship.setAttributeValue("id", "new-" + birdoRelationship.getId(), true);
     fiffyRelationship.setAttributeValue("id", "new-" + fiffyRelationship.getId(), true);
@@ -391,7 +391,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateRelationshipDefinitionsByReplaceElements(TestModelArgs args) {
+  void testUpdateRelationshipDefinitionsByReplaceElements(TestModelArgs args) {
     init(args);
     hedwigRelationship.replaceWithElement(timmyRelationship);
     pluckyRelationship.replaceWithElement(daisyRelationship);
@@ -402,7 +402,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateRelationshipDefinitionsByRemoveElements(TestModelArgs args) {
+  void testUpdateRelationshipDefinitionsByRemoveElements(TestModelArgs args) {
     init(args);
     tweety.getRelationshipDefinitions().remove(birdoRelationship);
     tweety.getRelationshipDefinitions().remove(fiffyRelationship);
@@ -413,7 +413,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testClearRelationshipDefinitions(TestModelArgs args) {
+  void testClearRelationshipDefinitions(TestModelArgs args) {
     init(args);
     tweety.getRelationshipDefinitions().clear();
     assertThat(tweety.getRelationshipDefinitions()).isEmpty();
@@ -421,7 +421,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testAddRelationsDefinitionRefsByHelper(TestModelArgs args) {
+  void testAddRelationsDefinitionRefsByHelper(TestModelArgs args) {
     init(args);
     assertThat(tweety.getRelationshipDefinitionRefs())
       .isNotEmpty()
@@ -441,7 +441,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateRelationshipDefinitionRefsByIdByHelper(TestModelArgs args) {
+  void testUpdateRelationshipDefinitionRefsByIdByHelper(TestModelArgs args) {
     init(args);
     hedwigRelationship.setId("child-relationship");
     pluckyRelationship.setId("friend-relationship");
@@ -452,7 +452,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateRelationshipDefinitionRefsByIdByAttributeName(TestModelArgs args) {
+  void testUpdateRelationshipDefinitionRefsByIdByAttributeName(TestModelArgs args) {
     init(args);
     birdoRelationship.setAttributeValue("id", "birdo-relationship", true);
     fiffyRelationship.setAttributeValue("id", "fiffy-relationship", true);
@@ -463,7 +463,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateRelationshipDefinitionRefsByReplaceElements(TestModelArgs args) {
+  void testUpdateRelationshipDefinitionRefsByReplaceElements(TestModelArgs args) {
     init(args);
     hedwigRelationship.replaceWithElement(timmyRelationship);
     pluckyRelationship.replaceWithElement(daisyRelationship);
@@ -474,7 +474,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateRelationshipDefinitionRefsByRemoveElements(TestModelArgs args) {
+  void testUpdateRelationshipDefinitionRefsByRemoveElements(TestModelArgs args) {
     init(args);
     tweety.getRelationshipDefinitions().remove(birdoRelationship);
     tweety.getRelationshipDefinitions().remove(fiffyRelationship);
@@ -485,7 +485,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateRelationshipDefinitionRefsByRemoveIdAttribute(TestModelArgs args) {
+  void testUpdateRelationshipDefinitionRefsByRemoveIdAttribute(TestModelArgs args) {
     init(args);
     birdoRelationship.removeAttribute("id");
     pluckyRelationship.removeAttribute("id");
@@ -496,7 +496,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testClearRelationshipDefinitionsRefs(TestModelArgs args) {
+  void testClearRelationshipDefinitionsRefs(TestModelArgs args) {
     init(args);
     tweety.getRelationshipDefinitionRefs().clear();
     assertThat(tweety.getRelationshipDefinitionRefs()).isEmpty();
@@ -506,7 +506,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testClearRelationshipDefinitionRefsByClearRelationshipDefinitions(TestModelArgs args) {
+  void testClearRelationshipDefinitionRefsByClearRelationshipDefinitions(TestModelArgs args) {
     init(args);
     assertThat(tweety.getRelationshipDefinitionRefs()).isNotEmpty();
     tweety.getRelationshipDefinitions().clear();
@@ -517,7 +517,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testAddRelationshipDefinitionRefElementsByHelper(TestModelArgs args) {
+  void testAddRelationshipDefinitionRefElementsByHelper(TestModelArgs args) {
     init(args);
     assertThat(tweety.getRelationshipDefinitionRefElements())
       .isNotEmpty()
@@ -541,7 +541,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testRelationshipDefinitionRefElementsByTextContent(TestModelArgs args) {
+  void testRelationshipDefinitionRefElementsByTextContent(TestModelArgs args) {
     init(args);
     Collection<RelationshipDefinitionRef> relationshipDefinitionRefElements = tweety.getRelationshipDefinitionRefElements();
     Collection<String> textContents = new ArrayList<String>();
@@ -558,7 +558,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateRelationshipDefinitionRefElementsByTextContent(TestModelArgs args) {
+  void testUpdateRelationshipDefinitionRefElementsByTextContent(TestModelArgs args) {
     init(args);
     List<RelationshipDefinitionRef> relationshipDefinitionRefs = new ArrayList<RelationshipDefinitionRef>(tweety.getRelationshipDefinitionRefElements());
 
@@ -575,7 +575,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateRelationshipDefinitionRefElementsByTextContentWithNamespace(TestModelArgs args) {
+  void testUpdateRelationshipDefinitionRefElementsByTextContentWithNamespace(TestModelArgs args) {
     init(args);
     List<RelationshipDefinitionRef> relationshipDefinitionRefs = new ArrayList<RelationshipDefinitionRef>(tweety.getRelationshipDefinitionRefElements());
 
@@ -592,7 +592,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateRelationshipDefinitionRefElementsByRemoveElements(TestModelArgs args) {
+  void testUpdateRelationshipDefinitionRefElementsByRemoveElements(TestModelArgs args) {
     init(args);
     List<RelationshipDefinitionRef> relationshipDefinitionRefs = new ArrayList<RelationshipDefinitionRef>(tweety.getRelationshipDefinitionRefElements());
     tweety.getRelationshipDefinitionRefElements().remove(relationshipDefinitionRefs.get(1));
@@ -604,7 +604,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testClearRelationshipDefinitionRefElements(TestModelArgs args) {
+  void testClearRelationshipDefinitionRefElements(TestModelArgs args) {
     init(args);
     tweety.getRelationshipDefinitionRefElements().clear();
     assertThat(tweety.getRelationshipDefinitionRefElements()).isEmpty();
@@ -617,7 +617,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testClearRelationshipDefinitionRefElementsByClearRelationshipDefinitionRefs(TestModelArgs args) {
+  void testClearRelationshipDefinitionRefElementsByClearRelationshipDefinitionRefs(TestModelArgs args) {
     init(args);
     tweety.getRelationshipDefinitionRefs().clear();
     assertThat(tweety.getRelationshipDefinitionRefs()).isEmpty();
@@ -630,7 +630,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testClearRelationshipDefinitionRefElementsByClearRelationshipDefinitions(TestModelArgs args) {
+  void testClearRelationshipDefinitionRefElementsByClearRelationshipDefinitions(TestModelArgs args) {
     init(args);
     tweety.getRelationshipDefinitions().clear();
     assertThat(tweety.getRelationshipDefinitionRefs()).isEmpty();
@@ -641,7 +641,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testGetBestFriends(TestModelArgs args) {
+  void testGetBestFriends(TestModelArgs args) {
     init(args);
     Collection<Animal> bestFriends = tweety.getBestFriends();
 
@@ -653,7 +653,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testAddBestFriend(TestModelArgs args) {
+  void testAddBestFriend(TestModelArgs args) {
     init(args);
     tweety.getBestFriends().add(daisy);
 
@@ -667,7 +667,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testRemoveBestFriendRef(TestModelArgs args) {
+  void testRemoveBestFriendRef(TestModelArgs args) {
     init(args);
     tweety.getBestFriends().remove(plucky);
 
@@ -681,7 +681,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testClearBestFriendRef(TestModelArgs args) {
+  void testClearBestFriendRef(TestModelArgs args) {
     init(args);
     tweety.getBestFriends().clear();
 
@@ -693,7 +693,7 @@ public class AnimalTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testClearAndAddBestFriendRef(TestModelArgs args) {
+  void testClearAndAddBestFriendRef(TestModelArgs args) {
     init(args);
     tweety.getBestFriends().clear();
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/BirdTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/BirdTest.java
@@ -106,7 +106,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testAddEggsByHelper(TestModelArgs args) {
+  void testAddEggsByHelper(TestModelArgs args) {
     init(args);
     assertThat(tweety.getEggs()).isNotEmpty().hasSize(3).containsOnly(egg1, egg2, egg3);
 
@@ -120,7 +120,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateEggsByIdByHelper(TestModelArgs args) {
+  void testUpdateEggsByIdByHelper(TestModelArgs args) {
 
     init(args);
 
@@ -131,7 +131,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateEggsByIdByAttributeName(TestModelArgs args) {
+  void testUpdateEggsByIdByAttributeName(TestModelArgs args) {
     init(args);
     egg1.setAttributeValue("id", "new-" + egg1.getId(), true);
     egg2.setAttributeValue("id", "new-" + egg2.getId(), true);
@@ -140,7 +140,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateEggsByReplaceElements(TestModelArgs args) {
+  void testUpdateEggsByReplaceElements(TestModelArgs args) {
     init(args);
     Egg egg4 = createEgg(modelInstance, "egg4");
     Egg egg5 = createEgg(modelInstance, "egg5");
@@ -151,7 +151,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateEggsByRemoveElement(TestModelArgs args) {
+  void testUpdateEggsByRemoveElement(TestModelArgs args) {
 
     init(args);
 
@@ -161,7 +161,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testClearEggs(TestModelArgs args) {
+  void testClearEggs(TestModelArgs args) {
 
     init(args);
 
@@ -171,7 +171,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetSpouseRefByHelper(TestModelArgs args) {
+  void testSetSpouseRefByHelper(TestModelArgs args) {
 
     init(args);
 
@@ -181,7 +181,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateSpouseByIdHelper(TestModelArgs args) {
+  void testUpdateSpouseByIdHelper(TestModelArgs args) {
 
     init(args);
 
@@ -191,7 +191,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateSpouseByIdByAttributeName(TestModelArgs args) {
+  void testUpdateSpouseByIdByAttributeName(TestModelArgs args) {
 
     init(args);
 
@@ -201,7 +201,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateSpouseByReplaceElement(TestModelArgs args) {
+  void testUpdateSpouseByReplaceElement(TestModelArgs args) {
 
     init(args);
 
@@ -211,7 +211,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateSpouseByRemoveElement(TestModelArgs args) {
+  void testUpdateSpouseByRemoveElement(TestModelArgs args) {
     init(args);
     Animals animals = (Animals) modelInstance.getDocumentElement();
     animals.getAnimals().remove(hedwig);
@@ -220,7 +220,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testClearSpouse(TestModelArgs args) {
+  void testClearSpouse(TestModelArgs args) {
 
     init(args);
 
@@ -230,7 +230,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetSpouseRefsByHelper(TestModelArgs args) {
+  void testSetSpouseRefsByHelper(TestModelArgs args) {
     init(args);
     SpouseRef spouseRef = modelInstance.newInstance(SpouseRef.class);
     spouseRef.setTextContent(timmy.getId());
@@ -240,7 +240,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSpouseRefsByTextContent(TestModelArgs args) {
+  void testSpouseRefsByTextContent(TestModelArgs args) {
 
     init(args);
 
@@ -250,7 +250,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateSpouseRefsByTextContent(TestModelArgs args) {
+  void testUpdateSpouseRefsByTextContent(TestModelArgs args) {
 
     init(args);
 
@@ -261,7 +261,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateSpouseRefsByTextContentWithNamespace(TestModelArgs args) {
+  void testUpdateSpouseRefsByTextContentWithNamespace(TestModelArgs args) {
 
     init(args);
 
@@ -272,7 +272,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testGetMother(TestModelArgs args) {
+  void testGetMother(TestModelArgs args) {
 
     init(args);
 
@@ -285,7 +285,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetMotherRefByHelper(TestModelArgs args) {
+  void testSetMotherRefByHelper(TestModelArgs args) {
 
     init(args);
 
@@ -295,7 +295,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateMotherByIdHelper(TestModelArgs args) {
+  void testUpdateMotherByIdHelper(TestModelArgs args) {
 
     init(args);
 
@@ -305,7 +305,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateMotherByIdByAttributeName(TestModelArgs args) {
+  void testUpdateMotherByIdByAttributeName(TestModelArgs args) {
 
     init(args);
 
@@ -315,7 +315,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateMotherByReplaceElement(TestModelArgs args) {
+  void testUpdateMotherByReplaceElement(TestModelArgs args) {
     init(args);
     tweety.replaceWithElement(timmy);
     assertThat(egg1.getMother()).isEqualTo(timmy);
@@ -323,7 +323,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateMotherByRemoveElement(TestModelArgs args) {
+  void testUpdateMotherByRemoveElement(TestModelArgs args) {
     init(args);
     egg1.setMother(hedwig);
     Animals animals = (Animals) modelInstance.getDocumentElement();
@@ -333,7 +333,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testClearMother(TestModelArgs args) {
+  void testClearMother(TestModelArgs args) {
 
     init(args);
 
@@ -343,7 +343,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testSetMotherRefsByHelper(TestModelArgs args) {
+  void testSetMotherRefsByHelper(TestModelArgs args) {
     init(args);
     Mother mother = modelInstance.newInstance(Mother.class);
     mother.setHref("#" + timmy.getId());
@@ -353,7 +353,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testMotherRefsByTextContent(TestModelArgs args) {
+  void testMotherRefsByTextContent(TestModelArgs args) {
 
     init(args);
 
@@ -363,7 +363,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateMotherRefsByTextContent(TestModelArgs args) {
+  void testUpdateMotherRefsByTextContent(TestModelArgs args) {
 
     init(args);
 
@@ -374,7 +374,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testGetGuards(TestModelArgs args) {
+  void testGetGuards(TestModelArgs args) {
     init(args);
     Collection<Animal> guards = egg1.getGuardians();
     assertThat(guards).isNotEmpty().hasSize(2);
@@ -387,7 +387,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testAddGuardianRefsByHelper(TestModelArgs args) {
+  void testAddGuardianRefsByHelper(TestModelArgs args) {
     init(args);
     assertThat(egg1.getGuardianRefs()).isNotEmpty().hasSize(2);
 
@@ -400,7 +400,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testGuardianRefsByTextContent(TestModelArgs args) {
+  void testGuardianRefsByTextContent(TestModelArgs args) {
     init(args);
     Collection<Guardian> guardianRefs = egg1.getGuardianRefs();
     Collection<String> hrefs = new ArrayList<String>();
@@ -414,7 +414,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateGuardianRefsByTextContent(TestModelArgs args) {
+  void testUpdateGuardianRefsByTextContent(TestModelArgs args) {
     init(args);
     List<Guardian> guardianRefs = new ArrayList<Guardian>(egg1.getGuardianRefs());
 
@@ -425,7 +425,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateGuardianRefsByRemoveElements(TestModelArgs args) {
+  void testUpdateGuardianRefsByRemoveElements(TestModelArgs args) {
     init(args);
     List<Guardian> guardianRefs = new ArrayList<Guardian>(egg1.getGuardianRefs());
     egg1.getGuardianRefs().remove(guardianRefs.get(1));
@@ -434,7 +434,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testClearGuardianRefs(TestModelArgs args) {
+  void testClearGuardianRefs(TestModelArgs args) {
     init(args);
     egg1.getGuardianRefs().clear();
     assertThat(egg1.getGuardianRefs()).isEmpty();
@@ -446,7 +446,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testGetGuardedEggs(TestModelArgs args) {
+  void testGetGuardedEggs(TestModelArgs args) {
 
     init(args);
 
@@ -459,7 +459,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testAddGuardedEggRefsByHelper(TestModelArgs args) {
+  void testAddGuardedEggRefsByHelper(TestModelArgs args) {
     init(args);
     assertThat(hedwig.getGuardedEggRefs()).isNotEmpty().hasSize(2);
 
@@ -472,7 +472,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testGuardedEggRefsByTextContent(TestModelArgs args) {
+  void testGuardedEggRefsByTextContent(TestModelArgs args) {
 
     init(args);
 
@@ -488,7 +488,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateGuardedEggRefsByTextContent(TestModelArgs args) {
+  void testUpdateGuardedEggRefsByTextContent(TestModelArgs args) {
     init(args);
     List<GuardEgg> guardianRefs = new ArrayList<GuardEgg>(hedwig.getGuardedEggRefs());
 
@@ -499,7 +499,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testUpdateGuardedEggRefsByRemoveElements(TestModelArgs args) {
+  void testUpdateGuardedEggRefsByRemoveElements(TestModelArgs args) {
 
     init(args);
 
@@ -510,7 +510,7 @@ public class BirdTest extends TestModelTest {
 
   @ParameterizedTest
   @MethodSource("models")
-  public void testClearGuardedEggRefs(TestModelArgs args) {
+  void testClearGuardedEggRefs(TestModelArgs args) {
     init(args);
     timmy.getGuardedEggRefs().clear();
     assertThat(timmy.getGuardedEggRefs()).isEmpty();

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/UnknownAnimalTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/UnknownAnimalTest.java
@@ -38,7 +38,7 @@ import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAME
 /**
  * @author Sebastian Menski
  */
-public class UnknownAnimalTest {
+class UnknownAnimalTest {
 
   private AbstractModelParser modelParser;
   private ModelInstance modelInstance;
@@ -46,7 +46,7 @@ public class UnknownAnimalTest {
   private ModelElementInstance flipper;
 
   @BeforeEach
-  public void parseModel() {
+  void parseModel() {
     modelParser = new TestModelParser();
     String testXml = this.getClass().getSimpleName() + ".xml";
     InputStream testXmlAsStream = this.getClass().getResourceAsStream(testXml);
@@ -56,13 +56,13 @@ public class UnknownAnimalTest {
   }
 
   @AfterEach
-  public void validateModel() {
+  void validateModel() {
     DomDocument document = modelInstance.getDocument();
     modelParser.validateModel(document);
   }
 
   @Test
-  public void testGetUnknownAnimalById() {
+  void testGetUnknownAnimalById() {
     assertThat(wanda).isNotNull();
     assertThat(wanda.getAttributeValue("id")).isEqualTo("wanda");
     assertThat(wanda.getAttributeValue("gender")).isEqualTo("Female");
@@ -75,7 +75,7 @@ public class UnknownAnimalTest {
   }
 
   @Test
-  public void testGetUnknownAnimalByType() {
+  void testGetUnknownAnimalByType() {
     ModelInstanceImpl modelInstanceImpl = (ModelInstanceImpl) modelInstance;
     ModelElementType unknownAnimalType = modelInstanceImpl.registerGenericType(MODEL_NAMESPACE, "unknownAnimal");
     List<ModelElementInstance> unknownAnimals = new ArrayList<ModelElementInstance>(modelInstance.getModelElementsByType(unknownAnimalType));
@@ -93,7 +93,7 @@ public class UnknownAnimalTest {
   }
 
   @Test
-  public void testAddUnknownAnimal() {
+  void testAddUnknownAnimal() {
     ModelInstanceImpl modelInstanceImpl = (ModelInstanceImpl) modelInstance;
     ModelElementType unknownAnimalType = modelInstanceImpl.registerGenericType(MODEL_NAMESPACE, "unknownAnimal");
     ModelElementType animalsType = modelInstance.getModel().getType(Animals.class);
@@ -112,7 +112,7 @@ public class UnknownAnimalTest {
   }
 
   @Test
-  public void testGetUnknownAttribute() {
+  void testGetUnknownAttribute() {
     assertThat(flipper.getAttributeValue("famous")).isEqualTo("true");
 
     assertThat(wanda.getAttributeValue("famous")).isNotEqualTo("true");
@@ -121,7 +121,7 @@ public class UnknownAnimalTest {
   }
 
   @Test
-  public void testAddRelationshipDefinitionToUnknownAnimal() {
+  void testAddRelationshipDefinitionToUnknownAnimal() {
     RelationshipDefinition friendRelationshipDefinition = modelInstance.newInstance(FriendRelationshipDefinition.class);
     friendRelationshipDefinition.setId("friend-relationship");
     friendRelationshipDefinition.setAttributeValue("animalRef", flipper.getAttributeValue("id"));
@@ -145,14 +145,14 @@ public class UnknownAnimalTest {
   }
 
   @Test
-  public void testAddChildToUnknownAnimal() {
+  void testAddChildToUnknownAnimal() {
     assertThat(wanda.getChildElementsByType(flipper.getElementType())).hasSize(0);
     wanda.insertElementAfter(flipper, null);
     assertThat(wanda.getChildElementsByType(flipper.getElementType())).hasSize(1);
   }
 
   @Test
-  public void testRemoveChildOfUnknownAnimal() {
+  void testRemoveChildOfUnknownAnimal() {
     assertThat(wanda.removeChildElement(flipper)).isFalse();
     wanda.insertElementAfter(flipper, null);
     assertThat(wanda.removeChildElement(flipper)).isTrue();
@@ -160,7 +160,7 @@ public class UnknownAnimalTest {
   }
 
   @Test
-  public void testReplaceChildOfUnknownAnimal() {
+  void testReplaceChildOfUnknownAnimal() {
     ModelElementInstance yogi = modelInstance.newInstance(flipper.getElementType());
     yogi.setAttributeValue("id", "yogi-bear", true);
     yogi.setAttributeValue("gender", "Male");

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/ModelElementTypeTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/ModelElementTypeTest.java
@@ -30,7 +30,7 @@ import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAME
 /**
  * @author Sebastian Menski
  */
-public class ModelElementTypeTest {
+class ModelElementTypeTest {
 
   private ModelInstance modelInstance;
   private Model model;
@@ -40,7 +40,7 @@ public class ModelElementTypeTest {
   private ModelElementType birdType;
 
   @BeforeEach
-  public void getTypes() {
+  void getTypes() {
     TestModelParser modelParser = new TestModelParser();
     modelInstance = modelParser.getEmptyModel();
     model = modelInstance.getModel();
@@ -51,7 +51,7 @@ public class ModelElementTypeTest {
   }
 
   @Test
-  public void testTypeName() {
+  void testTypeName() {
     assertThat(animalsType).hasTypeName("animals");
     assertThat(animalType).hasTypeName("animal");
     assertThat(flyingAnimalType).hasTypeName("flyingAnimal");
@@ -59,7 +59,7 @@ public class ModelElementTypeTest {
   }
 
   @Test
-  public void testTypeNamespace() {
+  void testTypeNamespace() {
     assertThat(animalsType).hasTypeNamespace(MODEL_NAMESPACE);
     assertThat(animalType).hasTypeNamespace(MODEL_NAMESPACE);
     assertThat(flyingAnimalType).hasTypeNamespace(MODEL_NAMESPACE);
@@ -67,7 +67,7 @@ public class ModelElementTypeTest {
   }
 
   @Test
-  public void testInstanceType() {
+  void testInstanceType() {
     assertThat(animalsType).hasInstanceType(Animals.class);
     assertThat(animalType).hasInstanceType(Animal.class);
     assertThat(flyingAnimalType).hasInstanceType(FlyingAnimal.class);
@@ -75,7 +75,7 @@ public class ModelElementTypeTest {
   }
 
   @Test
-  public void testAttributes() {
+  void testAttributes() {
     assertThat(animalsType).hasNoAttributes();
     assertThat(animalType).hasAttributes("id", "name", "father", "mother", "isEndangered", "gender", "age");
     assertThat(flyingAnimalType).hasAttributes("wingspan");
@@ -83,7 +83,7 @@ public class ModelElementTypeTest {
   }
 
   @Test
-  public void testBaseType() {
+  void testBaseType() {
     assertThat(animalsType).extendsNoType();
     assertThat(animalType).extendsNoType();
     assertThat(flyingAnimalType).extendsType(animalType);
@@ -91,7 +91,7 @@ public class ModelElementTypeTest {
   }
 
   @Test
-  public void testAbstractType() {
+  void testAbstractType() {
     assertThat(animalsType).isNotAbstract();
     assertThat(animalType).isAbstract();
     assertThat(flyingAnimalType).isAbstract();
@@ -99,7 +99,7 @@ public class ModelElementTypeTest {
   }
 
   @Test
-  public void testExtendingTypes() {
+  void testExtendingTypes() {
     assertThat(animalsType).isNotExtended();
     assertThat(animalType)
       .isExtendedBy(flyingAnimalType)
@@ -109,7 +109,7 @@ public class ModelElementTypeTest {
   }
 
   @Test
-  public void testModel() {
+  void testModel() {
     assertThat(animalsType).isPartOfModel(model);
     assertThat(animalType).isPartOfModel(model);
     assertThat(flyingAnimalType).isPartOfModel(model);
@@ -117,7 +117,7 @@ public class ModelElementTypeTest {
   }
 
   @Test
-  public void testInstances() {
+  void testInstances() {
     assertThat(animalsType.getInstances(modelInstance)).isEmpty();
     assertThat(animalType.getInstances(modelInstance)).isEmpty();
     assertThat(flyingAnimalType.getInstances(modelInstance)).isEmpty();
@@ -153,7 +153,7 @@ public class ModelElementTypeTest {
   }
 
   @Test
-  public void testChildElementTypes() {
+  void testChildElementTypes() {
     ModelElementType relationshipDefinitionType = model.getType(RelationshipDefinition.class);
     ModelElementType relationshipDefinitionRefType = model.getType(RelationshipDefinitionRef.class);
     ModelElementType flightPartnerRefType = model.getType(FlightPartnerRef.class);

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/validation/ModelValidationTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/validation/ModelValidationTest.java
@@ -31,12 +31,12 @@ import org.operaton.bpm.model.xml.testmodel.instance.Bird;
 /**
  * @author Daniel Meyer
  */
-public class ModelValidationTest {
+class ModelValidationTest {
 
   protected ModelInstance modelInstance;
 
   @BeforeEach
-  public void parseModel() {
+  void parseModel() {
     TestModelParser modelParser = new TestModelParser();
     String testXml = "org/operaton/bpm/model/xml/testmodel/instance/UnknownAnimalTest.xml";
     InputStream testXmlAsStream = this.getClass().getClassLoader().getResourceAsStream(testXml);
@@ -45,7 +45,7 @@ public class ModelValidationTest {
   }
 
   @Test
-  public void shouldValidateWithEmptyList() {
+  void shouldValidateWithEmptyList() {
     ValidationResults results = modelInstance.validate(List.of());
 
     assertThat(results).isNotNull();
@@ -53,7 +53,7 @@ public class ModelValidationTest {
   }
 
   @Test
-  public void shouldCollectWarnings() {
+  void shouldCollectWarnings() {
     List<ModelElementValidator<?>> validators = List.of(new IsAdultWarner());
 
     ValidationResults results = modelInstance.validate(validators);
@@ -65,7 +65,7 @@ public class ModelValidationTest {
   }
 
   @Test
-  public void shouldCollectErrors() {
+  void shouldCollectErrors() {
     List<ModelElementValidator<?>> validators = List.of(new IllegalBirdValidator("tweety"));
 
     ValidationResults results = modelInstance.validate(validators);
@@ -77,7 +77,7 @@ public class ModelValidationTest {
   }
 
   @Test
-  public void shouldWriteResults() {
+  void shouldWriteResults() {
     List<ModelElementValidator<?>> validators = List.of(new IllegalBirdValidator("tweety"));
 
     ValidationResults results = modelInstance.validate(validators);
@@ -89,7 +89,7 @@ public class ModelValidationTest {
   }
 
   @Test
-  public void shouldWriteResultsUntilMaxSize() {
+  void shouldWriteResultsUntilMaxSize() {
     // Given
     int maxSize = 120;
 
@@ -114,7 +114,7 @@ public class ModelValidationTest {
   }
 
   @Test
-  public void shouldCombineDifferentValidationResults() {
+  void shouldCombineDifferentValidationResults() {
     // Given
     int maxSize = 120;
 
@@ -139,7 +139,7 @@ public class ModelValidationTest {
   }
 
   @Test
-  public void shouldReturnResults() {
+  void shouldReturnResults() {
     List<ModelElementValidator<?>> validators =
         List.of(new IllegalBirdValidator("tweety"), new IsAdultWarner());
 

--- a/test-utils/assert/qa/src/test/java/org/operaton/bpm/engine/test/assertions/junit5/ProcessEngineExtensionCompatibilityTest.java
+++ b/test-utils/assert/qa/src/test/java/org/operaton/bpm/engine/test/assertions/junit5/ProcessEngineExtensionCompatibilityTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ProcessEngineExtensionCompatibilityTest {
+class ProcessEngineExtensionCompatibilityTest {
 
   @RegisterExtension
   ProcessEngineExtension extension = ProcessEngineExtension.builder().build();
@@ -37,13 +37,13 @@ public class ProcessEngineExtensionCompatibilityTest {
   RuntimeService runtimeService;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     runtimeService = extension.getRuntimeService();
   }
 
   @Test
   @Deployment(resources = {"simpleProcess.bpmn"})
-  public void shouldRunWithJUnit5Extension() {
+  void shouldRunWithJUnit5Extension() {
     // given
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testProcess");
 


### PR DESCRIPTION
Cleanup JUnit 5 test cases: `public` not needed on class and method declarations

related to #27 