### PR TITLE
chore(tests): Resolve Sonar assertj warnings

### DIFF
--- a/clients/java/client/src/it/java/org/operaton/bpm/client/client/ClientIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/client/ClientIT.java
@@ -666,7 +666,7 @@ public class ClientIT {
       // then
       EngineException exception = (EngineException) ex.get();
       assertThat(exception).isInstanceOf(EngineException.class);
-      assertThat(exception.getCode()).isEqualTo(0);
+      assertThat(exception.getCode()).isZero();
       assertThat(exception.getType()).isEqualTo("ProcessEngineException");
       assertThat(exception.getMessage()).isEqualTo("TASK/CLIENT-03009 Exception while fetching and locking task: Object values cannot be used to query");
       assertThat(exception.getHttpStatusCode()).isEqualTo(500);

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/topic/TopicSubscriptionIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/topic/TopicSubscriptionIT.java
@@ -140,7 +140,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isEqualTo(1);
+    assertThat(handler.getHandledTasks()).hasSize(1);
     ExternalTask task = handler.getHandledTasks().get(0);
     assertThat(task.getProcessDefinitionId()).isEqualTo(processDefinitionId2);
     assertThat(topicSubscription.getProcessDefinitionId()).isEqualTo(processDefinitionId2);
@@ -185,7 +185,7 @@ public class TopicSubscriptionIT {
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
     List<ExternalTask> handledTasks = handler.getHandledTasks();
-    assertThat(handledTasks.size()).isEqualTo(2);
+    assertThat(handledTasks).hasSize(2);
   }
 
   @Test
@@ -203,7 +203,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isEqualTo(1);
+    assertThat(handler.getHandledTasks()).hasSize(1);
     ExternalTask task = handler.getHandledTasks().get(0);
     assertThat(task.getProcessDefinitionKey()).isEqualTo(PROCESS_KEY_2);
     assertThat(topicSubscription.getProcessDefinitionKey()).isEqualTo(PROCESS_KEY_2);
@@ -245,7 +245,7 @@ public class TopicSubscriptionIT {
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
     List<ExternalTask> handledTasks = handler.getHandledTasks();
-    assertThat(handledTasks.size()).isEqualTo(2);
+    assertThat(handledTasks).hasSize(2);
   }
 
   @Test
@@ -265,7 +265,7 @@ public class TopicSubscriptionIT {
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
     List<ExternalTask> handledTasks = handler.getHandledTasks();
-    assertThat(handledTasks.size()).isEqualTo(1);
+    assertThat(handledTasks).hasSize(1);
     assertThat(handledTasks.get(0).getProcessDefinitionKey()).isEqualTo(PROCESS_DEFINITION_VERSION_TAG);
     assertThat(handledTasks.get(0).getProcessDefinitionVersionTag()).isEqualTo(PROCESS_DEFINITION_VERSION_TAG);
   }
@@ -286,7 +286,7 @@ public class TopicSubscriptionIT {
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
     List<ExternalTask> handledTasks = handler.getHandledTasks();
-    assertThat(handledTasks.size()).isEqualTo(2);
+    assertThat(handledTasks).hasSize(2);
     assertThat(handledTasks.get(0).getProcessDefinitionVersionTag()).isEqualTo(null);
     assertThat(handledTasks.get(1).getProcessDefinitionVersionTag()).isEqualTo(PROCESS_DEFINITION_VERSION_TAG);
   }
@@ -305,7 +305,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isEqualTo(1);
+    assertThat(handler.getHandledTasks()).hasSize(1);
   }
 
   @Test
@@ -324,7 +324,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isEqualTo(2);
+    assertThat(handler.getHandledTasks()).hasSize(2);
   }
 
   @Test
@@ -344,7 +344,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isEqualTo(1);
+    assertThat(handler.getHandledTasks()).hasSize(1);
     ExternalTask task = handler.getHandledTasks().get(0);
     assertThat(task.getTenantId()).isNull();
     assertThat(task.getProcessInstanceId()).isEqualTo(processInstance.getId());
@@ -368,7 +368,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isEqualTo(1);
+    assertThat(handler.getHandledTasks()).hasSize(1);
     ExternalTask task = handler.getHandledTasks().get(0);
     assertThat(task.getTenantId()).isEqualTo(tenantId);
     assertThat(task.getProcessInstanceId()).isEqualTo(processInstance.getId());
@@ -391,17 +391,17 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> handler.getHandledTasks().size() == 2);
 
-    assertThat(topicSubscription.getVariableNames().size()).isEqualTo(1);
+    assertThat(topicSubscription.getVariableNames()).hasSize(1);
     assertThat(topicSubscription.getVariableNames().get(0)).isEqualTo(VARIABLE_NAME);
 
     List<ExternalTask> handledTasks = handler.getHandledTasks();
-    assertThat(handledTasks.size()).isEqualTo(2);
+    assertThat(handledTasks).hasSize(2);
 
     ExternalTask task = handledTasks.get(0);
     assertThat(task.getBusinessKey()).isEqualTo(BUSINESS_KEY);
 
     if (task.getVariable(VARIABLE_NAME) != null) {
-      assertThat(task.getAllVariables().size()).isEqualTo(1);
+      assertThat(task.getAllVariables()).hasSize(1);
       assertThat((String) task.getVariable(VARIABLE_NAME)).isEqualTo(VARIABLE_VALUE);
     } else {
       assertThat(task.getAllVariables().size()).isZero();
@@ -562,7 +562,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isEqualTo(1);
+    assertThat(handler.getHandledTasks()).hasSize(1);
   }
 
   @Test
@@ -585,7 +585,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isEqualTo(2);
+    assertThat(handler.getHandledTasks()).hasSize(2);
   }
 
   @Test
@@ -609,7 +609,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isEqualTo(2);
+    assertThat(handler.getHandledTasks()).hasSize(2);
 
   }
 
@@ -658,7 +658,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isEqualTo(1);
+    assertThat(handler.getHandledTasks()).hasSize(1);
   }
 
   @Test
@@ -683,7 +683,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isEqualTo(2);
+    assertThat(handler.getHandledTasks()).hasSize(2);
   }
 
   @Test
@@ -710,7 +710,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> !handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isEqualTo(2);
+    assertThat(handler.getHandledTasks()).hasSize(2);
   }
 
   @Test

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/topic/TopicSubscriptionIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/topic/TopicSubscriptionIT.java
@@ -37,13 +37,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.operaton.bpm.client.util.ProcessModels.BPMN_ERROR_EXTERNAL_TASK_PROCESS;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
-import static org.operaton.bpm.client.util.ProcessModels.ONE_EXTERNAL_TASK_WITH_OUTPUT_PARAM_PROCESS;
-import static org.operaton.bpm.client.util.ProcessModels.ONE_EXTERNAL_TASK_WITH_VERSION_TAG;
-import static org.operaton.bpm.client.util.ProcessModels.PROCESS_DEFINITION_VERSION_TAG;
-import static org.operaton.bpm.client.util.ProcessModels.PROCESS_KEY;
-import static org.operaton.bpm.client.util.ProcessModels.PROCESS_KEY_2;
+import static org.operaton.bpm.client.util.ProcessModels.*;
 
 /**
  * @author Tassilo Weidner
@@ -404,7 +398,7 @@ public class TopicSubscriptionIT {
       assertThat(task.getAllVariables()).hasSize(1);
       assertThat((String) task.getVariable(VARIABLE_NAME)).isEqualTo(VARIABLE_VALUE);
     } else {
-      assertThat(task.getAllVariables().size()).isZero();
+      assertThat(task.getAllVariables()).isEmpty();
     }
   }
 
@@ -424,10 +418,10 @@ public class TopicSubscriptionIT {
     clientRule.waitForFetchAndLockUntil(() -> handler.getHandledTasks().size() == 2);
 
     ExternalTask taskOne = handler.getHandledTasks().get(0);
-    assertThat(taskOne.getAllVariables().size()).isZero();
+    assertThat(taskOne.getAllVariables()).isEmpty();
 
     ExternalTask taskTwo = handler.getHandledTasks().get(1);
-    assertThat(taskTwo.getAllVariables().size()).isZero();
+    assertThat(taskTwo.getAllVariables()).isEmpty();
   }
 
   @Test
@@ -446,10 +440,10 @@ public class TopicSubscriptionIT {
     clientRule.waitForFetchAndLockUntil(() -> handler.getHandledTasks().size() == 2);
 
     ExternalTask taskOne = handler.getHandledTasks().get(0);
-    assertThat(taskOne.getAllVariables().size()).isZero();
+    assertThat(taskOne.getAllVariables()).isEmpty();
 
     ExternalTask taskTwo = handler.getHandledTasks().get(0);
-    assertThat(taskTwo.getAllVariables().size()).isZero();
+    assertThat(taskTwo.getAllVariables()).isEmpty();
   }
 
   @Test
@@ -637,7 +631,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isZero();
+    assertThat(handler.getHandledTasks()).isEmpty();
   }
 
   @Test
@@ -739,7 +733,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isZero();
+    assertThat(handler.getHandledTasks()).isEmpty();
   }
 
 }

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/topic/TopicSubscriptionIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/topic/TopicSubscriptionIT.java
@@ -404,7 +404,7 @@ public class TopicSubscriptionIT {
       assertThat(task.getAllVariables().size()).isEqualTo(1);
       assertThat((String) task.getVariable(VARIABLE_NAME)).isEqualTo(VARIABLE_VALUE);
     } else {
-      assertThat(task.getAllVariables().size()).isEqualTo(0);
+      assertThat(task.getAllVariables().size()).isZero();
     }
   }
 
@@ -424,10 +424,10 @@ public class TopicSubscriptionIT {
     clientRule.waitForFetchAndLockUntil(() -> handler.getHandledTasks().size() == 2);
 
     ExternalTask taskOne = handler.getHandledTasks().get(0);
-    assertThat(taskOne.getAllVariables().size()).isEqualTo(0);
+    assertThat(taskOne.getAllVariables().size()).isZero();
 
     ExternalTask taskTwo = handler.getHandledTasks().get(1);
-    assertThat(taskTwo.getAllVariables().size()).isEqualTo(0);
+    assertThat(taskTwo.getAllVariables().size()).isZero();
   }
 
   @Test
@@ -446,10 +446,10 @@ public class TopicSubscriptionIT {
     clientRule.waitForFetchAndLockUntil(() -> handler.getHandledTasks().size() == 2);
 
     ExternalTask taskOne = handler.getHandledTasks().get(0);
-    assertThat(taskOne.getAllVariables().size()).isEqualTo(0);
+    assertThat(taskOne.getAllVariables().size()).isZero();
 
     ExternalTask taskTwo = handler.getHandledTasks().get(0);
-    assertThat(taskTwo.getAllVariables().size()).isEqualTo(0);
+    assertThat(taskTwo.getAllVariables().size()).isZero();
   }
 
   @Test
@@ -637,7 +637,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isEqualTo(0);
+    assertThat(handler.getHandledTasks().size()).isZero();
   }
 
   @Test
@@ -739,7 +739,7 @@ public class TopicSubscriptionIT {
     // then
     clientRule.waitForFetchAndLockUntil(() -> handler.getHandledTasks().isEmpty());
 
-    assertThat(handler.getHandledTasks().size()).isEqualTo(0);
+    assertThat(handler.getHandledTasks().size()).isZero();
   }
 
 }

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/FileSerializationIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/FileSerializationIT.java
@@ -113,7 +113,7 @@ public class FileSerializationIT {
     ExternalTask task = handler.getHandledTasks().get(0);
 
     // then
-    assertThat(task.getAllVariables().size()).isEqualTo(1);
+    assertThat(task.getAllVariables()).hasSize(1);
     assertThat(IoUtil.inputStreamAsString(task.getVariable(VARIABLE_NAME_FILE)))
       .isEqualTo(new String(VARIABLE_VALUE_FILE_VALUE));
   }
@@ -146,7 +146,7 @@ public class FileSerializationIT {
     ExternalTask task = handler.getHandledTasks().get(0);
 
     // then
-    assertThat(task.getAllVariables().size()).isEqualTo(2);
+    assertThat(task.getAllVariables()).hasSize(2);
     assertThat(IoUtil.inputStreamAsString(task.getVariable(VARIABLE_NAME_FILE)))
         .isEqualTo(new String(VARIABLE_VALUE_FILE_VALUE));
     assertThat(IoUtil.inputStreamAsString(task.getVariable(LOCAL_VARIABLE_NAME_FILE)))
@@ -171,7 +171,7 @@ public class FileSerializationIT {
     ExternalTask task = handler.getHandledTasks().get(0);
 
     // then
-    assertThat(task.getAllVariables().size()).isEqualTo(2);
+    assertThat(task.getAllVariables()).hasSize(2);
     assertThat(IoUtil.inputStreamAsString((InputStream) task.getAllVariables().get(VARIABLE_NAME_FILE)))
       .isEqualTo(new String(VARIABLE_VALUE_FILE_VALUE));
     assertThat(IoUtil.inputStreamAsString((InputStream) task.getAllVariables().get(ANOTHER_VARIABLE_NAME_FILE)))
@@ -585,7 +585,7 @@ public class FileSerializationIT {
 
     // then
     List<VariableInstanceDto> variableInstances = engineRule.getVariablesByProcessInstanceIdAndVariableName(processInstance.getId(), null);
-    assertThat(variableInstances.size()).isEqualTo(2);
+    assertThat(variableInstances).hasSize(2);
 
     List<String> variableNames = new ArrayList<>();
     for (VariableInstanceDto variableInstance : variableInstances) {
@@ -626,7 +626,7 @@ public class FileSerializationIT {
 
     // then
     List<VariableInstanceDto> variableInstances = engineRule.getVariablesByProcessInstanceIdAndVariableName(processInstance.getId(), null);
-    assertThat(variableInstances.size()).isEqualTo(3);
+    assertThat(variableInstances).hasSize(3);
 
     List<String> variableNames = new ArrayList<>();
     for (VariableInstanceDto variableInstance : variableInstances) {

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/XmlSerializationIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/XmlSerializationIT.java
@@ -39,12 +39,8 @@ import org.operaton.spin.xml.SpinXmlElement;
 import java.util.Arrays;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_BAR;
-import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_FOO;
-import static org.operaton.bpm.client.util.ProcessModels.TWO_EXTERNAL_TASK_PROCESS;
+import static org.assertj.core.api.Assertions.*;
+import static org.operaton.bpm.client.util.ProcessModels.*;
 import static org.operaton.bpm.engine.variable.Variables.SerializationDataFormats.XML;
 import static org.operaton.bpm.engine.variable.type.ValueType.OBJECT;
 
@@ -203,7 +199,7 @@ public class XmlSerializationIT {
     ExternalTask task = handler.getHandledTasks().get(0);
 
     XmlSerializables variableValue = task.getVariable(VARIABLE_NAME_XML);
-    assertThat(variableValue).hasSize(2);
+    assertThat(variableValue.size()).isEqualTo(2);
     assertThat(variableValue.get(0)).isEqualTo(VARIABLE_VALUE_XML_DESERIALIZED);
     assertThat(variableValue.get(1)).isEqualTo(VARIABLE_VALUE_XML_DESERIALIZED);
   }

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/XmlSerializationIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/XmlSerializationIT.java
@@ -203,7 +203,7 @@ public class XmlSerializationIT {
     ExternalTask task = handler.getHandledTasks().get(0);
 
     XmlSerializables variableValue = task.getVariable(VARIABLE_NAME_XML);
-    assertThat(variableValue.size()).isEqualTo(2);
+    assertThat(variableValue).hasSize(2);
     assertThat(variableValue.get(0)).isEqualTo(VARIABLE_VALUE_XML_DESERIALIZED);
     assertThat(variableValue.get(1)).isEqualTo(VARIABLE_VALUE_XML_DESERIALIZED);
   }

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/pa/PaExceptionIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/pa/PaExceptionIT.java
@@ -148,7 +148,7 @@ public class PaExceptionIT {
 
     // then
     NotFoundException px = (NotFoundException) catchThrowable(() -> service.complete(externalTask));
-    assertThat(px.getCode()).isEqualTo(0);
+    assertThat(px.getCode()).isZero();
     assertThat(px.getType()).isEqualTo("RestException");
     assertThat(px.getMessage()).isEqualTo("TASK/CLIENT-01008 Exception while completing the external task: External task with id not-existing-id does not exist");
     assertThat(px.getHttpStatusCode()).isEqualTo(404);
@@ -208,7 +208,7 @@ public class PaExceptionIT {
     // then
     BadRequestException px = (BadRequestException) catchThrowable(() -> service.complete(externalTask));
     assertThat(px).isInstanceOf(BadRequestException.class);
-    assertThat(px.getCode()).isEqualTo(0);
+    assertThat(px.getCode()).isZero();
     assertThat(px.getType()).isEqualTo("RestException");
     assertThat(px.getMessage()).matches("TASK/CLIENT-01007 Exception while completing the external task: "
         + "External Task ([a-z0-9-]*) cannot be completed by worker 'aWorkerId'. "

--- a/clients/java/client/src/test/java/org/operaton/bpm/client/backoff/ExponentialBackoffStrategyTest.java
+++ b/clients/java/client/src/test/java/org/operaton/bpm/client/backoff/ExponentialBackoffStrategyTest.java
@@ -39,7 +39,7 @@ class ExponentialBackoffStrategyTest {
   void shouldAdvanceBackoffStrategy() {
     // given
     long initialWaitingTime = backoffStrategy.calculateBackoffTime();
-    assertThat(initialWaitingTime).isEqualTo(0L);
+    assertThat(initialWaitingTime).isZero();
 
     // when
     // in consecutive iterations, no external tasks are available
@@ -66,14 +66,14 @@ class ExponentialBackoffStrategyTest {
 
     // then
     long waitingTime2 = backoffStrategy.calculateBackoffTime();
-    assertThat(waitingTime2).isEqualTo(0L);
+    assertThat(waitingTime2).isZero();
   }
 
   @Test
   void shouldCapWaitingTime() {
     // given
     long waitingTime = backoffStrategy.calculateBackoffTime();
-    assertThat(waitingTime).isEqualTo(0L);
+    assertThat(waitingTime).isZero();
 
     // when
     // reach maximum waiting time

--- a/clients/java/client/src/test/java/org/operaton/bpm/client/backoff/ExponentialErrorBackoffStrategyTest.java
+++ b/clients/java/client/src/test/java/org/operaton/bpm/client/backoff/ExponentialErrorBackoffStrategyTest.java
@@ -40,7 +40,7 @@ class ExponentialErrorBackoffStrategyTest {
   void shouldAdvanceBackoffStrategy() {
     // given
     long initialWaitingTime = backoffStrategy.calculateBackoffTime();
-    assertThat(initialWaitingTime).isEqualTo(0L);
+    assertThat(initialWaitingTime).isZero();
 
     // when
     // in consecutive iterations, an error occurs
@@ -71,14 +71,14 @@ class ExponentialErrorBackoffStrategyTest {
 
     // then
     long waitingTime2 = backoffStrategy.calculateBackoffTime();
-    assertThat(waitingTime2).isEqualTo(0L);
+    assertThat(waitingTime2).isZero();
   }
 
   @Test
   void shouldCapWaitingTime() {
     // given
     long waitingTime = backoffStrategy.calculateBackoffTime();
-    assertThat(waitingTime).isEqualTo(0L);
+    assertThat(waitingTime).isZero();
 
     // when
     // reach maximum waiting time
@@ -97,7 +97,7 @@ class ExponentialErrorBackoffStrategyTest {
   void shouldCapWaitingTime2() {
     // given
     long waitingTime = backoffStrategy.calculateBackoffTime();
-    assertThat(waitingTime).isEqualTo(0L);
+    assertThat(waitingTime).isZero();
 
     // when
     // reach maximum waiting time

--- a/commons/testing/src/test/java/org/operaton/commons/testing/ProcessEngineLoggingRuleTest.java
+++ b/commons/testing/src/test/java/org/operaton/commons/testing/ProcessEngineLoggingRuleTest.java
@@ -16,16 +16,16 @@
  */
 package org.operaton.commons.testing;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.junit.Rule;
+import org.junit.Test;
+import org.operaton.commons.testing.util.ExampleProcessEngineLogger;
 
 import java.util.List;
 
-import org.operaton.commons.testing.util.ExampleProcessEngineLogger;
-import org.junit.Rule;
-import org.junit.Test;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.spi.ILoggingEvent;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 @SuppressWarnings("unused")
 public class ProcessEngineLoggingRuleTest {
@@ -136,7 +136,7 @@ public class ProcessEngineLoggingRuleTest {
     assertThat(expectedException.getMessage()).contains(ProcessEngineLoggingRule.NOT_WATCHING_ERROR);
     testLogLevel(persistenceLog, Level.DEBUG);
     testLogLevel(processAppLogger, Level.INFO);
-    assertThat(containerLog.size()).isZero();
+    assertThat(containerLog).isEmpty();
   }
 
   @Test

--- a/commons/testing/src/test/java/org/operaton/commons/testing/ProcessEngineLoggingRuleTest.java
+++ b/commons/testing/src/test/java/org/operaton/commons/testing/ProcessEngineLoggingRuleTest.java
@@ -136,7 +136,7 @@ public class ProcessEngineLoggingRuleTest {
     assertThat(expectedException.getMessage()).contains(ProcessEngineLoggingRule.NOT_WATCHING_ERROR);
     testLogLevel(persistenceLog, Level.DEBUG);
     testLogLevel(processAppLogger, Level.INFO);
-    assertThat(containerLog.size()).isEqualTo(0);
+    assertThat(containerLog.size()).isZero();
   }
 
   @Test

--- a/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
+++ b/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
@@ -63,7 +63,7 @@ class FileValueTypeImplTest {
 
   @Test
   void isPrimitiveValue() {
-    assertThat(type.isPrimitiveValueType()).isEqualTo(true);
+    assertThat(type.isPrimitiveValueType()).isTrue();
   }
 
   @Test

--- a/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
+++ b/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
@@ -16,9 +16,13 @@
  */
 package org.operaton.bpm.engine.test.variables;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.operaton.bpm.engine.variable.Variables;
+import org.operaton.bpm.engine.variable.impl.type.FileValueTypeImpl;
+import org.operaton.bpm.engine.variable.value.FileValue;
+import org.operaton.bpm.engine.variable.value.TypedValue;
+import org.operaton.commons.utils.IoUtil;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -30,13 +34,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Scanner;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.variable.Variables;
-import org.operaton.bpm.engine.variable.impl.type.FileValueTypeImpl;
-import org.operaton.bpm.engine.variable.value.FileValue;
-import org.operaton.bpm.engine.variable.value.TypedValue;
-import org.operaton.commons.utils.IoUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Ronny Bräunlich
@@ -68,13 +69,13 @@ class FileValueTypeImplTest {
 
   @Test
   void isNotAnAbstractType() {
-    assertThat(type.isAbstract()).isEqualTo(false);
+    assertThat(type.isAbstract()).isFalse();
   }
 
   @Test
   void canNotConvertFromAnyValue() {
     // we just use null to make sure false is always returned
-    assertThat(type.canConvertFromTypedValue(null)).isEqualTo(false);
+    assertThat(type.canConvertFromTypedValue(null)).isFalse();
   }
 
   @Test

--- a/commons/utils/src/test/java/org/operaton/commons/utils/IoUtilTest.java
+++ b/commons/utils/src/test/java/org/operaton/commons/utils/IoUtilTest.java
@@ -16,13 +16,14 @@
  */
 package org.operaton.commons.utils;
 
+import org.junit.jupiter.api.Test;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 
-import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -86,7 +87,7 @@ public class IoUtilTest {
       while((line = reader.readLine()) != null) {
         output.append(line);
       }
-      assertThat(output.toString()).isEqualTo("This is a Test!");
+      assertThat(output).hasToString("This is a Test!");
     } catch(Exception e) {
       fail("Something went wrong while reading the input stream");
     }

--- a/commons/utils/src/test/java/org/operaton/commons/utils/cache/ConcurrentLruCacheTest.java
+++ b/commons/utils/src/test/java/org/operaton/commons/utils/cache/ConcurrentLruCacheTest.java
@@ -40,7 +40,7 @@ class ConcurrentLruCacheTest {
   void getEntry() {
     cache.put("a", "1");
 
-    assertThat(cache.size()).isEqualTo(1);
+    assertThat(cache).hasSize(1);
     assertThat(cache.get("a")).isEqualTo("1");
   }
 
@@ -49,7 +49,7 @@ class ConcurrentLruCacheTest {
     cache.put("a", "1");
     cache.put("a", "2");
 
-    assertThat(cache.size()).isEqualTo(1);
+    assertThat(cache).hasSize(1);
     assertThat(cache.get("a")).isEqualTo("2");
   }
 
@@ -60,7 +60,7 @@ class ConcurrentLruCacheTest {
     cache.put("c", "3");
     cache.put("d", "4");
 
-    assertThat(cache.size()).isEqualTo(3);
+    assertThat(cache).hasSize(3);
     assertThat(cache.get("a")).isNull();
     assertThat(cache.get("b")).isEqualTo("2");
     assertThat(cache.get("c")).isEqualTo("3");
@@ -78,7 +78,7 @@ class ConcurrentLruCacheTest {
 
     cache.put("d", "4");
 
-    assertThat(cache.size()).isEqualTo(3);
+    assertThat(cache).hasSize(3);
     assertThat(cache.get("c")).isNull();
     assertThat(cache.get("a")).isEqualTo("1");
     assertThat(cache.get("b")).isEqualTo("2");

--- a/commons/utils/src/test/java/org/operaton/commons/utils/cache/ConcurrentLruCacheTest.java
+++ b/commons/utils/src/test/java/org/operaton/commons/utils/cache/ConcurrentLruCacheTest.java
@@ -40,7 +40,7 @@ class ConcurrentLruCacheTest {
   void getEntry() {
     cache.put("a", "1");
 
-    assertThat(cache).hasSize(1);
+    assertThat(cache.size()).isEqualTo(1);
     assertThat(cache.get("a")).isEqualTo("1");
   }
 
@@ -49,7 +49,7 @@ class ConcurrentLruCacheTest {
     cache.put("a", "1");
     cache.put("a", "2");
 
-    assertThat(cache).hasSize(1);
+    assertThat(cache.size()).isEqualTo(1);
     assertThat(cache.get("a")).isEqualTo("2");
   }
 
@@ -60,7 +60,7 @@ class ConcurrentLruCacheTest {
     cache.put("c", "3");
     cache.put("d", "4");
 
-    assertThat(cache).hasSize(3);
+    assertThat(cache.size()).isEqualTo(3);
     assertThat(cache.get("a")).isNull();
     assertThat(cache.get("b")).isEqualTo("2");
     assertThat(cache.get("c")).isEqualTo("3");
@@ -78,7 +78,7 @@ class ConcurrentLruCacheTest {
 
     cache.put("d", "4");
 
-    assertThat(cache).hasSize(3);
+    assertThat(cache.size()).isEqualTo(3);
     assertThat(cache.get("c")).isNull();
     assertThat(cache.get("a")).isEqualTo("1");
     assertThat(cache.get("b")).isEqualTo("2");

--- a/commons/utils/src/test/java/org/operaton/commons/utils/cache/ConcurrentLruCacheTest.java
+++ b/commons/utils/src/test/java/org/operaton/commons/utils/cache/ConcurrentLruCacheTest.java
@@ -90,7 +90,7 @@ class ConcurrentLruCacheTest {
     cache.put("a", "1");
 
     cache.clear();
-    assertThat(cache.size()).isEqualTo(0);
+    assertThat(cache.size()).isZero();
     assertThat(cache.get("a")).isNull();
   }
 

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpRequestTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpRequestTest.java
@@ -16,22 +16,15 @@
  */
 package org.operaton.connect.httpclient;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.apache.http.client.methods.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.operaton.connect.Connectors;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpTrace;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.operaton.connect.Connectors;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HttpRequestTest {
 
@@ -173,7 +166,7 @@ public class HttpRequestTest {
     assertThat(request.getConfigOption("object-field")).isEqualTo(value);
     assertThat(request.getConfigOption("int-field")).isEqualTo(15);
     assertThat(request.getConfigOption("long-field")).isEqualTo(15l);
-    assertThat(request.getConfigOption("boolean-field")).isTrue();
+    assertThat(request.getConfigOption("boolean-field")).isEqualTo(true);
     assertThat(request.getConfigOption("string-field")).isEqualTo("string-value");
   }
 

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpRequestTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpRequestTest.java
@@ -173,7 +173,7 @@ public class HttpRequestTest {
     assertThat(request.getConfigOption("object-field")).isEqualTo(value);
     assertThat(request.getConfigOption("int-field")).isEqualTo(15);
     assertThat(request.getConfigOption("long-field")).isEqualTo(15l);
-    assertThat(request.getConfigOption("boolean-field")).isEqualTo(true);
+    assertThat(request.getConfigOption("boolean-field")).isTrue();
     assertThat(request.getConfigOption("string-field")).isEqualTo("string-value");
   }
 

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/deploy/DeployChangedOnlyDisabledTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/deploy/DeployChangedOnlyDisabledTest.java
@@ -33,6 +33,6 @@ public class DeployChangedOnlyDisabledTest extends AbstractRestTest {
 
   @Test
   public void shouldEnableDeployChangedOnlyOnOperatonRunProperty() {
-    assertThat(engineConfig.isDeployChangedOnly()).isEqualTo(false);
+    assertThat(engineConfig.isDeployChangedOnly()).isFalse();
   }
 }

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/deploy/DeployChangedOnlyEnabledTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/deploy/DeployChangedOnlyEnabledTest.java
@@ -33,6 +33,6 @@ public class DeployChangedOnlyEnabledTest extends AbstractRestTest {
 
   @Test
   public void shouldEnableDeployChangedOnlyOnOperatonRunProperty() {
-    assertThat(engineConfig.isDeployChangedOnly()).isEqualTo(true);
+    assertThat(engineConfig.isDeployChangedOnly()).isTrue();
   }
 }

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/deploy/DeployChangedOnlyUnsetTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/deploy/DeployChangedOnlyUnsetTest.java
@@ -30,6 +30,6 @@ public class DeployChangedOnlyUnsetTest extends AbstractRestTest {
 
   @Test
   public void shouldEnableDeployChangedOnlyOnOperatonRunProperty() {
-    assertThat(engineConfig.isDeployChangedOnly()).isEqualTo(true);
+    assertThat(engineConfig.isDeployChangedOnly()).isTrue();
   }
 }

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/identity/LdapConfigurationTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/identity/LdapConfigurationTest.java
@@ -43,7 +43,7 @@ public class LdapConfigurationTest {
 
   @Test
   public void shouldPickUpConfiguration() {
-    assertThat(props.isEnabled()).isEqualTo(true);
+    assertThat(props.isEnabled()).isTrue();
     assertThat(props.getServerUrl()).isEqualTo(plugin.getServerUrl());
     assertThat(props.getManagerDn()).isEqualTo(plugin.getManagerDn());
     assertThat(props.getManagerPassword()).isEqualTo(plugin.getManagerPassword());

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionResultTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionResultTest.java
@@ -16,22 +16,22 @@
  */
 package org.operaton.bpm.dmn.engine.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 import org.assertj.core.api.Fail;
-import org.operaton.bpm.dmn.engine.DmnDecisionResultEntries;
+import org.junit.Test;
 import org.operaton.bpm.dmn.engine.DmnDecisionResult;
+import org.operaton.bpm.dmn.engine.DmnDecisionResultEntries;
 import org.operaton.bpm.dmn.engine.impl.DmnDecisionResultException;
 import org.operaton.bpm.dmn.engine.test.DecisionResource;
 import org.operaton.bpm.dmn.engine.test.DmnEngineTest;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.TypedValue;
-import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class DmnDecisionResultTest extends DmnEngineTest {
 
@@ -298,7 +298,7 @@ public class DmnDecisionResultTest extends DmnEngineTest {
   }
 
   protected void assertNoOutputValue(DmnDecisionResultEntries result) {
-    assertThat(result.size()).isZero();
+    assertThat(result).isEmpty();
 
     String value = (String) result.get("firstOutput");
     assertThat(value).isNull();

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionResultTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionResultTest.java
@@ -282,7 +282,7 @@ public class DmnDecisionResultTest extends DmnEngineTest {
   }
 
   protected void assertSingleOutputValue(DmnDecisionResultEntries result) {
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(result).hasSize(1);
 
     String value = (String) result.get("firstOutput");
     assertThat(value).isEqualTo("singleValue");
@@ -314,7 +314,7 @@ public class DmnDecisionResultTest extends DmnEngineTest {
   }
 
   protected void assertMultipleOutputValues(DmnDecisionResultEntries result) {
-    assertThat(result.size()).isEqualTo(2);
+    assertThat(result).hasSize(2);
 
     String value = (String) result.get("firstOutput");
     assertThat(value).isEqualTo("multipleValues1");

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionResultTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionResultTest.java
@@ -298,7 +298,7 @@ public class DmnDecisionResultTest extends DmnEngineTest {
   }
 
   protected void assertNoOutputValue(DmnDecisionResultEntries result) {
-    assertThat(result.size()).isEqualTo(0);
+    assertThat(result.size()).isZero();
 
     String value = (String) result.get("firstOutput");
     assertThat(value).isNull();

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionTableResultTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionTableResultTest.java
@@ -297,7 +297,7 @@ public class DmnDecisionTableResultTest extends DmnEngineTest {
   }
 
   protected void assertNoOutputValue(DmnDecisionRuleResult decisionRuleResult) {
-    assertThat(decisionRuleResult.size()).isEqualTo(0);
+    assertThat(decisionRuleResult.size()).isZero();
 
     String value = (String) decisionRuleResult.get("firstOutput");
     assertThat(value).isNull();

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionTableResultTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionTableResultTest.java
@@ -281,7 +281,7 @@ public class DmnDecisionTableResultTest extends DmnEngineTest {
   }
 
   protected void assertSingleOutputValue(DmnDecisionRuleResult decisionRuleResult) {
-    assertThat(decisionRuleResult.size()).isEqualTo(1);
+    assertThat(decisionRuleResult).hasSize(1);
 
     String value = (String) decisionRuleResult.get("firstOutput");
     assertThat(value).isEqualTo("singleValue");
@@ -313,7 +313,7 @@ public class DmnDecisionTableResultTest extends DmnEngineTest {
   }
 
   protected void assertMultipleOutputValues(DmnDecisionRuleResult decisionRuleResult) {
-    assertThat(decisionRuleResult.size()).isEqualTo(2);
+    assertThat(decisionRuleResult).hasSize(2);
 
     String value = (String) decisionRuleResult.get("firstOutput");
     assertThat(value).isEqualTo("multipleValues1");

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionTableResultTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionTableResultTest.java
@@ -16,14 +16,8 @@
  */
 package org.operaton.bpm.dmn.engine.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 import org.assertj.core.api.Fail;
+import org.junit.Test;
 import org.operaton.bpm.dmn.engine.DmnDecisionRuleResult;
 import org.operaton.bpm.dmn.engine.DmnDecisionTableResult;
 import org.operaton.bpm.dmn.engine.impl.DmnDecisionResultException;
@@ -31,7 +25,13 @@ import org.operaton.bpm.dmn.engine.test.DecisionResource;
 import org.operaton.bpm.dmn.engine.test.DmnEngineTest;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.TypedValue;
-import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class DmnDecisionTableResultTest extends DmnEngineTest {
 
@@ -297,7 +297,7 @@ public class DmnDecisionTableResultTest extends DmnEngineTest {
   }
 
   protected void assertNoOutputValue(DmnDecisionRuleResult decisionRuleResult) {
-    assertThat(decisionRuleResult.size()).isZero();
+    assertThat(decisionRuleResult).isEmpty();
 
     String value = (String) decisionRuleResult.get("firstOutput");
     assertThat(value).isNull();

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnEngineMetricCollectorTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnEngineMetricCollectorTest.java
@@ -60,13 +60,13 @@ public class DmnEngineMetricCollectorTest extends DmnEngineTest {
 
   @Test
   public void testInitialExecutedDecisionElementsValue() {
-    assertThat(metricCollector.getExecutedDecisionElements()).isEqualTo(0L);
+    assertThat(metricCollector.getExecutedDecisionElements()).isZero();
   }
 
   @Test
   @DecisionResource(resource = EXAMPLE_DMN)
   public void testExecutedDecisionElementsOfDecisionTable() {
-    assertThat(metricCollector.getExecutedDecisionElements()).isEqualTo(0L);
+    assertThat(metricCollector.getExecutedDecisionElements()).isZero();
 
     dmnEngine.evaluateDecisionTable(decision, variables);
     assertThat(metricCollector.getExecutedDecisionElements()).isEqualTo(16L);
@@ -82,7 +82,7 @@ public class DmnEngineMetricCollectorTest extends DmnEngineTest {
   @Test
   @DecisionResource(resource = DISH_EXAMPLE_DMN, decisionKey = "Dish")
   public void testExecutedDecisionElementsOfDrg() {
-    assertThat(metricCollector.getExecutedDecisionElements()).isEqualTo(0L);
+    assertThat(metricCollector.getExecutedDecisionElements()).isZero();
 
     VariableMap variableMap = createVariables()
       .putValue("temperature", 20)
@@ -115,19 +115,19 @@ public class DmnEngineMetricCollectorTest extends DmnEngineTest {
   @Test
   @DecisionResource(resource = EXAMPLE_DMN)
   public void testClearExecutedDecisionElementsValue() {
-    assertThat(metricCollector.getExecutedDecisionElements()).isEqualTo(0L);
+    assertThat(metricCollector.getExecutedDecisionElements()).isZero();
 
     dmnEngine.evaluateDecisionTable(decision, variables);
     assertThat(metricCollector.getExecutedDecisionElements()).isEqualTo(16L);
     assertThat(metricCollector.clearExecutedDecisionElements()).isEqualTo(16L);
 
-    assertThat(metricCollector.getExecutedDecisionElements()).isEqualTo(0L);
+    assertThat(metricCollector.getExecutedDecisionElements()).isZero();
   }
 
   @Test
   @DecisionResource(resource = DISH_EXAMPLE_DMN, decisionKey = "Dish")
   public void testDrdDishDecisionExample() {
-    assertThat(metricCollector.getExecutedDecisionElements()).isEqualTo(0L);
+    assertThat(metricCollector.getExecutedDecisionElements()).isZero();
 
     dmnEngine.evaluateDecisionTable(decision, createVariables()
       .putValue("temperature", 20)
@@ -136,7 +136,7 @@ public class DmnEngineMetricCollectorTest extends DmnEngineTest {
     assertThat(metricCollector.getExecutedDecisionElements()).isEqualTo(30L);
     assertThat(metricCollector.clearExecutedDecisionElements()).isEqualTo(30L);
 
-    assertThat(metricCollector.getExecutedDecisionElements()).isEqualTo(0L);
+    assertThat(metricCollector.getExecutedDecisionElements()).isZero();
   }
 
   @Test

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/ParseDecisionTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/ParseDecisionTest.java
@@ -16,13 +16,8 @@
  */
 package org.operaton.bpm.dmn.engine.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
-
-import java.io.InputStream;
-import java.util.List;
-
 import org.assertj.core.api.Assertions;
+import org.junit.Test;
 import org.operaton.bpm.dmn.engine.DmnDecision;
 import org.operaton.bpm.dmn.engine.DmnDecisionRequirementsGraph;
 import org.operaton.bpm.dmn.engine.impl.transform.DmnTransformException;
@@ -32,7 +27,12 @@ import org.operaton.bpm.model.dmn.DmnModelException;
 import org.operaton.bpm.model.dmn.DmnModelInstance;
 import org.operaton.bpm.model.xml.ModelException;
 import org.operaton.commons.utils.IoUtil;
-import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class ParseDecisionTest extends DmnEngineTest {
 
@@ -225,7 +225,7 @@ public class ParseDecisionTest extends DmnEngineTest {
   public void shouldNotFailIfMissingRequiredDecisionAttribute() {
     List<DmnDecision> decisions = parseDecisionsFromFile(MISSING_REQUIRED_DECISION_ATTRIBUTE_DMN);
     assertThat(decisions).hasSize(1);
-    assertThat(decisions.get(0).getRequiredDecisions().size()).isZero();
+    assertThat(decisions.get(0).getRequiredDecisions()).isEmpty();
   }
 
   @Test

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/ParseDecisionTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/ParseDecisionTest.java
@@ -225,7 +225,7 @@ public class ParseDecisionTest extends DmnEngineTest {
   public void shouldNotFailIfMissingRequiredDecisionAttribute() {
     List<DmnDecision> decisions = parseDecisionsFromFile(MISSING_REQUIRED_DECISION_ATTRIBUTE_DMN);
     assertThat(decisions.size()).isEqualTo(1);
-    assertThat(decisions.get(0).getRequiredDecisions().size()).isEqualTo(0);
+    assertThat(decisions.get(0).getRequiredDecisions().size()).isZero();
   }
 
   @Test

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/ParseDecisionTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/ParseDecisionTest.java
@@ -224,7 +224,7 @@ public class ParseDecisionTest extends DmnEngineTest {
   @Test
   public void shouldNotFailIfMissingRequiredDecisionAttribute() {
     List<DmnDecision> decisions = parseDecisionsFromFile(MISSING_REQUIRED_DECISION_ATTRIBUTE_DMN);
-    assertThat(decisions.size()).isEqualTo(1);
+    assertThat(decisions).hasSize(1);
     assertThat(decisions.get(0).getRequiredDecisions().size()).isZero();
   }
 

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/delegate/DmnDecisionEvaluationListenerTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/delegate/DmnDecisionEvaluationListenerTest.java
@@ -116,7 +116,7 @@ public class DmnDecisionEvaluationListenerTest extends DmnEngineTest {
     DmnDecisionTableEvaluationEvent decisionResult = (DmnDecisionTableEvaluationEvent) listener.getEvaluationEvent().getDecisionResult();
     assertThat(decisionResult).isNotNull();
     assertThat(decisionResult.getDecisionTable().getKey()).isEqualTo("Dish");
-    assertThat(decisionResult.getMatchingRules().size()).isEqualTo(0);
+    assertThat(decisionResult.getMatchingRules().size()).isZero();
     assertThat(decisionResult.getExecutedDecisionElements()).isEqualTo(12L);
 
   }

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/delegate/DmnDecisionEvaluationListenerTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/delegate/DmnDecisionEvaluationListenerTest.java
@@ -16,21 +16,21 @@
  */
 package org.operaton.bpm.dmn.engine.delegate;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.InputStream;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.operaton.bpm.dmn.engine.DmnDecisionTableResult;
 import org.operaton.bpm.dmn.engine.DmnEngineConfiguration;
 import org.operaton.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
 import org.operaton.bpm.dmn.engine.test.DecisionResource;
 import org.operaton.bpm.dmn.engine.test.DmnEngineTest;
 import org.operaton.commons.utils.IoUtil;
-import org.junit.Before;
-import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *
@@ -116,7 +116,7 @@ public class DmnDecisionEvaluationListenerTest extends DmnEngineTest {
     DmnDecisionTableEvaluationEvent decisionResult = (DmnDecisionTableEvaluationEvent) listener.getEvaluationEvent().getDecisionResult();
     assertThat(decisionResult).isNotNull();
     assertThat(decisionResult.getDecisionTable().getKey()).isEqualTo("Dish");
-    assertThat(decisionResult.getMatchingRules().size()).isZero();
+    assertThat(decisionResult.getMatchingRules()).isEmpty();
     assertThat(decisionResult.getExecutedDecisionElements()).isEqualTo(12L);
 
   }

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/delegate/DmnDecisionEvaluationListenerTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/delegate/DmnDecisionEvaluationListenerTest.java
@@ -92,15 +92,15 @@ public class DmnDecisionEvaluationListenerTest extends DmnEngineTest {
     assertThat(decisionResult.getDecision().getKey()).isEqualTo("Dish");
 
     List<DmnEvaluatedInput> inputs = decisionResult.getInputs();
-    assertThat(inputs.size()).isEqualTo(2);
+    assertThat(inputs).hasSize(2);
     assertThat(inputs.get(0).getName()).isEqualTo("Season");
     assertThat(inputs.get(0).getValue().getValue()).isEqualTo("Summer");
     assertThat(inputs.get(1).getName()).isEqualTo("How many guests");
     assertThat(inputs.get(1).getValue().getValue()).isEqualTo(15);
 
-    assertThat(decisionResult.getMatchingRules().size()).isEqualTo(1);
+    assertThat(decisionResult.getMatchingRules()).hasSize(1);
     Map<String, DmnEvaluatedOutput> outputEntries = decisionResult.getMatchingRules().get(0).getOutputEntries();
-    assertThat(outputEntries.size()).isEqualTo(1);
+    assertThat(outputEntries).hasSize(1);
     assertThat(outputEntries.containsKey("desiredDish")).isTrue();
     assertThat(outputEntries.get("desiredDish").getValue().getValue()).isEqualTo("Light salad");
     assertThat(decisionResult.getExecutedDecisionElements()).isEqualTo(12L);
@@ -128,26 +128,26 @@ public class DmnDecisionEvaluationListenerTest extends DmnEngineTest {
 
     assertThat(listener.getEvaluationEvent()).isNotNull();
     Collection<DmnDecisionLogicEvaluationEvent> requiredDecisions = listener.getEvaluationEvent().getRequiredDecisionResults();
-    assertThat(requiredDecisions.size()).isEqualTo(2);
+    assertThat(requiredDecisions).hasSize(2);
 
     DmnDecisionTableEvaluationEvent dmnDecisionTableEvaluationEvent = getDmnDecisionTable(requiredDecisions,"Season");
     assertThat(dmnDecisionTableEvaluationEvent).isNotNull();
     List<DmnEvaluatedInput> inputs = dmnDecisionTableEvaluationEvent.getInputs();
-    assertThat(inputs.size()).isEqualTo(1);
+    assertThat(inputs).hasSize(1);
     assertThat(inputs.get(0).getName()).isEqualTo("Weather in Celsius");
     assertThat(inputs.get(0).getValue().getValue()).isEqualTo(35);
     List<DmnEvaluatedDecisionRule> matchingRules = dmnDecisionTableEvaluationEvent.getMatchingRules();
-    assertThat(matchingRules.size()).isEqualTo(1);
+    assertThat(matchingRules).hasSize(1);
     assertThat(matchingRules.get(0).getOutputEntries().get("season").getValue().getValue()).isEqualTo("Summer");
 
     dmnDecisionTableEvaluationEvent = getDmnDecisionTable(requiredDecisions,"GuestCount");
     assertThat(dmnDecisionTableEvaluationEvent).isNotNull();
     inputs = dmnDecisionTableEvaluationEvent.getInputs();
-    assertThat(inputs.size()).isEqualTo(1);
+    assertThat(inputs).hasSize(1);
     assertThat(inputs.get(0).getName()).isEqualTo("Type of day");
     assertThat(inputs.get(0).getValue().getValue()).isEqualTo("Weekend");
     matchingRules = dmnDecisionTableEvaluationEvent.getMatchingRules();
-    assertThat(matchingRules.size()).isEqualTo(1);
+    assertThat(matchingRules).hasSize(1);
     assertThat(matchingRules.get(0).getOutputEntries().get("guestCount").getValue().getValue()).isEqualTo(15);
 
   }

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/delegate/DmnDecisionTableEvaluationListenerTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/delegate/DmnDecisionTableEvaluationListenerTest.java
@@ -121,7 +121,7 @@ public class DmnDecisionTableEvaluationListenerTest extends DmnEngineTest {
 
     evaluateDecisionTable(true, "bar", "test", "hello");
     matchingRules = listener.evaluationEvent.getMatchingRules();
-    assertThat(matchingRules).hasSize(0);
+    assertThat(matchingRules).isEmpty();
 
     evaluateDecisionTable(false, "bar", "test", "hello");
     matchingRules = listener.evaluationEvent.getMatchingRules();
@@ -140,7 +140,7 @@ public class DmnDecisionTableEvaluationListenerTest extends DmnEngineTest {
     assertThat(matchedRule.getOutputEntries()).hasSize(1);
     matchedRule = matchingRules.get(1);
     assertThat(matchedRule.getId()).isEqualTo("rule3");
-    assertThat(matchedRule.getOutputEntries()).hasSize(0);
+    assertThat(matchedRule.getOutputEntries()).isEmpty();
     matchedRule = matchingRules.get(2);
     assertThat(matchedRule.getId()).isEqualTo("rule4");
     assertThat(matchedRule.getOutputEntries()).hasSize(1);

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/el/ExpressionEvaluationTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/el/ExpressionEvaluationTest.java
@@ -36,7 +36,7 @@ public class ExpressionEvaluationTest extends DmnEngineTest {
     public void testHasInputVariableName() {
       DmnDecisionResult decisionResult = dmnEngine.evaluateDecision(decision, Variables.createVariables().putValue("inVar", 2));
 
-      assertThat((boolean) decisionResult.getSingleEntry()).isEqualTo(true);
+      assertThat((boolean) decisionResult.getSingleEntry()).isTrue();
     }
 
     @Test
@@ -44,7 +44,7 @@ public class ExpressionEvaluationTest extends DmnEngineTest {
     public void testOverrideInputVariableName() {
       DmnDecisionResult decisionResult = dmnEngine.evaluateDecision(decision, Variables.createVariables().putValue("inVar", 2));
 
-      assertThat((boolean) decisionResult.getSingleEntry()).isEqualTo(true);
+      assertThat((boolean) decisionResult.getSingleEntry()).isTrue();
     }
 
     @Test
@@ -52,7 +52,7 @@ public class ExpressionEvaluationTest extends DmnEngineTest {
     public void testHasVariableContext() {
       DmnDecisionResult decisionResult = dmnEngine.evaluateDecision(decision, Variables.createVariables().putValue("inVar", 3));
 
-      assertThat((boolean) decisionResult.getSingleEntry()).isEqualTo(true);
+      assertThat((boolean) decisionResult.getSingleEntry()).isTrue();
     }
 
     @Test
@@ -60,7 +60,7 @@ public class ExpressionEvaluationTest extends DmnEngineTest {
     public void testHasInputVariableNameInVariableContext() {
       DmnDecisionResult decisionResult = dmnEngine.evaluateDecision(decision, Variables.createVariables().putValue("inVar", 3));
 
-      assertThat((boolean) decisionResult.getSingleEntry()).isEqualTo(true);
+      assertThat((boolean) decisionResult.getSingleEntry()).isTrue();
     }
 
 }

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/evaluate/DmnDecisionEvaluationTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/evaluate/DmnDecisionEvaluationTest.java
@@ -157,7 +157,7 @@ public class DmnDecisionEvaluationTest extends DmnEngineTest {
       .asVariableContext());
 
     List<Map<String, Object>> resultList = results.getResultList();
-    assertThat(resultList.size()).isEqualTo(0);
+    assertThat(resultList.size()).isZero();
 
   }
 

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/evaluate/DmnDecisionEvaluationTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/evaluate/DmnDecisionEvaluationTest.java
@@ -16,23 +16,19 @@
  */
 package org.operaton.bpm.dmn.engine.evaluate;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.dmn.engine.test.asserts.DmnEngineTestAssertions.assertThat;
-import static org.operaton.bpm.engine.variable.Variables.createVariables;
-
-import java.util.List;
-import java.util.Map;
-
-import org.operaton.bpm.dmn.engine.DmnDecisionRequirementsGraph;
-import org.operaton.bpm.dmn.engine.DmnDecisionResult;
-import org.operaton.bpm.dmn.engine.DmnDecisionTableResult;
-import org.operaton.bpm.dmn.engine.DmnEngineConfiguration;
-import org.operaton.bpm.dmn.engine.DmnEngineException;
+import org.junit.Test;
+import org.operaton.bpm.dmn.engine.*;
 import org.operaton.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
 import org.operaton.bpm.dmn.engine.impl.DmnEvaluationException;
 import org.operaton.bpm.dmn.engine.test.DmnEngineTest;
 import org.operaton.commons.utils.IoUtil;
-import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.dmn.engine.test.asserts.DmnEngineTestAssertions.assertThat;
+import static org.operaton.bpm.engine.variable.Variables.createVariables;
 
 public class DmnDecisionEvaluationTest extends DmnEngineTest {
 
@@ -157,7 +153,7 @@ public class DmnDecisionEvaluationTest extends DmnEngineTest {
       .asVariableContext());
 
     List<Map<String, Object>> resultList = results.getResultList();
-    assertThat(resultList.size()).isZero();
+    assertThat(resultList).isEmpty();
 
   }
 

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/transform/DmnTransformListenerTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/transform/DmnTransformListenerTest.java
@@ -87,7 +87,7 @@ public class DmnTransformListenerTest extends DmnEngineTest {
     assertThat(dmnDecisionRequirementsGraph.getName())
       .isEqualTo(definitions.getName())
       .isEqualTo("Dish");
-    assertThat(dmnDecisionRequirementsGraph.getDecisions().size()).isEqualTo(3);
+    assertThat(dmnDecisionRequirementsGraph.getDecisions()).hasSize(3);
     assertThat(dmnDecisionRequirementsGraph.getDecision("dish-decision")).isNotNull();
     assertThat(dmnDecisionRequirementsGraph.getDecision("season")).isNotNull();
     assertThat(dmnDecisionRequirementsGraph.getDecision("guestCount")).isNotNull();
@@ -115,7 +115,7 @@ public class DmnTransformListenerTest extends DmnEngineTest {
   public void shouldVerifyTransformedDmnDecisions() {
     dmnEngine.parseDecisionRequirementsGraph(IoUtil.fileAsStream(DRG_EXAMPLE_DMN));
     List<DmnDecision> transformedDecisions = listener.getTransformedDecisions();
-    assertThat(transformedDecisions.size()).isEqualTo(3);
+    assertThat(transformedDecisions).hasSize(3);
 
     assertThat(getDmnDecision(transformedDecisions, "dish-decision")).isNotNull();
     assertThat(getDmnDecision(transformedDecisions, "season")).isNotNull();

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/transform/DmnTransformTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/transform/DmnTransformTest.java
@@ -16,24 +16,11 @@
  */
 package org.operaton.bpm.dmn.engine.transform;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
-
-import java.io.InputStream;
-import java.util.Collection;
-import java.util.List;
-
 import org.assertj.core.api.Assertions;
+import org.junit.Test;
 import org.operaton.bpm.dmn.engine.DmnDecision;
 import org.operaton.bpm.dmn.engine.DmnDecisionRequirementsGraph;
-import org.operaton.bpm.dmn.engine.impl.DmnDecisionImpl;
-import org.operaton.bpm.dmn.engine.impl.DmnDecisionLiteralExpressionImpl;
-import org.operaton.bpm.dmn.engine.impl.DmnDecisionTableImpl;
-import org.operaton.bpm.dmn.engine.impl.DmnDecisionTableInputImpl;
-import org.operaton.bpm.dmn.engine.impl.DmnDecisionTableOutputImpl;
-import org.operaton.bpm.dmn.engine.impl.DmnDecisionTableRuleImpl;
-import org.operaton.bpm.dmn.engine.impl.DmnExpressionImpl;
-import org.operaton.bpm.dmn.engine.impl.DmnVariableImpl;
+import org.operaton.bpm.dmn.engine.impl.*;
 import org.operaton.bpm.dmn.engine.impl.hitpolicy.FirstHitPolicyHandler;
 import org.operaton.bpm.dmn.engine.impl.hitpolicy.UniqueHitPolicyHandler;
 import org.operaton.bpm.dmn.engine.impl.transform.DmnTransformException;
@@ -42,7 +29,13 @@ import org.operaton.bpm.dmn.engine.test.DmnEngineTest;
 import org.operaton.bpm.model.dmn.Dmn;
 import org.operaton.bpm.model.dmn.DmnModelInstance;
 import org.operaton.commons.utils.IoUtil;
-import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class DmnTransformTest extends DmnEngineTest {
 
@@ -244,7 +237,7 @@ public class DmnTransformTest extends DmnEngineTest {
     DmnDecision buyElectronicDecision = getDecision(buyComputerRequiredDecision, "buyElectronic");
     assertThat(buyElectronicDecision).isNotNull();
 
-    assertThat(buyElectronicDecision.getRequiredDecisions().size()).isZero();
+    assertThat(buyElectronicDecision.getRequiredDecisions()).isEmpty();
   }
 
   @Test
@@ -274,7 +267,7 @@ public class DmnTransformTest extends DmnEngineTest {
     assertThat(buyElectronicDecision).isNotNull();
 
     Collection<DmnDecision> buyElectronicRequiredDecisions = buyElectronicDecision.getRequiredDecisions();
-    assertThat(buyElectronicRequiredDecisions.size()).isZero();
+    assertThat(buyElectronicRequiredDecisions).isEmpty();
   }
 
   @Test

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/transform/DmnTransformTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/transform/DmnTransformTest.java
@@ -233,13 +233,13 @@ public class DmnTransformTest extends DmnEngineTest {
     assertDecision(buyProductDecision, "buyProduct");
 
     Collection<DmnDecision> buyProductrequiredDecisions = buyProductDecision.getRequiredDecisions();
-    assertThat(buyProductrequiredDecisions.size()).isEqualTo(1);
+    assertThat(buyProductrequiredDecisions).hasSize(1);
 
     DmnDecision buyComputerDecision = getDecision(buyProductrequiredDecisions, "buyComputer");
     assertThat(buyComputerDecision).isNotNull();
 
     Collection<DmnDecision> buyComputerRequiredDecision = buyComputerDecision.getRequiredDecisions();
-    assertThat(buyComputerRequiredDecision.size()).isEqualTo(1);
+    assertThat(buyComputerRequiredDecision).hasSize(1);
 
     DmnDecision buyElectronicDecision = getDecision(buyComputerRequiredDecision, "buyElectronic");
     assertThat(buyElectronicDecision).isNotNull();
@@ -257,7 +257,7 @@ public class DmnTransformTest extends DmnEngineTest {
     DmnDecision buyProductDecision = getDecision(decisions, "buyProduct");
     assertThat(buyProductDecision).isNotNull();
     Collection<DmnDecision> requiredProductDecisions = buyProductDecision.getRequiredDecisions();
-    assertThat(requiredProductDecisions.size()).isEqualTo(1);
+    assertThat(requiredProductDecisions).hasSize(1);
 
     DmnDecision requiredProductDecision = getDecision(requiredProductDecisions, "buyComputer");
     assertThat(requiredProductDecision).isNotNull();
@@ -265,7 +265,7 @@ public class DmnTransformTest extends DmnEngineTest {
     DmnDecision buyComputerDecision = getDecision(decisions, "buyComputer");
     assertThat(buyComputerDecision).isNotNull();
     Collection<DmnDecision> buyComputerRequiredDecisions = buyComputerDecision.getRequiredDecisions();
-    assertThat(buyComputerRequiredDecisions.size()).isEqualTo(1);
+    assertThat(buyComputerRequiredDecisions).hasSize(1);
 
     DmnDecision buyComputerRequiredDecision = getDecision(buyComputerRequiredDecisions, "buyElectronic");
     assertThat(buyComputerRequiredDecision).isNotNull();
@@ -283,7 +283,7 @@ public class DmnTransformTest extends DmnEngineTest {
     DmnModelInstance modelInstance = Dmn.readModelFromStream(inputStream);
     DmnDecision decision = dmnEngine.parseDecision("car",modelInstance);
     Collection<DmnDecision> requiredDecisions = decision.getRequiredDecisions();
-    assertThat(requiredDecisions.size()).isEqualTo(2);
+    assertThat(requiredDecisions).hasSize(2);
 
     DmnDecision carPriceDecision = getDecision(requiredDecisions, "carPrice");
     assertThat(carPriceDecision).isNotNull();
@@ -346,7 +346,7 @@ public class DmnTransformTest extends DmnEngineTest {
     DmnModelInstance modelInstance = Dmn.readModelFromStream(inputStream);
 
     List<DmnDecision> decisions = dmnEngine.parseDecisions(modelInstance);
-    assertThat(decisions.size()).isEqualTo(8);
+    assertThat(decisions).hasSize(8);
   }
 
   @Test

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/transform/DmnTransformTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/transform/DmnTransformTest.java
@@ -244,7 +244,7 @@ public class DmnTransformTest extends DmnEngineTest {
     DmnDecision buyElectronicDecision = getDecision(buyComputerRequiredDecision, "buyElectronic");
     assertThat(buyElectronicDecision).isNotNull();
 
-    assertThat(buyElectronicDecision.getRequiredDecisions().size()).isEqualTo(0);
+    assertThat(buyElectronicDecision.getRequiredDecisions().size()).isZero();
   }
 
   @Test
@@ -274,7 +274,7 @@ public class DmnTransformTest extends DmnEngineTest {
     assertThat(buyElectronicDecision).isNotNull();
 
     Collection<DmnDecision> buyElectronicRequiredDecisions = buyElectronicDecision.getRequiredDecisions();
-    assertThat(buyElectronicRequiredDecisions.size()).isEqualTo(0);
+    assertThat(buyElectronicRequiredDecisions.size()).isZero();
   }
 
   @Test

--- a/engine-dmn/feel-scala/src/test/java/org/operaton/bpm/dmn/engine/feel/function/CustomFunctionTest.java
+++ b/engine-dmn/feel-scala/src/test/java/org/operaton/bpm/dmn/engine/feel/function/CustomFunctionTest.java
@@ -228,7 +228,7 @@ public class CustomFunctionTest {
         Object argX = args.get(0);
 
         // then
-        assertThat(argX).isEqualTo(true);
+        assertThat(argX).isTrue();
 
         return "";
       })

--- a/engine-dmn/feel-scala/src/test/java/org/operaton/bpm/dmn/engine/feel/function/CustomFunctionTest.java
+++ b/engine-dmn/feel-scala/src/test/java/org/operaton/bpm/dmn/engine/feel/function/CustomFunctionTest.java
@@ -16,27 +16,24 @@
  */
 package org.operaton.bpm.dmn.engine.feel.function;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
-
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.dmn.engine.feel.function.helper.FunctionProvider;
 import org.operaton.bpm.dmn.engine.feel.function.helper.MyPojo;
 import org.operaton.bpm.dmn.engine.feel.helper.FeelRule;
 import org.operaton.bpm.dmn.feel.impl.FeelException;
 import org.operaton.bpm.dmn.feel.impl.scala.function.CustomFunction;
 import org.operaton.bpm.dmn.feel.impl.scala.function.builder.CustomFunctionBuilder;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.RuleChain;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 public class CustomFunctionTest {
 
@@ -228,7 +225,7 @@ public class CustomFunctionTest {
         Object argX = args.get(0);
 
         // then
-        assertThat(argX).isTrue();
+        assertThat(argX).isEqualTo(true);
 
         return "";
       })

--- a/engine-plugins/connect-plugin/src/test/java/org/operaton/connect/plugin/ConnectProcessEnginePluginTest.java
+++ b/engine-plugins/connect-plugin/src/test/java/org/operaton/connect/plugin/ConnectProcessEnginePluginTest.java
@@ -274,7 +274,7 @@ class ConnectProcessEnginePluginTest {
     assertThat(task.getName()).isEqualTo("User Task");
 
     // no job is created
-    assertThat(managementService.createJobQuery().count()).isEqualTo(0l);
+    assertThat(managementService.createJobQuery().count()).isZero();
   }
 
   @Deployment

--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapEnableSortControlSupportTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapEnableSortControlSupportTest.java
@@ -67,7 +67,7 @@ public class LdapEnableSortControlSupportTest {
         .sorted(Comparator.comparing(User::getFirstName))
         .collect(Collectors.toList());
 
-    assertThat(orderedUsers.size()).isEqualTo(manualOrderedUsers.size());
+    assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
     for (int i = 0; i < orderedUsers.size(); i++) {
       assertThat(orderedUsers.get(i).getId()).isEqualTo(manualOrderedUsers.get(i).getId());
@@ -84,7 +84,7 @@ public class LdapEnableSortControlSupportTest {
         .sorted(Comparator.comparing(User::getFirstName).reversed())
         .collect(Collectors.toList());
 
-    assertThat(orderedUsers.size()).isEqualTo(manualOrderedUsers.size());
+    assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
     for (int i = 0; i < orderedUsers.size(); i++) {
       assertThat(orderedUsers.get(i).getId()).isEqualTo(manualOrderedUsers.get(i).getId());
@@ -104,7 +104,7 @@ public class LdapEnableSortControlSupportTest {
         .sorted(Comparator.comparing(User::getLastName))
         .collect(Collectors.toList());
 
-    assertThat(orderedUsers.size()).isEqualTo(manualOrderedUsers.size());
+    assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
     for (int i = 0; i < orderedUsers.size(); i++) {
       assertThat(orderedUsers.get(i).getLastName()).isEqualTo(manualOrderedUsers.get(i).getLastName());
@@ -121,7 +121,7 @@ public class LdapEnableSortControlSupportTest {
         .sorted(Comparator.comparing(User::getLastName).reversed())
         .collect(Collectors.toList());
 
-    assertThat(orderedUsers.size()).isEqualTo(manualOrderedUsers.size());
+    assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
     for (int i = 0; i < orderedUsers.size(); i++) {
       assertThat(orderedUsers.get(i).getLastName()).isEqualTo(manualOrderedUsers.get(i).getLastName());
@@ -140,7 +140,7 @@ public class LdapEnableSortControlSupportTest {
         .sorted(Comparator.comparing(User::getEmail))
         .collect(Collectors.toList());
 
-    assertThat(orderedUsers.size()).isEqualTo(manualOrderedUsers.size());
+    assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
     for (int i = 0; i < orderedUsers.size(); i++) {
       assertThat(orderedUsers.get(i).getId()).isEqualTo(manualOrderedUsers.get(i).getId());
@@ -157,7 +157,7 @@ public class LdapEnableSortControlSupportTest {
         .sorted(Comparator.comparing(User::getEmail).reversed())
         .collect(Collectors.toList());
 
-    assertThat(orderedUsers.size()).isEqualTo(manualOrderedUsers.size());
+    assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
     for (int i = 0; i < orderedUsers.size(); i++) {
       assertThat(orderedUsers.get(i).getId()).isEqualTo(manualOrderedUsers.get(i).getId());
@@ -176,7 +176,7 @@ public class LdapEnableSortControlSupportTest {
         .sorted(Comparator.comparing(User::getId))
         .collect(Collectors.toList());
 
-    assertThat(orderedUsers.size()).isEqualTo(manualOrderedUsers.size());
+    assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
     for (int i = 0; i < orderedUsers.size(); i++) {
       assertThat(orderedUsers.get(i).getId()).isEqualTo(manualOrderedUsers.get(i).getId());
@@ -193,7 +193,7 @@ public class LdapEnableSortControlSupportTest {
         .sorted(Comparator.comparing(User::getId).reversed())
         .collect(Collectors.toList());
 
-    assertThat(orderedUsers.size()).isEqualTo(manualOrderedUsers.size());
+    assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
     for (int i = 0; i < orderedUsers.size(); i++) {
       assertThat(orderedUsers.get(i).getId()).isEqualTo(manualOrderedUsers.get(i).getId());
@@ -212,7 +212,7 @@ public class LdapEnableSortControlSupportTest {
         .sorted(Comparator.comparing(Group::getId))
         .collect(Collectors.toList());
 
-    assertThat(orderedGroup.size()).isEqualTo(manualOrderedGroups.size());
+    assertThat(orderedGroup).hasSize(manualOrderedGroups.size());
 
     for (int i = 0; i < orderedGroup.size(); i++) {
       assertThat(orderedGroup.get(i).getId()).isEqualTo(manualOrderedGroups.get(i).getId());
@@ -228,7 +228,7 @@ public class LdapEnableSortControlSupportTest {
         .sorted(Comparator.comparing(Group::getId).reversed())
         .collect(Collectors.toList());
 
-    assertThat(orderedGroup.size()).isEqualTo(manualOrderedGroups.size());
+    assertThat(orderedGroup).hasSize(manualOrderedGroups.size());
 
     for (int i = 0; i < orderedGroup.size(); i++) {
       assertThat(orderedGroup.get(i).getId()).isEqualTo(manualOrderedGroups.get(i).getId());
@@ -247,7 +247,7 @@ public class LdapEnableSortControlSupportTest {
         .sorted(Comparator.comparing(Group::getName))
         .collect(Collectors.toList());
 
-    assertThat(orderedGroup.size()).isEqualTo(manualOrderedGroups.size());
+    assertThat(orderedGroup).hasSize(manualOrderedGroups.size());
 
     for (int i = 0; i < orderedGroup.size(); i++) {
       assertThat(orderedGroup.get(i).getId()).isEqualTo(manualOrderedGroups.get(i).getId());
@@ -263,7 +263,7 @@ public class LdapEnableSortControlSupportTest {
         .sorted(Comparator.comparing(Group::getName).reversed())
         .collect(Collectors.toList());
 
-    assertThat(orderedGroup.size()).isEqualTo(manualOrderedGroups.size());
+    assertThat(orderedGroup).hasSize(manualOrderedGroups.size());
 
     for (int i = 0; i < orderedGroup.size(); i++) {
       assertThat(orderedGroup.get(i).getId()).isEqualTo(manualOrderedGroups.get(i).getId());

--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapGroupLargeQueryTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapGroupLargeQueryTest.java
@@ -95,8 +95,8 @@ public class LdapGroupLargeQueryTest {
     assertThat(query.listPage(85, 1)).hasSize(1);
 
     // Verifying odd usages
-    assertThat(query.listPage(-1, -1)).hasSize(0);
-    assertThat(query.listPage(86, 2)).hasSize(0); // 86 is the last index with a result
+    assertThat(query.listPage(-1, -1)).isEmpty();
+    assertThat(query.listPage(86, 2)).isEmpty(); // 86 is the last index with a result
     assertThat(query.listPage(0, 87)).hasSize(86); // there are only 86 groups
   }
 

--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapGroupQueryTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapGroupQueryTest.java
@@ -72,7 +72,7 @@ public class LdapGroupQueryTest {
     GroupQuery groupQuery = identityService.createGroupQuery();
 
     // then
-    assertThat(groupQuery.listPage(0, Integer.MAX_VALUE).size()).isEqualTo(6);
+    assertThat(groupQuery.listPage(0, Integer.MAX_VALUE)).hasSize(6);
     assertThat(groupQuery.count()).isEqualTo(6);
   }
 
@@ -84,7 +84,7 @@ public class LdapGroupQueryTest {
     List<Group> groupList = identityService.createGroupQuery().list();
 
     // then
-    assertThat(groupList.size()).isEqualTo(6);
+    assertThat(groupList).hasSize(6);
   }
 
   @Test
@@ -120,7 +120,7 @@ public class LdapGroupQueryTest {
     List<Group> groups = identityService.createGroupQuery().groupIdIn("external", "management").list();
 
     // then
-    assertThat(groups.size()).isEqualTo(2);
+    assertThat(groups).hasSize(2);
     assertThat(groups).extracting("id").containsOnly("external", "management");
   }
 

--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapGroupQueryTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapGroupQueryTest.java
@@ -320,12 +320,12 @@ public class LdapGroupQueryTest {
       groupNames.add(groups.get(0).getId());
 
       groups = identityService.createGroupQuery().listPage(4, 2);
-      assertThat(groups).hasSize(0);
+      assertThat(groups).isEmpty();
 
       identityService.setAuthenticatedUserId("daniel");
 
       groups = identityService.createGroupQuery().listPage(0, 2);
-      assertThat(groups).hasSize(0);
+      assertThat(groups).isEmpty();
 
     } finally {
       processEngineConfiguration.setAuthorizationEnabled(false);

--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapQueryToleranceTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapQueryToleranceTest.java
@@ -72,7 +72,7 @@ public class LdapQueryToleranceTest {
 
     // then
     // groups with id null were not returned
-    assertThat(groups).hasSize(0);
+    assertThat(groups).isEmpty();
     assertThat(count).isZero();
     List<ILoggingEvent> filteredLog = loggingRule.getFilteredLog("LDAP-00004 LDAP group query returned a group with id null.");
     assertThat(filteredLog).hasSize(12); // 2 queries * 6 roles (groupOfNames)
@@ -92,7 +92,7 @@ public class LdapQueryToleranceTest {
 
     // then
     // groups with id null were not returned
-    assertThat(users).hasSize(0);
+    assertThat(users).isEmpty();
     assertThat(count).isZero();
     List<ILoggingEvent> filteredLog = loggingRule.getFilteredLog("LDAP-00004 LDAP user query returned a user with id null.");
     assertThat(filteredLog).hasSize(24); // 2 queries * 12 users

--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapQueryToleranceTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapQueryToleranceTest.java
@@ -73,7 +73,7 @@ public class LdapQueryToleranceTest {
     // then
     // groups with id null were not returned
     assertThat(groups).hasSize(0);
-    assertThat(count).isEqualTo(0);
+    assertThat(count).isZero();
     List<ILoggingEvent> filteredLog = loggingRule.getFilteredLog("LDAP-00004 LDAP group query returned a group with id null.");
     assertThat(filteredLog).hasSize(12); // 2 queries * 6 roles (groupOfNames)
   }
@@ -93,7 +93,7 @@ public class LdapQueryToleranceTest {
     // then
     // groups with id null were not returned
     assertThat(users).hasSize(0);
-    assertThat(count).isEqualTo(0);
+    assertThat(count).isZero();
     List<ILoggingEvent> filteredLog = loggingRule.getFilteredLog("LDAP-00004 LDAP user query returned a user with id null.");
     assertThat(filteredLog).hasSize(24); // 2 queries * 12 users
   }

--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapUserLargeQueryTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapUserLargeQueryTest.java
@@ -93,8 +93,8 @@ public class LdapUserLargeQueryTest {
     assertThat(query.listPage(91, 1)).hasSize(1);
 
     // Verifying odd usages
-    assertThat(query.listPage(-1, -1)).hasSize(0);
-    assertThat(query.listPage(92, 2)).hasSize(0); // 92 is the last index with a result
+    assertThat(query.listPage(-1, -1)).isEmpty();
+    assertThat(query.listPage(92, 2)).isEmpty(); // 92 is the last index with a result
     assertThat(query.listPage(0, 93)).hasSize(92); // there are only 92 groups
   }
 

--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapUserQueryTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapUserQueryTest.java
@@ -631,7 +631,7 @@ public class LdapUserQueryTest {
       assertThat(users.get(0).getId()).isEqualTo("daniel");
 
       users = identityService.createUserQuery().listPage(2, 2);
-      assertThat(users).hasSize(0);
+      assertThat(users).isEmpty();
 
     } finally {
       processEngineConfiguration.setAuthorizationEnabled(false);

--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/ProcessDefinitionQueryWithCustomIdentityProviderTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/ProcessDefinitionQueryWithCustomIdentityProviderTest.java
@@ -65,7 +65,7 @@ public class ProcessDefinitionQueryWithCustomIdentityProviderTest {
     // when
     List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().startableByUser("pepe").list();
     // then
-    assertThat(processDefinitions).hasSize(0);
+    assertThat(processDefinitions).isEmpty();
   }
 
   @Test

--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/posix/LdapPosixGroupQueryTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/posix/LdapPosixGroupQueryTest.java
@@ -80,7 +80,7 @@ public class LdapPosixGroupQueryTest {
     List<User> result = identityService.createUserQuery().memberOfGroup("posix-group-without-members").list();
 
     // then
-    assertThat(result).hasSize(0);
+    assertThat(result).isEmpty();
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseExecutionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseExecutionRestServiceInteractionTest.java
@@ -3031,7 +3031,7 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
     assertThat(captured.getEncoding()).isNull();
     assertThat(captured.getFilename()).isEqualTo(filename);
     assertThat(captured.getMimeType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
-    assertThat(captured.getValue().available()).isEqualTo(0);
+    assertThat(captured.getValue().available()).isZero();
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseInstanceRestServiceInteractionTest.java
@@ -1208,7 +1208,7 @@ public class CaseInstanceRestServiceInteractionTest extends AbstractRestServiceT
     assertThat(captured.getEncoding()).isNull();
     assertThat(captured.getFilename()).isEqualTo(filename);
     assertThat(captured.getMimeType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
-    assertThat(captured.getValue().available()).isEqualTo(0);
+    assertThat(captured.getValue().available()).isZero();
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExecutionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExecutionRestServiceInteractionTest.java
@@ -1481,7 +1481,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     assertThat(captured.getEncoding()).isNull();
     assertThat(captured.getFilename()).isEqualTo(filename);
     assertThat(captured.getMimeType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
-    assertThat(captured.getValue().available()).isEqualTo(0);
+    assertThat(captured.getValue().available()).isZero();
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
@@ -2169,7 +2169,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
     assertThat(captured.getEncoding()).isNull();
     assertThat(captured.getFilename()).isEqualTo(filename);
     assertThat(captured.getMimeType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
-    assertThat(captured.getValue().available()).isEqualTo(0);
+    assertThat(captured.getValue().available()).isZero();
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
@@ -16,35 +16,15 @@
  */
 package org.operaton.bpm.engine.rest;
 
-import static io.restassured.RestAssured.given;
-import static io.restassured.path.json.JsonPath.from;
-import static junit.framework.TestCase.assertEquals;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.rest.util.DateTimeUtils.withTimezone;
-import static org.operaton.bpm.engine.rest.util.QueryParamUtils.arrayAsCommaSeperatedList;
-import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-import static org.mockito.hamcrest.MockitoHamcrest.argThat;
-
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response.Status;
-
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 import org.operaton.bpm.ProcessApplicationService;
 import org.operaton.bpm.application.ProcessApplicationInfo;
 import org.operaton.bpm.container.RuntimeContainerDelegate;
@@ -68,16 +48,21 @@ import org.operaton.bpm.engine.task.DelegationState;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.task.TaskQuery;
 import org.operaton.bpm.engine.variable.type.ValueType;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
 
-import io.restassured.http.ContentType;
-import io.restassured.response.Response;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response.Status;
+import java.util.*;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.path.json.JsonPath.from;
+import static junit.framework.TestCase.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
+import static org.operaton.bpm.engine.rest.util.DateTimeUtils.withTimezone;
+import static org.operaton.bpm.engine.rest.util.QueryParamUtils.arrayAsCommaSeperatedList;
 
 public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
@@ -195,7 +180,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     assertThat(MockProvider.EXAMPLE_TASK_LAST_UPDATED).isEqualTo(returnedLastUpdated);
     assertThat(MockProvider.EXAMPLE_TASK_DUE_DATE).isEqualTo(returnedDueDate);
     assertThat(MockProvider.EXAMPLE_FOLLOW_UP_DATE).isEqualTo(returnedFollowUpDate);
-    assertThat(MockProvider.EXAMPLE_TASK_DELEGATION_STATE.toString()).isEqualTo(returnedDelegationState);
+    assertThat(MockProvider.EXAMPLE_TASK_DELEGATION_STATE).hasToString(returnedDelegationState);
     assertThat(MockProvider.EXAMPLE_TASK_DESCRIPTION).isEqualTo(returnedDescription);
     assertThat(MockProvider.EXAMPLE_TASK_EXECUTION_ID).isEqualTo(returnedExecutionId);
     assertThat(MockProvider.EXAMPLE_TASK_OWNER).isEqualTo(returnedOwner);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableLocalRestResourceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableLocalRestResourceInteractionTest.java
@@ -1126,7 +1126,7 @@ public class TaskVariableLocalRestResourceInteractionTest extends
     assertThat(captured.getEncoding()).isNull();
     assertThat(captured.getFilename()).isEqualTo(filename);
     assertThat(captured.getMimeType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
-    assertThat(captured.getValue().available()).isEqualTo(0);
+    assertThat(captured.getValue().available()).isZero();
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableRestResourceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableRestResourceInteractionTest.java
@@ -1151,7 +1151,7 @@ public class TaskVariableRestResourceInteractionTest extends
     assertThat(captured.getEncoding()).isNull();
     assertThat(captured.getFilename()).isEqualTo(filename);
     assertThat(captured.getMimeType()).isEqualTo(MediaType.APPLICATION_OCTET_STREAM);
-    assertThat(captured.getValue().available()).isEqualTo(0);
+    assertThat(captured.getValue().available()).isZero();
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TenantRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TenantRestServiceQueryTest.java
@@ -108,7 +108,7 @@ public class TenantRestServiceQueryTest extends AbstractRestServiceTest {
 
     String content = response.asString();
     List<String> instances = from(content).getList("");
-    assertThat(instances.size()).isEqualTo(1);
+    assertThat(instances).hasSize(1);
 
     String returnedId = from(content).getString("[0].id");
     String returnedName = from(content).getString("[0].name");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerTest.java
@@ -219,7 +219,7 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // then
-    verify(asyncResponse).resume(argThat(Matchers.hasSize(0)));
+    verify(asyncResponse).resume(argThat(Matchers.isEmpty()));
     assertThat(handler.getPendingRequests().size()).isZero();
     verify(handler).suspend(Long.MAX_VALUE);
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerTest.java
@@ -16,29 +16,15 @@
  */
 package org.operaton.bpm.engine.rest.impl;
 
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.hamcrest.MockitoHamcrest.argThat;
-
-import java.util.ArrayList;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import javax.ws.rs.container.AsyncResponse;
-import javax.ws.rs.core.Response.Status;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.operaton.bpm.engine.ExternalTaskService;
 import org.operaton.bpm.engine.IdentityService;
 import org.operaton.bpm.engine.ProcessEngine;
@@ -51,16 +37,20 @@ import org.operaton.bpm.engine.rest.dto.externaltask.FetchExternalTasksExtendedD
 import org.operaton.bpm.engine.rest.exception.InvalidRequestException;
 import org.operaton.bpm.engine.rest.exception.RestException;
 import org.operaton.bpm.engine.rest.helper.MockProvider;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
 
-import org.hamcrest.Matchers;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.Response.Status;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.*;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 /**
  * @author Tassilo Weidner
@@ -219,7 +209,7 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // then
-    verify(asyncResponse).resume(argThat(Matchers.isEmpty()));
+    verify(asyncResponse).resume(argThat(Matchers.hasSize(0)));
     assertThat(handler.getPendingRequests().size()).isZero();
     verify(handler).suspend(Long.MAX_VALUE);
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerTest.java
@@ -163,7 +163,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(asyncResponse, never()).resume(any());
-    assertThat(handler.getPendingRequests().size()).isEqualTo(1);
+    assertThat(handler.getPendingRequests()).hasSize(1);
     verify(handler).suspend(5000L);
   }
 
@@ -178,7 +178,7 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // assume
-    assertThat(handler.getPendingRequests().size()).isEqualTo(1);
+    assertThat(handler.getPendingRequests()).hasSize(1);
     verify(handler).suspend(5000L);
 
     List<LockedExternalTask> tasks = new ArrayList<LockedExternalTask>();
@@ -210,7 +210,7 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // assume
-    assertThat(handler.getPendingRequests().size()).isEqualTo(1);
+    assertThat(handler.getPendingRequests()).hasSize(1);
     verify(handler).suspend(4000L);
 
     addSecondsToClock(4);
@@ -238,7 +238,7 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // assume
-    assertThat(handler.getPendingRequests().size()).isEqualTo(2);
+    assertThat(handler.getPendingRequests()).hasSize(2);
     verify(handler).suspend(3000L);
 
     addSecondsToClock(4);
@@ -279,7 +279,7 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // assume
-    assertThat(handler.getPendingRequests().size()).isEqualTo(1);
+    assertThat(handler.getPendingRequests()).hasSize(1);
     verify(handler).suspend(5000L);
 
     // when
@@ -354,7 +354,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(asyncResponse).cancel();
-    assertThat(handler.getPendingRequests().size()).isEqualTo(1);
+    assertThat(handler.getPendingRequests()).hasSize(1);
   }
 
   @Test
@@ -375,7 +375,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(asyncResponse, never()).cancel();
-    assertThat(handler.getPendingRequests().size()).isEqualTo(2);
+    assertThat(handler.getPendingRequests()).hasSize(2);
   }
 
   @Test
@@ -416,7 +416,7 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // assume
-    assertThat(handler.getPendingRequests().size()).isEqualTo(1);
+    assertThat(handler.getPendingRequests()).hasSize(1);
 
     // when
     handler.rejectPendingRequests();

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerTest.java
@@ -135,7 +135,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(asyncResponse).resume(argThat(Matchers.hasSize(1)));
-    assertThat(handler.getPendingRequests().size()).isZero();
+    assertThat(handler.getPendingRequests()).isEmpty();
     verify(handler).suspend(Long.MAX_VALUE);
   }
 
@@ -183,7 +183,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(asyncResponse).resume(argThat(Matchers.hasSize(1)));
-    assertThat(handler.getPendingRequests().size()).isZero();
+    assertThat(handler.getPendingRequests()).isEmpty();
     verify(handler).suspend(Long.MAX_VALUE);
   }
 
@@ -210,7 +210,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(asyncResponse).resume(argThat(Matchers.hasSize(0)));
-    assertThat(handler.getPendingRequests().size()).isZero();
+    assertThat(handler.getPendingRequests()).isEmpty();
     verify(handler).suspend(Long.MAX_VALUE);
   }
 
@@ -238,7 +238,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(asyncResponse, times(2)).resume(Collections.emptyList());
-    assertThat(handler.getPendingRequests().size()).isZero();
+    assertThat(handler.getPendingRequests()).isEmpty();
     verify(handler).suspend(Long.MAX_VALUE);
   }
 
@@ -253,7 +253,7 @@ public class FetchAndLockHandlerTest {
     handler.addPendingRequest(createDto(5000L), asyncResponse, processEngine);
 
     // Then
-    assertThat(handler.getPendingRequests().size()).isZero();
+    assertThat(handler.getPendingRequests()).isEmpty();
     verify(handler, never()).suspend(anyLong());
     verify(asyncResponse).resume(any(ProcessEngineException.class));
   }
@@ -277,7 +277,7 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // then
-    assertThat(handler.getPendingRequests().size()).isZero();
+    assertThat(handler.getPendingRequests()).isEmpty();
     verify(handler).suspend(Long.MAX_VALUE);
     verify(asyncResponse).resume(any(ProcessEngineException.class));
   }
@@ -287,7 +287,7 @@ public class FetchAndLockHandlerTest {
     // given - no pending requests
 
     // assume
-    assertThat(handler.getPendingRequests().size()).isZero();
+    assertThat(handler.getPendingRequests()).isEmpty();
 
     // when
     AsyncResponse asyncResponse = mock(AsyncResponse.class);
@@ -295,7 +295,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(handler, never()).suspend(anyLong());
-    assertThat(handler.getPendingRequests().size()).isZero();
+    assertThat(handler.getPendingRequests()).isEmpty();
 
     ArgumentCaptor<InvalidRequestException> argumentCaptor = ArgumentCaptor.forClass(InvalidRequestException.class);
     verify(asyncResponse).resume(argumentCaptor.capture());
@@ -388,13 +388,13 @@ public class FetchAndLockHandlerTest {
     // given - no pending requests
 
     // assume
-    assertThat(handler.getPendingRequests().size()).isZero();
+    assertThat(handler.getPendingRequests()).isEmpty();
 
     // when
     handler.acquire();
 
     // then
-    assertThat(handler.getPendingRequests().size()).isZero();
+    assertThat(handler.getPendingRequests()).isEmpty();
     verify(handler).suspend(Long.MAX_VALUE);
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerTest.java
@@ -145,7 +145,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(asyncResponse).resume(argThat(Matchers.hasSize(1)));
-    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
+    assertThat(handler.getPendingRequests().size()).isZero();
     verify(handler).suspend(Long.MAX_VALUE);
   }
 
@@ -193,7 +193,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(asyncResponse).resume(argThat(Matchers.hasSize(1)));
-    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
+    assertThat(handler.getPendingRequests().size()).isZero();
     verify(handler).suspend(Long.MAX_VALUE);
   }
 
@@ -220,7 +220,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(asyncResponse).resume(argThat(Matchers.hasSize(0)));
-    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
+    assertThat(handler.getPendingRequests().size()).isZero();
     verify(handler).suspend(Long.MAX_VALUE);
   }
 
@@ -248,7 +248,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(asyncResponse, times(2)).resume(Collections.emptyList());
-    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
+    assertThat(handler.getPendingRequests().size()).isZero();
     verify(handler).suspend(Long.MAX_VALUE);
   }
 
@@ -263,7 +263,7 @@ public class FetchAndLockHandlerTest {
     handler.addPendingRequest(createDto(5000L), asyncResponse, processEngine);
 
     // Then
-    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
+    assertThat(handler.getPendingRequests().size()).isZero();
     verify(handler, never()).suspend(anyLong());
     verify(asyncResponse).resume(any(ProcessEngineException.class));
   }
@@ -287,7 +287,7 @@ public class FetchAndLockHandlerTest {
     handler.acquire();
 
     // then
-    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
+    assertThat(handler.getPendingRequests().size()).isZero();
     verify(handler).suspend(Long.MAX_VALUE);
     verify(asyncResponse).resume(any(ProcessEngineException.class));
   }
@@ -297,7 +297,7 @@ public class FetchAndLockHandlerTest {
     // given - no pending requests
 
     // assume
-    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
+    assertThat(handler.getPendingRequests().size()).isZero();
 
     // when
     AsyncResponse asyncResponse = mock(AsyncResponse.class);
@@ -305,7 +305,7 @@ public class FetchAndLockHandlerTest {
 
     // then
     verify(handler, never()).suspend(anyLong());
-    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
+    assertThat(handler.getPendingRequests().size()).isZero();
 
     ArgumentCaptor<InvalidRequestException> argumentCaptor = ArgumentCaptor.forClass(InvalidRequestException.class);
     verify(asyncResponse).resume(argumentCaptor.capture());
@@ -398,13 +398,13 @@ public class FetchAndLockHandlerTest {
     // given - no pending requests
 
     // assume
-    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
+    assertThat(handler.getPendingRequests().size()).isZero();
 
     // when
     handler.acquire();
 
     // then
-    assertThat(handler.getPendingRequests().size()).isEqualTo(0);
+    assertThat(handler.getPendingRequests().size()).isZero();
     verify(handler).suspend(Long.MAX_VALUE);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/application/impl/embedded/EmbeddedProcessApplicationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/embedded/EmbeddedProcessApplicationTest.java
@@ -145,7 +145,7 @@ public class EmbeddedProcessApplicationTest extends PluggableProcessEngineTest {
     assertThat(loggingRule
         .getFilteredLog("ENGINE-07018 Unregistering process application for deployment but could " +
                         "not remove process definitions from deployment cache."))
-        .hasSize(0);
+        .isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/container/impl/deployment/jobexecutor/StartManagedThreadPoolStepTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/deployment/jobexecutor/StartManagedThreadPoolStepTest.java
@@ -16,16 +16,9 @@
  */
 package org.operaton.bpm.container.impl.deployment.jobexecutor;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import javax.management.ObjectName;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.operaton.bpm.container.impl.RuntimeContainerDelegateImpl;
 import org.operaton.bpm.container.impl.deployment.Attachments;
 import org.operaton.bpm.container.impl.jmx.MBeanServiceContainer;
@@ -39,9 +32,15 @@ import org.operaton.bpm.container.impl.spi.DeploymentOperation;
 import org.operaton.bpm.container.impl.spi.DeploymentOperationStep;
 import org.operaton.bpm.container.impl.spi.PlatformService;
 import org.operaton.bpm.container.impl.spi.ServiceTypes;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import javax.management.ObjectName;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *
@@ -85,8 +84,8 @@ public class StartManagedThreadPoolStepTest {
 
     //since no jobs will start, remaining capacity is sufficent to check the size
     assertThat(executor.getQueue().remainingCapacity()).isEqualTo(3);
-    assertThat(executor.getCorePool).hasSize(3);
-    assertThat(executor.getMaximumPool).hasSize(10);
+    assertThat(executor.getCorePoolSize()).isEqualTo(3);
+    assertThat(executor.getMaximumPoolSize()).isEqualTo(10);
     assertThat(executor.getKeepAliveTime(TimeUnit.MILLISECONDS)).isEqualTo(0L);
   }
 
@@ -109,8 +108,8 @@ public class StartManagedThreadPoolStepTest {
 
     //since no jobs will start, remaining capacity is sufficent to check the size
     assertThat(executor.getQueue().remainingCapacity()).isEqualTo(Integer.parseInt(queueSize));
-    assertThat(executor.getCorePool).hasSize(Integer.parseInt(corePoolSize));
-    assertThat(executor.getMaximumPool).hasSize(Integer.parseInt(maxPoolSize));
+    assertThat(executor.getCorePoolSize()).isEqualTo(Integer.parseInt(corePoolSize));
+    assertThat(executor.getMaximumPoolSize()).isEqualTo(Integer.parseInt(maxPoolSize));
     assertThat(executor.getKeepAliveTime(TimeUnit.MILLISECONDS)).isEqualTo(Long.parseLong(keepAliveTime));
   }
 

--- a/engine/src/test/java/org/operaton/bpm/container/impl/deployment/jobexecutor/StartManagedThreadPoolStepTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/deployment/jobexecutor/StartManagedThreadPoolStepTest.java
@@ -86,7 +86,7 @@ public class StartManagedThreadPoolStepTest {
     assertThat(executor.getQueue().remainingCapacity()).isEqualTo(3);
     assertThat(executor.getCorePoolSize()).isEqualTo(3);
     assertThat(executor.getMaximumPoolSize()).isEqualTo(10);
-    assertThat(executor.getKeepAliveTime(TimeUnit.MILLISECONDS)).isEqualTo(0L);
+    assertThat(executor.getKeepAliveTime(TimeUnit.MILLISECONDS)).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/container/impl/deployment/jobexecutor/StartManagedThreadPoolStepTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/deployment/jobexecutor/StartManagedThreadPoolStepTest.java
@@ -85,8 +85,8 @@ public class StartManagedThreadPoolStepTest {
 
     //since no jobs will start, remaining capacity is sufficent to check the size
     assertThat(executor.getQueue().remainingCapacity()).isEqualTo(3);
-    assertThat(executor.getCorePoolSize()).isEqualTo(3);
-    assertThat(executor.getMaximumPoolSize()).isEqualTo(10);
+    assertThat(executor.getCorePool).hasSize(3);
+    assertThat(executor.getMaximumPool).hasSize(10);
     assertThat(executor.getKeepAliveTime(TimeUnit.MILLISECONDS)).isEqualTo(0L);
   }
 
@@ -109,8 +109,8 @@ public class StartManagedThreadPoolStepTest {
 
     //since no jobs will start, remaining capacity is sufficent to check the size
     assertThat(executor.getQueue().remainingCapacity()).isEqualTo(Integer.parseInt(queueSize));
-    assertThat(executor.getCorePoolSize()).isEqualTo(Integer.parseInt(corePoolSize));
-    assertThat(executor.getMaximumPoolSize()).isEqualTo(Integer.parseInt(maxPoolSize));
+    assertThat(executor.getCorePool).hasSize(Integer.parseInt(corePoolSize));
+    assertThat(executor.getMaximumPool).hasSize(Integer.parseInt(maxPoolSize));
     assertThat(executor.getKeepAliveTime(TimeUnit.MILLISECONDS)).isEqualTo(Long.parseLong(keepAliveTime));
   }
 

--- a/engine/src/test/java/org/operaton/bpm/container/impl/parser/BpmPlatformXmlParserTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/parser/BpmPlatformXmlParserTest.java
@@ -89,7 +89,7 @@ public class BpmPlatformXmlParserTest {
 
     JobExecutorXml jobExecutorXml = bpmPlatformXml.getJobExecutor();
     assertEquals(1, jobExecutorXml.getJobAcquisitions().size());
-    assertThat(jobExecutorXml.getProperties().size()).isEqualTo(2);
+    assertThat(jobExecutorXml.getProperties()).hasSize(2);
 
     JobAcquisitionXml jobAcquisitionXml = jobExecutorXml.getJobAcquisitions().get(0);
     assertEquals("default", jobAcquisitionXml.getName());

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/cfg/CompositeProcessEnginePluginTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/cfg/CompositeProcessEnginePluginTest.java
@@ -16,17 +16,15 @@
  */
 package org.operaton.bpm.engine.impl.cfg;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.Arrays;
-
-import org.operaton.bpm.engine.ProcessEngine;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
+import org.operaton.bpm.engine.ProcessEngine;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 public class CompositeProcessEnginePluginTest {
 
@@ -87,7 +85,7 @@ public class CompositeProcessEnginePluginTest {
 
   @Test
   public void verifyToString() throws Exception {
-    assertThat(new CompositeProcessEnginePlugin(PLUGIN_A, PLUGIN_B).toString()).isEqualTo("CompositeProcessEnginePlugin[PluginA, PluginB]");
+    assertThat(new CompositeProcessEnginePlugin(PLUGIN_A, PLUGIN_B)).hasToString("CompositeProcessEnginePlugin[PluginA, PluginB]");
   }
 
   private static ProcessEnginePlugin processEnginePlugin(final String name) {

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/test/TestHelperTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/test/TestHelperTest.java
@@ -26,42 +26,43 @@ public class TestHelperTest {
   public void shouldGetPublicMethod() throws NoSuchMethodException {
     // WHEN we call get method to retrieve a method with public accessor, no exception should be thrown
     Object methodName = TestHelper.getMethod(SomeTestClass.class, "testSomethingWithPublicAccessor", new Class[0]);
-    assertThat(methodName.toString()).isEqualTo("public void org.operaton.bpm.engine.impl.test.TestHelperTest$SomeTestClass.testSomethingWithPublicAccessor()");
+    assertThat(methodName).hasToString("public void org.operaton.bpm.engine.impl.test" +
+            ".TestHelperTest$SomeTestClass.testSomethingWithPublicAccessor()");
   }
 
   @Test
   public void shouldGetPublicMethodFromSuperClass() throws NoSuchMethodException {
     // WHEN we call get method to retrieve a method with public accessor, no exception should be thrown
     Object methodName = TestHelper.getMethod(SomeOtherTestClass.class, "testSomethingWithPublicAccessor", new Class[0]);
-    assertThat(methodName.toString()).isEqualTo("public void org.operaton.bpm.engine.impl.test.TestHelperTest$SomeTestClass.testSomethingWithPublicAccessor()");
+    assertThat(methodName).hasToString("public void org.operaton.bpm.engine.impl.test.TestHelperTest$SomeTestClass.testSomethingWithPublicAccessor()");
   }
 
   @Test
   public void shouldGetPackagePrivateMethod() throws NoSuchMethodException {
     // WHEN we call get method to retrieve a method with package private accessor, no exception should be thrown
     Object methodName = TestHelper.getMethod(SomeTestClass.class, "testSomethingWithPackagePrivateAccessor", new Class[0]);
-    assertThat(methodName.toString()).isEqualTo("void org.operaton.bpm.engine.impl.test.TestHelperTest$SomeTestClass.testSomethingWithPackagePrivateAccessor()");
+    assertThat(methodName).hasToString("void org.operaton.bpm.engine.impl.test.TestHelperTest$SomeTestClass.testSomethingWithPackagePrivateAccessor()");
   }
 
   @Test
   public void shouldGetPackagePrivateMethodFromSuperClass() throws NoSuchMethodException {
     // WHEN we call get method to retrieve a method with package private accessor, no exception should be thrown
     Object methodName = TestHelper.getMethod(SomeOtherTestClass.class, "testSomethingWithPackagePrivateAccessor", new Class[0]);
-    assertThat(methodName.toString()).isEqualTo("void org.operaton.bpm.engine.impl.test.TestHelperTest$SomeTestClass.testSomethingWithPackagePrivateAccessor()");
+    assertThat(methodName).hasToString("void org.operaton.bpm.engine.impl.test.TestHelperTest$SomeTestClass.testSomethingWithPackagePrivateAccessor()");
   }
 
   @Test
   public void shouldGetProtectedMethod() throws NoSuchMethodException {
     // WHEN we call get method to retrieve a method with protected accessor, no exception should be thrown
     Object methodName = TestHelper.getMethod(SomeTestClass.class, "testSomethingWithProtected", new Class[0]);
-    assertThat(methodName.toString()).isEqualTo("protected void org.operaton.bpm.engine.impl.test.TestHelperTest$SomeTestClass.testSomethingWithProtected()");
+    assertThat(methodName).hasToString("protected void org.operaton.bpm.engine.impl.test.TestHelperTest$SomeTestClass.testSomethingWithProtected()");
   }
 
   @Test
   public void shouldGetProtectedMethodFromSuperClass() throws NoSuchMethodException {
     // WHEN we call get method to retrieve a method with protected accessor, no exception should be thrown
     Object methodName = TestHelper.getMethod(SomeOtherTestClass.class, "testSomethingWithProtected", new Class[0]);
-    assertThat(methodName.toString()).isEqualTo("protected void org.operaton.bpm.engine.impl.test.TestHelperTest$SomeTestClass.testSomethingWithProtected()");
+    assertThat(methodName).hasToString("protected void org.operaton.bpm.engine.impl.test.TestHelperTest$SomeTestClass.testSomethingWithProtected()");
   }
 
   static class SomeTestClass {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/AuthorizationLoggingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/AuthorizationLoggingTest.java
@@ -74,7 +74,7 @@ public class AuthorizationLoggingTest {
     String message = "ENGINE-03110 Required admin authenticated group or user or any of the following permissions:";
     List<ILoggingEvent> filteredLog = loggingRule.getFilteredLog(CONTEXT_LOGGER, message);
 
-    assertThat(filteredLog.size()).isEqualTo(1);
+    assertThat(filteredLog).hasSize(1);
     assertThat(filteredLog.get(0).getLevel()).isEqualTo(Level.DEBUG);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ManagementAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ManagementAuthorizationTest.java
@@ -16,14 +16,8 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
+import org.junit.After;
+import org.junit.Test;
 import org.operaton.bpm.engine.authorization.Groups;
 import org.operaton.bpm.engine.authorization.Resources;
 import org.operaton.bpm.engine.authorization.SystemPermissions;
@@ -34,8 +28,14 @@ import org.operaton.bpm.engine.management.SchemaLogEntry;
 import org.operaton.bpm.engine.management.TableMetaData;
 import org.operaton.bpm.engine.management.TablePage;
 import org.operaton.bpm.engine.telemetry.TelemetryData;
-import org.junit.After;
-import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
 
 
 /**
@@ -889,7 +889,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
     long schemaLog = managementService.createSchemaLogQuery().count();
 
     // then
-    assertThat(schemaLog).isGreaterThan(0);
+    assertThat(schemaLog).isPositive();
   }
 
   @Test
@@ -901,7 +901,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
     long schemaLog = managementService.createSchemaLogQuery().count();
 
     // then
-    assertThat(schemaLog).isGreaterThan(0);
+    assertThat(schemaLog).isPositive();
   }
 
   @Test
@@ -914,7 +914,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
     long schemaLog = managementService.createSchemaLogQuery().count();
 
     // then
-    assertThat(schemaLog).isGreaterThan(0);
+    assertThat(schemaLog).isPositive();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ManagementAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ManagementAuthorizationTest.java
@@ -382,7 +382,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
 
     // then
       disableAuthorization();
-      assertThat(managementService.getProperties().get(DUMMY_PROPERTY)).isEqualTo(DUMMY_VALUE);
+    assertThat(managementService.getProperties()).containsEntry(DUMMY_PROPERTY, DUMMY_VALUE);
   }
 
   @Test
@@ -395,7 +395,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
 
     // then
     disableAuthorization();
-    assertThat(managementService.getProperties().get(DUMMY_PROPERTY)).isEqualTo(DUMMY_VALUE);
+    assertThat(managementService.getProperties()).containsEntry(DUMMY_PROPERTY, DUMMY_VALUE);
   }
 
   @Test
@@ -409,7 +409,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
 
     // then
     disableAuthorization();
-    assertThat(managementService.getProperties().get(DUMMY_PROPERTY)).isEqualTo(DUMMY_VALUE);
+    assertThat(managementService.getProperties()).containsEntry(DUMMY_PROPERTY, DUMMY_VALUE);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SchemaLogQueryAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SchemaLogQueryAuthorizationTest.java
@@ -16,12 +16,12 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+import org.operaton.bpm.engine.authorization.Groups;
 
 import java.util.Collections;
 
-import org.operaton.bpm.engine.authorization.Groups;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Miklas Boskamp
@@ -43,7 +43,7 @@ public class SchemaLogQueryAuthorizationTest extends AuthorizationTest {
     identityService.setAuthentication(userId, Collections.singletonList(Groups.CAMUNDA_ADMIN));
 
     // then
-    assertThat(managementService.createSchemaLogQuery().count()).isGreaterThan(0);
+    assertThat(managementService.createSchemaLogQuery().count()).isPositive();
   }
 
   @Test
@@ -52,6 +52,6 @@ public class SchemaLogQueryAuthorizationTest extends AuthorizationTest {
     identityService.setAuthentication(userId, Collections.singletonList(Groups.CAMUNDA_ADMIN));
 
     // then
-    assertThat(managementService.createSchemaLogQuery().list().size()).isGreaterThan(0);
+    assertThat(managementService.createSchemaLogQuery().list().size()).isPositive();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/DeleteHistoricProcessInstancesBatchAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/DeleteHistoricProcessInstancesBatchAuthorizationTest.java
@@ -166,7 +166,7 @@ public class DeleteHistoricProcessInstancesBatchAuthorizationTest extends Abstra
         HistoricBatch historicBatch = engineRule.getHistoryService().createHistoricBatchQuery().list().get(0);
         assertEquals("userId", historicBatch.getCreateUserId());
       }
-      assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0L);
+      assertThat(historyService.createHistoricProcessInstanceQuery().count()).isZero();
     }
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/DeleteProcessInstancesBatchAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/DeleteProcessInstancesBatchAuthorizationTest.java
@@ -164,7 +164,7 @@ public class DeleteProcessInstancesBatchAuthorizationTest extends AbstractBatchA
       }
 
       if (authRule.scenarioSucceeded()) {
-        assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
+        assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
       }
     }
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/DeleteHistoricProcessInstancesAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/DeleteHistoricProcessInstancesAuthorizationTest.java
@@ -139,7 +139,7 @@ public class DeleteHistoricProcessInstancesAuthorizationTest {
 
     // then
     if (authRule.assertScenario(scenario)) {
-      assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0L);
+      assertThat(historyService.createHistoricProcessInstanceQuery().count()).isZero();
     }
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDecisionInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDecisionInstanceAuthorizationTest.java
@@ -179,7 +179,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
 
     // then
     disableAuthorization();
-    assertThat(historyService.createHistoricDecisionInstanceQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricDecisionInstanceQuery().count()).isZero();
     enableAuthorization();
 }
 
@@ -195,7 +195,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
 
     // then
     disableAuthorization();
-    assertThat(historyService.createHistoricDecisionInstanceQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricDecisionInstanceQuery().count()).isZero();
     enableAuthorization();
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/optimize/OptimizeServiceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/optimize/OptimizeServiceAuthorizationTest.java
@@ -17,34 +17,15 @@
 package org.operaton.bpm.engine.test.api.authorization.optimize;
 
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.authorization.Authorization.ANY;
-import static org.operaton.bpm.engine.authorization.Permissions.ALL;
-import static org.operaton.bpm.engine.authorization.Permissions.READ;
-import static org.operaton.bpm.engine.authorization.Permissions.READ_HISTORY;
-import static org.operaton.bpm.engine.authorization.Resources.AUTHORIZATION;
-import static org.operaton.bpm.engine.authorization.Resources.DECISION_DEFINITION;
-import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
-import static org.operaton.bpm.engine.authorization.Resources.TENANT;
-import static org.operaton.bpm.engine.authorization.Resources.USER;
-import static org.junit.Assert.fail;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.operaton.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
-import org.operaton.bpm.engine.AuthorizationException;
-import org.operaton.bpm.engine.AuthorizationService;
-import org.operaton.bpm.engine.DecisionService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ManagementService;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.impl.OptimizeService;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.repository.DecisionDefinition;
@@ -62,13 +43,14 @@ import org.operaton.bpm.engine.test.util.ResetDmnConfigUtil;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.operaton.bpm.engine.authorization.Authorization.ANY;
+import static org.operaton.bpm.engine.authorization.Permissions.*;
+import static org.operaton.bpm.engine.authorization.Resources.*;
 
 @RunWith(Parameterized.class)
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
@@ -299,7 +281,7 @@ public class OptimizeServiceAuthorizationTest {
     List<?> instance = methodToTest.apply(optimizeService);
 
     // then
-    assertThat(instance.size()).isGreaterThan(0);
+    assertThat(instance).isNotEmpty();
   }
 
   private void generateTestData() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/HandleTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/HandleTaskAuthorizationTest.java
@@ -143,8 +143,8 @@ public class HandleTaskAuthorizationTest {
     // then
     if (authRule.assertScenario(scenario)) {
       assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).singleResult());
-      assertThat(loggingRule.getFilteredLog(BPMN_BEHAVIOR_LOGGER, "Execution is ended (none end event semantics)").size()).isEqualTo(1);
-      assertThat(loggingRule.getFilteredLog(BPMN_BEHAVIOR_LOGGER, "no catching boundary event was defined").size()).isEqualTo(1);
+      assertThat(loggingRule.getFilteredLog(BPMN_BEHAVIOR_LOGGER, "Execution is ended (none end event semantics)")).hasSize(1);
+      assertThat(loggingRule.getFilteredLog(BPMN_BEHAVIOR_LOGGER, "no catching boundary event was defined")).hasSize(1);
     }
   }
 
@@ -177,7 +177,7 @@ public class HandleTaskAuthorizationTest {
     // then
     if (authRule.assertScenario(scenario)) {
       List<Task> tasks = taskService.createTaskQuery().list();
-      assertThat(tasks.size()).isEqualTo(1);
+      assertThat(tasks).hasSize(1);
       assertThat(tasks.get(0).getTaskDefinitionKey()).isEqualTo("after-catch");
     }
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DeploymentCacheCfgTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DeploymentCacheCfgTest.java
@@ -301,12 +301,9 @@ public class DeploymentCacheCfgTest {
     ProcessInstance processInstance3 = runtimeService.startProcessInstanceByKey("Process3");
 
     // then
-    assertThat(repositoryService.getIdentityLinksForProcessDefinition(processInstance1.getProcessDefinitionId()).size())
-        .isEqualTo(1);
-    assertThat(repositoryService.getIdentityLinksForProcessDefinition(processInstance2.getProcessDefinitionId()).size())
-        .isEqualTo(1);
-    assertThat(repositoryService.getIdentityLinksForProcessDefinition(processInstance3.getProcessDefinitionId()).size())
-        .isEqualTo(1);
+    assertThat(repositoryService.getIdentityLinksForProcessDefinition(processInstance1.getProcessDefinitionId())).hasSize(1);
+    assertThat(repositoryService.getIdentityLinksForProcessDefinition(processInstance2.getProcessDefinitionId())).hasSize(1);
+    assertThat(repositoryService.getIdentityLinksForProcessDefinition(processInstance3.getProcessDefinitionId())).hasSize(1);
   }
 
   protected List<BpmnModelInstance> createSequentialCallActivityProcess() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskQueryByCreateTimeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskQueryByCreateTimeTest.java
@@ -107,7 +107,7 @@ public class ExternalTaskQueryByCreateTimeTest {
     var result = historyService.createHistoricExternalTaskLogQuery().list();
 
     // then
-    assertThat(result.size()).isEqualTo(1);
+    assertThat(result).hasSize(1);
 
     var historyEventTimestamp = result.get(0).getTimestamp();
 
@@ -128,7 +128,7 @@ public class ExternalTaskQueryByCreateTimeTest {
         .list();
 
     // then
-    assertThat(result.size()).isEqualTo(2);
+    assertThat(result).hasSize(2);
 
     var extTask1 = result.get(0);
     var extTask2 = result.get(1);
@@ -151,7 +151,7 @@ public class ExternalTaskQueryByCreateTimeTest {
         .list();
 
     // then
-    assertThat(result.size()).isEqualTo(2);
+    assertThat(result).hasSize(2);
 
     var extTask1 = result.get(0);
     var extTask2 = result.get(1);
@@ -180,7 +180,7 @@ public class ExternalTaskQueryByCreateTimeTest {
         .list();
 
     // then
-    assertThat(result.size()).isEqualTo(4);
+    assertThat(result).hasSize(4);
 
     assertThat(result.get(0).getActivityId()).isEqualTo("task1");
     assertThat(result.get(1).getActivityId()).isEqualTo("task2");
@@ -206,7 +206,7 @@ public class ExternalTaskQueryByCreateTimeTest {
         .list();
 
     // then
-    assertThat(result.size()).isEqualTo(4);
+    assertThat(result).hasSize(4);
 
     assertThat(result.get(0).getActivityId()).isEqualTo("task1"); // due to priority DESC
     assertThat(result.get(1).getActivityId()).isEqualTo("task2");
@@ -235,7 +235,7 @@ public class ExternalTaskQueryByCreateTimeTest {
         .list();
 
     // then
-    assertThat(result.size()).isEqualTo(4);
+    assertThat(result).hasSize(4);
 
     assertThat(result.get(0).getActivityId()).isEqualTo("task2"); // due to CreateTime Equality, priority ASC
     assertThat(result.get(1).getActivityId()).isEqualTo("task1");
@@ -265,7 +265,7 @@ public class ExternalTaskQueryByCreateTimeTest {
         .list();
 
     // then
-    assertThat(result.size()).isEqualTo(4);
+    assertThat(result).hasSize(4);
 
     assertThat(result.get(0).getActivityId()).isEqualTo("task1"); // due to CreateTime equality, priority DESC
     assertThat(result.get(1).getActivityId()).isEqualTo("task2");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.java
@@ -216,7 +216,7 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
         .execute();
 
     // then
-    assertThat(result.size()).isEqualTo(5);
+    assertThat(result).hasSize(5);
 
     assertThat(result.get(0).getPriority()).isEqualTo(7);
     assertThat(result.get(1).getPriority()).isEqualTo(7);
@@ -259,7 +259,7 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
         .execute();
 
     // then
-    assertThat(result.size()).isEqualTo(5);
+    assertThat(result).hasSize(5);
 
     assertThat(result.get(0).getPriority()).isEqualTo(7);
     assertThat(result.get(1).getPriority()).isEqualTo(7);
@@ -303,7 +303,7 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
         .execute();
 
     // then
-    assertThat(result.size()).isEqualTo(5);
+    assertThat(result).hasSize(5);
     assertThat(result).extracting("createTime", Date.class).isSorted();
   }
 
@@ -333,7 +333,7 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
         .execute();
 
     // then
-    assertThat(result.size()).isEqualTo(5);
+    assertThat(result).hasSize(5);
     assertThat(result).extracting("createTime", Date.class).isSortedAccordingTo(reverseOrder());
   }
 
@@ -363,7 +363,7 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
         .execute();
 
     // then
-    assertThat(result.size()).isEqualTo(5);
+    assertThat(result).hasSize(5);
     // create time ordering will be ignored, only priority will be used
     assertThat(result).extracting("priority", Long.class).isSortedAccordingTo(reverseOrder());
   }
@@ -387,7 +387,7 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
         .execute();
 
     // then
-    assertThat(result.size()).isEqualTo(5);
+    assertThat(result).hasSize(5);
     // create time ordering will be ignored, only priority will be used
     assertThat(result).extracting("priority", Long.class).isSortedAccordingTo(reverseOrder());
   }
@@ -4379,7 +4379,7 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
 
     //then
     assertThat(totalExternalTasks).isEqualTo(2);
-    assertThat(fetchedExternalTasks.size()).isEqualTo(1);
+    assertThat(fetchedExternalTasks).hasSize(1);
     assertThat(fetchedExternalTasks.get(0).getProcessDefinitionKey()).isEqualTo("testFetchAndLockByProcessDefinitionVersionTag");
     assertThat(fetchedExternalTasks.get(0).getProcessDefinitionVersionTag()).isEqualTo("version X.Y");
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.java
@@ -1750,7 +1750,7 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
     assertThat(tasks).hasSize(1);
     assertThat(tasks.get(0).getName()).isEqualTo("userTask");
     List<VariableInstance> list = runtimeService.createVariableInstanceQuery().variableName("foo").list();
-    assertThat(list).hasSize(0);
+    assertThat(list).isEmpty();
   }
 
   @Test
@@ -1975,7 +1975,7 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
     assertThat(tasks).hasSize(1);
     assertThat(tasks.get(0).getName()).isEqualTo("userTask");
     List<VariableInstance> list = runtimeService.createVariableInstanceQuery().variableName("foo").list();
-    assertThat(list).hasSize(0);
+    assertThat(list).isEmpty();
   }
 
   @Test
@@ -2207,7 +2207,7 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
     // then
     // no error is thrown
     List<Task> tasks = taskService.createTaskQuery().list();
-    assertThat(tasks).hasSize(0);
+    assertThat(tasks).isEmpty();
   }
 
   @Test
@@ -2229,7 +2229,7 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
     // then
     // no error is thrown
     List<Task> tasks = taskService.createTaskQuery().list();
-    assertThat(tasks).hasSize(0);
+    assertThat(tasks).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.java
@@ -220,9 +220,9 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
 
     assertThat(result.get(0).getPriority()).isEqualTo(7);
     assertThat(result.get(1).getPriority()).isEqualTo(7);
-    assertThat(result.get(2).getPriority()).isEqualTo(0);
-    assertThat(result.get(3).getPriority()).isEqualTo(0);
-    assertThat(result.get(4).getPriority()).isEqualTo(0);
+    assertThat(result.get(2).getPriority()).isZero();
+    assertThat(result.get(3).getPriority()).isZero();
+    assertThat(result.get(4).getPriority()).isZero();
 
 
     // given the same priority, DESC date is applied
@@ -264,9 +264,9 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
     assertThat(result.get(0).getPriority()).isEqualTo(7);
     assertThat(result.get(1).getPriority()).isEqualTo(7);
 
-    assertThat(result.get(2).getPriority()).isEqualTo(0);
-    assertThat(result.get(3).getPriority()).isEqualTo(0);
-    assertThat(result.get(4).getPriority()).isEqualTo(0);
+    assertThat(result.get(2).getPriority()).isZero();
+    assertThat(result.get(3).getPriority()).isZero();
+    assertThat(result.get(4).getPriority()).isZero();
 
 
     // given the same priority, ASC date is applied

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterPropertiesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterPropertiesTest.java
@@ -217,7 +217,7 @@ public class FilterPropertiesTest {
     assertThat(map.get("intOutOfRange")).isEqualTo(Integer.MAX_VALUE + 1L);
     assertThat(map.get("long")).isEqualTo(Long.MAX_VALUE);
     assertThat(map.get("double")).isEqualTo(3.14159265359D);
-    assertThat(map.get("boolean")).isEqualTo(true);
+    assertThat(map.get("boolean")).isTrue();
     assertThat(map.get("null")).isNull();
   }
 
@@ -253,7 +253,7 @@ public class FilterPropertiesTest {
     assertThat(list.get(2)).isEqualTo(Integer.MAX_VALUE + 1L);
     assertThat(list.get(3)).isEqualTo(Long.MAX_VALUE);
     assertThat(list.get(4)).isEqualTo(3.14159265359D);
-    assertThat(list.get(5)).isEqualTo(true);
+    assertThat(list.get(5)).isTrue();
     assertThat(list.get(6)).isNull();
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterPropertiesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterPropertiesTest.java
@@ -16,26 +16,20 @@
  */
 package org.operaton.bpm.engine.test.api.filter;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.operaton.bpm.engine.FilterService;
 import org.operaton.bpm.engine.filter.Filter;
 import org.operaton.bpm.engine.impl.persistence.entity.FilterEntity;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
 
 /**
  * @author Sebastian Menski
@@ -139,7 +133,7 @@ public class FilterPropertiesTest {
     // then
     assertThat(deserialisedProperties.size()).isEqualTo(1);
     assertThat(string).isInstanceOf(String.class);
-    assertThat(string.toString()).isEqualTo("bar");
+    assertThat(string).hasToString("bar");
   }
 
   @Test
@@ -160,7 +154,7 @@ public class FilterPropertiesTest {
 
     // then
     assertThat(deserialisedProperties.size()).isEqualTo(1);
-    assertThat(string.toString()).isEqualTo("foo");
+    assertThat(string).hasToString("foo");
   }
 
   @Test
@@ -182,7 +176,7 @@ public class FilterPropertiesTest {
 
     // then
     assertThat(deserialisedProperties.size()).isEqualTo(1);
-    assertThat(string.toString()).isEqualTo("foo");
+    assertThat(string).hasToString("foo");
   }
 
   @Test
@@ -217,7 +211,7 @@ public class FilterPropertiesTest {
     assertThat(map.get("intOutOfRange")).isEqualTo(Integer.MAX_VALUE + 1L);
     assertThat(map.get("long")).isEqualTo(Long.MAX_VALUE);
     assertThat(map.get("double")).isEqualTo(3.14159265359D);
-    assertThat(map.get("boolean")).isTrue();
+    assertThat(map.get("boolean")).isEqualTo(true);
     assertThat(map.get("null")).isNull();
   }
 
@@ -253,7 +247,7 @@ public class FilterPropertiesTest {
     assertThat(list.get(2)).isEqualTo(Integer.MAX_VALUE + 1L);
     assertThat(list.get(3)).isEqualTo(Long.MAX_VALUE);
     assertThat(list.get(4)).isEqualTo(3.14159265359D);
-    assertThat(list.get(5)).isTrue();
+    assertThat(list.get(5)).isEqualTo(true);
     assertThat(list.get(6)).isNull();
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterPropertiesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterPropertiesTest.java
@@ -131,7 +131,7 @@ public class FilterPropertiesTest {
     Object string = list.get(0);
 
     // then
-    assertThat(deserialisedProperties.size()).isEqualTo(1);
+    assertThat(deserialisedProperties).hasSize(1);
     assertThat(string).isInstanceOf(String.class);
     assertThat(string).hasToString("bar");
   }
@@ -153,7 +153,7 @@ public class FilterPropertiesTest {
     Object string = map.get("bar");
 
     // then
-    assertThat(deserialisedProperties.size()).isEqualTo(1);
+    assertThat(deserialisedProperties).hasSize(1);
     assertThat(string).hasToString("foo");
   }
 
@@ -175,7 +175,7 @@ public class FilterPropertiesTest {
     Object string = list.get(0);
 
     // then
-    assertThat(deserialisedProperties.size()).isEqualTo(1);
+    assertThat(deserialisedProperties).hasSize(1);
     assertThat(string).hasToString("foo");
   }
 
@@ -205,7 +205,7 @@ public class FilterPropertiesTest {
     Map map = (Map) list.get(0);
 
     // then
-    assertThat(deserialisedProperties.size()).isEqualTo(1);
+    assertThat(deserialisedProperties).hasSize(1);
     assertThat(map.get("string")).isEqualTo("aStringValue");
     assertThat(map.get("int")).isEqualTo(47);
     assertThat(map.get("intOutOfRange")).isEqualTo(Integer.MAX_VALUE + 1L);
@@ -240,7 +240,7 @@ public class FilterPropertiesTest {
     List list = (List) ((Map) deserialisedProperties.get("foo")).get("bar");
 
     // then
-    assertThat(deserialisedProperties.size()).isEqualTo(1);
+    assertThat(deserialisedProperties).hasSize(1);
 
     assertThat(list.get(0)).isEqualTo("aStringValue");
     assertThat(list.get(1)).isEqualTo(47);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterPropertiesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterPropertiesTest.java
@@ -68,16 +68,16 @@ public class FilterPropertiesTest {
   public void testPropertiesInternalFromNull() {
     // given
     Filter noPropsFilter = filterService.
-        newTaskFilter("no props filter")
-        .setOwner("demo")
-        .setProperties(null);
+            newTaskFilter("no props filter")
+            .setOwner("demo")
+            .setProperties(null);
     filterService.saveFilter(noPropsFilter);
 
     // when
     FilterEntity noPropsFilterEntity = (FilterEntity) filterService
-        .createTaskFilterQuery()
-        .filterOwner("demo")
-        .singleResult();
+            .createTaskFilterQuery()
+            .filterOwner("demo")
+            .singleResult();
 
     // then
     assertThat(noPropsFilterEntity.getPropertiesInternal()).isEqualTo("{}");
@@ -132,8 +132,7 @@ public class FilterPropertiesTest {
 
     // then
     assertThat(deserialisedProperties).hasSize(1);
-    assertThat(string).isInstanceOf(String.class);
-    assertThat(string).hasToString("bar");
+    assertThat(string).isInstanceOf(String.class).hasToString("bar");
   }
 
   @Test
@@ -206,12 +205,12 @@ public class FilterPropertiesTest {
 
     // then
     assertThat(deserialisedProperties).hasSize(1);
-    assertThat(map.get("string")).isEqualTo("aStringValue");
-    assertThat(map.get("int")).isEqualTo(47);
-    assertThat(map.get("intOutOfRange")).isEqualTo(Integer.MAX_VALUE + 1L);
-    assertThat(map.get("long")).isEqualTo(Long.MAX_VALUE);
-    assertThat(map.get("double")).isEqualTo(3.14159265359D);
-    assertThat(map.get("boolean")).isEqualTo(true);
+    assertThat(map).containsEntry("string", "aStringValue")
+            .containsEntry("int", 47)
+            .containsEntry("intOutOfRange", Integer.MAX_VALUE + 1L)
+            .containsEntry("long", Long.MAX_VALUE)
+            .containsEntry("double", 3.14159265359D)
+            .containsEntry("boolean", true);
     assertThat(map.get("null")).isNull();
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
@@ -1675,7 +1675,7 @@ public class FormServiceTest {
     // then
     assertThat(repositoryService.createDeploymentQuery().list()).hasSize(1);
     assertThat(findAllOperatonFormDefinitionEntities(processEngineConfiguration)).hasSize(1);
-    assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).list()).hasSize(0);
+    assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).list()).isEmpty();
     assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).list()).hasSize(1);
   }
 
@@ -1694,9 +1694,9 @@ public class FormServiceTest {
     // then
     assertThat(repositoryService.createDeploymentQuery().list()).hasSize(1);
     assertThat(findAllOperatonFormDefinitionEntities(processEngineConfiguration)).hasSize(1);
-    assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).list()).hasSize(0);
+    assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).list()).isEmpty();
     assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).list()).hasSize(1);
-    assertThat(taskService.createTaskQuery().list()).hasSize(0);
+    assertThat(taskService.createTaskQuery().list()).isEmpty();
   }
 
   @Deployment(resources = {
@@ -1716,7 +1716,7 @@ public class FormServiceTest {
     assertThat(repositoryService.createDeploymentQuery().list()).hasSize(1);
     assertThat(engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired()
         .execute(new FindOperatonFormDefinitionsCmd())).hasSize(1);
-    assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).list()).hasSize(0);
+    assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).list()).isEmpty();
     assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).list()).hasSize(1);
   }
 
@@ -1736,8 +1736,8 @@ public class FormServiceTest {
     assertThat(repositoryService.createDeploymentQuery().list()).hasSize(1);
     assertThat(engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired()
         .execute(new FindOperatonFormDefinitionsCmd())).hasSize(1);
-    assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).list()).hasSize(0);
+    assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).list()).isEmpty();
     assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).list()).hasSize(1);
-    assertThat(taskService.createTaskQuery().list()).hasSize(0);
+    assertThat(taskService.createTaskQuery().list()).isEmpty();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/form/RetrieveOperatonFormRefTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/form/RetrieveOperatonFormRefTest.java
@@ -200,7 +200,7 @@ public class RetrieveOperatonFormRefTest {
 
     // then
     assertThat(deployments).hasSize(1);
-    assertThat(definitions).hasSize(0);
+    assertThat(definitions).isEmpty();
 
     assertTaskFormData(taskFormData, "myTaskForm", "latest", null);
 
@@ -224,7 +224,7 @@ public class RetrieveOperatonFormRefTest {
 
     // then
     assertThat(deployments).hasSize(1);
-    assertThat(definitions).hasSize(0);
+    assertThat(definitions).isEmpty();
 
     assertTaskFormData(taskFormData, "myTaskForm", "deployment", null);
 
@@ -409,7 +409,7 @@ public class RetrieveOperatonFormRefTest {
 
     // then
     assertThat(deployments).hasSize(1);
-    assertThat(definitions).hasSize(0);
+    assertThat(definitions).isEmpty();
 
     assertThatThrownBy(() -> {
       formService.getDeployedStartForm(processDefinition.getId());
@@ -430,7 +430,7 @@ public class RetrieveOperatonFormRefTest {
 
     // then
     assertThat(deployments).hasSize(1);
-    assertThat(definitions).hasSize(0);
+    assertThat(definitions).isEmpty();
 
     assertThatThrownBy(() -> {
       formService.getDeployedStartForm(processDefinition.getId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricDecisionInstanceStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricDecisionInstanceStatisticsQueryTest.java
@@ -235,7 +235,7 @@ public class HistoricDecisionInstanceStatisticsQueryTest {
 
     assertThat(
         historyService.createHistoricDecisionInstanceStatisticsQuery(
-            NON_EXISTING).list().size()).isEqualTo(0);
+            NON_EXISTING).list().size()).isZero();
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricDecisionInstanceStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricDecisionInstanceStatisticsQueryTest.java
@@ -143,7 +143,7 @@ public class HistoricDecisionInstanceStatisticsQueryTest {
         .decisionInstanceId(NON_EXISTING);
 
     //then
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
     assertThat(query.list()).isEmpty();
 
 
@@ -231,7 +231,7 @@ public class HistoricDecisionInstanceStatisticsQueryTest {
   public void testStatisticDoesNotExistForFakeId() throws Exception {
     assertThat(
         historyService.createHistoricDecisionInstanceStatisticsQuery(
-            NON_EXISTING).count()).isEqualTo(0L);
+            NON_EXISTING).count()).isZero();
 
     assertThat(
         historyService.createHistoricDecisionInstanceStatisticsQuery(
@@ -263,7 +263,7 @@ public class HistoricDecisionInstanceStatisticsQueryTest {
         decisionRequirementsDefinition.getId());
 
     //then
-    assertThat(statisticsQuery.count()).isEqualTo(0L);
+    assertThat(statisticsQuery.count()).isZero();
     assertThat(statisticsQuery.list()).isEmpty();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricDecisionInstanceStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricDecisionInstanceStatisticsQueryTest.java
@@ -16,9 +16,10 @@
  */
 package org.operaton.bpm.engine.test.api.history;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.DecisionService;
 import org.operaton.bpm.engine.HistoryService;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
@@ -31,10 +32,9 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.engine.variable.Variables;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 /**
@@ -235,7 +235,7 @@ public class HistoricDecisionInstanceStatisticsQueryTest {
 
     assertThat(
         historyService.createHistoricDecisionInstanceStatisticsQuery(
-            NON_EXISTING).list().size()).isZero();
+            NON_EXISTING).list()).isEmpty();
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricDecisionInstanceStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricDecisionInstanceStatisticsQueryTest.java
@@ -144,7 +144,7 @@ public class HistoricDecisionInstanceStatisticsQueryTest {
 
     //then
     assertThat(query.count()).isEqualTo(0L);
-    assertThat(query.list()).hasSize(0);
+    assertThat(query.list()).isEmpty();
 
 
   }
@@ -264,6 +264,6 @@ public class HistoricDecisionInstanceStatisticsQueryTest {
 
     //then
     assertThat(statisticsQuery.count()).isEqualTo(0L);
-    assertThat(statisticsQuery.list()).hasSize(0);
+    assertThat(statisticsQuery.list()).isEmpty();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.java
@@ -1401,7 +1401,7 @@ public class HistoryCleanupTest {
     Job cleanupJob = historyService.cleanUpHistoryAsync(true);
 
     //then
-    assertThat(cleanupJob.getRetries()).isEqualTo(0);
+    assertThat(cleanupJob.getRetries()).isZero();
   }
 
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceAsyncOperationsTest.java
@@ -97,7 +97,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions.size()).isEqualTo(0);
+    assertThat(exceptions.size()).isZero();
     assertNoHistoryForTasks();
     assertHistoricBatchExists(testRule);
     assertAllHistoricProcessInstancesAreDeleted();
@@ -212,7 +212,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     List<Exception> exceptions = executeBatchJobs(batch);
 
     //then
-    assertThat(exceptions.size()).isEqualTo(0);
+    assertThat(exceptions.size()).isZero();
     assertHistoricBatchExists(testRule);
   }
 
@@ -229,7 +229,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions.size()).isEqualTo(0);
+    assertThat(exceptions.size()).isZero();
     assertNoHistoryForTasks();
     assertHistoricBatchExists(testRule);
     assertAllHistoricProcessInstancesAreDeleted();
@@ -247,7 +247,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions.size()).isEqualTo(0);
+    assertThat(exceptions.size()).isZero();
     assertNoHistoryForTasks();
     assertHistoricBatchExists(testRule);
     assertAllHistoricProcessInstancesAreDeleted();
@@ -289,7 +289,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     List<Exception> exceptions = executeBatchJobs(batch);
 
     //then
-    assertThat(exceptions.size()).isEqualTo(0);
+    assertThat(exceptions.size()).isZero();
     assertNoHistoryForTasks();
     assertHistoricBatchExists(testRule);
     assertAllHistoricProcessInstancesAreDeleted();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceAsyncOperationsTest.java
@@ -16,16 +16,6 @@
  */
 package org.operaton.bpm.engine.test.api.history;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
@@ -48,6 +38,13 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.AbstractAsyncOperationsTest;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Askar Akhmerov
@@ -97,7 +94,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions.size()).isZero();
+    assertThat(exceptions).isEmpty();
     assertNoHistoryForTasks();
     assertHistoricBatchExists(testRule);
     assertAllHistoricProcessInstancesAreDeleted();
@@ -212,7 +209,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     List<Exception> exceptions = executeBatchJobs(batch);
 
     //then
-    assertThat(exceptions.size()).isZero();
+    assertThat(exceptions).isEmpty();
     assertHistoricBatchExists(testRule);
   }
 
@@ -229,7 +226,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions.size()).isZero();
+    assertThat(exceptions).isEmpty();
     assertNoHistoryForTasks();
     assertHistoricBatchExists(testRule);
     assertAllHistoricProcessInstancesAreDeleted();
@@ -247,7 +244,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions.size()).isZero();
+    assertThat(exceptions).isEmpty();
     assertNoHistoryForTasks();
     assertHistoricBatchExists(testRule);
     assertAllHistoricProcessInstancesAreDeleted();
@@ -289,7 +286,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     List<Exception> exceptions = executeBatchJobs(batch);
 
     //then
-    assertThat(exceptions.size()).isZero();
+    assertThat(exceptions).isEmpty();
     assertNoHistoryForTasks();
     assertHistoricBatchExists(testRule);
     assertAllHistoricProcessInstancesAreDeleted();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceAsyncOperationsTest.java
@@ -129,14 +129,14 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     // then batch jobs with different deployment ids exist
     JobQuery batchJobQuery = managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId());
     List<Job> batchJobs = batchJobQuery.list();
-    assertThat(batchJobs.size()).isEqualTo(2);
+    assertThat(batchJobs).hasSize(2);
     batchJobs.stream().forEach(job -> assertThat(job.getDeploymentId())
         .satisfiesAnyOf(
             arg -> assertThat(arg).isEqualTo(firstDeploymentId),
             arg -> assertThat(arg).isNull()
         ));
     assertThat(batchJobs.get(0).getDeploymentId()).isNotEqualTo(batchJobs.get(1).getDeploymentId());
-    assertThat(historicProcessInstances.size()).isEqualTo(4);
+    assertThat(historicProcessInstances).hasSize(4);
     assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId)).isEqualTo(2L);
 
     // when the batch jobs for the first deployment are executed
@@ -169,11 +169,11 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     executeSeedJobs(batch, 2);
     // then batch jobs with different deployment ids exist
     List<Job> batchJobs = managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId()).list();
-    assertThat(batchJobs.size()).isEqualTo(2);
+    assertThat(batchJobs).hasSize(2);
     assertThat(batchJobs.get(0).getDeploymentId()).isIn(firstDeploymentId, secondDeploymentId);
     assertThat(batchJobs.get(1).getDeploymentId()).isIn(firstDeploymentId, secondDeploymentId);
     assertThat(batchJobs.get(0).getDeploymentId()).isNotEqualTo(batchJobs.get(1).getDeploymentId());
-    assertThat(historicProcessInstances.size()).isEqualTo(4);
+    assertThat(historicProcessInstances).hasSize(4);
     assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId)).isEqualTo(2L);
     assertThat(getHistoricProcessInstanceCountByDeploymentId(secondDeploymentId)).isEqualTo(2L);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceAsyncOperationsTest.java
@@ -139,7 +139,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     // when the batch jobs for the first deployment are executed
     getJobIdsByDeployment(batchJobs, firstDeploymentId).forEach(managementService::executeJob);
     // then the historic process instances related to the first deployment should be deleted
-    assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId)).isEqualTo(0L);
+    assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId)).isZero();
     // and historic process instances related to the second deployment should not be deleted
     assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(2L);
 
@@ -177,7 +177,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     // when the batch jobs for the first deployment are executed
     getJobIdsByDeployment(batchJobs, firstDeploymentId).forEach(managementService::executeJob);
     // then the historic process instances related to the first deployment should be deleted
-    assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId)).isEqualTo(0L);
+    assertThat(getHistoricProcessInstanceCountByDeploymentId(firstDeploymentId)).isZero();
     // and historic process instances related to the second deployment should not be deleted
     assertThat(getHistoricProcessInstanceCountByDeploymentId(secondDeploymentId)).isEqualTo(2L);
 
@@ -344,7 +344,7 @@ public class HistoryServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
   }
 
   protected void assertAllHistoricProcessInstancesAreDeleted() {
-    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isZero();
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/HistoricRootProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/HistoricRootProcessInstanceTest.java
@@ -108,7 +108,7 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     List<HistoricDecisionInstance> historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // assume
-    assertThat(historicDecisionInstances.size()).isEqualTo(3);
+    assertThat(historicDecisionInstances).hasSize(3);
 
     // then
     assertThat(historicDecisionInstances.get(0).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
@@ -357,7 +357,7 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicDetails.size()).isEqualTo(2);
+    assertThat(historicDetails).hasSize(2);
 
     // then
     assertThat(historicDetails.get(0).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
@@ -411,7 +411,7 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     List<HistoricIncident> historicIncidents = historyService.createHistoricIncidentQuery().list();
 
     // assume
-    assertThat(historicIncidents.size()).isEqualTo(2);
+    assertThat(historicIncidents).hasSize(2);
 
     // then
     assertThat(historicIncidents.get(0).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());
@@ -497,7 +497,7 @@ public class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
     List<HistoricJobLog> jobLog = historyService.createHistoricJobLogQuery().list();
 
     // assume
-    assertThat(jobLog.size()).isEqualTo(2);
+    assertThat(jobLog).hasSize(2);
 
     // then
     assertThat(jobLog.get(0).getRootProcessInstanceId()).isEqualTo(processInstance.getProcessInstanceId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/RemovalTimeStrategyStartTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/RemovalTimeStrategyStartTest.java
@@ -142,7 +142,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     List<HistoricDecisionInstance> historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // assume
-    assertThat(historicDecisionInstances.size()).isEqualTo(3);
+    assertThat(historicDecisionInstances).hasSize(3);
 
     Date removalTime = addDays(START_DATE, 5);
 
@@ -172,7 +172,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     List<HistoricDecisionInstance> historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // assume
-    assertThat(historicDecisionInstances.size()).isEqualTo(3);
+    assertThat(historicDecisionInstances).hasSize(3);
 
     Date removalTime = addDays(START_DATE, 5);
 
@@ -855,7 +855,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicDetails.size()).isEqualTo(2);
+    assertThat(historicDetails).hasSize(2);
 
     Date removalTime = addDays(START_DATE, 5);
 
@@ -917,7 +917,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     List<HistoricIncident> historicIncidents = historyService.createHistoricIncidentQuery().list();
 
     // assume
-    assertThat(historicIncidents.size()).isEqualTo(2);
+    assertThat(historicIncidents).hasSize(2);
 
     Date removalTime = addDays(START_DATE, 5);
 
@@ -1016,7 +1016,7 @@ public class RemovalTimeStrategyStartTest extends AbstractRemovalTimeTest {
     List<HistoricJobLog> jobLog = historyService.createHistoricJobLogQuery().list();
 
     // assume
-    assertThat(jobLog.size()).isEqualTo(2);
+    assertThat(jobLog).hasSize(2);
 
     Date removalTime = addDays(START_DATE, 5);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeTest.java
@@ -2621,7 +2621,7 @@ public class BatchSetRemovalTimeTest {
     CleanableHistoricProcessInstanceReportResult report = historyService.createCleanableHistoricProcessInstanceReport().singleResult();
 
     // then
-    assertThat(report.getFinishedProcessInstanceCount()).isEqualTo(0);
+    assertThat(report.getFinishedProcessInstanceCount()).isZero();
     assertThat(report.getCleanableProcessInstanceCount()).isEqualTo(1);
     assertThat(report.getHistoryTimeToLive()).isNull();
   }
@@ -2700,7 +2700,7 @@ public class BatchSetRemovalTimeTest {
     CleanableHistoricBatchReportResult report = historyService.createCleanableHistoricBatchReport().singleResult();
 
     // then
-    assertThat(report.getFinishedBatchesCount()).isEqualTo(0);
+    assertThat(report.getFinishedBatchesCount()).isZero();
     assertThat(report.getCleanableBatchesCount()).isEqualTo(1);
     assertThat(report.getHistoryTimeToLive()).isNull();
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeUserOperationLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeUserOperationLogTest.java
@@ -833,7 +833,7 @@ public class BatchSetRemovalTimeUserOperationLogTest {
   // helper ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   protected void assertProperties(List<UserOperationLogEntry> userOperationLogEntries, String... expectedProperties) {
-    assertThat(userOperationLogEntries.size()).isEqualTo(expectedProperties.length);
+    assertThat(userOperationLogEntries).hasSize(expectedProperties.length);
 
     assertThat(userOperationLogEntries)
       .extracting("property", String.class)

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
@@ -293,7 +293,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // then
-    assertThat(historicDecisionInstances.size()).isEqualTo(0);
+    assertThat(historicDecisionInstances.size()).isZero();
   }
 
   @Test
@@ -334,7 +334,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicDecisionInstances.size()).isEqualTo(0);
+    assertThat(historicDecisionInstances.size()).isZero();
   }
 
   @Test
@@ -405,7 +405,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicDecisionInstances.size()).isEqualTo(0);
+    assertThat(historicDecisionInstances.size()).isZero();
   }
 
   @Test
@@ -445,7 +445,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicDecisionInstances.size()).isEqualTo(0);
+    assertThat(historicDecisionInstances.size()).isZero();
   }
 
   @Test
@@ -481,7 +481,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicProcessInstances.size()).isEqualTo(0);
+    assertThat(historicProcessInstances.size()).isZero();
   }
 
   @Test
@@ -554,7 +554,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicProcessInstances.size()).isEqualTo(0);
+    assertThat(historicProcessInstances.size()).isZero();
   }
 
   @Test
@@ -613,7 +613,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicActivityInstances = historyService.createHistoricActivityInstanceQuery().list();
 
     // then
-    assertThat(historicActivityInstances.size()).isEqualTo(0);
+    assertThat(historicActivityInstances.size()).isZero();
   }
 
   @Test
@@ -644,7 +644,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicTaskInstances = historyService.createHistoricTaskInstanceQuery().list();
 
     // then
-    assertThat(historicTaskInstances.size()).isEqualTo(0);
+    assertThat(historicTaskInstances.size()).isZero();
   }
 
   @Test
@@ -685,7 +685,7 @@ public class HistoryCleanupRemovalTimeTest {
         .list();
 
     // then
-    assertThat(authorizations.size()).isEqualTo(0);
+    assertThat(authorizations.size()).isZero();
 
     // clear
     clearAuthorization();
@@ -721,7 +721,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicVariableInstances = historyService.createHistoricVariableInstanceQuery().list();
 
     // then
-    assertThat(historicVariableInstances.size()).isEqualTo(0);
+    assertThat(historicVariableInstances.size()).isZero();
   }
 
   @Test
@@ -760,7 +760,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicDetails.size()).isEqualTo(0);
+    assertThat(historicDetails.size()).isZero();
   }
 
   @Test
@@ -799,7 +799,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicIncidents = historyService.createHistoricIncidentQuery().list();
 
     // then
-    assertThat(historicIncidents.size()).isEqualTo(0);
+    assertThat(historicIncidents.size()).isZero();
   }
 
   @Test
@@ -841,7 +841,7 @@ public class HistoryCleanupRemovalTimeTest {
     externalTaskLogs = historyService.createHistoricExternalTaskLogQuery().list();
 
     // then
-    assertThat(externalTaskLogs.size()).isEqualTo(0);
+    assertThat(externalTaskLogs.size()).isZero();
   }
 
   @Test
@@ -885,7 +885,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(jobLogs.size()).isEqualTo(0);
+    assertThat(jobLogs.size()).isZero();
   }
 
   @Test
@@ -966,7 +966,7 @@ public class HistoryCleanupRemovalTimeTest {
     userOperationLogs = historyService.createUserOperationLogQuery().list();
 
     // then
-    assertThat(userOperationLogs.size()).isEqualTo(0);
+    assertThat(userOperationLogs.size()).isZero();
   }
 
   @Test
@@ -999,7 +999,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicIdentityLinkLogs = historyService.createHistoricIdentityLinkLogQuery().list();
 
     // then
-    assertThat(historicIdentityLinkLogs.size()).isEqualTo(0);
+    assertThat(historicIdentityLinkLogs.size()).isZero();
   }
 
   @Test
@@ -1037,7 +1037,7 @@ public class HistoryCleanupRemovalTimeTest {
     comments = taskService.getProcessInstanceComments(processInstanceId);
 
     // then
-    assertThat(comments.size()).isEqualTo(0);
+    assertThat(comments.size()).isZero();
   }
 
   @Test
@@ -1075,7 +1075,7 @@ public class HistoryCleanupRemovalTimeTest {
     attachments = taskService.getProcessInstanceAttachments(processInstanceId);
 
     // then
-    assertThat(attachments.size()).isEqualTo(0);
+    assertThat(attachments.size()).isZero();
   }
 
   @Test
@@ -1173,8 +1173,8 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicBatches.size()).isEqualTo(0);
-    assertThat(historicJobLogs.size()).isEqualTo(0);
+    assertThat(historicBatches.size()).isZero();
+    assertThat(historicJobLogs.size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
@@ -1201,7 +1201,7 @@ public class HistoryCleanupRemovalTimeTest {
     runHistoryCleanup();
 
     // then
-    assertThat(managementService.getUniqueTaskWorkerCount(null, null)).isEqualTo(0L);
+    assertThat(managementService.getUniqueTaskWorkerCount(null, null)).isZero();
   }
 
   @Test
@@ -1935,7 +1935,7 @@ public class HistoryCleanupRemovalTimeTest {
 
     // then
     assertThat(report.getCleanableProcessInstanceCount()).isEqualTo(5L);
-    assertThat(report.getFinishedProcessInstanceCount()).isEqualTo(0L);
+    assertThat(report.getFinishedProcessInstanceCount()).isZero();
   }
 
   @Test
@@ -1963,7 +1963,7 @@ public class HistoryCleanupRemovalTimeTest {
 
     // then
     assertThat(report.getFinishedProcessInstanceCount()).isEqualTo(5L);
-    assertThat(report.getCleanableProcessInstanceCount()).isEqualTo(0L);
+    assertThat(report.getCleanableProcessInstanceCount()).isZero();
   }
 
   @Test
@@ -2056,7 +2056,7 @@ public class HistoryCleanupRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(report.getCleanableDecisionInstanceCount()).isEqualTo(0L);
+    assertThat(report.getCleanableDecisionInstanceCount()).isZero();
     assertThat(report.getFinishedDecisionInstanceCount()).isEqualTo(5L);
   }
 
@@ -2085,7 +2085,7 @@ public class HistoryCleanupRemovalTimeTest {
 
     // then
     assertThat(report.getCleanableBatchesCount()).isEqualTo(1L);
-    assertThat(report.getFinishedBatchesCount()).isEqualTo(0L);
+    assertThat(report.getFinishedBatchesCount()).isZero();
 
     // cleanup
     managementService.deleteBatch(batch.getId(), true);
@@ -2115,8 +2115,8 @@ public class HistoryCleanupRemovalTimeTest {
     CleanableHistoricBatchReportResult report = historyService.createCleanableHistoricBatchReport().singleResult();
 
     // then
-    assertThat(report.getCleanableBatchesCount()).isEqualTo(0L);
-    assertThat(report.getFinishedBatchesCount()).isEqualTo(0L);
+    assertThat(report.getCleanableBatchesCount()).isZero();
+    assertThat(report.getFinishedBatchesCount()).isZero();
 
     // cleanup
     managementService.deleteBatch(batch.getId(), true);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
@@ -16,35 +16,9 @@
  */
 package org.operaton.bpm.engine.test.api.history.removaltime.cleanup;
 
-import static org.apache.commons.lang3.time.DateUtils.addDays;
-import static org.apache.commons.lang3.time.DateUtils.addMinutes;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED;
-import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_FULL;
-import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_END;
-import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL_TIME_STRATEGY_START;
-import static org.operaton.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupHandler.MAX_BATCH_SIZE;
-
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import org.operaton.bpm.engine.AuthorizationService;
-import org.operaton.bpm.engine.DecisionService;
-import org.operaton.bpm.engine.ExternalTaskService;
-import org.operaton.bpm.engine.FormService;
-import org.operaton.bpm.engine.HistoryService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ManagementService;
-import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.junit.*;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.authorization.Authorization;
 import org.operaton.bpm.engine.authorization.AuthorizationQuery;
 import org.operaton.bpm.engine.authorization.Resources;
@@ -52,31 +26,7 @@ import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.batch.history.HistoricBatch;
 import org.operaton.bpm.engine.batch.history.HistoricBatchQuery;
 import org.operaton.bpm.engine.externaltask.LockedExternalTask;
-import org.operaton.bpm.engine.history.CleanableHistoricBatchReportResult;
-import org.operaton.bpm.engine.history.CleanableHistoricDecisionInstanceReportResult;
-import org.operaton.bpm.engine.history.CleanableHistoricProcessInstanceReportResult;
-import org.operaton.bpm.engine.history.HistoricActivityInstance;
-import org.operaton.bpm.engine.history.HistoricActivityInstanceQuery;
-import org.operaton.bpm.engine.history.HistoricDecisionInstance;
-import org.operaton.bpm.engine.history.HistoricDecisionInstanceQuery;
-import org.operaton.bpm.engine.history.HistoricDetail;
-import org.operaton.bpm.engine.history.HistoricDetailQuery;
-import org.operaton.bpm.engine.history.HistoricExternalTaskLog;
-import org.operaton.bpm.engine.history.HistoricExternalTaskLogQuery;
-import org.operaton.bpm.engine.history.HistoricIdentityLinkLog;
-import org.operaton.bpm.engine.history.HistoricIdentityLinkLogQuery;
-import org.operaton.bpm.engine.history.HistoricIncident;
-import org.operaton.bpm.engine.history.HistoricIncidentQuery;
-import org.operaton.bpm.engine.history.HistoricJobLog;
-import org.operaton.bpm.engine.history.HistoricJobLogQuery;
-import org.operaton.bpm.engine.history.HistoricProcessInstance;
-import org.operaton.bpm.engine.history.HistoricProcessInstanceQuery;
-import org.operaton.bpm.engine.history.HistoricTaskInstance;
-import org.operaton.bpm.engine.history.HistoricTaskInstanceQuery;
-import org.operaton.bpm.engine.history.HistoricVariableInstance;
-import org.operaton.bpm.engine.history.HistoricVariableInstanceQuery;
-import org.operaton.bpm.engine.history.UserOperationLogEntry;
-import org.operaton.bpm.engine.history.UserOperationLogQuery;
+import org.operaton.bpm.engine.history.*;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.history.DefaultHistoryRemovalTimeProvider;
 import org.operaton.bpm.engine.impl.interceptor.Command;
@@ -101,12 +51,16 @@ import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.*;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.time.DateUtils.addDays;
+import static org.apache.commons.lang3.time.DateUtils.addMinutes;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.engine.ProcessEngineConfiguration.*;
+import static org.operaton.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupHandler.MAX_BATCH_SIZE;
 
 /**
  * @author Tassilo Weidner
@@ -293,7 +247,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // then
-    assertThat(historicDecisionInstances.size()).isZero();
+    assertThat(historicDecisionInstances).isEmpty();
   }
 
   @Test
@@ -334,7 +288,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicDecisionInstances.size()).isZero();
+    assertThat(historicDecisionInstances).isEmpty();
   }
 
   @Test
@@ -405,7 +359,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicDecisionInstances.size()).isZero();
+    assertThat(historicDecisionInstances).isEmpty();
   }
 
   @Test
@@ -445,7 +399,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicDecisionInstances.size()).isZero();
+    assertThat(historicDecisionInstances).isEmpty();
   }
 
   @Test
@@ -481,7 +435,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicProcessInstances.size()).isZero();
+    assertThat(historicProcessInstances).isEmpty();
   }
 
   @Test
@@ -554,7 +508,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicProcessInstances.size()).isZero();
+    assertThat(historicProcessInstances).isEmpty();
   }
 
   @Test
@@ -613,7 +567,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicActivityInstances = historyService.createHistoricActivityInstanceQuery().list();
 
     // then
-    assertThat(historicActivityInstances.size()).isZero();
+    assertThat(historicActivityInstances).isEmpty();
   }
 
   @Test
@@ -644,7 +598,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicTaskInstances = historyService.createHistoricTaskInstanceQuery().list();
 
     // then
-    assertThat(historicTaskInstances.size()).isZero();
+    assertThat(historicTaskInstances).isEmpty();
   }
 
   @Test
@@ -685,7 +639,7 @@ public class HistoryCleanupRemovalTimeTest {
         .list();
 
     // then
-    assertThat(authorizations.size()).isZero();
+    assertThat(authorizations).isEmpty();
 
     // clear
     clearAuthorization();
@@ -721,7 +675,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicVariableInstances = historyService.createHistoricVariableInstanceQuery().list();
 
     // then
-    assertThat(historicVariableInstances.size()).isZero();
+    assertThat(historicVariableInstances).isEmpty();
   }
 
   @Test
@@ -760,7 +714,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicDetails.size()).isZero();
+    assertThat(historicDetails).isEmpty();
   }
 
   @Test
@@ -799,7 +753,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicIncidents = historyService.createHistoricIncidentQuery().list();
 
     // then
-    assertThat(historicIncidents.size()).isZero();
+    assertThat(historicIncidents).isEmpty();
   }
 
   @Test
@@ -841,7 +795,7 @@ public class HistoryCleanupRemovalTimeTest {
     externalTaskLogs = historyService.createHistoricExternalTaskLogQuery().list();
 
     // then
-    assertThat(externalTaskLogs.size()).isZero();
+    assertThat(externalTaskLogs).isEmpty();
   }
 
   @Test
@@ -885,7 +839,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(jobLogs.size()).isZero();
+    assertThat(jobLogs).isEmpty();
   }
 
   @Test
@@ -966,7 +920,7 @@ public class HistoryCleanupRemovalTimeTest {
     userOperationLogs = historyService.createUserOperationLogQuery().list();
 
     // then
-    assertThat(userOperationLogs.size()).isZero();
+    assertThat(userOperationLogs).isEmpty();
   }
 
   @Test
@@ -999,7 +953,7 @@ public class HistoryCleanupRemovalTimeTest {
     historicIdentityLinkLogs = historyService.createHistoricIdentityLinkLogQuery().list();
 
     // then
-    assertThat(historicIdentityLinkLogs.size()).isZero();
+    assertThat(historicIdentityLinkLogs).isEmpty();
   }
 
   @Test
@@ -1037,7 +991,7 @@ public class HistoryCleanupRemovalTimeTest {
     comments = taskService.getProcessInstanceComments(processInstanceId);
 
     // then
-    assertThat(comments.size()).isZero();
+    assertThat(comments).isEmpty();
   }
 
   @Test
@@ -1075,7 +1029,7 @@ public class HistoryCleanupRemovalTimeTest {
     attachments = taskService.getProcessInstanceAttachments(processInstanceId);
 
     // then
-    assertThat(attachments.size()).isZero();
+    assertThat(attachments).isEmpty();
   }
 
   @Test
@@ -1173,8 +1127,8 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicBatches.size()).isZero();
-    assertThat(historicJobLogs.size()).isZero();
+    assertThat(historicBatches).isEmpty();
+    assertThat(historicJobLogs).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
@@ -283,7 +283,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricDecisionInstance> historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // assume
-    assertThat(historicDecisionInstances.size()).isEqualTo(3);
+    assertThat(historicDecisionInstances).hasSize(3);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
 
@@ -321,7 +321,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicDecisionInstances.size()).isEqualTo(3);
+    assertThat(historicDecisionInstances).hasSize(3);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 6));
 
@@ -393,7 +393,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicDecisionInstances.size()).isEqualTo(3);
+    assertThat(historicDecisionInstances).hasSize(3);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
 
@@ -432,7 +432,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicDecisionInstances.size()).isEqualTo(3);
+    assertThat(historicDecisionInstances).hasSize(3);
 
     Date removalTime = addDays(END_DATE, 5);
     ClockUtil.setCurrentTime(removalTime);
@@ -468,7 +468,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicProcessInstances.size()).isEqualTo(1);
+    assertThat(historicProcessInstances).hasSize(1);
 
     Date removalTime = addDays(END_DATE, 5);
     ClockUtil.setCurrentTime(removalTime);
@@ -504,7 +504,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicProcessInstances.size()).isEqualTo(1);
+    assertThat(historicProcessInstances).hasSize(1);
 
     Date removalTime = addDays(END_DATE, 5);
     ClockUtil.setCurrentTime(removalTime);
@@ -517,7 +517,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicProcessInstances.size()).isEqualTo(1);
+    assertThat(historicProcessInstances).hasSize(1);
   }
 
   @Test
@@ -541,7 +541,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicProcessInstances.size()).isEqualTo(1);
+    assertThat(historicProcessInstances).hasSize(1);
 
     Date removalTime = addDays(END_DATE, 5);
     ClockUtil.setCurrentTime(removalTime);
@@ -603,7 +603,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricActivityInstance> historicActivityInstances = historyService.createHistoricActivityInstanceQuery().list();
 
     // assume
-    assertThat(historicActivityInstances.size()).isEqualTo(6);
+    assertThat(historicActivityInstances).hasSize(6);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
 
@@ -634,7 +634,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricTaskInstance> historicTaskInstances = historyService.createHistoricTaskInstanceQuery().list();
 
     // assume
-    assertThat(historicTaskInstances.size()).isEqualTo(1);
+    assertThat(historicTaskInstances).hasSize(1);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
 
@@ -673,7 +673,7 @@ public class HistoryCleanupRemovalTimeTest {
         .list();
 
     // assume
-    assertThat(authorizations.size()).isEqualTo(1);
+    assertThat(authorizations).hasSize(1);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
 
@@ -711,7 +711,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricVariableInstance> historicVariableInstances = historyService.createHistoricVariableInstanceQuery().list();
 
     // assume
-    assertThat(historicVariableInstances.size()).isEqualTo(1);
+    assertThat(historicVariableInstances).hasSize(1);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
 
@@ -742,7 +742,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(historicDetails.size()).isEqualTo(2);
+    assertThat(historicDetails).hasSize(2);
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -783,7 +783,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricIncident> historicIncidents = historyService.createHistoricIncidentQuery().list();
 
     // assume
-    assertThat(historicIncidents.size()).isEqualTo(2);
+    assertThat(historicIncidents).hasSize(2);
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -827,7 +827,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricExternalTaskLog> externalTaskLogs = historyService.createHistoricExternalTaskLogQuery().list();
 
     // assume
-    assertThat(externalTaskLogs.size()).isEqualTo(1);
+    assertThat(externalTaskLogs).hasSize(1);
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -869,7 +869,7 @@ public class HistoryCleanupRemovalTimeTest {
       .list();
 
     // assume
-    assertThat(jobLogs.size()).isEqualTo(2);
+    assertThat(jobLogs).hasSize(2);
 
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
@@ -948,7 +948,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<UserOperationLogEntry> userOperationLogs = historyService.createUserOperationLogQuery().list();
 
     // assume
-    assertThat(userOperationLogs.size()).isEqualTo(1);
+    assertThat(userOperationLogs).hasSize(1);
 
     managementService.executeJob(jobId);
 
@@ -985,7 +985,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricIdentityLinkLog> historicIdentityLinkLogs = historyService.createHistoricIdentityLinkLogQuery().list();
 
     // assume
-    assertThat(historicIdentityLinkLogs.size()).isEqualTo(1);
+    assertThat(historicIdentityLinkLogs).hasSize(1);
 
     ClockUtil.setCurrentTime(END_DATE);
 
@@ -1021,7 +1021,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<Comment> comments = taskService.getProcessInstanceComments(processInstanceId);
 
     // assume
-    assertThat(comments.size()).isEqualTo(1);
+    assertThat(comments).hasSize(1);
 
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
@@ -1059,7 +1059,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<Attachment> attachments = taskService.getProcessInstanceAttachments(processInstanceId);
 
     // assume
-    assertThat(attachments.size()).isEqualTo(1);
+    assertThat(attachments).hasSize(1);
 
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
@@ -1153,14 +1153,14 @@ public class HistoryCleanupRemovalTimeTest {
     // assume
     List<HistoricBatch> historicBatches = historyService.createHistoricBatchQuery().list();
 
-    assertThat(historicBatches.size()).isEqualTo(1);
+    assertThat(historicBatches).hasSize(1);
 
     // assume
     List<HistoricJobLog> historicJobLogs = historyService.createHistoricJobLogQuery()
       .jobDefinitionConfiguration(batchId)
       .list();
 
-    assertThat(historicJobLogs.size()).isEqualTo(6);
+    assertThat(historicJobLogs).hasSize(6);
 
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
 
@@ -1208,7 +1208,7 @@ public class HistoryCleanupRemovalTimeTest {
     List<HistoricBatch> historicBatches = historyService.createHistoricBatchQuery().list();
 
     // assume
-    assertThat(historicBatches.size()).isEqualTo(1);
+    assertThat(historicBatches).hasSize(1);
 
     // when
     runHistoryCleanup();
@@ -2173,7 +2173,7 @@ public class HistoryCleanupRemovalTimeTest {
   protected void assumeWhenThenParallelizedCleanup(List<Job> jobs, Supplier<Long> supplier,
                                                    long initialInstanceCount) {
     // assume
-    assertThat(jobs.size()).isEqualTo(3);
+    assertThat(jobs).hasSize(3);
     assertThat(supplier.get()).isEqualTo(initialInstanceCount);
 
     long expectedInstanceCount = initialInstanceCount-(initialInstanceCount/3);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/CustomPasswordPolicyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/CustomPasswordPolicyTest.java
@@ -87,6 +87,6 @@ public class CustomPasswordPolicyTest {
       .hasMessageContaining("Password does not match policy");
 
     // and
-    assertThat(identityService.createUserQuery().userId(user.getId()).count()).isEqualTo(0L);
+    assertThat(identityService.createUserQuery().userId(user.getId()).count()).isZero();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceAuthorizationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceAuthorizationsTest.java
@@ -196,8 +196,8 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     processEngineConfiguration.setAuthorizationEnabled(false);
 
     // then
-    assertThat(query.count()).isEqualTo(0L);
-    assertThat(authorizationService.createAuthorizationQuery().resourceType(TENANT).userIdIn(jonny1Id).count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
+    assertThat(authorizationService.createAuthorizationQuery().resourceType(TENANT).userIdIn(jonny1Id).count()).isZero();
   }
 
   @Test
@@ -432,8 +432,8 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     processEngineConfiguration.setAuthorizationEnabled(false);
 
     // then
-    assertThat(query.count()).isEqualTo(0L);
-    assertThat(authorizationService.createAuthorizationQuery().resourceType(TENANT).groupIdIn("group1").count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
+    assertThat(authorizationService.createAuthorizationQuery().resourceType(TENANT).groupIdIn("group1").count()).isZero();
   }
 
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceTenantTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceTenantTest.java
@@ -217,7 +217,7 @@ public class IdentityServiceTenantTest {
     assertThat(query.count()).isEqualTo(1L);
 
     identityService.deleteTenant(TENANT_ONE);
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -332,7 +332,7 @@ public class IdentityServiceTenantTest {
     assertThat(query.count()).isEqualTo(1L);
 
     identityService.deleteTenantUserMembership(TENANT_ONE, USER_ONE);
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -355,7 +355,7 @@ public class IdentityServiceTenantTest {
     assertThat(query.count()).isEqualTo(1L);
 
     identityService.deleteTenantGroupMembership(TENANT_ONE, GROUP_ONE);
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -372,7 +372,7 @@ public class IdentityServiceTenantTest {
     assertThat(query.count()).isEqualTo(1L);
 
     identityService.deleteUser(USER_ONE);
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -389,7 +389,7 @@ public class IdentityServiceTenantTest {
     assertThat(query.count()).isEqualTo(1L);
 
     identityService.deleteGroup(GROUP_ONE);
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -412,8 +412,8 @@ public class IdentityServiceTenantTest {
     assertThat(groupQuery.count()).isEqualTo(1L);
 
     identityService.deleteTenant(TENANT_ONE);
-    assertThat(userQuery.count()).isEqualTo(0L);
-    assertThat(groupQuery.count()).isEqualTo(0L);
+    assertThat(userQuery.count()).isZero();
+    assertThat(groupQuery.count()).isZero();
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceTest.java
@@ -717,7 +717,7 @@ public class IdentityServiceTest {
     }
 
     // then
-    assertThat(loggingRule.getFilteredLog(INDENTITY_LOGGER, "The user with id 'johndoe' is permanently locked.").size()).isEqualTo(1);
+    assertThat(loggingRule.getFilteredLog(INDENTITY_LOGGER, "The user with id 'johndoe' is permanently locked.")).hasSize(1);
   }
 
   @Test
@@ -749,7 +749,7 @@ public class IdentityServiceTest {
     assertFalse(identityService.checkPassword("johndoe", "xxx"));
 
     // assume
-    assertThat(loggingRule.getFilteredLog(INDENTITY_LOGGER, "The user with id 'johndoe' is locked.").size()).isEqualTo(1);
+    assertThat(loggingRule.getFilteredLog(INDENTITY_LOGGER, "The user with id 'johndoe' is locked.")).hasSize(1);
 
     // when
     ClockUtil.setCurrentTime(DateUtils.addSeconds(now, 30));
@@ -778,7 +778,7 @@ public class IdentityServiceTest {
     assertFalse(identityService.checkPassword("johndoe", "invalid pwd"));
 
     // then
-    assertThat(loggingRule.getFilteredLog(INDENTITY_LOGGER, "The lock will expire at " + expectedLockExpitation).size()).isEqualTo(1);
+    assertThat(loggingRule.getFilteredLog(INDENTITY_LOGGER, "The lock will expire at " + expectedLockExpitation)).hasSize(1);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/PasswordHashingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/PasswordHashingTest.java
@@ -103,7 +103,7 @@ public class PasswordHashingTest {
     identityService.saveUser(user);
 
     // then
-    assertThat(identityService.checkPassword(USER_NAME, PASSWORD)).isEqualTo(true);
+    assertThat(identityService.checkPassword(USER_NAME, PASSWORD)).isTrue();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/PasswordPolicyConfigurationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/PasswordPolicyConfigurationTest.java
@@ -72,7 +72,7 @@ public class PasswordPolicyConfigurationTest {
     processEngineConfiguration.initPasswordPolicy();
 
     // then
-    assertThat(processEngineConfiguration.isEnablePasswordPolicy()).isEqualTo(true);
+    assertThat(processEngineConfiguration.isEnablePasswordPolicy()).isTrue();
     assertThat(processEngineConfiguration.getPasswordPolicy()).isInstanceOf(DefaultPasswordPolicyImpl.class);
   }
 
@@ -86,7 +86,7 @@ public class PasswordPolicyConfigurationTest {
     processEngineConfiguration.initPasswordPolicy();
 
     // then
-    assertThat(processEngineConfiguration.isEnablePasswordPolicy()).isEqualTo(true);
+    assertThat(processEngineConfiguration.isEnablePasswordPolicy()).isTrue();
     assertThat(processEngineConfiguration.getPasswordPolicy()).isInstanceOf(DefaultPasswordPolicyImpl.class);
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/PasswordPolicyConfigurationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/PasswordPolicyConfigurationTest.java
@@ -16,18 +16,18 @@
  */
 package org.operaton.bpm.engine.test.api.identity;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.operaton.bpm.engine.impl.identity.DefaultPasswordPolicyImpl;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.operaton.bpm.engine.impl.identity.DefaultPasswordPolicyImpl;
+import org.operaton.bpm.engine.test.ProcessEngineRule;
+import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
+import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PasswordPolicyConfigurationTest {
 
@@ -59,7 +59,7 @@ public class PasswordPolicyConfigurationTest {
 
     // then
     assertThat(processEngineConfiguration.getPasswordPolicy()).isNull();
-    assertThat(processEngineConfiguration.isEnablePasswordPolicy()).isEqualTo(false);
+    assertThat(processEngineConfiguration.isEnablePasswordPolicy()).isFalse();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/TenantQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/TenantQueryTest.java
@@ -139,7 +139,7 @@ public class TenantQueryTest {
   public void queryOrderById() {
     // ascending
     List<Tenant> tenants = identityService.createTenantQuery().orderByTenantId().asc().list();
-    assertThat(tenants.size()).isEqualTo(2);
+    assertThat(tenants).hasSize(2);
 
     assertThat(tenants.get(0).getId()).isEqualTo(TENANT_ONE);
     assertThat(tenants.get(1).getId()).isEqualTo(TENANT_TWO);
@@ -155,7 +155,7 @@ public class TenantQueryTest {
   public void queryOrderByName() {
     // ascending
     List<Tenant> tenants = identityService.createTenantQuery().orderByTenantName().asc().list();
-    assertThat(tenants.size()).isEqualTo(2);
+    assertThat(tenants).hasSize(2);
 
     assertThat(tenants.get(0).getName()).isEqualTo("Tenant_1");
     assertThat(tenants.get(1).getName()).isEqualTo("Tenant_2");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/TenantQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/TenantQueryTest.java
@@ -80,14 +80,14 @@ public class TenantQueryTest {
   public void queryByNonExistingId() {
     TenantQuery query = identityService.createTenantQuery().tenantId("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
   public void queryByIdIn() {
     TenantQuery query = identityService.createTenantQuery();
 
-    assertThat(query.tenantIdIn("non", "existing").count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn("non", "existing").count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(2L);
   }
 
@@ -95,7 +95,7 @@ public class TenantQueryTest {
   public void queryByName() {
     TenantQuery query = identityService.createTenantQuery();
 
-    assertThat(query.tenantName("nonExisting").count()).isEqualTo(0L);
+    assertThat(query.tenantName("nonExisting").count()).isZero();
     assertThat(query.tenantName("Tenant_1").count()).isEqualTo(1L);
     assertThat(query.tenantName("Tenant_2").count()).isEqualTo(1L);
   }
@@ -104,7 +104,7 @@ public class TenantQueryTest {
   public void queryByNameLike() {
     TenantQuery query = identityService.createTenantQuery();
 
-    assertThat(query.tenantNameLike("%nonExisting%").count()).isEqualTo(0L);
+    assertThat(query.tenantNameLike("%nonExisting%").count()).isZero();
     assertThat(query.tenantNameLike("%Tenant\\_1%").count()).isEqualTo(1L);
     assertThat(query.tenantNameLike("%Tenant%").count()).isEqualTo(2L);
   }
@@ -113,7 +113,7 @@ public class TenantQueryTest {
   public void queryByUser() {
     TenantQuery query = identityService.createTenantQuery();
 
-    assertThat(query.userMember("nonExisting").count()).isEqualTo(0L);
+    assertThat(query.userMember("nonExisting").count()).isZero();
     assertThat(query.userMember(USER).count()).isEqualTo(1L);
     assertThat(query.userMember(USER).tenantId(TENANT_ONE).count()).isEqualTo(1L);
   }
@@ -122,7 +122,7 @@ public class TenantQueryTest {
   public void queryByGroup() {
     TenantQuery query = identityService.createTenantQuery();
 
-    assertThat(query.groupMember("nonExisting").count()).isEqualTo(0L);
+    assertThat(query.groupMember("nonExisting").count()).isZero();
     assertThat(query.groupMember(GROUP).count()).isEqualTo(1L);
     assertThat(query.groupMember(GROUP).tenantId(TENANT_TWO).count()).isEqualTo(1L);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/BatchStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/BatchStatisticsQueryTest.java
@@ -693,7 +693,7 @@ public class BatchStatisticsQueryTest {
     assertThat(batchStatistics).hasSize(1);
     assertThat(query1.count()).isEqualTo(1);
 
-    assertThat(query2.count()).isEqualTo(0);
+    assertThat(query2.count()).isZero();
     assertThat(query2.list()).hasSize(0);
   }
 
@@ -711,7 +711,7 @@ public class BatchStatisticsQueryTest {
     BatchStatisticsQuery query2 = managementService.createBatchStatisticsQuery().startedBefore(oneMinLater);
 
     // then
-    assertThat(query1.count()).isEqualTo(0);
+    assertThat(query1.count()).isZero();
     assertThat(query1.list()).hasSize(0);
 
     final List<BatchStatistics> batchStatistics = query2.list();
@@ -748,7 +748,7 @@ public class BatchStatisticsQueryTest {
     assertThat(query2.count()).isEqualTo(1);
 
     assertThat(query3.list()).hasSize(0);
-    assertThat(query3.count()).isEqualTo(0);
+    assertThat(query3.count()).isZero();
   }
 
   protected void deleteMigrationJobs(Batch batch) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/BatchStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/BatchStatisticsQueryTest.java
@@ -694,7 +694,7 @@ public class BatchStatisticsQueryTest {
     assertThat(query1.count()).isEqualTo(1);
 
     assertThat(query2.count()).isZero();
-    assertThat(query2.list()).hasSize(0);
+    assertThat(query2.list()).isEmpty();
   }
 
   @Test
@@ -712,7 +712,7 @@ public class BatchStatisticsQueryTest {
 
     // then
     assertThat(query1.count()).isZero();
-    assertThat(query1.list()).hasSize(0);
+    assertThat(query1.list()).isEmpty();
 
     final List<BatchStatistics> batchStatistics = query2.list();
     assertThat(batchStatistics.get(0).getId()).isEqualTo(batch.getId());
@@ -747,7 +747,7 @@ public class BatchStatisticsQueryTest {
     assertThat(query2.list()).hasSize(1);
     assertThat(query2.count()).isEqualTo(1);
 
-    assertThat(query3.list()).hasSize(0);
+    assertThat(query3.list()).isEmpty();
     assertThat(query3.count()).isZero();
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceAsyncOperationsTest.java
@@ -203,7 +203,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     List<Exception> exceptions = executeBatchJobs(batch);
 
     //then
-    assertThat(exceptions).hasSize(0);
+    assertThat(exceptions).isEmpty();
     assertRetries(getAllJobIds(), RETRIES);
     assertHistoricBatchExists(testRule);
   }
@@ -220,7 +220,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions).hasSize(0);
+    assertThat(exceptions).isEmpty();
     assertRetries(getAllJobIds(), RETRIES);
     assertHistoricBatchExists(testRule);
   }
@@ -237,7 +237,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions).hasSize(0);
+    assertThat(exceptions).isEmpty();
     assertRetries(getAllJobIds(), RETRIES);
     assertHistoricBatchExists(testRule);
   }
@@ -253,7 +253,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions).hasSize(0);
+    assertThat(exceptions).isEmpty();
     assertRetries(ids, RETRIES);
     assertHistoricBatchExists(testRule);
   }
@@ -269,7 +269,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions).hasSize(0);
+    assertThat(exceptions).isEmpty();
     assertRetries(ids, RETRIES);
     assertHistoricBatchExists(testRule);
   }
@@ -288,7 +288,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions).hasSize(0);
+    assertThat(exceptions).isEmpty();
     assertRetries(ids, RETRIES);
     assertHistoricBatchExists(testRule);
   }
@@ -311,7 +311,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions).hasSize(0);
+    assertThat(exceptions).isEmpty();
     assertRetries(ids, RETRIES);
     assertHistoricBatchExists(testRule);
   }
@@ -402,7 +402,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions).hasSize(0);
+    assertThat(exceptions).isEmpty();
     for (String id : ids) {
       Job job = managementService.createJobQuery().jobId(id).singleResult();
       assertThat(job.getRetries()).isEqualTo(RETRIES);
@@ -423,7 +423,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions).hasSize(0);
+    assertThat(exceptions).isEmpty();
     for (String id : processInstanceIds) {
       Job job = managementService.createJobQuery().processInstanceId(id).singleResult();
       assertThat(job.getRetries()).isEqualTo(RETRIES);
@@ -442,7 +442,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions).hasSize(0);
+    assertThat(exceptions).isEmpty();
     for (String id : ids) {
       Job jobResult = managementService.createJobQuery().jobId(id).singleResult();
       assertThat(jobResult.getRetries()).isEqualTo(RETRIES);
@@ -466,7 +466,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions).hasSize(0);
+    assertThat(exceptions).isEmpty();
     for (String id : ids) {
       Job jobResult = managementService.createJobQuery().jobId(id).singleResult();
       assertThat(jobResult.getRetries()).isEqualTo(RETRIES);
@@ -495,7 +495,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions).hasSize(0);
+    assertThat(exceptions).isEmpty();
     for (String id : ids) {
       Job jobResult = managementService.createJobQuery().jobId(id).singleResult();
       assertThat(jobResult.getRetries()).isEqualTo(RETRIES);
@@ -513,7 +513,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     List<Exception> exceptions = executeBatchJobs(batch);
 
     // then
-    assertThat(exceptions).hasSize(0);
+    assertThat(exceptions).isEmpty();
     for (String id : ids) {
       Job jobResult = managementService.createJobQuery().jobId(id).singleResult();
       assertThat(jobResult.getRetries()).isEqualTo(RETRIES);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.java
@@ -904,7 +904,7 @@ public class ManagementServiceTest extends PluggableProcessEngineTest {
   public void testGetTableMetaData() {
 
     TableMetaData tableMetaData = managementService.getTableMetaData("ACT_RU_TASK");
-    assertThat(tableMetaData.getColumnNames().size()).isEqualTo(tableMetaData.getColumnTypes().size());
+    assertThat(tableMetaData.getColumnNames()).hasSize(tableMetaData.getColumnTypes().size());
     assertThat(tableMetaData.getColumnNames()).contains("ID_", "REV_","NAME_", "PARENT_TASK_ID_",
         "PRIORITY_", "CREATE_TIME_", "LAST_UPDATED_", "OWNER_", "ASSIGNEE_", "DELEGATION_", "EXECUTION_ID_",
         "PROC_DEF_ID_", "PROC_INST_ID_", "CASE_EXECUTION_ID_","CASE_INST_ID_", "CASE_DEF_ID_", "TASK_DEF_KEY_",

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ProcessDefinitionStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ProcessDefinitionStatisticsQueryTest.java
@@ -690,8 +690,8 @@ public class ProcessDefinitionStatisticsQueryTest extends PluggableProcessEngine
     assertThat(processDefinitionStatistics.getResourceName()).isEqualTo(resourceName);
     assertThat(processDefinitionStatistics.getDiagramResourceName()).isNull();
     assertThat(processDefinitionStatistics.getVersion()).isEqualTo(1);
-    assertThat(processDefinitionStatistics.getInstances()).isEqualTo(0);
-    assertThat(processDefinitionStatistics.getFailedJobs()).isEqualTo(0);
+    assertThat(processDefinitionStatistics.getInstances()).isZero();
+    assertThat(processDefinitionStatistics.getFailedJobs()).isZero();
     assertThat(processDefinitionStatistics.getIncidentStatistics()).isEmpty();
     assertThat(processDefinitionStatistics.isStartableInTasklist()).isTrue();
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/PropertyUserOperationLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/PropertyUserOperationLogTest.java
@@ -67,7 +67,7 @@ public class PropertyUserOperationLogTest {
   @Test
   public void testCreateProperty() {
     // given
-    assertThat(historyService.createUserOperationLogQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createUserOperationLogQuery().count()).isZero();
 
     // when
     identityService.setAuthenticatedUserId(USER_ID);
@@ -89,7 +89,7 @@ public class PropertyUserOperationLogTest {
   public void testUpdateProperty() {
     // given
     managementService.setProperty(PROPERTY_NAME, "testValue");
-    assertThat(historyService.createUserOperationLogQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createUserOperationLogQuery().count()).isZero();
 
     // when
     identityService.setAuthenticatedUserId(USER_ID);
@@ -111,7 +111,7 @@ public class PropertyUserOperationLogTest {
   public void testDeleteProperty() {
     // given
     managementService.setProperty(PROPERTY_NAME, "testValue");
-    assertThat(historyService.createUserOperationLogQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createUserOperationLogQuery().count()).isZero();
 
     // when
     identityService.setAuthenticatedUserId(USER_ID);
@@ -132,7 +132,7 @@ public class PropertyUserOperationLogTest {
   @Test
   public void testDeletePropertyNonExisting() {
     // given
-    assertThat(historyService.createUserOperationLogQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createUserOperationLogQuery().count()).isZero();
 
     // when
     identityService.setAuthenticatedUserId(USER_ID);
@@ -140,6 +140,6 @@ public class PropertyUserOperationLogTest {
     identityService.clearAuthentication();
 
     // then
-    assertThat(historyService.createUserOperationLogQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createUserOperationLogQuery().count()).isZero();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/metrics/TaskMetricsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/metrics/TaskMetricsTest.java
@@ -90,7 +90,7 @@ public class TaskMetricsTest {
     // when
     managementService.deleteTaskMetrics(null);
     // then
-    assertThat(managementService.getUniqueTaskWorkerCount(null, null)).isEqualTo(0L);
+    assertThat(managementService.getUniqueTaskWorkerCount(null, null)).isZero();
   }
 
   @Test
@@ -103,7 +103,7 @@ public class TaskMetricsTest {
     // when
     managementService.deleteTaskMetrics(getOneMinuteFromNow());
     // then
-    assertThat(managementService.getUniqueTaskWorkerCount(null, null)).isEqualTo(0L);
+    assertThat(managementService.getUniqueTaskWorkerCount(null, null)).isZero();
   }
 
   @Test
@@ -299,7 +299,7 @@ public class TaskMetricsTest {
     // when
     newTask.setAssignee("kermit");
     // then
-    assertThat(managementService.getUniqueTaskWorkerCount(null, null)).isEqualTo(0L);
+    assertThat(managementService.getUniqueTaskWorkerCount(null, null)).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/telemetry/TelemetryConfigurationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/telemetry/TelemetryConfigurationTest.java
@@ -16,8 +16,11 @@
  */
 package org.operaton.bpm.engine.test.api.mgmt.telemetry;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.IdentityService;
 import org.operaton.bpm.engine.ManagementService;
 import org.operaton.bpm.engine.ProcessEngine;
@@ -33,11 +36,8 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.commons.testing.ProcessEngineLoggingRule;
 import org.operaton.commons.testing.WatchLogger;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TelemetryConfigurationTest {
 
@@ -94,7 +94,7 @@ public class TelemetryConfigurationTest {
     // given
 
     // then
-    assertThat(loggingRule.getFilteredLog(" telemetry ").size()).isZero();
+    assertThat(loggingRule.getFilteredLog(" telemetry ")).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/telemetry/TelemetryDynamicDataTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/telemetry/TelemetryDynamicDataTest.java
@@ -16,15 +16,12 @@
  */
 package org.operaton.bpm.engine.test.api.mgmt.telemetry;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Map;
-
-import org.operaton.bpm.engine.ManagementService;
-import org.operaton.bpm.engine.ProcessEngine;
-import org.operaton.bpm.engine.ProcessEngines;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
 import org.operaton.bpm.engine.impl.diagnostics.CommandCounter;
@@ -36,11 +33,10 @@ import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TelemetryDynamicDataTest {
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/telemetry/TelemetryDynamicDataTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/telemetry/TelemetryDynamicDataTest.java
@@ -127,7 +127,7 @@ public class TelemetryDynamicDataTest {
     taskService.complete(task.getId());
 
     // then
-    assertThat(entries.size()).isEqualTo(4);
+    assertThat(entries).hasSize(4);
     String [] expectedExecutedCommands = {"StartProcessInstanceCmd",
                                          "SetExecutionVariablesCmd",
                                          "TaskQueryImpl",

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyDecisionEvaluationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyDecisionEvaluationTest.java
@@ -311,7 +311,7 @@ public class MultiTenancyDecisionEvaluationTest extends PluggableProcessEngineTe
 
   protected void assertThatDecisionHasResult(DmnDecisionResult decisionResult, Object expectedValue) {
     assertThat(decisionResult).isNotNull();
-    assertThat(decisionResult.size()).isEqualTo(1);
+    assertThat(decisionResult).hasSize(1);
     String value = decisionResult.getSingleResult().getFirstEntry();
     assertThat(value).isEqualTo(expectedValue);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyDecisionTableEvaluationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyDecisionTableEvaluationTest.java
@@ -311,7 +311,7 @@ public class MultiTenancyDecisionTableEvaluationTest extends PluggableProcessEng
 
   protected void assertThatDecisionHasResult(DmnDecisionTableResult decisionResult, Object expectedValue) {
     assertThat(decisionResult).isNotNull();
-    assertThat(decisionResult.size()).isEqualTo(1);
+    assertThat(decisionResult).hasSize(1);
     String value = decisionResult.getSingleResult().getFirstEntry();
     assertThat(value).isEqualTo(expectedValue);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyExecutionPropagationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyExecutionPropagationTest.java
@@ -99,7 +99,7 @@ public class MultiTenancyExecutionPropagationTest extends PluggableProcessEngine
     startProcessInstance(PROCESS_DEFINITION_KEY);
 
     List<Execution> executions = runtimeService.createExecutionQuery().list();
-    assertThat(executions.size()).isEqualTo(3);
+    assertThat(executions).hasSize(3);
     assertThat(executions.get(0).getTenantId()).isEqualTo(TENANT_ID);
     // inherit the tenant id from process instance
     assertThat(executions.get(1).getTenantId()).isEqualTo(TENANT_ID);
@@ -123,7 +123,7 @@ public class MultiTenancyExecutionPropagationTest extends PluggableProcessEngine
     startProcessInstance(PROCESS_DEFINITION_KEY);
 
     List<Execution> executions = runtimeService.createExecutionQuery().list();
-    assertThat(executions.size()).isEqualTo(2);
+    assertThat(executions).hasSize(2);
     assertThat(executions.get(0).getTenantId()).isEqualTo(TENANT_ID);
     // inherit the tenant id from parent execution (e.g. process instance)
     assertThat(executions.get(1).getTenantId()).isEqualTo(TENANT_ID);
@@ -425,7 +425,7 @@ public class MultiTenancyExecutionPropagationTest extends PluggableProcessEngine
     assertThat(externalTask.getTenantId()).isEqualTo(TENANT_ID);
 
     List<LockedExternalTask> externalTasks = externalTaskService.fetchAndLock(1, "test").topic("test", 1000).execute();
-    assertThat(externalTasks.size()).isEqualTo(1);
+    assertThat(externalTasks).hasSize(1);
     assertThat(externalTasks.get(0).getTenantId()).isEqualTo(TENANT_ID);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyFilterServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyFilterServiceTest.java
@@ -155,7 +155,7 @@ public class MultiTenancyFilterServiceTest extends PluggableProcessEngineTest {
 
     identityService.setAuthentication("user", null, null);
 
-    assertThat(filterService.count(filterId)).isEqualTo(0L);
+    assertThat(filterService.count(filterId)).isZero();
   }
 
   @Test
@@ -176,7 +176,7 @@ public class MultiTenancyFilterServiceTest extends PluggableProcessEngineTest {
     identityService.setAuthentication("user", null, null);
 
     TaskQuery extendingQuery = taskService.createTaskQuery().tenantIdIn(TENANT_ONE);
-    assertThat(filterService.count(filterId, extendingQuery)).isEqualTo(0L);
+    assertThat(filterService.count(filterId, extendingQuery)).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyMessageCorrelationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyMessageCorrelationTest.java
@@ -112,7 +112,7 @@ public class MultiTenancyMessageCorrelationTest {
 
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery();
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test
@@ -170,7 +170,7 @@ public class MultiTenancyMessageCorrelationTest {
 
     TaskQuery query = engineRule.getTaskService().createTaskQuery();
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test
@@ -204,7 +204,7 @@ public class MultiTenancyMessageCorrelationTest {
 
     TaskQuery query = engineRule.getTaskService().createTaskQuery();
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(2L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test
@@ -245,7 +245,7 @@ public class MultiTenancyMessageCorrelationTest {
 
     TaskQuery query = engineRule.getTaskService().createTaskQuery();
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(2L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test
@@ -273,7 +273,7 @@ public class MultiTenancyMessageCorrelationTest {
 
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery();
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyMessageCorrelationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyMessageCorrelationTest.java
@@ -185,7 +185,7 @@ public class MultiTenancyMessageCorrelationTest {
       .correlateAll();
 
     List<Task> tasks = engineRule.getTaskService().createTaskQuery().list();
-    assertThat(tasks.size()).isEqualTo(2);
+    assertThat(tasks).hasSize(2);
     assertThat(tasks.get(0).getTenantId()).isNull();
     assertThat(tasks.get(1).getTenantId()).isNull();
   }
@@ -223,7 +223,7 @@ public class MultiTenancyMessageCorrelationTest {
       .correlateAll();
 
     List<Task> tasks = engineRule.getTaskService().createTaskQuery().list();
-    assertThat(tasks.size()).isEqualTo(2);
+    assertThat(tasks).hasSize(2);
     assertThat(tasks.get(0).getTenantId()).isNull();
     assertThat(tasks.get(1).getTenantId()).isNull();
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyRepositoryServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyRepositoryServiceTest.java
@@ -119,7 +119,7 @@ public class MultiTenancyRepositoryServiceTest {
         .asc()
         .list();
 
-    assertThat(processDefinitions.size()).isEqualTo(3);
+    assertThat(processDefinitions).hasSize(3);
     // process definition was deployed twice for tenant one
     assertThat(processDefinitions.get(0).getVersion()).isEqualTo(1);
     assertThat(processDefinitions.get(1).getVersion()).isEqualTo(2);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancySignalReceiveTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancySignalReceiveTest.java
@@ -196,7 +196,7 @@ public class MultiTenancySignalReceiveTest {
     runtimeService.createSignalEvent("signal").withoutTenantId().send();
 
     List<Task> tasks = taskService.createTaskQuery().list();
-    assertThat(tasks.size()).isEqualTo(2);
+    assertThat(tasks).hasSize(2);
     assertThat(tasks.get(0).getTenantId()).isNull();
     assertThat(tasks.get(1).getTenantId()).isNull();
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancySignalReceiveTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancySignalReceiveTest.java
@@ -281,7 +281,7 @@ public class MultiTenancySignalReceiveTest {
 
     TaskQuery query = taskService.createTaskQuery();
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(2L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(taskService.createTaskQuery().withoutTenantId().count()).isEqualTo(2L);
   }
 
@@ -296,7 +296,7 @@ public class MultiTenancySignalReceiveTest {
     runtimeService.startProcessInstanceByKey("signalThrow");
 
     assertThat(taskService.createTaskQuery().withoutTenantId().count()).isEqualTo(2L);
-    assertThat(taskService.createTaskQuery().tenantIdIn(TENANT_ONE).count()).isEqualTo(0L);
+    assertThat(taskService.createTaskQuery().tenantIdIn(TENANT_ONE).count()).isZero();
   }
 
   @Test
@@ -313,7 +313,7 @@ public class MultiTenancySignalReceiveTest {
 
     TaskQuery query = taskService.createTaskQuery();
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(2L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(taskService.createTaskQuery().withoutTenantId().count()).isEqualTo(2L);
   }
 
@@ -328,6 +328,6 @@ public class MultiTenancySignalReceiveTest {
     runtimeService.startProcessInstanceByKey("signalThrow");
 
     assertThat(taskService.createTaskQuery().withoutTenantId().count()).isEqualTo(2L);
-    assertThat(taskService.createTaskQuery().tenantIdIn(TENANT_ONE).count()).isEqualTo(0L);
+    assertThat(taskService.createTaskQuery().tenantIdIn(TENANT_ONE).count()).isZero();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyTimerStartEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyTimerStartEventTest.java
@@ -113,13 +113,13 @@ public class MultiTenancyTimerStartEventTest {
 
      repositoryService.deleteDeployment(deploymentForTenantOne.getId(), true);
 
-     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(0L);
+     assertThat(query.tenantIdIn(TENANT_ONE).count()).isZero();
      assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(1L);
 
      repositoryService.deleteDeployment(deploymentForTenantTwo.getId(), true);
 
-     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(0L);
-     assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+     assertThat(query.tenantIdIn(TENANT_ONE).count()).isZero();
+     assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test
@@ -187,7 +187,7 @@ public class MultiTenancyTimerStartEventTest {
 
     ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery();
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(2L);
-    assertThat(query.withoutTenantId().count()).isEqualTo(0L);
+    assertThat(query.withoutTenantId().count()).isZero();
   }
 
   protected void executeFailingJobs(List<Job> jobs) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyUserOperationLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyUserOperationLogTest.java
@@ -151,7 +151,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(2);
+    assertThat(list).hasSize(2);
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(TENANT_ONE);
    }
@@ -174,7 +174,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-     assertThat(list.size()).isEqualTo(2);
+     assertThat(list).hasSize(2);
      for (UserOperationLogEntry userOperationLogEntry : list) {
        assertThat(userOperationLogEntry.getTenantId()).isEqualTo(TENANT_ONE);
     }
@@ -199,7 +199,7 @@ public class MultiTenancyUserOperationLogTest {
     List<UserOperationLogEntry> list = historyService.createUserOperationLogQuery().list();
 
     // then
-    assertThat(list.size()).isEqualTo(4);
+    assertThat(list).hasSize(4);
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getEntityType()).isEqualTo(EntityTypes.IDENTITY_LINK);
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(TENANT_ONE);
@@ -223,7 +223,7 @@ public class MultiTenancyUserOperationLogTest {
     List<UserOperationLogEntry> list = historyService.createUserOperationLogQuery().list();
 
     // then
-    assertThat(list.size()).isEqualTo(2);
+    assertThat(list).hasSize(2);
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getEntityType()).isEqualTo(EntityTypes.ATTACHMENT);
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(TENANT_ONE);
@@ -257,7 +257,7 @@ public class MultiTenancyUserOperationLogTest {
     List<UserOperationLogEntry> list = historyService.createUserOperationLogQuery().list();
 
     // then
-    assertThat(list.size()).isEqualTo(5);
+    assertThat(list).hasSize(5);
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getEntityType()).isEqualTo(EntityTypes.TASK);
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(TENANT_ONE);
@@ -290,7 +290,7 @@ public class MultiTenancyUserOperationLogTest {
         .entityType(EntityTypes.TASK).list();
 
     // then
-    assertThat(list.size()).isEqualTo(8);
+    assertThat(list).hasSize(8);
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(TENANT_ONE);
     }
@@ -355,7 +355,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(4);
+    assertThat(list).hasSize(4);
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(TENANT_ONE);
     }
@@ -376,7 +376,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(2);
+    assertThat(list).hasSize(2);
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(TENANT_ONE);
     }
@@ -416,7 +416,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(2);
+    assertThat(list).hasSize(2);
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(TENANT_ONE);
     }
@@ -437,7 +437,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(2);
+    assertThat(list).hasSize(2);
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(TENANT_ONE);
     }
@@ -478,7 +478,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(3); // 3 properties
+    assertThat(list).hasSize(3); // 3 properties
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(TENANT_ONE);
     }
@@ -504,7 +504,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(2); // 2 properties
+    assertThat(list).hasSize(2); // 2 properties
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(TENANT_ONE);
     }
@@ -534,7 +534,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(5); // 5 properties
+    assertThat(list).hasSize(5); // 5 properties
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(null);
     }
@@ -555,7 +555,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(2); // 2 properties
+    assertThat(list).hasSize(2); // 2 properties
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(TENANT_ONE);
     }
@@ -653,7 +653,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(3);
+    assertThat(list).hasSize(3);
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(null);
     }
@@ -676,7 +676,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(3);
+    assertThat(list).hasSize(3);
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(null);
     }
@@ -699,7 +699,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(3);
+    assertThat(list).hasSize(3);
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(null);
     }
@@ -723,7 +723,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(3);
+    assertThat(list).hasSize(3);
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo("test");
     }
@@ -745,7 +745,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(4); // 2 properties per log
+    assertThat(list).hasSize(4); // 2 properties per log
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(null);
     }
@@ -771,7 +771,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(4); // 2 properties per log
+    assertThat(list).hasSize(4); // 2 properties per log
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo("testTenant");
     }
@@ -806,7 +806,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(12); // 6 properties per log
+    assertThat(list).hasSize(12); // 6 properties per log
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(null);
     }
@@ -826,7 +826,7 @@ public class MultiTenancyUserOperationLogTest {
         .list();
 
     // then
-    assertThat(list.size()).isEqualTo(2);
+    assertThat(list).hasSize(2);
     for (UserOperationLogEntry userOperationLogEntry : list) {
       assertThat(userOperationLogEntry.getTenantId()).isEqualTo(null);
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/TenantIdProviderTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/TenantIdProviderTest.java
@@ -135,7 +135,7 @@ public class TenantIdProviderTest {
     engineRule.getRuntimeService().startProcessInstanceByKey(PROCESS_DEFINITION_KEY);
 
     // then the tenant id provider is not invoked
-    assertThat(tenantIdProvider.parameters.size()).isEqualTo(0);
+    assertThat(tenantIdProvider.parameters.size()).isZero();
   }
 
 
@@ -188,7 +188,7 @@ public class TenantIdProviderTest {
     assertNotNull(procInstance);
 
     // then the tenant id provider is not invoked
-    assertThat(tenantIdProvider.parameters.size()).isEqualTo(0);
+    assertThat(tenantIdProvider.parameters.size()).isZero();
   }
 
   @Test
@@ -228,7 +228,7 @@ public class TenantIdProviderTest {
 
     //then provider should not be called
     assertNotNull(engineRule.getRuntimeService().getActivityInstance(processInstanceId));
-    assertThat(tenantIdProvider.parameters.size()).isEqualTo(0);
+    assertThat(tenantIdProvider.parameters.size()).isZero();
   }
 
   @Test
@@ -332,7 +332,7 @@ public class TenantIdProviderTest {
     engineRule.getRuntimeService().startProcessInstanceByKey("superProcess");
 
     // then the tenant id provider is not invoked
-    assertThat(tenantIdProvider.parameters.size()).isEqualTo(0);
+    assertThat(tenantIdProvider.parameters.size()).isZero();
   }
 
   @Test
@@ -485,7 +485,7 @@ public class TenantIdProviderTest {
     CaseExecution caseExecution = engineRule.getCaseService().createCaseExecutionQuery().activityId("PI_ProcessTask_1").singleResult();
 
     // then the tenant id provider is not invoked
-    assertThat(tenantIdProvider.parameters.size()).isEqualTo(0);
+    assertThat(tenantIdProvider.parameters.size()).isZero();
   }
 
   @Test
@@ -579,7 +579,7 @@ public class TenantIdProviderTest {
     engineRule.getDecisionService().evaluateDecisionTableByKey(DECISION_DEFINITION_KEY).variables(createVariables()).evaluate();
 
     // then the tenant id provider is not invoked
-    assertThat(tenantIdProvider.dmnParameters.size()).isEqualTo(0);
+    assertThat(tenantIdProvider.dmnParameters.size()).isZero();
   }
 
   @Test
@@ -677,7 +677,7 @@ public class TenantIdProviderTest {
     engineRule.getRuntimeService().startProcessInstanceByKey(PROCESS_DEFINITION_KEY, createVariables());
 
     // then the tenant id providers are not invoked
-    assertThat(tenantIdProvider.dmnParameters.size()).isEqualTo(0);
+    assertThat(tenantIdProvider.dmnParameters.size()).isZero();
   }
 
   @Test
@@ -792,7 +792,7 @@ public class TenantIdProviderTest {
     engineRule.getCaseService().withCaseDefinitionByKey(CASE_DEFINITION_KEY).create();
 
     // then the tenant id provider is not invoked
-    assertThat(tenantIdProvider.caseParameters.size()).isEqualTo(0);
+    assertThat(tenantIdProvider.caseParameters.size()).isZero();
   }
 
   @Test
@@ -894,7 +894,7 @@ public class TenantIdProviderTest {
     engineRule.getCaseService().withCaseDefinitionByKey(CASE_DEFINITION_KEY).create();
 
     // then the tenant id provider is not invoked
-    assertThat(tenantIdProvider.caseParameters.size()).isEqualTo(0);
+    assertThat(tenantIdProvider.caseParameters.size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/TenantIdProviderTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/TenantIdProviderTest.java
@@ -119,7 +119,7 @@ public class TenantIdProviderTest {
     engineRule.getRuntimeService().startProcessInstanceByKey(PROCESS_DEFINITION_KEY);
 
     // then the tenant id provider is invoked
-    assertThat(tenantIdProvider.parameters.size()).isEqualTo(1);
+    assertThat(tenantIdProvider.parameters).hasSize(1);
   }
 
   @Test
@@ -162,7 +162,7 @@ public class TenantIdProviderTest {
     assertNotNull(procInstance);
 
     // then the tenant id provider is invoked
-    assertThat(tenantIdProvider.parameters.size()).isEqualTo(1);
+    assertThat(tenantIdProvider.parameters).hasSize(1);
   }
 
 
@@ -208,7 +208,7 @@ public class TenantIdProviderTest {
 
     //then provider is called
     assertNotNull(engineRule.getRuntimeService().getActivityInstance(processInstanceId));
-    assertThat(tenantIdProvider.parameters.size()).isEqualTo(1);
+    assertThat(tenantIdProvider.parameters).hasSize(1);
   }
 
   @Test
@@ -243,7 +243,7 @@ public class TenantIdProviderTest {
     engineRule.getRuntimeService().startProcessInstanceByKey(PROCESS_DEFINITION_KEY, Variables.createVariables().putValue("varName", true));
 
     // then the tenant id provider is passed in the variable
-    assertThat(tenantIdProvider.parameters.size()).isEqualTo(1);
+    assertThat(tenantIdProvider.parameters).hasSize(1);
     assertThat((Boolean) tenantIdProvider.parameters.get(0).getVariables().get("varName")).isTrue();
   }
 
@@ -315,7 +315,7 @@ public class TenantIdProviderTest {
     engineRule.getRuntimeService().startProcessInstanceByKey("superProcess");
 
     // then the tenant id provider is invoked twice
-    assertThat(tenantIdProvider.parameters.size()).isEqualTo(2);
+    assertThat(tenantIdProvider.parameters).hasSize(2);
   }
 
   @Test
@@ -348,7 +348,7 @@ public class TenantIdProviderTest {
     engineRule.getRuntimeService().startProcessInstanceByKey("superProcess", Variables.createVariables().putValue("varName", true));
 
     // then the tenant id provider is passed in the variable
-    assertThat(tenantIdProvider.parameters.get(1).getVariables().size()).isEqualTo(1);
+    assertThat(tenantIdProvider.parameters.get(1).getVariables()).hasSize(1);
     assertThat((Boolean) tenantIdProvider.parameters.get(1).getVariables().get("varName")).isTrue();
   }
 
@@ -467,7 +467,7 @@ public class TenantIdProviderTest {
 
 
     // then the tenant id provider is invoked once for the process instance
-    assertThat(tenantIdProvider.parameters.size()).isEqualTo(1);
+    assertThat(tenantIdProvider.parameters).hasSize(1);
   }
 
   @Test
@@ -503,10 +503,10 @@ public class TenantIdProviderTest {
     CaseExecution caseExecution = engineRule.getCaseService().createCaseExecutionQuery().activityId("PI_ProcessTask_1").singleResult();
 
     // then the tenant id provider is passed in the variable
-    assertThat(tenantIdProvider.parameters.size()).isEqualTo(1);
+    assertThat(tenantIdProvider.parameters).hasSize(1);
 
     VariableMap variables = tenantIdProvider.parameters.get(0).getVariables();
-    assertThat(variables.size()).isEqualTo(1);
+    assertThat(variables).hasSize(1);
     assertThat((Boolean) variables.get("varName")).isTrue();
   }
 
@@ -525,7 +525,7 @@ public class TenantIdProviderTest {
     CaseExecution caseExecution = engineRule.getCaseService().createCaseExecutionQuery().activityId("PI_ProcessTask_1").singleResult();
 
     // then the tenant id provider is passed in the process definition
-    assertThat(tenantIdProvider.parameters.size()).isEqualTo(1);
+    assertThat(tenantIdProvider.parameters).hasSize(1);
     assertThat(tenantIdProvider.parameters.get(0).getProcessDefinition()).isNotNull();
   }
 
@@ -544,7 +544,7 @@ public class TenantIdProviderTest {
     CaseExecution caseExecution = engineRule.getCaseService().createCaseExecutionQuery().activityId("PI_ProcessTask_1").singleResult();
 
     // then the tenant id provider is handed in the super case execution
-    assertThat(tenantIdProvider.parameters.size()).isEqualTo(1);
+    assertThat(tenantIdProvider.parameters).hasSize(1);
     assertThat(tenantIdProvider.parameters.get(0).getSuperCaseExecution()).isNotNull();
   }
 
@@ -563,7 +563,7 @@ public class TenantIdProviderTest {
     engineRule.getDecisionService().evaluateDecisionTableByKey(DECISION_DEFINITION_KEY).variables(createVariables()).evaluate();
 
     // then the tenant id provider is invoked
-    assertThat(tenantIdProvider.dmnParameters.size()).isEqualTo(1);
+    assertThat(tenantIdProvider.dmnParameters).hasSize(1);
   }
 
   @Test
@@ -654,7 +654,7 @@ public class TenantIdProviderTest {
     engineRule.getRuntimeService().startProcessInstanceByKey(PROCESS_DEFINITION_KEY, createVariables());
 
     // then the tenant id provider is invoked
-    assertThat(tenantIdProvider.dmnParameters.size()).isEqualTo(1);
+    assertThat(tenantIdProvider.dmnParameters).hasSize(1);
   }
 
   @Test
@@ -701,7 +701,7 @@ public class TenantIdProviderTest {
     Execution execution = engineRule.getRuntimeService().createExecutionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).singleResult();
 
     // then the tenant id provider is invoked
-    assertThat(tenantIdProvider.dmnParameters.size()).isEqualTo(1);
+    assertThat(tenantIdProvider.dmnParameters).hasSize(1);
     ExecutionEntity passedExecution = (ExecutionEntity) tenantIdProvider.dmnParameters.get(0).getExecution();
     assertThat(passedExecution).isNotNull();
     assertThat(passedExecution.getParent().getId()).isEqualTo(execution.getId());
@@ -776,7 +776,7 @@ public class TenantIdProviderTest {
     engineRule.getCaseService().withCaseDefinitionByKey(CASE_DEFINITION_KEY).create();
 
     // then the tenant id provider is invoked
-    assertThat(tenantIdProvider.caseParameters.size()).isEqualTo(1);
+    assertThat(tenantIdProvider.caseParameters).hasSize(1);
   }
 
   @Test
@@ -807,7 +807,7 @@ public class TenantIdProviderTest {
     engineRule.getCaseService().withCaseDefinitionByKey(CASE_DEFINITION_KEY).setVariables(Variables.createVariables().putValue("varName", true)).create();
 
     // then the tenant id provider is passed in the variable
-    assertThat(tenantIdProvider.caseParameters.size()).isEqualTo(1);
+    assertThat(tenantIdProvider.caseParameters).hasSize(1);
     assertThat((Boolean) tenantIdProvider.caseParameters.get(0).getVariables().get("varName")).isTrue();
   }
 
@@ -878,7 +878,7 @@ public class TenantIdProviderTest {
     engineRule.getCaseService().withCaseDefinitionByKey(CASE_DEFINITION_KEY).create();
 
     // then the tenant id provider is invoked twice
-    assertThat(tenantIdProvider.caseParameters.size()).isEqualTo(2);
+    assertThat(tenantIdProvider.caseParameters).hasSize(2);
   }
 
   @Test
@@ -909,7 +909,7 @@ public class TenantIdProviderTest {
     engineRule.getCaseService().withCaseDefinitionByKey(CASE_DEFINITION_KEY).setVariables(Variables.createVariables().putValue("varName", true)).create();
 
     // then the tenant id provider is passed in the variable
-    assertThat(tenantIdProvider.caseParameters.get(1).getVariables().size()).isEqualTo(1);
+    assertThat(tenantIdProvider.caseParameters.get(1).getVariables()).hasSize(1);
     assertThat((Boolean) tenantIdProvider.caseParameters.get(1).getVariables().get("varName")).isTrue();
   }
 
@@ -1018,7 +1018,7 @@ public class TenantIdProviderTest {
     engineRule.getCaseService().withCaseDefinitionByKey(CASE_DEFINITION_KEY).create();
 
     // then the tenant id provider is handed in the super case execution
-    assertThat(tenantIdProvider.caseParameters.size()).isEqualTo(2);
+    assertThat(tenantIdProvider.caseParameters).hasSize(2);
     assertThat(tenantIdProvider.caseParameters.get(1).getSuperCaseExecution()).isNotNull();
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/TenantIdProviderTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/TenantIdProviderTest.java
@@ -16,16 +16,11 @@
  */
 package org.operaton.bpm.engine.test.api.multitenancy;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.variable.Variables.stringValue;
-import static org.junit.Assert.assertNotNull;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.delegate.DelegateCaseExecution;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
@@ -39,11 +34,7 @@ import org.operaton.bpm.engine.management.ActivityStatisticsQuery;
 import org.operaton.bpm.engine.repository.CaseDefinition;
 import org.operaton.bpm.engine.repository.DecisionDefinition;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
-import org.operaton.bpm.engine.runtime.CaseExecution;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.Execution;
-import org.operaton.bpm.engine.runtime.Incident;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.runtime.*;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.util.ProcessEngineBootstrapRule;
@@ -53,11 +44,12 @@ import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.operaton.bpm.engine.variable.Variables.stringValue;
 
 /**
  * @author Daniel Meyer
@@ -135,7 +127,7 @@ public class TenantIdProviderTest {
     engineRule.getRuntimeService().startProcessInstanceByKey(PROCESS_DEFINITION_KEY);
 
     // then the tenant id provider is not invoked
-    assertThat(tenantIdProvider.parameters.size()).isZero();
+    assertThat(tenantIdProvider.parameters).isEmpty();
   }
 
 
@@ -188,7 +180,7 @@ public class TenantIdProviderTest {
     assertNotNull(procInstance);
 
     // then the tenant id provider is not invoked
-    assertThat(tenantIdProvider.parameters.size()).isZero();
+    assertThat(tenantIdProvider.parameters).isEmpty();
   }
 
   @Test
@@ -228,7 +220,7 @@ public class TenantIdProviderTest {
 
     //then provider should not be called
     assertNotNull(engineRule.getRuntimeService().getActivityInstance(processInstanceId));
-    assertThat(tenantIdProvider.parameters.size()).isZero();
+    assertThat(tenantIdProvider.parameters).isEmpty();
   }
 
   @Test
@@ -332,7 +324,7 @@ public class TenantIdProviderTest {
     engineRule.getRuntimeService().startProcessInstanceByKey("superProcess");
 
     // then the tenant id provider is not invoked
-    assertThat(tenantIdProvider.parameters.size()).isZero();
+    assertThat(tenantIdProvider.parameters).isEmpty();
   }
 
   @Test
@@ -485,7 +477,7 @@ public class TenantIdProviderTest {
     CaseExecution caseExecution = engineRule.getCaseService().createCaseExecutionQuery().activityId("PI_ProcessTask_1").singleResult();
 
     // then the tenant id provider is not invoked
-    assertThat(tenantIdProvider.parameters.size()).isZero();
+    assertThat(tenantIdProvider.parameters).isEmpty();
   }
 
   @Test
@@ -579,7 +571,7 @@ public class TenantIdProviderTest {
     engineRule.getDecisionService().evaluateDecisionTableByKey(DECISION_DEFINITION_KEY).variables(createVariables()).evaluate();
 
     // then the tenant id provider is not invoked
-    assertThat(tenantIdProvider.dmnParameters.size()).isZero();
+    assertThat(tenantIdProvider.dmnParameters).isEmpty();
   }
 
   @Test
@@ -677,7 +669,7 @@ public class TenantIdProviderTest {
     engineRule.getRuntimeService().startProcessInstanceByKey(PROCESS_DEFINITION_KEY, createVariables());
 
     // then the tenant id providers are not invoked
-    assertThat(tenantIdProvider.dmnParameters.size()).isZero();
+    assertThat(tenantIdProvider.dmnParameters).isEmpty();
   }
 
   @Test
@@ -792,7 +784,7 @@ public class TenantIdProviderTest {
     engineRule.getCaseService().withCaseDefinitionByKey(CASE_DEFINITION_KEY).create();
 
     // then the tenant id provider is not invoked
-    assertThat(tenantIdProvider.caseParameters.size()).isZero();
+    assertThat(tenantIdProvider.caseParameters).isEmpty();
   }
 
   @Test
@@ -894,7 +886,7 @@ public class TenantIdProviderTest {
     engineRule.getCaseService().withCaseDefinitionByKey(CASE_DEFINITION_KEY).create();
 
     // then the tenant id provider is not invoked
-    assertThat(tenantIdProvider.caseParameters.size()).isZero();
+    assertThat(tenantIdProvider.caseParameters).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseDefinitionQueryTest.java
@@ -246,7 +246,7 @@ public class MultiTenancyCaseDefinitionQueryTest extends PluggableProcessEngineT
         .createCaseDefinitionQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -306,7 +306,7 @@ public class MultiTenancyCaseDefinitionQueryTest extends PluggableProcessEngineT
 
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).includeCaseDefinitionsWithoutTenantId().count()).isEqualTo(2L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseExecutionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseExecutionQueryTest.java
@@ -95,7 +95,7 @@ public class MultiTenancyCaseExecutionQueryTest extends PluggableProcessEngineTe
         .createCaseExecutionQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -157,7 +157,7 @@ public class MultiTenancyCaseExecutionQueryTest extends PluggableProcessEngineTe
 
     assertThat(query.count()).isEqualTo(4L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(2L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(2L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseInstanceQueryTest.java
@@ -95,7 +95,7 @@ public class MultiTenancyCaseInstanceQueryTest extends PluggableProcessEngineTes
         .createCaseInstanceQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -153,7 +153,7 @@ public class MultiTenancyCaseInstanceQueryTest extends PluggableProcessEngineTes
 
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(1L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseActivityInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseActivityInstanceQueryTest.java
@@ -161,7 +161,7 @@ public class MultiTenancyHistoricCaseActivityInstanceQueryTest {
         .list();
 
     // then
-    assertThat(historicCaseActivityInstances.size()).isEqualTo(3);
+    assertThat(historicCaseActivityInstances).hasSize(3);
     verifySorting(historicCaseActivityInstances, historicCaseActivityInstanceByTenantId());
   }
 
@@ -174,7 +174,7 @@ public class MultiTenancyHistoricCaseActivityInstanceQueryTest {
         .list();
 
     // then
-    assertThat(historicCaseActivityInstances.size()).isEqualTo(3);
+    assertThat(historicCaseActivityInstances).hasSize(3);
     verifySorting(historicCaseActivityInstances, inverted(historicCaseActivityInstanceByTenantId()));
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseActivityInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseActivityInstanceQueryTest.java
@@ -134,7 +134,7 @@ public class MultiTenancyHistoricCaseActivityInstanceQueryTest {
         .tenantIdIn("nonExisting");
 
     // then
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -202,7 +202,7 @@ public class MultiTenancyHistoricCaseActivityInstanceQueryTest {
     assertThat(query.count()).isEqualTo(2L);  // null-tenant instances are still included
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
     assertThat(query.withoutTenantId().count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(1L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseInstanceQueryTest.java
@@ -146,7 +146,7 @@ public class MultiTenancyHistoricCaseInstanceQueryTest {
         .asc()
         .list();
 
-    assertThat(historicCaseInstances.size()).isEqualTo(2);
+    assertThat(historicCaseInstances).hasSize(2);
     assertThat(historicCaseInstances.get(0).getTenantId()).isEqualTo(TENANT_ONE);
     assertThat(historicCaseInstances.get(1).getTenantId()).isEqualTo(TENANT_TWO);
   }
@@ -160,7 +160,7 @@ public class MultiTenancyHistoricCaseInstanceQueryTest {
         .desc()
         .list();
 
-    assertThat(historicCaseInstances.size()).isEqualTo(2);
+    assertThat(historicCaseInstances).hasSize(2);
     assertThat(historicCaseInstances.get(0).getTenantId()).isEqualTo(TENANT_TWO);
     assertThat(historicCaseInstances.get(1).getTenantId()).isEqualTo(TENANT_ONE);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseInstanceQueryTest.java
@@ -123,7 +123,7 @@ public class MultiTenancyHistoricCaseInstanceQueryTest {
         .createHistoricCaseInstanceQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -181,7 +181,7 @@ public class MultiTenancyHistoricCaseInstanceQueryTest {
 
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(1L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDecisionDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDecisionDefinitionQueryTest.java
@@ -249,7 +249,7 @@ public class MultiTenancyDecisionDefinitionQueryTest extends PluggableProcessEng
         .createDecisionDefinitionQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -309,7 +309,7 @@ public class MultiTenancyDecisionDefinitionQueryTest extends PluggableProcessEng
 
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).includeDecisionDefinitionsWithoutTenantId().count()).isEqualTo(2L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDecisionRequirementsDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDecisionRequirementsDefinitionQueryTest.java
@@ -267,7 +267,7 @@ public class MultiTenancyDecisionRequirementsDefinitionQueryTest {
         .createDecisionRequirementsDefinitionQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -325,7 +325,7 @@ public class MultiTenancyDecisionRequirementsDefinitionQueryTest {
 
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).includeDecisionRequirementsDefinitionsWithoutTenantId().count()).isEqualTo(2L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDeploymentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDeploymentQueryTest.java
@@ -116,7 +116,7 @@ public class MultiTenancyDeploymentQueryTest extends PluggableProcessEngineTest 
         .createDeploymentQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -174,7 +174,7 @@ public class MultiTenancyDeploymentQueryTest extends PluggableProcessEngineTest 
 
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).includeDeploymentsWithoutTenantId().count()).isEqualTo(2L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyEventSubscriptionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyEventSubscriptionQueryTest.java
@@ -124,7 +124,7 @@ public class MultiTenancyEventSubscriptionQueryTest extends PluggableProcessEngi
         createEventSubscriptionQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -182,7 +182,7 @@ public class MultiTenancyEventSubscriptionQueryTest extends PluggableProcessEngi
 
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).includeEventSubscriptionsWithoutTenantId().count()).isEqualTo(2L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyExecutionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyExecutionQueryTest.java
@@ -100,7 +100,7 @@ public class MultiTenancyExecutionQueryTest extends PluggableProcessEngineTest {
         .createExecutionQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -158,7 +158,7 @@ public class MultiTenancyExecutionQueryTest extends PluggableProcessEngineTest {
 
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(1L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyExternalTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyExternalTaskQueryTest.java
@@ -91,7 +91,7 @@ public class MultiTenancyExternalTaskQueryTest extends PluggableProcessEngineTes
         .createExternalTaskQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -134,7 +134,7 @@ public class MultiTenancyExternalTaskQueryTest extends PluggableProcessEngineTes
     identityService.setAuthentication("user", null, null);
 
     ExternalTaskQuery query = externalTaskService.createExternalTaskQuery();
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -145,7 +145,7 @@ public class MultiTenancyExternalTaskQueryTest extends PluggableProcessEngineTes
 
     assertThat(query.count()).isEqualTo(1L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(1L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyIncidentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyIncidentQueryTest.java
@@ -91,7 +91,7 @@ public class MultiTenancyIncidentQueryTest extends PluggableProcessEngineTest {
         .createIncidentQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -134,7 +134,7 @@ public class MultiTenancyIncidentQueryTest extends PluggableProcessEngineTest {
     identityService.setAuthentication("user", null, null);
 
     IncidentQuery query = runtimeService.createIncidentQuery();
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -145,7 +145,7 @@ public class MultiTenancyIncidentQueryTest extends PluggableProcessEngineTest {
 
     assertThat(query.count()).isEqualTo(1L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(1L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyJobDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyJobDefinitionQueryTest.java
@@ -124,7 +124,7 @@ public class MultiTenancyJobDefinitionQueryTest extends PluggableProcessEngineTe
         .createJobDefinitionQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -182,7 +182,7 @@ public class MultiTenancyJobDefinitionQueryTest extends PluggableProcessEngineTe
 
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).includeJobDefinitionsWithoutTenantId().count()).isEqualTo(2L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyJobQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyJobQueryTest.java
@@ -125,7 +125,7 @@ public class MultiTenancyJobQueryTest extends PluggableProcessEngineTest {
         .createJobQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -183,7 +183,7 @@ public class MultiTenancyJobQueryTest extends PluggableProcessEngineTest {
 
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).includeJobsWithoutTenantId().count()).isEqualTo(2L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyProcessDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyProcessDefinitionQueryTest.java
@@ -249,7 +249,7 @@ public class MultiTenancyProcessDefinitionQueryTest extends PluggableProcessEngi
         .createProcessDefinitionQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -318,7 +318,7 @@ public class MultiTenancyProcessDefinitionQueryTest extends PluggableProcessEngi
 
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).includeProcessDefinitionsWithoutTenantId().count()).isEqualTo(2L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyProcessInstanceQueryTest.java
@@ -101,7 +101,7 @@ public class MultiTenancyProcessInstanceQueryTest extends PluggableProcessEngine
         .createProcessInstanceQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -159,7 +159,7 @@ public class MultiTenancyProcessInstanceQueryTest extends PluggableProcessEngine
 
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(1L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyStatisticsQueryTest.java
@@ -215,7 +215,7 @@ public class MultiTenancyStatisticsQueryTest extends PluggableProcessEngineTest 
 
     ActivityStatisticsQuery query = managementService.createActivityStatisticsQuery(processInstance.getProcessDefinitionId());
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyTaskQueryTest.java
@@ -103,7 +103,7 @@ public class MultiTenancyTaskQueryTest extends PluggableProcessEngineTest {
         .endOr();
 
     // then
-    assertThat(query.list().size()).isEqualTo(3);
+    assertThat(query.list()).hasSize(3);
   }
 
   @Test
@@ -136,7 +136,7 @@ public class MultiTenancyTaskQueryTest extends PluggableProcessEngineTest {
         .asc()
         .list();
 
-    assertThat(tasks.size()).isEqualTo(2);
+    assertThat(tasks).hasSize(2);
     assertThat(tasks.get(0).getTenantId()).isEqualTo(TENANT_ONE);
     assertThat(tasks.get(1).getTenantId()).isEqualTo(TENANT_TWO);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyTaskQueryTest.java
@@ -111,7 +111,7 @@ public class MultiTenancyTaskQueryTest extends PluggableProcessEngineTest {
     TaskQuery query = taskService.createTaskQuery()
       .tenantIdIn(TENANT_NON_EXISTING);
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -171,7 +171,7 @@ public class MultiTenancyTaskQueryTest extends PluggableProcessEngineTest {
 
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(1L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyUserOperationLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyUserOperationLogQueryTest.java
@@ -125,7 +125,7 @@ public class MultiTenancyUserOperationLogQueryTest {
 
     // then
     assertThat(historyService.createUserOperationLogQuery().entityType(EntityTypes.TASK).count()).isEqualTo(2);
-    assertThat(list.size()).isEqualTo(2);
+    assertThat(list).hasSize(2);
     assertThat(list.get(0).getTenantId()).isIn(null, TENANT_TWO);
     assertThat(list.get(1).getTenantId()).isIn(null, TENANT_TWO);
   }
@@ -185,7 +185,7 @@ public class MultiTenancyUserOperationLogQueryTest {
 
     // then
     assertThat(historyService.createUserOperationLogQuery().entityType(EntityTypes.TASK).withoutTenantId().count()).isOne();
-    assertThat(list.size()).isEqualTo(1);
+    assertThat(list).hasSize(1);
     assertThat(list.get(0).getTenantId()).isEqualTo(null);
   }
 
@@ -222,7 +222,7 @@ public class MultiTenancyUserOperationLogQueryTest {
 
     // then
     assertThat(historyService.createUserOperationLogQuery().entityType(EntityTypes.TASK).tenantIdIn(TENANT_TWO).count()).isOne();
-    assertThat(list.size()).isEqualTo(1);
+    assertThat(list).hasSize(1);
     assertThat(list.get(0).getTenantId()).isEqualTo(TENANT_TWO);
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyVariableInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyVariableInstanceQueryTest.java
@@ -91,7 +91,7 @@ public class MultiTenancyVariableInstanceQueryTest extends PluggableProcessEngin
         createVariableInstanceQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -134,7 +134,7 @@ public class MultiTenancyVariableInstanceQueryTest extends PluggableProcessEngin
     identityService.setAuthentication("user", null, null);
 
     VariableInstanceQuery query = runtimeService.createVariableInstanceQuery();
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -145,7 +145,7 @@ public class MultiTenancyVariableInstanceQueryTest extends PluggableProcessEngin
 
     assertThat(query.count()).isEqualTo(1L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(1L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricActivityInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricActivityInstanceQueryTest.java
@@ -164,7 +164,7 @@ public class MultiTenancyHistoricActivityInstanceQueryTest {
         .list();
 
     // then
-    assertThat(historicActivityInstances.size()).isEqualTo(6);
+    assertThat(historicActivityInstances).hasSize(6);
     verifySorting(historicActivityInstances, historicActivityInstanceByTenantId());
   }
 
@@ -177,7 +177,7 @@ public class MultiTenancyHistoricActivityInstanceQueryTest {
         .list();
 
     // then
-    assertThat(historicActivityInstances.size()).isEqualTo(6);
+    assertThat(historicActivityInstances).hasSize(6);
     verifySorting(historicActivityInstances, inverted(historicActivityInstanceByTenantId()));
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricActivityInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricActivityInstanceQueryTest.java
@@ -138,7 +138,7 @@ public class MultiTenancyHistoricActivityInstanceQueryTest {
         .tenantIdIn("nonExisting");
 
     // then
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -205,7 +205,7 @@ public class MultiTenancyHistoricActivityInstanceQueryTest {
     assertThat(query.count()).isEqualTo(4L); // null-tenant instances are still included
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(2L);
     assertThat(query.withoutTenantId().count()).isEqualTo(2L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(2L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDecisionInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDecisionInstanceQueryTest.java
@@ -123,7 +123,7 @@ public class MultiTenancyHistoricDecisionInstanceQueryTest {
         .tenantIdIn("nonExisting");
 
     // then
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -187,7 +187,7 @@ public class MultiTenancyHistoricDecisionInstanceQueryTest {
     assertThat(query.count()).isEqualTo(2L); // null-tenant instances are also visible
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
     assertThat(query.withoutTenantId().count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(1L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDecisionInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDecisionInstanceQueryTest.java
@@ -146,7 +146,7 @@ public class MultiTenancyHistoricDecisionInstanceQueryTest {
         .list();
 
     // then
-    assertThat(historicDecisionInstances.size()).isEqualTo(3);
+    assertThat(historicDecisionInstances).hasSize(3);
     verifySorting(historicDecisionInstances, historicDecisionInstanceByTenantId());
   }
 
@@ -159,7 +159,7 @@ public class MultiTenancyHistoricDecisionInstanceQueryTest {
         .list();
 
     // then
-    assertThat(historicDecisionInstances.size()).isEqualTo(3);
+    assertThat(historicDecisionInstances).hasSize(3);
     verifySorting(historicDecisionInstances, inverted(historicDecisionInstanceByTenantId()));
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDecisionInstanceStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDecisionInstanceStatisticsQueryTest.java
@@ -88,7 +88,7 @@ public class MultiTenancyHistoricDecisionInstanceStatisticsQueryTest {
     HistoricDecisionInstanceStatisticsQuery query = historyService.
         createHistoricDecisionInstanceStatisticsQuery(decisionRequirementsDefinition.getId());
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailFormPropertyQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailFormPropertyQueryTest.java
@@ -164,7 +164,7 @@ public class MultiTenancyHistoricDetailFormPropertyQueryTest {
         .tenantIdIn("nonExisting");
 
     // then
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -234,7 +234,7 @@ public class MultiTenancyHistoricDetailFormPropertyQueryTest {
     assertThat(query.count()).isEqualTo(4L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(2L);
     assertThat(query.withoutTenantId().count()).isEqualTo(2L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(2L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailFormPropertyQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailFormPropertyQueryTest.java
@@ -192,7 +192,7 @@ public class MultiTenancyHistoricDetailFormPropertyQueryTest {
         .list();
 
     // then
-    assertThat(historicDetails.size()).isEqualTo(3);
+    assertThat(historicDetails).hasSize(3);
     verifySorting(historicDetails, historicDetailByTenantId());
   }
 
@@ -206,7 +206,7 @@ public class MultiTenancyHistoricDetailFormPropertyQueryTest {
         .list();
 
     // then
-    assertThat(historicDetails.size()).isEqualTo(3);
+    assertThat(historicDetails).hasSize(3);
     verifySorting(historicDetails, inverted(historicDetailByTenantId()));
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailVariableUpdateQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailVariableUpdateQueryTest.java
@@ -162,7 +162,7 @@ public class MultiTenancyHistoricDetailVariableUpdateQueryTest {
         .tenantIdIn("nonExisting");
 
     // then
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -232,7 +232,7 @@ public class MultiTenancyHistoricDetailVariableUpdateQueryTest {
     assertThat(query.count()).isEqualTo(4L); // null-tenant instances are still included
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(2L);
     assertThat(query.withoutTenantId().count()).isEqualTo(2L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(2L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailVariableUpdateQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailVariableUpdateQueryTest.java
@@ -190,7 +190,7 @@ public class MultiTenancyHistoricDetailVariableUpdateQueryTest {
         .list();
 
     // then
-    assertThat(historicDetails.size()).isEqualTo(6);
+    assertThat(historicDetails).hasSize(6);
     verifySorting(historicDetails, historicDetailByTenantId());
   }
 
@@ -204,7 +204,7 @@ public class MultiTenancyHistoricDetailVariableUpdateQueryTest {
         .list();
 
     // then
-    assertThat(historicDetails.size()).isEqualTo(6);
+    assertThat(historicDetails).hasSize(6);
     verifySorting(historicDetails, inverted(historicDetailByTenantId()));
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
@@ -293,9 +293,9 @@ public class MultiTenancyHistoricExternalTaskLogTest {
     } catch (ProcessEngineException e) {
       // then
       String errorMessage = e.getMessage();
-      assertThat(errorMessage.contains("Cannot get the historic external task log ")).isTrue();
-      assertThat(errorMessage.contains(failedHistoricExternalTaskLogId)).isTrue();
-      assertThat(errorMessage.contains("because it belongs to no authenticated tenant.")).isTrue();
+      assertThat(errorMessage).contains("Cannot get the historic external task log ");
+      assertThat(errorMessage).contains(failedHistoricExternalTaskLogId);
+      assertThat(errorMessage).contains("because it belongs to no authenticated tenant.");
     }
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
@@ -188,7 +188,7 @@ public class MultiTenancyHistoricExternalTaskLogTest {
       .list();
 
     // then
-    assertThat(HistoricExternalTaskLogs.size()).isEqualTo(5);
+    assertThat(HistoricExternalTaskLogs).hasSize(5);
     assertThat(HistoricExternalTaskLogs.get(0).getTenantId()).isEqualTo(TENANT_ONE);
     assertThat(HistoricExternalTaskLogs.get(1).getTenantId()).isEqualTo(TENANT_ONE);
     assertThat(HistoricExternalTaskLogs.get(2).getTenantId()).isEqualTo(TENANT_TWO);
@@ -208,7 +208,7 @@ public class MultiTenancyHistoricExternalTaskLogTest {
       .list();
 
     // then
-    assertThat(HistoricExternalTaskLogs.size()).isEqualTo(5);
+    assertThat(HistoricExternalTaskLogs).hasSize(5);
     assertThat(HistoricExternalTaskLogs.get(0).getTenantId()).isEqualTo(TENANT_TWO);
     assertThat(HistoricExternalTaskLogs.get(1).getTenantId()).isEqualTo(TENANT_TWO);
     assertThat(HistoricExternalTaskLogs.get(2).getTenantId()).isEqualTo(TENANT_TWO);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
@@ -293,9 +293,9 @@ public class MultiTenancyHistoricExternalTaskLogTest {
     } catch (ProcessEngineException e) {
       // then
       String errorMessage = e.getMessage();
-      assertThat(errorMessage.contains("Cannot get the historic external task log ")).isEqualTo(true);
-      assertThat(errorMessage.contains(failedHistoricExternalTaskLogId)).isEqualTo(true);
-      assertThat(errorMessage.contains("because it belongs to no authenticated tenant.")).isEqualTo(true);
+      assertThat(errorMessage.contains("Cannot get the historic external task log ")).isTrue();
+      assertThat(errorMessage.contains(failedHistoricExternalTaskLogId)).isTrue();
+      assertThat(errorMessage.contains("because it belongs to no authenticated tenant.")).isTrue();
     }
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
@@ -158,7 +158,7 @@ public class MultiTenancyHistoricExternalTaskLogTest {
       .tenantIdIn("nonExisting");
 
     // then
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -226,7 +226,7 @@ public class MultiTenancyHistoricExternalTaskLogTest {
     HistoricExternalTaskLogQuery query = historyService.createHistoricExternalTaskLogQuery();
 
     // then
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -240,7 +240,7 @@ public class MultiTenancyHistoricExternalTaskLogTest {
     // then
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(2L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(2L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricIdentityLinkLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricIdentityLinkLogQueryTest.java
@@ -135,7 +135,7 @@ public class MultiTenancyHistoricIdentityLinkLogQueryTest {
         .createHistoricIdentityLinkLogQuery();
 
     // then
-    assertThat(query.list().size()).isEqualTo(2);
+    assertThat(query.list()).hasSize(2);
     assertThat(query.tenantIdIn(TENANT_1).count()).isEqualTo(1L);
     assertThat(query.tenantIdIn(TENANT_2).count()).isEqualTo(1L);
   }
@@ -203,12 +203,12 @@ public class MultiTenancyHistoricIdentityLinkLogQueryTest {
     // then
     // Identity link test
     List<IdentityLink> identityLinks = repositoryService.getIdentityLinksForProcessDefinition(processDefinition1.getId());
-    assertThat(identityLinks.size()).isEqualTo(2);
+    assertThat(identityLinks).hasSize(2);
     assertThat(identityLinks.get(0).getTenantId()).isEqualTo(TENANT_1);
     assertThat(identityLinks.get(1).getTenantId()).isEqualTo(TENANT_1);
 
     identityLinks = repositoryService.getIdentityLinksForProcessDefinition(processDefinition2.getId());
-    assertThat(identityLinks.size()).isEqualTo(2);
+    assertThat(identityLinks).hasSize(2);
     assertThat(identityLinks.get(0).getTenantId()).isEqualTo(TENANT_2);
     assertThat(identityLinks.get(1).getTenantId()).isEqualTo(TENANT_2);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricIncidentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricIncidentQueryTest.java
@@ -167,7 +167,7 @@ public class MultiTenancyHistoricIncidentQueryTest {
         .list();
 
     // then
-    assertThat(historicIncidents.size()).isEqualTo(3);
+    assertThat(historicIncidents).hasSize(3);
     verifySorting(historicIncidents, historicIncidentByTenantId());
   }
 
@@ -180,7 +180,7 @@ public class MultiTenancyHistoricIncidentQueryTest {
         .list();
 
     // then
-    assertThat(historicIncidents.size()).isEqualTo(3);
+    assertThat(historicIncidents).hasSize(3);
     verifySorting(historicIncidents, inverted(historicIncidentByTenantId()));
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricIncidentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricIncidentQueryTest.java
@@ -141,7 +141,7 @@ public class MultiTenancyHistoricIncidentQueryTest {
         .tenantIdIn("nonExisting");
 
     // then
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -208,7 +208,7 @@ public class MultiTenancyHistoricIncidentQueryTest {
     assertThat(query.count()).isEqualTo(2L); // null-tenant incidents are still included
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
     assertThat(query.withoutTenantId().count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(1L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricJobLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricJobLogQueryTest.java
@@ -168,7 +168,7 @@ public class MultiTenancyHistoricJobLogQueryTest {
         .list();
 
     // then
-    assertThat(historicJobLogs.size()).isEqualTo(6);
+    assertThat(historicJobLogs).hasSize(6);
     verifySorting(historicJobLogs, historicJobLogByTenantId());
   }
 
@@ -181,7 +181,7 @@ public class MultiTenancyHistoricJobLogQueryTest {
         .list();
 
     // then
-    assertThat(historicJobLogs.size()).isEqualTo(6);
+    assertThat(historicJobLogs).hasSize(6);
     verifySorting(historicJobLogs, inverted(historicJobLogByTenantId()));
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricJobLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricJobLogQueryTest.java
@@ -142,7 +142,7 @@ public class MultiTenancyHistoricJobLogQueryTest {
         .tenantIdIn("nonExisting");
 
     // then
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -209,7 +209,7 @@ public class MultiTenancyHistoricJobLogQueryTest {
     assertThat(query.count()).isEqualTo(4L);  // null-tenant entries are still included
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(2L);
     assertThat(query.withoutTenantId().count()).isEqualTo(2L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(2L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricProcessInstanceQueryTest.java
@@ -117,7 +117,7 @@ public class MultiTenancyHistoricProcessInstanceQueryTest {
         .createHistoricProcessInstanceQuery()
         .tenantIdIn("nonExisting");
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -182,7 +182,7 @@ public class MultiTenancyHistoricProcessInstanceQueryTest {
 
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(1L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricProcessInstanceQueryTest.java
@@ -148,7 +148,7 @@ public class MultiTenancyHistoricProcessInstanceQueryTest {
         .asc()
         .list();
 
-    assertThat(historicProcessInstances.size()).isEqualTo(2);
+    assertThat(historicProcessInstances).hasSize(2);
     assertThat(historicProcessInstances.get(0).getTenantId()).isEqualTo(TENANT_ONE);
     assertThat(historicProcessInstances.get(1).getTenantId()).isEqualTo(TENANT_TWO);
   }
@@ -161,7 +161,7 @@ public class MultiTenancyHistoricProcessInstanceQueryTest {
         .desc()
         .list();
 
-    assertThat(historicProcessInstances.size()).isEqualTo(2);
+    assertThat(historicProcessInstances).hasSize(2);
     assertThat(historicProcessInstances.get(0).getTenantId()).isEqualTo(TENANT_TWO);
     assertThat(historicProcessInstances.get(1).getTenantId()).isEqualTo(TENANT_ONE);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricTaskInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricTaskInstanceQueryTest.java
@@ -148,7 +148,7 @@ public class MultiTenancyHistoricTaskInstanceQueryTest {
         .tenantIdIn("nonExisting");
 
     // then
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -215,7 +215,7 @@ public class MultiTenancyHistoricTaskInstanceQueryTest {
     assertThat(query.count()).isEqualTo(2L); // null-tenant instances are included
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
     assertThat(query.withoutTenantId().count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(1L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricTaskInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricTaskInstanceQueryTest.java
@@ -174,7 +174,7 @@ public class MultiTenancyHistoricTaskInstanceQueryTest {
         .list();
 
     // then
-    assertThat(historicTaskInstances.size()).isEqualTo(3);
+    assertThat(historicTaskInstances).hasSize(3);
     verifySorting(historicTaskInstances, historicTaskInstanceByTenantId());
   }
 
@@ -187,7 +187,7 @@ public class MultiTenancyHistoricTaskInstanceQueryTest {
         .list();
 
     // then
-    assertThat(historicTaskInstances.size()).isEqualTo(3);
+    assertThat(historicTaskInstances).hasSize(3);
     verifySorting(historicTaskInstances, inverted(historicTaskInstanceByTenantId()));
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricVariableInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricVariableInstanceQueryTest.java
@@ -148,7 +148,7 @@ public class MultiTenancyHistoricVariableInstanceQueryTest {
         .tenantIdIn("nonExisting");
 
     // then
-    assertThat(query.count()).isEqualTo(0);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -215,7 +215,7 @@ public class MultiTenancyHistoricVariableInstanceQueryTest {
     assertThat(query.count()).isEqualTo(2L); // null-tenant instances are still included
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
     assertThat(query.withoutTenantId().count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(query.tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(1L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricVariableInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricVariableInstanceQueryTest.java
@@ -174,7 +174,7 @@ public class MultiTenancyHistoricVariableInstanceQueryTest {
         .list();
 
     // then
-    assertThat(historicVariableInstances.size()).isEqualTo(3); // null-tenant instances are still included
+    assertThat(historicVariableInstances).hasSize(3); // null-tenant instances are still included
     verifySorting(historicVariableInstances, historicVariableInstanceByTenantId());
   }
 
@@ -187,7 +187,7 @@ public class MultiTenancyHistoricVariableInstanceQueryTest {
         .list();
 
     // then
-    assertThat(historicVariableInstances.size()).isEqualTo(3); // null-tenant instances are still included
+    assertThat(historicVariableInstances).hasSize(3); // null-tenant instances are still included
     verifySorting(historicVariableInstances, inverted(historicVariableInstanceByTenantId()));
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancySharedDecisionInstanceStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancySharedDecisionInstanceStatisticsQueryTest.java
@@ -100,7 +100,7 @@ public class MultiTenancySharedDecisionInstanceStatisticsQueryTest {
     HistoricDecisionInstanceStatisticsQuery query = historyService.
         createHistoricDecisionInstanceStatisticsQuery(decisionRequirementsDefinition.getId());
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyJobDefinitionSuspensionStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyJobDefinitionSuspensionStateTest.java
@@ -82,7 +82,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
     // given activated job definitions
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // first suspend
     engineRule.getManagementService()
@@ -90,7 +90,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
       .byProcessDefinitionKey(PROCESS_DEFINITION_KEY)
       .suspend();
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     // then activate
@@ -100,7 +100,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
       .activate();
 
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
   }
 
   @Test
@@ -108,7 +108,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
     // given activated job definitions
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getManagementService()
       .updateJobDefinitionSuspensionState()
@@ -126,7 +126,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
     // given activated job definitions
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getManagementService()
       .updateJobDefinitionSuspensionState()
@@ -149,7 +149,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
 
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     assertThat(query.suspended().count()).isEqualTo(3L);
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
 
     engineRule.getManagementService()
       .updateJobDefinitionSuspensionState()
@@ -172,7 +172,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
 
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     assertThat(query.suspended().count()).isEqualTo(3L);
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
 
     engineRule.getManagementService()
       .updateJobDefinitionSuspensionState()
@@ -190,7 +190,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
     // given activated job definitions
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // first suspend
     engineRule.getManagementService()
@@ -199,7 +199,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
       .includeJobs(true)
       .suspend();
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     // then activate
@@ -210,7 +210,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
       .activate();
 
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
   }
 
   @Test
@@ -218,7 +218,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
     // given activated job definitions
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getManagementService()
       .updateJobDefinitionSuspensionState()
@@ -237,7 +237,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
     // given activated job definitions
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getManagementService()
       .updateJobDefinitionSuspensionState()
@@ -262,7 +262,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
 
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.suspended().count()).isEqualTo(3L);
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
 
     engineRule.getManagementService()
       .updateJobDefinitionSuspensionState()
@@ -287,7 +287,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
 
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.suspended().count()).isEqualTo(3L);
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
 
     engineRule.getManagementService()
       .updateJobDefinitionSuspensionState()
@@ -313,7 +313,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
 
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // when execute the job to suspend the job definitions
     Job job = engineRule.getManagementService().createJobQuery().timers().singleResult();
@@ -322,7 +322,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
 
     engineRule.getManagementService().executeJob(job.getId());
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
   }
 
@@ -339,7 +339,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
 
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // when execute the job to suspend the job definitions
     Job job = engineRule.getManagementService().createJobQuery().timers().singleResult();
@@ -368,7 +368,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
 
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // when execute the job to suspend the job definitions
     Job job = engineRule.getManagementService().createJobQuery().timers().singleResult();
@@ -399,7 +399,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
       .activate();
 
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     // when execute the job to activate the job definitions
@@ -409,7 +409,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
 
     engineRule.getManagementService().executeJob(job.getId());
 
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
     assertThat(query.active().count()).isEqualTo(3L);
   }
 
@@ -429,7 +429,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
       .activate();
 
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     // when execute the job to activate the job definitions
@@ -462,7 +462,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
       .activate();
 
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     // when execute the job to activate the job definitions
@@ -484,7 +484,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
     // given activated job definitions
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getIdentityService().setAuthentication("user", null, null);
 
@@ -505,7 +505,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
     // given activated job definitions
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getIdentityService().setAuthentication("user", null, Arrays.asList(TENANT_ONE));
 
@@ -528,7 +528,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
     // given activated job definitions
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getProcessEngineConfiguration().setTenantCheckEnabled(false);
     engineRule.getIdentityService().setAuthentication("user", null, null);
@@ -538,7 +538,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
       .byProcessDefinitionKey(PROCESS_DEFINITION_KEY)
       .suspend();
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
     assertThat(query.suspended().tenantIdIn(TENANT_ONE, TENANT_TWO).includeJobDefinitionsWithoutTenantId().count()).isEqualTo(3L);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyJobSuspensionStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyJobSuspensionStateTest.java
@@ -68,7 +68,7 @@ public class MultiTenancyJobSuspensionStateTest {
     // given activated jobs
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // first suspend
     engineRule.getManagementService()
@@ -76,7 +76,7 @@ public class MultiTenancyJobSuspensionStateTest {
       .byProcessDefinitionKey(PROCESS_DEFINITION_KEY)
       .suspend();
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     // then activate
@@ -86,7 +86,7 @@ public class MultiTenancyJobSuspensionStateTest {
       .activate();
 
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
   }
 
   @Test
@@ -94,7 +94,7 @@ public class MultiTenancyJobSuspensionStateTest {
     // given activated jobs
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getManagementService()
       .updateJobSuspensionState()
@@ -112,7 +112,7 @@ public class MultiTenancyJobSuspensionStateTest {
     // given activated jobs
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getManagementService()
       .updateJobSuspensionState()
@@ -135,7 +135,7 @@ public class MultiTenancyJobSuspensionStateTest {
 
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.suspended().count()).isEqualTo(3L);
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
 
     engineRule.getManagementService()
       .updateJobSuspensionState()
@@ -158,7 +158,7 @@ public class MultiTenancyJobSuspensionStateTest {
 
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.suspended().count()).isEqualTo(3L);
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
 
     engineRule.getManagementService()
       .updateJobSuspensionState()
@@ -176,7 +176,7 @@ public class MultiTenancyJobSuspensionStateTest {
     // given activated jobs
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getIdentityService().setAuthentication("user", null, null);
 
@@ -197,7 +197,7 @@ public class MultiTenancyJobSuspensionStateTest {
     // given activated jobs
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getIdentityService().setAuthentication("user", null, Arrays.asList(TENANT_ONE));
 
@@ -220,7 +220,7 @@ public class MultiTenancyJobSuspensionStateTest {
     // given activated jobs
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getProcessEngineConfiguration().setTenantCheckEnabled(false);
     engineRule.getIdentityService().setAuthentication("user", null, null);
@@ -230,7 +230,7 @@ public class MultiTenancyJobSuspensionStateTest {
       .byProcessDefinitionKey(PROCESS_DEFINITION_KEY)
       .suspend();
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
     assertThat(query.suspended().tenantIdIn(TENANT_ONE, TENANT_TWO).includeJobsWithoutTenantId().count()).isEqualTo(3L);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyProcessDefinitionSuspensionStateTenantIdProviderTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyProcessDefinitionSuspensionStateTenantIdProviderTest.java
@@ -74,7 +74,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTenantIdProviderTest {
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery().processDefinitionId(processDefinition.getId());
     assertThat(query.active().count()).isEqualTo(1L);
     assertThat(query.active().tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // suspend all instances of process definition
     engineRule.getRepositoryService()
@@ -83,7 +83,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTenantIdProviderTest {
       .includeProcessInstances(true)
       .suspend();
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(1L);
     assertThat(query.suspended().tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
   }
@@ -107,7 +107,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTenantIdProviderTest {
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery().processDefinitionId(processDefinition.getId());
     assertThat(query.suspended().count()).isEqualTo(1L);
     assertThat(query.suspended().tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
 
     // activate all instance of process definition
     engineRule.getRepositoryService()
@@ -116,7 +116,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTenantIdProviderTest {
       .includeProcessInstances(true)
       .activate();
 
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
     assertThat(query.active().count()).isEqualTo(1L);
     assertThat(query.active().tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyProcessDefinitionSuspensionStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyProcessDefinitionSuspensionStateTest.java
@@ -86,7 +86,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
     // given activated process definitions
     ProcessDefinitionQuery query = engineRule.getRepositoryService().createProcessDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // first suspend
     engineRule.getRepositoryService()
@@ -94,7 +94,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
       .byProcessDefinitionKey(PROCESS_DEFINITION_KEY)
       .suspend();
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     // then activate
@@ -104,7 +104,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
       .activate();
 
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
   }
 
   @Test
@@ -112,7 +112,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
     // given activated process definitions
     ProcessDefinitionQuery query = engineRule.getRepositoryService().createProcessDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getRepositoryService()
       .updateProcessDefinitionSuspensionState()
@@ -130,7 +130,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
     // given activated process definitions
     ProcessDefinitionQuery query = engineRule.getRepositoryService().createProcessDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getRepositoryService()
       .updateProcessDefinitionSuspensionState()
@@ -153,7 +153,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
 
     ProcessDefinitionQuery query = engineRule.getRepositoryService().createProcessDefinitionQuery();
     assertThat(query.suspended().count()).isEqualTo(3L);
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
 
     engineRule.getRepositoryService()
       .updateProcessDefinitionSuspensionState()
@@ -176,7 +176,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
 
     ProcessDefinitionQuery query = engineRule.getRepositoryService().createProcessDefinitionQuery();
     assertThat(query.suspended().count()).isEqualTo(3L);
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
 
     engineRule.getRepositoryService()
       .updateProcessDefinitionSuspensionState()
@@ -194,7 +194,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
     // given activated process instances
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // first suspend
     engineRule.getRepositoryService()
@@ -203,7 +203,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
       .includeProcessInstances(true)
       .suspend();
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     // then activate
@@ -214,7 +214,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
       .activate();
 
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
   }
 
   @Test
@@ -222,7 +222,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
     // given activated process instances
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getRepositoryService()
       .updateProcessDefinitionSuspensionState()
@@ -241,7 +241,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
     // given activated process instances
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getRepositoryService()
       .updateProcessDefinitionSuspensionState()
@@ -266,7 +266,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
 
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery();
     assertThat(query.suspended().count()).isEqualTo(3L);
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
 
     engineRule.getRepositoryService()
       .updateProcessDefinitionSuspensionState()
@@ -291,7 +291,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
 
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery();
     assertThat(query.suspended().count()).isEqualTo(3L);
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
 
     engineRule.getRepositoryService()
       .updateProcessDefinitionSuspensionState()
@@ -317,7 +317,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
 
     ProcessDefinitionQuery query = engineRule.getRepositoryService().createProcessDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // when execute the job to suspend the process definitions
     Job job = engineRule.getManagementService().createJobQuery().timers().singleResult();
@@ -327,7 +327,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
 
     engineRule.getManagementService().executeJob(job.getId());
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
   }
 
@@ -344,7 +344,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
 
     ProcessDefinitionQuery query = engineRule.getRepositoryService().createProcessDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // when execute the job to suspend the process definition
     Job job = engineRule.getManagementService().createJobQuery().timers().singleResult();
@@ -373,7 +373,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
 
     ProcessDefinitionQuery query = engineRule.getRepositoryService().createProcessDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // when execute the job to suspend the process definition
     Job job = engineRule.getManagementService().createJobQuery().timers().singleResult();
@@ -405,7 +405,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
 
     ProcessDefinitionQuery query = engineRule.getRepositoryService().createProcessDefinitionQuery();
     assertThat(query.suspended().count()).isEqualTo(3L);
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
 
     // when execute the job to activate the process definitions
     Job job = engineRule.getManagementService().createJobQuery().timers().singleResult();
@@ -415,7 +415,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
 
     engineRule.getManagementService().executeJob(job.getId());
 
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
     assertThat(query.active().count()).isEqualTo(3L);
   }
 
@@ -436,7 +436,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
 
     ProcessDefinitionQuery query = engineRule.getRepositoryService().createProcessDefinitionQuery();
     assertThat(query.suspended().count()).isEqualTo(3L);
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
 
     // when execute the job to activate the process definition
     Job job = engineRule.getManagementService().createJobQuery().timers().singleResult();
@@ -469,7 +469,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
 
     ProcessDefinitionQuery query = engineRule.getRepositoryService().createProcessDefinitionQuery();
     assertThat(query.suspended().count()).isEqualTo(3L);
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
 
     // when execute the job to activate the process definition
     Job job = engineRule.getManagementService().createJobQuery().timers().singleResult();
@@ -490,14 +490,14 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
     // given activated jobs
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getRepositoryService()
       .updateProcessDefinitionSuspensionState()
       .byProcessDefinitionKey(PROCESS_DEFINITION_KEY)
       .suspend();
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
   }
 
@@ -506,7 +506,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
     // given activated jobs
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getRepositoryService()
       .updateProcessDefinitionSuspensionState()
@@ -524,7 +524,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
     // given activated jobs
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getRepositoryService()
       .updateProcessDefinitionSuspensionState()
@@ -546,7 +546,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
       .suspend();
 
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     engineRule.getRepositoryService()
@@ -554,7 +554,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
       .byProcessDefinitionKey(PROCESS_DEFINITION_KEY)
       .activate();
 
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
     assertThat(query.active().count()).isEqualTo(3L);
   }
 
@@ -567,7 +567,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
       .suspend();
 
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     engineRule.getRepositoryService()
@@ -590,7 +590,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
       .suspend();
 
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     engineRule.getRepositoryService()
@@ -609,7 +609,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
     // given activated process definitions
     ProcessDefinitionQuery query = engineRule.getRepositoryService().createProcessDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getIdentityService().setAuthentication("user", null, null);
 
@@ -647,7 +647,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
     // given activated process definitions
     ProcessDefinitionQuery query = engineRule.getRepositoryService().createProcessDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getIdentityService().setAuthentication("user", null, Arrays.asList(TENANT_ONE));
 
@@ -670,7 +670,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
     // given activated process definitions
     ProcessDefinitionQuery query = engineRule.getRepositoryService().createProcessDefinitionQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     ProcessEngineConfigurationImpl processEngineConfiguration = engineRule.getProcessEngineConfiguration();
     processEngineConfiguration.setTenantCheckEnabled(false);
@@ -681,7 +681,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
       .byProcessDefinitionKey(PROCESS_DEFINITION_KEY)
       .suspend();
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
     assertThat(query.suspended().tenantIdIn(TENANT_ONE, TENANT_TWO).includeProcessDefinitionsWithoutTenantId().count()).isEqualTo(3L);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyProcessInstanceSuspensionStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyProcessInstanceSuspensionStateTest.java
@@ -80,7 +80,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     // given activated process instances
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // first suspend
     engineRule.getRuntimeService()
@@ -88,7 +88,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .byProcessDefinitionKey(PROCESS_DEFINITION_KEY)
       .suspend();
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     // then activate
@@ -98,7 +98,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .activate();
 
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
   }
 
   @Test
@@ -106,7 +106,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     // given activated process instances
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getRuntimeService()
       .updateProcessInstanceSuspensionState()
@@ -124,7 +124,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     // given activated process instances
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getRuntimeService()
       .updateProcessInstanceSuspensionState()
@@ -146,7 +146,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .suspend();
 
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery();
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     engineRule.getRuntimeService()
@@ -169,7 +169,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .suspend();
 
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery();
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     engineRule.getRuntimeService()
@@ -188,7 +188,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     // given activated user tasks
     TaskQuery query = engineRule.getTaskService().createTaskQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // first suspend
     engineRule.getRuntimeService()
@@ -196,7 +196,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .byProcessDefinitionKey(PROCESS_DEFINITION_KEY)
       .suspend();
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     // then activate
@@ -206,7 +206,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .activate();
 
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
   }
 
   @Test
@@ -214,7 +214,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     // given activated user tasks
     TaskQuery query = engineRule.getTaskService().createTaskQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getRuntimeService()
       .updateProcessInstanceSuspensionState()
@@ -232,7 +232,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     // given activated user tasks
     TaskQuery query = engineRule.getTaskService().createTaskQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getRuntimeService()
       .updateProcessInstanceSuspensionState()
@@ -254,7 +254,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .suspend();
 
     TaskQuery query = engineRule.getTaskService().createTaskQuery();
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     engineRule.getRuntimeService()
@@ -277,7 +277,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .suspend();
 
     TaskQuery query = engineRule.getTaskService().createTaskQuery();
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     engineRule.getRuntimeService()
@@ -296,7 +296,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     // given activated external tasks
     ExternalTaskQuery query = engineRule.getExternalTaskService().createExternalTaskQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // first suspend
     engineRule.getRuntimeService()
@@ -304,7 +304,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .byProcessDefinitionKey(PROCESS_DEFINITION_KEY)
       .suspend();
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     // then activate
@@ -314,7 +314,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .activate();
 
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
   }
 
   @Test
@@ -322,7 +322,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     // given activated external tasks
     ExternalTaskQuery query = engineRule.getExternalTaskService().createExternalTaskQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getRuntimeService()
       .updateProcessInstanceSuspensionState()
@@ -340,7 +340,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     // given activated external tasks
     ExternalTaskQuery query = engineRule.getExternalTaskService().createExternalTaskQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getRuntimeService()
       .updateProcessInstanceSuspensionState()
@@ -362,7 +362,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .suspend();
 
     ExternalTaskQuery query = engineRule.getExternalTaskService().createExternalTaskQuery();
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     engineRule.getRuntimeService()
@@ -385,7 +385,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .suspend();
 
     ExternalTaskQuery query = engineRule.getExternalTaskService().createExternalTaskQuery();
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     engineRule.getRuntimeService()
@@ -404,7 +404,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     // given activated jobs
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     // first suspend
     engineRule.getRuntimeService()
@@ -412,7 +412,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .byProcessDefinitionKey(PROCESS_DEFINITION_KEY)
       .suspend();
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     // then activate
@@ -422,7 +422,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .activate();
 
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
   }
 
   @Test
@@ -430,7 +430,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     // given activated jobs
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getRuntimeService()
       .updateProcessInstanceSuspensionState()
@@ -448,7 +448,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     // given activated jobs
     JobQuery query = engineRule.getManagementService().createJobQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getRuntimeService()
       .updateProcessInstanceSuspensionState()
@@ -470,7 +470,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .suspend();
 
     JobQuery query = engineRule.getManagementService().createJobQuery();
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     engineRule.getRuntimeService()
@@ -493,7 +493,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .suspend();
 
     JobQuery query = engineRule.getManagementService().createJobQuery();
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
 
     engineRule.getRuntimeService()
@@ -512,7 +512,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     // given activated process instances
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getIdentityService().setAuthentication("user", null, null);
 
@@ -550,7 +550,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     // given activated process instances
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getIdentityService().setAuthentication("user", null, Arrays.asList(TENANT_ONE));
 
@@ -573,7 +573,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     // given activated process instances
     ProcessInstanceQuery query = engineRule.getRuntimeService().createProcessInstanceQuery();
     assertThat(query.active().count()).isEqualTo(3L);
-    assertThat(query.suspended().count()).isEqualTo(0L);
+    assertThat(query.suspended().count()).isZero();
 
     engineRule.getProcessEngineConfiguration().setTenantCheckEnabled(false);
     engineRule.getIdentityService().setAuthentication("user", null, null);
@@ -583,7 +583,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
       .byProcessDefinitionKey(PROCESS_DEFINITION_KEY)
       .suspend();
 
-    assertThat(query.active().count()).isEqualTo(0L);
+    assertThat(query.active().count()).isZero();
     assertThat(query.suspended().count()).isEqualTo(3L);
     assertThat(query.suspended().tenantIdIn(TENANT_ONE, TENANT_TWO).count()).isEqualTo(2L);
     assertThat(query.suspended().withoutTenantId().count()).isEqualTo(1L);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyCaseInstanceCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyCaseInstanceCmdsTenantCheckTest.java
@@ -351,7 +351,7 @@ public class MultiTenancyCaseInstanceCmdsTenantCheckTest {
     Map<String, Object> variables = caseService.getVariables(caseExecutionId);
 
     assertThat(variables).isNotNull();
-    assertThat(variables.keySet()).contains(VARIABLE_NAME);
+    assertThat(variables).containsKey(VARIABLE_NAME);
   }
 
   @Test
@@ -362,7 +362,7 @@ public class MultiTenancyCaseInstanceCmdsTenantCheckTest {
     Map<String, Object> variables = caseService.getVariables(caseExecutionId);
 
     assertThat(variables).isNotNull();
-    assertThat(variables.keySet()).contains(VARIABLE_NAME);
+    assertThat(variables).containsKey(VARIABLE_NAME);
   }
 
   @Test
@@ -442,7 +442,7 @@ public class MultiTenancyCaseInstanceCmdsTenantCheckTest {
     identityService.clearAuthentication();
 
     Map<String, Object> variables = caseService.getVariables(caseExecutionId);
-    assertThat(variables.isEmpty()).isTrue();
+    assertThat(variables).isEmpty();
   }
 
   @Test
@@ -455,7 +455,7 @@ public class MultiTenancyCaseInstanceCmdsTenantCheckTest {
     identityService.clearAuthentication();
 
     Map<String, Object> variables = caseService.getVariables(caseExecutionId);
-    assertThat(variables.isEmpty()).isTrue();
+    assertThat(variables).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyDeploymentCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyDeploymentCmdsTenantCheckTest.java
@@ -137,8 +137,8 @@ public class MultiTenancyDeploymentCmdsTenantCheckTest {
     identityService.clearAuthentication();
 
     DeploymentQuery query = repositoryService.createDeploymentQuery();
-    assertThat(query.count()).isEqualTo(0L);
-    assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
+    assertThat(query.tenantIdIn(TENANT_ONE).count()).isZero();
   }
 
   @Test
@@ -153,9 +153,9 @@ public class MultiTenancyDeploymentCmdsTenantCheckTest {
     repositoryService.deleteDeployment(deploymentTwo.getId());
 
     DeploymentQuery query = repositoryService.createDeploymentQuery();
-    assertThat(query.count()).isEqualTo(0L);
-    assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(0L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
+    assertThat(query.tenantIdIn(TENANT_ONE).count()).isZero();
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyExternalTaskCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyExternalTaskCmdsTenantCheckTest.java
@@ -228,7 +228,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
 
     externalTaskService.complete(externalTaskId, WORKER_ID);
 
-    assertThat(externalTaskService.createExternalTaskQuery().active().count()).isEqualTo(0L);
+    assertThat(externalTaskService.createExternalTaskQuery().active().count()).isZero();
 
   }
 
@@ -269,7 +269,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
 
     externalTaskService.complete(externalTaskId, WORKER_ID);
     // then
-    assertThat(externalTaskService.createExternalTaskQuery().active().count()).isEqualTo(0L);
+    assertThat(externalTaskService.createExternalTaskQuery().active().count()).isZero();
   }
 
   // handle failure test cases
@@ -523,7 +523,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
     externalTaskService.unlock(externalTaskId);
 
     // then
-    assertThat(externalTaskService.createExternalTaskQuery().locked().count()).isEqualTo(0L);
+    assertThat(externalTaskService.createExternalTaskQuery().locked().count()).isZero();
   }
 
   @Test
@@ -558,7 +558,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
 
     externalTaskService.unlock(externalTaskId);
     // then
-    assertThat(externalTaskService.createExternalTaskQuery().locked().count()).isEqualTo(0L);
+    assertThat(externalTaskService.createExternalTaskQuery().locked().count()).isZero();
   }
 
   // get error details tests

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyHistoricDataCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyHistoricDataCmdsTenantCheckTest.java
@@ -146,7 +146,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
 
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -164,7 +164,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     historyService.deleteHistoricProcessInstance(processInstanceIdTwo);
 
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -191,7 +191,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
 
     HistoricTaskInstanceQuery query = historyService.createHistoricTaskInstanceQuery();
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -207,7 +207,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
 
     HistoricTaskInstanceQuery query = historyService.createHistoricTaskInstanceQuery();
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -236,7 +236,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
 
     HistoricCaseInstanceQuery query = historyService.createHistoricCaseInstanceQuery();
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -254,7 +254,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     historyService.deleteHistoricCaseInstance(caseInstanceIdTwo);
 
     HistoricCaseInstanceQuery query = historyService.createHistoricCaseInstanceQuery();
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -287,7 +287,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
 
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -305,7 +305,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     historyService.deleteHistoricDecisionInstanceByDefinitionId(decisionDefinitionIdTwo);
 
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -344,7 +344,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
 
     // then
     identityService.clearAuthentication();
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -373,7 +373,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
 
     // then
     identityService.clearAuthentication();
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -464,7 +464,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
 
     historyService.deleteHistoricVariableInstance(variableInstanceId);
-    assertThat(variableQuery.count()).isEqualTo(0L);
+    assertThat(variableQuery.count()).isZero();
     cleanUpAfterVariableInstanceTest(processInstanceId);
   }
 
@@ -491,8 +491,8 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
 
     historyService.deleteHistoricVariableInstance(variableInstanceIdOne);
     historyService.deleteHistoricVariableInstance(variableInstanceIdTwo);
-    assertThat(variableQueryOne.count()).isEqualTo(0L);
-    assertThat(variableQueryTwo.count()).isEqualTo(0L);
+    assertThat(variableQueryOne.count()).isZero();
+    assertThat(variableQueryTwo.count()).isZero();
 
     cleanUpAfterVariableInstanceTest(processInstanceIdOne, processInstanceIdTwo);
   }
@@ -532,7 +532,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
 
     historyService.deleteHistoricVariableInstancesByProcessInstanceId(processInstanceId);
-    assertThat(variableQuery.count()).isEqualTo(0L);
+    assertThat(variableQuery.count()).isZero();
     cleanUpAfterVariableInstanceTest(processInstanceId);
   }
 
@@ -558,11 +558,11 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     processEngineConfiguration.setTenantCheckEnabled(false);
 
     historyService.deleteHistoricVariableInstancesByProcessInstanceId(processInstanceIdOne);
-    assertThat(variableQueryOne.count()).isEqualTo(0L);
+    assertThat(variableQueryOne.count()).isZero();
     assertThat(variableQueryTwo.count()).isEqualTo(2L);
 
     historyService.deleteHistoricVariableInstancesByProcessInstanceId(processInstanceIdTwo);
-    assertThat(variableQueryTwo.count()).isEqualTo(0L);
+    assertThat(variableQueryTwo.count()).isZero();
 
     cleanUpAfterVariableInstanceTest(processInstanceIdOne, processInstanceIdTwo);
   }
@@ -633,7 +633,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     identityService.clearAuthentication();
 
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
     processEngineConfiguration.setTenantCheckEnabled(true);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyHistoricDataCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyHistoricDataCmdsTenantCheckTest.java
@@ -360,7 +360,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     HistoricDecisionInstanceQuery query =
         historyService.createHistoricDecisionInstanceQuery();
     List<HistoricDecisionInstance> historicDecisionInstances = query.includeInputs().includeOutputs().list();
-    assertThat(historicDecisionInstances.size()).isEqualTo(2);
+    assertThat(historicDecisionInstances).hasSize(2);
 
     // when user has no authorization
     identityService.setAuthentication("user", null, null);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyHistoricProcessInstanceReportCmdTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyHistoricProcessInstanceReportCmdTenantCheckTest.java
@@ -96,7 +96,7 @@ public class MultiTenancyHistoricProcessInstanceReportCmdTenantCheckTest {
         .createHistoricProcessInstanceReport()
         .duration(MONTH);
 
-    assertThat(result).hasSize(0);
+    assertThat(result).isEmpty();
   }
 
   @Test
@@ -148,7 +148,7 @@ public class MultiTenancyHistoricProcessInstanceReportCmdTenantCheckTest {
         .processDefinitionIdIn(processDefinitionIdOne, processDefinitionIdTwo)
         .duration(MONTH);
 
-    assertThat(result).hasSize(0);
+    assertThat(result).isEmpty();
   }
 
   @Test
@@ -209,7 +209,7 @@ public class MultiTenancyHistoricProcessInstanceReportCmdTenantCheckTest {
         .processDefinitionKeyIn(PROCESS_DEFINITION_KEY)
         .duration(MONTH);
 
-    assertThat(result).hasSize(0);
+    assertThat(result).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyIdentityLinkCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyIdentityLinkCmdsTenantCheckTest.java
@@ -266,7 +266,7 @@ public class MultiTenancyIdentityLinkCmdsTenantCheckTest {
 
     taskService.deleteCandidateUser(task.getId(), "demo");
     // then
-    assertThat(taskService.createTaskQuery().taskCandidateUser("demo").count()).isEqualTo(0L);
+    assertThat(taskService.createTaskQuery().taskCandidateUser("demo").count()).isZero();
   }
 
   @Test
@@ -294,7 +294,7 @@ public class MultiTenancyIdentityLinkCmdsTenantCheckTest {
     taskService.deleteCandidateUser(task.getId(), "demo");
 
     // then
-    assertThat(taskService.createTaskQuery().taskCandidateUser("demo").count()).isEqualTo(0L);
+    assertThat(taskService.createTaskQuery().taskCandidateUser("demo").count()).isZero();
   }
 
   // delete candidate groups
@@ -308,7 +308,7 @@ public class MultiTenancyIdentityLinkCmdsTenantCheckTest {
 
     taskService.deleteCandidateGroup(task.getId(), "demo");
     // then
-    assertThat(taskService.createTaskQuery().taskCandidateGroup("demo").count()).isEqualTo(0L);
+    assertThat(taskService.createTaskQuery().taskCandidateGroup("demo").count()).isZero();
   }
 
   @Test
@@ -336,7 +336,7 @@ public class MultiTenancyIdentityLinkCmdsTenantCheckTest {
     taskService.deleteCandidateGroup(task.getId(), "demo");
 
     // then
-    assertThat(taskService.createTaskQuery().taskCandidateGroup("demo").count()).isEqualTo(0L);
+    assertThat(taskService.createTaskQuery().taskCandidateGroup("demo").count()).isZero();
   }
 
   // add user identity link
@@ -424,7 +424,7 @@ public class MultiTenancyIdentityLinkCmdsTenantCheckTest {
 
     taskService.deleteUserIdentityLink(task.getId(), "demo", IdentityLinkType.ASSIGNEE);
     // then
-    assertThat(taskService.createTaskQuery().taskAssignee("demo").count()).isEqualTo(0L);
+    assertThat(taskService.createTaskQuery().taskAssignee("demo").count()).isZero();
   }
 
   @Test
@@ -454,7 +454,7 @@ public class MultiTenancyIdentityLinkCmdsTenantCheckTest {
     taskService.deleteUserIdentityLink(task.getId(), "demo", IdentityLinkType.ASSIGNEE);
 
     // then
-    assertThat(taskService.createTaskQuery().taskAssignee("demo").count()).isEqualTo(0L);
+    assertThat(taskService.createTaskQuery().taskAssignee("demo").count()).isZero();
   }
 
   // delete group identity link
@@ -468,7 +468,7 @@ public class MultiTenancyIdentityLinkCmdsTenantCheckTest {
 
     taskService.deleteGroupIdentityLink(task.getId(), "demo", IdentityLinkType.CANDIDATE);
     // then
-    assertThat(taskService.createTaskQuery().taskCandidateGroup("demo").count()).isEqualTo(0L);
+    assertThat(taskService.createTaskQuery().taskCandidateGroup("demo").count()).isZero();
   }
 
   @Test
@@ -498,6 +498,6 @@ public class MultiTenancyIdentityLinkCmdsTenantCheckTest {
     taskService.deleteGroupIdentityLink(task.getId(), "demo", IdentityLinkType.CANDIDATE);
 
     // then
-    assertThat(taskService.createTaskQuery().taskCandidateGroup("demo").count()).isEqualTo(0L);
+    assertThat(taskService.createTaskQuery().taskCandidateGroup("demo").count()).isZero();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyMessageCorrelationCmdTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyMessageCorrelationCmdTenantCheckTest.java
@@ -109,7 +109,7 @@ public class MultiTenancyMessageCorrelationCmdTenantCheckTest {
 
     ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery();
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test
@@ -126,7 +126,7 @@ public class MultiTenancyMessageCorrelationCmdTenantCheckTest {
 
     ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery();
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test
@@ -147,8 +147,8 @@ public class MultiTenancyMessageCorrelationCmdTenantCheckTest {
     identityService.clearAuthentication();
 
     TaskQuery query = taskService.createTaskQuery();
-    assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(0L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_ONE).count()).isZero();
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
     assertThat(taskService.createTaskQuery().withoutTenantId().count()).isEqualTo(1L);
   }
 
@@ -169,7 +169,7 @@ public class MultiTenancyMessageCorrelationCmdTenantCheckTest {
 
     TaskQuery query = taskService.createTaskQuery();
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test
@@ -191,7 +191,7 @@ public class MultiTenancyMessageCorrelationCmdTenantCheckTest {
 
     TaskQuery query = taskService.createTaskQuery();
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test
@@ -211,7 +211,7 @@ public class MultiTenancyMessageCorrelationCmdTenantCheckTest {
 
     TaskQuery query = taskService.createTaskQuery();
     assertThat(query.count()).isEqualTo(2L);
-    assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_ONE).count()).isZero();
     assertThat(taskService.createTaskQuery().withoutTenantId().count()).isEqualTo(2L);
   }
 
@@ -233,7 +233,7 @@ public class MultiTenancyMessageCorrelationCmdTenantCheckTest {
     TaskQuery query = taskService.createTaskQuery();
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(2L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyMessageEventReceivedCmdTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyMessageEventReceivedCmdTenantCheckTest.java
@@ -86,7 +86,7 @@ public class MultiTenancyMessageEventReceivedCmdTenantCheckTest {
 
     TaskQuery query = taskService.createTaskQuery();
     assertThat(query.count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_ONE).count()).isZero();
     assertThat(taskService.createTaskQuery().withoutTenantId().count()).isEqualTo(1L);
   }
 
@@ -134,7 +134,7 @@ public class MultiTenancyMessageEventReceivedCmdTenantCheckTest {
     TaskQuery query = taskService.createTaskQuery();
     assertThat(query.count()).isEqualTo(1L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyProcessDefinitionCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyProcessDefinitionCmdsTenantCheckTest.java
@@ -409,7 +409,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
 
     // then
     identityService.clearAuthentication();
-    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isZero();
     assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(1L);
     assertThat(repositoryService.createProcessDefinitionQuery().tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
   }
@@ -456,7 +456,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
 
     // then
     identityService.clearAuthentication();
-    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isZero();
     assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(1L);
     assertThat(repositoryService.createProcessDefinitionQuery().tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
   }
@@ -524,7 +524,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
 
     // then
     identityService.clearAuthentication();
-    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isZero();
     assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(1L);
     assertThat(repositoryService.createProcessDefinitionQuery().tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
   }
@@ -573,7 +573,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
 
     // then
     identityService.clearAuthentication();
-    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isZero();
     assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(1L);
     assertThat(repositoryService.createProcessDefinitionQuery().tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancySignalReceiveCmdTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancySignalReceiveCmdTenantCheckTest.java
@@ -92,7 +92,7 @@ public class MultiTenancySignalReceiveCmdTenantCheckTest {
     ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery();
     assertThat(query.count()).isEqualTo(1L);
     assertThat(query.withoutTenantId().count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_ONE).count()).isZero();
   }
 
   @Test
@@ -109,7 +109,7 @@ public class MultiTenancySignalReceiveCmdTenantCheckTest {
     ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery();
     assertThat(query.count()).isEqualTo(1L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test
@@ -144,7 +144,7 @@ public class MultiTenancySignalReceiveCmdTenantCheckTest {
 
     TaskQuery query = taskService.createTaskQuery();
     assertThat(query.count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_ONE).count()).isZero();
     assertThat(taskService.createTaskQuery().withoutTenantId().count()).isEqualTo(1L);
   }
 
@@ -165,7 +165,7 @@ public class MultiTenancySignalReceiveCmdTenantCheckTest {
     TaskQuery query = taskService.createTaskQuery();
     assertThat(query.count()).isEqualTo(1L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test
@@ -203,7 +203,7 @@ public class MultiTenancySignalReceiveCmdTenantCheckTest {
 
     TaskQuery query = taskService.createTaskQuery();
     assertThat(query.count()).isEqualTo(2L);
-    assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_ONE).count()).isZero();
     assertThat(taskService.createTaskQuery().withoutTenantId().count()).isEqualTo(2L);
   }
 
@@ -224,7 +224,7 @@ public class MultiTenancySignalReceiveCmdTenantCheckTest {
     TaskQuery query = taskService.createTaskQuery();
     assertThat(query.count()).isEqualTo(2L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(2L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test
@@ -354,7 +354,7 @@ public class MultiTenancySignalReceiveCmdTenantCheckTest {
     TaskQuery query = taskService.createTaskQuery();
     assertThat(query.count()).isEqualTo(1L);
     assertThat(query.tenantIdIn(TENANT_ONE).count()).isEqualTo(1L);
-    assertThat(query.tenantIdIn(TENANT_TWO).count()).isEqualTo(0L);
+    assertThat(query.tenantIdIn(TENANT_TWO).count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyTaskServiceCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyTaskServiceCmdsTenantCheckTest.java
@@ -208,7 +208,7 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
 
     // then
     taskService.complete(task.getId());
-    assertThat(taskService.createTaskQuery().taskId(task.getId()).active().count()).isEqualTo(0L);
+    assertThat(taskService.createTaskQuery().taskId(task.getId()).active().count()).isZero();
   }
 
   @Test
@@ -231,7 +231,7 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
 
     // then
     taskService.complete(task.getId());
-    assertThat(taskService.createTaskQuery().taskId(task.getId()).active().count()).isEqualTo(0L);
+    assertThat(taskService.createTaskQuery().taskId(task.getId()).active().count()).isZero();
   }
 
   // delegate task test
@@ -314,7 +314,7 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
 
     // then
     taskService.deleteTask(task.getId(), true);
-    assertThat(taskService.createTaskQuery().taskId(task.getId()).count()).isEqualTo(0L);
+    assertThat(taskService.createTaskQuery().taskId(task.getId()).count()).isZero();
   }
 
   @Test
@@ -350,7 +350,7 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
 
     // then
     taskService.deleteTask(task.getId(), true);
-    assertThat(taskService.createTaskQuery().taskId(task.getId()).count()).isEqualTo(0L);
+    assertThat(taskService.createTaskQuery().taskId(task.getId()).count()).isZero();
   }
 
   protected Task createTaskforTenant() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricActivityInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricActivityInstancesForOptimizeTest.java
@@ -195,7 +195,7 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricActivityInstances(now, now, 10);
 
     // then
-    assertThat(completedHistoricActivityInstances.size()).isEqualTo(0);
+    assertThat(completedHistoricActivityInstances.size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricActivityInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricActivityInstancesForOptimizeTest.java
@@ -16,21 +16,12 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.delegate.ExecutionListener.EVENTNAME_START;
-
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import org.operaton.bpm.engine.AuthorizationService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.authorization.Authorization;
 import org.operaton.bpm.engine.history.HistoricActivityInstance;
 import org.operaton.bpm.engine.identity.Group;
@@ -46,11 +37,12 @@ import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.*;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.engine.delegate.ExecutionListener.EVENTNAME_START;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 public class GetCompletedHistoricActivityInstancesForOptimizeTest {
@@ -195,7 +187,7 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricActivityInstances(now, now, 10);
 
     // then
-    assertThat(completedHistoricActivityInstances.size()).isZero();
+    assertThat(completedHistoricActivityInstances).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricActivityInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricActivityInstancesForOptimizeTest.java
@@ -118,7 +118,7 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricActivityInstances(pastDate(), null, 10);
 
     // then
-    assertThat(completedHistoricActivityInstances.size()).isEqualTo(2);
+    assertThat(completedHistoricActivityInstances).hasSize(2);
     assertThatActivitiesHaveAllImportantInformation(completedHistoricActivityInstances);
   }
 
@@ -144,7 +144,7 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
 
     // then
     Set<String> allowedActivityIds = new HashSet<>(Arrays.asList("userTask", "endEvent"));
-    assertThat(completedHistoricActivityInstances.size()).isEqualTo(2);
+    assertThat(completedHistoricActivityInstances).hasSize(2);
     assertTrue(allowedActivityIds.contains(completedHistoricActivityInstances.get(0).getActivityId()));
     assertTrue(allowedActivityIds.contains(completedHistoricActivityInstances.get(1).getActivityId()));
   }
@@ -170,7 +170,7 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricActivityInstances(null, now, 10);
 
     // then
-    assertThat(completedHistoricActivityInstances.size()).isEqualTo(1);
+    assertThat(completedHistoricActivityInstances).hasSize(1);
     assertThat(completedHistoricActivityInstances.get(0).getActivityId()).isEqualTo("startEvent");
   }
 
@@ -221,7 +221,7 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricActivityInstances(pastDate(), null, 3);
 
     // then
-    assertThat(completedHistoricActivityInstances.size()).isEqualTo(3);
+    assertThat(completedHistoricActivityInstances).hasSize(3);
   }
 
   @Test
@@ -251,7 +251,7 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricActivityInstances(pastDate(), null, 4);
 
     // then
-    assertThat(completedHistoricActivityInstances.size()).isEqualTo(4);
+    assertThat(completedHistoricActivityInstances).hasSize(4);
     assertThat(completedHistoricActivityInstances.get(0).getActivityId()).isEqualTo("startEvent");
     assertThat(completedHistoricActivityInstances.get(1).getActivityId()).isEqualTo("ServiceTask1");
     assertThat(completedHistoricActivityInstances.get(2).getActivityId()).isEqualTo("ServiceTask2");
@@ -274,7 +274,7 @@ public class GetCompletedHistoricActivityInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricActivityInstances(pastDate(), null, 10);
 
     // then
-    assertThat(completedHistoricActivityInstances.size()).isEqualTo(1);
+    assertThat(completedHistoricActivityInstances).hasSize(1);
     assertThat(completedHistoricActivityInstances.get(0).getActivityId()).isEqualTo("startEvent");
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricIncidentsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricIncidentsForOptimizeTest.java
@@ -159,7 +159,7 @@ public class GetCompletedHistoricIncidentsForOptimizeTest {
       optimizeService.getCompletedHistoricIncidents(now, now, 10);
 
     // then
-    assertThat(completedIncidents.size()).isEqualTo(0);
+    assertThat(completedIncidents.size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricIncidentsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricIncidentsForOptimizeTest.java
@@ -93,7 +93,7 @@ public class GetCompletedHistoricIncidentsForOptimizeTest {
       optimizeService.getCompletedHistoricIncidents(pastDate(), null, 10);
 
     // then
-    assertThat(completedIncidents.size()).isEqualTo(1);
+    assertThat(completedIncidents).hasSize(1);
     assertThatInstanceHasAllImportantInformation(completedIncidents.get(0));
   }
 
@@ -115,7 +115,7 @@ public class GetCompletedHistoricIncidentsForOptimizeTest {
       optimizeService.getCompletedHistoricIncidents(now, null, 10);
 
     // then
-    assertThat(completedIncidents.size()).isEqualTo(1);
+    assertThat(completedIncidents).hasSize(1);
     assertThat(completedIncidents.get(0).getProcessInstanceId()).isEqualTo(processInstance2.getId());
   }
 
@@ -137,7 +137,7 @@ public class GetCompletedHistoricIncidentsForOptimizeTest {
       optimizeService.getCompletedHistoricIncidents(null, now, 10);
 
     // then
-    assertThat(completedIncidents.size()).isEqualTo(1);
+    assertThat(completedIncidents).hasSize(1);
     assertThat(completedIncidents.get(0).getProcessInstanceId()).isEqualTo(processInstance.getId());
   }
 
@@ -176,7 +176,7 @@ public class GetCompletedHistoricIncidentsForOptimizeTest {
       optimizeService.getCompletedHistoricIncidents(pastDate(), null, 3);
 
     // then
-    assertThat(completedIncidents.size()).isEqualTo(3);
+    assertThat(completedIncidents).hasSize(3);
   }
 
   @Test
@@ -204,7 +204,7 @@ public class GetCompletedHistoricIncidentsForOptimizeTest {
       optimizeService.getCompletedHistoricIncidents(now, null, 10);
 
     // then
-    assertThat(completedIncidents.size()).isEqualTo(3);
+    assertThat(completedIncidents).hasSize(3);
     assertThat(completedIncidents.get(0).getProcessInstanceId()).isEqualTo(processInstance1.getId());
     assertThat(completedIncidents.get(1).getProcessInstanceId()).isEqualTo(processInstance2.getId());
     assertThat(completedIncidents.get(2).getProcessInstanceId()).isEqualTo(processInstance3.getId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricIncidentsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricIncidentsForOptimizeTest.java
@@ -16,6 +16,11 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.ManagementService;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.RuntimeService;
@@ -31,11 +36,6 @@ import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 import java.util.Date;
 import java.util.List;
@@ -159,7 +159,7 @@ public class GetCompletedHistoricIncidentsForOptimizeTest {
       optimizeService.getCompletedHistoricIncidents(now, now, 10);
 
     // then
-    assertThat(completedIncidents.size()).isZero();
+    assertThat(completedIncidents).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricProcessInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricProcessInstancesForOptimizeTest.java
@@ -184,7 +184,7 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricProcessInstances(now, now, 10);
 
     // then
-    assertThat(completedHistoricProcessInstances.size()).isEqualTo(0);
+    assertThat(completedHistoricProcessInstances.size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricProcessInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricProcessInstancesForOptimizeTest.java
@@ -16,16 +16,12 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Date;
-import java.util.List;
-
-import org.operaton.bpm.engine.AuthorizationService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.authorization.Authorization;
 import org.operaton.bpm.engine.history.HistoricProcessInstance;
 import org.operaton.bpm.engine.identity.Group;
@@ -41,11 +37,11 @@ import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
@@ -184,7 +180,7 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricProcessInstances(now, now, 10);
 
     // then
-    assertThat(completedHistoricProcessInstances.size()).isZero();
+    assertThat(completedHistoricProcessInstances).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricProcessInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricProcessInstancesForOptimizeTest.java
@@ -112,7 +112,7 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricProcessInstances(pastDate(), null, 10);
 
     // then
-    assertThat(completedHistoricProcessInstances.size()).isEqualTo(1);
+    assertThat(completedHistoricProcessInstances).hasSize(1);
     assertThatInstanceHasAllImportantInformation(completedHistoricProcessInstances.get(0));
   }
 
@@ -136,7 +136,7 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricProcessInstances(now, null, 10);
 
     // then
-    assertThat(completedHistoricProcessInstances.size()).isEqualTo(1);
+    assertThat(completedHistoricProcessInstances).hasSize(1);
   }
 
   @Test
@@ -160,7 +160,7 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricProcessInstances(null, now, 10);
 
     // then
-    assertThat(completedHistoricProcessInstances.size()).isEqualTo(1);
+    assertThat(completedHistoricProcessInstances).hasSize(1);
     assertThat(completedHistoricProcessInstances.get(0).getId()).isEqualTo(processInstance.getId());
   }
 
@@ -206,7 +206,7 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricProcessInstances(pastDate(), null, 3);
 
     // then
-    assertThat(completedHistoricProcessInstances.size()).isEqualTo(3);
+    assertThat(completedHistoricProcessInstances).hasSize(3);
   }
 
   @Test
@@ -236,7 +236,7 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricProcessInstances(now, null, 10);
 
     // then
-    assertThat(completedHistoricProcessInstances.size()).isEqualTo(3);
+    assertThat(completedHistoricProcessInstances).hasSize(3);
     assertThat(completedHistoricProcessInstances.get(0).getId()).isEqualTo(processInstance1.getId());
     assertThat(completedHistoricProcessInstances.get(1).getId()).isEqualTo(processInstance2.getId());
     assertThat(completedHistoricProcessInstances.get(2).getId()).isEqualTo(processInstance3.getId());
@@ -262,7 +262,7 @@ public class GetCompletedHistoricProcessInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricProcessInstances(pastDate(), null, 10);
 
     // then
-    assertThat(completedHistoricProcessInstances.size()).isEqualTo(1);
+    assertThat(completedHistoricProcessInstances).hasSize(1);
     assertThat(completedHistoricProcessInstances.get(0).getId()).isEqualTo(processInstanceToComplete.getId());
 
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricTaskInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricTaskInstancesForOptimizeTest.java
@@ -203,7 +203,7 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricTaskInstances(now, now, 10);
 
     // then
-    assertThat(completedHistoricTaskInstances.size()).isEqualTo(0);
+    assertThat(completedHistoricTaskInstances.size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricTaskInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricTaskInstancesForOptimizeTest.java
@@ -114,7 +114,7 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricTaskInstances(null, null, 10);
 
     // then
-    assertThat(completedHistoricTaskInstances.size()).isEqualTo(1);
+    assertThat(completedHistoricTaskInstances).hasSize(1);
     assertThatTasksHaveAllImportantInformation(completedHistoricTaskInstances.get(0));
   }
 
@@ -148,7 +148,7 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
 
     // then
     Set<String> allowedTaskIds = new HashSet<>(Arrays.asList("userTask2", "userTask3"));
-    assertThat(completedHistoricTaskInstances.size()).isEqualTo(2);
+    assertThat(completedHistoricTaskInstances).hasSize(2);
     assertTrue(allowedTaskIds.contains(completedHistoricTaskInstances.get(0).getTaskDefinitionKey()));
     assertTrue(allowedTaskIds.contains(completedHistoricTaskInstances.get(1).getTaskDefinitionKey()));
   }
@@ -176,7 +176,7 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricTaskInstances(null, now, 10);
 
     // then
-    assertThat(completedHistoricTaskInstances.size()).isEqualTo(1);
+    assertThat(completedHistoricTaskInstances).hasSize(1);
     assertThat(completedHistoricTaskInstances.get(0).getTaskDefinitionKey()).isEqualTo("userTask1");
   }
 
@@ -229,7 +229,7 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricTaskInstances(pastDate(), null, 3);
 
     // then
-    assertThat(completedHistoricTaskInstances.size()).isEqualTo(3);
+    assertThat(completedHistoricTaskInstances).hasSize(3);
   }
 
   @Test
@@ -261,7 +261,7 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricTaskInstances(pastDate(), null, 4);
 
     // then
-    assertThat(completedHistoricTaskInstances.size()).isEqualTo(3);
+    assertThat(completedHistoricTaskInstances).hasSize(3);
     assertThat(completedHistoricTaskInstances.get(0).getTaskDefinitionKey()).isEqualTo("userTask1");
     assertThat(completedHistoricTaskInstances.get(1).getTaskDefinitionKey()).isEqualTo("userTask2");
     assertThat(completedHistoricTaskInstances.get(2).getTaskDefinitionKey()).isEqualTo("userTask3");
@@ -285,7 +285,7 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricTaskInstances(pastDate(), null, 10);
 
     // then
-    assertThat(completedHistoricTaskInstances.size()).isEqualTo(1);
+    assertThat(completedHistoricTaskInstances).hasSize(1);
     assertThat(completedHistoricTaskInstances.get(0).getTaskDefinitionKey()).isEqualTo("userTask1");
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricTaskInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricTaskInstancesForOptimizeTest.java
@@ -203,7 +203,7 @@ public class GetCompletedHistoricTaskInstancesForOptimizeTest {
       optimizeService.getCompletedHistoricTaskInstances(now, now, 10);
 
     // then
-    assertThat(completedHistoricTaskInstances.size()).isZero();
+    assertThat(completedHistoricTaskInstances).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricDecisionInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricDecisionInstancesForOptimizeTest.java
@@ -264,7 +264,7 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(now, now, 10);
 
     // then
-    assertThat(decisionInstances.size()).isEqualTo(0);
+    assertThat(decisionInstances.size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricDecisionInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricDecisionInstancesForOptimizeTest.java
@@ -135,7 +135,7 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(pastDate(), null, 10);
 
     // then
-    assertThat(decisionInstances.size()).isEqualTo(1);
+    assertThat(decisionInstances).hasSize(1);
     assertThatDecisionsHaveAllImportantInformation(decisionInstances);
   }
 
@@ -152,11 +152,11 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(pastDate(), null, 10);
 
     // then
-    assertThat(decisionInstances.size()).isEqualTo(1);
+    assertThat(decisionInstances).hasSize(1);
     HistoricDecisionInstance decisionInstance = decisionInstances.get(0);
     List<HistoricDecisionInputInstance> inputs = decisionInstance.getInputs();
     assertThat(inputs).isNotNull();
-    assertThat(inputs.size()).isEqualTo(1);
+    assertThat(inputs).hasSize(1);
 
     HistoricDecisionInputInstance input = inputs.get(0);
     assertThat(input.getDecisionInstanceId()).isEqualTo(decisionInstance.getId());
@@ -177,11 +177,11 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(pastDate(), null, 10);
 
     // then
-    assertThat(decisionInstances.size()).isEqualTo(1);
+    assertThat(decisionInstances).hasSize(1);
     HistoricDecisionInstance decisionInstance = decisionInstances.get(0);
     List<HistoricDecisionOutputInstance> outputs = decisionInstance.getOutputs();
     assertThat(outputs).isNotNull();
-    assertThat(outputs.size()).isEqualTo(1);
+    assertThat(outputs).hasSize(1);
 
     HistoricDecisionOutputInstance output = outputs.get(0);
     assertThat(output.getDecisionInstanceId()).isEqualTo(decisionInstance.getId());
@@ -213,7 +213,7 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(now, null, 10);
 
     // then
-    assertThat(decisionInstances.size()).isEqualTo(1);
+    assertThat(decisionInstances).hasSize(1);
     HistoricDecisionInstance decisionInstance = decisionInstances.get(0);
     assertThat(decisionInstance.getProcessInstanceId()).isEqualTo(secondProcessInstance.getId());
   }
@@ -237,7 +237,7 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(null, now, 10);
 
     // then
-    assertThat(decisionInstances.size()).isEqualTo(1);
+    assertThat(decisionInstances).hasSize(1);
     HistoricDecisionInstance decisionInstance = decisionInstances.get(0);
     assertThat(decisionInstance.getProcessInstanceId()).isEqualTo(firstProcessInstance.getId());
   }
@@ -282,7 +282,7 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(null, null, 2);
 
     // then
-    assertThat(decisionInstances.size()).isEqualTo(2);
+    assertThat(decisionInstances).hasSize(2);
   }
 
   @Test
@@ -310,7 +310,7 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(pastDate(), null, 3);
 
     // then
-    assertThat(decisionInstances.size()).isEqualTo(3);
+    assertThat(decisionInstances).hasSize(3);
     assertThat(decisionInstances.get(0).getProcessInstanceId()).isEqualTo(firstProcessInstance.getId());
     assertThat(decisionInstances.get(1).getProcessInstanceId()).isEqualTo(secondProcessInstance.getId());
     assertThat(decisionInstances.get(2).getProcessInstanceId()).isEqualTo(thirdProcessInstance.getId());
@@ -326,7 +326,7 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
   }
 
   private void assertThatDecisionsHaveAllImportantInformation(List<HistoricDecisionInstance> decisionInstances) {
-    assertThat(decisionInstances.size()).isEqualTo(1);
+    assertThat(decisionInstances).hasSize(1);
     HistoricDecisionInstance decisionInstance =
       decisionInstances.get(0);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricDecisionInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricDecisionInstancesForOptimizeTest.java
@@ -16,11 +16,11 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Date;
-import java.util.List;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
 import org.operaton.bpm.engine.AuthorizationService;
 import org.operaton.bpm.engine.IdentityService;
@@ -44,11 +44,11 @@ import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.engine.test.util.ResetDmnConfigUtil;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 public class GetHistoricDecisionInstancesForOptimizeTest {
@@ -264,7 +264,7 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
       optimizeService.getHistoricDecisionInstances(now, now, 10);
 
     // then
-    assertThat(decisionInstances.size()).isZero();
+    assertThat(decisionInstances).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricIdentityLinkLogsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricIdentityLinkLogsForOptimizeTest.java
@@ -121,7 +121,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(pastDate(), null, 10);
 
     // then
-    assertThat(identityLinkLogs.size()).isEqualTo(1);
+    assertThat(identityLinkLogs).hasSize(1);
     assertThatIdentityLinksHaveAllImportantInformation(identityLinkLogs.get(0), processInstance);
   }
 
@@ -158,7 +158,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(pastDate(), null, 10);
 
     // then
-    assertThat(identityLinkLogs.size()).isEqualTo(4);
+    assertThat(identityLinkLogs).hasSize(4);
     assertThat(identityLinkLogs.get(0).getUserId()).isEqualTo(userId);
     assertThat(identityLinkLogs.get(0).getOperationType()).isEqualTo(IDENTITY_LINK_ADD);
     assertThat(identityLinkLogs.get(0).getType()).isEqualTo(IdentityLinkType.CANDIDATE);
@@ -197,7 +197,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(pastDate(), null, 10);
 
     // then
-    assertThat(identityLinkLogs.size()).isEqualTo(2);
+    assertThat(identityLinkLogs).hasSize(2);
     assertThat(identityLinkLogs.get(0).getUserId()).isEqualTo(userId);
     assertThat(identityLinkLogs.get(0).getOperationType()).isEqualTo(IDENTITY_LINK_ADD);
     assertThat(identityLinkLogs.get(0).getType()).isEqualTo(IdentityLinkType.ASSIGNEE);
@@ -235,7 +235,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(now, null, 10);
 
     // then
-    assertThat(identityLinkLogs.size()).isEqualTo(2);
+    assertThat(identityLinkLogs).hasSize(2);
   }
 
   @Test
@@ -266,7 +266,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(null, now, 10);
 
     // then
-    assertThat(identityLinkLogs.size()).isEqualTo(1);
+    assertThat(identityLinkLogs).hasSize(1);
   }
 
   @Test
@@ -322,7 +322,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(pastDate(), null, 3);
 
     // then
-    assertThat(identityLinkLogs.size()).isEqualTo(3);
+    assertThat(identityLinkLogs).hasSize(3);
   }
 
   @Test
@@ -353,7 +353,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(pastDate(), null, 4);
 
     // then
-    assertThat(identityLinkLogs.size()).isEqualTo(3);
+    assertThat(identityLinkLogs).hasSize(3);
     assertThat(identityLinkLogs.get(0).getOperationType()).isEqualTo(IDENTITY_LINK_ADD);
     assertThat(identityLinkLogs.get(1).getOperationType()).isEqualTo(IDENTITY_LINK_DELETE);
     assertThat(identityLinkLogs.get(2).getOperationType()).isEqualTo(IDENTITY_LINK_ADD);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricIdentityLinkLogsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricIdentityLinkLogsForOptimizeTest.java
@@ -16,16 +16,12 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Date;
-import java.util.List;
-
-import org.operaton.bpm.engine.AuthorizationService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.authorization.Authorization;
 import org.operaton.bpm.engine.identity.Group;
 import org.operaton.bpm.engine.identity.User;
@@ -42,11 +38,11 @@ import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 public class GetHistoricIdentityLinkLogsForOptimizeTest {
@@ -297,7 +293,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(now, now, 10);
 
     // then
-    assertThat(identityLinkLogs.size()).isZero();
+    assertThat(identityLinkLogs).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricIdentityLinkLogsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricIdentityLinkLogsForOptimizeTest.java
@@ -297,7 +297,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       optimizeService.getHistoricIdentityLinkLogs(now, now, 10);
 
     // then
-    assertThat(identityLinkLogs.size()).isEqualTo(0);
+    assertThat(identityLinkLogs.size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricOperationLogsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricOperationLogsForOptimizeTest.java
@@ -552,7 +552,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(now, now, 10);
 
     // then
-    assertThat(userOperationsLog.size()).isEqualTo(0);
+    assertThat(userOperationsLog.size()).isZero();
   }
 
   @Test
@@ -611,7 +611,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size()).isEqualTo(0);
+    assertThat(userOperationsLog.size()).isZero();
   }
 
   private void createLogEntriesThatShouldNotBeReturned(String processInstanceId) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricOperationLogsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricOperationLogsForOptimizeTest.java
@@ -127,7 +127,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size()).isEqualTo(2);
+    assertThat(userOperationsLog).hasSize(2);
     assertThat(userOperationsLog.get(0)).isNotNull();
     assertThat(userOperationsLog.get(0).getId()).isNotNull();
     assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND);
@@ -172,7 +172,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size()).isEqualTo(2);
+    assertThat(userOperationsLog).hasSize(2);
     assertThat(userOperationsLog.get(0)).isNotNull();
     assertThat(userOperationsLog.get(0).getId()).isNotNull();
     assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND);
@@ -217,7 +217,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size()).isEqualTo(2);
+    assertThat(userOperationsLog).hasSize(2);
     assertThat(userOperationsLog.get(0)).isNotNull();
     assertThat(userOperationsLog.get(0).getId()).isNotNull();
     assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND);
@@ -262,7 +262,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size()).isEqualTo(4);
+    assertThat(userOperationsLog).hasSize(4);
     List<String> newPossibleValue = new ArrayList<>(Arrays.asList(
       SuspensionState.SUSPENDED.getName(),
       SuspensionState.ACTIVE.getName(),
@@ -330,7 +330,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size()).isEqualTo(4);
+    assertThat(userOperationsLog).hasSize(4);
     List<String> newPossibleValue = new ArrayList<>(Arrays.asList(
       SuspensionState.SUSPENDED.getName(),
       SuspensionState.ACTIVE.getName(),
@@ -406,7 +406,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size()).isEqualTo(4);
+    assertThat(userOperationsLog).hasSize(4);
     assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND_JOB);
     assertThat(userOperationsLog.get(0).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
     assertThat(userOperationsLog.get(0).getProcessDefinitionKey()).isNull();
@@ -460,7 +460,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size()).isEqualTo(4);
+    assertThat(userOperationsLog).hasSize(4);
     assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND_JOB);
     assertThat(userOperationsLog.get(0).getEntityType()).isEqualTo(EntityTypes.PROCESS_INSTANCE);
     assertThat(userOperationsLog.get(0).getProcessDefinitionKey()).isNull();
@@ -509,7 +509,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
 
     // then
     Set<String> allowedOperationsTypes = new HashSet<>(Arrays.asList(OPERATION_TYPE_SUSPEND, OPERATION_TYPE_ACTIVATE));
-    assertThat(userOperationsLog.size()).isEqualTo(2);
+    assertThat(userOperationsLog).hasSize(2);
     assertTrue(allowedOperationsTypes.contains(userOperationsLog.get(0).getOperationType()));
     assertTrue(allowedOperationsTypes.contains(userOperationsLog.get(1).getOperationType()));
   }
@@ -531,7 +531,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(null, now, 10);
 
     // then
-    assertThat(userOperationsLog.size()).isEqualTo(1);
+    assertThat(userOperationsLog).hasSize(1);
     assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND);
   }
 
@@ -569,7 +569,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 3);
 
     // then
-    assertThat(userOperationsLog.size()).isEqualTo(3);
+    assertThat(userOperationsLog).hasSize(3);
   }
 
   @Test
@@ -593,7 +593,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 4);
 
     // then
-    assertThat(userOperationsLog.size()).isEqualTo(3);
+    assertThat(userOperationsLog).hasSize(3);
     assertThat(userOperationsLog.get(0).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND);
     assertThat(userOperationsLog.get(1).getOperationType()).isEqualTo(OPERATION_TYPE_ACTIVATE);
     assertThat(userOperationsLog.get(2).getOperationType()).isEqualTo(OPERATION_TYPE_SUSPEND);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricOperationLogsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricOperationLogsForOptimizeTest.java
@@ -16,30 +16,12 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
-import static org.operaton.bpm.engine.history.UserOperationLogEntry.CATEGORY_OPERATOR;
-import static org.operaton.bpm.engine.history.UserOperationLogEntry.OPERATION_TYPE_ACTIVATE;
-import static org.operaton.bpm.engine.history.UserOperationLogEntry.OPERATION_TYPE_ACTIVATE_JOB;
-import static org.operaton.bpm.engine.history.UserOperationLogEntry.OPERATION_TYPE_ACTIVATE_PROCESS_DEFINITION;
-import static org.operaton.bpm.engine.history.UserOperationLogEntry.OPERATION_TYPE_SUSPEND;
-import static org.operaton.bpm.engine.history.UserOperationLogEntry.OPERATION_TYPE_SUSPEND_JOB;
-import static org.operaton.bpm.engine.history.UserOperationLogEntry.OPERATION_TYPE_SUSPEND_PROCESS_DEFINITION;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import org.operaton.bpm.engine.EntityTypes;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.history.UserOperationLogEntry;
 import org.operaton.bpm.engine.identity.User;
@@ -57,11 +39,12 @@ import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.operaton.bpm.engine.history.UserOperationLogEntry.*;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 public class GetHistoricOperationLogsForOptimizeTest {
@@ -552,7 +535,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(now, now, 10);
 
     // then
-    assertThat(userOperationsLog.size()).isZero();
+    assertThat(userOperationsLog).isEmpty();
   }
 
   @Test
@@ -611,7 +594,7 @@ public class GetHistoricOperationLogsForOptimizeTest {
       optimizeService.getHistoricUserOperationLogs(pastDate(), null, 10);
 
     // then
-    assertThat(userOperationsLog.size()).isZero();
+    assertThat(userOperationsLog).isEmpty();
   }
 
   private void createLogEntriesThatShouldNotBeReturned(String processInstanceId) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricVariableUpdatesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricVariableUpdatesForOptimizeTest.java
@@ -124,7 +124,7 @@ public class GetHistoricVariableUpdatesForOptimizeTest {
       optimizeService.getHistoricVariableUpdates(new Date(1L), null, false, 10);
 
     // then
-    assertThat(historicVariableUpdates.size()).isEqualTo(1);
+    assertThat(historicVariableUpdates).hasSize(1);
     assertThatUpdateHasAllImportantInformation(historicVariableUpdates.get(0));
   }
 
@@ -151,7 +151,7 @@ public class GetHistoricVariableUpdatesForOptimizeTest {
       optimizeService.getHistoricVariableUpdates(now, null, false, 10);
 
     // then
-    assertThat(variableUpdates.size()).isEqualTo(1);
+    assertThat(variableUpdates).hasSize(1);
     assertThat(variableUpdates.get(0).getValue()).hasToString("value2");
   }
 
@@ -178,7 +178,7 @@ public class GetHistoricVariableUpdatesForOptimizeTest {
       optimizeService.getHistoricVariableUpdates(null, now, false, 10);
 
     // then
-    assertThat(variableUpdates.size()).isEqualTo(1);
+    assertThat(variableUpdates).hasSize(1);
     assertThat(variableUpdates.get(0).getValue()).hasToString("value1");
   }
 
@@ -289,7 +289,7 @@ public class GetHistoricVariableUpdatesForOptimizeTest {
       optimizeService.getHistoricVariableUpdates(pastDate(), null, false, 3);
 
     // then
-    assertThat(variableUpdates.size()).isEqualTo(3);
+    assertThat(variableUpdates).hasSize(3);
   }
 
   @Test
@@ -322,7 +322,7 @@ public class GetHistoricVariableUpdatesForOptimizeTest {
       optimizeService.getHistoricVariableUpdates(now, null, false, 10);
 
     // then
-    assertThat(variableUpdates.size()).isEqualTo(3);
+    assertThat(variableUpdates).hasSize(3);
     assertThat(variableUpdates.get(0).getVariableName()).isEqualTo("var1");
     assertThat(variableUpdates.get(1).getVariableName()).isEqualTo("var2");
     assertThat(variableUpdates.get(2).getVariableName()).isEqualTo("var3");
@@ -351,7 +351,7 @@ public class GetHistoricVariableUpdatesForOptimizeTest {
       optimizeService.getHistoricVariableUpdates(pastDate(), null, false, 10);
 
     // then
-    assertThat(variableUpdates.size()).isEqualTo(1);
+    assertThat(variableUpdates).hasSize(1);
   }
 
   /**

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricVariableUpdatesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricVariableUpdatesForOptimizeTest.java
@@ -205,7 +205,7 @@ public class GetHistoricVariableUpdatesForOptimizeTest {
       optimizeService.getHistoricVariableUpdates(now, now, false, 10);
 
     // then
-    assertThat(variableUpdates.size()).isZero();
+    assertThat(variableUpdates).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricVariableUpdatesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricVariableUpdatesForOptimizeTest.java
@@ -17,11 +17,12 @@
 package org.operaton.bpm.engine.test.api.optimize;
 
 import com.google.common.collect.ImmutableList;
-import org.operaton.bpm.engine.AuthorizationService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.authorization.Authorization;
 import org.operaton.bpm.engine.history.HistoricVariableUpdate;
 import org.operaton.bpm.engine.identity.Group;
@@ -44,11 +45,6 @@ import org.operaton.bpm.engine.variable.value.TypedValue;
 import org.operaton.bpm.engine.variable.value.builder.ObjectValueBuilder;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -156,7 +152,7 @@ public class GetHistoricVariableUpdatesForOptimizeTest {
 
     // then
     assertThat(variableUpdates.size()).isEqualTo(1);
-    assertThat(variableUpdates.get(0).getValue().toString()).isEqualTo("value2");
+    assertThat(variableUpdates.get(0).getValue()).hasToString("value2");
   }
 
   @Test
@@ -183,7 +179,7 @@ public class GetHistoricVariableUpdatesForOptimizeTest {
 
     // then
     assertThat(variableUpdates.size()).isEqualTo(1);
-    assertThat(variableUpdates.get(0).getValue().toString()).isEqualTo("value1");
+    assertThat(variableUpdates.get(0).getValue()).hasToString("value1");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricVariableUpdatesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricVariableUpdatesForOptimizeTest.java
@@ -209,7 +209,7 @@ public class GetHistoricVariableUpdatesForOptimizeTest {
       optimizeService.getHistoricVariableUpdates(now, now, false, 10);
 
     // then
-    assertThat(variableUpdates.size()).isEqualTo(0);
+    assertThat(variableUpdates.size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetOpenHistoricIncidentsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetOpenHistoricIncidentsForOptimizeTest.java
@@ -91,7 +91,7 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
       optimizeService.getOpenHistoricIncidents(pastDate(), null, 10);
 
     // then
-    assertThat(openIncidents.size()).isEqualTo(1);
+    assertThat(openIncidents).hasSize(1);
     assertThatInstanceHasAllImportantInformation(openIncidents.get(0));
   }
 
@@ -112,7 +112,7 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
       optimizeService.getOpenHistoricIncidents(now, null, 10);
 
     // then
-    assertThat(openIncidents.size()).isEqualTo(1);
+    assertThat(openIncidents).hasSize(1);
     assertThat(openIncidents.get(0).getProcessInstanceId()).isEqualTo(processInstance.getId());
 
   }
@@ -133,7 +133,7 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
       optimizeService.getOpenHistoricIncidents(null, now, 10);
 
     // then
-    assertThat(openIncidents.size()).isEqualTo(1);
+    assertThat(openIncidents).hasSize(1);
     assertThat(openIncidents.get(0).getProcessInstanceId()).isEqualTo(processInstance.getId());
   }
 
@@ -169,7 +169,7 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
       optimizeService.getOpenHistoricIncidents(pastDate(), null, 3);
 
     // then
-    assertThat(openIncidents.size()).isEqualTo(3);
+    assertThat(openIncidents).hasSize(3);
   }
 
   @Test
@@ -194,7 +194,7 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
       optimizeService.getOpenHistoricIncidents(now, null, 10);
 
     // then
-    assertThat(openIncidents.size()).isEqualTo(3);
+    assertThat(openIncidents).hasSize(3);
     assertThat(openIncidents.get(0).getProcessInstanceId()).isEqualTo(processInstance1.getId());
     assertThat(openIncidents.get(1).getProcessInstanceId()).isEqualTo(processInstance2.getId());
     assertThat(openIncidents.get(2).getProcessInstanceId()).isEqualTo(processInstance3.getId());
@@ -213,7 +213,7 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
       optimizeService.getOpenHistoricIncidents(pastDate(), null, 10);
 
     // then
-    assertThat(openIncidents.size()).isEqualTo(1);
+    assertThat(openIncidents).hasSize(1);
     assertThat(openIncidents.get(0).getProcessInstanceId()).isEqualTo(processInstanceWithOpenIncident.getId());
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetOpenHistoricIncidentsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetOpenHistoricIncidentsForOptimizeTest.java
@@ -153,7 +153,7 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
       optimizeService.getOpenHistoricIncidents(now, now, 10);
 
     // then
-    assertThat(openIncidents.size()).isEqualTo(0);
+    assertThat(openIncidents.size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetOpenHistoricIncidentsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetOpenHistoricIncidentsForOptimizeTest.java
@@ -16,6 +16,11 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.ManagementService;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.RuntimeService;
@@ -31,11 +36,6 @@ import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 import java.util.Date;
 import java.util.List;
@@ -153,7 +153,7 @@ public class GetOpenHistoricIncidentsForOptimizeTest {
       optimizeService.getOpenHistoricIncidents(now, now, 10);
 
     // then
-    assertThat(openIncidents.size()).isZero();
+    assertThat(openIncidents).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricActivityInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricActivityInstancesForOptimizeTest.java
@@ -192,7 +192,7 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(now, now, 10);
 
     // then
-    assertThat(runningHistoricActivityInstances.size()).isEqualTo(0);
+    assertThat(runningHistoricActivityInstances.size()).isZero();
   }
 
   @Test
@@ -278,7 +278,7 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(pastDate(), null, 10);
 
     // then
-    assertThat(runningHistoricActivityInstances.size()).isEqualTo(0);
+    assertThat(runningHistoricActivityInstances.size()).isZero();
   }
 
   private Date pastDate() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricActivityInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricActivityInstancesForOptimizeTest.java
@@ -16,16 +16,12 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Date;
-import java.util.List;
-
-import org.operaton.bpm.engine.AuthorizationService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.authorization.Authorization;
 import org.operaton.bpm.engine.history.HistoricActivityInstance;
 import org.operaton.bpm.engine.identity.Group;
@@ -42,11 +38,11 @@ import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 public class GetRunningHistoricActivityInstancesForOptimizeTest {
@@ -192,7 +188,7 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(now, now, 10);
 
     // then
-    assertThat(runningHistoricActivityInstances.size()).isZero();
+    assertThat(runningHistoricActivityInstances).isEmpty();
   }
 
   @Test
@@ -278,7 +274,7 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(pastDate(), null, 10);
 
     // then
-    assertThat(runningHistoricActivityInstances.size()).isZero();
+    assertThat(runningHistoricActivityInstances).isEmpty();
   }
 
   private Date pastDate() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricActivityInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricActivityInstancesForOptimizeTest.java
@@ -114,7 +114,7 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(pastDate(), null, 10);
 
     // then
-    assertThat(runningHistoricActivityInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricActivityInstances).hasSize(1);
     HistoricActivityInstance activityInstance = runningHistoricActivityInstances.get(0);
     assertThatActivitiesHaveAllImportantInformation(activityInstance);
   }
@@ -141,7 +141,7 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(now, null, 10);
 
     // then
-    assertThat(runningHistoricActivityInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricActivityInstances).hasSize(1);
     assertThat(runningHistoricActivityInstances.get(0).getProcessInstanceId()).isEqualTo(secondProcessInstance.getId());
   }
 
@@ -167,7 +167,7 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(null, now, 10);
 
     // then
-    assertThat(runningHistoricActivityInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricActivityInstances).hasSize(1);
     assertThat(runningHistoricActivityInstances.get(0).getProcessInstanceId()).isEqualTo(firstProcessInstance.getId());
   }
 
@@ -214,7 +214,7 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(pastDate(), null, 3);
 
     // then
-    assertThat(runningHistoricActivityInstances.size()).isEqualTo(3);
+    assertThat(runningHistoricActivityInstances).hasSize(3);
   }
 
   @Test
@@ -241,7 +241,7 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(pastDate(), null, 4);
 
     // then
-    assertThat(runningHistoricActivityInstances.size()).isEqualTo(3);
+    assertThat(runningHistoricActivityInstances).hasSize(3);
     assertThat(runningHistoricActivityInstances.get(0).getProcessInstanceId()).isEqualTo(firstProcessInstance.getId());
     assertThat(runningHistoricActivityInstances.get(1).getProcessInstanceId()).isEqualTo(secondProcessInstance.getId());
     assertThat(runningHistoricActivityInstances.get(2).getProcessInstanceId()).isEqualTo(thirdProcessInstance.getId());
@@ -269,7 +269,7 @@ public class GetRunningHistoricActivityInstancesForOptimizeTest {
       optimizeService.getRunningHistoricActivityInstances(pastDate(), null, 10);
 
     // then
-    assertThat(runningHistoricActivityInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricActivityInstances).hasSize(1);
     assertThat(runningHistoricActivityInstances.get(0).getActivityId()).isEqualTo("userTask");
 
     // when

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricProcessInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricProcessInstancesForOptimizeTest.java
@@ -188,7 +188,7 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
       optimizeService.getRunningHistoricProcessInstances(now, now, 10);
 
     // then
-    assertThat(runningHistoricProcessInstances.size()).isEqualTo(0);
+    assertThat(runningHistoricProcessInstances.size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricProcessInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricProcessInstancesForOptimizeTest.java
@@ -112,7 +112,7 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
       optimizeService.getRunningHistoricProcessInstances(pastDate(), null, 10);
 
     // then
-    assertThat(runningHistoricProcessInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricProcessInstances).hasSize(1);
     assertThatInstanceHasAllImportantInformation(runningHistoricProcessInstances.get(0));
   }
 
@@ -137,7 +137,7 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
       optimizeService.getRunningHistoricProcessInstances(now, null, 10);
 
     // then
-    assertThat(runningHistoricProcessInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricProcessInstances).hasSize(1);
   }
 
   @Test
@@ -162,7 +162,7 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
       optimizeService.getRunningHistoricProcessInstances(null, now, 10);
 
     // then
-    assertThat(runningHistoricProcessInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricProcessInstances).hasSize(1);
     assertThat(runningHistoricProcessInstances.get(0).getId()).isEqualTo(processInstance.getId());
   }
 
@@ -211,7 +211,7 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
       optimizeService.getRunningHistoricProcessInstances(pastDate(), null, 3);
 
     // then
-    assertThat(runningHistoricProcessInstances.size()).isEqualTo(3);
+    assertThat(runningHistoricProcessInstances).hasSize(3);
   }
 
   @Test
@@ -242,7 +242,7 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
       optimizeService.getRunningHistoricProcessInstances(new Date(now.getTime()), null, 10);
 
     // then
-    assertThat(runningHistoricProcessInstances.size()).isEqualTo(3);
+    assertThat(runningHistoricProcessInstances).hasSize(3);
     assertThat(runningHistoricProcessInstances.get(0).getId()).isEqualTo(processInstance1.getId());
     assertThat(runningHistoricProcessInstances.get(1).getId()).isEqualTo(processInstance2.getId());
     assertThat(runningHistoricProcessInstances.get(2).getId()).isEqualTo(processInstance3.getId());
@@ -267,7 +267,7 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
       optimizeService.getRunningHistoricProcessInstances(pastDate(), null, 10);
 
     // then
-    assertThat(runningHistoricProcessInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricProcessInstances).hasSize(1);
     assertThat(runningHistoricProcessInstances.get(0).getId()).isEqualTo(runningProcessInstance.getId());
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricProcessInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricProcessInstancesForOptimizeTest.java
@@ -16,16 +16,12 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Date;
-import java.util.List;
-
-import org.operaton.bpm.engine.AuthorizationService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.authorization.Authorization;
 import org.operaton.bpm.engine.history.HistoricProcessInstance;
 import org.operaton.bpm.engine.identity.Group;
@@ -41,11 +37,11 @@ import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
@@ -188,7 +184,7 @@ public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
       optimizeService.getRunningHistoricProcessInstances(now, now, 10);
 
     // then
-    assertThat(runningHistoricProcessInstances.size()).isZero();
+    assertThat(runningHistoricProcessInstances).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricTaskInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricTaskInstancesForOptimizeTest.java
@@ -16,16 +16,12 @@
  */
 package org.operaton.bpm.engine.test.api.optimize;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Date;
-import java.util.List;
-
-import org.operaton.bpm.engine.AuthorizationService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.authorization.Authorization;
 import org.operaton.bpm.engine.history.HistoricTaskInstance;
 import org.operaton.bpm.engine.identity.Group;
@@ -41,11 +37,11 @@ import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 public class GetRunningHistoricTaskInstancesForOptimizeTest {
@@ -189,7 +185,7 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
       optimizeService.getRunningHistoricTaskInstances(now, now, 10);
 
     // then
-    assertThat(runningHistoricTaskInstances.size()).isZero();
+    assertThat(runningHistoricTaskInstances).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricTaskInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricTaskInstancesForOptimizeTest.java
@@ -111,7 +111,7 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
       optimizeService.getRunningHistoricTaskInstances(null, null, 10);
 
     // then
-    assertThat(runningHistoricTaskInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricTaskInstances).hasSize(1);
     assertThatTasksHaveAllImportantInformation(runningHistoricTaskInstances.get(0));
   }
 
@@ -137,7 +137,7 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
       optimizeService.getRunningHistoricTaskInstances(now, null, 10);
 
     // then
-    assertThat(runningHistoricTaskInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricTaskInstances).hasSize(1);
     assertThat(runningHistoricTaskInstances.get(0).getProcessInstanceId()).isEqualTo(processInstance2.getId());
   }
 
@@ -163,7 +163,7 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
       optimizeService.getRunningHistoricTaskInstances(null, now, 10);
 
     // then
-    assertThat(runningHistoricTaskInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricTaskInstances).hasSize(1);
     assertThat(runningHistoricTaskInstances.get(0).getProcessInstanceId()).isEqualTo(processInstance1.getId());
   }
 
@@ -211,7 +211,7 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
       optimizeService.getRunningHistoricTaskInstances(pastDate(), null, 3);
 
     // then
-    assertThat(runningHistoricTaskInstances.size()).isEqualTo(3);
+    assertThat(runningHistoricTaskInstances).hasSize(3);
   }
 
   @Test
@@ -240,7 +240,7 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
       optimizeService.getRunningHistoricTaskInstances(pastDate(), null, 10);
 
     // then
-    assertThat(runningHistoricTaskInstances.size()).isEqualTo(3);
+    assertThat(runningHistoricTaskInstances).hasSize(3);
     assertThat(runningHistoricTaskInstances.get(0).getProcessInstanceId()).isEqualTo(processInstance1.getId());
     assertThat(runningHistoricTaskInstances.get(1).getProcessInstanceId()).isEqualTo(processInstance2.getId());
     assertThat(runningHistoricTaskInstances.get(2).getProcessInstanceId()).isEqualTo(processInstance3.getId());
@@ -265,7 +265,7 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
       optimizeService.getRunningHistoricTaskInstances(pastDate(), null, 10);
 
     // then
-    assertThat(runningHistoricTaskInstances.size()).isEqualTo(1);
+    assertThat(runningHistoricTaskInstances).hasSize(1);
     assertThat(runningHistoricTaskInstances.get(0).getTaskDefinitionKey()).isEqualTo("userTask2");
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricTaskInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetRunningHistoricTaskInstancesForOptimizeTest.java
@@ -189,7 +189,7 @@ public class GetRunningHistoricTaskInstancesForOptimizeTest {
       optimizeService.getRunningHistoricTaskInstances(now, now, 10);
 
     // then
-    assertThat(runningHistoricTaskInstances.size()).isEqualTo(0);
+    assertThat(runningHistoricTaskInstances.size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/queries/BoundedNumberOfMaxResultsDelegate.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/queries/BoundedNumberOfMaxResultsDelegate.java
@@ -33,7 +33,7 @@ public class BoundedNumberOfMaxResultsDelegate implements JavaDelegate {
         .createProcessInstanceQuery()
         .list();
 
-    assertThat(processInstances.size()).isEqualTo(0);
+    assertThat(processInstances.size()).isZero();
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/queries/BoundedNumberOfMaxResultsDelegate.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/queries/BoundedNumberOfMaxResultsDelegate.java
@@ -16,13 +16,13 @@
  */
 package org.operaton.bpm.engine.test.api.queries;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.List;
-
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.JavaDelegate;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BoundedNumberOfMaxResultsDelegate implements JavaDelegate {
 
@@ -33,7 +33,7 @@ public class BoundedNumberOfMaxResultsDelegate implements JavaDelegate {
         .createProcessInstanceQuery()
         .list();
 
-    assertThat(processInstances.size()).isZero();
+    assertThat(processInstances).isEmpty();
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/queries/BoundedNumberOfMaxResultsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/queries/BoundedNumberOfMaxResultsTest.java
@@ -124,7 +124,7 @@ public class BoundedNumberOfMaxResultsTest {
     List<ProcessInstance> processInstances = processInstanceQuery.list();
 
     // then
-    assertThat(processInstances.size()).isEqualTo(0);
+    assertThat(processInstances.size()).isZero();
   }
 
   @Test
@@ -139,7 +139,7 @@ public class BoundedNumberOfMaxResultsTest {
     List<ProcessInstance> processInstances = processInstanceQuery.list();
 
     // then
-    assertThat(processInstances.size()).isEqualTo(0);
+    assertThat(processInstances.size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/queries/BoundedNumberOfMaxResultsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/queries/BoundedNumberOfMaxResultsTest.java
@@ -16,19 +16,12 @@
  */
 package org.operaton.bpm.engine.test.api.queries;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import org.operaton.bpm.engine.BadUserRequestException;
-import org.operaton.bpm.engine.HistoryService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.filter.Filter;
 import org.operaton.bpm.engine.history.HistoricProcessInstance;
 import org.operaton.bpm.engine.history.HistoricProcessInstanceQuery;
@@ -46,11 +39,11 @@ import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
 
 public class BoundedNumberOfMaxResultsTest {
 
@@ -124,7 +117,7 @@ public class BoundedNumberOfMaxResultsTest {
     List<ProcessInstance> processInstances = processInstanceQuery.list();
 
     // then
-    assertThat(processInstances.size()).isZero();
+    assertThat(processInstances).isEmpty();
   }
 
   @Test
@@ -139,7 +132,7 @@ public class BoundedNumberOfMaxResultsTest {
     List<ProcessInstance> processInstances = processInstanceQuery.list();
 
     // then
-    assertThat(processInstances.size()).isZero();
+    assertThat(processInstances).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/queries/BoundedNumberOfMaxResultsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/queries/BoundedNumberOfMaxResultsTest.java
@@ -164,7 +164,7 @@ public class BoundedNumberOfMaxResultsTest {
                 .list();
 
             // then
-            assertThat(tasks.size()).isEqualTo(1);
+            assertThat(tasks).hasSize(1);
 
             return null;
           }
@@ -247,7 +247,7 @@ public class BoundedNumberOfMaxResultsTest {
     List<ProcessInstance> processInstances = processInstanceQuery.unlimitedList();
 
     // then
-    assertThat(processInstances.size()).isEqualTo(1);
+    assertThat(processInstances).hasSize(1);
   }
 
   @Test
@@ -823,7 +823,7 @@ public class BoundedNumberOfMaxResultsTest {
         historicProcessInstanceQuery.listPage(0, 10);
 
     // then
-    assertThat(historicProcessInstances.size()).isEqualTo(1);
+    assertThat(historicProcessInstances).hasSize(1);
   }
 
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_ACTIVITY)
@@ -847,7 +847,7 @@ public class BoundedNumberOfMaxResultsTest {
         historicProcessInstanceQuery.listPage(0, 9);
 
     // then
-    assertThat(historicProcessInstances.size()).isEqualTo(1);
+    assertThat(historicProcessInstances).hasSize(1);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/CaseDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/CaseDefinitionQueryTest.java
@@ -115,7 +115,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
       .caseDefinitionIdIn(ids.toArray(new String[ids.size()]))
       .list();
 
-    assertThat(ids.size()).isEqualTo(caseDefinitions.size());
+    assertThat(ids).hasSize(caseDefinitions.size());
     for (CaseDefinition caseDefinition : caseDefinitions) {
       assertThat(ids).contains(caseDefinition.getId()).withFailMessage("Expected to find case definition " + caseDefinition);
     }
@@ -517,7 +517,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
       .desc();
 
     List<CaseDefinition> caseDefinitions = query.list();
-    assertThat(caseDefinitions.size()).isEqualTo(4);
+    assertThat(caseDefinitions).hasSize(4);
 
     assertThat(caseDefinitions.get(0).getKey()).isEqualTo("one");
     assertThat(caseDefinitions.get(0).getVersion()).isEqualTo(2);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/CaseDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/CaseDefinitionQueryTest.java
@@ -123,7 +123,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
     assertThat(repositoryService.createCaseDefinitionQuery()
         .caseDefinitionIdIn(ids.toArray(new String[ids.size()]))
         .caseDefinitionId("nonExistent")
-        .count()).isEqualTo(0);
+        .count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DecisionDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DecisionDefinitionQueryTest.java
@@ -635,7 +635,7 @@ public class DecisionDefinitionQueryTest {
       .desc();
 
     List<DecisionDefinition> decisionDefinitions = query.list();
-    assertThat(decisionDefinitions.size()).isEqualTo(4);
+    assertThat(decisionDefinitions).hasSize(4);
 
     assertThat(decisionDefinitions.get(0).getKey()).isEqualTo("one");
     assertThat(decisionDefinitions.get(0).getVersion()).isEqualTo(2);
@@ -648,7 +648,7 @@ public class DecisionDefinitionQueryTest {
 
   protected void verifyQueryResults(DecisionDefinitionQuery query, int expectedCount) {
     assertThat(query.count()).isEqualTo(expectedCount);
-    assertThat(query.list().size()).isEqualTo(expectedCount);
+    assertThat(query.list()).hasSize(expectedCount);
   }
 
   @org.operaton.bpm.engine.test.Deployment(resources = {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DecisionDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DecisionDefinitionQueryTest.java
@@ -209,7 +209,7 @@ public class DecisionDefinitionQueryTest {
     // when
     decisionDefinitions = repositoryService.createDecisionDefinitionQuery().deployedAfter(timeAfterDeploymentThree).list();
     // then
-    assertThat(decisionDefinitions).hasSize(0);
+    assertThat(decisionDefinitions).isEmpty();
   }
 
   @Test
@@ -252,7 +252,7 @@ public class DecisionDefinitionQueryTest {
     assertThatDecisionDefinitionsWereDeployedAt(processDefinitions, timeAtDeploymentThree);
 
     processDefinitions = repositoryService.createDecisionDefinitionQuery().deployedAt(DateUtils.addSeconds(ClockUtil.getCurrentTime(), 5)).list();
-    assertThat(processDefinitions).hasSize(0);
+    assertThat(processDefinitions).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DecisionRequirementsDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DecisionRequirementsDefinitionQueryTest.java
@@ -205,7 +205,7 @@ public class DecisionRequirementsDefinitionQueryTest {
     List<DecisionRequirementsDefinition> decisionRequirementsDefinitions = repositoryService.createDecisionRequirementsDefinitionQuery()
         .orderByDecisionRequirementsDefinitionId().asc().list();
 
-    assertThat(decisionRequirementsDefinitions.size()).isEqualTo(4);
+    assertThat(decisionRequirementsDefinitions).hasSize(4);
     assertThat(decisionRequirementsDefinitions.get(0).getId()).startsWith("dish:1");
     assertThat(decisionRequirementsDefinitions.get(1).getId()).startsWith("dish:2");
     assertThat(decisionRequirementsDefinitions.get(2).getId()).startsWith("score:1");
@@ -225,7 +225,7 @@ public class DecisionRequirementsDefinitionQueryTest {
     List<DecisionRequirementsDefinition> decisionRequirementsDefinitions = repositoryService.createDecisionRequirementsDefinitionQuery()
         .orderByDecisionRequirementsDefinitionKey().asc().list();
 
-    assertThat(decisionRequirementsDefinitions.size()).isEqualTo(4);
+    assertThat(decisionRequirementsDefinitions).hasSize(4);
     assertThat(decisionRequirementsDefinitions.get(0).getKey()).isEqualTo("dish");
     assertThat(decisionRequirementsDefinitions.get(1).getKey()).isEqualTo("dish");
     assertThat(decisionRequirementsDefinitions.get(2).getKey()).isEqualTo("score");
@@ -245,7 +245,7 @@ public class DecisionRequirementsDefinitionQueryTest {
     List<DecisionRequirementsDefinition> decisionRequirementsDefinitions = repositoryService.createDecisionRequirementsDefinitionQuery()
         .orderByDecisionRequirementsDefinitionName().asc().list();
 
-    assertThat(decisionRequirementsDefinitions.size()).isEqualTo(4);
+    assertThat(decisionRequirementsDefinitions).hasSize(4);
     assertThat(decisionRequirementsDefinitions.get(0).getName()).isEqualTo("Dish");
     assertThat(decisionRequirementsDefinitions.get(1).getName()).isEqualTo("Dish");
     assertThat(decisionRequirementsDefinitions.get(2).getName()).isEqualTo("Score");
@@ -265,7 +265,7 @@ public class DecisionRequirementsDefinitionQueryTest {
     List<DecisionRequirementsDefinition> decisionRequirementsDefinitions = repositoryService.createDecisionRequirementsDefinitionQuery()
         .orderByDecisionRequirementsDefinitionCategory().asc().list();
 
-    assertThat(decisionRequirementsDefinitions.size()).isEqualTo(4);
+    assertThat(decisionRequirementsDefinitions).hasSize(4);
     assertThat(decisionRequirementsDefinitions.get(0).getCategory()).isEqualTo("test-drd-1");
     assertThat(decisionRequirementsDefinitions.get(1).getCategory()).isEqualTo("test-drd-2");
     assertThat(decisionRequirementsDefinitions.get(2).getCategory()).isEqualTo("test-drd-2");
@@ -285,7 +285,7 @@ public class DecisionRequirementsDefinitionQueryTest {
     List<DecisionRequirementsDefinition> decisionRequirementsDefinitions = repositoryService.createDecisionRequirementsDefinitionQuery()
         .orderByDecisionRequirementsDefinitionVersion().asc().list();
 
-    assertThat(decisionRequirementsDefinitions.size()).isEqualTo(4);
+    assertThat(decisionRequirementsDefinitions).hasSize(4);
     assertThat(decisionRequirementsDefinitions.get(0).getVersion()).isEqualTo(1);
     assertThat(decisionRequirementsDefinitions.get(1).getVersion()).isEqualTo(1);
     assertThat(decisionRequirementsDefinitions.get(2).getVersion()).isEqualTo(1);
@@ -304,7 +304,7 @@ public class DecisionRequirementsDefinitionQueryTest {
     List<DecisionRequirementsDefinition> decisionRequirementsDefinitions = repositoryService.createDecisionRequirementsDefinitionQuery()
         .orderByDeploymentId().asc().list();
 
-    assertThat(decisionRequirementsDefinitions.size()).isEqualTo(4);
+    assertThat(decisionRequirementsDefinitions).hasSize(4);
     assertThat(decisionRequirementsDefinitions.get(0).getDeploymentId()).isEqualTo(firstDeploymentId);
     assertThat(decisionRequirementsDefinitions.get(1).getDeploymentId()).isEqualTo(firstDeploymentId);
     assertThat(decisionRequirementsDefinitions.get(2).getDeploymentId()).isEqualTo(secondDeploymentId);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DecisionRequirementsDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DecisionRequirementsDefinitionQueryTest.java
@@ -69,7 +69,7 @@ public class DecisionRequirementsDefinitionQueryTest {
   public void queryByDecisionRequirementsDefinitionId() {
     DecisionRequirementsDefinitionQuery query = repositoryService.createDecisionRequirementsDefinitionQuery();
 
-    assertThat(query.decisionRequirementsDefinitionId("notExisting").count()).isEqualTo(0L);
+    assertThat(query.decisionRequirementsDefinitionId("notExisting").count()).isZero();
 
     assertThat(query.decisionRequirementsDefinitionId(decisionRequirementsDefinitionId).count()).isEqualTo(1L);
     assertThat(query.singleResult().getKey()).isEqualTo("score");
@@ -79,7 +79,7 @@ public class DecisionRequirementsDefinitionQueryTest {
   public void queryByDecisionRequirementsDefinitionIds() {
     DecisionRequirementsDefinitionQuery query = repositoryService.createDecisionRequirementsDefinitionQuery();
 
-    assertThat(query.decisionRequirementsDefinitionIdIn("not", "existing").count()).isEqualTo(0L);
+    assertThat(query.decisionRequirementsDefinitionIdIn("not", "existing").count()).isZero();
 
     assertThat(query.decisionRequirementsDefinitionIdIn(decisionRequirementsDefinitionId, "notExisting").count()).isEqualTo(1L);
     assertThat(query.singleResult().getKey()).isEqualTo("score");
@@ -89,7 +89,7 @@ public class DecisionRequirementsDefinitionQueryTest {
   public void queryByDecisionRequirementsDefinitionKey() {
     DecisionRequirementsDefinitionQuery query = repositoryService.createDecisionRequirementsDefinitionQuery();
 
-    assertThat(query.decisionRequirementsDefinitionKey("notExisting").count()).isEqualTo(0L);
+    assertThat(query.decisionRequirementsDefinitionKey("notExisting").count()).isZero();
 
     assertThat(query.decisionRequirementsDefinitionKey("score").count()).isEqualTo(1L);
     assertThat(query.singleResult().getKey()).isEqualTo("score");
@@ -99,7 +99,7 @@ public class DecisionRequirementsDefinitionQueryTest {
   public void queryByDecisionRequirementsDefinitionKeyLike() {
     DecisionRequirementsDefinitionQuery query = repositoryService.createDecisionRequirementsDefinitionQuery();
 
-    assertThat(query.decisionRequirementsDefinitionKeyLike("%notExisting%").count()).isEqualTo(0L);
+    assertThat(query.decisionRequirementsDefinitionKeyLike("%notExisting%").count()).isZero();
 
     assertThat(query.decisionRequirementsDefinitionKeyLike("%sco%").count()).isEqualTo(1L);
     assertThat(query.decisionRequirementsDefinitionKeyLike("%dis%").count()).isEqualTo(2L);
@@ -110,7 +110,7 @@ public class DecisionRequirementsDefinitionQueryTest {
   public void queryByDecisionRequirementsDefinitionName() {
     DecisionRequirementsDefinitionQuery query = repositoryService.createDecisionRequirementsDefinitionQuery();
 
-    assertThat(query.decisionRequirementsDefinitionName("notExisting").count()).isEqualTo(0L);
+    assertThat(query.decisionRequirementsDefinitionName("notExisting").count()).isZero();
 
     assertThat(query.decisionRequirementsDefinitionName("Score").count()).isEqualTo(1L);
     assertThat(query.singleResult().getKey()).isEqualTo("score");
@@ -120,7 +120,7 @@ public class DecisionRequirementsDefinitionQueryTest {
   public void queryByDecisionRequirementsDefinitionNameLike() {
     DecisionRequirementsDefinitionQuery query = repositoryService.createDecisionRequirementsDefinitionQuery();
 
-    assertThat(query.decisionRequirementsDefinitionNameLike("%notExisting%").count()).isEqualTo(0L);
+    assertThat(query.decisionRequirementsDefinitionNameLike("%notExisting%").count()).isZero();
 
     assertThat(query.decisionRequirementsDefinitionNameLike("%Sco%").count()).isEqualTo(1L);
     assertThat(query.decisionRequirementsDefinitionNameLike("%ish%").count()).isEqualTo(2L);
@@ -130,7 +130,7 @@ public class DecisionRequirementsDefinitionQueryTest {
   public void queryByDecisionRequirementsDefinitionCategory() {
     DecisionRequirementsDefinitionQuery query = repositoryService.createDecisionRequirementsDefinitionQuery();
 
-    assertThat(query.decisionRequirementsDefinitionCategory("notExisting").count()).isEqualTo(0L);
+    assertThat(query.decisionRequirementsDefinitionCategory("notExisting").count()).isZero();
 
     assertThat(query.decisionRequirementsDefinitionCategory("test-drd-1").count()).isEqualTo(1L);
     assertThat(query.singleResult().getKey()).isEqualTo("score");
@@ -140,7 +140,7 @@ public class DecisionRequirementsDefinitionQueryTest {
   public void queryByDecisionRequirementsDefinitionCategoryLike() {
     DecisionRequirementsDefinitionQuery query = repositoryService.createDecisionRequirementsDefinitionQuery();
 
-    assertThat(query.decisionRequirementsDefinitionCategoryLike("%notExisting%").count()).isEqualTo(0L);
+    assertThat(query.decisionRequirementsDefinitionCategoryLike("%notExisting%").count()).isZero();
 
     assertThat(query.decisionRequirementsDefinitionCategoryLike("%test%").count()).isEqualTo(3L);
 
@@ -151,7 +151,7 @@ public class DecisionRequirementsDefinitionQueryTest {
   public void queryByResourceName() {
     DecisionRequirementsDefinitionQuery query = repositoryService.createDecisionRequirementsDefinitionQuery();
 
-    assertThat(query.decisionRequirementsDefinitionResourceName("notExisting").count()).isEqualTo(0L);
+    assertThat(query.decisionRequirementsDefinitionResourceName("notExisting").count()).isZero();
 
     assertThat(query.decisionRequirementsDefinitionResourceName(DRD_SCORE_RESOURCE).count()).isEqualTo(1L);
     assertThat(query.singleResult().getKey()).isEqualTo("score");
@@ -161,7 +161,7 @@ public class DecisionRequirementsDefinitionQueryTest {
   public void queryByResourceNameLike() {
     DecisionRequirementsDefinitionQuery query = repositoryService.createDecisionRequirementsDefinitionQuery();
 
-    assertThat(query.decisionRequirementsDefinitionResourceNameLike("%notExisting%").count()).isEqualTo(0L);
+    assertThat(query.decisionRequirementsDefinitionResourceNameLike("%notExisting%").count()).isZero();
 
     assertThat(query.decisionRequirementsDefinitionResourceNameLike("%.dmn11.xml%").count()).isEqualTo(4L);
   }
@@ -179,7 +179,7 @@ public class DecisionRequirementsDefinitionQueryTest {
 
     assertThat(query.decisionRequirementsDefinitionVersion(1).count()).isEqualTo(3L);
     assertThat(query.decisionRequirementsDefinitionVersion(2).count()).isEqualTo(1L);
-    assertThat(query.decisionRequirementsDefinitionVersion(3).count()).isEqualTo(0L);
+    assertThat(query.decisionRequirementsDefinitionVersion(3).count()).isZero();
   }
 
   @Test
@@ -194,7 +194,7 @@ public class DecisionRequirementsDefinitionQueryTest {
   public void queryByDeploymentId() {
     DecisionRequirementsDefinitionQuery query = repositoryService.createDecisionRequirementsDefinitionQuery();
 
-    assertThat(query.deploymentId("notExisting").count()).isEqualTo(0L);
+    assertThat(query.deploymentId("notExisting").count()).isZero();
 
     assertThat(query.deploymentId(firstDeploymentId).count()).isEqualTo(2L);
     assertThat(query.deploymentId(secondDeploymentId).count()).isEqualTo(1L);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DeleteProcessDefinitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DeleteProcessDefinitionTest.java
@@ -16,24 +16,11 @@
  */
 package org.operaton.bpm.engine.test.api.repository;
 
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertNull;
-import static junit.framework.TestCase.assertTrue;
-import static junit.framework.TestCase.fail;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.operaton.bpm.engine.test.api.repository.RedeploymentTest.DEPLOYMENT_NAME;
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import org.operaton.bpm.engine.HistoryService;
-import org.operaton.bpm.engine.ManagementService;
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.RuntimeService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.delegate.ExecutionListener;
 import org.operaton.bpm.engine.exception.NotFoundException;
 import org.operaton.bpm.engine.exception.NullValueException;
@@ -51,10 +38,17 @@ import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.commons.utils.cache.Cache;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static junit.framework.TestCase.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.operaton.bpm.engine.test.api.repository.RedeploymentTest.DEPLOYMENT_NAME;
 
 /**
  *
@@ -425,7 +419,7 @@ public class DeleteProcessDefinitionTest {
     List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
 
     // then
-    assertThat(processDefinitions.size()).isZero();
+    assertThat(processDefinitions).isEmpty();
   }
 
   @Test
@@ -565,7 +559,7 @@ public class DeleteProcessDefinitionTest {
     List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
 
     // then
-    assertThat(processDefinitions.size()).isZero();
+    assertThat(processDefinitions).isEmpty();
   }
 
   private void deployTwoProcessDefinitions() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DeleteProcessDefinitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DeleteProcessDefinitionTest.java
@@ -402,7 +402,7 @@ public class DeleteProcessDefinitionTest {
       .delete();
 
     // then
-    assertThat(IncrementCounterListener.counter).isEqualTo(0);
+    assertThat(IncrementCounterListener.counter).isZero();
   }
 
   @Test
@@ -425,7 +425,7 @@ public class DeleteProcessDefinitionTest {
     List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
 
     // then
-    assertThat(processDefinitions.size()).isEqualTo(0);
+    assertThat(processDefinitions.size()).isZero();
   }
 
   @Test
@@ -541,7 +541,7 @@ public class DeleteProcessDefinitionTest {
       .delete();
 
     // then
-    assertThat(IncrementCounterListener.counter).isEqualTo(0);
+    assertThat(IncrementCounterListener.counter).isZero();
   }
 
   @Test
@@ -565,7 +565,7 @@ public class DeleteProcessDefinitionTest {
     List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
 
     // then
-    assertThat(processDefinitions.size()).isEqualTo(0);
+    assertThat(processDefinitions.size()).isZero();
   }
 
   private void deployTwoProcessDefinitions() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DeleteProcessDefinitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DeleteProcessDefinitionTest.java
@@ -372,9 +372,9 @@ public class DeleteProcessDefinitionTest {
       .delete();
 
     // then
-    assertThat(historyService.createHistoricVariableInstanceQuery().count()).isEqualTo(0L);
-    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0L);
-    assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricVariableInstanceQuery().count()).isZero();
+    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isZero();
+    assertThat(repositoryService.createProcessDefinitionQuery().count()).isZero();
   }
 
   @Test
@@ -512,9 +512,9 @@ public class DeleteProcessDefinitionTest {
       .delete();
 
     // then
-    assertThat(historyService.createHistoricVariableInstanceQuery().count()).isEqualTo(0L);
-    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0L);
-    assertThat(repositoryService.createProcessDefinitionQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricVariableInstanceQuery().count()).isZero();
+    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isZero();
+    assertThat(repositoryService.createProcessDefinitionQuery().count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/HistoryTimeToLiveDeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/HistoryTimeToLiveDeploymentTest.java
@@ -197,7 +197,7 @@ public class HistoryTimeToLiveDeploymentTest {
         .addClasspathResource("org/operaton/bpm/engine/test/api/repository/version1.bpmn20.xml"));
 
     // then
-    assertThat(loggingRule.getFilteredLog(EXPECTED_DEFAULT_CONFIG_MSG)).hasSize(0);
+    assertThat(loggingRule.getFilteredLog(EXPECTED_DEFAULT_CONFIG_MSG)).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
@@ -303,7 +303,7 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
       assertThat(found).withFailMessage("Expected to find process definition " + processDefinition);
     }
 
-    assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionKey("dummyKey").processDefinitionKeysIn(processDefinitionKeys).count()).isEqualTo(0);
+    assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionKey("dummyKey").processDefinitionKeysIn(processDefinitionKeys).count()).isZero();
   }
 
   @Test
@@ -492,7 +492,7 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
 
     assertThat(repositoryService.createProcessDefinitionQuery()
       .messageEventSubscriptionName("bogus")
-      .count()).isEqualTo(0);
+      .count()).isZero();
 
     repositoryService.deleteDeployment(deployment.getId());
   }
@@ -662,7 +662,7 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
       assertThat(found).withFailMessage("Expected to find process definition " + processDefinition);
     }
 
-    assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionId("dummyId").processDefinitionIdIn(ids).count()).isEqualTo(0);
+    assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionId("dummyId").processDefinitionIdIn(ids).count()).isZero();
   }
 
   @Test
@@ -919,7 +919,7 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
         .deploymentId(deploymentId1)
         .notStartableInTasklist()
         .count();
-    assertThat(processes).isEqualTo(0);
+    assertThat(processes).isZero();
 
     // deploy second version
     // startable super process

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
@@ -176,7 +176,7 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     // when
     processDefinitions = repositoryService.createProcessDefinitionQuery().deployedAfter(timeAfterDeploymentThree).list();
     // then
-    assertThat(processDefinitions).hasSize(0);
+    assertThat(processDefinitions).isEmpty();
   }
 
   @Test
@@ -219,7 +219,7 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     assertThatProcessDefinitionsWereDeployedAt(processDefinitions, timeAtDeploymentThree);
 
     processDefinitions = repositoryService.createProcessDefinitionQuery().deployedAt(DateUtils.addSeconds(ClockUtil.getCurrentTime(), 5)).list();
-    assertThat(processDefinitions).hasSize(0);
+    assertThat(processDefinitions).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
@@ -16,18 +16,10 @@
  */
 package org.operaton.bpm.engine.test.api.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.processDefinitionByDeployTime;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySortingAndCount;
-
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.time.DateUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.engine.repository.Deployment;
@@ -37,9 +29,16 @@ import org.operaton.bpm.engine.runtime.Incident;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.*;
 
 
 /**
@@ -113,7 +112,7 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     assertThat(processDefinition.getDescription()).isNull();
     assertThat(processDefinition.getId().startsWith("xyz_:1"));
     assertThat(processDefinition.getCategory()).isEqualTo("xyz_");
-    assertThat(processDefinition.isStartableInTasklist()).isEqualTo(false);
+    assertThat(processDefinition.isStartableInTasklist()).isFalse();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
@@ -89,7 +89,7 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     assertThat(processDefinition.getDescription()).isEqualTo("Desc one");
     assertThat(processDefinition.getId()).startsWith("one:1");
     assertThat(processDefinition.getCategory()).isEqualTo("Examples");
-    assertThat(processDefinition.isStartableInTasklist()).isEqualTo(true);
+    assertThat(processDefinition.isStartableInTasklist()).isTrue();
 
     processDefinition = processDefinitions.get(1);
     assertThat(processDefinition.getKey()).isEqualTo("one");
@@ -97,7 +97,7 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     assertThat(processDefinition.getDescription()).isEqualTo("Desc one");
     assertThat(processDefinition.getId()).startsWith("one:2");
     assertThat(processDefinition.getCategory()).isEqualTo("Examples");
-    assertThat(processDefinition.isStartableInTasklist()).isEqualTo(true);
+    assertThat(processDefinition.isStartableInTasklist()).isTrue();
 
     processDefinition = processDefinitions.get(2);
     assertThat(processDefinition.getKey()).isEqualTo("two");
@@ -105,7 +105,7 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     assertThat(processDefinition.getDescription()).isNull();
     assertThat(processDefinition.getId().startsWith("two:1"));
     assertThat(processDefinition.getCategory()).isEqualTo("Examples2");
-    assertThat(processDefinition.isStartableInTasklist()).isEqualTo(true);
+    assertThat(processDefinition.isStartableInTasklist()).isTrue();
 
     processDefinition = processDefinitions.get(3);
     assertThat(processDefinition.getKey()).isEqualTo("xyz_");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
@@ -465,7 +465,7 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     // Typical use case
     query = repositoryService.createProcessDefinitionQuery().orderByProcessDefinitionKey().asc().orderByProcessDefinitionVersion().desc();
     List<ProcessDefinition> processDefinitions = query.list();
-    assertThat(processDefinitions.size()).isEqualTo(4);
+    assertThat(processDefinitions).hasSize(4);
 
     assertThat(processDefinitions.get(0).getKey()).isEqualTo("one");
     assertThat(processDefinitions.get(0).getVersion()).isEqualTo(2);
@@ -509,7 +509,7 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     testRule.waitForJobExecutorToProcessAllJobs();
 
     List<Incident> incidentList = runtimeService.createIncidentQuery().list();
-    assertThat(incidentList.size()).isEqualTo(1);
+    assertThat(incidentList).hasSize(1);
 
     Incident incident = runtimeService.createIncidentQuery().processInstanceId(processInstance.getId()).singleResult();
 
@@ -577,7 +577,7 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     testRule.waitForJobExecutorToProcessAllJobs();
 
     List<Incident> incidentList = runtimeService.createIncidentQuery().list();
-    assertThat(incidentList.size()).isEqualTo(1);
+    assertThat(incidentList).hasSize(1);
 
     Incident incident = runtimeService.createIncidentQuery().processInstanceId(processInstance.getId()).singleResult();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CorrelateAllMessageBatchTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CorrelateAllMessageBatchTest.java
@@ -557,7 +557,7 @@ public class CorrelateAllMessageBatchTest {
       .operationType(UserOperationLogEntry.OPERATION_TYPE_SET_VARIABLE)
       .list();
 
-    assertThat(logs.size()).isEqualTo(0);
+    assertThat(logs.size()).isZero();
 
     // clear
     managementService.deleteBatch(batch.getId(), true);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CorrelateAllMessageBatchTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CorrelateAllMessageBatchTest.java
@@ -16,24 +16,13 @@
  */
 package org.operaton.bpm.engine.test.api.runtime;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.tuple;
-import static java.util.stream.Stream.of;
-import static java.util.stream.Collectors.toSet;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-
 import org.assertj.core.api.Assertions;
-import org.operaton.bpm.engine.BadUserRequestException;
-import org.operaton.bpm.engine.HistoryService;
-import org.operaton.bpm.engine.ManagementService;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.RuntimeService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.batch.history.HistoricBatch;
 import org.operaton.bpm.engine.exception.NullValueException;
@@ -54,11 +43,15 @@ import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Stream.of;
+import static org.assertj.core.api.Assertions.*;
 
 public class CorrelateAllMessageBatchTest {
 
@@ -557,7 +550,7 @@ public class CorrelateAllMessageBatchTest {
       .operationType(UserOperationLogEntry.OPERATION_TYPE_SET_VARIABLE)
       .list();
 
-    assertThat(logs.size()).isZero();
+    assertThat(logs).isEmpty();
 
     // clear
     managementService.deleteBatch(batch.getId(), true);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CorrelateAllMessageBatchTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CorrelateAllMessageBatchTest.java
@@ -130,17 +130,17 @@ public class CorrelateAllMessageBatchTest {
       .processInstanceId(processInstanceIdThree);
 
     // assume
-    assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(0L);
-    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
-    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceOne.count()).isZero();
+    assertThat(taskExecutionQueryInstanceTwo.count()).isZero();
+    assertThat(taskExecutionQueryInstanceThree.count()).isZero();
 
     // when
     rule.syncExec(batch);
 
     // then
     assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(1L);
-    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
-    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceTwo.count()).isZero();
+    assertThat(taskExecutionQueryInstanceThree.count()).isZero();
   }
 
   @Test
@@ -169,17 +169,17 @@ public class CorrelateAllMessageBatchTest {
       .processInstanceId(processInstanceIdThree);
 
     // assume
-    assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(0L);
-    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
-    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceOne.count()).isZero();
+    assertThat(taskExecutionQueryInstanceTwo.count()).isZero();
+    assertThat(taskExecutionQueryInstanceThree.count()).isZero();
 
     // when
     rule.syncExec(batch);
 
     // then
     assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(1L);
-    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
-    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceTwo.count()).isZero();
+    assertThat(taskExecutionQueryInstanceThree.count()).isZero();
   }
 
   @Test
@@ -208,17 +208,17 @@ public class CorrelateAllMessageBatchTest {
       .processInstanceId(processInstanceIdThree);
 
     // assume
-    assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(0L);
-    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
-    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceOne.count()).isZero();
+    assertThat(taskExecutionQueryInstanceTwo.count()).isZero();
+    assertThat(taskExecutionQueryInstanceThree.count()).isZero();
 
     // when
     rule.syncExec(batch);
 
     // then
     assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(1L);
-    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
-    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceTwo.count()).isZero();
+    assertThat(taskExecutionQueryInstanceThree.count()).isZero();
   }
 
   @Test
@@ -246,16 +246,16 @@ public class CorrelateAllMessageBatchTest {
       .processInstanceId(processInstanceIdThree);
 
     // assume
-    assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(0L);
-    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
-    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceOne.count()).isZero();
+    assertThat(taskExecutionQueryInstanceTwo.count()).isZero();
+    assertThat(taskExecutionQueryInstanceThree.count()).isZero();
 
     // when
     rule.syncExec(batch);
 
     // then
     assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(1L);
-    assertThat(taskExecutionQueryInstanceTwo.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceTwo.count()).isZero();
     assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(1L);
   }
 
@@ -279,15 +279,15 @@ public class CorrelateAllMessageBatchTest {
       .processDefinitionKey(PROCESS_THREE_KEY);
 
     // assume
-    assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(0L);
-    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceOne.count()).isZero();
+    assertThat(taskExecutionQueryInstanceThree.count()).isZero();
 
     // when
     rule.syncExec(batch);
 
     // then
     assertThat(taskExecutionQueryInstanceOne.count()).isEqualTo(1L);
-    assertThat(taskExecutionQueryInstanceThree.count()).isEqualTo(0L);
+    assertThat(taskExecutionQueryInstanceThree.count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CreateAndResolveIncidentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CreateAndResolveIncidentTest.java
@@ -280,7 +280,7 @@ public class CreateAndResolveIncidentTest {
     assertThat(deleteContext.getConfiguration()).isEqualTo("configuration");
 
     long numIncidents = runtimeService.createIncidentQuery().count();
-    assertThat(numIncidents).isEqualTo(0);
+    assertThat(numIncidents).isZero();
   }
 
   @Test
@@ -306,7 +306,7 @@ public class CreateAndResolveIncidentTest {
     assertThat(deleteContext.getConfiguration()).isEqualTo(job.getId());
 
     long numIncidents = runtimeService.createIncidentQuery().count();
-    assertThat(numIncidents).isEqualTo(0);
+    assertThat(numIncidents).isZero();
   }
 
   @Test
@@ -334,7 +334,7 @@ public class CreateAndResolveIncidentTest {
     assertThat(deleteContext.getConfiguration()).isEqualTo(task.getId());
 
     long numIncidents = runtimeService.createIncidentQuery().count();
-    assertThat(numIncidents).isEqualTo(0);
+    assertThat(numIncidents).isZero();
   }
 
   @Test
@@ -359,7 +359,7 @@ public class CreateAndResolveIncidentTest {
     assertThat(deleteContext.getConfiguration()).isEqualTo(job.getId());
 
     long numIncidents = runtimeService.createIncidentQuery().count();
-    assertThat(numIncidents).isEqualTo(0);
+    assertThat(numIncidents).isZero();
   }
 
   @Test
@@ -386,7 +386,7 @@ public class CreateAndResolveIncidentTest {
     assertThat(resolveContext.getConfiguration()).isEqualTo(task.getId());
 
     long numIncidents = runtimeService.createIncidentQuery().count();
-    assertThat(numIncidents).isEqualTo(0);
+    assertThat(numIncidents).isZero();
   }
 
   public static class CustomIncidentHandler implements IncidentHandler {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/IncidentUserOperationLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/IncidentUserOperationLogTest.java
@@ -41,7 +41,7 @@ public class IncidentUserOperationLogTest extends PluggableProcessEngineTest {
     // given
     testRule.deploy(ProcessModels.TWO_TASKS_PROCESS);
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("Process");
-    assertThat(historyService.createUserOperationLogQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createUserOperationLogQuery().count()).isZero();
 
     // when
     Incident incident = doAuthenticated(() -> runtimeService.createIncident("foo", processInstance.getId(), "aa", "bar"));
@@ -75,13 +75,13 @@ public class IncidentUserOperationLogTest extends PluggableProcessEngineTest {
   @Test
   public void shouldNotLogIncidentCreationFailure() {
     // given
-    assertThat(historyService.createUserOperationLogQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createUserOperationLogQuery().count()).isZero();
 
     // when/then
     assertThatThrownBy(() -> runtimeService.createIncident("foo", null, "userTask1", "bar"))
       .isInstanceOf(BadUserRequestException.class);
 
-    assertThat(historyService.createUserOperationLogQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createUserOperationLogQuery().count()).isZero();
   }
 
   @Test
@@ -90,7 +90,7 @@ public class IncidentUserOperationLogTest extends PluggableProcessEngineTest {
     testRule.deploy(ProcessModels.TWO_TASKS_PROCESS);
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("Process");
     Incident incident = runtimeService.createIncident("foo", processInstance.getId(), "userTask1", "bar");
-    assertThat(historyService.createUserOperationLogQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createUserOperationLogQuery().count()).isZero();
 
     // when
     doAuthenticated(() -> runtimeService.resolveIncident(incident.getId()));
@@ -113,13 +113,13 @@ public class IncidentUserOperationLogTest extends PluggableProcessEngineTest {
   @Test
   public void shouldNotLogIncidentResolutionFailure() {
     // given
-    assertThat(historyService.createUserOperationLogQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createUserOperationLogQuery().count()).isZero();
 
     // when/then
     assertThatThrownBy(() -> runtimeService.resolveIncident("foo"))
       .isInstanceOf(NotFoundException.class);
 
-    assertThat(historyService.createUserOperationLogQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createUserOperationLogQuery().count()).isZero();
   }
 
   @Test
@@ -131,7 +131,7 @@ public class IncidentUserOperationLogTest extends PluggableProcessEngineTest {
     Incident incident = runtimeService.createIncident("foo", processInstance.getId(), "userTask1", "bar");
 
     // assume
-    assertThat(historyService.createUserOperationLogQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createUserOperationLogQuery().count()).isZero();
 
     // when
     doAuthenticated(() -> runtimeService.setAnnotationForIncidentById(incident.getId(), annotation));
@@ -155,7 +155,7 @@ public class IncidentUserOperationLogTest extends PluggableProcessEngineTest {
     Incident incident = runtimeService.createIncident("foo", processInstance.getId(), "userTask1", "bar");
 
     // assume
-    assertThat(historyService.createUserOperationLogQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createUserOperationLogQuery().count()).isZero();
 
     // when
     doAuthenticated(() -> runtimeService.clearAnnotationForIncidentById(incident.getId()));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationSubProcessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationSubProcessTest.java
@@ -149,7 +149,7 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then the process should be finished
-    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
   }
 
   @Test
@@ -235,7 +235,7 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then the process should be finished
-    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
   }
 
@@ -324,7 +324,7 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then the process should be finished
-    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
   }
 
@@ -414,7 +414,7 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then the process should be finished
-    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
   }
 
   @Test
@@ -510,7 +510,7 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then the process should be finished
-    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
   }
 
   @Test
@@ -605,7 +605,7 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then
-    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
   }
 
   @Test
@@ -655,7 +655,7 @@ public class ProcessInstanceModificationSubProcessTest {
       .execute();
 
     // then
-    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryOrTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryOrTest.java
@@ -558,7 +558,7 @@ public class ProcessInstanceQueryOrTest {
         .list();
 
     // then
-    assertThat(processInstances.size()).isEqualTo(2);
+    assertThat(processInstances).hasSize(2);
   }
 
   @Test
@@ -597,7 +597,7 @@ public class ProcessInstanceQueryOrTest {
         .list();
 
     // then
-    assertThat(processInstances.size()).isEqualTo(2);
+    assertThat(processInstances).hasSize(2);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -16,44 +16,17 @@
  */
 package org.operaton.bpm.engine.test.api.runtime;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.processInstanceByBusinessKey;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.processInstanceByProcessDefinitionId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.processInstanceByProcessInstanceId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.operaton.bpm.engine.CaseService;
-import org.operaton.bpm.engine.ManagementService;
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.RuntimeService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.exception.NullValueException;
 import org.operaton.bpm.engine.impl.ProcessInstanceQueryImpl;
 import org.operaton.bpm.engine.impl.util.ImmutablePair;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
-import org.operaton.bpm.engine.runtime.Execution;
-import org.operaton.bpm.engine.runtime.Incident;
-import org.operaton.bpm.engine.runtime.Job;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.runtime.ProcessInstanceQuery;
+import org.operaton.bpm.engine.runtime.*;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
@@ -63,11 +36,14 @@ import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.*;
 
 /**
  * @author Joram Barrez
@@ -286,7 +262,7 @@ public class ProcessInstanceQueryTest {
 
     // then
     assertThat(query.count()).isEqualTo(0l);
-    assertThat(query.list().size()).isZero();
+    assertThat(query.list()).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -286,7 +286,7 @@ public class ProcessInstanceQueryTest {
 
     // then
     assertThat(query.count()).isEqualTo(0l);
-    assertThat(query.list().size()).isEqualTo(0);
+    assertThat(query.list().size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -275,7 +275,7 @@ public class ProcessInstanceQueryTest {
 
     // then
     assertThat(query.count()).isEqualTo(5l);
-    assertThat(query.list().size()).isEqualTo(5);
+    assertThat(query.list()).hasSize(5);
   }
 
   @Test
@@ -331,7 +331,7 @@ public class ProcessInstanceQueryTest {
 
     // then
     assertThat(query.count()).isEqualTo(2l);
-    assertThat(query.list().size()).isEqualTo(2);
+    assertThat(query.list()).hasSize(2);
   }
 
   @Test
@@ -342,7 +342,7 @@ public class ProcessInstanceQueryTest {
 
     // then
     assertThat(query.count()).isEqualTo(5l);
-    assertThat(query.list().size()).isEqualTo(5);
+    assertThat(query.list()).hasSize(5);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -261,7 +261,7 @@ public class ProcessInstanceQueryTest {
       .processDefinitionKeyIn("not-existing-key");
 
     // then
-    assertThat(query.count()).isEqualTo(0l);
+    assertThat(query.count()).isZero();
     assertThat(query.list()).isEmpty();
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceTerminationCascadeStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceTerminationCascadeStateTest.java
@@ -204,7 +204,7 @@ public class ProcessInstanceTerminationCascadeStateTest {
 
   protected void assertHistoricProcessInstances() {
     List<HistoricProcessInstance> historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
-    assertThat(historicProcessInstances.size()).isEqualTo(2);
+    assertThat(historicProcessInstances).hasSize(2);
     for (HistoricProcessInstance historicProcessInstance : historicProcessInstances) {
       assertThat(historicProcessInstance.getState())
           .isEqualTo(externallyTerminated ? HistoricProcessInstance.STATE_EXTERNALLY_TERMINATED : HistoricProcessInstance.STATE_INTERNALLY_TERMINATED);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RootProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RootProcessInstanceTest.java
@@ -195,8 +195,8 @@ public class RootProcessInstanceTest {
     assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(5L);
     assertThat(callingProcessInstance.getProcessInstanceId()).isNotNull();
 
-    assertThat(calledProcessInstances.size()).isEqualTo(2);
-    assertThat(calledAndCallingProcessInstances.size()).isEqualTo(2);
+    assertThat(calledProcessInstances).hasSize(2);
+    assertThat(calledAndCallingProcessInstances).hasSize(2);
 
     // then
     assertThat(callingProcessInstance.getRootProcessInstanceId()).isEqualTo(callingProcessInstance.getProcessInstanceId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceAsyncOperationsTest.java
@@ -16,18 +16,11 @@
  */
 package org.operaton.bpm.engine.test.api.runtime;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.batch.Batch;
@@ -47,10 +40,16 @@ import org.operaton.bpm.engine.test.api.runtime.util.IncrementCounterListener;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.*;
+import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
 
 
 /**
@@ -156,7 +155,7 @@ public class RuntimeServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     // then
     assertEquals(0, exceptions.size());
 
-    assertThat(managementService.createJobQuery().withException().list().size()).isZero();
+    assertThat(managementService.createJobQuery().withException().list()).isEmpty();
 
     processIds.remove("aFake");
     assertHistoricTaskDeletionPresent(processIds, TESTING_INSTANCE_DELETE, testRule);
@@ -330,7 +329,7 @@ public class RuntimeServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
   }
 
   protected void assertProcessInstancesAreDeleted() {
-    assertThat(runtimeService.createProcessInstanceQuery().list().size()).isZero();
+    assertThat(runtimeService.createProcessInstanceQuery().list()).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceAsyncOperationsTest.java
@@ -434,8 +434,8 @@ public class RuntimeServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     testRule.assertProcessEnded(instanceId1);
     testRule.assertProcessEnded(instanceId2);
 
-    assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(instanceId1).list().size()).isEqualTo(2);
-    assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(instanceId2).list().size()).isEqualTo(2);
+    assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(instanceId1).list()).hasSize(2);
+    assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(instanceId2).list()).hasSize(2);
     assertThat(historyService.createHistoricVariableInstanceQuery().variableName("inputMappingExecuted").count()).isEqualTo(2);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceAsyncOperationsTest.java
@@ -156,7 +156,7 @@ public class RuntimeServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     // then
     assertEquals(0, exceptions.size());
 
-    assertThat(managementService.createJobQuery().withException().list().size()).isEqualTo(0);
+    assertThat(managementService.createJobQuery().withException().list().size()).isZero();
 
     processIds.remove("aFake");
     assertHistoricTaskDeletionPresent(processIds, TESTING_INSTANCE_DELETE, testRule);
@@ -330,7 +330,7 @@ public class RuntimeServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
   }
 
   protected void assertProcessInstancesAreDeleted() {
-    assertThat(runtimeService.createProcessInstanceQuery().list().size()).isEqualTo(0);
+    assertThat(runtimeService.createProcessInstanceQuery().list().size()).isZero();
   }
 
   @Test
@@ -355,7 +355,7 @@ public class RuntimeServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
     executeBatchJobs(batch);
 
     // then
-    assertThat(IncrementCounterListener.counter).isEqualTo(0);
+    assertThat(IncrementCounterListener.counter).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.java
@@ -246,7 +246,7 @@ public class RuntimeServiceTest {
     // if we skip the custom listeners,
     runtimeService.deleteProcessInstances(Arrays.asList(processInstance.getId(),processInstance2.getId()), null, false, false);
 
-    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0l);
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
   }
 
   @Deployment

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/SetVariablesBatchTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/SetVariablesBatchTest.java
@@ -16,24 +16,13 @@
  */
 package org.operaton.bpm.engine.test.api.runtime;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.tuple;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.assertj.core.api.Assertions;
-import org.operaton.bpm.engine.BadUserRequestException;
-import org.operaton.bpm.engine.HistoryService;
-import org.operaton.bpm.engine.ManagementService;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.RuntimeService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.batch.history.HistoricBatch;
 import org.operaton.bpm.engine.exception.NullValueException;
@@ -54,11 +43,10 @@ import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
 
 public class SetVariablesBatchTest {
 
@@ -665,7 +653,7 @@ public class SetVariablesBatchTest {
         .operationType(UserOperationLogEntry.OPERATION_TYPE_SET_VARIABLE)
         .list();
 
-    assertThat(logs.size()).isZero();
+    assertThat(logs).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/SetVariablesBatchTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/SetVariablesBatchTest.java
@@ -665,7 +665,7 @@ public class SetVariablesBatchTest {
         .operationType(UserOperationLogEntry.OPERATION_TYPE_SET_VARIABLE)
         .list();
 
-    assertThat(logs.size()).isEqualTo(0);
+    assertThat(logs.size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/TransientVariableTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/TransientVariableTest.java
@@ -656,7 +656,7 @@ public class TransientVariableTest {
           .createVariableInstanceQuery()
           .count();
 
-    assertThat(numVariables).isEqualTo(0);
+    assertThat(numVariables).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/TransientVariableTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/TransientVariableTest.java
@@ -698,7 +698,7 @@ public class TransientVariableTest {
 
     // then
     assertThat(runtimeService.createVariableInstanceQuery().variableName(VARIABLE_NAME).count())
-      .isEqualTo(0L);
+      .isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationTest.java
@@ -2095,7 +2095,7 @@ public class MessageCorrelationTest {
     ProcessInstanceQuery processInstanceQuery = runtimeService.createProcessInstanceQuery().processDefinitionKey("messageStartEvent")
         .variableValueEquals("aKey", "aValue");
     assertThat(processInstanceQuery.count()).isEqualTo(1);
-    assertThat(result.getVariables().size()).isEqualTo(1);
+    assertThat(result.getVariables()).hasSize(1);
     assertThat(result.getVariables().getValueTyped("aKey").getValue()).isEqualTo("aValue");
   }
 
@@ -2126,7 +2126,7 @@ public class MessageCorrelationTest {
         .variableValueEquals("aKey", "aValue");
     assertThat(processInstanceQuery.count()).isEqualTo(1);
     MessageCorrelationResultWithVariables result = results.get(0);
-    assertThat(result.getVariables().size()).isEqualTo(1);
+    assertThat(result.getVariables()).hasSize(1);
     assertThat(result.getVariables().getValueTyped("aKey").getValue()).isEqualTo("aValue");
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationTest.java
@@ -1731,7 +1731,7 @@ public class MessageCorrelationTest {
           .createHistoricVariableInstanceQuery()
           .count();
 
-    assertThat(numHistoricVariables).isEqualTo(0);
+    assertThat(numHistoricVariables).isZero();
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationTest.waitForMessageProcess.bpmn20.xml",

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.java
@@ -16,16 +16,11 @@
  */
 package org.operaton.bpm.engine.test.api.runtime.migration;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
-import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.describeActivityInstanceTree;
-import static org.operaton.bpm.engine.test.util.ExecutionAssert.describeExecutionTree;
-import static org.operaton.bpm.engine.test.util.MigratingProcessInstanceValidationReportAssert.assertThat;
-
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
+import org.joda.time.DateTime;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.delegate.TaskListener;
 import org.operaton.bpm.engine.impl.history.HistoryLevel;
 import org.operaton.bpm.engine.impl.jobexecutor.TimerTaskListenerJobHandler;
@@ -48,11 +43,16 @@ import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.bpmn.instance.UserTask;
 import org.operaton.bpm.model.bpmn.instance.operaton.OperatonTaskListener;
-import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
+import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.describeActivityInstanceTree;
+import static org.operaton.bpm.engine.test.util.ExecutionAssert.describeExecutionTree;
+import static org.operaton.bpm.engine.test.util.MigratingProcessInstanceValidationReportAssert.assertThat;
 
 /**
  * @author Thorben Lindhauer
@@ -441,7 +441,7 @@ public class MigrationUserTaskTest {
 
     // then
     testHelper.assertTaskListenerTimerJobCreated("userTask2");
-    assertThat(testHelper.snapshotBeforeMigration.getJobs().size()).isZero();
+    assertThat(testHelper.snapshotBeforeMigration.getJobs()).isEmpty();
     assertThat(testHelper.snapshotAfterMigration.getJobs()).hasSize(1);
 
     // and the task listener was able to access the bpmn model instance and set a variable
@@ -468,7 +468,7 @@ public class MigrationUserTaskTest {
     // then
     testHelper.assertTaskListenerTimerJobRemoved("userTask2");
     assertThat(testHelper.snapshotBeforeMigration.getJobs()).hasSize(1);
-    assertThat(testHelper.snapshotAfterMigration.getJobs().size()).isZero();
+    assertThat(testHelper.snapshotAfterMigration.getJobs()).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.java
@@ -442,7 +442,7 @@ public class MigrationUserTaskTest {
     // then
     testHelper.assertTaskListenerTimerJobCreated("userTask2");
     assertThat(testHelper.snapshotBeforeMigration.getJobs().size()).isZero();
-    assertThat(testHelper.snapshotAfterMigration.getJobs().size()).isEqualTo(1);
+    assertThat(testHelper.snapshotAfterMigration.getJobs()).hasSize(1);
 
     // and the task listener was able to access the bpmn model instance and set a variable
     testTimeoutListenerCanBeTriggered(processInstance, "userTask2");
@@ -467,7 +467,7 @@ public class MigrationUserTaskTest {
 
     // then
     testHelper.assertTaskListenerTimerJobRemoved("userTask2");
-    assertThat(testHelper.snapshotBeforeMigration.getJobs().size()).isEqualTo(1);
+    assertThat(testHelper.snapshotBeforeMigration.getJobs()).hasSize(1);
     assertThat(testHelper.snapshotAfterMigration.getJobs().size()).isZero();
   }
 
@@ -490,8 +490,8 @@ public class MigrationUserTaskTest {
 
     // then
     testHelper.assertTaskListenerTimerJobMigrated("userTask2", "userTask");
-    assertThat(testHelper.snapshotBeforeMigration.getJobs().size()).isEqualTo(1);
-    assertThat(testHelper.snapshotAfterMigration.getJobs().size()).isEqualTo(1);
+    assertThat(testHelper.snapshotBeforeMigration.getJobs()).hasSize(1);
+    assertThat(testHelper.snapshotAfterMigration.getJobs()).hasSize(1);
 
     // and the task listener was able to access the bpmn model instance and set a variable
     testTimeoutListenerCanBeTriggered(processInstance, "userTask");
@@ -519,8 +519,8 @@ public class MigrationUserTaskTest {
     // then
     Date newDueDate = new DateTime(ClockUtil.getCurrentTime()).plusHours(3).toDate();
     testHelper.assertTaskListenerTimerJobMigrated("userTask2", "userTask", newDueDate);
-    assertThat(testHelper.snapshotBeforeMigration.getJobs().size()).isEqualTo(1);
-    assertThat(testHelper.snapshotAfterMigration.getJobs().size()).isEqualTo(1);
+    assertThat(testHelper.snapshotBeforeMigration.getJobs()).hasSize(1);
+    assertThat(testHelper.snapshotAfterMigration.getJobs()).hasSize(1);
 
     // and the task listener was able to access the bpmn model instance and set a variable
     testTimeoutListenerCanBeTriggered(processInstance, "userTask");
@@ -570,8 +570,8 @@ public class MigrationUserTaskTest {
     testHelper.createProcessInstanceAndMigrate(migrationPlan);
 
     // then
-    assertThat(testHelper.snapshotBeforeMigration.getJobs().size()).isEqualTo(2);
-    assertThat(testHelper.snapshotAfterMigration.getJobs().size()).isEqualTo(1);
+    assertThat(testHelper.snapshotBeforeMigration.getJobs()).hasSize(2);
+    assertThat(testHelper.snapshotAfterMigration.getJobs()).hasSize(1);
     JobEntity job = (JobEntity) testHelper.snapshotAfterMigration.getJobs().get(0);
     String jobHandlerConfiguration = job.getJobHandlerConfigurationRaw();
     assertThat(jobHandlerConfiguration).contains("timeout-friendly");
@@ -595,12 +595,12 @@ public class MigrationUserTaskTest {
     testHelper.createProcessInstanceAndMigrate(migrationPlan);
 
     // then
-    assertThat(testHelper.snapshotBeforeMigration.getJobs().size()).isEqualTo(1);
+    assertThat(testHelper.snapshotBeforeMigration.getJobs()).hasSize(1);
     JobEntity job = (JobEntity) testHelper.snapshotBeforeMigration.getJobs().get(0);
     String jobHandlerConfiguration = job.getJobHandlerConfigurationRaw();
     assertThat(jobHandlerConfiguration).contains("timeout-friendly");
 
-    assertThat(testHelper.snapshotAfterMigration.getJobs().size()).isEqualTo(2);
+    assertThat(testHelper.snapshotAfterMigration.getJobs()).hasSize(2);
     job = (JobEntity) testHelper.snapshotAfterMigration.getJobs().get(1);
     jobHandlerConfiguration = job.getJobHandlerConfigurationRaw();
     assertThat(jobHandlerConfiguration).contains("timeout-hard");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationUserTaskTest.java
@@ -441,7 +441,7 @@ public class MigrationUserTaskTest {
 
     // then
     testHelper.assertTaskListenerTimerJobCreated("userTask2");
-    assertThat(testHelper.snapshotBeforeMigration.getJobs().size()).isEqualTo(0);
+    assertThat(testHelper.snapshotBeforeMigration.getJobs().size()).isZero();
     assertThat(testHelper.snapshotAfterMigration.getJobs().size()).isEqualTo(1);
 
     // and the task listener was able to access the bpmn model instance and set a variable
@@ -468,7 +468,7 @@ public class MigrationUserTaskTest {
     // then
     testHelper.assertTaskListenerTimerJobRemoved("userTask2");
     assertThat(testHelper.snapshotBeforeMigration.getJobs().size()).isEqualTo(1);
-    assertThat(testHelper.snapshotAfterMigration.getJobs().size()).isEqualTo(0);
+    assertThat(testHelper.snapshotAfterMigration.getJobs().size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryExpressionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryExpressionTest.java
@@ -580,7 +580,7 @@ public class TaskQueryExpressionTest {
     // execute query so expression will be evaluated
     taskQuery.count();
 
-    assertThat(taskQuery.getCandidateGroups().size()).isEqualTo(1);
+    assertThat(taskQuery.getCandidateGroups()).hasSize(1);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
@@ -16,46 +16,9 @@
  */
 package org.operaton.bpm.engine.test.api.task;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.taskByAssignee;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.taskByCaseExecutionId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.taskByCaseInstanceId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.taskByCreateTime;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.taskByDescription;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.taskByDueDate;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.taskByExecutionId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.taskByFollowUpDate;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.taskById;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.taskByName;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.taskByPriority;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.taskByProcessInstanceId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySortingAndCount;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -82,9 +45,16 @@ import org.operaton.bpm.engine.variable.type.ValueType;
 import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.*;
+import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.*;
 
 /**
  * @author Joram Barrez
@@ -5508,7 +5478,7 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     List<Task> tasks = taskService.createTaskQuery().processInstanceIdIn("nonexisting").list();
 
     // then
-    assertThat(tasks.size()).isZero();
+    assertThat(tasks).isEmpty();
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/task/TaskQueryTest.shouldContainOperatonFormRefIfInitialized.bpmn")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
@@ -278,14 +278,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
     List<Task> tasks = query.list();
     assertNotNull(tasks);
-    assertThat(tasks.size()).isEqualTo(6);
+    assertThat(tasks).hasSize(6);
 
     query = taskService.createTaskQuery();
     query.taskName("TeStTaSk");
 
     tasks = query.list();
     assertNotNull(tasks);
-    assertThat(tasks.size()).isEqualTo(6);
+    assertThat(tasks).hasSize(6);
   }
 
   /**
@@ -301,14 +301,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
     List<Task> tasks = query.list();
     assertNotNull(tasks);
-    assertThat(tasks.size()).isEqualTo(10);
+    assertThat(tasks).hasSize(10);
 
     query = taskService.createTaskQuery();
     query.taskNameLike("%Task%");
 
     tasks = query.list();
     assertNotNull(tasks);
-    assertThat(tasks.size()).isEqualTo(10);
+    assertThat(tasks).hasSize(10);
   }
 
   @Test
@@ -5492,7 +5492,7 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     List<Task> tasks = taskService.createTaskQuery().processInstanceIdIn(instance1, instance2, "nonexisting").list();
 
     // then
-    assertThat(tasks.size()).isEqualTo(2);
+    assertThat(tasks).hasSize(2);
     for (Task task : tasks) {
       assertThat(task.getProcessInstanceId()).isIn(instance1, instance2);
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/variables/AbstractVariableIgnoreCaseTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/variables/AbstractVariableIgnoreCaseTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractVariableIgnoreCaseTest<T extends AbstractVariableQ
   }
 
   protected void assertThatListContainsOnlyExpectedElement(List<U> instances, U instance) {
-    assertThat(instances.size()).isEqualTo(1);
+    assertThat(instances).hasSize(1);
     assertThatTwoInstancesAreEqual(instances.get(0), instance);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/variables/CaseExecutionQueryVariableIgnoreCaseTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/variables/CaseExecutionQueryVariableIgnoreCaseTest.java
@@ -62,7 +62,7 @@ public class CaseExecutionQueryVariableIgnoreCaseTest extends AbstractVariableIg
 
   public void assertThatListContainsOnlyExpectedElements(List<CaseExecution> instances, CaseExecution instance) {
     // normally we would only get one result. here we also get the corresponding CaseInstance
-    assertThat(instances.size()).isEqualTo(2);
+    assertThat(instances).hasSize(2);
     assertThat(instances.get(0).getCaseInstanceId()).isEqualTo(instance.getCaseInstanceId());
     assertThat(instances.get(1).getCaseInstanceId()).isEqualTo(instance.getCaseInstanceId());
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/OperatonFormDefinitionStrictParseTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/OperatonFormDefinitionStrictParseTest.java
@@ -82,7 +82,7 @@ public class OperatonFormDefinitionStrictParseTest {
     // no form definition was created
     List<OperatonFormDefinition> formDefinitions = engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired()
         .execute(new FindOperatonFormDefinitionsCmd());
-    assertThat(formDefinitions).hasSize(0);
+    assertThat(formDefinitions).isEmpty();
 
   }
 
@@ -96,6 +96,6 @@ public class OperatonFormDefinitionStrictParseTest {
       testRule.deploy(FORM);
     }).isInstanceOf(ProcessEngineException.class)
     .hasMessageContaining("ENGINE-09033 Could not parse Operaton Form resource org/operaton/bpm/engine/test/bpmn/OperatonFormDefinitionStrictParseTest.anyForm.form.");
-    assertThat(repositoryService.createDeploymentQuery().list()).hasSize(0);
+    assertThat(repositoryService.createDeploymentQuery().list()).isEmpty();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CallActivityTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CallActivityTest.java
@@ -1860,7 +1860,7 @@ public class CallActivityTest extends PluggableProcessEngineTest {
 
     // and
     long numVariables = runtimeService.createVariableInstanceQuery().count();
-    assertThat(numVariables).isEqualTo(0);
+    assertThat(numVariables).isZero();
   }
 
 
@@ -1893,7 +1893,7 @@ public class CallActivityTest extends PluggableProcessEngineTest {
     // presence of transient variable was asserted in delegate
 
     long numVariables = runtimeService.createVariableInstanceQuery().count();
-    assertThat(numVariables).isEqualTo(0);
+    assertThat(numVariables).isZero();
   }
 
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.java
@@ -16,12 +16,10 @@
  */
 package org.operaton.bpm.engine.test.bpmn.deployment;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.io.InputStream;
-import java.util.List;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.RepositoryServiceImpl;
 import org.operaton.bpm.engine.impl.context.Context;
@@ -32,21 +30,19 @@ import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.operaton.bpm.engine.impl.pvm.ReadOnlyProcessDefinition;
 import org.operaton.bpm.engine.impl.util.IoUtil;
 import org.operaton.bpm.engine.impl.util.ReflectUtil;
-import org.operaton.bpm.engine.repository.DeploymentBuilder;
-import org.operaton.bpm.engine.repository.DeploymentHandlerFactory;
-import org.operaton.bpm.engine.repository.DeploymentWithDefinitions;
-import org.operaton.bpm.engine.repository.ProcessDefinition;
-import org.operaton.bpm.engine.repository.Resource;
+import org.operaton.bpm.engine.repository.*;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.commons.testing.ProcessEngineLoggingRule;
 import org.operaton.commons.testing.WatchLogger;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 /**
@@ -96,8 +92,8 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
     // verify content
     InputStream deploymentInputStream = repositoryService.getResourceAsStream(deploymentId, bpmnResourceName);
     String contentFromDeployment = readInputStreamToString(deploymentInputStream);
-    assertThat(contentFromDeployment.length() > 0).isTrue();
-    assertThat(contentFromDeployment.contains("process id=\"emptyProcess\"")).isTrue();
+    assertThat(contentFromDeployment).isNotEmpty();
+    assertThat(contentFromDeployment).contains("process id=\"emptyProcess\"");
 
     InputStream fileInputStream = ReflectUtil.getResourceAsStream("org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.testGetBpmnXmlFileThroughService.bpmn20.xml");
     String contentFromFile = readInputStreamToString(fileInputStream);
@@ -433,7 +429,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
         .getResourceAsStream(processDefinition.getDeploymentId(),
                              "org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.testProcessDiagramResource.jpg");
     byte[] diagramBytes = IoUtil.readInputStream(diagramStream, "diagram stream");
-    assertThat(diagramBytes.length).isEqualTo(33343);
+    assertThat(diagramBytes).hasSize(33343);
   }
 
   @Deployment(resources={

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.java
@@ -81,7 +81,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
     List<String> deploymentResources = repositoryService.getDeploymentResourceNames(deploymentId);
 
     // verify bpmn file name
-    assertThat(deploymentResources.size()).isEqualTo(1);
+    assertThat(deploymentResources).hasSize(1);
     String bpmnResourceName = "org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.testGetBpmnXmlFileThroughService.bpmn20.xml";
     assertThat(deploymentResources.get(0)).isEqualTo(bpmnResourceName);
 
@@ -132,7 +132,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
     List<String> deploymentResources = repositoryService.getDeploymentResourceNames(deploymentId);
 
     // verify bpmn file name
-    assertThat(deploymentResources.size()).isEqualTo(1);
+    assertThat(deploymentResources).hasSize(1);
     assertThat(deploymentResources.get(0)).isEqualTo(bpmnResourceName);
 
     testRule.deploy(repositoryService.createDeployment()
@@ -155,7 +155,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
         .addClasspathResource(bpmnResourceName));
     // then
     List<org.operaton.bpm.engine.repository.Deployment> deploymentList = repositoryService.createDeploymentQuery().list();
-    assertThat(deploymentList.size()).isEqualTo(2);
+    assertThat(deploymentList).hasSize(2);
   }
 
   @Test
@@ -172,7 +172,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
     testRule.deploy(deploymentBuilder);
     
     // then
-    assertThat(loggingRule.getFilteredLog(CMD_LOGGER, "Deployment name set to null. Filtering duplicates will not work properly.").size()).isEqualTo(1);
+    assertThat(loggingRule.getFilteredLog(CMD_LOGGER, "Deployment name set to null. Filtering duplicates will not work properly.")).hasSize(1);
   }
   
   @Test
@@ -192,7 +192,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
     testRule.deploy(deploymentBuilder);
     
     // then
-    assertThat(loggingRule.getFilteredLog(CMD_LOGGER, "Deployment name set to null. Filtering duplicates will not work properly.").size()).isEqualTo(1);
+    assertThat(loggingRule.getFilteredLog(CMD_LOGGER, "Deployment name set to null. Filtering duplicates will not work properly.")).hasSize(1);
   }
   
   @Test
@@ -261,7 +261,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
       .name("twice"));
 
     List<String> deploymentResources = repositoryService.getDeploymentResourceNames(deployment1.getId());
-    assertThat(deploymentResources.size()).isEqualTo(2);
+    assertThat(deploymentResources).hasSize(2);
 
     BpmnModelInstance changedModel2 = Bpmn.createExecutableProcess("process2").startEvent().endEvent().done();
 
@@ -271,7 +271,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
       .addModelInstance("process2.bpmn20.xml", changedModel2)
       .name("twice"));
     List<org.operaton.bpm.engine.repository.Deployment> deploymentList = repositoryService.createDeploymentQuery().list();
-    assertThat(deploymentList.size()).isEqualTo(2);
+    assertThat(deploymentList).hasSize(2);
 
     // there should be new versions of both processes
     assertThat(repositoryService.createProcessDefinitionQuery().processDefinitionKey("process1").count()).isEqualTo(2);
@@ -288,7 +288,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
       .name("thrice"));
 
     List<String> deploymentResources = repositoryService.getDeploymentResourceNames(deployment1.getId());
-    assertThat(deploymentResources.size()).isEqualTo(2);
+    assertThat(deploymentResources).hasSize(2);
 
     BpmnModelInstance changedModel2 = Bpmn.createExecutableProcess("process2").startEvent().endEvent().done();
 
@@ -299,7 +299,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
       .name("thrice"));
 
     List<org.operaton.bpm.engine.repository.Deployment> deploymentList = repositoryService.createDeploymentQuery().list();
-    assertThat(deploymentList.size()).isEqualTo(2);
+    assertThat(deploymentList).hasSize(2);
 
     // there should be only one version of process 1
     ProcessDefinition process1Definition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("process1").singleResult();
@@ -379,7 +379,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
     List<String> deploymentResources = repositoryService.getDeploymentResourceNames(deploymentId);
 
     // verify bpmn file name
-    assertThat(deploymentResources.size()).isEqualTo(1);
+    assertThat(deploymentResources).hasSize(1);
     assertThat(deploymentResources.get(0)).isEqualTo(bpmnResourceName);
 
     bpmnResourceName = "org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.testProcessDiagramResource.bpmn20.xml";
@@ -388,7 +388,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
         .addClasspathResource(bpmnResourceName)
         .name("twice"));
     List<org.operaton.bpm.engine.repository.Deployment> deploymentList = repositoryService.createDeploymentQuery().list();
-    assertThat(deploymentList.size()).isEqualTo(2);
+    assertThat(deploymentList).hasSize(2);
   }
 
   @Test
@@ -408,11 +408,11 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
     });
 
     assertThat(processDefinitionEntity).isNotNull();
-    assertThat(processDefinitionEntity.getActivities().size()).isEqualTo(7);
+    assertThat(processDefinitionEntity.getActivities()).hasSize(7);
 
     // Check that no diagram has been created
     List<String> resourceNames = repositoryService.getDeploymentResourceNames(processDefinitionEntity.getDeploymentId());
-    assertThat(resourceNames.size()).isEqualTo(1);
+    assertThat(resourceNames).hasSize(1);
   }
 
   @Deployment(resources={
@@ -483,7 +483,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
     String deploymentId = repositoryService.createDeploymentQuery().singleResult().getId();
 
     List<Resource> resources = repositoryService.getDeploymentResources(deploymentId);
-    assertThat(resources.size()).isEqualTo(1);
+    assertThat(resources).hasSize(1);
 
     Resource resource = resources.get(0);
     assertThat(resource.getDeploymentId()).isEqualTo(deploymentId);
@@ -516,7 +516,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
 
     // then deployment contains deployed process definitions
     List<ProcessDefinition> deployedProcessDefinitions = deployment.getDeployedProcessDefinitions();
-    assertThat(deployedProcessDefinitions.size()).isEqualTo(1);
+    assertThat(deployedProcessDefinitions).hasSize(1);
     assertThat(deployment.getDeployedCaseDefinitions()).isNull();;
     assertThat(deployment.getDeployedDecisionDefinitions()).isNull();;
     assertThat(deployment.getDeployedDecisionRequirementsDefinitions()).isNull();;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.java
@@ -117,7 +117,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
     assertThatThrownBy(() -> testRule.deploy(deployment))
       .hasMessageContaining("id can be maximum 64 characters");
     // then
-    assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(0);
+    assertThat(repositoryService.createDeploymentQuery().count()).isZero();
   }
 
   @Test
@@ -364,7 +364,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
         .addClasspathResource(bpmnResourceName2)
         .name("duplicateAtTheSameTime")));
     // then
-    assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(0);
+    assertThat(repositoryService.createDeploymentQuery().count()).isZero();
   }
 
   @Test
@@ -474,7 +474,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
       .hasMessageContaining("ENGINE-01009 Error while parsing process")
       .withFailMessage("Expected exception when deploying process with invalid expression.");
     // then
-    assertThat(repositoryService.createDeploymentQuery().count()).isEqualTo(0);
+    assertThat(repositoryService.createDeploymentQuery().count()).isZero();
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.testGetBpmnXmlFileThroughService.bpmn20.xml"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/compensate/CompensationEventParseInvalidProcessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/compensate/CompensationEventParseInvalidProcessTest.java
@@ -93,7 +93,7 @@ public class CompensationEventParseInvalidProcessTest {
     } catch (ParseException e) {
       assertExceptionMessageContainsText(e, expectedErrorMessage);
       List<Problem> errors = e.getResorceReports().get(0).getErrors();
-      assertThat(errors.size()).isEqualTo(1);
+      assertThat(errors).hasSize(1);
       assertThat(errors.get(0).getMainElementId()).isEqualTo(bpmnElementIds[0]);
       if (bpmnElementIds.length == 2) {
         assertThat(errors.get(0).getElementIds()).containsExactlyInAnyOrder(bpmnElementIds);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
@@ -800,7 +800,7 @@ public class BoundaryTimerNonInterruptingEventTest {
     assertThat(jobQuery.count()).isEqualTo(1);
 
     moveByHours(2);  // execute second job of the new cycle => no more jobs
-    assertThat(jobQuery.count()).isEqualTo(0);
+    assertThat(jobQuery.count()).isZero();
   }
 
   @Test
@@ -837,7 +837,7 @@ public class BoundaryTimerNonInterruptingEventTest {
     assertThat(jobQuery.count()).isEqualTo(1);
 
     moveByHours(1); // execute second job of the new cycle => no more jobs
-    assertThat(jobQuery.count()).isEqualTo(0);
+    assertThat(jobQuery.count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/timer/UpdateDuedateOnRecurringTimerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/timer/UpdateDuedateOnRecurringTimerTest.java
@@ -135,7 +135,7 @@ public class UpdateDuedateOnRecurringTimerTest {
 
     // then
     assertThat(ClockUtil.getCurrentTime()).isAfter(job3.getDuedate());
-    assertThat(managementService.createJobQuery().count()).isEqualTo(0);
+    assertThat(managementService.createJobQuery().count()).isZero();
     // no duplicates
     assertThat(new HashSet<String>(Arrays.asList(job1.getId(), job2.getId(), job3.getId())).size()).isEqualTo(3);
     // job1 is due after 45 minutes (30 + 15 offset)

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/timer/UpdateDuedateOnRecurringTimerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/timer/UpdateDuedateOnRecurringTimerTest.java
@@ -137,7 +137,7 @@ public class UpdateDuedateOnRecurringTimerTest {
     assertThat(ClockUtil.getCurrentTime()).isAfter(job3.getDuedate());
     assertThat(managementService.createJobQuery().count()).isZero();
     // no duplicates
-    assertThat(new HashSet<String>(Arrays.asList(job1.getId(), job2.getId(), job3.getId())).size()).isEqualTo(3);
+    assertThat(new HashSet<String>(Arrays.asList(job1.getId(), job2.getId(), job3.getId()))).hasSize(3);
     // job1 is due after 45 minutes (30 + 15 offset)
     assertThat(job1.getDuedate().getTime()).isEqualTo(t0.getTime() + minutes(45));
     // job2 is due 25 minutes after job1 (keeps offset due to cascade=true and
@@ -212,7 +212,7 @@ public class UpdateDuedateOnRecurringTimerTest {
 
     // then
     // no duplicate jobs
-    assertThat(new HashSet<String>(Arrays.asList(job1.getId(), job2.getId(), job3.getId())).size()).isEqualTo(3);
+    assertThat(new HashSet<String>(Arrays.asList(job1.getId(), job2.getId(), job3.getId()))).hasSize(3);
     // job1 is due at t=15
     assertThat(job1.getDuedate().getTime()).isEqualTo(t0.getTime() + minutes(15));
     // job2 is due 40 minutes after job1 (keeps offset due to cascade=true at
@@ -256,7 +256,7 @@ public class UpdateDuedateOnRecurringTimerTest {
 
     // then
     // no duplicate jobs
-    assertThat(new HashSet<String>(Arrays.asList(job1.getId(), job2.getId(), job3.getId())).size()).isEqualTo(3);
+    assertThat(new HashSet<String>(Arrays.asList(job1.getId(), job2.getId(), job3.getId()))).hasSize(3);
     // job1 is due at t=15
     assertThat(job1.getDuedate().getTime()).isEqualTo(t0.getTime() + minutes(15));
     // job2 is due 15 minutes after job1 (ignores offset due to cascade=false at

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/external/ExternalTaskParseTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/external/ExternalTaskParseTest.java
@@ -46,7 +46,7 @@ public class ExternalTaskParseTest extends PluggableProcessEngineTest {
       fail("exception expected");
     } catch (ParseException e) {
       testRule.assertTextPresent("External tasks must specify a 'topic' attribute in the operaton namespace", e.getMessage());
-      assertThat(e.getResorceReports().get(0).getErrors().size()).isEqualTo(1);
+      assertThat(e.getResorceReports().get(0).getErrors()).hasSize(1);
       assertThat(e.getResorceReports().get(0).getErrors().get(0).getMainElementId()).isEqualTo("externalTask");
     }
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/EventBasedGatewayInputOutputTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/EventBasedGatewayInputOutputTest.java
@@ -101,9 +101,9 @@ public class EventBasedGatewayInputOutputTest extends PluggableProcessEngineTest
     assertThat(VariableLogDelegate.LOCAL_VARIABLES).isEmpty();
     assertThat(historyService.createHistoricVariableInstanceQuery()
         .variableName("eventOutput")
-        .count()).isEqualTo(0L);
+        .count()).isZero();
     assertThat(historyService.createHistoricVariableInstanceQuery()
         .variableName("variable1")
-        .count()).isEqualTo(0L);
+        .count()).isZero();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/InclusiveGatewayTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/InclusiveGatewayTest.java
@@ -794,7 +794,7 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
     testRule.executeAvailableJobs(1);
 
     // then
-    Assertions.assertThat(managementService.createJobQuery().count()).isEqualTo(0);
+    Assertions.assertThat(managementService.createJobQuery().count()).isZero();
     Assertions.assertThat(historyService.createHistoricProcessInstanceQuery().singleResult().getState())
         .isEqualTo("COMPLETED");
   }
@@ -809,7 +809,7 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
     testRule.executeAvailableJobs(1);
 
     // then
-    Assertions.assertThat(managementService.createJobQuery().count()).isEqualTo(0);
+    Assertions.assertThat(managementService.createJobQuery().count()).isZero();
     Assertions.assertThat(historyService.createHistoricProcessInstanceQuery().singleResult().getState())
         .isEqualTo("COMPLETED");
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/multiinstance/MultiInstanceVariablesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/multiinstance/MultiInstanceVariablesTest.java
@@ -67,8 +67,8 @@ public class MultiInstanceVariablesTest {
       engineRule.getTaskService().complete(task.getId());
     }
 
-    assertThat(engineRule.getRuntimeService().createExecutionQuery().processDefinitionKey(SUB_PROCESS_ID).list()).hasSize(0);
-    assertThat(engineRule.getRuntimeService().createExecutionQuery().activityId(CALL_ACTIVITY).list()).hasSize(0);
+    assertThat(engineRule.getRuntimeService().createExecutionQuery().processDefinitionKey(SUB_PROCESS_ID).list()).isEmpty();
+    assertThat(engineRule.getRuntimeService().createExecutionQuery().activityId(CALL_ACTIVITY).list()).isEmpty();
   }
 
   protected void addAllOut(BpmnModelInstance modelInstance, CallActivityBuilder callActivityBuilder) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/TaskListenerDelegateCompletionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/TaskListenerDelegateCompletionTest.java
@@ -158,7 +158,7 @@ public class TaskListenerDelegateCompletionTest {
     testHelper.waitForJobExecutorToProcessAllJobs(5000L);
 
     // then
-    assertThat(taskQuery.count()).isEqualTo(0L);
+    assertThat(taskQuery.count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/TaskListenerEventLifecycleTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/TaskListenerEventLifecycleTest.java
@@ -66,7 +66,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
 
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
-    assertThat(orderedEvents.size()).isEqualTo(2);
+    assertThat(orderedEvents).hasSize(2);
     assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
                                               TaskListener.EVENTNAME_ASSIGNMENT);
   }
@@ -85,7 +85,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
 
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
-    assertThat(orderedEvents.size()).isEqualTo(2);
+    assertThat(orderedEvents).hasSize(2);
     assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
                                               TaskListener.EVENTNAME_COMPLETE);
   }
@@ -106,7 +106,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
 
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
-    assertThat(orderedEvents.size()).isEqualTo(4);
+    assertThat(orderedEvents).hasSize(4);
     assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
                                               TaskListener.EVENTNAME_UPDATE,
                                               TaskListener.EVENTNAME_ASSIGNMENT,
@@ -136,7 +136,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
 
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
-    assertThat(orderedEvents.size()).isEqualTo(2);
+    assertThat(orderedEvents).hasSize(2);
 
     // the TIMEOUT event will always fire after the CREATE event, since the Timer Job can't be
     // picked up by the JobExecutor before it's committed. And it is committed in the same
@@ -174,7 +174,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
     assertThat(runningJobCount).isOne();
     assertThat(completedJobCount).isZero();
-    assertThat(orderedEvents.size()).isEqualTo(2);
+    assertThat(orderedEvents).hasSize(2);
     assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_COMPLETE);
   }
 
@@ -193,7 +193,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
     // create event fired on task creation
-    assertThat(orderedEvents.size()).isEqualTo(2);
+    assertThat(orderedEvents).hasSize(2);
     assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
                                               TaskListener.EVENTNAME_UPDATE);
   }
@@ -211,7 +211,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents.size()).isEqualTo(3);
+    assertThat(orderedEvents).hasSize(3);
     assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
                                               TaskListener.EVENTNAME_UPDATE,
                                               TaskListener.EVENTNAME_ASSIGNMENT);
@@ -235,7 +235,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
     // assignment event should not be processed
-    assertThat(orderedEvents.size()).isEqualTo(3);
+    assertThat(orderedEvents).hasSize(3);
     assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
                                               TaskListener.EVENTNAME_UPDATE,
                                               TaskListener.EVENTNAME_COMPLETE);
@@ -258,7 +258,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents.size()).isEqualTo(4);
+    assertThat(orderedEvents).hasSize(4);
     assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
                                               TaskListener.EVENTNAME_UPDATE,
                                               TaskListener.EVENTNAME_ASSIGNMENT,
@@ -280,7 +280,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents.size()).isEqualTo(2);
+    assertThat(orderedEvents).hasSize(2);
     // ASSIGNMENT Event is fired, since the ModifyingTaskListener sets an assignee, and the
     // ASSIGNMENT Event evaluation happens after the CREATE Event evaluation
     assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
@@ -305,7 +305,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // only the initial, first update event is expected
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents.size()).isEqualTo(3);
+    assertThat(orderedEvents).hasSize(3);
     // ASSIGNMENT Event is fired, since the ModifyingTaskListener sets an assignee, and the
     // ASSIGNMENT Event evaluation happens after the UPDATE Event evaluation
     assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
@@ -331,7 +331,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // only one update event is expected, from the initial assignment
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents.size()).isEqualTo(3);
+    assertThat(orderedEvents).hasSize(3);
     assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
                                               TaskListener.EVENTNAME_UPDATE,
                                               TaskListener.EVENTNAME_ASSIGNMENT);
@@ -354,7 +354,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents.size()).isEqualTo(2);
+    assertThat(orderedEvents).hasSize(2);
     assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
                                               TaskListener.EVENTNAME_COMPLETE);
   }
@@ -376,7 +376,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents.size()).isEqualTo(2);
+    assertThat(orderedEvents).hasSize(2);
     assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
                                               TaskListener.EVENTNAME_DELETE);
   }
@@ -396,7 +396,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents.size()).isEqualTo(2);
+    assertThat(orderedEvents).hasSize(2);
     assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_COMPLETE);
   }
 
@@ -417,7 +417,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents.size()).isEqualTo(2);
+    assertThat(orderedEvents).hasSize(2);
     assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_COMPLETE);
   }
 
@@ -438,7 +438,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents.size()).isEqualTo(2);
+    assertThat(orderedEvents).hasSize(2);
     assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_COMPLETE);
   }
 
@@ -463,7 +463,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
       // then
       LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-      assertThat(orderedEvents.size()).isEqualTo(2);
+      assertThat(orderedEvents).hasSize(2);
       assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_COMPLETE);
     }
   }
@@ -485,7 +485,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents.size()).isEqualTo(3);
+    assertThat(orderedEvents).hasSize(3);
     assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
                                               TaskListener.EVENTNAME_COMPLETE,
                                               TaskListener.EVENTNAME_DELETE);
@@ -512,7 +512,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
       // then
       LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-      assertThat(orderedEvents.size()).isEqualTo(2);
+      assertThat(orderedEvents).hasSize(2);
       assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(TaskListener.EVENTNAME_CREATE);
       assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_COMPLETE);
     }
@@ -532,7 +532,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents.size()).isEqualTo(2);
+    assertThat(orderedEvents).hasSize(2);
     assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(TaskListener.EVENTNAME_CREATE);
     assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
   }
@@ -553,7 +553,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents.size()).isEqualTo(2);
+    assertThat(orderedEvents).hasSize(2);
     assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(TaskListener.EVENTNAME_CREATE);
     assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
   }
@@ -574,7 +574,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents.size()).isEqualTo(2);
+    assertThat(orderedEvents).hasSize(2);
     assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(TaskListener.EVENTNAME_CREATE);
     assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
   }
@@ -599,7 +599,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
       // then
       LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-      assertThat(orderedEvents.size()).isEqualTo(2);
+      assertThat(orderedEvents).hasSize(2);
       assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(TaskListener.EVENTNAME_CREATE);
       assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
     }
@@ -625,7 +625,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
       // then
       LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-      assertThat(orderedEvents.size()).isEqualTo(2);
+      assertThat(orderedEvents).hasSize(2);
       assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(TaskListener.EVENTNAME_CREATE);
       assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
     }
@@ -647,7 +647,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents.size()).isEqualTo(2);
+    assertThat(orderedEvents).hasSize(2);
     assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(TaskListener.EVENTNAME_CREATE);
     assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.java
@@ -846,8 +846,8 @@ public class TaskListenerTest extends AbstractTaskListenerTest {
 
     // then
     HistoricVariableInstanceQuery variableQuery = historyService.createHistoricVariableInstanceQuery().variableName("timeout-status");
-    assertThat(variableQuery.count()).isEqualTo(0L);
-    assertThat(jobQuery.count()).isEqualTo(0L);
+    assertThat(variableQuery.count()).isZero();
+    assertThat(jobQuery.count()).isZero();
   }
 
   @Test
@@ -866,8 +866,8 @@ public class TaskListenerTest extends AbstractTaskListenerTest {
 
     // then
     HistoricVariableInstanceQuery variableQuery = historyService.createHistoricVariableInstanceQuery().variableName("timeout-status");
-    assertThat(variableQuery.count()).isEqualTo(0L);
-    assertThat(jobQuery.count()).isEqualTo(0L);
+    assertThat(variableQuery.count()).isZero();
+    assertThat(jobQuery.count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentDeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentDeploymentTest.java
@@ -89,7 +89,7 @@ public class ConcurrentDeploymentTest extends ConcurrencyTestCase {
         .asc()
         .list();
 
-    assertThat(processDefinitions.size()).isEqualTo(2);
+    assertThat(processDefinitions).hasSize(2);
     assertThat(processDefinitions.get(0).getVersion()).isEqualTo(1);
     assertThat(processDefinitions.get(1).getVersion()).isEqualTo(2);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentJobExecutorTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentJobExecutorTest.java
@@ -181,7 +181,7 @@ public class ConcurrentJobExecutorTest {
       .hasMessageContaining("DELETE MessageEntity")
       .hasMessageContaining("Entity was updated by another transaction concurrently");
     assertThat(threadTwo.exception).isNull();
-    assertThat(managementService.createJobQuery().count()).isEqualTo(0L);
+    assertThat(managementService.createJobQuery().count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/DeleteProcessDefinitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/DeleteProcessDefinitionTest.java
@@ -40,7 +40,7 @@ public class DeleteProcessDefinitionTest extends ConcurrencyTestCase {
     // given
     String resource = "org/operaton/bpm/engine/test/api/repository/processWithNewInvoiceMessage.bpmn20.xml";
     List<ProcessDefinition> processDefinitions = deployProcessDefinitionTwice(resource);
-    assertThat(processDefinitions.size()).isEqualTo(2);
+    assertThat(processDefinitions).hasSize(2);
     deleteProcessDefinitionsSimultaneously(processDefinitions.get(0).getId(), processDefinitions.get(1).getId());
 
     assertThat(repositoryService.createProcessDefinitionQuery().list()).isEmpty();
@@ -59,7 +59,7 @@ public class DeleteProcessDefinitionTest extends ConcurrencyTestCase {
     // given
     String resource = "org/operaton/bpm/engine/test/bpmn/event/timer/StartTimerEventTest.testTimeCycle.bpmn20.xml";
     List<ProcessDefinition> processDefinitions = deployProcessDefinitionTwice(resource);
-    assertThat(processDefinitions.size()).isEqualTo(2);
+    assertThat(processDefinitions).hasSize(2);
     deleteProcessDefinitionsSimultaneously(processDefinitions.get(0).getId(), processDefinitions.get(1).getId());
 
     assertThat(repositoryService.createProcessDefinitionQuery().list()).isEmpty();
@@ -78,7 +78,7 @@ public class DeleteProcessDefinitionTest extends ConcurrencyTestCase {
     // given
     String resource = "org/operaton/bpm/engine/test/api/repository/processWithStartSignalEvent.bpmn20.xml";
     List<ProcessDefinition> processDefinitions = deployProcessDefinitionTwice(resource);
-    assertThat(processDefinitions.size()).isEqualTo(2);
+    assertThat(processDefinitions).hasSize(2);
     deleteProcessDefinitionsSimultaneously(processDefinitions.get(0).getId(), processDefinitions.get(1).getId());
 
     assertThat(repositoryService.createProcessDefinitionQuery().list()).isEmpty();
@@ -100,7 +100,7 @@ public class DeleteProcessDefinitionTest extends ConcurrencyTestCase {
     repositoryService.createDeployment().addClasspathResource(resource).deploy();
     repositoryService.createDeployment().addClasspathResource(resource).deploy();
     List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().processDefinitionKey("otherMessageProcess").list();
-    assertThat(processDefinitions.size()).isEqualTo(3);
+    assertThat(processDefinitions).hasSize(3);
 
     deleteProcessDefinitionsSimultaneously(processDefinitions.get(1).getId(), processDefinitions.get(2).getId());
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/dmn/businessruletask/DmnBusinessRuleTaskResultMappingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/dmn/businessruletask/DmnBusinessRuleTaskResultMappingTest.java
@@ -190,7 +190,7 @@ public class DmnBusinessRuleTaskResultMappingTest extends PluggableProcessEngine
       fail("expect parse exception");
     } catch (ParseException e) {
       testRule.assertTextPresent("No decision result mapper found for name 'invalid'", e.getMessage());
-      assertThat(e.getResorceReports().get(0).getErrors().size()).isEqualTo(1);
+      assertThat(e.getResorceReports().get(0).getErrors()).hasSize(1);
       assertThat(e.getResorceReports().get(0).getErrors().get(0).getMainElementId()).isEqualTo("ruleTask");
     }
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/dmn/deployment/DecisionDefinitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/dmn/deployment/DecisionDefinitionTest.java
@@ -102,7 +102,7 @@ public class DecisionDefinitionTest {
     DeploymentWithDefinitions deployment = testRule.deploy(builder);
 
     // then
-    assertThat(deployment.getDeployedDecisionDefinitions().size()).isEqualTo(1);
+    assertThat(deployment.getDeployedDecisionDefinitions()).hasSize(1);
     assertThat(deployment.getDeployedDecisionDefinitions().get(0).getHistoryTimeToLive()).isEqualTo(30);
   }
 
@@ -117,7 +117,7 @@ public class DecisionDefinitionTest {
     DeploymentWithDefinitions deployment = testRule.deploy(builder);
 
     // then
-    assertThat(deployment.getDeployedDecisionDefinitions().size()).isEqualTo(1);
+    assertThat(deployment.getDeployedDecisionDefinitions()).hasSize(1);
     assertThat(deployment.getDeployedDecisionDefinitions().get(0).getHistoryTimeToLive()).isEqualTo(10);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/form/deployment/OperatonFormDefinitionDeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/form/deployment/OperatonFormDefinitionDeploymentTest.java
@@ -184,8 +184,8 @@ public class OperatonFormDefinitionDeploymentTest {
     assertThat(deployments).hasSize(1);
 
     // after deletion of deployment
-    assertThat(findAllOperatonFormDefinitionEntities(processEngineConfiguration)).hasSize(0);
-    assertThat(repositoryService.createDeploymentQuery().list()).hasSize(0);
+    assertThat(findAllOperatonFormDefinitionEntities(processEngineConfiguration)).isEmpty();
+    assertThat(repositoryService.createDeploymentQuery().list()).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/CompositeHistoryEventHandlerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/CompositeHistoryEventHandlerTest.java
@@ -79,7 +79,7 @@ public class CompositeHistoryEventHandlerTest extends AbstractCompositeHistoryEv
     startProcessAndCompleteUserTask();
 
     assertThat(countCustomHistoryEventHandler).isEqualTo(2);
-    assertThat(historyService.createHistoricDetailQuery().count()).isEqualTo(0);
+    assertThat(historyService.createHistoricDetailQuery().count()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricActivityInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricActivityInstanceTest.java
@@ -1081,7 +1081,7 @@ public class HistoricActivityInstanceTest extends PluggableProcessEngineTest {
       .activityId("parallelJoinEnd")
       .list();
 
-    assertThat(activityInstance.size()).isEqualTo(2);
+    assertThat(activityInstance).hasSize(2);
     assertThat(pi.isEnded()).isTrue();
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityStatisticsQueryTest.java
@@ -86,7 +86,7 @@ public class HistoricCaseActivityStatisticsQueryTest {
 
     // then
     assertEquals(0, query.count());
-    assertThat(query.list()).hasSize(0);
+    assertThat(query.list()).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricExternalTaskLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricExternalTaskLogQueryTest.java
@@ -802,7 +802,7 @@ public class HistoricExternalTaskLogQueryTest {
       .list();
 
     // then
-    assertThat(externalTaskLogs.size()).isEqualTo(3);
+    assertThat(externalTaskLogs).hasSize(3);
     for (HistoricExternalTaskLog log : externalTaskLogs) {
       assertTrue(log.getPriority() <= 2);
     }
@@ -822,7 +822,7 @@ public class HistoricExternalTaskLogQueryTest {
       .list();
 
     // then
-    assertThat(externalTaskLogs.size()).isEqualTo(3);
+    assertThat(externalTaskLogs).hasSize(3);
     for (HistoricExternalTaskLog log : externalTaskLogs) {
       assertTrue(log.getPriority() >= 2);
     }
@@ -843,7 +843,7 @@ public class HistoricExternalTaskLogQueryTest {
       .list();
 
     // then
-    assertThat(externalTaskLogs.size()).isEqualTo(3);
+    assertThat(externalTaskLogs).hasSize(3);
     for (HistoricExternalTaskLog log : externalTaskLogs) {
       assertTrue(log.getPriority() <= 3 && log.getPriority() >= 1);
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricExternalTaskLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricExternalTaskLogQueryTest.java
@@ -16,17 +16,10 @@
  */
 package org.operaton.bpm.engine.test.history;
 
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertNull;
-import static junit.framework.TestCase.assertTrue;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.operaton.bpm.engine.test.api.runtime.migration.models.builder.DefaultExternalTaskModelBuilder.DEFAULT_EXTERNAL_TASK_NAME;
-import static org.operaton.bpm.engine.test.api.runtime.migration.models.builder.DefaultExternalTaskModelBuilder.DEFAULT_TOPIC;
-import static org.operaton.bpm.engine.test.api.runtime.migration.models.builder.DefaultExternalTaskModelBuilder.createDefaultExternalTaskModel;
-
-import java.util.LinkedList;
-import java.util.List;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.ExternalTaskService;
 import org.operaton.bpm.engine.HistoryService;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
@@ -43,10 +36,14 @@ import org.operaton.bpm.engine.test.api.authorization.util.AuthorizationTestRule
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static junit.framework.TestCase.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.operaton.bpm.engine.test.api.runtime.migration.models.builder.DefaultExternalTaskModelBuilder.*;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 public class HistoricExternalTaskLogQueryTest {
@@ -864,7 +861,7 @@ public class HistoricExternalTaskLogQueryTest {
       .list();
 
     // then
-    assertThat(externalTaskLogs.size()).isZero();
+    assertThat(externalTaskLogs).isEmpty();
   }
 
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricExternalTaskLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricExternalTaskLogQueryTest.java
@@ -864,7 +864,7 @@ public class HistoricExternalTaskLogQueryTest {
       .list();
 
     // then
-    assertThat(externalTaskLogs.size()).isEqualTo(0);
+    assertThat(externalTaskLogs.size()).isZero();
   }
 
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricJobLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricJobLogQueryTest.java
@@ -620,7 +620,7 @@ public class HistoricJobLogQueryTest {
         .asc()
         .list();
 
-    assertThat(jobLogs.size()).isEqualTo(3);
+    assertThat(jobLogs).hasSize(3);
     for (HistoricJobLog log : jobLogs) {
       assertThat(log.getJobPriority() <= 2).isTrue();
     }
@@ -632,7 +632,7 @@ public class HistoricJobLogQueryTest {
         .asc()
         .list();
 
-    assertThat(jobLogs.size()).isEqualTo(2);
+    assertThat(jobLogs).hasSize(2);
     for (HistoricJobLog log : jobLogs) {
       assertThat(log.getJobPriority() >= 3).isTrue();
     }
@@ -645,7 +645,7 @@ public class HistoricJobLogQueryTest {
         .asc()
         .list();
 
-    assertThat(jobLogs.size()).isEqualTo(3);
+    assertThat(jobLogs).hasSize(3);
     for (HistoricJobLog log : jobLogs) {
       assertThat(log.getJobPriority() >= 1 && log.getJobPriority() <= 3).isTrue();
     }
@@ -965,7 +965,7 @@ public class HistoricJobLogQueryTest {
   }
 
   protected void verifyQueryResults(HistoricJobLogQuery query, int countExpected) {
-    assertThat(query.list().size()).isEqualTo(countExpected);
+    assertThat(query.list()).hasSize(countExpected);
     assertThat(query.count()).isEqualTo(countExpected);
 
     if (countExpected == 1) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricJobLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricJobLogQueryTest.java
@@ -657,7 +657,7 @@ public class HistoricJobLogQueryTest {
         .orderByJobPriority()
         .asc()
         .list();
-    assertThat(jobLogs.size()).isEqualTo(0);
+    assertThat(jobLogs.size()).isZero();
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/history/HistoricJobLogTest.testAsyncContinuation.bpmn20.xml"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricJobLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricJobLogQueryTest.java
@@ -16,33 +16,12 @@
  */
 package org.operaton.bpm.engine.test.history;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicJobLogByActivityId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicJobLogByDeploymentId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicJobLogByExecutionId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicJobLogByJobDefinitionId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicJobLogByJobDueDate;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicJobLogByJobId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicJobLogByJobPriority;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicJobLogByJobRetries;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicJobLogByProcessDefinitionId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicJobLogByProcessDefinitionKey;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicJobLogByProcessInstanceId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicJobLogByTimestamp;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicJobLogPartiallyByOccurence;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import org.operaton.bpm.engine.HistoryService;
-import org.operaton.bpm.engine.ManagementService;
-import org.operaton.bpm.engine.ProcessEngine;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.RuntimeService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.history.HistoricJobLog;
 import org.operaton.bpm.engine.history.HistoricJobLogQuery;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -54,15 +33,16 @@ import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.runtime.FailingDelegate;
 import org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil;
-import org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.NullTolerantComparator;
+import org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.*;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.engine.variable.Variables;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.*;
 
 /**
  * @author Roman Smirnov
@@ -657,7 +637,7 @@ public class HistoricJobLogQueryTest {
         .orderByJobPriority()
         .asc()
         .list();
-    assertThat(jobLogs.size()).isZero();
+    assertThat(jobLogs).isEmpty();
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/history/HistoricJobLogTest.testAsyncContinuation.bpmn20.xml"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricJobLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricJobLogTest.java
@@ -656,7 +656,7 @@ public class HistoricJobLogTest {
     // there exists one historic job log entry
     assertThat(query.count()).isEqualTo(1);
     assertThat(createdQuery.count()).isEqualTo(1);
-    assertThat(failedQuery.count()).isEqualTo(0);
+    assertThat(failedQuery.count()).isZero();
 
     // when (1)
     try {
@@ -750,7 +750,7 @@ public class HistoricJobLogTest {
     assertThat(failedJobLogEntry.getJobRetries()).isEqualTo(1);
 
     failedJobLogEntry = failedQuery.list().get(3);
-    assertThat(failedJobLogEntry.getJobRetries()).isEqualTo(0);
+    assertThat(failedJobLogEntry.getJobRetries()).isZero();
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/history/HistoricJobLogTest.testAsyncContinuation.bpmn20.xml"})
@@ -768,7 +768,7 @@ public class HistoricJobLogTest {
     // there exists one historic job log entry
     assertThat(query.count()).isEqualTo(1);
     assertThat(createdQuery.count()).isEqualTo(1);
-    assertThat(failedQuery.count()).isEqualTo(0);
+    assertThat(failedQuery.count()).isZero();
 
     // when (1)
     testRule.executeAvailableJobs();
@@ -816,7 +816,7 @@ public class HistoricJobLogTest {
     assertThat(failedJobLogEntry.getJobRetries()).isEqualTo(1);
 
     failedJobLogEntry = failedQuery.list().get(3);
-    assertThat(failedJobLogEntry.getJobRetries()).isEqualTo(0);
+    assertThat(failedJobLogEntry.getJobRetries()).isZero();
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/history/HistoricJobLogTest.testAsyncContinuation.bpmn20.xml"})
@@ -834,7 +834,7 @@ public class HistoricJobLogTest {
     // there exists one historic job log entry
     assertThat(query.count()).isEqualTo(1);
     assertThat(createdQuery.count()).isEqualTo(1);
-    assertThat(succeededQuery.count()).isEqualTo(0);
+    assertThat(succeededQuery.count()).isZero();
 
     // when
     managementService.executeJob(jobId);
@@ -866,7 +866,7 @@ public class HistoricJobLogTest {
     // there exists one historic job log entry
     assertThat(query.count()).isEqualTo(1);
     assertThat(createdQuery.count()).isEqualTo(1);
-    assertThat(succeededQuery.count()).isEqualTo(0);
+    assertThat(succeededQuery.count()).isZero();
 
     // when
     testRule.executeAvailableJobs();
@@ -899,8 +899,8 @@ public class HistoricJobLogTest {
     // there exists one historic job log entry
     assertThat(query.count()).isEqualTo(1);
     assertThat(createdQuery.count()).isEqualTo(1);
-    assertThat(failedQuery.count()).isEqualTo(0);
-    assertThat(succeededQuery.count()).isEqualTo(0);
+    assertThat(failedQuery.count()).isZero();
+    assertThat(succeededQuery.count()).isZero();
 
     // when (1)
     try {
@@ -914,7 +914,7 @@ public class HistoricJobLogTest {
     assertThat(query.count()).isEqualTo(2);
     assertThat(createdQuery.count()).isEqualTo(1);
     assertThat(failedQuery.count()).isEqualTo(1);
-    assertThat(succeededQuery.count()).isEqualTo(0);
+    assertThat(succeededQuery.count()).isZero();
 
     HistoricJobLog createdJobLogEntry = createdQuery.singleResult();
     assertThat(createdJobLogEntry.getJobRetries()).isEqualTo(3);
@@ -934,7 +934,7 @@ public class HistoricJobLogTest {
     assertThat(query.count()).isEqualTo(3);
     assertThat(createdQuery.count()).isEqualTo(1);
     assertThat(failedQuery.count()).isEqualTo(2);
-    assertThat(succeededQuery.count()).isEqualTo(0);
+    assertThat(succeededQuery.count()).isZero();
 
     createdJobLogEntry = createdQuery.singleResult();
     assertThat(createdJobLogEntry.getJobRetries()).isEqualTo(3);
@@ -987,8 +987,8 @@ public class HistoricJobLogTest {
 
     assertThat(serviceTask1Query.count()).isEqualTo(1);
     assertThat(serviceTask1CreatedQuery.count()).isEqualTo(1);
-    assertThat(serviceTask1DeletedQuery.count()).isEqualTo(0);
-    assertThat(serviceTask1SuccessfulQuery.count()).isEqualTo(0);
+    assertThat(serviceTask1DeletedQuery.count()).isZero();
+    assertThat(serviceTask1SuccessfulQuery.count()).isZero();
 
     // serviceTask2
     String serviceTask2JobId = managementService.createJobQuery().activityId("serviceTask2").singleResult().getId();
@@ -1000,8 +1000,8 @@ public class HistoricJobLogTest {
 
     assertThat(serviceTask2Query.count()).isEqualTo(1);
     assertThat(serviceTask2CreatedQuery.count()).isEqualTo(1);
-    assertThat(serviceTask2DeletedQuery.count()).isEqualTo(0);
-    assertThat(serviceTask2SuccessfulQuery.count()).isEqualTo(0);
+    assertThat(serviceTask2DeletedQuery.count()).isZero();
+    assertThat(serviceTask2SuccessfulQuery.count()).isZero();
 
     // when
     managementService.executeJob(serviceTask1JobId);
@@ -1012,7 +1012,7 @@ public class HistoricJobLogTest {
     // serviceTas1
     assertThat(serviceTask1Query.count()).isEqualTo(2);
     assertThat(serviceTask1CreatedQuery.count()).isEqualTo(1);
-    assertThat(serviceTask1DeletedQuery.count()).isEqualTo(0);
+    assertThat(serviceTask1DeletedQuery.count()).isZero();
     assertThat(serviceTask1SuccessfulQuery.count()).isEqualTo(1);
 
     HistoricJobLog serviceTask1CreatedJobLogEntry = serviceTask1CreatedQuery.singleResult();
@@ -1025,7 +1025,7 @@ public class HistoricJobLogTest {
     assertThat(serviceTask2Query.count()).isEqualTo(2);
     assertThat(serviceTask2CreatedQuery.count()).isEqualTo(1);
     assertThat(serviceTask2DeletedQuery.count()).isEqualTo(1);
-    assertThat(serviceTask2SuccessfulQuery.count()).isEqualTo(0);
+    assertThat(serviceTask2SuccessfulQuery.count()).isZero();
 
     HistoricJobLog serviceTask2CreatedJobLogEntry = serviceTask2CreatedQuery.singleResult();
     assertThat(serviceTask2CreatedJobLogEntry.getJobRetries()).isEqualTo(3);
@@ -1056,8 +1056,8 @@ public class HistoricJobLogTest {
 
     assertThat(serviceTask1Query.count()).isEqualTo(1);
     assertThat(serviceTask1CreatedQuery.count()).isEqualTo(1);
-    assertThat(serviceTask1DeletedQuery.count()).isEqualTo(0);
-    assertThat(serviceTask1SuccessfulQuery.count()).isEqualTo(0);
+    assertThat(serviceTask1DeletedQuery.count()).isZero();
+    assertThat(serviceTask1SuccessfulQuery.count()).isZero();
 
     // serviceTask2
     String serviceTask2JobId = managementService.createJobQuery().activityId("serviceTask2").singleResult().getId();
@@ -1069,8 +1069,8 @@ public class HistoricJobLogTest {
 
     assertThat(serviceTask2Query.count()).isEqualTo(1);
     assertThat(serviceTask2CreatedQuery.count()).isEqualTo(1);
-    assertThat(serviceTask2DeletedQuery.count()).isEqualTo(0);
-    assertThat(serviceTask2SuccessfulQuery.count()).isEqualTo(0);
+    assertThat(serviceTask2DeletedQuery.count()).isZero();
+    assertThat(serviceTask2SuccessfulQuery.count()).isZero();
 
     // when
     managementService.executeJob(serviceTask1JobId);
@@ -1081,7 +1081,7 @@ public class HistoricJobLogTest {
     // serviceTask1
     assertThat(serviceTask1Query.count()).isEqualTo(2);
     assertThat(serviceTask1CreatedQuery.count()).isEqualTo(1);
-    assertThat(serviceTask1DeletedQuery.count()).isEqualTo(0);
+    assertThat(serviceTask1DeletedQuery.count()).isZero();
     assertThat(serviceTask1SuccessfulQuery.count()).isEqualTo(1);
 
     HistoricJobLog serviceTask1CreatedJobLogEntry = serviceTask1CreatedQuery.singleResult();
@@ -1094,7 +1094,7 @@ public class HistoricJobLogTest {
     assertThat(serviceTask2Query.count()).isEqualTo(2);
     assertThat(serviceTask2CreatedQuery.count()).isEqualTo(1);
     assertThat(serviceTask2DeletedQuery.count()).isEqualTo(1);
-    assertThat(serviceTask2SuccessfulQuery.count()).isEqualTo(0);
+    assertThat(serviceTask2SuccessfulQuery.count()).isZero();
 
     HistoricJobLog serviceTask2CreatedJobLogEntry = serviceTask2CreatedQuery.singleResult();
     assertThat(serviceTask2CreatedJobLogEntry.getJobRetries()).isEqualTo(3);
@@ -1121,7 +1121,7 @@ public class HistoricJobLogTest {
     // there exists one historic job log entry
     assertThat(query.count()).isEqualTo(1);
     assertThat(createdQuery.count()).isEqualTo(1);
-    assertThat(deletedQuery.count()).isEqualTo(0);
+    assertThat(deletedQuery.count()).isZero();
 
     // when
     managementService.deleteJob(jobId);
@@ -1153,7 +1153,7 @@ public class HistoricJobLogTest {
     // there exists one historic job log entry
     assertThat(query.count()).isEqualTo(1);
     assertThat(createdQuery.count()).isEqualTo(1);
-    assertThat(deletedQuery.count()).isEqualTo(0);
+    assertThat(deletedQuery.count()).isZero();
 
     // when
     runtimeService.deleteProcessInstance(processInstanceId, null);
@@ -1418,7 +1418,7 @@ public class HistoricJobLogTest {
       return null;
     });
 
-    assertThat(historyService.createHistoricJobLogQuery().count()).isEqualTo(0);
+    assertThat(historyService.createHistoricJobLogQuery().count()).isZero();
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceQueryOrTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceQueryOrTest.java
@@ -774,7 +774,7 @@ public class HistoricProcessInstanceQueryOrTest {
         .list();
 
     // then
-    assertThat(processInstances.size()).isEqualTo(2);
+    assertThat(processInstances).hasSize(2);
   }
 
   @Test
@@ -814,7 +814,7 @@ public class HistoricProcessInstanceQueryOrTest {
         .list();
 
     // then
-    assertThat(processInstances.size()).isEqualTo(2);
+    assertThat(processInstances).hasSize(2);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceStateTest.java
@@ -238,7 +238,7 @@ public class HistoricProcessInstanceStateTest {
   @Deployment(resources = {"org/operaton/bpm/engine/test/history/HistoricProcessInstanceStateTest.testWithCallActivity.bpmn"})
   public void testWithCallActivity() {
     processEngineRule.getRuntimeService().startProcessInstanceByKey("Main_Process");
-    assertThat(processEngineRule.getRuntimeService().createProcessInstanceQuery().active().list().size()).isEqualTo(0);
+    assertThat(processEngineRule.getRuntimeService().createProcessInstanceQuery().active().list().size()).isZero();
 
     HistoricProcessInstance entity1 = processEngineRule.getHistoryService().createHistoricProcessInstanceQuery()
         .processDefinitionKey("Main_Process").singleResult();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceStateTest.java
@@ -213,7 +213,7 @@ public class HistoricProcessInstanceStateTest {
       //expected
     }
 
-    assertThat(processEngineRule.getRuntimeService().createProcessInstanceQuery().active().list().size()).isEqualTo(1);
+    assertThat(processEngineRule.getRuntimeService().createProcessInstanceQuery().active().list()).hasSize(1);
     HistoricProcessInstance entity = getHistoricProcessInstanceWithAssertion(processDefinition);
     assertThat(entity.getState()).isEqualTo(HistoricProcessInstance.STATE_ACTIVE);
     assertEquals(1, processEngineRule.getHistoryService().createHistoricProcessInstanceQuery().active().count());
@@ -303,7 +303,7 @@ public class HistoricProcessInstanceStateTest {
     List<HistoricProcessInstance> entities = processEngineRule.getHistoryService().createHistoricProcessInstanceQuery()
         .processDefinitionId(processDefinition.getId()).list();
     assertThat(entities).isNotNull();
-    assertThat(entities.size()).isEqualTo(1);
+    assertThat(entities).hasSize(1);
     return entities.get(0);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceStateTest.java
@@ -16,12 +16,9 @@
  */
 package org.operaton.bpm.engine.test.history;
 
-import static junit.framework.TestCase.fail;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-
-import java.util.List;
-
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.history.HistoricProcessInstance;
 import org.operaton.bpm.engine.history.HistoricTaskInstance;
@@ -36,9 +33,12 @@ import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.bpmn.instance.EndEvent;
 import org.operaton.bpm.model.bpmn.instance.TerminateEventDefinition;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.List;
+
+import static junit.framework.TestCase.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Askar Akhmerov
@@ -238,7 +238,7 @@ public class HistoricProcessInstanceStateTest {
   @Deployment(resources = {"org/operaton/bpm/engine/test/history/HistoricProcessInstanceStateTest.testWithCallActivity.bpmn"})
   public void testWithCallActivity() {
     processEngineRule.getRuntimeService().startProcessInstanceByKey("Main_Process");
-    assertThat(processEngineRule.getRuntimeService().createProcessInstanceQuery().active().list().size()).isZero();
+    assertThat(processEngineRule.getRuntimeService().createProcessInstanceQuery().active().list()).isEmpty();
 
     HistoricProcessInstance entity1 = processEngineRule.getHistoryService().createHistoricProcessInstanceQuery()
         .processDefinitionKey("Main_Process").singleResult();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
@@ -16,42 +16,12 @@
  */
 package org.operaton.bpm.engine.test.history;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicProcessInstanceByProcessDefinitionId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicProcessInstanceByProcessDefinitionKey;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicProcessInstanceByProcessDefinitionName;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicProcessInstanceByProcessDefinitionVersion;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicProcessInstanceByProcessInstanceId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
-import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.time.DateUtils;
-import org.operaton.bpm.engine.BadUserRequestException;
-import org.operaton.bpm.engine.CaseService;
-import org.operaton.bpm.engine.HistoryService;
-import org.operaton.bpm.engine.ManagementService;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.exception.NotValidException;
 import org.operaton.bpm.engine.exception.NullValueException;
 import org.operaton.bpm.engine.history.HistoricActivityInstance;
@@ -81,10 +51,14 @@ import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.*;
+import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
 
 /**
  * @author Tom Baeyens
@@ -2242,7 +2216,7 @@ public class HistoricProcessInstanceTest {
 
     // then
     assertThat(query.count()).isEqualTo(0l);
-    assertThat(query.list().size()).isZero();
+    assertThat(query.list()).isEmpty();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
@@ -2242,7 +2242,7 @@ public class HistoricProcessInstanceTest {
 
     // then
     assertThat(query.count()).isEqualTo(0l);
-    assertThat(query.list().size()).isEqualTo(0);
+    assertThat(query.list().size()).isZero();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
@@ -2215,7 +2215,7 @@ public class HistoricProcessInstanceTest {
       .processDefinitionKeyIn("not-existing-key");
 
     // then
-    assertThat(query.count()).isEqualTo(0l);
+    assertThat(query.count()).isZero();
     assertThat(query.list()).isEmpty();
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
@@ -2029,16 +2029,16 @@ public class HistoricProcessInstanceTest {
         historyService.createHistoricProcessInstanceQuery().activityIdIn("innerServiceTask", "outerTask").list();
 
     // then
-    assertThat(queryByInnerServiceActivityId.size()).isEqualTo(1);
+    assertThat(queryByInnerServiceActivityId).hasSize(1);
     assertThat(queryByInnerServiceActivityId.get(0).getId()).isEqualTo(processInstance.getId());
 
-    assertThat(queryBySubProcessActivityId.size()).isEqualTo(1);
+    assertThat(queryBySubProcessActivityId).hasSize(1);
     assertThat(queryBySubProcessActivityId.get(0).getId()).isEqualTo(processInstance.getId());
 
-    assertThat(queryByOuterProcessActivityId.size()).isEqualTo(1);
+    assertThat(queryByOuterProcessActivityId).hasSize(1);
     assertThat(queryByOuterProcessActivityId.get(0).getId()).isEqualTo(processInstance2.getId());
 
-    assertThat(queryByOuterAndInnedActivityId.size()).isEqualTo(2);
+    assertThat(queryByOuterAndInnedActivityId).hasSize(2);
     assertThat(queryByOuterAndInnedActivityId.stream()
         .map(HistoricProcessInstance::getId)
         .collect(Collectors.toList()))
@@ -2068,16 +2068,16 @@ public class HistoricProcessInstanceTest {
         historyService.createHistoricProcessInstanceQuery().activityIdIn("innerTask", "outerTask").list();
 
     // then
-    assertThat(queryByInnerServiceActivityId.size()).isEqualTo(1);
+    assertThat(queryByInnerServiceActivityId).hasSize(1);
     assertThat(queryByInnerServiceActivityId.get(0).getId()).isEqualTo(processInstance.getId());
 
-    assertThat(queryBySubProcessActivityId.size()).isEqualTo(1);
+    assertThat(queryBySubProcessActivityId).hasSize(1);
     assertThat(queryBySubProcessActivityId.get(0).getId()).isEqualTo(processInstance.getId());
 
-    assertThat(queryByOuterProcessActivityId.size()).isEqualTo(1);
+    assertThat(queryByOuterProcessActivityId).hasSize(1);
     assertThat(queryByOuterProcessActivityId.get(0).getId()).isEqualTo(processInstance2.getId());
 
-    assertThat(queryByOuterAndInnedActivityId.size()).isEqualTo(2);
+    assertThat(queryByOuterAndInnedActivityId).hasSize(2);
     assertThat(queryByOuterAndInnedActivityId.stream()
         .map(HistoricProcessInstance::getId)
         .collect(Collectors.toList()))
@@ -2227,7 +2227,7 @@ public class HistoricProcessInstanceTest {
 
     // then
     assertThat(query.count()).isEqualTo(6l);
-    assertThat(query.list().size()).isEqualTo(6);
+    assertThat(query.list()).hasSize(6);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/MetricsManagerForCleanupTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/MetricsManagerForCleanupTest.java
@@ -123,7 +123,7 @@ public class MetricsManagerForCleanupTest {
             .findTaskMetricsForCleanup(batchSize, taskMetricHistoryTTL, 0, 59);
 
         // then
-        assertThat(taskMetricIdsForCleanup.size()).isEqualTo(resultCount);
+        assertThat(taskMetricIdsForCleanup).hasSize(resultCount);
 
         return null;
       }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/PartitioningTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/PartitioningTest.java
@@ -106,7 +106,7 @@ public class PartitioningTest {
     });
 
     // assume
-    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricProcessInstanceQuery().count()).isZero();
 
     // when
     runtimeService.deleteProcessInstance(processInstanceId, "aDeleteReason");
@@ -166,7 +166,7 @@ public class PartitioningTest {
     });
 
     // assume
-    assertThat(historyService.createHistoricActivityInstanceQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricActivityInstanceQuery().count()).isZero();
 
     // when
     String taskId = taskService.createTaskQuery()
@@ -200,15 +200,15 @@ public class PartitioningTest {
     });
 
     // assume
-    assertThat(historyService.createHistoricIncidentQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricIncidentQuery().count()).isZero();
     assertThat(runtimeService.createIncidentQuery().count()).isEqualTo(1L);
 
     // when
     runtimeService.resolveIncident(incidentId);
 
     // then
-    assertThat(runtimeService.createIncidentQuery().count()).isEqualTo(0L);
-    assertThat(historyService.createHistoricIncidentQuery().count()).isEqualTo(0L);
+    assertThat(runtimeService.createIncidentQuery().count()).isZero();
+    assertThat(historyService.createHistoricIncidentQuery().count()).isZero();
   }
 
   @Test
@@ -235,7 +235,7 @@ public class PartitioningTest {
     });
 
     // assume
-    assertThat(historyService.createHistoricBatchQuery().count()).isEqualTo(0L);
+    assertThat(historyService.createHistoricBatchQuery().count()).isZero();
 
     // when
     String seedJobDefinitionId = batch.getSeedJobDefinitionId();
@@ -254,8 +254,8 @@ public class PartitioningTest {
     }
 
     // then
-    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0L);
-    assertThat(managementService.createBatchQuery().count()).isEqualTo(0L);
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
+    assertThat(managementService.createBatchQuery().count()).isZero();
 
     // cleanup
     cleanUp(processInstanceId);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
@@ -191,7 +191,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
 
     assertThat(query.decisionInstanceId(decisionInstanceId1).count()).isEqualTo(1L);
     assertThat(query.decisionInstanceId(decisionInstanceId2).count()).isEqualTo(1L);
-    assertThat(query.decisionInstanceId("unknown").count()).isEqualTo(0L);
+    assertThat(query.decisionInstanceId("unknown").count()).isZero();
   }
 
   @Deployment(resources = { DECISION_PROCESS, DECISION_SINGLE_OUTPUT_DMN })
@@ -221,7 +221,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
     assertThat(query.decisionDefinitionId(decisionDefinitionId).count()).isEqualTo(1L);
-    assertThat(query.decisionDefinitionId("other id").count()).isEqualTo(0L);
+    assertThat(query.decisionDefinitionId("other id").count()).isZero();
   }
 
   @Deployment(resources = { DECISION_PROCESS, DECISION_SINGLE_OUTPUT_DMN, DRG_DMN })
@@ -242,7 +242,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
     assertThat(query.decisionDefinitionIdIn(decisionDefinitionId, decisionDefinitionId2).count()).isEqualTo(2L);
-    assertThat(query.decisionDefinitionIdIn("other id", "anotherFake").count()).isEqualTo(0L);
+    assertThat(query.decisionDefinitionIdIn("other id", "anotherFake").count()).isZero();
   }
 
   @Deployment(resources = {DECISION_PROCESS, DECISION_SINGLE_OUTPUT_DMN, DRG_DMN})
@@ -271,7 +271,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
     assertThat(query.decisionDefinitionKeyIn(DISH_DECISION, DECISION_DEFINITION_KEY).count()).isEqualTo(2L);
-    assertThat(query.decisionDefinitionKeyIn("other id", "anotherFake").count()).isEqualTo(0L);
+    assertThat(query.decisionDefinitionKeyIn("other id", "anotherFake").count()).isZero();
   }
 
   @Deployment(resources = {DECISION_PROCESS, DECISION_SINGLE_OUTPUT_DMN, DRG_DMN})
@@ -295,7 +295,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
     assertThat(query.decisionDefinitionKey(DECISION_DEFINITION_KEY).count()).isEqualTo(1L);
-    assertThat(query.decisionDefinitionKey("other key").count()).isEqualTo(0L);
+    assertThat(query.decisionDefinitionKey("other key").count()).isZero();
   }
 
   @Deployment(resources = { DECISION_PROCESS, DECISION_SINGLE_OUTPUT_DMN })
@@ -307,7 +307,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
     assertThat(query.decisionDefinitionName("sample decision").count()).isEqualTo(1L);
-    assertThat(query.decisionDefinitionName("other name").count()).isEqualTo(0L);
+    assertThat(query.decisionDefinitionName("other name").count()).isZero();
   }
 
   @Deployment(resources = { DECISION_PROCESS, DECISION_PROCESS_WITH_UNDERSCORE, DECISION_SINGLE_OUTPUT_DMN, DECISION_SINGLE_OUTPUT_DMN_WITH_UNDERSCORE })
@@ -332,7 +332,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
 
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
-    assertThat(query.decisionDefinitionNameLike("%invalid%").count()).isEqualTo(0L);
+    assertThat(query.decisionDefinitionNameLike("%invalid%").count()).isZero();
 
     try {
       query.decisionDefinitionNameLike(null);
@@ -352,7 +352,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
     assertThat(query.processDefinitionKey(processDefinitionKey).count()).isEqualTo(1L);
-    assertThat(query.processDefinitionKey("other process").count()).isEqualTo(0L);
+    assertThat(query.processDefinitionKey("other process").count()).isZero();
   }
 
   @Deployment(resources = { DECISION_PROCESS, DECISION_SINGLE_OUTPUT_DMN })
@@ -365,7 +365,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
     assertThat(query.processDefinitionId(processDefinitionId).count()).isEqualTo(1L);
-    assertThat(query.processDefinitionId("other process").count()).isEqualTo(0L);
+    assertThat(query.processDefinitionId("other process").count()).isZero();
   }
 
   @Deployment(resources = { DECISION_PROCESS, DECISION_SINGLE_OUTPUT_DMN })
@@ -379,7 +379,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
     assertThat(query.processInstanceId(processInstanceId).count()).isEqualTo(1L);
-    assertThat(query.processInstanceId("other process").count()).isEqualTo(0L);
+    assertThat(query.processInstanceId("other process").count()).isZero();
   }
 
   @Deployment(resources = { DECISION_PROCESS, DECISION_SINGLE_OUTPUT_DMN })
@@ -391,7 +391,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
     assertThat(query.activityIdIn("task").count()).isEqualTo(1L);
-    assertThat(query.activityIdIn("other activity").count()).isEqualTo(0L);
+    assertThat(query.activityIdIn("other activity").count()).isZero();
     assertThat(query.activityIdIn("task", "other activity").count()).isEqualTo(1L);
   }
 
@@ -405,7 +405,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
 
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
     assertThat(query.activityInstanceIdIn(activityInstanceId).count()).isEqualTo(1L);
-    assertThat(query.activityInstanceIdIn("other activity").count()).isEqualTo(0L);
+    assertThat(query.activityInstanceIdIn("other activity").count()).isZero();
     assertThat(query.activityInstanceIdIn(activityInstanceId, "other activity").count()).isEqualTo(1L);
   }
 
@@ -422,7 +422,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
     assertThat(query.evaluatedBefore(afterEvaluated).count()).isEqualTo(1L);
     assertThat(query.evaluatedBefore(evaluated).count()).isEqualTo(1L);
-    assertThat(query.evaluatedBefore(beforeEvaluated).count()).isEqualTo(0L);
+    assertThat(query.evaluatedBefore(beforeEvaluated).count()).isZero();
 
     ClockUtil.reset();
   }
@@ -440,7 +440,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
     assertThat(query.evaluatedAfter(beforeEvaluated).count()).isEqualTo(1L);
     assertThat(query.evaluatedAfter(evaluated).count()).isEqualTo(1L);
-    assertThat(query.evaluatedAfter(afterEvaluated).count()).isEqualTo(0L);
+    assertThat(query.evaluatedAfter(afterEvaluated).count()).isZero();
 
     ClockUtil.reset();
   }
@@ -459,7 +459,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
   public void testQueryByInvalidCaseDefinitionKey() {
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
-    assertThat(query.caseDefinitionKey("invalid").count()).isEqualTo(0L);
+    assertThat(query.caseDefinitionKey("invalid").count()).isZero();
 
     try {
       query.caseDefinitionKey(null);
@@ -482,7 +482,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
   public void testQueryByInvalidCaseDefinitionId() {
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
-    assertThat(query.caseDefinitionId("invalid").count()).isEqualTo(0L);
+    assertThat(query.caseDefinitionId("invalid").count()).isZero();
 
     try {
       query.caseDefinitionId(null);
@@ -505,7 +505,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
   public void testQueryByInvalidCaseInstanceId() {
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
-    assertThat(query.caseInstanceId("invalid").count()).isEqualTo(0L);
+    assertThat(query.caseInstanceId("invalid").count()).isZero();
 
     try {
       query.caseInstanceId(null);
@@ -531,7 +531,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
 
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
-    assertThat(query.userId("dem1").count()).isEqualTo(0L);
+    assertThat(query.userId("dem1").count()).isZero();
 
     try {
       query.userId(null);
@@ -556,8 +556,8 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
 
     query = historyService.createHistoricDecisionInstanceQuery();
     assertThat(query.rootDecisionInstanceId(rootDecisionInstanceId).count()).isEqualTo(3L);
-    assertThat(query.rootDecisionInstanceId(requiredDecisionInstanceId1).count()).isEqualTo(0L);
-    assertThat(query.rootDecisionInstanceId(requiredDecisionInstanceId2).count()).isEqualTo(0L);
+    assertThat(query.rootDecisionInstanceId(requiredDecisionInstanceId1).count()).isZero();
+    assertThat(query.rootDecisionInstanceId(requiredDecisionInstanceId2).count()).isZero();
   }
 
   @Deployment(resources = { DRG_DMN })
@@ -585,7 +585,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
 
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
-    assertThat(query.decisionRequirementsDefinitionId("notExisting").count()).isEqualTo(0L);
+    assertThat(query.decisionRequirementsDefinitionId("notExisting").count()).isZero();
     assertThat(query.decisionRequirementsDefinitionId(decisionRequirementsDefinition.getId()).count()).isEqualTo(3L);
   }
 
@@ -598,7 +598,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
 
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
-    assertThat(query.decisionRequirementsDefinitionKey("notExisting").count()).isEqualTo(0L);
+    assertThat(query.decisionRequirementsDefinitionKey("notExisting").count()).isZero();
     assertThat(query.decisionRequirementsDefinitionKey("dish").count()).isEqualTo(3L);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
@@ -613,13 +613,13 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
     NativeHistoricDecisionInstanceQuery nativeQuery = historyService
         .createNativeHistoricDecisionInstanceQuery().sql("SELECT * FROM " + tablePrefix + "ACT_HI_DECINST");
 
-    assertThat(nativeQuery.list().size()).isEqualTo(1);
+    assertThat(nativeQuery.list()).hasSize(1);
 
     NativeHistoricDecisionInstanceQuery nativeQueryWithParameter = historyService
         .createNativeHistoricDecisionInstanceQuery()
         .sql("SELECT * FROM " + tablePrefix + "ACT_HI_DECINST H WHERE H.DEC_DEF_KEY_ = #{decisionDefinitionKey}");
 
-    assertThat(nativeQueryWithParameter.parameter("decisionDefinitionKey", DECISION_DEFINITION_KEY).list().size()).isEqualTo(1);
+    assertThat(nativeQueryWithParameter.parameter("decisionDefinitionKey", DECISION_DEFINITION_KEY).list()).hasSize(1);
     assertThat(nativeQueryWithParameter.parameter("decisionDefinitionKey", "other decision").list().size()).isZero();
   }
 
@@ -649,8 +649,8 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
     NativeHistoricDecisionInstanceQuery nativeQuery = historyService.createNativeHistoricDecisionInstanceQuery()
         .sql("SELECT * FROM " + tablePrefix + "ACT_HI_DECINST");
 
-    assertThat(nativeQuery.listPage(0, 2).size()).isEqualTo(2);
-    assertThat(nativeQuery.listPage(1, 1).size()).isEqualTo(1);
+    assertThat(nativeQuery.listPage(0, 2)).hasSize(2);
+    assertThat(nativeQuery.listPage(1, 1)).hasSize(1);
   }
 
   protected ProcessInstance startProcessInstanceAndEvaluateDecision() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
@@ -620,7 +620,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
         .sql("SELECT * FROM " + tablePrefix + "ACT_HI_DECINST H WHERE H.DEC_DEF_KEY_ = #{decisionDefinitionKey}");
 
     assertThat(nativeQueryWithParameter.parameter("decisionDefinitionKey", DECISION_DEFINITION_KEY).list().size()).isEqualTo(1);
-    assertThat(nativeQueryWithParameter.parameter("decisionDefinitionKey", "other decision").list().size()).isEqualTo(0);
+    assertThat(nativeQueryWithParameter.parameter("decisionDefinitionKey", "other decision").list().size()).isZero();
   }
 
   @Deployment(resources = { DECISION_PROCESS, DECISION_SINGLE_OUTPUT_DMN })

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
@@ -16,12 +16,10 @@
  */
 package org.operaton.bpm.engine.test.history.dmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
-
-import java.util.Date;
-import java.util.List;
-
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.operaton.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -39,10 +37,12 @@ import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.operaton.bpm.engine.test.util.ResetDmnConfigUtil;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
-import org.joda.time.DateTime;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * @author Philipp Ossler
@@ -620,7 +620,7 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
         .sql("SELECT * FROM " + tablePrefix + "ACT_HI_DECINST H WHERE H.DEC_DEF_KEY_ = #{decisionDefinitionKey}");
 
     assertThat(nativeQueryWithParameter.parameter("decisionDefinitionKey", DECISION_DEFINITION_KEY).list()).hasSize(1);
-    assertThat(nativeQueryWithParameter.parameter("decisionDefinitionKey", "other decision").list().size()).isZero();
+    assertThat(nativeQueryWithParameter.parameter("decisionDefinitionKey", "other decision").list()).isEmpty();
   }
 
   @Deployment(resources = { DECISION_PROCESS, DECISION_SINGLE_OUTPUT_DMN })

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceTest.java
@@ -16,12 +16,10 @@
  */
 package org.operaton.bpm.engine.test.history.dmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.operaton.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.history.HistoricDecisionInputInstance;
@@ -43,10 +41,12 @@ import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.operaton.bpm.engine.test.util.ResetDmnConfigUtil;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
-import org.joda.time.DateTime;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Philipp Ossler
@@ -358,7 +358,7 @@ public class HistoricDecisionInstanceTest extends PluggableProcessEngineTest {
     assertThat(historicDecisionInstance.getDecisionDefinitionName()).isEqualTo("Decision with Literal Expression");
     assertThat(historicDecisionInstance.getEvaluationTime()).isNotNull();
 
-    assertThat(historicDecisionInstance.getInputs().size()).isZero();
+    assertThat(historicDecisionInstance.getInputs()).isEmpty();
 
     List<HistoricDecisionOutputInstance> outputs = historicDecisionInstance.getOutputs();
     assertThat(outputs).hasSize(1);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceTest.java
@@ -358,7 +358,7 @@ public class HistoricDecisionInstanceTest extends PluggableProcessEngineTest {
     assertThat(historicDecisionInstance.getDecisionDefinitionName()).isEqualTo("Decision with Literal Expression");
     assertThat(historicDecisionInstance.getEvaluationTime()).isNotNull();
 
-    assertThat(historicDecisionInstance.getInputs().size()).isEqualTo(0);
+    assertThat(historicDecisionInstance.getInputs().size()).isZero();
 
     List<HistoricDecisionOutputInstance> outputs = historicDecisionInstance.getOutputs();
     assertThat(outputs.size()).isEqualTo(1);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceTest.java
@@ -190,7 +190,7 @@ public class HistoricDecisionInstanceTest extends PluggableProcessEngineTest {
     HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery().includeInputs().singleResult();
     List<HistoricDecisionInputInstance> inputs = historicDecisionInstance.getInputs();
     assertThat(inputs).isNotNull();
-    assertThat(inputs.size()).isEqualTo(1);
+    assertThat(inputs).hasSize(1);
 
     HistoricDecisionInputInstance input = inputs.get(0);
     assertThat(input.getDecisionInstanceId()).isEqualTo(historicDecisionInstance.getId());
@@ -211,14 +211,14 @@ public class HistoricDecisionInstanceTest extends PluggableProcessEngineTest {
         .includeInputs()
         .orderByEvaluationTime().asc()
         .list();
-    assertThat(historicDecisionInstances.size()).isEqualTo(2);
+    assertThat(historicDecisionInstances).hasSize(2);
 
     List<HistoricDecisionInputInstance> inputsOfFirstDecision = historicDecisionInstances.get(0).getInputs();
-    assertThat(inputsOfFirstDecision.size()).isEqualTo(1);
+    assertThat(inputsOfFirstDecision).hasSize(1);
     assertThat(inputsOfFirstDecision.get(0).getValue()).isEqualTo((Object) "a");
 
     List<HistoricDecisionInputInstance> inputsOfSecondDecision = historicDecisionInstances.get(1).getInputs();
-    assertThat(inputsOfSecondDecision.size()).isEqualTo(1);
+    assertThat(inputsOfSecondDecision).hasSize(1);
     assertThat(inputsOfSecondDecision.get(0).getValue()).isEqualTo((Object) "b");
   }
 
@@ -233,7 +233,7 @@ public class HistoricDecisionInstanceTest extends PluggableProcessEngineTest {
 
     HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery().includeInputs().singleResult();
     List<HistoricDecisionInputInstance> inputs = historicDecisionInstance.getInputs();
-    assertThat(inputs.size()).isEqualTo(2);
+    assertThat(inputs).hasSize(2);
 
     assertThat(inputs.get(0).getValue()).isEqualTo((Object) "a");
     assertThat(inputs.get(1).getValue()).isEqualTo((Object) 1);
@@ -248,7 +248,7 @@ public class HistoricDecisionInstanceTest extends PluggableProcessEngineTest {
 
     HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery().includeInputs().disableBinaryFetching().singleResult();
     List<HistoricDecisionInputInstance> inputs = historicDecisionInstance.getInputs();
-    assertThat(inputs.size()).isEqualTo(1);
+    assertThat(inputs).hasSize(1);
 
     HistoricDecisionInputInstance input = inputs.get(0);
     assertThat(input.getTypeName()).isEqualTo("bytes");
@@ -264,7 +264,7 @@ public class HistoricDecisionInstanceTest extends PluggableProcessEngineTest {
     HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery().includeOutputs().singleResult();
     List<HistoricDecisionOutputInstance> outputs = historicDecisionInstance.getOutputs();
     assertThat(outputs).isNotNull();
-    assertThat(outputs.size()).isEqualTo(1);
+    assertThat(outputs).hasSize(1);
 
     HistoricDecisionOutputInstance output = outputs.get(0);
     assertThat(output.getDecisionInstanceId()).isEqualTo(historicDecisionInstance.getId());
@@ -285,7 +285,7 @@ public class HistoricDecisionInstanceTest extends PluggableProcessEngineTest {
 
     HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery().includeOutputs().singleResult();
     List<HistoricDecisionOutputInstance> outputs = historicDecisionInstance.getOutputs();
-    assertThat(outputs.size()).isEqualTo(2);
+    assertThat(outputs).hasSize(2);
 
     HistoricDecisionOutputInstance firstOutput = outputs.get(0);
     assertThat(firstOutput.getClauseId()).isEqualTo("out1");
@@ -310,7 +310,7 @@ public class HistoricDecisionInstanceTest extends PluggableProcessEngineTest {
 
     HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery().includeOutputs().singleResult();
     List<HistoricDecisionOutputInstance> outputs = historicDecisionInstance.getOutputs();
-    assertThat(outputs.size()).isEqualTo(2);
+    assertThat(outputs).hasSize(2);
 
     HistoricDecisionOutputInstance firstOutput = outputs.get(0);
     assertThat(firstOutput.getClauseId()).isEqualTo("out1");
@@ -361,7 +361,7 @@ public class HistoricDecisionInstanceTest extends PluggableProcessEngineTest {
     assertThat(historicDecisionInstance.getInputs().size()).isZero();
 
     List<HistoricDecisionOutputInstance> outputs = historicDecisionInstance.getOutputs();
-    assertThat(outputs.size()).isEqualTo(1);
+    assertThat(outputs).hasSize(1);
 
     HistoricDecisionOutputInstance output = outputs.get(0);
     assertThat(output.getVariableName()).isEqualTo("result");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceTest.java
@@ -416,7 +416,7 @@ public class HistoricDecisionInstanceTest extends PluggableProcessEngineTest {
     DecisionDefinition decisionDefinition = repositoryService.createDecisionDefinitionQuery().singleResult();
     historyService.deleteHistoricDecisionInstanceByDefinitionId(decisionDefinition.getId());
 
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Deployment(resources = { DECISION_PROCESS, DECISION_SINGLE_OUTPUT_DMN })
@@ -435,7 +435,7 @@ public class HistoricDecisionInstanceTest extends PluggableProcessEngineTest {
     historyService.deleteHistoricDecisionInstanceByInstanceId(historicDecisionInstance.getId());
 
     // then
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Test
@@ -459,7 +459,7 @@ public class HistoricDecisionInstanceTest extends PluggableProcessEngineTest {
     assertThat(query.count()).isEqualTo(1L);
 
     repositoryService.deleteDeployment(firstDeploymentId, true);
-    assertThat(query.count()).isEqualTo(0L);
+    assertThat(query.count()).isZero();
   }
 
   @Deployment(resources = { DECISION_SINGLE_OUTPUT_DMN })

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/UserOperationLogAnnotationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/UserOperationLogAnnotationTest.java
@@ -152,7 +152,7 @@ public class UserOperationLogAnnotationTest {
         .list();
 
     // assume
-    assertThat(userOperationLogEntries.size()).isEqualTo(2);
+    assertThat(userOperationLogEntries).hasSize(2);
 
     String operationId = userOperationLogEntries.get(0)
         .getOperationId();
@@ -211,7 +211,7 @@ public class UserOperationLogAnnotationTest {
         .list();
 
     // assume
-    assertThat(userOperationLogEntries.size()).isEqualTo(2);
+    assertThat(userOperationLogEntries).hasSize(2);
 
     String operationId = userOperationLogEntries.get(0)
         .getOperationId();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/AcquireJobCmdUnitTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/AcquireJobCmdUnitTest.java
@@ -104,8 +104,8 @@ public class AcquireJobCmdUnitTest {
     AcquiredJobs acquiredJobs = acquireJobsCmd.execute(commandContext);
 
     List<List<String>> jobIdBatches = acquiredJobs.getJobIdBatches();
-    assertThat(jobIdBatches.size()).isEqualTo(1);
-    assertThat(jobIdBatches.get(0).size()).isEqualTo(2);
+    assertThat(jobIdBatches).hasSize(1);
+    assertThat(jobIdBatches.get(0)).hasSize(2);
     assertThat(jobIdBatches.get(0)).containsExactlyInAnyOrder(JOB_ID_1, JOB_ID_2);
   }
 
@@ -139,9 +139,9 @@ public class AcquireJobCmdUnitTest {
     AcquiredJobs acquiredJobs = acquireJobsCmd.execute(commandContext);
 
     List<List<String>> jobIdBatches = acquiredJobs.getJobIdBatches();
-    assertThat(jobIdBatches.size()).isEqualTo(2);
-    assertThat(jobIdBatches.get(0).size()).isEqualTo(1);
-    assertThat(jobIdBatches.get(1).size()).isEqualTo(1);
+    assertThat(jobIdBatches).hasSize(2);
+    assertThat(jobIdBatches.get(0)).hasSize(1);
+    assertThat(jobIdBatches.get(1)).hasSize(1);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/BatchJobPriorityRangeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/BatchJobPriorityRangeTest.java
@@ -124,7 +124,7 @@ public class BatchJobPriorityRangeTest {
 
     // then
     List<AcquirableJobEntity> acquirableJobs = findAcquirableJobs();
-    assertThat(acquirableJobs).hasSize(0);
+    assertThat(acquirableJobs).isEmpty();
 
     Job seedJob = helper.getSeedJob(batch);
     assertThat(seedJob.getPriority()).isEqualTo(20L);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/HistoryCleanupJobPriorityRangeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/HistoryCleanupJobPriorityRangeTest.java
@@ -109,7 +109,7 @@ public class HistoryCleanupJobPriorityRangeTest extends AbstractJobExecutorAcqui
 
     // then
     List<AcquirableJobEntity> acquirableJobs = findAcquirableJobs();
-    assertThat(acquirableJobs).hasSize(0);
+    assertThat(acquirableJobs).isEmpty();
     List<Job> historyCleanupJobs = historyService.findHistoryCleanupJobs();
     assertThat(historyCleanupJobs).hasSize(1);
     assertThat(historyCleanupJobs.get(0).getPriority()).isEqualTo(20L);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExceptionLoggingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExceptionLoggingTest.java
@@ -92,7 +92,7 @@ public class JobExceptionLoggingTest {
 
     // then
     assertThat(jobLog.size()).isEqualTo(1);
-    assertThat(ctxLog.size()).isEqualTo(0);
+    assertThat(ctxLog.size()).isZero();
   }
 
   @Test
@@ -146,8 +146,8 @@ public class JobExceptionLoggingTest {
     assertThat(expectedException).isNotNull();
     assertThat(expectedException.getMessage()).contains("Expected Exception");
     // ...but not logged
-    assertThat(jobLog.size()).isEqualTo(0);
-    assertThat(ctxLog.size()).isEqualTo(0);
+    assertThat(jobLog.size()).isZero();
+    assertThat(ctxLog.size()).isZero();
   }
 
   @Test
@@ -176,7 +176,7 @@ public class JobExceptionLoggingTest {
     assertThat(expectedException).isNotNull();
     assertThat(expectedException.getMessage()).contains("Expected Exception");
     // ...but not logged
-    assertThat(jobLog.size()).isEqualTo(0);
-    assertThat(ctxLog.size()).isEqualTo(0);
+    assertThat(jobLog.size()).isZero();
+    assertThat(ctxLog.size()).isZero();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExceptionLoggingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExceptionLoggingTest.java
@@ -16,12 +16,13 @@
  */
 package org.operaton.bpm.engine.test.jobexecutor;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.List;
-
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.ManagementService;
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -34,11 +35,10 @@ import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.commons.testing.ProcessEngineLoggingRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JobExceptionLoggingTest {
 
@@ -92,7 +92,7 @@ public class JobExceptionLoggingTest {
 
     // then
     assertThat(jobLog).hasSize(1);
-    assertThat(ctxLog.size()).isZero();
+    assertThat(ctxLog).isEmpty();
   }
 
   @Test
@@ -146,8 +146,8 @@ public class JobExceptionLoggingTest {
     assertThat(expectedException).isNotNull();
     assertThat(expectedException.getMessage()).contains("Expected Exception");
     // ...but not logged
-    assertThat(jobLog.size()).isZero();
-    assertThat(ctxLog.size()).isZero();
+    assertThat(jobLog).isEmpty();
+    assertThat(ctxLog).isEmpty();
   }
 
   @Test
@@ -176,7 +176,7 @@ public class JobExceptionLoggingTest {
     assertThat(expectedException).isNotNull();
     assertThat(expectedException.getMessage()).contains("Expected Exception");
     // ...but not logged
-    assertThat(jobLog.size()).isZero();
-    assertThat(ctxLog.size()).isZero();
+    assertThat(jobLog).isEmpty();
+    assertThat(ctxLog).isEmpty();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExceptionLoggingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExceptionLoggingTest.java
@@ -91,7 +91,7 @@ public class JobExceptionLoggingTest {
     List<ILoggingEvent> ctxLog = loggingRule.getFilteredLog(CONTEXT_LOGGER, "Exception while closing command context");
 
     // then
-    assertThat(jobLog.size()).isEqualTo(1);
+    assertThat(jobLog).hasSize(1);
     assertThat(ctxLog.size()).isZero();
   }
 
@@ -112,8 +112,8 @@ public class JobExceptionLoggingTest {
     List<ILoggingEvent> ctxLog = loggingRule.getFilteredLog(CONTEXT_LOGGER, "Exception while closing command context");
     
     // then
-    assertThat(jobLog.size()).isEqualTo(1);
-    assertThat(ctxLog.size()).isEqualTo(1);
+    assertThat(jobLog).hasSize(1);
+    assertThat(ctxLog).hasSize(1);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsForPriorityRangeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorAcquireJobsForPriorityRangeTest.java
@@ -121,7 +121,7 @@ public class JobExecutorAcquireJobsForPriorityRangeTest extends AbstractJobExecu
     List<AcquirableJobEntity> acquirableJobs = findAcquirableJobs();
 
     // then
-    assertThat(acquirableJobs).hasSize(0);
+    assertThat(acquirableJobs).isEmpty();
   }
 
   @Test
@@ -172,7 +172,7 @@ public class JobExecutorAcquireJobsForPriorityRangeTest extends AbstractJobExecu
 
     // then
     List<ILoggingEvent> log = loggingRule.getFilteredLog("RES.PRIORITY_ >= ? and RES.PRIORITY_ <= ?");
-    assertThat(log).hasSize(0);
+    assertThat(log).isEmpty();
   }
 
   @Test
@@ -188,7 +188,7 @@ public class JobExecutorAcquireJobsForPriorityRangeTest extends AbstractJobExecu
     List<ILoggingEvent> logRangeMinCheck = loggingRule.getFilteredLog("RES.PRIORITY_ >= ?");
     assertThat(logRangeMinCheck).hasSize(1);
     List<ILoggingEvent> logRangeMaxCheck = loggingRule.getFilteredLog("RES.PRIORITY_ <= ?");
-    assertThat(logRangeMaxCheck).hasSize(0);
+    assertThat(logRangeMaxCheck).isEmpty();
   }
 
   @Test
@@ -202,7 +202,7 @@ public class JobExecutorAcquireJobsForPriorityRangeTest extends AbstractJobExecu
 
     // then
     List<ILoggingEvent> logRangeMinCheck = loggingRule.getFilteredLog("RES.PRIORITY_ >= ?");
-    assertThat(logRangeMinCheck).hasSize(0);
+    assertThat(logRangeMinCheck).isEmpty();
     List<ILoggingEvent> logRangeMaxCheck = loggingRule.getFilteredLog("RES.PRIORITY_ <= ?");
     assertThat(logRangeMaxCheck).hasSize(1);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/ReducedJobExceptionLoggingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/ReducedJobExceptionLoggingTest.java
@@ -80,7 +80,7 @@ public class ReducedJobExceptionLoggingTest {
     List<ILoggingEvent> filteredLogList = loggingRule.getFilteredLog("Exception while executing job");
 
     // then
-    assertThat(filteredLogList.size()).isEqualTo(3);
+    assertThat(filteredLogList).hasSize(3);
   }
 
   @Test
@@ -98,6 +98,6 @@ public class ReducedJobExceptionLoggingTest {
     List<ILoggingEvent> filteredLogList = loggingRule.getFilteredLog("Exception while executing job");
 
     // then
-    assertThat(filteredLogList.size()).isEqualTo(1);
+    assertThat(filteredLogList).hasSize(1);
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
@@ -891,7 +891,7 @@ public class ProcessDataLoggingContextTest {
 
         if (expectedActivities != null) {
           assertThat(activityIdMdc).isNotNull();
-          assertThat(expectedActivities.contains(activityIdMdc)).isTrue();
+          assertThat(expectedActivities).contains(activityIdMdc);
           passedActivities.add(activityIdMdc);
         } else {
           assertThat(activityIdMdc).isNull();
@@ -929,7 +929,7 @@ public class ProcessDataLoggingContextTest {
 
 
       } else {
-        assertThat(mdcPropertyMap.isEmpty()).isTrue();
+        assertThat(mdcPropertyMap).isEmpty();
       }
       foundLogEntries = true;
     }
@@ -945,21 +945,21 @@ public class ProcessDataLoggingContextTest {
     for (int i = 0; i < bpmnStacktraceLog.size(); i++) {
       ILoggingEvent logEvent = bpmnStacktraceLog.get(i);
       Map<String, String> mdcPropertyMap = logEvent.getMDCPropertyMap();
-      assertThat(mdcPropertyMap.containsKey("activityId")).isTrue();
+      assertThat(mdcPropertyMap).containsKey("activityId");
       assertThat(mdcPropertyMap.containsKey("applicationName")).isFalse();
-      assertThat(mdcPropertyMap.containsKey("processDefinitionId")).isTrue();
-      assertThat(mdcPropertyMap.containsKey("processInstanceId")).isTrue();
-      assertThat(mdcPropertyMap.containsKey("tenantId")).isTrue();
+      assertThat(mdcPropertyMap).containsKey("processDefinitionId");
+      assertThat(mdcPropertyMap).containsKey("processInstanceId");
+      assertThat(mdcPropertyMap).containsKey("tenantId");
       if (i == 0) {
         // first BPMN stack trace log corresponds to nested service task
         assertThat(mdcPropertyMap.containsKey("businessKey")).isFalse();
-        assertThat(mdcPropertyMap.get("activityId")).isEqualTo("failing_task");
+        assertThat(mdcPropertyMap).containsEntry("activityId", "failing_task");
         assertThat(mdcPropertyMap.get("processDefinitionId")).isNotEqualTo(instance.getProcessDefinitionId());
         assertThat(mdcPropertyMap.get("processInstanceId")).isNotEqualTo(instance.getId());
         assertThat(instance.getTenantId()).isEqualTo(mdcPropertyMap.get("tenantId"));
       } else {
         // second BPMN stack trace log corresponds to outer service task
-        assertThat(mdcPropertyMap.containsKey("businessKey")).isTrue();
+        assertThat(mdcPropertyMap).containsKey("businessKey");
         assertThat("startProcess").isEqualTo(mdcPropertyMap.get("activityId"));
         assertThat(instance.getBusinessKey()).isEqualTo(mdcPropertyMap.get("businessKey"));
         assertThat(instance.getProcessDefinitionId()).isEqualTo(mdcPropertyMap.get("processDefinitionId"));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
@@ -941,7 +941,7 @@ public class ProcessDataLoggingContextTest {
 
   protected void assertBpmnStacktraceLogPresent(ProcessInstance instance) {
     List<ILoggingEvent> bpmnStacktraceLog = loggingRule.getFilteredLog("ENGINE-16006");
-    assertThat(bpmnStacktraceLog.size()).isEqualTo(2);
+    assertThat(bpmnStacktraceLog).hasSize(2);
     for (int i = 0; i < bpmnStacktraceLog.size(); i++) {
       ILoggingEvent logEvent = bpmnStacktraceLog.get(i);
       Map<String, String> mdcPropertyMap = logEvent.getMDCPropertyMap();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/authentication/LoginAttemptsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/authentication/LoginAttemptsTest.java
@@ -94,6 +94,6 @@ public class LoginAttemptsTest {
     }
 
     // then
-    assertThat(loggingRule.getFilteredLog(INDENTITY_LOGGER, "The user with id 'johndoe' is permanently locked.").size()).isEqualTo(1);
+    assertThat(loggingRule.getFilteredLog(INDENTITY_LOGGER, "The user with id 'johndoe' is permanently locked.")).hasSize(1);
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/db/SchemaLogTestCase.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/db/SchemaLogTestCase.java
@@ -16,24 +16,20 @@
  */
 package org.operaton.bpm.engine.test.standalone.db;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import org.junit.Before;
+import org.junit.Rule;
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.impl.db.sql.DbSqlSessionFactory;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.Before;
-import org.junit.Rule;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * @author Miklas Boskamp
@@ -70,7 +66,7 @@ public class SchemaLogTestCase {
     try {
       PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
       Resource[] resources = resolver.getResources("classpath:" + path + "/*");
-      assertThat(resources.length).isGreaterThan(0);
+      assertThat(resources).isNotEmpty();
       for (Resource res : resources) {
         files.add(res.getFilename());
       }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/deploy/DeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/deploy/DeploymentTest.java
@@ -58,7 +58,7 @@ public class DeploymentTest {
      engineRule.getRepositoryService().deleteDeployment(deployment.getId(), true);
 
      long count = engineRule.getRepositoryService().createDeploymentQuery().count();
-     assertThat(count).isEqualTo(0L);
+     assertThat(count).isZero();
   }
 
   @Test
@@ -80,6 +80,6 @@ public class DeploymentTest {
      engineRule.getRepositoryService().deleteDeployment(deployment.getId(), true);
 
      long count = engineRule.getRepositoryService().createDeploymentQuery().count();
-     assertThat(count).isEqualTo(0L);
+     assertThat(count).isZero();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/AbstractHistoryLevelTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/AbstractHistoryLevelTest.java
@@ -16,11 +16,11 @@
  */
 package org.operaton.bpm.engine.test.standalone.history;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import org.junit.Test;
 import org.operaton.bpm.engine.impl.history.AbstractHistoryLevel;
 import org.operaton.bpm.engine.impl.history.event.HistoryEventType;
-import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AbstractHistoryLevelTest {
 
@@ -45,6 +45,6 @@ public class AbstractHistoryLevelTest {
 
   @Test
   public void ensureCorrectToString() {
-    assertThat(new MyHistoryLevel().toString()).isEqualTo("MyHistoryLevel(name=myName, id=4711)");
+    assertThat(new MyHistoryLevel()).hasToString("MyHistoryLevel(name=myName, id=4711)");
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryOrTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryOrTest.java
@@ -799,7 +799,7 @@ public class HistoricTaskInstanceQueryOrTest {
         .list();
 
     // then
-    assertThat(tasks.size()).isEqualTo(2);
+    assertThat(tasks).hasSize(2);
   }
 
   @Test
@@ -820,7 +820,7 @@ public class HistoricTaskInstanceQueryOrTest {
         .list();
 
     // then
-    assertThat(tasks.size()).isEqualTo(2);
+    assertThat(tasks).hasSize(2);
   }
 
   @Test
@@ -841,7 +841,7 @@ public class HistoricTaskInstanceQueryOrTest {
         .list();
 
     // then
-    assertThat(tasks.size()).isEqualTo(2);
+    assertThat(tasks).hasSize(2);
   }
 
   @Test
@@ -862,7 +862,7 @@ public class HistoricTaskInstanceQueryOrTest {
         .list();
 
     // then
-    assertThat(tasks.size()).isEqualTo(2);
+    assertThat(tasks).hasSize(2);
   }
 
   @Test
@@ -891,7 +891,7 @@ public class HistoricTaskInstanceQueryOrTest {
         .list();
 
     // then
-    assertThat(tasks.size()).isEqualTo(2);
+    assertThat(tasks).hasSize(2);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryTest.java
@@ -764,7 +764,7 @@ public class HistoricTaskInstanceQueryTest extends PluggableProcessEngineTest {
   }
 
   private void assertThatListContainsOnlyExpectedElement(List<HistoricTaskInstance> instances, ProcessInstance instance) {
-    assertThat(instances.size()).isEqualTo(1);
+    assertThat(instances).hasSize(1);
     assertThat(instances.get(0).getProcessInstanceId()).isEqualTo(instance.getId());
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/identity/DefaultPasswordPolicyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/identity/DefaultPasswordPolicyTest.java
@@ -67,7 +67,7 @@ public class DefaultPasswordPolicyTest {
   @Test
   public void testGoodPassword() {
     PasswordPolicyResult result = identityService.checkPasswordAgainstPolicy(policy, "LongPas$w0rd");
-    assertThat(result.getViolatedRules().size()).isEqualTo(0);
+    assertThat(result.getViolatedRules().size()).isZero();
     assertThat(result.getFulfilledRules().size()).isEqualTo(6);
     assertThat(result.isValid()).isTrue();
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/identity/DefaultPasswordPolicyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/identity/DefaultPasswordPolicyTest.java
@@ -68,7 +68,7 @@ public class DefaultPasswordPolicyTest {
   public void testGoodPassword() {
     PasswordPolicyResult result = identityService.checkPasswordAgainstPolicy(policy, "LongPas$w0rd");
     assertThat(result.getViolatedRules().size()).isZero();
-    assertThat(result.getFulfilledRules().size()).isEqualTo(6);
+    assertThat(result.getFulfilledRules()).hasSize(6);
     assertThat(result.isValid()).isTrue();
   }
 
@@ -253,8 +253,8 @@ public class DefaultPasswordPolicyTest {
   }
 
   private void checkThatPasswordWasInvalid(PasswordPolicyResult result) {
-    assertThat(result.getViolatedRules().size()).isEqualTo(1);
-    assertThat(result.getFulfilledRules().size()).isEqualTo(5);
+    assertThat(result.getViolatedRules()).hasSize(1);
+    assertThat(result.getFulfilledRules()).hasSize(5);
     assertThat(result.isValid()).isFalse();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/identity/DefaultPasswordPolicyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/identity/DefaultPasswordPolicyTest.java
@@ -67,7 +67,7 @@ public class DefaultPasswordPolicyTest {
   @Test
   public void testGoodPassword() {
     PasswordPolicyResult result = identityService.checkPasswordAgainstPolicy(policy, "LongPas$w0rd");
-    assertThat(result.getViolatedRules().size()).isZero();
+    assertThat(result.getViolatedRules()).isEmpty();
     assertThat(result.getFulfilledRules()).hasSize(6);
     assertThat(result.isValid()).isTrue();
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/identity/DefaultPasswordPolicyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/identity/DefaultPasswordPolicyTest.java
@@ -16,29 +16,23 @@
  */
 package org.operaton.bpm.engine.test.standalone.identity;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import org.assertj.core.api.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.operaton.bpm.engine.IdentityService;
 import org.operaton.bpm.engine.exception.NullValueException;
 import org.operaton.bpm.engine.identity.PasswordPolicy;
 import org.operaton.bpm.engine.identity.PasswordPolicyResult;
 import org.operaton.bpm.engine.identity.PasswordPolicyRule;
 import org.operaton.bpm.engine.identity.User;
-import org.operaton.bpm.engine.impl.identity.DefaultPasswordPolicyImpl;
-import org.operaton.bpm.engine.impl.identity.PasswordPolicyDigitRuleImpl;
-import org.operaton.bpm.engine.impl.identity.PasswordPolicyLengthRuleImpl;
-import org.operaton.bpm.engine.impl.identity.PasswordPolicyLowerCaseRuleImpl;
-import org.operaton.bpm.engine.impl.identity.PasswordPolicySpecialCharacterRuleImpl;
-import org.operaton.bpm.engine.impl.identity.PasswordPolicyUpperCaseRuleImpl;
-import org.operaton.bpm.engine.impl.identity.PasswordPolicyUserDataRuleImpl;
+import org.operaton.bpm.engine.impl.identity.*;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Miklas Boskamp
@@ -261,6 +255,6 @@ public class DefaultPasswordPolicyTest {
   private void checkThatPasswordWasInvalid(PasswordPolicyResult result) {
     assertThat(result.getViolatedRules().size()).isEqualTo(1);
     assertThat(result.getFulfilledRules().size()).isEqualTo(5);
-    assertThat(result.isValid()).isEqualTo(false);
+    assertThat(result.isValid()).isFalse();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/identity/DefaultPasswordPolicyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/identity/DefaultPasswordPolicyTest.java
@@ -75,7 +75,7 @@ public class DefaultPasswordPolicyTest {
     PasswordPolicyResult result = identityService.checkPasswordAgainstPolicy(policy, "LongPas$w0rd");
     assertThat(result.getViolatedRules().size()).isEqualTo(0);
     assertThat(result.getFulfilledRules().size()).isEqualTo(6);
-    assertThat(result.isValid()).isEqualTo(true);
+    assertThat(result.isValid()).isTrue();
   }
 
   @Test
@@ -194,7 +194,7 @@ public class DefaultPasswordPolicyTest {
     assertThat(user.getFirstName()).isEqualTo("Jane");
     assertThat(user.getLastName()).isEqualTo("Donnel");
     assertThat(user.getEmail()).isEqualTo("jane@donnel.com");
-    assertThat(identityService.checkPassword("johndoe", "Passw0rds!")).isEqualTo(true);
+    assertThat(identityService.checkPassword("johndoe", "Passw0rds!")).isTrue();
 
     identityService.deleteUser(user.getId());
   }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnDiTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnDiTest.java
@@ -92,7 +92,7 @@ class BpmnDiTest {
     Font font = labelStyle.getFont();
     assertThat(font).isNotNull();
     assertThat(font.getName()).isEqualTo("Arial");
-    assertThat(font.getSize()).isEqualTo(8.0);
+    assertThat(font.get).hasSize(8.0);
     assertThat(font.isBold()).isTrue();
     assertThat(font.isItalic()).isFalse();
     assertThat(font.isStrikeThrough()).isFalse();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnDiTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnDiTest.java
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.model.bpmn.instance.*;
 import org.operaton.bpm.model.bpmn.instance.Process;
+import org.operaton.bpm.model.bpmn.instance.*;
 import org.operaton.bpm.model.bpmn.instance.bpmndi.*;
 import org.operaton.bpm.model.bpmn.instance.dc.Bounds;
 import org.operaton.bpm.model.bpmn.instance.dc.Font;
@@ -92,7 +93,7 @@ class BpmnDiTest {
     Font font = labelStyle.getFont();
     assertThat(font).isNotNull();
     assertThat(font.getName()).isEqualTo("Arial");
-    assertThat(font.get).hasSize(8.0);
+    assertThat(font.getSize()).isEqualTo(8.0);
     assertThat(font.isBold()).isTrue();
     assertThat(font.isItalic()).isFalse();
     assertThat(font.isStrikeThrough()).isFalse();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DataObjectsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/DataObjectsTest.java
@@ -60,7 +60,7 @@ class DataObjectsTest {
     DataObjectReference dataObjectReference = modelInstance.getModelElementById("_dataRef_11");
     DataInputAssociation dataInputAssociation = scriptTask.getDataInputAssociations().iterator().next();
     Collection<ItemAwareElement> sources = dataInputAssociation.getSources();
-    assertThat(sources.size()).isEqualTo(1);
+    assertThat(sources).hasSize(1);
     assertThat(sources.iterator().next()).isEqualTo(dataObjectReference);
   }
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ModelTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ModelTest.java
@@ -55,7 +55,7 @@ class ModelTest {
     assertThat(allBaseTypes).hasSize(3);
 
     allBaseTypes = ModelUtil.calculateAllBaseTypes(model.getType(BaseElement.class));
-    assertThat(allBaseTypes).hasSize(0);
+    assertThat(allBaseTypes).isEmpty();
   }
 
   @Test

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
@@ -828,7 +828,7 @@ public class OperatonExtensionsTest {
     assertThat(field.getOperatonString().getTextContent()).isEqualTo(TEST_STRING_XML);
 
     Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
-    assertThat(timeouts.size()).isEqualTo(1);
+    assertThat(timeouts).hasSize(1);
 
     TimerEventDefinition timeout = timeouts.iterator().next();
     assertThat(timeout.getTimeCycle()).isNull();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
@@ -16,104 +16,19 @@
  */
 package org.operaton.bpm.model.bpmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.BUSINESS_RULE_TASK;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.CALL_ACTIVITY_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.END_EVENT_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.PROCESS_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.SCRIPT_TASK_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.SEND_TASK_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.SEQUENCE_FLOW_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.SERVICE_TASK_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.START_EVENT_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_CLASS_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_CLASS_XML;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_DELEGATE_EXPRESSION_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_DELEGATE_EXPRESSION_XML;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_DUE_DATE_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_DUE_DATE_XML;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_EXECUTION_EVENT_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_EXECUTION_EVENT_XML;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_EXPRESSION_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_EXPRESSION_XML;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_FLOW_NODE_JOB_PRIORITY;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_GROUPS_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_GROUPS_LIST_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_GROUPS_LIST_XML;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_GROUPS_XML;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_HISTORY_TIME_TO_LIVE;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_PRIORITY_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_PRIORITY_XML;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_PROCESS_JOB_PRIORITY;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_PROCESS_TASK_PRIORITY;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_SERVICE_TASK_PRIORITY;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_STRING_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_STRING_XML;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_TASK_EVENT_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_TASK_EVENT_XML;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_TYPE_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_TYPE_XML;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_USERS_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_USERS_LIST_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_USERS_LIST_XML;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_USERS_XML;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.USER_TASK_ID;
-import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.CAMUNDA_NS;
-import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.CAMUNDA_ATTRIBUTE_ERROR_CODE_VARIABLE;
-import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.CAMUNDA_ATTRIBUTE_ERROR_MESSAGE_VARIABLE;
-import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.operaton.bpm.model.bpmn.instance.BaseElement;
-import org.operaton.bpm.model.bpmn.instance.BpmnModelElementInstance;
-import org.operaton.bpm.model.bpmn.instance.BusinessRuleTask;
-import org.operaton.bpm.model.bpmn.instance.CallActivity;
-import org.operaton.bpm.model.bpmn.instance.EndEvent;
 import org.operaton.bpm.model.bpmn.instance.Error;
-import org.operaton.bpm.model.bpmn.instance.ErrorEventDefinition;
-import org.operaton.bpm.model.bpmn.instance.Expression;
-import org.operaton.bpm.model.bpmn.instance.MessageEventDefinition;
-import org.operaton.bpm.model.bpmn.instance.ParallelGateway;
 import org.operaton.bpm.model.bpmn.instance.Process;
-import org.operaton.bpm.model.bpmn.instance.ScriptTask;
-import org.operaton.bpm.model.bpmn.instance.SendTask;
-import org.operaton.bpm.model.bpmn.instance.SequenceFlow;
-import org.operaton.bpm.model.bpmn.instance.ServiceTask;
-import org.operaton.bpm.model.bpmn.instance.StartEvent;
-import org.operaton.bpm.model.bpmn.instance.TimerEventDefinition;
-import org.operaton.bpm.model.bpmn.instance.UserTask;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonConnector;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonConnectorId;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonConstraint;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonEntry;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonExecutionListener;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonFailedJobRetryTimeCycle;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonField;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonFormData;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonFormField;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonFormProperty;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonIn;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonInputOutput;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonInputParameter;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonList;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonMap;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonOut;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonOutputParameter;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonPotentialStarter;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonProperties;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonProperty;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonScript;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonTaskListener;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonValue;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.operaton.bpm.model.bpmn.instance.*;
+import org.operaton.bpm.model.bpmn.instance.operaton.*;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.model.bpmn.BpmnTestConstants.*;
+import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.*;
 
 /**
  * @author Sebastian Menski
@@ -270,7 +185,7 @@ public class OperatonExtensionsTest {
   @ParameterizedTest(name = "Namespace: {0}")
   void testIsStartableInTasklist(String namespace, BpmnModelInstance modelInstance) {
     initOperatonExtensionsTest(namespace, modelInstance);
-    assertThat(process.isOperatonStartableInTasklist()).isEqualTo(false);
+    assertThat(process.isOperatonStartableInTasklist()).isFalse();
   }
 
   @MethodSource("parameters")

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/QueryTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/QueryTest.java
@@ -87,13 +87,13 @@ class QueryTest {
     ModelElementType gatewayType = modelInstance.getModel().getType(Gateway.class);
 
     assertThat(startSucceeding.filterByType(taskType).list()).hasSize(1);
-    assertThat(startSucceeding.filterByType(gatewayType).list()).hasSize(0);
+    assertThat(startSucceeding.filterByType(gatewayType).list()).isEmpty();
 
     assertThat(gateway1Succeeding.filterByType(taskType).list()).hasSize(1);
     assertThat(gateway1Succeeding.filterByType(gatewayType).list()).hasSize(1);
 
     assertThat(gateway2Succeeding.filterByType(taskType).list()).hasSize(3);
-    assertThat(gateway2Succeeding.filterByType(gatewayType).list()).hasSize(0);
+    assertThat(gateway2Succeeding.filterByType(gatewayType).list()).isEmpty();
   }
 
   @Test

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ResourceRolesTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ResourceRolesTest.java
@@ -43,7 +43,7 @@ class ResourceRolesTest {
   void testGetPerformer() {
     UserTask userTask = modelInstance.getModelElementById("_3");
     Collection<ResourceRole> resourceRoles = userTask.getResourceRoles();
-    assertThat(resourceRoles.size()).isEqualTo(1);
+    assertThat(resourceRoles).hasSize(1);
     ResourceRole resourceRole = resourceRoles.iterator().next();
     assertThat(resourceRole instanceof Performer).isTrue();
     assertThat(resourceRole.getName()).isEqualTo("Task performer");
@@ -53,7 +53,7 @@ class ResourceRolesTest {
   void testGetHumanPerformer() {
     UserTask userTask = modelInstance.getModelElementById("_7");
     Collection<ResourceRole> resourceRoles = userTask.getResourceRoles();
-    assertThat(resourceRoles.size()).isEqualTo(1);
+    assertThat(resourceRoles).hasSize(1);
     ResourceRole resourceRole = resourceRoles.iterator().next();
     assertThat(resourceRole instanceof HumanPerformer).isTrue();
     assertThat(resourceRole.getName()).isEqualTo("Task human performer");
@@ -63,7 +63,7 @@ class ResourceRolesTest {
   void testGetPotentialOwner() {
     UserTask userTask = modelInstance.getModelElementById("_9");
     Collection<ResourceRole> resourceRoles = userTask.getResourceRoles();
-    assertThat(resourceRoles.size()).isEqualTo(1);
+    assertThat(resourceRoles).hasSize(1);
     ResourceRole resourceRole = resourceRoles.iterator().next();
     assertThat(resourceRole instanceof PotentialOwner).isTrue();
     assertThat(resourceRole.getName()).isEqualTo("Task potential owner");

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
@@ -1576,7 +1576,7 @@ public class ProcessBuilderTest {
     assertThat(signalEventDefinition.getSignal().getName()).isEqualTo("signal");
 
     List<OperatonIn> operatonInParams = signalEventDefinition.getExtensionElements().getElementsQuery().filterByType(OperatonIn.class).list();
-    assertThat(operatonInParams.size()).isEqualTo(4);
+    assertThat(operatonInParams).hasSize(4);
 
     int paramCounter = 0;
     for (OperatonIn inParam : operatonInParams) {
@@ -1615,7 +1615,7 @@ public class ProcessBuilderTest {
     SignalEventDefinition signalEventDefinition = assertAndGetSingleEventDefinition("throw", SignalEventDefinition.class);
 
     List<OperatonIn> operatonInParams = signalEventDefinition.getExtensionElements().getElementsQuery().filterByType(OperatonIn.class).list();
-    assertThat(operatonInParams.size()).isEqualTo(1);
+    assertThat(operatonInParams).hasSize(1);
 
     assertThat(operatonInParams.get(0).getOperatonVariables()).isEqualTo("all");
   }
@@ -1781,7 +1781,7 @@ public class ProcessBuilderTest {
     assertThat(taskListener.getOperatonEvent()).isEqualTo("timeout");
 
     Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
-    assertThat(timeouts.size()).isEqualTo(1);
+    assertThat(timeouts).hasSize(1);
 
     TimerEventDefinition timeout = timeouts.iterator().next();
     assertThat(timeout.getTimeCycle()).isNotNull();
@@ -1809,7 +1809,7 @@ public class ProcessBuilderTest {
     assertThat(taskListener.getOperatonEvent()).isEqualTo("timeout");
 
     Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
-    assertThat(timeouts.size()).isEqualTo(1);
+    assertThat(timeouts).hasSize(1);
 
     TimerEventDefinition timeout = timeouts.iterator().next();
     assertThat(timeout.getTimeCycle()).isNull();
@@ -1837,7 +1837,7 @@ public class ProcessBuilderTest {
     assertThat(taskListener.getOperatonEvent()).isEqualTo("timeout");
 
     Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
-    assertThat(timeouts.size()).isEqualTo(1);
+    assertThat(timeouts).hasSize(1);
 
     TimerEventDefinition timeout = timeouts.iterator().next();
     assertThat(timeout.getTimeCycle()).isNull();
@@ -1865,7 +1865,7 @@ public class ProcessBuilderTest {
     assertThat(taskListener.getOperatonEvent()).isEqualTo("timeout");
 
     Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
-    assertThat(timeouts.size()).isEqualTo(1);
+    assertThat(timeouts).hasSize(1);
 
     TimerEventDefinition timeout = timeouts.iterator().next();
     assertThat(timeout.getTimeCycle()).isNull();
@@ -1893,7 +1893,7 @@ public class ProcessBuilderTest {
     assertThat(taskListener.getOperatonEvent()).isEqualTo("timeout");
 
     Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
-    assertThat(timeouts.size()).isEqualTo(1);
+    assertThat(timeouts).hasSize(1);
 
     TimerEventDefinition timeout = timeouts.iterator().next();
     assertThat(timeout.getTimeCycle()).isNotNull();
@@ -1921,7 +1921,7 @@ public class ProcessBuilderTest {
     assertThat(taskListener.getOperatonEvent()).isEqualTo("timeout");
 
     Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
-    assertThat(timeouts.size()).isEqualTo(1);
+    assertThat(timeouts).hasSize(1);
 
     TimerEventDefinition timeout = timeouts.iterator().next();
     assertThat(timeout.getTimeCycle()).isNull();
@@ -1949,7 +1949,7 @@ public class ProcessBuilderTest {
     assertThat(taskListener.getOperatonEvent()).isEqualTo("timeout");
 
     Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
-    assertThat(timeouts.size()).isEqualTo(1);
+    assertThat(timeouts).hasSize(1);
 
     TimerEventDefinition timeout = timeouts.iterator().next();
     assertThat(timeout.getTimeCycle()).isNotNull();
@@ -1977,7 +1977,7 @@ public class ProcessBuilderTest {
     assertThat(taskListener.getOperatonEvent()).isEqualTo("timeout");
 
     Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
-    assertThat(timeouts.size()).isEqualTo(1);
+    assertThat(timeouts).hasSize(1);
 
     TimerEventDefinition timeout = timeouts.iterator().next();
     assertThat(timeout.getTimeCycle()).isNull();
@@ -2005,7 +2005,7 @@ public class ProcessBuilderTest {
     assertThat(taskListener.getOperatonEvent()).isEqualTo("timeout");
 
     Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
-    assertThat(timeouts.size()).isEqualTo(1);
+    assertThat(timeouts).hasSize(1);
 
     TimerEventDefinition timeout = timeouts.iterator().next();
     assertThat(timeout.getTimeCycle()).isNull();
@@ -2033,7 +2033,7 @@ public class ProcessBuilderTest {
     assertThat(taskListener.getOperatonEvent()).isEqualTo("timeout");
 
     Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
-    assertThat(timeouts.size()).isEqualTo(1);
+    assertThat(timeouts).hasSize(1);
 
     TimerEventDefinition timeout = timeouts.iterator().next();
     assertThat(timeout.getTimeCycle()).isNotNull();
@@ -2061,7 +2061,7 @@ public class ProcessBuilderTest {
     assertThat(taskListener.getOperatonEvent()).isEqualTo("timeout");
 
     Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
-    assertThat(timeouts.size()).isEqualTo(1);
+    assertThat(timeouts).hasSize(1);
 
     TimerEventDefinition timeout = timeouts.iterator().next();
     assertThat(timeout.getTimeCycle()).isNull();
@@ -2089,7 +2089,7 @@ public class ProcessBuilderTest {
     assertThat(taskListener.getOperatonEvent()).isEqualTo("timeout");
 
     Collection<TimerEventDefinition> timeouts = taskListener.getTimeouts();
-    assertThat(timeouts.size()).isEqualTo(1);
+    assertThat(timeouts).hasSize(1);
 
     TimerEventDefinition timeout = timeouts.iterator().next();
     assertThat(timeout.getTimeCycle()).isNull();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
@@ -618,7 +618,7 @@ public class ProcessBuilderTest {
       .done();
 
     Process process = modelInstance.getModelElementById(PROCESS_ID);
-    assertThat(process.isOperatonStartableInTasklist()).isEqualTo(true);
+    assertThat(process.isOperatonStartableInTasklist()).isTrue();
   }
 
   @Test

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
@@ -16,121 +16,29 @@
  */
 package org.operaton.bpm.model.bpmn.builder;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Fail.fail;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.BOUNDARY_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.CALL_ACTIVITY_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.CATCH_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.CONDITION_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.EXTERNAL_TASK_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.FORM_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.PROCESS_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.SERVICE_TASK_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.START_EVENT_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.SUB_PROCESS_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TASK_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_CLASS_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_CONDITION;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_CONDITIONAL_VARIABLE_EVENTS;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_CONDITIONAL_VARIABLE_EVENTS_LIST;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_CONDITIONAL_VARIABLE_NAME;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_DELEGATE_EXPRESSION_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_DUE_DATE_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_EXPRESSION_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_EXTERNAL_TASK_TOPIC;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_FOLLOW_UP_DATE_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_GROUPS_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_GROUPS_LIST_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_HISTORY_TIME_TO_LIVE;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_PRIORITY_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_PROCESS_TASK_PRIORITY;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_SERVICE_TASK_PRIORITY;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_STARTABLE_IN_TASKLIST;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_STRING_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_STRING_FORM_REF_BINDING;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_STRING_FORM_REF_VERSION;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_USERS_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_USERS_LIST_API;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TEST_VERSION_TAG;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.TRANSACTION_ID;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.USER_TASK_ID;
-import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.BPMN20_NS;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.operaton.bpm.model.bpmn.*;
+import org.operaton.bpm.model.bpmn.instance.Error;
+import org.operaton.bpm.model.bpmn.instance.Process;
+import org.operaton.bpm.model.bpmn.instance.*;
+import org.operaton.bpm.model.bpmn.instance.operaton.*;
+import org.operaton.bpm.model.xml.Model;
+import org.operaton.bpm.model.xml.instance.ModelElementInstance;
+import org.operaton.bpm.model.xml.type.ModelElementType;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
-import org.operaton.bpm.model.bpmn.AssociationDirection;
-import org.operaton.bpm.model.bpmn.Bpmn;
-import org.operaton.bpm.model.bpmn.BpmnModelException;
-import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.operaton.bpm.model.bpmn.GatewayDirection;
-import org.operaton.bpm.model.bpmn.TransactionMethod;
-import org.operaton.bpm.model.bpmn.instance.Activity;
-import org.operaton.bpm.model.bpmn.instance.Association;
-import org.operaton.bpm.model.bpmn.instance.BaseElement;
-import org.operaton.bpm.model.bpmn.instance.BoundaryEvent;
-import org.operaton.bpm.model.bpmn.instance.BpmnModelElementInstance;
-import org.operaton.bpm.model.bpmn.instance.BusinessRuleTask;
-import org.operaton.bpm.model.bpmn.instance.CallActivity;
-import org.operaton.bpm.model.bpmn.instance.CompensateEventDefinition;
-import org.operaton.bpm.model.bpmn.instance.ConditionalEventDefinition;
-import org.operaton.bpm.model.bpmn.instance.Definitions;
-import org.operaton.bpm.model.bpmn.instance.Documentation;
-import org.operaton.bpm.model.bpmn.instance.EndEvent;
-import org.operaton.bpm.model.bpmn.instance.Error;
-import org.operaton.bpm.model.bpmn.instance.ErrorEventDefinition;
-import org.operaton.bpm.model.bpmn.instance.Escalation;
-import org.operaton.bpm.model.bpmn.instance.EscalationEventDefinition;
-import org.operaton.bpm.model.bpmn.instance.Event;
-import org.operaton.bpm.model.bpmn.instance.EventDefinition;
-import org.operaton.bpm.model.bpmn.instance.ExtensionElements;
-import org.operaton.bpm.model.bpmn.instance.FlowElement;
-import org.operaton.bpm.model.bpmn.instance.FlowNode;
-import org.operaton.bpm.model.bpmn.instance.Gateway;
-import org.operaton.bpm.model.bpmn.instance.InclusiveGateway;
-import org.operaton.bpm.model.bpmn.instance.Message;
-import org.operaton.bpm.model.bpmn.instance.MessageEventDefinition;
-import org.operaton.bpm.model.bpmn.instance.MultiInstanceLoopCharacteristics;
-import org.operaton.bpm.model.bpmn.instance.Process;
-import org.operaton.bpm.model.bpmn.instance.ReceiveTask;
-import org.operaton.bpm.model.bpmn.instance.ScriptTask;
-import org.operaton.bpm.model.bpmn.instance.SendTask;
-import org.operaton.bpm.model.bpmn.instance.SequenceFlow;
-import org.operaton.bpm.model.bpmn.instance.ServiceTask;
-import org.operaton.bpm.model.bpmn.instance.Signal;
-import org.operaton.bpm.model.bpmn.instance.SignalEventDefinition;
-import org.operaton.bpm.model.bpmn.instance.StartEvent;
-import org.operaton.bpm.model.bpmn.instance.SubProcess;
-import org.operaton.bpm.model.bpmn.instance.Task;
-import org.operaton.bpm.model.bpmn.instance.TimeCycle;
-import org.operaton.bpm.model.bpmn.instance.TimeDate;
-import org.operaton.bpm.model.bpmn.instance.TimeDuration;
-import org.operaton.bpm.model.bpmn.instance.TimerEventDefinition;
-import org.operaton.bpm.model.bpmn.instance.Transaction;
-import org.operaton.bpm.model.bpmn.instance.UserTask;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonErrorEventDefinition;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonExecutionListener;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonFailedJobRetryTimeCycle;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonFormData;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonFormField;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonIn;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonInputOutput;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonInputParameter;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonOut;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonOutputParameter;
-import org.operaton.bpm.model.bpmn.instance.operaton.OperatonTaskListener;
-import org.operaton.bpm.model.xml.Model;
-import org.operaton.bpm.model.xml.instance.ModelElementInstance;
-import org.operaton.bpm.model.xml.type.ModelElementType;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Fail.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.operaton.bpm.model.bpmn.BpmnTestConstants.*;
+import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.BPMN20_NS;
 
 
 /**
@@ -3566,11 +3474,11 @@ public class ProcessBuilderTest {
     SubProcess subProcess = eventSubProcess.getElement();
 
     // no input or output from the sub process
-    assertThat(subProcess.getIncoming().isEmpty());
-    assertThat(subProcess.getOutgoing().isEmpty());
+    assertThat(subProcess.getIncoming()).isEmpty();
+    assertThat(subProcess.getOutgoing()).isEmpty();
 
     // subProcess was triggered by event
-    assertThat(eventSubProcess.getElement().triggeredByEvent());
+    assertThat(eventSubProcess.getElement().triggeredByEvent()).isTrue();
 
     // subProcess contains startEvent, sendTask and endEvent
     assertThat(subProcess.getChildElementsByType(StartEvent.class)).isNotNull();
@@ -3607,11 +3515,11 @@ public class ProcessBuilderTest {
     SubProcess eventSubProcess = modelInstance.getModelElementById("myeventsubprocess");
 
     // no input or output from the sub process
-    assertThat(eventSubProcess.getIncoming().isEmpty());
-    assertThat(eventSubProcess.getOutgoing().isEmpty());
+    assertThat(eventSubProcess.getIncoming()).isEmpty();
+    assertThat(eventSubProcess.getOutgoing()).isEmpty();
 
     // subProcess was triggered by event
-    assertThat(eventSubProcess.triggeredByEvent());
+    assertThat(eventSubProcess.triggeredByEvent()).isTrue();
 
     // subProcess contains startEvent, sendTask and endEvent
     assertThat(eventSubProcess.getChildElementsByType(StartEvent.class)).isNotNull();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/CompatabilityTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/CompatabilityTest.java
@@ -15,11 +15,6 @@
  * limitations under the License.
  */
 package org.operaton.bpm.model.bpmn.instance.operaton;
-import static org.operaton.bpm.model.bpmn.BpmnTestConstants.PROCESS_ID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Collection;
 
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.Bpmn;
@@ -28,6 +23,11 @@ import org.operaton.bpm.model.bpmn.OperatonExtensionsTest;
 import org.operaton.bpm.model.bpmn.impl.BpmnModelConstants;
 import org.operaton.bpm.model.bpmn.impl.instance.ProcessImpl;
 import org.operaton.bpm.model.bpmn.instance.ExtensionElements;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.model.bpmn.BpmnTestConstants.PROCESS_ID;
 
 /**
  * Test to check the interoperability when changing elements and attributes with
@@ -69,7 +69,7 @@ class CompatabilityTest {
     assertThat(process.getAttributeValueNs(BpmnModelConstants.CAMUNDA_NS, "jobPriority")).isEqualTo(priority);
     assertThat(process.getAttributeValueNs(BpmnModelConstants.CAMUNDA_NS, "taskPriority")).isEqualTo(priority);
     assertThat(process.getAttributeValueNs(BpmnModelConstants.CAMUNDA_NS, "historyTimeToLive")).isEqualTo(historyTimeToLive.toString());
-    assertThat(process.isOperatonStartableInTasklist()).isEqualTo(false);
+    assertThat(process.isOperatonStartableInTasklist()).isFalse();
     assertThat(process.getOperatonVersionTag()).isEqualTo("v1.0.0");
   }
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/validation/ValidateProcessTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/validation/ValidateProcessTest.java
@@ -51,13 +51,13 @@ class ValidateProcessTest {
     assertThat(validationResults.hasErrors()).isTrue();
 
     Map<ModelElementInstance, List<ValidationResult>> results = validationResults.getResults();
-    assertThat(results.size()).isEqualTo(1);
+    assertThat(results).hasSize(1);
 
     Process process = bpmnModelInstance.getDefinitions().getChildElementsByType(Process.class).iterator().next();
     assertThat(results.containsKey(process)).isTrue();
 
     List<ValidationResult> resultsForProcess = results.get(process);
-    assertThat(resultsForProcess.size()).isEqualTo(1);
+    assertThat(resultsForProcess).hasSize(1);
 
     ValidationResult validationResult = resultsForProcess.get(0);
     assertThat(validationResult.getElement()).isEqualTo(process);

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/AbstractModelElementInstanceTest.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/AbstractModelElementInstanceTest.java
@@ -226,7 +226,7 @@ public abstract class AbstractModelElementInstanceTest {
       assertThatType().hasNoChildElements();
     }
     else {
-      assertThat(modelElementType.getChildElementTypes().size()).isEqualTo(childElementAssumptions.size());
+      assertThat(modelElementType.getChildElementTypes()).hasSize(childElementAssumptions.size());
       for (ChildElementAssumption assumption : childElementAssumptions) {
         assertThatType().hasChildElements(assumption.childElementType);
         if (assumption.namespaceUri != null) {

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
@@ -100,7 +100,7 @@ public class AlternativeNsTest extends TestModelTest {
     ModelElementInstance birdo = modelInstance.getModelElementById("birdo");
     assertThat(birdo).isNotNull();
     Collection<Wings> elements = birdo.getChildElementsByType(Wings.class);
-    assertThat(elements.size()).isEqualTo(1);
+    assertThat(elements).hasSize(1);
     assertThat(elements.iterator().next().getTextContent()).isEqualTo("zisch");
   }
 
@@ -115,7 +115,7 @@ public class AlternativeNsTest extends TestModelTest {
     Collection<Wings> elements = donald.getChildElementsByType(Wings.class);
 
     // then
-    assertThat(elements.size()).isEqualTo(1);
+    assertThat(elements).hasSize(1);
     assertThat(elements.iterator().next().getTextContent()).isEqualTo("flappy");
   }
 
@@ -194,7 +194,7 @@ public class AlternativeNsTest extends TestModelTest {
     wings.setTextContent("kawusch");
 
     List<DomElement> childElementsByNameNs = birdo.getDomElement().getChildElementsByNameNs(MECHANICAL_NS, "wings");
-    assertThat(childElementsByNameNs.size()).isEqualTo(1);
+    assertThat(childElementsByNameNs).hasSize(1);
     assertThat(childElementsByNameNs.get(0).getTextContent()).isEqualTo("kawusch");
   }
 
@@ -211,7 +211,7 @@ public class AlternativeNsTest extends TestModelTest {
 
     // then
     List<DomElement> childElementsByNameNs = donald.getDomElement().getChildElementsByNameNs(YET_ANOTHER_NS, "wings");
-    assertThat(childElementsByNameNs.size()).isEqualTo(1);
+    assertThat(childElementsByNameNs).hasSize(1);
     assertThat(childElementsByNameNs.get(0).getTextContent()).isEqualTo("kawusch");
   }
 
@@ -223,7 +223,7 @@ public class AlternativeNsTest extends TestModelTest {
     bird.setWings(modelInstance.newInstance(Wings.class));
 
     List<DomElement> childElementsByNameNs = bird.getDomElement().getChildElementsByNameNs(TestModelConstants.NEWER_NAMESPACE, "wings");
-    assertThat(childElementsByNameNs.size()).isEqualTo(1);
+    assertThat(childElementsByNameNs).hasSize(1);
   }
 
   @ParameterizedTest

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.model.xml.testmodel.instance;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -25,7 +24,6 @@ import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.impl.ModelImpl;
 import org.operaton.bpm.model.xml.instance.DomElement;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
-import org.operaton.bpm.model.xml.instance.ModelElementInstanceTest;
 import org.operaton.bpm.model.xml.testmodel.Gender;
 import org.operaton.bpm.model.xml.testmodel.TestModelConstants;
 import org.operaton.bpm.model.xml.testmodel.TestModelTest;
@@ -128,7 +126,7 @@ public class AlternativeNsTest extends TestModelTest {
     Bird plucky = modelInstance.getModelElementById("plucky");
     assertThat(plucky).isNotNull();
     Boolean extendedWings = plucky.canHazExtendedWings();
-    assertThat(extendedWings).isEqualTo(false);
+    assertThat(extendedWings).isFalse();
   }
 
   @ParameterizedTest
@@ -153,7 +151,7 @@ public class AlternativeNsTest extends TestModelTest {
     assertThat(plucky).isNotNull();
     //validate old value
     Boolean extendedWings = plucky.canHazExtendedWings();
-    assertThat(extendedWings).isEqualTo(false);
+    assertThat(extendedWings).isFalse();
     //change it
     plucky.setCanHazExtendedWings(true);
     String attributeValueNs = plucky.getAttributeValueNs(MECHANICAL_NS, "canHazExtendedWings");

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
@@ -142,7 +142,7 @@ public class AlternativeNsTest extends TestModelTest {
     Boolean extendedWings = donald.canHazExtendedWings();
 
     // then
-    assertThat(extendedWings).isEqualTo(true);
+    assertThat(extendedWings).isTrue();
   }
 
   @ParameterizedTest

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/UnknownAnimalTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/UnknownAnimalTest.java
@@ -146,7 +146,7 @@ class UnknownAnimalTest {
 
   @Test
   void testAddChildToUnknownAnimal() {
-    assertThat(wanda.getChildElementsByType(flipper.getElementType())).hasSize(0);
+    assertThat(wanda.getChildElementsByType(flipper.getElementType())).isEmpty();
     wanda.insertElementAfter(flipper, null);
     assertThat(wanda.getChildElementsByType(flipper.getElementType())).hasSize(1);
   }

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/child/ChildElementCollectionTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/child/ChildElementCollectionTest.java
@@ -186,7 +186,7 @@ public class ChildElementCollectionTest extends TestModelTest {
     Collection<FlightPartnerRef> flightPartners = Arrays.asList(birdoRef, daisyRef, pluckyRef);
 
     // directly test collection methods and not use the appropriate assertion methods
-    assertThat(flightPartnerRefs.size()).isEqualTo(2);
+    assertThat(flightPartnerRefs).hasSize(2);
     assertThat(flightPartnerRefs.isEmpty()).isFalse();
     assertThat(flightPartnerRefs.contains(daisyRef));
     assertThat(flightPartnerRefs.toArray()).isEqualTo(new Object[]{daisyRef, pluckyRef});

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/reference/ReferenceTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/reference/ReferenceTest.java
@@ -173,7 +173,7 @@ public class ReferenceTest extends TestModelTest {
     Collection<FlyingAnimal> flightPartners = Arrays.asList(new FlyingAnimal[]{birdo, daffy, daisy, plucky});
 
     // directly test collection methods and not use the	appropriate assertion methods
-    assertThat(referenceTargetElements.size()).isEqualTo(1);
+    assertThat(referenceTargetElements).hasSize(1);
     assertThat(referenceTargetElements.isEmpty()).isFalse();
     assertThat(referenceTargetElements.contains(daffy)).isTrue();
     assertThat(referenceTargetElements.toArray()).isEqualTo(new Object[]{daffy});

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/validation/ModelValidationTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/validation/ModelValidationTest.java
@@ -60,7 +60,7 @@ class ModelValidationTest {
 
     assertThat(results).isNotNull();
     assertThat(results.hasErrors()).isFalse();
-    assertThat(results.getErrorCount()).isEqualTo(0);
+    assertThat(results.getErrorCount()).isZero();
     assertThat(results.getWarinigCount()).isEqualTo(7);
   }
 
@@ -73,7 +73,7 @@ class ModelValidationTest {
     assertThat(results).isNotNull();
     assertThat(results.hasErrors()).isTrue();
     assertThat(results.getErrorCount()).isEqualTo(1);
-    assertThat(results.getWarinigCount()).isEqualTo(0);
+    assertThat(results.getWarinigCount()).isZero();
   }
 
   @Test

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/validation/ModelValidationTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/validation/ModelValidationTest.java
@@ -150,7 +150,7 @@ class ModelValidationTest {
     assertThat(results.getWarinigCount()).isEqualTo(7);
 
     var resultsByElement = results.getResults();
-    assertThat(resultsByElement.size()).isEqualTo(7);
+    assertThat(resultsByElement).hasSize(7);
 
     for (var resultEntry : resultsByElement.entrySet()) {
       Bird element = (Bird) resultEntry.getKey();
@@ -159,14 +159,14 @@ class ModelValidationTest {
       assertThat(validationResults).isNotNull();
 
       if (element.getId().equals("tweety")) {
-        assertThat(validationResults.size()).isEqualTo(2);
+        assertThat(validationResults).hasSize(2);
         ValidationResult error = validationResults.remove(0);
         assertThat(error.getType()).isEqualTo(ValidationResultType.ERROR);
         assertThat(error.getCode()).isEqualTo(20);
         assertThat(error.getMessage()).isEqualTo("Bird tweety is illegal");
         assertThat(error.getElement()).isEqualTo(element);
       } else {
-        assertThat(validationResults.size()).isEqualTo(1);
+        assertThat(validationResults).hasSize(1);
       }
 
       ValidationResult warning = validationResults.get(0);

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/validation/ModelValidationTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/validation/ModelValidationTest.java
@@ -16,17 +16,18 @@
  */
 package org.operaton.bpm.model.xml.validation;
 
-import static org.assertj.core.api.Assertions.*;
-
-import java.io.InputStream;
-import java.io.StringWriter;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelInstance;
 import org.operaton.bpm.model.xml.impl.validation.ModelValidationResultsImpl;
 import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import org.operaton.bpm.model.xml.testmodel.instance.Bird;
+
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Daniel Meyer
@@ -85,7 +86,7 @@ class ModelValidationTest {
     StringWriter stringWriter = new StringWriter();
     results.write(stringWriter, new TestResultFormatter());
 
-    assertThat(stringWriter.toString()).isEqualTo("tweety\n\tERROR (20): Bird tweety is illegal\n");
+    assertThat(stringWriter).hasToString("tweety\n\tERROR (20): Bird tweety is illegal\n");
   }
 
   @Test

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/FeelEngineIT.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/FeelEngineIT.java
@@ -71,7 +71,7 @@ public class FeelEngineIT extends AbstractFoxPlatformIntegrationTest {
         .includeOutputs()
         .singleResult();
 
-    assertThat(hdi.getOutputs().size()).isEqualTo(1);
+    assertThat(hdi.getOutputs()).hasSize(1);
     assertThat(hdi.getOutputs().get(0).getValue()).isTrue();
   }
 
@@ -89,7 +89,7 @@ public class FeelEngineIT extends AbstractFoxPlatformIntegrationTest {
         .includeOutputs()
         .singleResult();
 
-    assertThat(hdi.getOutputs().size()).isEqualTo(1);
+    assertThat(hdi.getOutputs()).hasSize(1);
     assertThat(hdi.getOutputs().get(0).getValue()).isTrue();
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/FeelEngineIT.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/FeelEngineIT.java
@@ -72,7 +72,7 @@ public class FeelEngineIT extends AbstractFoxPlatformIntegrationTest {
         .singleResult();
 
     assertThat(hdi.getOutputs().size()).isEqualTo(1);
-    assertThat(hdi.getOutputs().get(0).getValue()).isEqualTo(true);
+    assertThat(hdi.getOutputs().get(0).getValue()).isTrue();
   }
 
   @Test
@@ -90,7 +90,7 @@ public class FeelEngineIT extends AbstractFoxPlatformIntegrationTest {
         .singleResult();
 
     assertThat(hdi.getOutputs().size()).isEqualTo(1);
-    assertThat(hdi.getOutputs().get(0).getValue()).isEqualTo(true);
+    assertThat(hdi.getOutputs().get(0).getValue()).isTrue();
   }
 
   // HELPER

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/FeelEngineIT.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/FeelEngineIT.java
@@ -16,16 +16,16 @@
  */
 package org.operaton.bpm.integrationtest.functional.spin;
 
-import org.operaton.bpm.engine.history.HistoricDecisionInstance;
-import org.operaton.bpm.engine.variable.VariableMap;
-import org.operaton.bpm.engine.variable.Variables;
-import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
-import org.operaton.spin.Spin;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.operaton.bpm.engine.history.HistoricDecisionInstance;
+import org.operaton.bpm.engine.variable.VariableMap;
+import org.operaton.bpm.engine.variable.Variables;
+import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+import org.operaton.spin.Spin;
 
 import java.util.Arrays;
 import java.util.List;
@@ -72,7 +72,7 @@ public class FeelEngineIT extends AbstractFoxPlatformIntegrationTest {
         .singleResult();
 
     assertThat(hdi.getOutputs()).hasSize(1);
-    assertThat(hdi.getOutputs().get(0).getValue()).isTrue();
+    assertThat(hdi.getOutputs().get(0).getValue()).isEqualTo(true);
   }
 
   @Test
@@ -90,7 +90,7 @@ public class FeelEngineIT extends AbstractFoxPlatformIntegrationTest {
         .singleResult();
 
     assertThat(hdi.getOutputs()).hasSize(1);
-    assertThat(hdi.getOutputs().get(0).getValue()).isTrue();
+    assertThat(hdi.getOutputs().get(0).getValue()).isEqualTo(true);
   }
 
   // HELPER

--- a/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/optimize/OptimizeApiPageSizeTest.java
+++ b/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/optimize/OptimizeApiPageSizeTest.java
@@ -57,7 +57,7 @@ public class OptimizeApiPageSizeTest {
     final List<?> pageOfEntries = scenario.getOptimizeServiceFunction().apply(OPTIMIZE_PAGE_SIZE);
 
     // then
-    assertThat(pageOfEntries.size()).isEqualTo(OPTIMIZE_PAGE_SIZE);
+    assertThat(pageOfEntries).hasSize(OPTIMIZE_PAGE_SIZE);
   }
 
   private Object[] optimizeServiceFunctions() {

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7170/pvm/AsyncJoinTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7170/pvm/AsyncJoinTest.java
@@ -64,7 +64,7 @@ public class AsyncJoinTest {
     managementService.executeJob(jobIdNotifyListener.get());
 
     // then
-    Assertions.assertThat(jobQuery.count()).isEqualTo(0);
+    Assertions.assertThat(jobQuery.count()).isZero();
     Assertions.assertThat(engineRule.historicProcessInstance().getState())
         .isEqualTo("COMPLETED");
   }
@@ -90,7 +90,7 @@ public class AsyncJoinTest {
     managementService.executeJob(jobIdNotifyListener.get());
 
     // then
-    Assertions.assertThat(jobQuery.count()).isEqualTo(0);
+    Assertions.assertThat(jobQuery.count()).isZero();
     Assertions.assertThat(engineRule.historicProcessInstance().getState())
         .isEqualTo("COMPLETED");
   }

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7200/batch/SetRemovalTimeToProcessInstanceTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7200/batch/SetRemovalTimeToProcessInstanceTest.java
@@ -84,7 +84,7 @@ public class SetRemovalTimeToProcessInstanceTest {
         .singleResult();
     assertThat(historicActivityInstance.getRemovalTime()).isEqualTo(removalTime);
 
-    assertThat(managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId()).count()).isEqualTo(0);
+    assertThat(managementService.createJobQuery().jobDefinitionId(batch.getBatchJobDefinitionId()).count()).isZero();
   }
 
 }

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineConfigFileTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineConfigFileTest.java
@@ -16,21 +16,21 @@
  */
 package org.operaton.bpm.quarkus.engine.test.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import jakarta.inject.Inject;
-import java.sql.SQLException;
-
 import io.quarkus.test.QuarkusUnitTest;
+import jakarta.inject.Inject;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.jobexecutor.JobExecutor;
 import org.operaton.bpm.quarkus.engine.extension.OperatonEngineConfig;
 import org.operaton.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class OperatonEngineConfigFileTest {
 
@@ -67,8 +67,8 @@ public class OperatonEngineConfigFileTest {
     assertThat(jobExecutor.getMaxWait()).isEqualTo(65000);
     assertThat(jobExecutor.getBackoffTimeInMillis()).isEqualTo(5);
     // assert correct thread pool config
-    assertThat(config.jobExecutor().threadPool().maxPool).hasSize(12);
-    assertThat(config.jobExecutor().threadPool().queue).hasSize(5);
+    assertThat(config.jobExecutor().threadPool().maxPoolSize()).isEqualTo(12);
+    assertThat(config.jobExecutor().threadPool().queueSize()).isEqualTo(5);
     // assert correct datasource
     assertThat(config.datasource()).hasValue("operaton");
     assertThat(configuration.getDataSource().getConnection()).asString().contains("h2:mem:operaton");

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineConfigFileTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineConfigFileTest.java
@@ -67,8 +67,8 @@ public class OperatonEngineConfigFileTest {
     assertThat(jobExecutor.getMaxWait()).isEqualTo(65000);
     assertThat(jobExecutor.getBackoffTimeInMillis()).isEqualTo(5);
     // assert correct thread pool config
-    assertThat(config.jobExecutor().threadPool().maxPoolSize()).isEqualTo(12);
-    assertThat(config.jobExecutor().threadPool().queueSize()).isEqualTo(5);
+    assertThat(config.jobExecutor().threadPool().maxPool).hasSize(12);
+    assertThat(config.jobExecutor().threadPool().queue).hasSize(5);
     // assert correct datasource
     assertThat(config.datasource()).hasValue("operaton");
     assertThat(configuration.getDataSource().getConnection()).asString().contains("h2:mem:operaton");

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineConfigurationConfigTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineConfigurationConfigTest.java
@@ -16,19 +16,18 @@
  */
 package org.operaton.bpm.quarkus.engine.test.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import jakarta.inject.Inject;
-
 import io.quarkus.test.QuarkusUnitTest;
-import org.operaton.bpm.engine.ProcessEngine;
-import org.operaton.bpm.quarkus.engine.extension.OperatonEngineConfig;
-import org.operaton.bpm.quarkus.engine.extension.QuarkusProcessEngineConfiguration;
-import org.operaton.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
+import jakarta.inject.Inject;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.quarkus.engine.extension.OperatonEngineConfig;
+import org.operaton.bpm.quarkus.engine.extension.QuarkusProcessEngineConfiguration;
+import org.operaton.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class OperatonEngineConfigurationConfigTest {
 
@@ -62,8 +61,8 @@ public class OperatonEngineConfigurationConfigTest {
         = (QuarkusProcessEngineConfiguration) processEngine.getProcessEngineConfiguration();
 
     // then
-    assertThat(configuration.isCmmnEnabled()).isEqualTo(false);
-    assertThat(configuration.isDmnEnabled()).isEqualTo(false);
+    assertThat(configuration.isCmmnEnabled()).isFalse();
+    assertThat(configuration.isDmnEnabled()).isFalse();
     assertThat(configuration.getHistory()).isEqualTo("none");
   }
 

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineJobExecutorConfigTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineJobExecutorConfigTest.java
@@ -44,8 +44,8 @@ public class OperatonEngineJobExecutorConfigTest {
     // given a custom application.properties file
 
     // then
-    assertThat(config.jobExecutor().threadPool().maxPoolSize()).isEqualTo(12);
-    assertThat(config.jobExecutor().threadPool().queueSize()).isEqualTo(5);
+    assertThat(config.jobExecutor().threadPool().maxPool).hasSize(12);
+    assertThat(config.jobExecutor().threadPool().queue).hasSize(5);
   }
 
   @Test

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineJobExecutorConfigTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineJobExecutorConfigTest.java
@@ -16,17 +16,16 @@
  */
 package org.operaton.bpm.quarkus.engine.test.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import jakarta.inject.Inject;
-
 import io.quarkus.test.QuarkusUnitTest;
-import org.operaton.bpm.quarkus.engine.extension.OperatonEngineConfig;
-import org.operaton.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
+import jakarta.inject.Inject;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.operaton.bpm.quarkus.engine.extension.OperatonEngineConfig;
+import org.operaton.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class OperatonEngineJobExecutorConfigTest {
 
@@ -44,8 +43,8 @@ public class OperatonEngineJobExecutorConfigTest {
     // given a custom application.properties file
 
     // then
-    assertThat(config.jobExecutor().threadPool().maxPool).hasSize(12);
-    assertThat(config.jobExecutor().threadPool().queue).hasSize(5);
+    assertThat(config.jobExecutor().threadPool().maxPoolSize()).isEqualTo(12);
+    assertThat(config.jobExecutor().threadPool().queueSize()).isEqualTo(5);
   }
 
   @Test

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineProgrammaticAndConfigFileTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineProgrammaticAndConfigFileTest.java
@@ -16,24 +16,24 @@
  */
 package org.operaton.bpm.quarkus.engine.test.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import io.quarkus.test.QuarkusUnitTest;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
-import java.sql.SQLException;
-
-import io.quarkus.test.QuarkusUnitTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.jobexecutor.JobExecutor;
 import org.operaton.bpm.quarkus.engine.extension.OperatonEngineConfig;
 import org.operaton.bpm.quarkus.engine.extension.QuarkusProcessEngineConfiguration;
 import org.operaton.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class OperatonEngineProgrammaticAndConfigFileTest {
 
@@ -88,8 +88,8 @@ public class OperatonEngineProgrammaticAndConfigFileTest {
     assertThat(jobExecutor.getMaxWait()).isEqualTo(65000);
     assertThat(jobExecutor.getBackoffTimeInMillis()).isEqualTo(5);
     // assert correct thread pool config
-    assertThat(config.jobExecutor().threadPool().maxPool).hasSize(12);
-    assertThat(config.jobExecutor().threadPool().queue).hasSize(5);
+    assertThat(config.jobExecutor().threadPool().maxPoolSize()).isEqualTo(12);
+    assertThat(config.jobExecutor().threadPool().queueSize()).isEqualTo(5);
     // assert correct datasource
     assertThat(config.datasource()).hasValue("operaton");
     assertThat(configuration.getDataSource().getConnection()).asString().contains("h2:mem:operaton");

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineProgrammaticAndConfigFileTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineProgrammaticAndConfigFileTest.java
@@ -88,8 +88,8 @@ public class OperatonEngineProgrammaticAndConfigFileTest {
     assertThat(jobExecutor.getMaxWait()).isEqualTo(65000);
     assertThat(jobExecutor.getBackoffTimeInMillis()).isEqualTo(5);
     // assert correct thread pool config
-    assertThat(config.jobExecutor().threadPool().maxPoolSize()).isEqualTo(12);
-    assertThat(config.jobExecutor().threadPool().queueSize()).isEqualTo(5);
+    assertThat(config.jobExecutor().threadPool().maxPool).hasSize(12);
+    assertThat(config.jobExecutor().threadPool().queue).hasSize(5);
     // assert correct datasource
     assertThat(config.datasource()).hasValue("operaton");
     assertThat(configuration.getDataSource().getConnection()).asString().contains("h2:mem:operaton");

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/id/ConfigureDbIdGeneratorTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/id/ConfigureDbIdGeneratorTest.java
@@ -17,6 +17,13 @@
 package org.operaton.bpm.quarkus.engine.test.id;
 
 import io.quarkus.test.QuarkusUnitTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.TaskService;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -24,18 +31,10 @@ import org.operaton.bpm.engine.impl.db.DbIdGenerator;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.quarkus.engine.extension.QuarkusProcessEngineConfiguration;
 import org.operaton.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Produces;
-import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ConfigureDbIdGeneratorTest {
+class ConfigureDbIdGeneratorTest {
 
   @RegisterExtension
   static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
@@ -59,12 +58,12 @@ public class ConfigureDbIdGeneratorTest {
   }
 
   @Test
-  public void shouldConfigureDbIdGenerator() {
+  void shouldConfigureDbIdGenerator() {
     Task task = taskService.newTask();
     taskService.saveTask(task);
 
     String id = taskService.createTaskQuery().singleResult().getId();
-    assertThat(Long.parseLong(id)).isGreaterThan(0);
+    assertThat(Long.parseLong(id)).isPositive();
 
     ProcessEngineConfigurationImpl engineConfig =
         (ProcessEngineConfigurationImpl) processEngine.getProcessEngineConfiguration();

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.java
@@ -186,7 +186,7 @@ public class TransactionIntegrationTest {
     // then
     Job job = managementService.createJobQuery().singleResult();
 
-    assertThat(job.getRetries()).isEqualTo(0);
+    assertThat(job.getRetries()).isZero();
     assertThat(job.getExceptionMessage()).isEqualTo("Unable to commit transaction");
 
     String stacktrace = managementService.getJobExceptionStacktrace(job.getId());
@@ -205,7 +205,7 @@ public class TransactionIntegrationTest {
     // then
     Job job = managementService.createJobQuery().singleResult();
 
-    assertThat(job.getRetries()).isEqualTo(0);
+    assertThat(job.getRetries()).isZero();
     assertThat(job.getExceptionMessage()).isEqualTo("Unable to commit transaction");
 
     String stacktrace = managementService.getJobExceptionStacktrace(job.getId());
@@ -224,7 +224,7 @@ public class TransactionIntegrationTest {
     // then
     Job job = managementService.createJobQuery().singleResult();
 
-    assertThat(job.getRetries()).isEqualTo(0);
+    assertThat(job.getRetries()).isZero();
     assertThat(job.getExceptionMessage()).isEqualTo("Unable to commit transaction");
 
     String stacktrace = managementService.getJobExceptionStacktrace(job.getId());

--- a/spin/core/src/test/java/org/operaton/spin/impl/util/RewindableReaderTest.java
+++ b/spin/core/src/test/java/org/operaton/spin/impl/util/RewindableReaderTest.java
@@ -38,7 +38,7 @@ public class RewindableReaderTest {
   public void shouldRead() throws IOException {
     // read(char[])
     reader = newReaderInstance(EXAMPLE_INPUT_STRING, DEFAULT_BUFFER_SIZE);
-    assertThat(reader.getRewindBufferSize()).isEqualTo(DEFAULT_BUFFER_SIZE);
+    assertThat(reader.getRewindBuffer).hasSize(DEFAULT_BUFFER_SIZE);
     assertThat(reader.getCurrentRewindableCapacity()).isEqualTo(DEFAULT_BUFFER_SIZE);
 
     char[] buffer = new char[5];

--- a/spin/core/src/test/java/org/operaton/spin/impl/util/RewindableReaderTest.java
+++ b/spin/core/src/test/java/org/operaton/spin/impl/util/RewindableReaderTest.java
@@ -16,16 +16,16 @@
  */
 package org.operaton.spin.impl.util;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import org.junit.After;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.Arrays;
 
-import org.junit.After;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class RewindableReaderTest {
 
@@ -38,7 +38,7 @@ public class RewindableReaderTest {
   public void shouldRead() throws IOException {
     // read(char[])
     reader = newReaderInstance(EXAMPLE_INPUT_STRING, DEFAULT_BUFFER_SIZE);
-    assertThat(reader.getRewindBuffer).hasSize(DEFAULT_BUFFER_SIZE);
+    assertThat(reader.getRewindBufferSize()).isEqualTo(DEFAULT_BUFFER_SIZE);
     assertThat(reader.getCurrentRewindableCapacity()).isEqualTo(DEFAULT_BUFFER_SIZE);
 
     char[] buffer = new char[5];

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/JsonTestConstants.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/JsonTestConstants.java
@@ -98,7 +98,7 @@ public class JsonTestConstants {
 
     List<RegularCustomer> customers = order.getCustomers();
     assertThat(customers).isNotNull();
-    assertThat(customers.size()).isEqualTo(3);
+    assertThat(customers).hasSize(3);
 
     assertThat(customers).extracting("name", "contractStartDate")
     .contains(

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeEditListPropertyTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeEditListPropertyTest.java
@@ -93,7 +93,7 @@ public class JsonTreeEditListPropertyTest {
   public void readIndexOfExistentValue() {
     Integer i = currencies.indexOf("euro");
 
-    assertThat(i).isEqualTo(0);
+    assertThat(i).isZero();
   }
 
   // ----------------- 2) lastIndexOf ----------------------

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeJsonPathScriptTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeJsonPathScriptTest.java
@@ -114,7 +114,7 @@ public abstract class JsonTreeJsonPathScriptTest extends ScriptTest {
 
     SpinList<SpinJsonNode> nodeList2 = script.getVariable("nodeList");
 
-    assertThat(nodeList2.size()).isEqualTo(1);
+    assertThat(nodeList2).hasSize(1);
     assertThat(nodeList2.get(0).prop("name").stringValue()).isEqualTo("Waldo");
   }
 

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeJsonPathScriptTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeJsonPathScriptTest.java
@@ -110,7 +110,7 @@ public abstract class JsonTreeJsonPathScriptTest extends ScriptTest {
   public void shouldGetFilteredResult() {
     SpinList<SpinJsonNode> nodeList = script.getVariable("emptyList");
 
-    assertThat(nodeList.size()).isEqualTo(0);
+    assertThat(nodeList.size()).isZero();
 
     SpinList<SpinJsonNode> nodeList2 = script.getVariable("nodeList");
 

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeJsonPathScriptTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeJsonPathScriptTest.java
@@ -16,9 +16,7 @@
  */
 package org.operaton.spin.json.tree;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.spin.json.JsonTestConstants.EXAMPLE_JSON_FILE_NAME;
-
+import org.junit.Test;
 import org.operaton.spin.SpinList;
 import org.operaton.spin.impl.test.Script;
 import org.operaton.spin.impl.test.ScriptTest;
@@ -26,7 +24,9 @@ import org.operaton.spin.impl.test.ScriptVariable;
 import org.operaton.spin.json.SpinJsonDataFormatException;
 import org.operaton.spin.json.SpinJsonNode;
 import org.operaton.spin.json.SpinJsonPathException;
-import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.spin.json.JsonTestConstants.EXAMPLE_JSON_FILE_NAME;
 
 /**
  * @author Thorben Lindhauer
@@ -110,7 +110,7 @@ public abstract class JsonTreeJsonPathScriptTest extends ScriptTest {
   public void shouldGetFilteredResult() {
     SpinList<SpinJsonNode> nodeList = script.getVariable("emptyList");
 
-    assertThat(nodeList.size()).isZero();
+    assertThat(nodeList).isEmpty();
 
     SpinList<SpinJsonNode> nodeList2 = script.getVariable("nodeList");
 

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeJsonPathTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeJsonPathTest.java
@@ -16,17 +16,17 @@
  */
 package org.operaton.spin.json.tree;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.operaton.spin.Spin.JSON;
-import static org.operaton.spin.json.JsonTestConstants.EXAMPLE_JSON;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.operaton.spin.SpinList;
 import org.operaton.spin.json.SpinJsonDataFormatException;
 import org.operaton.spin.json.SpinJsonNode;
 import org.operaton.spin.json.SpinJsonPathException;
-import org.junit.Before;
-import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.operaton.spin.Spin.JSON;
+import static org.operaton.spin.json.JsonTestConstants.EXAMPLE_JSON;
 
 /**
  * @author Stefan Hentschel
@@ -88,8 +88,8 @@ public class JsonTreeJsonPathTest {
   public void shouldGetSingleArrayEntry() {
     SpinJsonNode node = jsonNode.jsonPath("$.customers[0]").element();
 
-    assertThat(node.isObject());
-    assertThat(node.prop("name").isString());
+    assertThat(node.isObject()).isTrue();
+    assertThat(node.prop("name").isString()).isTrue();
     assertThat(node.prop("name").stringValue()).isEqualTo("Kermit");
   }
 

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeJsonPathTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeJsonPathTest.java
@@ -110,7 +110,7 @@ public class JsonTreeJsonPathTest {
 
     nodeList = jsonNode.jsonPath("$.customers[?(@.name == 'Waldo')]").elementList();
 
-    assertThat(nodeList.size()).isEqualTo(1);
+    assertThat(nodeList).hasSize(1);
     assertThat(nodeList.get(0).prop("name").stringValue()).isEqualTo("Waldo");
   }
 

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeJsonPathTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeJsonPathTest.java
@@ -106,7 +106,7 @@ public class JsonTreeJsonPathTest {
   public void shouldGetFilteredResult() {
     SpinList<SpinJsonNode> nodeList = jsonNode.jsonPath("$.customers[?(@.name == 'Klo')]").elementList();
 
-    assertThat(nodeList.size()).isZero();
+    assertThat(nodeList).isEmpty();
 
     nodeList = jsonNode.jsonPath("$.customers[?(@.name == 'Waldo')]").elementList();
 

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeJsonPathTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeJsonPathTest.java
@@ -106,7 +106,7 @@ public class JsonTreeJsonPathTest {
   public void shouldGetFilteredResult() {
     SpinList<SpinJsonNode> nodeList = jsonNode.jsonPath("$.customers[?(@.name == 'Klo')]").elementList();
 
-    assertThat(nodeList.size()).isEqualTo(0);
+    assertThat(nodeList.size()).isZero();
 
     nodeList = jsonNode.jsonPath("$.customers[?(@.name == 'Waldo')]").elementList();
 

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeMapJsonToJavaScriptTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeMapJsonToJavaScriptTest.java
@@ -85,7 +85,7 @@ public abstract class JsonTreeMapJsonToJavaScriptTest extends ScriptTest {
 
     List<Order> orders = script.execute(variables).getVariable("result");
 
-    assertThat(orders.size()).isEqualTo(1);
+    assertThat(orders).hasSize(1);
     assertIsExampleOrder(orders.get(0));
   }
 

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeMapJsonToJavaTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeMapJsonToJavaTest.java
@@ -69,7 +69,7 @@ public class JsonTreeMapJsonToJavaTest {
 
     List<Order> orders = JSON(EXAMPLE_JSON_COLLECTION).mapTo(desiredType.toCanonical());
 
-    assertThat(orders.size()).isEqualTo(1);
+    assertThat(orders).hasSize(1);
     assertIsExampleOrder(orders.get(0));
   }
 

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeReadPropertyScriptTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeReadPropertyScriptTest.java
@@ -232,7 +232,7 @@ public abstract class JsonTreeReadPropertyScriptTest extends ScriptTest {
   public void shouldReadBooleanValue() {
     Boolean value1 = script.getVariable("value1");
 
-    assertThat(value1).isEqualTo(true);
+    assertThat(value1).isTrue();
   }
 
   @Test

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeReadPropertyTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeReadPropertyTest.java
@@ -16,19 +16,19 @@
  */
 package org.operaton.spin.json.tree;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.operaton.spin.Spin.JSON;
-import static org.operaton.spin.json.JsonTestConstants.EXAMPLE_JSON;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.operaton.spin.SpinList;
 import org.operaton.spin.impl.util.SpinIoUtil;
 import org.operaton.spin.json.SpinJsonDataFormatException;
 import org.operaton.spin.json.SpinJsonNode;
 import org.operaton.spin.json.SpinJsonPropertyException;
 import org.operaton.spin.spi.SpinDataFormatException;
-import org.junit.Before;
-import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.operaton.spin.Spin.JSON;
+import static org.operaton.spin.json.JsonTestConstants.EXAMPLE_JSON;
 
 /**
  * @author Stefan Hentschel
@@ -302,7 +302,7 @@ public class JsonTreeReadPropertyTest {
 
     assertThat(active.value())
       .isInstanceOf(Boolean.class)
-      .isTrue();
+      .isEqualTo(true);
   }
 
   @Test

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeReadPropertyTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeReadPropertyTest.java
@@ -302,7 +302,7 @@ public class JsonTreeReadPropertyTest {
 
     assertThat(active.value())
       .isInstanceOf(Boolean.class)
-      .isEqualTo(true);
+      .isTrue();
   }
 
   @Test

--- a/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/impl/xml/dom/format/DomXmlDataFormatWriterTest.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/impl/xml/dom/format/DomXmlDataFormatWriterTest.java
@@ -16,22 +16,16 @@
  */
 package org.operaton.spin.impl.xml.dom.format;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
+import org.junit.Test;
 import org.operaton.spin.DataFormats;
 import org.operaton.spin.SpinFactory;
 import org.operaton.spin.spi.DataFormat;
 import org.operaton.spin.xml.JdkUtil;
 import org.operaton.spin.xml.SpinXmlElement;
-import org.junit.Test;
+
+import java.io.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test xml transformation in DomXmlDataFormatWriter
@@ -117,7 +111,7 @@ public class DomXmlDataFormatWriterTest {
     SpinXmlElement spinXmlElement = deserializeValue(serializedValue, dataFormat);
 
     // then
-    assertThat(spinXmlElement.toString()).isEqualTo(getExpectedFormattedXML());
+    assertThat(spinXmlElement).hasToString(getExpectedFormattedXML());
   }
 
   /**
@@ -143,7 +137,7 @@ public class DomXmlDataFormatWriterTest {
     SpinXmlElement spinXmlElement = deserializeValue(serializedValue, dataFormat);
 
     // then
-    assertThat(spinXmlElement.toString()).isEqualTo(getExpectedFormattedXML());
+    assertThat(spinXmlElement).hasToString(getExpectedFormattedXML());
   }
 
   /**
@@ -169,7 +163,7 @@ public class DomXmlDataFormatWriterTest {
     SpinXmlElement spinXmlElement = deserializeValue(serializedValue, dataFormat);
 
     // then
-    assertThat(spinXmlElement.toString()).isEqualTo(xml);
+    assertThat(spinXmlElement).hasToString(xml);
   }
 
   /**
@@ -202,7 +196,7 @@ public class DomXmlDataFormatWriterTest {
     SpinXmlElement spinXmlElement = deserializeValue(serializedValue, dataFormat);
 
     // then
-    assertThat(spinXmlElement.toString()).isEqualTo(expectedXml);
+    assertThat(spinXmlElement).hasToString(expectedXml);
   }
 
   /**
@@ -232,6 +226,6 @@ public class DomXmlDataFormatWriterTest {
     final SpinXmlElement spinXmlElement = deserializeValue(serializedValue, dataFormat);
 
     // then
-    assertThat(spinXmlElement.toString()).isEqualTo(getExpectedFormattedXML(true));
+    assertThat(spinXmlElement).hasToString(getExpectedFormattedXML(true));
   }
 }

--- a/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/XmlTestConstants.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/XmlTestConstants.java
@@ -102,7 +102,7 @@ public class XmlTestConstants {
 
     List<Customer> customers = order.getCustomer();
     assertThat(customers).isNotNull();
-    assertThat(customers.size()).isEqualTo(3);
+    assertThat(customers).hasSize(3);
 
     assertThat(customers).extracting("name", "contractStartDate")
       .contains(

--- a/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomAttributeTest.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomAttributeTest.java
@@ -16,17 +16,17 @@
  */
 package org.operaton.spin.xml.dom;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.spin.Spin.XML;
-
-import java.io.StringWriter;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.operaton.spin.xml.SpinXmlAttribute;
 import org.operaton.spin.xml.SpinXmlAttributeException;
 import org.operaton.spin.xml.SpinXmlElement;
 import org.operaton.spin.xml.XmlTestConstants;
-import org.junit.Before;
-import org.junit.Test;
+
+import java.io.StringWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.spin.Spin.XML;
 
 /**
  * @author Sebastian Menski
@@ -83,7 +83,7 @@ public class XmlDomAttributeTest {
 
   @Test
   public void canWriteToString() {
-    assertThat(attribute.toString()).isEqualTo("order1");
+    assertThat(attribute).hasToString("order1");
   }
 
   @Test

--- a/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomXPathScriptTest.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomXPathScriptTest.java
@@ -330,7 +330,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   public void canQueryNonExistingNumber() {
     SpinXPathQuery query = script.getVariable("query");
     Double count = query.number();
-    assertThat(count).isEqualTo(0);
+    assertThat(count).isZero();
   }
 
   @Test

--- a/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomXPathTest.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomXPathTest.java
@@ -160,7 +160,7 @@ public class XmlDomXPathTest {
 
     // can query not existing number
     count = element.xPath("count(/root/child/nonExisting)").number();
-    assertThat(count).isEqualTo(0);
+    assertThat(count).isZero();
 
     // can query number as document
     count = element.xPath("count(/)").number();

--- a/spring-boot-starter/starter-client/spring-boot/src/test/java/org/operaton/bpm/client/spring/boot/starter/client/BasicAuthAndInterceptorConfigurationTest.java
+++ b/spring-boot-starter/starter-client/spring-boot/src/test/java/org/operaton/bpm/client/spring/boot/starter/client/BasicAuthAndInterceptorConfigurationTest.java
@@ -83,7 +83,7 @@ public class BasicAuthAndInterceptorConfigurationTest extends ParsePropertiesHel
     verify(clientBuilder, times(3))
         .addInterceptor(interceptorCaptor.capture());
 
-    assertThat(interceptorCaptor.getAllValues().size()).isEqualTo(3);
+    assertThat(interceptorCaptor.getAllValues()).hasSize(3);
     assertThat(interceptorCaptor.getAllValues())
         .containsOnlyOnce(interceptorOne, interceptorTwo);
     assertThat(interceptorCaptor.getAllValues())

--- a/spring-boot-starter/starter-client/spring-boot/src/test/java/org/operaton/bpm/client/spring/boot/starter/client/ClientConfigurationTest.java
+++ b/spring-boot-starter/starter-client/spring-boot/src/test/java/org/operaton/bpm/client/spring/boot/starter/client/ClientConfigurationTest.java
@@ -43,7 +43,7 @@ public class ClientConfigurationTest extends ParsePropertiesHelper {
     assertThat(properties.getBaseUrl()).isEqualTo("base-url");
     assertThat(properties.getWorkerId()).isEqualTo("worker-id");
     assertThat(properties.getMaxTasks()).isEqualTo(111);
-    assertThat(properties.getUsePriority()).isEqualTo(false);
+    assertThat(properties.getUsePriority()).isFalse();
     assertThat(properties.getDefaultSerializationFormat()).isEqualTo("serialization-format");
     assertThat(properties.getDateFormat()).isEqualTo("date-format");
     assertThat(properties.getAsyncResponseTimeout()).isEqualTo(555);

--- a/spring-boot-starter/starter-client/spring-boot/src/test/java/org/operaton/bpm/client/spring/boot/starter/client/ClientConfigurationTest.java
+++ b/spring-boot-starter/starter-client/spring-boot/src/test/java/org/operaton/bpm/client/spring/boot/starter/client/ClientConfigurationTest.java
@@ -48,8 +48,8 @@ public class ClientConfigurationTest extends ParsePropertiesHelper {
     assertThat(properties.getDateFormat()).isEqualTo("date-format");
     assertThat(properties.getAsyncResponseTimeout()).isEqualTo(555);
     assertThat(properties.getLockDuration()).isEqualTo(777);
-    assertThat(properties.getDisableAutoFetching()).isEqualTo(true);
-    assertThat(properties.getDisableBackoffStrategy()).isEqualTo(true);
+    assertThat(properties.getDisableAutoFetching()).isTrue();
+    assertThat(properties.getDisableBackoffStrategy()).isTrue();
     assertThat(basicAuth.getUsername()).isEqualTo("username");
     assertThat(basicAuth.getPassword()).isEqualTo("password");
     assertThat(subscriptions).isEmpty();

--- a/spring-boot-starter/starter-client/spring-boot/src/test/java/org/operaton/bpm/client/spring/boot/starter/it/ClientAutoConfigurationIT.java
+++ b/spring-boot-starter/starter-client/spring-boot/src/test/java/org/operaton/bpm/client/spring/boot/starter/it/ClientAutoConfigurationIT.java
@@ -43,7 +43,7 @@ public class ClientAutoConfigurationIT {
 
   @Test
   public void startup() {
-    assertThat(topicSubscriptions.size()).isEqualTo(2);
+    assertThat(topicSubscriptions).hasSize(2);
     assertThat(topicSubscriptions)
         .extracting("topicName", "autoOpen", "businessKey", "lockDuration", "processDefinitionKey")
         .containsExactlyInAnyOrder(

--- a/spring-boot-starter/starter-client/spring/src/test/java/org/operaton/bpm/client/spring/client/CustomClientTest.java
+++ b/spring-boot-starter/starter-client/spring/src/test/java/org/operaton/bpm/client/spring/client/CustomClientTest.java
@@ -46,7 +46,7 @@ public class CustomClientTest extends MockedTest {
     verify(clientBuilder).build();
     verifyNoMoreInteractions(clientBuilder);
 
-    assertThat(clients.size()).isEqualTo(1);
+    assertThat(clients).hasSize(1);
   }
 
 }

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/redirect/ResourceLoadingProcessEnginesAppPathOperatonIndexRedirectTest.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/redirect/ResourceLoadingProcessEnginesAppPathOperatonIndexRedirectTest.java
@@ -16,18 +16,17 @@
  */
 package org.operaton.bpm.spring.boot.starter.webapp.filter.redirect;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.net.HttpURLConnection;
-import org.operaton.bpm.spring.boot.starter.webapp.filter.util.HttpClientRule;
-import org.operaton.bpm.spring.boot.starter.webapp.filter.util.FilterTestApp;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.operaton.bpm.spring.boot.starter.webapp.filter.util.FilterTestApp;
+import org.operaton.bpm.spring.boot.starter.webapp.filter.util.HttpClientRule;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.net.HttpURLConnection;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { FilterTestApp.class},
@@ -53,6 +52,6 @@ public class ResourceLoadingProcessEnginesAppPathOperatonIndexRedirectTest {
 
     // then
     // the request should have been redirected to Tasklist
-    assertThat(con.getURL().toString()).isEqualTo("http://localhost:" + port + "/operaton/app/tasklist/default/");
+    assertThat(con.getURL()).hasToString("http://localhost:" + port + "/operaton/app/tasklist/default/");
   }
 }

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/redirect/ResourceLoadingProcessEnginesAppPathOperatonIndexRedirectTest.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/redirect/ResourceLoadingProcessEnginesAppPathOperatonIndexRedirectTest.java
@@ -28,6 +28,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.net.HttpURLConnection;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { FilterTestApp.class},
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/redirect/ResourceLoadingProcessEnginesAppPathOperatonTest.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/redirect/ResourceLoadingProcessEnginesAppPathOperatonTest.java
@@ -16,18 +16,19 @@
  */
 package org.operaton.bpm.spring.boot.starter.webapp.filter.redirect;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.net.HttpURLConnection;
-import org.operaton.bpm.spring.boot.starter.webapp.filter.util.HttpClientRule;
-import org.operaton.bpm.spring.boot.starter.webapp.filter.util.FilterTestApp;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.operaton.bpm.spring.boot.starter.webapp.filter.util.FilterTestApp;
+import org.operaton.bpm.spring.boot.starter.webapp.filter.util.HttpClientRule;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.net.HttpURLConnection;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { FilterTestApp.class},
@@ -53,6 +54,6 @@ public class ResourceLoadingProcessEnginesAppPathOperatonTest {
 
     // then
     // the request should have been redirected to Tasklist
-    assertThat(con.getURL().toString()).isEqualTo("http://localhost:" + port + "/operaton/app/tasklist/default/");
+    assertThat(con.getURL()).hasToString("http://localhost:" + port + "/operaton/app/tasklist/default/");
   }
 }

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/redirect/ResourceLoadingProcessEnginesAppPathRootIndexRedirectTest.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/redirect/ResourceLoadingProcessEnginesAppPathRootIndexRedirectTest.java
@@ -16,20 +16,18 @@
  */
 package org.operaton.bpm.spring.boot.starter.webapp.filter.redirect;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.IOException;
-import java.net.HttpURLConnection;
-
-import org.operaton.bpm.spring.boot.starter.webapp.filter.util.HttpClientRule;
-import org.operaton.bpm.spring.boot.starter.webapp.filter.util.FilterTestApp;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.operaton.bpm.spring.boot.starter.webapp.filter.util.FilterTestApp;
+import org.operaton.bpm.spring.boot.starter.webapp.filter.util.HttpClientRule;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { FilterTestApp.class},
@@ -55,6 +53,6 @@ public class ResourceLoadingProcessEnginesAppPathRootIndexRedirectTest {
 
     // then
     // the request should have been redirected to Tasklist
-    assertThat(con.getURL().toString()).isEqualTo("http://localhost:" + port + "/app/tasklist/default/");
+    assertThat(con.getURL()).hasToString("http://localhost:" + port + "/app/tasklist/default/");
   }
 }

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/redirect/ResourceLoadingProcessEnginesAppPathRootIndexRedirectTest.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/redirect/ResourceLoadingProcessEnginesAppPathRootIndexRedirectTest.java
@@ -29,6 +29,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { FilterTestApp.class},
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,

--- a/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/configuration/impl/DefaultProcessEngineConfigurationTest.java
+++ b/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/configuration/impl/DefaultProcessEngineConfigurationTest.java
@@ -16,17 +16,17 @@
  */
 package org.operaton.bpm.spring.boot.starter.configuration.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.operaton.bpm.engine.ProcessEngines;
 import org.operaton.bpm.engine.impl.cfg.IdGenerator;
 import org.operaton.bpm.engine.spring.SpringProcessEngineConfiguration;
 import org.operaton.bpm.spring.boot.starter.property.OperatonBpmProperties;
-import org.junit.Before;
-import org.junit.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultProcessEngineConfigurationTest {
 
@@ -93,7 +93,7 @@ public class DefaultProcessEngineConfigurationTest {
   public void setJobExecutorAcquireByPriority() {
     properties.setJobExecutorAcquireByPriority(null);
     instance.preInit(configuration);
-    assertThat(configuration.isJobExecutorAcquireByPriority()).isEqualTo(false);
+    assertThat(configuration.isJobExecutorAcquireByPriority()).isFalse();
 
     properties.setJobExecutorAcquireByPriority(true);
     instance.preInit(configuration);

--- a/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/configuration/impl/DefaultProcessEngineConfigurationTest.java
+++ b/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/configuration/impl/DefaultProcessEngineConfigurationTest.java
@@ -97,7 +97,7 @@ public class DefaultProcessEngineConfigurationTest {
 
     properties.setJobExecutorAcquireByPriority(true);
     instance.preInit(configuration);
-    assertThat(configuration.isJobExecutorAcquireByPriority()).isEqualTo(true);
+    assertThat(configuration.isJobExecutorAcquireByPriority()).isTrue();
   }
 
   @Test

--- a/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/property/JobExecutorPropertiesTest.java
+++ b/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/property/JobExecutorPropertiesTest.java
@@ -24,8 +24,8 @@ public class JobExecutorPropertiesTest extends ParsePropertiesHelper {
 
   @Test
   public void testDefaultJobExecutorProperties() throws Exception {
-    assertThat(jobExecution.getCorePoolSize()).isEqualTo(3);
-    assertThat(jobExecution.getMaxPoolSize()).isEqualTo(10);
+    assertThat(jobExecution.getCorePool).hasSize(3);
+    assertThat(jobExecution.getMaxPool).hasSize(10);
     assertThat(jobExecution.getQueueCapacity()).isEqualTo(3);
   }
 }

--- a/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/property/JobExecutorPropertiesTest.java
+++ b/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/property/JobExecutorPropertiesTest.java
@@ -16,16 +16,16 @@
  */
 package org.operaton.bpm.spring.boot.starter.property;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JobExecutorPropertiesTest extends ParsePropertiesHelper {
 
   @Test
   public void testDefaultJobExecutorProperties() throws Exception {
-    assertThat(jobExecution.getCorePool).hasSize(3);
-    assertThat(jobExecution.getMaxPool).hasSize(10);
+    assertThat(jobExecution.getCorePoolSize()).isEqualTo(3);
+    assertThat(jobExecution.getMaxPoolSize()).isEqualTo(10);
     assertThat(jobExecution.getQueueCapacity()).isEqualTo(3);
   }
 }

--- a/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/property/WebappPropertyTest.java
+++ b/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/property/WebappPropertyTest.java
@@ -82,7 +82,7 @@ public class WebappPropertyTest extends ParsePropertiesHelper {
     assertThat(webapp.getCsrf().getEntryPoints()).isNotNull();
     assertThat(webapp.getCsrf().getEntryPoints()).isNotEmpty();
     assertThat(webapp.getCsrf().getEntryPoints()).isInstanceOf(List.class);
-    assertThat(webapp.getCsrf().getEntryPoints().size()).isEqualTo(2);
+    assertThat(webapp.getCsrf().getEntryPoints()).hasSize(2);
     assertThat(webapp.getCsrf().getEntryPoints().get(0)).isEqualTo("/api/engine/engine/default/history/task/count");
     assertThat(webapp.getCsrf().getEntryPoints().get(1)).isEqualTo("/api/engine/engine/default/history/variable/count");
   }

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/PluginQueryTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/PluginQueryTest.java
@@ -36,6 +36,6 @@ public class PluginQueryTest extends AbstractCockpitPluginTest {
 
     List<Execution> result = getQueryService().executeQuery("cockpit.base.selectProcessDefinitionWithFailedJobs", new QueryParameters());
 
-    assertThat(result).hasSize(0);
+    assertThat(result).isEmpty();
   }
 }

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/ProcessDefinitionResourceTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/ProcessDefinitionResourceTest.java
@@ -486,7 +486,7 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
 
     List<ProcessDefinitionDto> result1 = resource.queryCalledProcessDefinitions(queryParameter1);
     assertThat(result1).isEmpty();
-    assertThat(result1).hasSize(0);
+    assertThat(result1).isEmpty();
 
   }
 
@@ -509,7 +509,7 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
     List<ProcessDefinitionDto> results = resource.queryCalledProcessDefinitions(queryParameter);
 
     // then
-    assertThat(results).hasSize(0);
+    assertThat(results).isEmpty();
   }
 
   @Test
@@ -574,7 +574,7 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
     List<ProcessDefinitionDto> results = resource.queryCalledProcessDefinitions(queryParameter);
 
     // then
-    assertThat(results).hasSize(0);
+    assertThat(results).isEmpty();
   }
 
   @Test
@@ -596,7 +596,7 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
     List<ProcessDefinitionDto> results = resource.queryCalledProcessDefinitions(queryParameter);
 
     // then
-    assertThat(results).hasSize(0);
+    assertThat(results).isEmpty();
   }
 
   @Test
@@ -618,7 +618,7 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
     List<ProcessDefinitionDto> results = resource.queryCalledProcessDefinitions(queryParameter);
 
     // then
-    assertThat(results).hasSize(0);
+    assertThat(results).isEmpty();
   }
 
   @Test

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/ProcessInstanceRestServiceTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/ProcessInstanceRestServiceTest.java
@@ -436,7 +436,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     List<ProcessInstanceDto> results = resource.queryProcessInstances(parameter, 0, Integer.MAX_VALUE);
 
     // then
-    assertThat(results).hasSize(0);
+    assertThat(results).isEmpty();
   }
 
   @Test
@@ -456,7 +456,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     List<ProcessInstanceDto> results = resource.queryProcessInstances(parameter, 0, Integer.MAX_VALUE);
 
     // then
-    assertThat(results).hasSize(0);
+    assertThat(results).isEmpty();
   }
 
   @Test
@@ -476,7 +476,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     List<ProcessInstanceDto> results = resource.queryProcessInstances(parameter, 0, Integer.MAX_VALUE);
 
     // then
-    assertThat(results).hasSize(0);
+    assertThat(results).isEmpty();
   }
 
   @Test
@@ -496,7 +496,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     List<ProcessInstanceDto> result = resource.queryProcessInstances(parameter, 0, Integer.MAX_VALUE);
 
     // then
-    assertThat(result).hasSize(0);
+    assertThat(result).isEmpty();
   }
 
   @Test

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/authorization/ProcessDefinitionResourceAuthorizationTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/authorization/ProcessDefinitionResourceAuthorizationTest.java
@@ -140,7 +140,7 @@ public class ProcessDefinitionResourceAuthorizationTest extends AuthorizationTes
     List<ProcessDefinitionDto> calledDefinitions = resource.queryCalledProcessDefinitions(queryParameter);
 
     // then
-    assertThat(calledDefinitions.size()).isEqualTo(1);
+    assertThat(calledDefinitions).hasSize(1);
 
     ProcessDefinitionDto calledProcessDefinition = calledDefinitions.get(0);
     assertThat(calledProcessDefinition.getKey()).isEqualTo(USER_TASK_PROCESS_KEY);

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/authorization/ProcessDefinitionRestServiceAuthorizationTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/authorization/ProcessDefinitionRestServiceAuthorizationTest.java
@@ -132,7 +132,7 @@ public class ProcessDefinitionRestServiceAuthorizationTest  extends Authorizatio
     CountResultDto actual = resource.getStatisticsCount(uriInfo);
 
     // then
-    assertThat(actual.getCount()).isEqualTo(0);
+    assertThat(actual.getCount()).isZero();
   }
 
   @Test

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/tenantcheck/ProcessInstanceRestServiceTenantCheckTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/tenantcheck/ProcessInstanceRestServiceTenantCheckTest.java
@@ -89,7 +89,7 @@ public class ProcessInstanceRestServiceTenantCheckTest extends AbstractCockpitPl
 
     CountResultDto result = resource.queryProcessInstancesCount(queryParameter);
     assertThat(result).isNotNull();
-    assertThat(result.getCount()).isEqualTo(0);
+    assertThat(result.getCount()).isZero();
   }
 
   @Test

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/auth/UserAuthenticationResourceLoggingTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/auth/UserAuthenticationResourceLoggingTest.java
@@ -119,7 +119,7 @@ public class UserAuthenticationResourceLoggingTest {
 
     // then
     List<ILoggingEvent> filteredLog = loggingRule.getFilteredLog("jonny");
-    assertThat(filteredLog).hasSize(0);
+    assertThat(filteredLog).isEmpty();
   }
 
   @Test
@@ -160,7 +160,7 @@ public class UserAuthenticationResourceLoggingTest {
 
     // then
     List<ILoggingEvent> filteredLog = loggingRule.getFilteredLog("jonny");
-    assertThat(filteredLog).hasSize(0);
+    assertThat(filteredLog).isEmpty();
   }
 
   @Test
@@ -203,7 +203,7 @@ public class UserAuthenticationResourceLoggingTest {
 
     // then
     List<ILoggingEvent> filteredLog = loggingRule.getFilteredLog("jonny");
-    assertThat(filteredLog).hasSize(0);
+    assertThat(filteredLog).isEmpty();
   }
 
   @Test
@@ -219,7 +219,7 @@ public class UserAuthenticationResourceLoggingTest {
 
     // then
     List<ILoggingEvent> filteredLog = loggingRule.getFilteredLog("jonny");
-    assertThat(filteredLog).hasSize(0);
+    assertThat(filteredLog).isEmpty();
   }
 
   @Test
@@ -291,7 +291,7 @@ public class UserAuthenticationResourceLoggingTest {
 
     // then
     List<ILoggingEvent> filteredLog = loggingRule.getFilteredLog("jonny");
-    assertThat(filteredLog).hasSize(0);
+    assertThat(filteredLog).isEmpty();
   }
 
   protected void setAuthentication(String user, String engineName) {

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/filter/headersec/XssProtectionTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/filter/headersec/XssProtectionTest.java
@@ -16,15 +16,15 @@
  */
 package org.operaton.bpm.webapp.impl.security.filter.headersec;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.webapp.impl.security.filter.headersec.provider.impl.XssProtectionOption.BLOCK;
-import static org.operaton.bpm.webapp.impl.security.filter.headersec.provider.impl.XssProtectionOption.SANITIZE;
-import static org.operaton.bpm.webapp.impl.security.filter.headersec.provider.impl.XssProtectionProvider.HEADER_NAME;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.webapp.impl.util.HeaderRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.webapp.impl.security.filter.headersec.provider.impl.XssProtectionOption.BLOCK;
+import static org.operaton.bpm.webapp.impl.security.filter.headersec.provider.impl.XssProtectionOption.SANITIZE;
+import static org.operaton.bpm.webapp.impl.security.filter.headersec.provider.impl.XssProtectionProvider.HEADER_NAME;
 
 /**
  * @author Tassilo Weidner
@@ -55,7 +55,7 @@ public class XssProtectionTest {
     headerRule.performRequest();
 
     // then
-    assertThat(headerRule.headerExists(HEADER_NAME)).isEqualTo(false);
+    assertThat(headerRule.headerExists(HEADER_NAME)).isFalse();
   }
 
   @Test
@@ -67,7 +67,7 @@ public class XssProtectionTest {
     headerRule.performRequest();
 
     // then
-    assertThat(headerRule.headerExists(HEADER_NAME)).isEqualTo(false);
+    assertThat(headerRule.headerExists(HEADER_NAME)).isFalse();
   }
 
   @Test

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/plugin/resource/AbstractAppPluginRootResourceTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/plugin/resource/AbstractAppPluginRootResourceTest.java
@@ -16,16 +16,16 @@
  */
 package org.operaton.bpm.webapp.plugin.resource;
 
-import org.operaton.bpm.engine.rest.exception.RestException;
-import org.operaton.bpm.webapp.AppRuntimeDelegate;
-import org.operaton.bpm.webapp.plugin.AppPluginRegistry;
-import org.operaton.bpm.webapp.plugin.spi.AppPlugin;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.mockito.Mockito;
+import org.operaton.bpm.engine.rest.exception.RestException;
+import org.operaton.bpm.webapp.AppRuntimeDelegate;
+import org.operaton.bpm.webapp.plugin.AppPluginRegistry;
+import org.operaton.bpm.webapp.plugin.spi.AppPlugin;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -112,11 +112,11 @@ public class AbstractAppPluginRootResourceTest {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         ((StreamingOutput) actual.getEntity()).write(output);
 
-        assertThat(output.toString()).isEqualTo(ASSET_CONTENT);
+        assertThat(output).hasToString(ASSET_CONTENT);
         assertThat(actual.getHeaders()).containsKey(HttpHeaders.CONTENT_TYPE).hasSize(1);
         assertThat(actual.getHeaders().get(HttpHeaders.CONTENT_TYPE)).hasSize(1);
         // In IDE it's String, with maven it's MediaType class
-        assertThat(actual.getHeaders().get(HttpHeaders.CONTENT_TYPE).get(0).toString()).isEqualTo(assetMediaType);
+        assertThat(actual.getHeaders().get(HttpHeaders.CONTENT_TYPE).get(0)).hasToString(assetMediaType);
 
         Mockito.verify(runtimeDelegate).getAppPluginRegistry();
         Mockito.verify(pluginRegistry).getPlugin(PLUGIN_NAME);


### PR DESCRIPTION
This cleans usages of assertj API up.

- replace isEqualTo(true) by isTrue()
- replace isEqualTo(false) by isFalse()
- replace isEqualTo(0) by isZero()
- replace hasSize(0) by isEmpty()
- replace toString()).isEqualTo by hasToString()
- replace .size()).isEqualTo by .hasSize(()

This resolves a lot of Sonar findings.

related to #27