### PR TITLE
refactor(tests): Make BatchHelper independent of ProcessEngineRule

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/ProcessEngineProvider.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/ProcessEngineProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright itemis AG and/or licensed to itemis AG
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. itemis AG licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine;
+
+public interface ProcessEngineProvider {
+  ProcessEngine getProcessEngine();
+}

--- a/engine/src/main/java/org/operaton/bpm/engine/test/ProcessEngineRule.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/test/ProcessEngineRule.java
@@ -16,34 +16,22 @@
  */
 package org.operaton.bpm.engine.test;
 
-import java.io.FileNotFoundException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import org.operaton.bpm.engine.AuthorizationService;
-import org.operaton.bpm.engine.CaseService;
-import org.operaton.bpm.engine.DecisionService;
-import org.operaton.bpm.engine.ExternalTaskService;
-import org.operaton.bpm.engine.FilterService;
-import org.operaton.bpm.engine.FormService;
-import org.operaton.bpm.engine.HistoryService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ManagementService;
-import org.operaton.bpm.engine.ProcessEngine;
-import org.operaton.bpm.engine.ProcessEngineServices;
-import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.junit.Assume;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.impl.ProcessEngineImpl;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.diagnostics.PlatformDiagnosticsRegistry;
 import org.operaton.bpm.engine.impl.test.RequiredDatabase;
 import org.operaton.bpm.engine.impl.test.TestHelper;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
-import org.junit.Assume;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 
 /**
@@ -100,7 +88,7 @@ import org.junit.runners.model.Statement;
  *
  * @author Tom Baeyens
  */
-public class ProcessEngineRule extends TestWatcher implements ProcessEngineServices {
+public class ProcessEngineRule extends TestWatcher implements ProcessEngineServices, ProcessEngineProvider {
 
   protected String configurationResource = "operaton.cfg.xml";
   protected String configurationResourceCompat = "activiti.cfg.xml";

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionTest.java
@@ -666,7 +666,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
     }
 
     public JobDefinition getExecutionJobDefinition(Batch batch) {
-      return engineRule.getManagementService().createJobDefinitionQuery()
+      return getManagementService().createJobDefinitionQuery()
           .jobDefinitionId(batch.getBatchJobDefinitionId())
           .jobType(Batch.TYPE_HISTORIC_DECISION_INSTANCE_DELETION)
           .singleResult();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchModificationHelper.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchModificationHelper.java
@@ -16,15 +16,14 @@
  */
 package org.operaton.bpm.engine.test.api.runtime;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.management.JobDefinition;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class BatchModificationHelper extends BatchHelper {
 
@@ -38,11 +37,9 @@ public class BatchModificationHelper extends BatchHelper {
   }
 
   public Batch startAfterAsync(String key, int numberOfProcessInstances, String activityId, String processDefinitionId) {
-    RuntimeService runtimeService = engineRule.getRuntimeService();
-
     List<String> processInstanceIds = startInstances(key, numberOfProcessInstances);
 
-    return runtimeService
+    return getRuntimeService()
       .createModification(processDefinitionId)
       .startAfterActivity(activityId)
       .processInstanceIds(processInstanceIds)
@@ -50,33 +47,27 @@ public class BatchModificationHelper extends BatchHelper {
   }
 
   public Batch startBeforeAsync(String key, int numberOfProcessInstances, String activityId, String processDefinitionId) {
-    RuntimeService runtimeService = engineRule.getRuntimeService();
-
     List<String> processInstanceIds = startInstances(key, numberOfProcessInstances);
 
-    return runtimeService.createModification(processDefinitionId).startBeforeActivity(activityId).processInstanceIds(processInstanceIds).executeAsync();
+    return getRuntimeService().createModification(processDefinitionId).startBeforeActivity(activityId).processInstanceIds(processInstanceIds).executeAsync();
   }
 
   public Batch startTransitionAsync(String key, int numberOfProcessInstances, String transitionId, String processDefinitionId) {
-    RuntimeService runtimeService = engineRule.getRuntimeService();
-
     List<String> processInstanceIds = startInstances(key, numberOfProcessInstances);
 
-    return runtimeService.createModification(processDefinitionId).startTransition(transitionId).processInstanceIds(processInstanceIds).executeAsync();
+    return getRuntimeService().createModification(processDefinitionId).startTransition(transitionId).processInstanceIds(processInstanceIds).executeAsync();
   }
 
   public Batch cancelAllAsync(String key, int numberOfProcessInstances, String activityId, String processDefinitionId) {
-    RuntimeService runtimeService = engineRule.getRuntimeService();
-
     List<String> processInstanceIds = startInstances(key, numberOfProcessInstances);
 
-    return runtimeService.createModification(processDefinitionId).cancelAllForActivity(activityId).processInstanceIds(processInstanceIds).executeAsync();
+    return getRuntimeService().createModification(processDefinitionId).cancelAllForActivity(activityId).processInstanceIds(processInstanceIds).executeAsync();
   }
 
   public List<String> startInstances(String key, int numOfInstances) {
     List<String> instances = new ArrayList<String>();
     for (int i = 0; i < numOfInstances; i++) {
-      ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceByKey(key);
+      ProcessInstance processInstance = getRuntimeService().startProcessInstanceByKey(key);
       instances.add(processInstance.getId());
     }
 
@@ -86,7 +77,7 @@ public class BatchModificationHelper extends BatchHelper {
 
   @Override
   public JobDefinition getExecutionJobDefinition(Batch batch) {
-    return engineRule.getManagementService()
+    return getManagementService()
         .createJobDefinitionQuery().jobDefinitionId(batch.getBatchJobDefinitionId()).jobType(Batch.TYPE_PROCESS_INSTANCE_MODIFICATION).singleResult();
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchRestartHelper.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchRestartHelper.java
@@ -16,23 +16,18 @@
  */
 package org.operaton.bpm.engine.test.api.runtime;
 
-import static org.junit.Assert.assertNotNull;
-
+import org.operaton.bpm.engine.ProcessEngineProvider;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.management.JobDefinition;
 import org.operaton.bpm.engine.runtime.Job;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
+
+import static org.junit.Assert.assertNotNull;
 
 
 public class BatchRestartHelper extends BatchHelper {
 
-  public BatchRestartHelper(ProcessEngineRule engineRule) {
-    super(engineRule);
-  }
-
-  public BatchRestartHelper(PluggableProcessEngineTest testCase) {
-    super(testCase);
+  public BatchRestartHelper (ProcessEngineProvider processEngineProvider) {
+    super(processEngineProvider);
   }
 
   @Override

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchSuspensionHelper.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchSuspensionHelper.java
@@ -16,14 +16,14 @@
  */
 package org.operaton.bpm.engine.test.api.runtime;
 
+import org.operaton.bpm.engine.ProcessEngineProvider;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.management.JobDefinition;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 
 public class BatchSuspensionHelper extends BatchHelper {
 
-  public BatchSuspensionHelper(ProcessEngineRule engineRule) {
-    super(engineRule);
+  public BatchSuspensionHelper(ProcessEngineProvider processEngineProvider) {
+    super(processEngineProvider);
   }
 
   @Override

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/batch/BatchMigrationHelper.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/batch/BatchMigrationHelper.java
@@ -16,35 +16,35 @@
  */
 package org.operaton.bpm.engine.test.api.runtime.migration.batch;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import org.operaton.bpm.engine.ProcessEngineProvider;
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.management.JobDefinition;
 import org.operaton.bpm.engine.migration.MigrationInstructionsBuilder;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.api.runtime.BatchHelper;
 import org.operaton.bpm.engine.test.api.runtime.migration.MigrationTestRule;
 import org.operaton.bpm.engine.test.api.runtime.migration.models.ProcessModels;
 
-public class BatchMigrationHelper extends BatchHelper{
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class BatchMigrationHelper extends BatchHelper {
 
   protected MigrationTestRule migrationRule;
 
   public ProcessDefinition sourceProcessDefinition;
   public ProcessDefinition targetProcessDefinition;
 
-  public BatchMigrationHelper(ProcessEngineRule engineRule, MigrationTestRule migrationRule) {
-    super(engineRule);
-    this.migrationRule = migrationRule;
+  public BatchMigrationHelper(ProcessEngineProvider processEngineProvider) {
+    this(processEngineProvider, null);
   }
 
-  public BatchMigrationHelper(ProcessEngineRule engineRule) {
-    this(engineRule, null);
+  public BatchMigrationHelper(ProcessEngineProvider processEngineProvider, MigrationTestRule migrationRule) {
+    super(processEngineProvider);
+    this.migrationRule = migrationRule;
   }
 
   public ProcessDefinition getSourceProcessDefinition() {
@@ -56,7 +56,7 @@ public class BatchMigrationHelper extends BatchHelper{
   }
 
   public Batch createMigrationBatchWithSize(int batchSize) {
-    int invocationsPerBatchJob = ((ProcessEngineConfigurationImpl) engineRule.getProcessEngine().getProcessEngineConfiguration()).getInvocationsPerBatchJob();
+    int invocationsPerBatchJob = ((ProcessEngineConfigurationImpl) getProcessEngine().getProcessEngineConfiguration()).getInvocationsPerBatchJob();
     return migrateProcessInstancesAsync(invocationsPerBatchJob * batchSize);
   }
 
@@ -81,21 +81,20 @@ public class BatchMigrationHelper extends BatchHelper{
                                             ProcessDefinition targetProcessDefinition,
                                             Map<String, Object> variables,
                                             boolean authenticated) {
-    RuntimeService runtimeService = engineRule.getRuntimeService();
-
     List<String> processInstanceIds = new ArrayList<>(numberOfProcessInstances);
+    RuntimeService runtimeService = getRuntimeService();
     for (int i = 0; i < numberOfProcessInstances; i++) {
       String srcProcessDefinitionId = sourceProcessDefinition.getId();
       String processInstanceId =
-          runtimeService.startProcessInstanceById(srcProcessDefinitionId).getId();
+              runtimeService.startProcessInstanceById(srcProcessDefinitionId).getId();
       processInstanceIds.add(processInstanceId);
     }
 
     if (authenticated) {
-      engineRule.getIdentityService().setAuthenticatedUserId("user");
+      getIdentityService().setAuthenticatedUserId("user");
     }
 
-    MigrationInstructionsBuilder planBuilder = engineRule.getRuntimeService()
+    MigrationInstructionsBuilder planBuilder = runtimeService
         .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
         .mapEqualActivities();
 
@@ -118,17 +117,17 @@ public class BatchMigrationHelper extends BatchHelper{
 
   @Override
   public JobDefinition getExecutionJobDefinition(Batch batch) {
-    return engineRule.getManagementService()
+    return getManagementService()
       .createJobDefinitionQuery().jobDefinitionId(batch.getBatchJobDefinitionId()).jobType(Batch.TYPE_PROCESS_INSTANCE_MIGRATION).singleResult();
   }
 
   public long countSourceProcessInstances() {
-    return engineRule.getRuntimeService()
+    return getRuntimeService()
       .createProcessInstanceQuery().processDefinitionId(sourceProcessDefinition.getId()).count();
   }
 
   public long countTargetProcessInstances() {
-    return engineRule.getRuntimeService()
+    return getRuntimeService()
       .createProcessInstanceQuery().processDefinitionId(targetProcessDefinition.getId()).count();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/util/PluggableProcessEngineTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/util/PluggableProcessEngineTest.java
@@ -19,19 +19,7 @@ package org.operaton.bpm.engine.test.util;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.operaton.bpm.engine.AuthorizationService;
-import org.operaton.bpm.engine.CaseService;
-import org.operaton.bpm.engine.DecisionService;
-import org.operaton.bpm.engine.ExternalTaskService;
-import org.operaton.bpm.engine.FilterService;
-import org.operaton.bpm.engine.FormService;
-import org.operaton.bpm.engine.HistoryService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ManagementService;
-import org.operaton.bpm.engine.ProcessEngine;
-import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.persistence.entity.JobEntity;
@@ -46,7 +34,7 @@ import org.junit.rules.RuleChain;
 /**
  * Base class for the process engine test cases.
  */
-public class PluggableProcessEngineTest {
+public class PluggableProcessEngineTest implements ProcessEngineProvider {
 
   protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
   protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);

--- a/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/util/BatchModificationJobHelper.java
+++ b/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/util/BatchModificationJobHelper.java
@@ -16,20 +16,20 @@
  */
 package org.operaton.bpm.qa.largedata.util;
 
+import org.operaton.bpm.engine.ProcessEngineProvider;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.management.JobDefinition;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.api.runtime.BatchHelper;
 
 public class BatchModificationJobHelper extends BatchHelper {
 
-  public BatchModificationJobHelper(ProcessEngineRule engineRule) {
-    super(engineRule);
+  public BatchModificationJobHelper(ProcessEngineProvider processEngineProvider) {
+    super(processEngineProvider);
   }
 
   @Override
   public JobDefinition getExecutionJobDefinition(Batch batch) {
-    return engineRule.getManagementService()
+    return getManagementService()
         .createJobDefinitionQuery()
         .jobDefinitionId(batch.getBatchJobDefinitionId())
         .jobType(Batch.TYPE_SET_JOB_RETRIES)


### PR DESCRIPTION
This change introduces the interface `ProcessEngineProvider`, which is implemented by the classes `ProcessEngineRule` and `PluggableProcessEngineTest`.

The BatchHelper class hierarchy is decoupled from `ProcessEngineRule` and `PluggableProcessEngineTest` by using this interface to access the ProcessEngine and its services.

This is a preparation step for migrating test cases away from these both classes.

related to #27