### PR TITLE
refactor(tests): JUnit 5 migration - module qa/large-data-tests

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/test/ProcessEngineRule.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/test/ProcessEngineRule.java
@@ -95,7 +95,7 @@ public class ProcessEngineRule extends TestWatcher implements ProcessEngineServi
   protected String deploymentId = null;
   protected List<String> additionalDeployments = new ArrayList<>();
 
-  protected boolean ensureCleanAfterTest = false;
+  protected boolean ensureCleanAfterTest;
 
   protected ProcessEngine processEngine;
   protected ProcessEngineConfigurationImpl processEngineConfiguration;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchModificationHelper.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchModificationHelper.java
@@ -33,7 +33,7 @@ public class BatchModificationHelper extends BatchHelper {
   public BatchModificationHelper(ProcessEngineRule engineRule) {
     super(engineRule);
     this.testRule = new ProcessEngineTestRule(engineRule);
-    currentProcessInstances = new ArrayList<String>();
+    currentProcessInstances = new ArrayList<>();
   }
 
   public Batch startAfterAsync(String key, int numberOfProcessInstances, String activityId, String processDefinitionId) {
@@ -65,7 +65,7 @@ public class BatchModificationHelper extends BatchHelper {
   }
 
   public List<String> startInstances(String key, int numOfInstances) {
-    List<String> instances = new ArrayList<String>();
+    List<String> instances = new ArrayList<>();
     for (int i = 0; i < numOfInstances; i++) {
       ProcessInstance processInstance = getRuntimeService().startProcessInstanceByKey(key);
       instances.add(processInstance.getId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/util/PluggableProcessEngineTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/util/PluggableProcessEngineTest.java
@@ -103,14 +103,4 @@ public class PluggableProcessEngineTest implements ProcessEngineProvider {
     return result;
   }
 
-  protected void deleteHistoryCleanupJobs() {
-    final List<Job> jobs = historyService.findHistoryCleanupJobs();
-    for (final Job job: jobs) {
-      processEngineConfiguration.getCommandExecutorTxRequired().execute((Command<Void>) commandContext -> {
-        commandContext.getJobManager().deleteJob((JobEntity) job);
-        return null;
-      });
-    }
-  }
-
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/util/PluggableProcessEngineTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/util/PluggableProcessEngineTest.java
@@ -16,25 +16,36 @@
  */
 package org.operaton.bpm.engine.test.util;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.operaton.bpm.engine.*;
-import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.operaton.bpm.engine.impl.interceptor.Command;
-import org.operaton.bpm.engine.impl.persistence.entity.JobEntity;
-import org.operaton.bpm.engine.impl.util.ClockUtil;
-import org.operaton.bpm.engine.runtime.ActivityInstance;
-import org.operaton.bpm.engine.runtime.Job;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.AuthorizationService;
+import org.operaton.bpm.engine.CaseService;
+import org.operaton.bpm.engine.DecisionService;
+import org.operaton.bpm.engine.ExternalTaskService;
+import org.operaton.bpm.engine.FilterService;
+import org.operaton.bpm.engine.FormService;
+import org.operaton.bpm.engine.HistoryService;
+import org.operaton.bpm.engine.IdentityService;
+import org.operaton.bpm.engine.ManagementService;
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.ProcessEngineProvider;
+import org.operaton.bpm.engine.RepositoryService;
+import org.operaton.bpm.engine.RuntimeService;
+import org.operaton.bpm.engine.TaskService;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.operaton.bpm.engine.impl.util.ClockUtil;
+import org.operaton.bpm.engine.runtime.ActivityInstance;
+import org.operaton.bpm.engine.runtime.Job;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * Base class for the process engine test cases.
  */
-public class PluggableProcessEngineTest implements ProcessEngineProvider {
+public abstract class PluggableProcessEngineTest implements ProcessEngineProvider {
 
   protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
   protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -109,6 +109,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <version>${version.junit5}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.junit.platform</groupId>
         <artifactId>junit-platform-testkit</artifactId>
         <version>1.11.3</version>

--- a/qa/large-data-tests/pom.xml
+++ b/qa/large-data-tests/pom.xml
@@ -43,6 +43,12 @@
       <artifactId>JUnitParams</artifactId>
       <version>1.1.1</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -52,14 +58,19 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.operaton.bpm</groupId>
+      <artifactId>operaton-bpm-junit5</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/DeleteDeploymentCascadeTest.java
+++ b/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/DeleteDeploymentCascadeTest.java
@@ -16,49 +16,48 @@
  */
 package org.operaton.bpm.qa.largedata;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.operaton.bpm.engine.HistoryService;
+import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.engine.history.HistoricProcessInstance;
 import org.operaton.bpm.engine.impl.db.sql.DbSqlSessionFactory;
 import org.operaton.bpm.engine.impl.util.CollectionUtil;
 import org.operaton.bpm.engine.repository.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.qa.largedata.util.EngineDataGenerator;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
 
-public class DeleteDeploymentCascadeTest {
+import java.util.List;
+import java.util.stream.Collectors;
 
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule("operaton.cfg.xml");
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeleteDeploymentCascadeTest {
+
+  @RegisterExtension
+  static ProcessEngineExtension processEngineExtension = ProcessEngineExtension.builder().configurationResource("operaton.cfg.xml").build();
 
   protected static final String DATA_PREFIX = DeleteDeploymentCascadeTest.class.getSimpleName();
 
   protected int GENERATE_PROCESS_INSTANCES_COUNT = 2500;
+  protected ProcessEngine processEngine;
   protected RepositoryService repositoryService;
   protected HistoryService historyService;
   protected EngineDataGenerator generator;
-  
-  @Before
-  public void init() {
-    repositoryService = processEngineRule.getProcessEngine().getRepositoryService();
-    historyService = processEngineRule.getProcessEngine().getHistoryService();
 
+  @BeforeEach
+  void init() {
     // generate data
-    generator = new EngineDataGenerator(processEngineRule.getProcessEngine(), GENERATE_PROCESS_INSTANCES_COUNT, DATA_PREFIX);
+    generator = new EngineDataGenerator(processEngine, GENERATE_PROCESS_INSTANCES_COUNT, DATA_PREFIX);
     generator.deployDefinitions();
     generator.generateCompletedProcessInstanceData();
   }
 
-  @After
-  public void teardown() {
+  @AfterEach
+  void teardown() {
     Deployment deployment = repositoryService.createDeploymentQuery().deploymentName(generator.getDeploymentName()).singleResult();
     if (deployment != null) {
       List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
@@ -75,7 +74,7 @@ public class DeleteDeploymentCascadeTest {
   }
 
   @Test
-  public void shouldDeleteCascadeWithLargeParameterCount() {
+  void shouldDeleteCascadeWithLargeParameterCount() {
     // given
     Deployment deployment = repositoryService.createDeploymentQuery().deploymentName(generator.getDeploymentName()).singleResult();
 

--- a/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/optimize/OptimizeApiPageSizeTest.java
+++ b/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/optimize/OptimizeApiPageSizeTest.java
@@ -16,6 +16,10 @@
  */
 package org.operaton.bpm.qa.largedata.optimize;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Function;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -24,18 +28,15 @@ import org.operaton.bpm.engine.impl.OptimizeService;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.qa.largedata.util.EngineDataGenerator;
 
-import java.util.List;
-import java.util.function.Function;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 class OptimizeApiPageSizeTest {
 
   private static OptimizeService optimizeService;
   private static final int OPTIMIZE_PAGE_SIZE = 10_000;
 
   @RegisterExtension
-  static ProcessEngineExtension processEngineExtension = ProcessEngineExtension.builder().configurationResource("operaton.cfg.xml").build();
+  static ProcessEngineExtension processEngineExtension = ProcessEngineExtension.builder()
+      .configurationResource("operaton.cfg.xml")
+      .build();
 
   @BeforeAll
   static void init() {
@@ -43,7 +44,8 @@ class OptimizeApiPageSizeTest {
 
     // given the generated engine data
     // make sure that there are at least two pages of each entity available
-    EngineDataGenerator generator = new EngineDataGenerator(processEngineExtension.getProcessEngine(), OPTIMIZE_PAGE_SIZE * 2, OptimizeApiPageSizeTest.class.getSimpleName());
+    EngineDataGenerator generator = new EngineDataGenerator(processEngineExtension.getProcessEngine(),
+        OPTIMIZE_PAGE_SIZE * 2, OptimizeApiPageSizeTest.class.getSimpleName());
     generator.generateData();
   }
 
@@ -57,48 +59,48 @@ class OptimizeApiPageSizeTest {
     assertThat(pageOfEntries).hasSize(OPTIMIZE_PAGE_SIZE);
   }
 
-  private static Object[] optimizeServiceFunctions() {
+  private Object[] optimizeServiceFunctions() {
     return new TestScenario[]{
-        new TestScenario(
-            (pageSize) -> optimizeService.getRunningHistoricActivityInstances(null, null, pageSize),
-            "running historic activity instances"
-        ),
-        new TestScenario(
-            (pageSize) -> optimizeService.getCompletedHistoricActivityInstances(null, null, pageSize),
-            "completed historic activity instances"
-        ),
-        new TestScenario(
-            (pageSize) -> optimizeService.getRunningHistoricProcessInstances(null, null, pageSize),
-            "running historic process instances"
-        ),
-        new TestScenario(
-            (pageSize) -> optimizeService.getCompletedHistoricProcessInstances(null, null, pageSize),
-            "completed historic process instances"
-        ),
-        new TestScenario(
-            (pageSize) -> optimizeService.getRunningHistoricTaskInstances(null, null, pageSize),
-            "running historic task instances"
-        ),
-        new TestScenario(
-            (pageSize) -> optimizeService.getCompletedHistoricTaskInstances(null, null, pageSize),
-            "completed historic task instances"
-        ),
-        new TestScenario(
-            (pageSize) -> optimizeService.getHistoricIdentityLinkLogs(null, null, pageSize),
-            "historic identity link logs"
-        ),
-        new TestScenario(
-            (pageSize) -> optimizeService.getHistoricUserOperationLogs(null, null, pageSize),
-            "historic user operation logs"
-        ),
-        new TestScenario(
-            (pageSize) -> optimizeService.getHistoricVariableUpdates(null, null, true, pageSize),
-            "historic variable updates"
-        ),
-        new TestScenario(
-            (pageSize) -> optimizeService.getHistoricDecisionInstances(null, null, pageSize),
-            "historic decision instances"
-        )
+      new TestScenario(
+        pageSize -> optimizeService.getRunningHistoricActivityInstances(null, null, pageSize),
+        "running historic activity instances"
+      ),
+      new TestScenario(
+        pageSize -> optimizeService.getCompletedHistoricActivityInstances(null, null, pageSize),
+        "completed historic activity instances"
+      ),
+      new TestScenario(
+        pageSize -> optimizeService.getRunningHistoricProcessInstances(null, null, pageSize),
+        "running historic process instances"
+      ),
+      new TestScenario(
+        pageSize -> optimizeService.getCompletedHistoricProcessInstances(null, null, pageSize),
+        "completed historic process instances"
+      ),
+      new TestScenario(
+        pageSize -> optimizeService.getRunningHistoricTaskInstances(null, null, pageSize),
+        "running historic task instances"
+      ),
+      new TestScenario(
+        pageSize -> optimizeService.getCompletedHistoricTaskInstances(null, null, pageSize),
+        "completed historic task instances"
+      ),
+      new TestScenario(
+        pageSize -> optimizeService.getHistoricIdentityLinkLogs(null, null, pageSize),
+        "historic identity link logs"
+      ),
+      new TestScenario(
+        pageSize -> optimizeService.getHistoricUserOperationLogs(null, null, pageSize),
+        "historic user operation logs"
+      ),
+      new TestScenario(
+        pageSize -> optimizeService.getHistoricVariableUpdates(null, null, true, pageSize),
+        "historic variable updates"
+      ),
+      new TestScenario(
+        pageSize -> optimizeService.getHistoricDecisionInstances(null, null, pageSize),
+        "historic decision instances"
+      )
     };
   }
 

--- a/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/optimize/OptimizeApiPageSizeTest.java
+++ b/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/optimize/OptimizeApiPageSizeTest.java
@@ -16,43 +16,40 @@
  */
 package org.operaton.bpm.qa.largedata.optimize;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.operaton.bpm.engine.impl.OptimizeService;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.qa.largedata.util.EngineDataGenerator;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.util.List;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(JUnitParamsRunner.class)
-public class OptimizeApiPageSizeTest {
+class OptimizeApiPageSizeTest {
 
   private static OptimizeService optimizeService;
   private static final int OPTIMIZE_PAGE_SIZE = 10_000;
 
-  @ClassRule
-  public static ProcessEngineRule processEngineRule = new ProcessEngineRule("operaton.cfg.xml");
+  @RegisterExtension
+  static ProcessEngineExtension processEngineExtension = ProcessEngineExtension.builder().configurationResource("operaton.cfg.xml").build();
 
-  @BeforeClass
-  public static void init() {
-    optimizeService = processEngineRule.getProcessEngineConfiguration().getOptimizeService();
+  @BeforeAll
+  static void init() {
+    optimizeService = processEngineExtension.getProcessEngineConfiguration().getOptimizeService();
 
     // given the generated engine data
     // make sure that there are at least two pages of each entity available
-    EngineDataGenerator generator = new EngineDataGenerator(processEngineRule.getProcessEngine(), OPTIMIZE_PAGE_SIZE * 2, OptimizeApiPageSizeTest.class.getSimpleName());
+    EngineDataGenerator generator = new EngineDataGenerator(processEngineExtension.getProcessEngine(), OPTIMIZE_PAGE_SIZE * 2, OptimizeApiPageSizeTest.class.getSimpleName());
     generator.generateData();
   }
 
-  @Test
-  @Parameters(method = "optimizeServiceFunctions")
-  public void databaseCanCopeWithPageSize(TestScenario scenario) {
+  @ParameterizedTest
+  @MethodSource("optimizeServiceFunctions")
+  void databaseCanCopeWithPageSize(TestScenario scenario) {
     // when
     final List<?> pageOfEntries = scenario.getOptimizeServiceFunction().apply(OPTIMIZE_PAGE_SIZE);
 
@@ -60,48 +57,48 @@ public class OptimizeApiPageSizeTest {
     assertThat(pageOfEntries).hasSize(OPTIMIZE_PAGE_SIZE);
   }
 
-  private Object[] optimizeServiceFunctions() {
+  private static Object[] optimizeServiceFunctions() {
     return new TestScenario[]{
-      new TestScenario(
-        (pageSize) -> optimizeService.getRunningHistoricActivityInstances(null, null, pageSize),
-        "running historic activity instances"
-      ),
-      new TestScenario(
-        (pageSize) -> optimizeService.getCompletedHistoricActivityInstances(null, null, pageSize),
-        "completed historic activity instances"
-      ),
-      new TestScenario(
-        (pageSize) -> optimizeService.getRunningHistoricProcessInstances(null, null, pageSize),
-        "running historic process instances"
-      ),
-      new TestScenario(
-        (pageSize) -> optimizeService.getCompletedHistoricProcessInstances(null, null, pageSize),
-        "completed historic process instances"
-      ),
-      new TestScenario(
-        (pageSize) -> optimizeService.getRunningHistoricTaskInstances(null, null, pageSize),
-        "running historic task instances"
-      ),
-      new TestScenario(
-        (pageSize) -> optimizeService.getCompletedHistoricTaskInstances(null, null, pageSize),
-        "completed historic task instances"
-      ),
-      new TestScenario(
-        (pageSize) -> optimizeService.getHistoricIdentityLinkLogs(null, null, pageSize),
-        "historic identity link logs"
-      ),
-      new TestScenario(
-        (pageSize) -> optimizeService.getHistoricUserOperationLogs(null, null, pageSize),
-        "historic user operation logs"
-      ),
-      new TestScenario(
-        (pageSize) -> optimizeService.getHistoricVariableUpdates(null, null, true, pageSize),
-        "historic variable updates"
-      ),
-      new TestScenario(
-        (pageSize) -> optimizeService.getHistoricDecisionInstances(null, null, pageSize),
-        "historic decision instances"
-      )
+        new TestScenario(
+            (pageSize) -> optimizeService.getRunningHistoricActivityInstances(null, null, pageSize),
+            "running historic activity instances"
+        ),
+        new TestScenario(
+            (pageSize) -> optimizeService.getCompletedHistoricActivityInstances(null, null, pageSize),
+            "completed historic activity instances"
+        ),
+        new TestScenario(
+            (pageSize) -> optimizeService.getRunningHistoricProcessInstances(null, null, pageSize),
+            "running historic process instances"
+        ),
+        new TestScenario(
+            (pageSize) -> optimizeService.getCompletedHistoricProcessInstances(null, null, pageSize),
+            "completed historic process instances"
+        ),
+        new TestScenario(
+            (pageSize) -> optimizeService.getRunningHistoricTaskInstances(null, null, pageSize),
+            "running historic task instances"
+        ),
+        new TestScenario(
+            (pageSize) -> optimizeService.getCompletedHistoricTaskInstances(null, null, pageSize),
+            "completed historic task instances"
+        ),
+        new TestScenario(
+            (pageSize) -> optimizeService.getHistoricIdentityLinkLogs(null, null, pageSize),
+            "historic identity link logs"
+        ),
+        new TestScenario(
+            (pageSize) -> optimizeService.getHistoricUserOperationLogs(null, null, pageSize),
+            "historic user operation logs"
+        ),
+        new TestScenario(
+            (pageSize) -> optimizeService.getHistoricVariableUpdates(null, null, true, pageSize),
+            "historic variable updates"
+        ),
+        new TestScenario(
+            (pageSize) -> optimizeService.getHistoricDecisionInstances(null, null, pageSize),
+            "historic decision instances"
+        )
     };
   }
 


### PR DESCRIPTION
This change refactors the code for module `qa/large-data-tests`.

It builds up on the refactoring of `BatchHelper` (https://github.com/operaton/operaton/pull/217).

related to #27 
fixes #225 