### PR TITLE
chore: Add Open Rewrite plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -529,6 +529,41 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>openrewrite</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.openrewrite.maven</groupId>
+            <artifactId>rewrite-maven-plugin</artifactId>
+            <version>5.45.0</version>
+            <configuration>
+              <activeRecipes>
+                org.openrewrite.java.RemoveUnusedImports
+              </activeRecipes>
+              <failOnDryRunResults>true</failOnDryRunResults>
+              <exclusions>
+                **/node/**
+              </exclusions>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.openrewrite.recipe</groupId>
+                <artifactId>rewrite-static-analysis</artifactId>
+                <version>1.20.0</version>
+              </dependency>
+              <dependency>
+                <groupId>org.openrewrite.recipe</groupId>
+                <artifactId>rewrite-testing-frameworks</artifactId>
+                <version>2.22.0</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
   </profiles>
 
   <repositories>


### PR DESCRIPTION
This change adds a profile `openrewrite` to the root POM and activates the "Remove unused imports" recipe.

The changes by the recipe are added via https://github.com/operaton/operaton/pull/221

See also this [forum thread](https://forum.operaton.org/t/open-rewrite-cleanups/72).

fixes #220