### PR TITLE
openapi(tasks): include task state in response specification

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/history/HistoricTaskInstanceDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/history/HistoricTaskInstanceDto.ftl
@@ -167,7 +167,13 @@
       type = "string"
       desc = "The process instance id of the root process instance that initiated the process
               containing this task."
-      last = true
+  />
+
+  <@lib.property
+    name = "taskState"
+    type = "string"
+    desc = "The task's state."
+    last = true
   />
 
 </@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/task/TaskDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/task/TaskDto.ftl
@@ -129,8 +129,13 @@
     <@lib.property
         name = "tenantId"
         type = "string"
-        last = true
         desc = "If not `null`, the tenant id of the task." />
+
+    <@lib.property
+        name = "taskState"
+        type = "string"
+        desc = "The task's state."
+        last = true />
 
 </@lib.dto>
 </#macro>


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/4683

Backported commit d27a7be1a70 from the camunda-bpm-platform repository.
Original author: Joaquín <joaquin.felici@camunda.com>