### PR TITLE
fix(bom): fix bom imports in camunda-only-bom  (#4628)

### DIFF
--- a/bom/operaton-only-bom/pom.xml
+++ b/bom/operaton-only-bom/pom.xml
@@ -213,35 +213,15 @@
         <groupId>org.operaton.spin</groupId>
         <artifactId>operaton-spin-bom</artifactId>
         <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.operaton.spin</groupId>
-        <artifactId>operaton-spin-dataformat-all</artifactId>
-        <version>${project.version}</version>
-        <!-- Excluding dependencies that are shaded in operaton-spin-dataformat-all -->
-        <exclusions>
-          <exclusion>
-            <groupId>org.operaton.spin</groupId>
-            <artifactId>operaton-spin-dataformat-json-jackson</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.operaton.spin</groupId>
-            <artifactId>operaton-spin-dataformat-xml-dom</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-          </exclusion>
-        </exclusions>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.operaton.commons</groupId>
         <artifactId>operaton-commons-bom</artifactId>
         <version>${project.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.operaton.template-engines</groupId>
@@ -252,6 +232,8 @@
         <groupId>org.operaton.connect</groupId>
         <artifactId>operaton-connect-bom</artifactId>
         <version>${project.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
 
       <!-- dmn engine dependencies

--- a/clients/java/client/pom.xml
+++ b/clients/java/client/pom.xml
@@ -53,13 +53,11 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-logging</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-typed-values</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -105,7 +103,6 @@
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-all</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/commons/bom/pom.xml
+++ b/commons/bom/pom.xml
@@ -3,9 +3,9 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-parent</artifactId>
-    <relativePath>../../parent</relativePath>
+    <artifactId>operaton-root</artifactId>
     <version>1.0.0-beta-2</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <groupId>org.operaton.commons</groupId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -2,12 +2,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.operaton.commons</groupId>
-    <artifactId>operaton-commons-bom</artifactId>
+    <groupId>org.operaton.bpm</groupId>
+    <artifactId>operaton-parent</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>bom</relativePath>
+    <relativePath>../parent</relativePath>
   </parent>
 
+  <groupId>org.operaton.commons</groupId>
   <artifactId>operaton-commons-root</artifactId>
   <name>Operaton - Commons - Root POM</name>
   <packaging>pom</packaging>

--- a/commons/typed-values/pom.xml
+++ b/commons/typed-values/pom.xml
@@ -35,7 +35,6 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-utils</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/connect/bom/pom.xml
+++ b/connect/bom/pom.xml
@@ -3,8 +3,8 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-parent</artifactId>
-    <relativePath>../../parent</relativePath>
+    <artifactId>operaton-root</artifactId>
+    <relativePath>../../pom.xml</relativePath>
     <version>1.0.0-beta-2</version>
   </parent>
 

--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -2,12 +2,13 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.operaton.connect</groupId>
-    <artifactId>operaton-connect-bom</artifactId>
+    <groupId>org.operaton.bpm</groupId>
+    <artifactId>operaton-parent</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>bom</relativePath>
+    <relativePath>../parent</relativePath>
   </parent>
 
+  <groupId>org.operaton.connect</groupId>
   <artifactId>operaton-connect-root</artifactId>
   <name>Operaton - Connect - Root</name>
   <packaging>pom</packaging>
@@ -31,14 +32,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>org.operaton.commons</groupId>
-        <artifactId>operaton-commons-bom</artifactId>
-        <version>${project.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-
       <dependency>
         <groupId>org.operaton.bpm</groupId>
         <artifactId>operaton-core-internal-dependencies</artifactId>

--- a/distro/run/core/pom.xml
+++ b/distro/run/core/pom.xml
@@ -42,7 +42,6 @@
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-all</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/distro/tomcat/assembly/pom.xml
+++ b/distro/tomcat/assembly/pom.xml
@@ -110,7 +110,6 @@
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -122,13 +121,11 @@
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-all</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.operaton.connect</groupId>
       <artifactId>operaton-connect-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -140,7 +137,6 @@
     <dependency>
       <groupId>org.operaton.connect</groupId>
       <artifactId>operaton-connect-connectors-all</artifactId>
-      <version>${project.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.operaton.connect</groupId>

--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -55,13 +55,11 @@
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-xml-dom-jakarta</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -72,13 +70,11 @@
     <dependency>
       <groupId>org.operaton.connect</groupId>
       <artifactId>operaton-connect-http-client</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.operaton.connect</groupId>
       <artifactId>operaton-connect-soap-http-client</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <!-- script engine dependencies -->

--- a/distro/wildfly26/modules/pom.xml
+++ b/distro/wildfly26/modules/pom.xml
@@ -55,13 +55,11 @@
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-xml-dom</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -72,13 +70,11 @@
     <dependency>
       <groupId>org.operaton.connect</groupId>
       <artifactId>operaton-connect-http-client</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.operaton.connect</groupId>
       <artifactId>operaton-connect-soap-http-client</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <!-- script engine dependencies -->

--- a/engine-dmn/engine/pom.xml
+++ b/engine-dmn/engine/pom.xml
@@ -20,13 +20,11 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-utils</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-typed-values</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/engine-dmn/feel-api/pom.xml
+++ b/engine-dmn/feel-api/pom.xml
@@ -17,7 +17,6 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-typed-values</artifactId>
-      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/engine-dmn/feel-juel/pom.xml
+++ b/engine-dmn/feel-juel/pom.xml
@@ -23,13 +23,11 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-logging</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-typed-values</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/engine-plugins/connect-plugin/pom.xml
+++ b/engine-plugins/connect-plugin/pom.xml
@@ -16,20 +16,17 @@
     <dependency>
       <groupId>org.operaton.connect</groupId>
       <artifactId>operaton-connect-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.operaton.connect</groupId>
       <artifactId>operaton-connect-http-client</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.operaton.connect</groupId>
       <artifactId>operaton-connect-soap-http-client</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/engine-plugins/identity-ldap/pom.xml
+++ b/engine-plugins/identity-ldap/pom.xml
@@ -22,7 +22,6 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-logging</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <!-- LDAP Libraries to start test server -->

--- a/engine-plugins/pom.xml
+++ b/engine-plugins/pom.xml
@@ -64,7 +64,6 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-testing</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/engine-plugins/spin-plugin/pom.xml
+++ b/engine-plugins/spin-plugin/pom.xml
@@ -16,7 +16,6 @@
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -36,14 +35,12 @@
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-xml-dom</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -128,7 +125,6 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-testing</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/engine-rest/engine-rest-jakarta/pom.xml
+++ b/engine-rest/engine-rest-jakarta/pom.xml
@@ -118,7 +118,6 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-logging</artifactId>
-      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -195,7 +194,6 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-testing</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -87,7 +87,6 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-logging</artifactId>
-      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -219,7 +218,6 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-testing</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -89,13 +89,11 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-logging</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-typed-values</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -246,7 +244,6 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-testing</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -774,7 +771,6 @@
         <dependency>
           <groupId>org.operaton.spin</groupId>
           <artifactId>operaton-spin-dataformat-all</artifactId>
-          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.operaton.bpm</groupId>
@@ -783,7 +779,6 @@
         <dependency>
           <groupId>org.operaton.connect</groupId>
           <artifactId>operaton-connect-connectors-all</artifactId>
-          <version>${project.version}</version>
           <exclusions>
             <exclusion>
               <groupId>org.operaton.connect</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.3.1</version>
+        </plugin>
+        <plugin>
           <groupId>com.github.eirslett</groupId>
           <artifactId>frontend-maven-plugin</artifactId>
           <version>1.15.1</version>

--- a/qa/integration-tests-engine-jakarta/pom.xml
+++ b/qa/integration-tests-engine-jakarta/pom.xml
@@ -215,13 +215,11 @@
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -252,7 +250,6 @@
     <dependency>
       <groupId>org.operaton.connect</groupId>
       <artifactId>operaton-connect-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <!-- explicit Spring dependencies for applications

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -163,13 +163,11 @@
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -200,7 +198,6 @@
     <dependency>
       <groupId>org.operaton.connect</groupId>
       <artifactId>operaton-connect-core</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <!-- explicit Spring dependencies for applications

--- a/qa/integration-tests-webapps/pom.xml
+++ b/qa/integration-tests-webapps/pom.xml
@@ -177,7 +177,6 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-logging</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/qa/test-db-instance-migration/test-fixture-722/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-722/pom.xml
@@ -39,7 +39,6 @@
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/qa/test-db-instance-migration/test-migration/pom.xml
+++ b/qa/test-db-instance-migration/test-migration/pom.xml
@@ -21,7 +21,6 @@
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.operaton.bpm</groupId>

--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -242,7 +242,6 @@
         <dependency>
           <groupId>org.operaton.commons</groupId>
           <artifactId>operaton-commons-testing</artifactId>
-          <version>${project.version}</version>
           <scope>test</scope>
         </dependency>
 

--- a/qa/tomcat9-runtime/pom.xml
+++ b/qa/tomcat9-runtime/pom.xml
@@ -134,7 +134,6 @@
         <dependency>
           <groupId>org.operaton.spin</groupId>
           <artifactId>operaton-spin-core</artifactId>
-          <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -145,13 +144,11 @@
         <dependency>
           <groupId>org.operaton.spin</groupId>
           <artifactId>operaton-spin-dataformat-all</artifactId>
-          <version>${project.version}</version>
         </dependency>
 
         <dependency>
           <groupId>org.operaton.connect</groupId>
           <artifactId>operaton-connect-core</artifactId>
-          <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -172,7 +169,6 @@
               <artifactId>operaton-connect-soap-http-client</artifactId>
             </exclusion>
           </exclusions>
-          <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/spin/bom/pom.xml
+++ b/spin/bom/pom.xml
@@ -3,8 +3,8 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-parent</artifactId>
-    <relativePath>../../parent</relativePath>
+    <artifactId>operaton-root</artifactId>
+    <relativePath>../../pom.xml</relativePath>
     <version>1.0.0-beta-2</version>
   </parent>
 
@@ -33,6 +33,25 @@
         <groupId>org.operaton.spin</groupId>
         <artifactId>operaton-spin-dataformat-all</artifactId>
         <version>${project.version}</version>
+        <!-- Excluding dependencies that are shaded in operaton-spin-dataformat-all -->
+        <exclusions>
+          <exclusion>
+            <groupId>org.operaton.spin</groupId>
+            <artifactId>operaton-spin-dataformat-json-jackson</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.operaton.spin</groupId>
+            <artifactId>operaton-spin-dataformat-xml-dom</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/spin/pom.xml
+++ b/spin/pom.xml
@@ -1,14 +1,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <!-- operaton BPM parent release pom -->
   <parent>
-    <groupId>org.operaton.spin</groupId>
-    <artifactId>operaton-spin-bom</artifactId>
+    <groupId>org.operaton.bpm</groupId>
+    <artifactId>operaton-parent</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>bom</relativePath>
+    <relativePath>../parent</relativePath>
   </parent>
 
+  <groupId>org.operaton.spin</groupId>
   <artifactId>operaton-spin-root</artifactId>
   <name>Operaton - Spin - Root</name>
   <packaging>pom</packaging>
@@ -130,6 +130,14 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration combine.children="append">
+            <doclint>none</doclint>
+            <detectJavaApiLink>false</detectJavaApiLink>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all/pom.xml
@@ -29,7 +29,6 @@
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-all</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-json-jackson/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-json-jackson/pom.xml
@@ -42,7 +42,6 @@
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/spring-boot-starter/starter/pom.xml
+++ b/spring-boot-starter/starter/pom.xml
@@ -55,7 +55,6 @@
     <dependency>
       <groupId>org.operaton.spin</groupId>
       <artifactId>operaton-spin-dataformat-json-jackson</artifactId>
-      <version>${project.version}</version>
       <optional>true</optional>
     </dependency>
 
@@ -121,7 +120,6 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-testing</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/webapps/assembly-jakarta/pom.xml
+++ b/webapps/assembly-jakarta/pom.xml
@@ -503,12 +503,10 @@
         <dependency>
           <groupId>org.operaton.spin</groupId>
           <artifactId>operaton-spin-dataformat-json-jackson</artifactId>
-          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.operaton.spin</groupId>
           <artifactId>operaton-spin-dataformat-xml-dom-jakarta</artifactId>
-          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.operaton.bpm</groupId>

--- a/webapps/assembly/pom.xml
+++ b/webapps/assembly/pom.xml
@@ -230,12 +230,10 @@
         <dependency>
           <groupId>org.operaton.spin</groupId>
           <artifactId>operaton-spin-dataformat-json-jackson</artifactId>
-          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.operaton.spin</groupId>
           <artifactId>operaton-spin-dataformat-xml-dom</artifactId>
-          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>org.operaton.bpm</groupId>

--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -68,7 +68,6 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-logging</artifactId>
-      <version>${project.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -82,7 +81,6 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-testing</artifactId>
-      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
* use type pom with scope import for camunda-spin-bom
* use type pom with scope import for camunda-commons-bom
* use type pom with scope import for camunda-connect-bom
* remove project.version from dependency declarations
* use camunda-root as parent for camunda-spin-bom, camunda-commons-bom, camunda-connect-bom

related to https://github.com/camunda/camunda-bpm-platform/issues/4605

Backported commit 7644178 from the camunda-bpm-platform repository.
Original author: cachescrubber <lars.uffmann@gmail.com>