### PR TITLE
Disable failsafe in external task client

### DIFF
--- a/clients/java/client/pom.xml
+++ b/clients/java/client/pom.xml
@@ -230,6 +230,10 @@
               <goal>integration-test</goal>
               <goal>verify</goal>
             </goals>
+            <configuration>
+              <!-- FIXME: Issue#251 -->
+              <skip>true</skip>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Tests disabled to avoid flaky builds.

relates to #251 