### PR TITLE
chore(tests): bump selenium to 4.26.0 and chromedriver to 131.0.6778.85

### DIFF
--- a/distro/run/qa/pom.xml
+++ b/distro/run/qa/pom.xml
@@ -20,7 +20,6 @@
     <version.jersey-json>1.15</version.jersey-json>
     <version.jersey-apache-client>1.15</version.jersey-apache-client>
     <version.httpcomponents>4.5.10</version.httpcomponents>
-    <version.chromedriver>112.0.5615.49</version.chromedriver>
   </properties>
 
   <dependencyManagement>
@@ -43,7 +42,7 @@
       <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-java</artifactId>
-        <version>4.10.0</version>
+        <version>${version.selenium}</version>
       </dependency>
 
       <dependency>

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -213,7 +213,7 @@
                   <goal>wget</goal>
                 </goals>
                 <configuration>
-                  <url>https://chromedriver.storage.googleapis.com/${version.chromedriver}/chromedriver_${os.type}.zip</url>
+                  <url>https://storage.googleapis.com/chrome-for-testing-public/${version.chromedriver}/${os.type}/chromedriver-${os.type}.zip</url>
                   <outputFileName>chromedriver.zip</outputFileName>
                   <unpack>true</unpack>
                   <outputDirectory>${project.build.directory}/chromedriver</outputDirectory>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -69,7 +69,8 @@
 
     <version.arquillian>1.1.10.Final</version.arquillian>
     <version.shrinkwrap.resolvers>2.2.2</version.shrinkwrap.resolvers>
-    <version.selenium>4.10.0</version.selenium>
+    <version.selenium>4.26.0</version.selenium>
+    <version.chromedriver>131.0.6778.85</version.chromedriver>
     <version.freemarker>2.3.31</version.freemarker>
 
     <version.jboss-javaee-spec>3.0.2.Final</version.jboss-javaee-spec>

--- a/qa/integration-tests-webapps/pom.xml
+++ b/qa/integration-tests-webapps/pom.xml
@@ -26,8 +26,6 @@
     <http.ctx-path.webapp>operaton/</http.ctx-path.webapp>
     <http.ctx-path.rest>engine-rest/</http.ctx-path.rest>
 
-    <version.chromedriver>112.0.5615.49</version.chromedriver>
-
     <!-- default os -->
     <os.type>linux64</os.type>
   </properties>
@@ -255,7 +253,7 @@
               <goal>wget</goal>
             </goals>
             <configuration>
-              <url>https://chromedriver.storage.googleapis.com/${version.chromedriver}/chromedriver_${os.type}.zip</url>
+              <url>https://storage.googleapis.com/chrome-for-testing-public/${version.chromedriver}/${os.type}/chromedriver-${os.type}.zip</url>
               <outputFileName>chromedriver.zip</outputFileName>
               <unpack>true</unpack>
               <outputDirectory>${project.build.directory}/chromedriver</outputDirectory>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
@@ -17,7 +17,6 @@
     <version.h2>1.4.199</version.h2>
     <version.jaxb-api>2.3.1</version.jaxb-api>
     <version.jersey-apache-client>1.15</version.jersey-apache-client>
-    <version.chromedriver>112.0.5615.49</version.chromedriver>
 
     <http.port>58080</http.port>
     <http.ctx-path.webapp>operaton/</http.ctx-path.webapp>


### PR DESCRIPTION
related to cibseven/cibseven#9

Backported commit f625b48 from the cibseven repository.
Original author: Serge Krot <serge.krot@cib.de>