### PR TITLE
Make distros downloadable as separate artifacts

### DIFF
--- a/.github/scripts/prepare-distros-archive.sh
+++ b/.github/scripts/prepare-distros-archive.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-TARGET_DIR=$1
-
-echo "📦 Collecting distros"
-mkdir -p $TARGET_DIR
-mv distro/sql-script/target/operaton-sql-scripts-*.tar.gz $TARGET_DIR
-mv distro/tomcat/distro/target/operaton-bpm-tomcat-*.tar.gz $TARGET_DIR

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,64 +37,121 @@ concurrency:
 jobs:
   build:
     name: Build
-    strategy:
-      fail-fast: true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
-      with:
-        # Prevent Shallow Clone to satisfy Sonarqube
-        fetch-depth: 0
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: maven
-    - name: Cache Maven packages
-      uses: actions/cache@v4
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-    - name: Cache SonarCloud packages
-      uses: actions/cache@v4
-      with:
-        path: ~/.sonar/cache
-        key: ${{ runner.os }}-sonar
-        restore-keys: ${{ runner.os }}-sonar
-    - name: Maven Build
-      shell: bash
-      run: |
-        echo "Creating a flag file 'executeJacoco' for each module containing tests. \
-        This triggers activation of the 'coverage' profile."
-        find . -type d | while read -r dir; do
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Maven Build
+        id: maven-build
+        shell: bash
+        run: |
+          echo "Creating a flag file 'executeJacoco' for each module containing tests. \
+          This triggers activation of the 'coverage' profile."
+          find . -type d | while read -r dir; do
           if [[ -d "$dir/src/test/java" || -d "$dir/target/generated-test-sources/java" ]]; then
             # Create an empty file target/executeJacoco if the condition is met
             mkdir -p "$dir/target"
             touch "$dir/target/executeJacoco"
           fi
-        done
-        ./mvnw verify
-        ./mvnw --non-recursive org.jacoco:jacoco-maven-plugin:report-aggregate
-    - name: Publish Test Report
-      if: always()
-      uses: mikepenz/action-junit-report@v4 #https://github.com/marketplace/actions/junit-report-action
-      with:
-        report_paths: ${{ github.workspace }}/**/target/surefire-reports/*.xml
-        require_passed_tests: true
-    - name: Upload Surefire Reports
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: surefire-reports
-        path: ${{ github.workspace }}/**/target/surefire-reports/**
-        retention-days: 30
-    - name: Sonarqube Analysis
-      if: env.SONAR_TOKEN && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request')
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      shell: bash
-      run: ./mvnw org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=operaton_operaton
-      continue-on-error: true
+          done
+          ./mvnw verify
+          ./mvnw --non-recursive org.jacoco:jacoco-maven-plugin:report-aggregate
+      - name: Publish Test Report
+        if: always()
+        #https://github.com/marketplace/actions/junit-report-action
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: ${{ github.workspace }}/**/target/surefire-reports/*.xml
+          require_passed_tests: true
+      - name: Upload Surefire Reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: ${{ github.workspace }}/**/target/surefire-reports/**
+          retention-days: 30
+      - name: Sonarqube Analysis
+        if: env.SONAR_TOKEN && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        shell: bash
+        run: ./mvnw org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=operaton_operaton
+        continue-on-error: true
+      - name: Cache build artifacts
+        uses: actions/cache/save@v4
+        if: ${{ matrix.java == 17 }}
+        with:
+          path: |
+            distro/**/target/operaton-*.gz
+            distro/webjar/target/operaton-webapp-webjar-*.jar
+          key: ${{ github.run_id }}-build-artifacts
+
+  publish:
+    name: Publish
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Restore build artifacts cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            distro/**/target/operaton-*.gz
+            distro/webjar/target/operaton-webapp-webjar-*.jar
+          key: ${{ github.run_id }}-build-artifacts
+          fail-on-cache-miss: true
+      - run: |
+          sudo apt-get update > /dev/null
+          sudo apt-get install -y xq > /dev/null
+          PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1)
+          TOMCAT_VERSION=$(xq --xpath project/properties/version.tomcat parent/pom.xml)
+          WILDFLY_VERSION=$(xq --xpath project/properties/version.wildfly parent/pom.xml)
+          echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
+          echo "TOMCAT_VERSION=$TOMCAT_VERSION" >> $GITHUB_ENV
+          echo "WILDFLY_VERSION=$WILDFLY_VERSION" >> $GITHUB_ENV
+      - name: Upload distro Tomcat
+        id: upload-distro-tomcat
+        uses: actions/upload-artifact@v4
+        with:
+          name: Operaton (Tomcat ${{ env.TOMCAT_VERSION }} Bundle)
+          path: distro/tomcat/distro/target/operaton-bpm-tomcat-${{ env.PROJECT_VERSION }}.tar.gz
+          if-no-files-found: error
+      - name: Upload distro Wildfly
+        id: upload-distro-wildfly
+        uses: actions/upload-artifact@v4
+        with:
+          name: Operaton (Wildfly ${{ env.WILDFLY_VERSION }} Bundle)
+          path: distro/wildfly/distro/target/operaton-bpm-wildfly-${{ env.PROJECT_VERSION }}.tar.gz
+          if-no-files-found: error
+      - name: Upload distro WebJar
+        id: upload-distro-webjar
+        uses: actions/upload-artifact@v4
+        with:
+          name: Operaton (WebJar Bundle)
+          path: distro/webjar/target/operaton-webapp-webjar-${{ env.PROJECT_VERSION }}.jar
+          if-no-files-found: error
+      - name: Upload distro sql-scripts
+        id: upload-distro-sql-scripts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Operaton SQL Scripts
+          path: distro/sql-script/target/operaton-sql-scripts-${{ env.PROJECT_VERSION }}.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,6 @@ jobs:
         continue-on-error: true
       - name: Cache build artifacts
         uses: actions/cache/save@v4
-        if: ${{ matrix.java == 17 }}
         with:
           path: |
             distro/**/target/operaton-*.gz
@@ -123,10 +122,8 @@ jobs:
           sudo apt-get install -y xq > /dev/null
           PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1)
           TOMCAT_VERSION=$(xq --xpath project/properties/version.tomcat parent/pom.xml)
-          WILDFLY_VERSION=$(xq --xpath project/properties/version.wildfly parent/pom.xml)
           echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
           echo "TOMCAT_VERSION=$TOMCAT_VERSION" >> $GITHUB_ENV
-          echo "WILDFLY_VERSION=$WILDFLY_VERSION" >> $GITHUB_ENV
       - name: Upload distro Tomcat
         id: upload-distro-tomcat
         uses: actions/upload-artifact@v4
@@ -134,20 +131,7 @@ jobs:
           name: Operaton (Tomcat ${{ env.TOMCAT_VERSION }} Bundle)
           path: distro/tomcat/distro/target/operaton-bpm-tomcat-${{ env.PROJECT_VERSION }}.tar.gz
           if-no-files-found: error
-      - name: Upload distro Wildfly
-        id: upload-distro-wildfly
-        uses: actions/upload-artifact@v4
-        with:
-          name: Operaton (Wildfly ${{ env.WILDFLY_VERSION }} Bundle)
-          path: distro/wildfly/distro/target/operaton-bpm-wildfly-${{ env.PROJECT_VERSION }}.tar.gz
-          if-no-files-found: error
-      - name: Upload distro WebJar
-        id: upload-distro-webjar
-        uses: actions/upload-artifact@v4
-        with:
-          name: Operaton (WebJar Bundle)
-          path: distro/webjar/target/operaton-webapp-webjar-${{ env.PROJECT_VERSION }}.jar
-          if-no-files-found: error
+          retention-days: 10
       - name: Upload distro sql-scripts
         id: upload-distro-sql-scripts
         uses: actions/upload-artifact@v4
@@ -155,3 +139,4 @@ jobs:
           name: Operaton SQL Scripts
           path: distro/sql-script/target/operaton-sql-scripts-${{ env.PROJECT_VERSION }}.tar.gz
           if-no-files-found: error
+          retention-days: 10

--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -121,6 +121,7 @@ jobs:
           name: Operaton (Tomcat ${{ env.TOMCAT_VERSION }} Bundle)
           path: distro/tomcat/distro/target/operaton-bpm-tomcat-${{ env.PROJECT_VERSION }}.tar.gz
           if-no-files-found: error
+          retention-days: 30
       - name: Upload distro Wildfly
         id: upload-distro-wildfly
         uses: actions/upload-artifact@v4
@@ -128,6 +129,7 @@ jobs:
           name: Operaton (Wildfly ${{ env.WILDFLY_VERSION }} Bundle)
           path: distro/wildfly/distro/target/operaton-bpm-wildfly-${{ env.PROJECT_VERSION }}.tar.gz
           if-no-files-found: error
+          retention-days: 30
       - name: Upload distro WebJar
         id: upload-distro-webjar
         uses: actions/upload-artifact@v4
@@ -135,6 +137,7 @@ jobs:
           name: Operaton (WebJar Bundle)
           path: distro/webjar/target/operaton-webapp-webjar-${{ env.PROJECT_VERSION }}.jar
           if-no-files-found: error
+          retention-days: 30
       - name: Upload distro sql-scripts
         id: upload-distro-sql-scripts
         uses: actions/upload-artifact@v4
@@ -142,3 +145,4 @@ jobs:
           name: Operaton SQL Scripts
           path: distro/sql-script/target/operaton-sql-scripts-${{ env.PROJECT_VERSION }}.tar.gz
           if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -11,24 +11,17 @@ concurrency:
 
 jobs:
   build:
-    name: Nightly Build and Report Generation
+    name: Build
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]     # If needed multi-OS add macos-13, windows-latest
-    runs-on: ${{ matrix.os }}
-
+        java: [17, 21]
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set Up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'maven'
       - name: Cache Maven packages
         uses: actions/cache@v4
         with:
@@ -36,45 +29,45 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Maven Build
+        id: maven-build
         shell: bash
         run: |
           echo "Creating a flag file 'executeJacoco' for each module containing tests. \
           This triggers activation of the 'coverage' profile."
           find . -type d | while read -r dir; do
           if [[ -d "$dir/src/test/java" || -d "$dir/target/generated-test-sources/java" ]]; then
-           # Create an empty file target/executeJacoco if the condition is met
-           mkdir -p "$dir/target"
-           touch "$dir/target/executeJacoco"
+            # Create an empty file target/executeJacoco if the condition is met
+            mkdir -p "$dir/target"
+            touch "$dir/target/executeJacoco"
           fi
           done
-          ./mvnw \
-            -Dmaven.repo.local=${{ github.workspace }}/.m2 \
-             clean install
-          .github/scripts/prepare-distros-archive.sh target/distros
-
-      - name: Archive Distros
-        uses: actions/upload-artifact@v4
+          ./mvnw -Pdistro,distro-tomcat,distro-wildfly,distro-webjar,distro-starter,distro-serverless,h2-in-memory verify
+          ./mvnw --non-recursive org.jacoco:jacoco-maven-plugin:report-aggregate
+      - name: Publish Test Report
+        if: always()
+        #https://github.com/marketplace/actions/junit-report-action
+        uses: mikepenz/action-junit-report@v4
         with:
-          name: distros
-          path: target/distros/**
-
+          report_paths: ${{ github.workspace }}/**/target/surefire-reports/*.xml
+          require_passed_tests: true
+      - name: Cache build artifacts
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            distro/**/target/operaton-*.gz
+            distro/webjar/target/operaton-webapp-webjar-*.jar
+          key: ${{ github.run_id }}-build-artifacts
 
   report:
     name: Generate Reports
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set Up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'maven'
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -82,9 +75,7 @@ jobs:
       - name: Generate Reports
         run: |
           PROJECT_ROOT=$(pwd)
-          ./mvnw \
-            -DskipTests \
-            verify \
+          ./mvnw verify\
             versions:dependency-updates-aggregate-report \
             versions:plugin-updates-aggregate-report \
             -Dsave=true -Ddisplay=false io.github.orhankupusoglu:sloc-maven-plugin:sloc \
@@ -96,3 +87,58 @@ jobs:
           name: reports
           path: |
             **/target/reports/**
+
+  publish:
+    name: Publish
+    needs: build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Restore build artifacts cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            distro/**/target/operaton-*.gz
+            distro/webjar/target/operaton-webapp-webjar-*.jar
+          key: ${{ github.run_id }}-build-artifacts
+          fail-on-cache-miss: true
+      - run: |
+          sudo apt-get update > /dev/null
+          sudo apt-get install -y xq > /dev/null
+          PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1)
+          TOMCAT_VERSION=$(xq --xpath project/properties/version.tomcat parent/pom.xml)
+          WILDFLY_VERSION=$(xq --xpath project/properties/version.wildfly parent/pom.xml)
+          echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
+          echo "TOMCAT_VERSION=$TOMCAT_VERSION" >> $GITHUB_ENV
+          echo "WILDFLY_VERSION=$WILDFLY_VERSION" >> $GITHUB_ENV
+      - name: Upload distro Tomcat
+        id: upload-distro-tomcat
+        uses: actions/upload-artifact@v4
+        with:
+          name: Operaton (Tomcat ${{ env.TOMCAT_VERSION }} Bundle)
+          path: distro/tomcat/distro/target/operaton-bpm-tomcat-${{ env.PROJECT_VERSION }}.tar.gz
+          if-no-files-found: error
+      - name: Upload distro Wildfly
+        id: upload-distro-wildfly
+        uses: actions/upload-artifact@v4
+        with:
+          name: Operaton (Wildfly ${{ env.WILDFLY_VERSION }} Bundle)
+          path: distro/wildfly/distro/target/operaton-bpm-wildfly-${{ env.PROJECT_VERSION }}.tar.gz
+          if-no-files-found: error
+      - name: Upload distro WebJar
+        id: upload-distro-webjar
+        uses: actions/upload-artifact@v4
+        with:
+          name: Operaton (WebJar Bundle)
+          path: distro/webjar/target/operaton-webapp-webjar-${{ env.PROJECT_VERSION }}.jar
+          if-no-files-found: error
+      - name: Upload distro sql-scripts
+        id: upload-distro-sql-scripts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Operaton SQL Scripts
+          path: distro/sql-script/target/operaton-sql-scripts-${{ env.PROJECT_VERSION }}.tar.gz
+          if-no-files-found: error

--- a/distro/wildfly/subsystem/pom.xml
+++ b/distro/wildfly/subsystem/pom.xml
@@ -107,7 +107,6 @@
             <include>**/*TestCase.java</include>
             <include>**/*Test.java</include>
           </includes>
-          <forkMode>once</forkMode>
         </configuration>
       </plugin>
     </plugins>

--- a/distro/wildfly26/subsystem/pom.xml
+++ b/distro/wildfly26/subsystem/pom.xml
@@ -105,9 +105,8 @@
             <include>**/*TestCase.java</include>
             <include>**/*Test.java</include>
           </includes>
-          <forkMode>once</forkMode>
         </configuration>
-      </plugin>     
+      </plugin>
     </plugins>
   </build>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -17,7 +17,6 @@
   </description>
 
   <properties>
-    <version.quarkus>3.15.0</version.quarkus>
     <version.spring.framework>5.3.39</version.spring.framework>
     <version.spring.framework6>6.1.15</version.spring.framework6>
     <version.spring-boot>3.3.6</version.spring-boot>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <version.joda-time>2.12.5</version.joda-time>
     <version.uuid-generator>4.3.0</version.uuid-generator>
     <version.feel-scala>1.18.1</version.feel-scala>
+    <version.quarkus>3.15.0</version.quarkus>
     <version.java>17</version.java>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
@@ -427,7 +428,7 @@
         <module>javaee/ejb-client-jakarta</module>
         <module>distro/license-book</module>
         <module>distro/wildfly</module>
-        <module>distro/wildfly26</module>
+        <!--module>distro/wildfly26</module>-->
       </modules>
     </profile>
 


### PR DESCRIPTION
This change makes the distributions "Operaton (Tomcat Bundle)" and "Operaton SQL Scripts" available as separately downloadable artifacts. Before, both distros were packaged into a single "distros" zip file.

fixes #280 