### PR TITLE
chore(build): Remove obsolete relativePath declarations

### DIFF
--- a/bom/operaton-bom/pom.xml
+++ b/bom/operaton-bom/pom.xml
@@ -6,7 +6,6 @@
     <groupId>org.operaton.bpm</groupId>
     <artifactId>operaton-bom-root</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <artifactId>operaton-bom</artifactId>

--- a/bom/operaton-only-bom/pom.xml
+++ b/bom/operaton-only-bom/pom.xml
@@ -6,7 +6,6 @@
     <groupId>org.operaton.bpm</groupId>
     <artifactId>operaton-bom-root</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <artifactId>operaton-only-bom</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -6,7 +6,6 @@
     <groupId>org.operaton.bpm</groupId>
     <artifactId>operaton-root</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <artifactId>operaton-bom-root</artifactId>

--- a/distro/run/assembly/pom.xml
+++ b/distro/run/assembly/pom.xml
@@ -6,7 +6,6 @@
     <groupId>org.operaton.bpm.run</groupId>
     <artifactId>operaton-bpm-run-root</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>operaton-bpm-run-assembly</artifactId>

--- a/distro/run/core/pom.xml
+++ b/distro/run/core/pom.xml
@@ -6,7 +6,6 @@
     <groupId>org.operaton.bpm.run</groupId>
     <artifactId>operaton-bpm-run-root</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>operaton-bpm-run-core</artifactId>

--- a/distro/run/distro/pom.xml
+++ b/distro/run/distro/pom.xml
@@ -6,7 +6,6 @@
     <groupId>org.operaton.bpm.run</groupId>
     <artifactId>operaton-bpm-run-root</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>operaton-bpm-run</artifactId>

--- a/distro/run/modules/oauth2/pom.xml
+++ b/distro/run/modules/oauth2/pom.xml
@@ -6,7 +6,6 @@
     <groupId>org.operaton.bpm.run</groupId>
     <artifactId>operaton-bpm-run-modules</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>operaton-bpm-run-modules-oauth2</artifactId>

--- a/distro/run/modules/pom.xml
+++ b/distro/run/modules/pom.xml
@@ -6,7 +6,6 @@
     <groupId>org.operaton.bpm.run</groupId>
     <artifactId>operaton-bpm-run-root</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>operaton-bpm-run-modules</artifactId>

--- a/distro/run/modules/rest/pom.xml
+++ b/distro/run/modules/rest/pom.xml
@@ -6,7 +6,6 @@
     <groupId>org.operaton.bpm.run</groupId>
     <artifactId>operaton-bpm-run-modules</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>operaton-bpm-run-modules-rest</artifactId>

--- a/distro/run/modules/webapps/pom.xml
+++ b/distro/run/modules/webapps/pom.xml
@@ -6,7 +6,6 @@
     <groupId>org.operaton.bpm.run</groupId>
     <artifactId>operaton-bpm-run-modules</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>operaton-bpm-run-modules-webapps</artifactId>

--- a/distro/run/qa/example-plugin/pom.xml
+++ b/distro/run/qa/example-plugin/pom.xml
@@ -5,7 +5,6 @@
     <groupId>org.operaton.bpm.run</groupId>
     <artifactId>operaton-bpm-run-qa</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>operaton-bpm-run-example-plugin</artifactId>

--- a/distro/run/qa/integration-tests/pom.xml
+++ b/distro/run/qa/integration-tests/pom.xml
@@ -6,7 +6,6 @@
     <groupId>org.operaton.bpm.run</groupId>
     <artifactId>operaton-bpm-run-qa</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>operaton-bpm-run-qa-integration-tests</artifactId>

--- a/distro/run/qa/pom.xml
+++ b/distro/run/qa/pom.xml
@@ -6,7 +6,6 @@
     <groupId>org.operaton.bpm.run</groupId>
     <artifactId>operaton-bpm-run-root</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>operaton-bpm-run-qa</artifactId>

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -6,7 +6,6 @@
     <groupId>org.operaton.bpm.run</groupId>
     <artifactId>operaton-bpm-run-qa</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>..</relativePath>
   </parent>
 
   <artifactId>operaton-bpm-run-qa-runtime</artifactId>

--- a/engine-rest/assembly/pom.xml
+++ b/engine-rest/assembly/pom.xml
@@ -7,7 +7,6 @@
   <parent>
     <groupId>org.operaton.bpm</groupId>
     <artifactId>operaton-engine-rest-root</artifactId>
-    <relativePath>../</relativePath>
     <version>1.0.0-beta-2</version>
   </parent>
   

--- a/engine-rest/engine-rest-jakarta/pom.xml
+++ b/engine-rest/engine-rest-jakarta/pom.xml
@@ -8,7 +8,6 @@
   <parent>
     <groupId>org.operaton.bpm</groupId>
     <artifactId>operaton-engine-rest-root</artifactId>
-    <relativePath>../</relativePath>
     <version>1.0.0-beta-2</version>
   </parent>
 

--- a/engine-rest/engine-rest-openapi-generator/pom.xml
+++ b/engine-rest/engine-rest-openapi-generator/pom.xml
@@ -7,7 +7,6 @@
   <parent>
     <groupId>org.operaton.bpm</groupId>
     <artifactId>operaton-engine-rest-root</artifactId>
-    <relativePath>../</relativePath>
     <version>1.0.0-beta-2</version>
   </parent>
 

--- a/engine-rest/engine-rest-openapi/pom.xml
+++ b/engine-rest/engine-rest-openapi/pom.xml
@@ -7,7 +7,6 @@
   <parent>
     <groupId>org.operaton.bpm</groupId>
     <artifactId>operaton-engine-rest-root</artifactId>
-    <relativePath>../</relativePath>
     <version>1.0.0-beta-2</version>
   </parent>
 

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -7,7 +7,6 @@
   <parent>
     <groupId>org.operaton.bpm</groupId>
     <artifactId>operaton-engine-rest-root</artifactId>
-    <relativePath>../</relativePath>
     <version>1.0.0-beta-2</version>
   </parent>
 

--- a/examples/invoice-jakarta/pom.xml
+++ b/examples/invoice-jakarta/pom.xml
@@ -8,7 +8,6 @@
   <parent>
     <groupId>org.operaton.bpm.example</groupId>
     <artifactId>operaton-example-root</artifactId>
-    <relativePath>../</relativePath>
     <version>1.0.0-beta-2</version>
   </parent>
 

--- a/examples/invoice/pom.xml
+++ b/examples/invoice/pom.xml
@@ -8,7 +8,6 @@
   <parent>
     <groupId>org.operaton.bpm.example</groupId>
     <artifactId>operaton-example-root</artifactId>
-    <relativePath>../</relativePath>
     <version>1.0.0-beta-2</version>
   </parent>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -5,7 +5,6 @@
     <groupId>org.operaton.bpm</groupId>
     <artifactId>operaton-root</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <artifactId>operaton-parent</artifactId>

--- a/qa/integration-tests-webapps/integration-tests/pom.xml
+++ b/qa/integration-tests-webapps/integration-tests/pom.xml
@@ -8,7 +8,6 @@
     <groupId>org.operaton.bpm.qa</groupId>
     <artifactId>operaton-qa-integration-tests-webapps-root</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>../</relativePath>
   </parent>
   
   <!-- 

--- a/qa/integration-tests-webapps/shared-engine/pom.xml
+++ b/qa/integration-tests-webapps/shared-engine/pom.xml
@@ -8,7 +8,6 @@
     <groupId>org.operaton.bpm.qa</groupId>
     <artifactId>operaton-qa-integration-tests-webapps-root</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <dependencies>

--- a/test-utils/assert/core/pom.xml
+++ b/test-utils/assert/core/pom.xml
@@ -8,7 +8,6 @@
   <parent>
     <groupId>org.operaton.bpm</groupId>
     <artifactId>operaton-bpm-assert-root</artifactId>
-    <relativePath>../</relativePath>
     <version>1.0.0-beta-2</version>
   </parent>
   

--- a/test-utils/assert/qa/pom.xml
+++ b/test-utils/assert/qa/pom.xml
@@ -8,7 +8,6 @@
   <parent>
     <groupId>org.operaton.bpm</groupId>
     <artifactId>operaton-bpm-assert-root</artifactId>
-    <relativePath>../</relativePath>
     <version>1.0.0-beta-2</version>
   </parent>
 

--- a/webapps/assembly-jakarta/pom.xml
+++ b/webapps/assembly-jakarta/pom.xml
@@ -7,7 +7,6 @@
     <groupId>org.operaton.bpm.webapp</groupId>
     <artifactId>operaton-webapp-root</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <artifactId>operaton-webapp-jakarta</artifactId>

--- a/webapps/assembly/pom.xml
+++ b/webapps/assembly/pom.xml
@@ -7,7 +7,6 @@
     <groupId>org.operaton.bpm.webapp</groupId>
     <artifactId>operaton-webapp-root</artifactId>
     <version>1.0.0-beta-2</version>
-    <relativePath>../</relativePath>
   </parent>
 
   <artifactId>operaton-webapp</artifactId>


### PR DESCRIPTION
The <relativePath> tag is not needed when the pom is located in the parent directory.

fixes #301