### PR TITLE
chore(version): Update database version

### DIFF
--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -15,7 +15,7 @@
 
   <properties>
     <commons-codec.version>1.15</commons-codec.version>
-    <connect.version.old>1.6.0</connect.version.old>
+    <connect.version.old>7.22.0</connect.version.old>
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
 
     <license.includeTransitiveDependencies>false</license.includeTransitiveDependencies>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -30,7 +30,7 @@
     <version.liquibase>4.8.0</version.liquibase>
 
     <!-- needed for sql script and backward compatibility checks -->
-    <operaton.version.old>7.21.0</operaton.version.old>
+    <operaton.version.old>7.22.0</operaton.version.old>
 
     <!-- Testcontainers JDBC URL parameters. By default, an empty string -->
     <database.tc.params />

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.db2.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.db2.create.engine.sql
@@ -66,7 +66,7 @@ create table ACT_GE_SCHEMA_LOG (
 );
 
 insert into ACT_GE_SCHEMA_LOG
-values ('0', CURRENT_TIMESTAMP, '7.22.0');
+values ('0', CURRENT_TIMESTAMP, '7.23.0');
 
 create table ACT_RE_DEPLOYMENT (
     ID_ varchar(64) not null,

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.h2.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.h2.create.engine.sql
@@ -66,7 +66,7 @@ create table ACT_GE_SCHEMA_LOG (
 );
 
 insert into ACT_GE_SCHEMA_LOG
-values ('0', CURRENT_TIMESTAMP, '7.22.0');
+values ('0', CURRENT_TIMESTAMP, '7.23.0');
 
 create table ACT_RE_DEPLOYMENT (
     ID_ varchar(64),

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.mariadb.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.mariadb.create.engine.sql
@@ -66,7 +66,7 @@ create table ACT_GE_SCHEMA_LOG (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_bin;
 
 insert into ACT_GE_SCHEMA_LOG
-values ('0', CURRENT_TIMESTAMP, '7.22.0');
+values ('0', CURRENT_TIMESTAMP, '7.23.0');
 
 create table ACT_RE_DEPLOYMENT (
     ID_ varchar(64),

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.mssql.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.mssql.create.engine.sql
@@ -66,7 +66,7 @@ create table ACT_GE_SCHEMA_LOG (
 );
 
 insert into ACT_GE_SCHEMA_LOG
-values ('0', CURRENT_TIMESTAMP, '7.22.0');
+values ('0', CURRENT_TIMESTAMP, '7.23.0');
 
 create table ACT_RE_DEPLOYMENT (
     ID_ nvarchar(64),

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.mysql.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.mysql.create.engine.sql
@@ -66,7 +66,7 @@ create table ACT_GE_SCHEMA_LOG (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_bin;
 
 insert into ACT_GE_SCHEMA_LOG
-values ('0', CURRENT_TIMESTAMP, '7.22.0');
+values ('0', CURRENT_TIMESTAMP, '7.23.0');
 
 create table ACT_RE_DEPLOYMENT (
     ID_ varchar(64),

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.oracle.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.oracle.create.engine.sql
@@ -66,7 +66,7 @@ create table ACT_GE_SCHEMA_LOG (
 );
 
 insert into ACT_GE_SCHEMA_LOG
-values ('0', CURRENT_TIMESTAMP, '7.22.0');
+values ('0', CURRENT_TIMESTAMP, '7.23.0');
 
 create table ACT_RE_DEPLOYMENT (
     ID_ NVARCHAR2(64),

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.postgres.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.postgres.create.engine.sql
@@ -66,7 +66,7 @@ create table ACT_GE_SCHEMA_LOG (
 );
 
 insert into ACT_GE_SCHEMA_LOG
-values ('0', CURRENT_TIMESTAMP, '7.22.0');
+values ('0', CURRENT_TIMESTAMP, '7.23.0');
 
 create table ACT_RE_DEPLOYMENT (
     ID_ varchar(64),

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/operaton-changelog.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/operaton-changelog.xml
@@ -140,8 +140,16 @@
              stripComments="true"/>
   </changeSet>
 
-  <changeSet author="Camunda" id="7.22.0-tag">
-    <tagDatabase tag="7.22.0"/>
+  <changeSet author="Camunda" id="7.22-to-7.23">
+    <sqlFile path="upgrade/${db.name}_engine_7.22_to_7.23.sql"
+             encoding="UTF-8"
+             relativeToChangelogFile="true"
+             splitStatements="true"
+             stripComments="true"/>
+  </changeSet>
+
+  <changeSet author="Camunda" id="7.23.0-tag">
+    <tagDatabase tag="7.23.0"/>
   </changeSet>
 
 </databaseChangeLog>

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/db2_engine_7.22_to_7.23.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/db2_engine_7.22_to_7.23.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. Camunda licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1200', CURRENT_TIMESTAMP, '7.23.0');

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/h2_engine_7.22_to_7.23.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/h2_engine_7.22_to_7.23.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. Camunda licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1200', CURRENT_TIMESTAMP, '7.23.0');

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/mariadb_engine_7.22_to_7.23.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/mariadb_engine_7.22_to_7.23.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. Camunda licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1200', CURRENT_TIMESTAMP, '7.23.0');

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/mssql_engine_7.22_to_7.23.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/mssql_engine_7.22_to_7.23.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. Camunda licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1200', CURRENT_TIMESTAMP, '7.23.0');

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/mysql_engine_7.22_to_7.23.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/mysql_engine_7.22_to_7.23.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. Camunda licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1200', CURRENT_TIMESTAMP, '7.23.0');

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/oracle_engine_7.22_to_7.23.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/oracle_engine_7.22_to_7.23.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. Camunda licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1200', CURRENT_TIMESTAMP, '7.23.0');

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/postgres_engine_7.22_to_7.23.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/postgres_engine_7.22_to_7.23.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. Camunda licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1200', CURRENT_TIMESTAMP, '7.23.0');

--- a/qa/test-db-instance-migration/pom.xml
+++ b/qa/test-db-instance-migration/pom.xml
@@ -42,6 +42,7 @@
     <module>test-fixture-720</module>
     <module>test-fixture-721</module>
     <module>test-fixture-722</module>
+    <module>test-fixture-723</module>
     <module>test-migration</module>
   </modules>
 

--- a/qa/test-db-instance-migration/test-fixture-723/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-723/pom.xml
@@ -4,28 +4,31 @@
   <parent>
     <groupId>org.operaton.bpm.qa.upgrade</groupId>
     <artifactId>operaton-qa-db-instance-migration</artifactId>
-    <version>1.0.0-beta-2</version>
+    <version>7.23.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>operaton-qa-upgrade-test-fixture-722</artifactId>
+  <artifactId>operaton-qa-upgrade-test-fixture-723</artifactId>
   <packaging>jar</packaging>
-  <name>operaton BPM - QA - upgrade - instance migration - test fixture - 7.22.0</name>
+  <name>operaton BPM - QA - upgrade - instance migration - test fixture - 7.23.0</name>
 
   <properties>
+    <!-- delete when 7.23 is released -->
+    <operaton.version.current>${project.version}</operaton.version.current>
     <operaton.version.previous>7.22.0</operaton.version.previous>
   </properties>
 
-   <dependencyManagement>
-     <dependencies>
-       <dependency>
-         <groupId>org.operaton.bpm</groupId>
-         <artifactId>operaton-bom</artifactId>
-         <version>7.22.0</version>
-         <scope>import</scope>
-         <type>pom</type>
-       </dependency>
-     </dependencies>
-   </dependencyManagement>
+  <!-- uncomment when 7.23 is released -->
+<!--   <dependencyManagement> -->
+<!--     <dependencies> -->
+<!--       <dependency> -->
+<!--         <groupId>org.operaton.bpm</groupId> -->
+<!--         <artifactId>operaton-bom</artifactId> -->
+<!--         <version>7.23.0</version> -->
+<!--         <scope>import</scope> -->
+<!--         <type>pom</type> -->
+<!--       </dependency> -->
+<!--     </dependencies> -->
+<!--   </dependencyManagement> -->
 
   <dependencies>
     <dependency>
@@ -103,7 +106,9 @@
                     <artifactItem>
                       <groupId>org.operaton.bpm.distro</groupId>
                       <artifactId>operaton-sql-scripts</artifactId>
-                      <version>7.22.0</version>
+                      <!-- Replace after 7.23.0 release -->
+                      <version>${operaton.version.current}</version>
+                      <!--<version>7.23.0</version>-->
                       <type>test-jar</type>
                       <outputDirectory>${project.build.directory}/scripts-current</outputDirectory>
                       <overWrite>true</overWrite>
@@ -113,7 +118,8 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
+          <!-- uncomment when 7.23 is released -->
+          <!--<plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
             <configuration>
@@ -134,11 +140,10 @@
                 </configuration>
               </execution>
             </executions>
-          </plugin>
+          </plugin>-->
         </plugins>
       </build>
     </profile>
   </profiles>
 
-  <description>${project.name}</description>
 </project>

--- a/qa/test-db-instance-migration/test-fixture-723/src/main/java/org/operaton/bpm/qa/upgrade/TestFixture.java
+++ b/qa/test-db-instance-migration/test-fixture-723/src/main/java/org/operaton/bpm/qa/upgrade/TestFixture.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.qa.upgrade;
+
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.ProcessEngineConfiguration;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+
+public class TestFixture {
+
+  public static final String ENGINE_VERSION = "7.23.0";
+
+  public TestFixture(ProcessEngine processEngine) {
+  }
+
+  public static void main(String... args) {
+    ProcessEngineConfigurationImpl processEngineConfiguration = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration
+      .createProcessEngineConfigurationFromResource("operaton.cfg.xml");
+    ProcessEngine processEngine = processEngineConfiguration.buildProcessEngine();
+
+    // register test scenarios
+    ScenarioRunner runner = new ScenarioRunner(processEngine, ENGINE_VERSION);
+
+    // example scenario setup
+    // runner.setupScenarios(ExampleScenario.class);
+
+    processEngine.close();
+  }
+}

--- a/qa/test-db-instance-migration/test-fixture-723/src/main/resources/operaton.cfg.xml
+++ b/qa/test-db-instance-migration/test-fixture-723/src/main/resources/operaton.cfg.xml
@@ -17,18 +17,18 @@
     <!-- job executor configurations -->
     <property name="jobExecutorActivate" value="false" />
 
-    <!-- enabled authorization -->
-    <property name="authorizationEnabled" value="true" />
-
     <!-- mail server configurations -->
     <property name="mailServerPort" value="${mail.server.port}" />
     <property name="history" value="full" />
 
-    <!-- disable metrics -->
-    <property name="metricsEnabled" value="false" />
+    <!-- turn off metrics reporter -->
     <property name="dbMetricsReporterActivate" value="false" />
+    <property name="taskMetricsEnabled" value="false" />
 
-    <property name="jdbcBatchProcessing" value="false"/>
+    <property name="defaultSerializationFormat" value="application/json"/>
+
+    <property name="jdbcBatchProcessing" value="${jdbcBatchProcessing}"/>
+
   </bean>
 
 </beans>

--- a/qa/test-db-rolling-update/create-new-engine/pom.xml
+++ b/qa/test-db-rolling-update/create-new-engine/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <operaton.version.current>${project.version}</operaton.version.current>
-    <operaton.version.previous>7.21.0</operaton.version.previous>
+    <operaton.version.previous>7.22.0</operaton.version.previous>
   </properties>
 
   <dependencies>

--- a/qa/test-db-rolling-update/create-old-engine/pom.xml
+++ b/qa/test-db-rolling-update/create-old-engine/pom.xml
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>org.operaton.bpm</groupId>
         <artifactId>operaton-bom</artifactId>
-        <version>7.21.0</version>
+        <version>7.22.0</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/qa/test-db-rolling-update/create-old-engine/src/main/resources/operaton.auth.cfg.xml
+++ b/qa/test-db-rolling-update/create-old-engine/src/main/resources/operaton.auth.cfg.xml
@@ -33,8 +33,6 @@
     <property name="generalResourceWhitelistPattern" value=".+"/>
 
     <property name="enforceHistoryTimeToLive" value="false" />
-
-
   </bean>
 
 </beans>

--- a/qa/test-db-rolling-update/rolling-update-util/pom.xml
+++ b/qa/test-db-rolling-update/rolling-update-util/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
         <groupId>org.operaton.bpm</groupId>
         <artifactId>operaton-bom</artifactId>
-        <version>7.21.0</version>
+        <version>7.22.0</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/qa/test-db-rolling-update/test-old-engine/pom.xml
+++ b/qa/test-db-rolling-update/test-old-engine/pom.xml
@@ -17,7 +17,7 @@
       <dependency>
         <groupId>org.operaton.bpm</groupId>
         <artifactId>operaton-bom</artifactId>
-        <version>7.21.0</version>
+        <version>7.22.0</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -12,7 +12,7 @@
   <name>Operaton - QA - test new schema with old engine</name>
 
   <properties>
-    <operaton.old.engine.version>7.21.0</operaton.old.engine.version>
+    <operaton.old.engine.version>7.22.0</operaton.old.engine.version>
     <surefire.memArgs>-Xmx2g -XX:MetaspaceSize=128m</surefire.memArgs>
   </properties>
 
@@ -91,20 +91,6 @@
       </build>
     </profile>
 
-     <profile>
-      <id>oracle-23</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <skipTests>true</skipTests>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>   
-
     <profile>
       <id>old-engine</id>
 
@@ -114,7 +100,7 @@
             <groupId>org.operaton.bpm</groupId>
             <artifactId>operaton-bom</artifactId>
             <!-- Cannot use variables due to bug in Maven Release Plugin -->
-            <version>7.21.0</version>
+            <version>7.22.0</version>
             <scope>import</scope>
             <type>pom</type>
           </dependency>
@@ -427,6 +413,9 @@
                 <!-- The test is not relevant in `old-engine` setup since the feature has been removed -->
                 <!-- See https://github.com/camunda/camunda-bpm-platform/pull/4544#discussion_r1728748399 -->
                 <exclude>**/ConcurrentTelemetryConfigurationTest.java</exclude>
+
+                <!-- The test is not relevant in `old-engine` setup and lacks necessary resource files -->
+                <exclude>**DatabaseNamingConsistencyTest.java</exclude>
               </excludes>
               <testFailureIgnore>false</testFailureIgnore>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>

--- a/spin/pom.xml
+++ b/spin/pom.xml
@@ -26,7 +26,7 @@
     <json-junit-fluent.version>1.1.6</json-junit-fluent.version>
     <powermock.version>2.0.9</powermock.version>
     <mockito.version>3.3.3</mockito.version>
-    <spin.version.old>1.23.0</spin.version.old>
+    <spin.version.old>7.22.0</spin.version.old>
 
     <license.includeTransitiveDependencies>false</license.includeTransitiveDependencies>
     <additionalparam>-Xdoclint:none</additionalparam>


### PR DESCRIPTION
* Add instance migration project

* Adjust create scripts

* Create upgrade scripts

* Add the new changeSets to liquibase

* add migration fixture for 7.23

* update old engine test

* remove telemetry fields from old engine cfg

* chore(database): remove telemetryReporterActivate from old-engine and rolling-update tests

* adjust old version for spin and connect

* exclude DatabaseNamingConsistencyTest in test-old-engine

* chore(database): activate oracle23 in old-engine stage in CI (#4677)

related to #203
related to camunda/camunda-bpm-platform#4556

Backported commit 396d635ce7 from the camunda-bpm-platform repository.
Original author: psavidis <69160690+psavidis@users.noreply.github.com>