### PR TITLE
Changed parent poms from operaton-database-settings to root/parent pom's

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -10,8 +10,8 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-database-settings</artifactId>
-    <relativePath>../../database</relativePath>
+    <artifactId>operaton-parent</artifactId>
+    <relativePath>../../parent</relativePath>
     <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
 

--- a/commons/typed-values/pom.xml
+++ b/commons/typed-values/pom.xml
@@ -8,8 +8,8 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-database-settings</artifactId>
-    <relativePath>../../database</relativePath>
+    <artifactId>operaton-parent</artifactId>
+    <relativePath>../../parent</relativePath>
     <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
 

--- a/distro/jboss/pom.xml
+++ b/distro/jboss/pom.xml
@@ -3,8 +3,8 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-database-settings</artifactId>
-    <relativePath>../../database</relativePath>
+    <artifactId>operaton-parent</artifactId>
+    <relativePath>../../parent</relativePath>
     <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
   

--- a/distro/license-book/pom.xml
+++ b/distro/license-book/pom.xml
@@ -3,8 +3,8 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-database-settings</artifactId>
-    <relativePath>../../database</relativePath>
+    <artifactId>operaton-parent</artifactId>
+    <relativePath>../../parent</relativePath>
     <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
 

--- a/engine-cdi/core/pom.xml
+++ b/engine-cdi/core/pom.xml
@@ -8,8 +8,7 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-database-settings</artifactId>
-    <relativePath>../../database</relativePath>
+    <artifactId>operaton-cdi-compatibility-root</artifactId>
     <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
 

--- a/engine-cdi/jakarta/pom.xml
+++ b/engine-cdi/jakarta/pom.xml
@@ -8,9 +8,8 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-database-settings</artifactId>
-    <relativePath>../../database</relativePath>
-    <version>1.0.0-beta-3-SNAPSHOT</version>
+    <artifactId>operaton-cdi-compatibility-root</artifactId>
+    <version>1.0.0-beta-2</version>
   </parent>
 
   <properties>

--- a/engine-cdi/jakarta/pom.xml
+++ b/engine-cdi/jakarta/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.operaton.bpm</groupId>
     <artifactId>operaton-cdi-compatibility-root</artifactId>
-    <version>1.0.0-beta-2</version>
+    <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/engine-dmn/pom.xml
+++ b/engine-dmn/pom.xml
@@ -3,8 +3,8 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-database-settings</artifactId>
-    <relativePath>../database</relativePath>
+    <artifactId>operaton-parent</artifactId>
+    <relativePath>../parent</relativePath>
     <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
 

--- a/engine-spring/core-6/pom.xml
+++ b/engine-spring/core-6/pom.xml
@@ -6,8 +6,7 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-database-settings</artifactId>
-    <relativePath>../../database</relativePath>
+    <artifactId>operaton-spring-compatibility-root</artifactId>
     <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
 

--- a/engine-spring/core/pom.xml
+++ b/engine-spring/core/pom.xml
@@ -6,8 +6,7 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-database-settings</artifactId>
-    <relativePath>../../database</relativePath>
+    <artifactId>operaton-spring-compatibility-root</artifactId>
     <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
 

--- a/javaee/ejb-service/pom.xml
+++ b/javaee/ejb-service/pom.xml
@@ -9,9 +9,9 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-database-settings</artifactId>
-    <relativePath>../../database</relativePath>
-    <version>1.0.0-beta-3-SNAPSHOT</version>
+    <artifactId>operaton-parent</artifactId>
+    <relativePath>../../parent</relativePath>
+    <version>1.0.0-beta-2</version>
   </parent>
 
   <dependencyManagement>

--- a/javaee/ejb-service/pom.xml
+++ b/javaee/ejb-service/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.operaton.bpm</groupId>
     <artifactId>operaton-parent</artifactId>
     <relativePath>../../parent</relativePath>
-    <version>1.0.0-beta-2</version>
+    <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
 
   <dependencyManagement>

--- a/juel/pom.xml
+++ b/juel/pom.xml
@@ -4,8 +4,8 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-database-settings</artifactId>
-    <relativePath>../database</relativePath>
+    <artifactId>operaton-parent</artifactId>
+    <relativePath>../parent</relativePath>
     <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
 

--- a/model-api/pom.xml
+++ b/model-api/pom.xml
@@ -10,8 +10,8 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-database-settings</artifactId>
-    <relativePath>../database</relativePath>
+    <artifactId>operaton-parent</artifactId>
+    <relativePath>../parent</relativePath>
     <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
 

--- a/quarkus-extension/pom.xml
+++ b/quarkus-extension/pom.xml
@@ -4,8 +4,8 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-database-settings</artifactId>
-    <relativePath>../database</relativePath>
+    <artifactId>operaton-parent</artifactId>
+    <relativePath>../parent</relativePath>
     <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
 

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -3,8 +3,8 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-database-settings</artifactId>
-    <relativePath>../database</relativePath>
+    <artifactId>operaton-parent</artifactId>
+    <relativePath>../parent</relativePath>
     <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
 

--- a/test-utils/archunit/pom.xml
+++ b/test-utils/archunit/pom.xml
@@ -7,8 +7,8 @@
 
     <parent>
         <groupId>org.operaton.bpm</groupId>
-        <artifactId>operaton-database-settings</artifactId>
-        <relativePath>../../database</relativePath>
+        <artifactId>operaton-parent</artifactId>
+        <relativePath>../../parent</relativePath>
         <version>1.0.0-beta-3-SNAPSHOT</version>
     </parent>
 

--- a/test-utils/assert/core/pom.xml
+++ b/test-utils/assert/core/pom.xml
@@ -52,7 +52,6 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>${version.h2}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test-utils/assert/qa/pom.xml
+++ b/test-utils/assert/qa/pom.xml
@@ -54,7 +54,6 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>${version.h2}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/test-utils/junit5-extension-dmn/pom.xml
+++ b/test-utils/junit5-extension-dmn/pom.xml
@@ -8,9 +8,9 @@
 
   <parent>
     <groupId>org.operaton.bpm</groupId>
-    <artifactId>operaton-database-settings</artifactId>
+    <artifactId>operaton-parent</artifactId>
     <version>1.0.0-beta-3-SNAPSHOT</version>
-    <relativePath>../../database</relativePath>
+    <relativePath>../../parent</relativePath>
   </parent>
 
   <dependencyManagement>


### PR DESCRIPTION
fix(engine): Change parent poms from operaton-database-settings to root/parent pom's

- replace operaton-database-settings with root/parent pom's where database dependencies and settings are not required

fixes #294