### PR TITLE
chore: Code cleanup, resolve Sonar issues

### DIFF
--- a/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/AbstractTypedValueMapper.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/AbstractTypedValueMapper.java
@@ -23,7 +23,7 @@ public abstract class AbstractTypedValueMapper<T extends TypedValue> implements 
 
   protected ValueType valueType;
 
-  public AbstractTypedValueMapper(ValueType type) {
+  protected AbstractTypedValueMapper(ValueType type) {
     valueType = type;
   }
 

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/VariableValue.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/VariableValue.java
@@ -51,18 +51,14 @@ public class VariableValue<T extends TypedValue> {
   }
 
   public T getTypedValue(boolean deserializeValue) {
-    if (cachedValue != null && cachedValue instanceof SerializableValue) {
-      SerializableValue serializableValue = (SerializableValue) cachedValue;
-      if(deserializeValue && !serializableValue.isDeserialized()) {
-        cachedValue = null;
-      }
+    if (deserializeValue && cachedValue instanceof SerializableValue serializableValue && !serializableValue.isDeserialized()) {
+      cachedValue = null;
     }
 
     if (cachedValue == null) {
       cachedValue = getSerializer().readValue(typedValueField, deserializeValue);
 
-      if (cachedValue instanceof DeferredFileValueImpl) {
-        DeferredFileValueImpl fileValue = (DeferredFileValueImpl) cachedValue;
+      if (cachedValue instanceof DeferredFileValueImpl fileValue) {
         fileValue.setExecutionId(executionId);
         fileValue.setVariableName(variableName);
       }

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/mapper/ByteArrayValueMapper.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/mapper/ByteArrayValueMapper.java
@@ -70,11 +70,13 @@ public class ByteArrayValueMapper extends PrimitiveValueMapper<BytesValue> {
     }
   }
 
+  @Override
   protected boolean canWriteValue(TypedValue typedValue) {
     Object value = typedValue.getValue();
     return super.canWriteValue(typedValue) || value instanceof InputStream;
   }
 
+  @Override
   protected boolean canReadValue(TypedValueField typedValueField) {
     Object value = typedValueField.getValue();
     return value == null || value instanceof String;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.java
@@ -226,11 +226,11 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
 
 
     // given the same priority, DESC date is applied
-    assertThat(result.get(0).getCreateTime()).isAfterOrEqualsTo(result.get(1).getCreateTime());
+    assertThat(result.get(0).getCreateTime()).isAfterOrEqualTo(result.get(1).getCreateTime());
 
     // given the rest of priorities, DESC date should apply between them
-    assertThat(result.get(2).getCreateTime()).isAfterOrEqualsTo(result.get(3).getCreateTime());
-    assertThat(result.get(3).getCreateTime()).isAfterOrEqualsTo(result.get(4).getCreateTime());
+    assertThat(result.get(2).getCreateTime()).isAfterOrEqualTo(result.get(3).getCreateTime());
+    assertThat(result.get(3).getCreateTime()).isAfterOrEqualTo(result.get(4).getCreateTime());
   }
 
   @Deployment(resources = {
@@ -270,11 +270,11 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
 
 
     // given the same priority, ASC date is applied
-    assertThat(result.get(0).getCreateTime()).isBeforeOrEqualsTo(result.get(1).getCreateTime());
+    assertThat(result.get(0).getCreateTime()).isBeforeOrEqualTo(result.get(1).getCreateTime());
 
     // given the rest of priorities, ASC date should apply between them
-    assertThat(result.get(2).getCreateTime()).isBeforeOrEqualsTo(result.get(3).getCreateTime());
-    assertThat(result.get(3).getCreateTime()).isBeforeOrEqualsTo(result.get(4).getCreateTime());
+    assertThat(result.get(2).getCreateTime()).isBeforeOrEqualTo(result.get(3).getCreateTime());
+    assertThat(result.get(3).getCreateTime()).isBeforeOrEqualTo(result.get(4).getCreateTime());
   }
 
   @Deployment(resources = {
@@ -2624,7 +2624,7 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
     externalTaskService.handleFailure(task.getId(), WORKER_ID, ERROR_MESSAGE, 0, 3000L);
     externalTaskService.setRetries(task.getId(), 5);
     ClockUtil.setCurrentTime(nowPlus(3000L));
-    tasks = externalTaskService.fetchAndLock(5, WORKER_ID)
+    externalTaskService.fetchAndLock(5, WORKER_ID)
         .topic(TOPIC_NAME, LOCK_TIME)
         .execute();
     ClockUtil.setCurrentTime(nowPlus(4000L));
@@ -2969,12 +2969,12 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
     LockedExternalTask task = tasks.get(0);
     externalTaskService.handleFailure(task.getId(), WORKER_ID, ERROR_MESSAGE, 2, 3000L);
     ClockUtil.setCurrentTime(nowPlus(3000L));
-    tasks = externalTaskService.fetchAndLock(5, WORKER_ID)
+    externalTaskService.fetchAndLock(5, WORKER_ID)
         .topic(TOPIC_NAME, LOCK_TIME)
         .execute();
     ClockUtil.setCurrentTime(nowPlus(5000L));
     externalTaskService.handleFailure(task.getId(), WORKER_ID, ERROR_MESSAGE, 1, 3000L);
-    tasks = externalTaskService.fetchAndLock(5, WORKER_ID)
+    externalTaskService.fetchAndLock(5, WORKER_ID)
         .topic(TOPIC_NAME, LOCK_TIME)
         .execute();
 
@@ -3103,7 +3103,7 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
     externalTasks = externalTaskService.fetchAndLock(1, "anotherWorkerId", true)
       .topic(TOPIC_NAME, LOCK_TIME)
       .execute();
-    assertEquals(externalTasks.get(0).getPriority(), 9);
+    assertThat(externalTasks.get(0).getPriority()).isEqualTo(9);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
@@ -3126,8 +3126,8 @@ public class ExternalTaskServiceTest extends PluggableProcessEngineTest {
     externalTasks = externalTaskService.fetchAndLock(1, WORKER_ID, true)
       .topic(TOPIC_NAME, LOCK_TIME)
       .execute();
-    assertEquals(1, externalTasks.size());
-    assertEquals(externalTasks.get(0).getPriority(), 9);
+    assertThat(externalTasks).hasSize(1);
+    assertThat(externalTasks.get(0).getPriority()).isEqualTo(9);
   }
 
   @Deployment

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/timer/StartTimerEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/timer/StartTimerEventTest.java
@@ -16,35 +16,16 @@
  */
 package org.operaton.bpm.engine.test.bpmn.event.timer;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
+import org.joda.time.LocalDateTime;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.operaton.bpm.engine.impl.cmd.DeleteJobsCmd;
 import org.operaton.bpm.engine.impl.interceptor.CommandExecutor;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.engine.impl.util.IoUtil;
-import org.operaton.bpm.engine.runtime.ExecutionQuery;
-import org.operaton.bpm.engine.runtime.Job;
-import org.operaton.bpm.engine.runtime.JobQuery;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.runtime.ProcessInstanceQuery;
-import org.operaton.bpm.engine.runtime.ProcessInstantiationBuilder;
+import org.operaton.bpm.engine.runtime.*;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.task.TaskQuery;
 import org.operaton.bpm.engine.test.Deployment;
@@ -54,11 +35,15 @@ import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.bpmn.builder.ProcessBuilder;
-import org.joda.time.LocalDateTime;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
 
 /**
  * @author Joram Barrez
@@ -320,7 +305,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
 
     // we deploy new process version, with some small change
     InputStream in = getClass().getResourceAsStream("StartTimerEventTest.testVersionUpgradeShouldCancelJobs.bpmn20.xml");
-    String process = new String(IoUtil.readInputStream(in, "")).replaceAll("beforeChange", "changed");
+    String process = new String(IoUtil.readInputStream(in, "")).replace("beforeChange", "changed");
     IoUtil.closeSilently(in);
     in = new ByteArrayInputStream(process.getBytes());
     String id = repositoryService.createDeployment().addInputStream("StartTimerEventTest.testVersionUpgradeShouldCancelJobs.bpmn20.xml", in).deploy().getId();
@@ -381,7 +366,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     assertEquals(1, jobQuery.count());
 
     // we deploy new process version, with some small change
-    String processChanged = process.replaceAll("beforeChange", "changed");
+    String processChanged = process.replace("beforeChange", "changed");
     in = new ByteArrayInputStream(processChanged.getBytes());
     String secondDeploymentId = repositoryService.createDeployment().addInputStream("StartTimerEventTest.testVersionUpgradeShouldCancelJobs.bpmn20.xml", in)
         .deploy().getId();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/util/GetBpmnModelElementTypeRule.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/util/GetBpmnModelElementTypeRule.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.model.bpmn.util;
 
 import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.xml.Model;
@@ -38,7 +37,7 @@ public class GetBpmnModelElementTypeRule implements GetModelElementTypeRule, Bef
   @Override
   public void beforeAll(ExtensionContext context) {
     String className = context.getTestClass().orElseThrow().getName();
-    className =  className.replaceAll("Test", "");
+    className =  className.replace("Test", "");
     Class<? extends ModelElementInstance> instanceClass = null;
     try {
       instanceClass = (Class<? extends ModelElementInstance>) Class.forName(className);

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/util/GetCmmnModelElementTypeRule.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/util/GetCmmnModelElementTypeRule.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.model.cmmn.util;
 
 import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.operaton.bpm.model.cmmn.Cmmn;
 import org.operaton.bpm.model.xml.Model;
@@ -39,7 +38,7 @@ public class GetCmmnModelElementTypeRule implements GetModelElementTypeRule, Bef
   @Override
   public void beforeAll(ExtensionContext context) {
     String className = context.getTestClass().orElseThrow().getName();
-    className =  className.replaceAll("Test", "");
+    className =  className.replace("Test", "");
     Class<? extends ModelElementInstance> instanceClass = null;
     try {
       instanceClass = (Class<? extends ModelElementInstance>) Class.forName(className);

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/instance/ModelElementInstanceTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/instance/ModelElementInstanceTest.java
@@ -35,7 +35,7 @@ import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAME
  * @author Daniel Meyer
  * @author Sebastian Menski
  */
-public class ModelElementInstanceTest extends TestModelTest {
+class ModelElementInstanceTest extends TestModelTest {
 
   private Animals animals;
   private Bird tweety;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/beans/ExampleSignallableActivityBehaviorBean.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/beans/ExampleSignallableActivityBehaviorBean.java
@@ -16,11 +16,11 @@
  */
 package org.operaton.bpm.integrationtest.functional.cdi.beans;
 
-import javax.inject.Named;
-
 import org.operaton.bpm.engine.impl.bpmn.behavior.AbstractBpmnActivityBehavior;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.operaton.bpm.engine.impl.pvm.delegate.SignallableActivityBehavior;
+
+import javax.inject.Named;
 
 /**
  * @author Daniel Meyer
@@ -29,10 +29,11 @@ import org.operaton.bpm.engine.impl.pvm.delegate.SignallableActivityBehavior;
 @Named
 public class ExampleSignallableActivityBehaviorBean extends AbstractBpmnActivityBehavior implements SignallableActivityBehavior {
 
+  @Override
   public void execute(ActivityExecution execution) throws Exception {
-
   }
 
+  @Override
   public void signal(ActivityExecution execution, String signalEvent, Object signalData) throws Exception {
     leave(execution);
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/JavaDelegateResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/JavaDelegateResolutionTest.java
@@ -16,9 +16,6 @@
  */
 package org.operaton.bpm.integrationtest.functional.classloading.war;
 
-import org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleDelegate;
-import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
-import org.operaton.bpm.integrationtest.util.TestContainer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -27,6 +24,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleDelegate;
+import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+import org.operaton.bpm.integrationtest.util.TestContainer;
 
 
 /**
@@ -78,7 +78,7 @@ public class JavaDelegateResolutionTest extends AbstractFoxPlatformIntegrationTe
 
   @Test
   @OperateOnDeployment("clientDeployment")
-  public void testResolveClassFromJobExecutor() throws InterruptedException {
+  public void testResolveClassFromJobExecutor() {
 
     runtimeService.startProcessInstanceByKey("testResolveClassFromJobExecutor");
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/request/JobExecutorRequestContextLocalInvocationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/request/JobExecutorRequestContextLocalInvocationTest.java
@@ -16,18 +16,6 @@
  */
 package org.operaton.bpm.integrationtest.functional.ejb.request;
 
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.task.Task;
-import org.operaton.bpm.integrationtest.functional.cdi.beans.RequestScopedDelegateBean;
-import org.operaton.bpm.integrationtest.functional.ejb.request.beans.InvocationCounter;
-import org.operaton.bpm.integrationtest.functional.ejb.request.beans.InvocationCounterDelegateBean;
-import org.operaton.bpm.integrationtest.functional.ejb.request.beans.InvocationCounterDelegateBeanLocal;
-import org.operaton.bpm.integrationtest.functional.ejb.request.beans.InvocationCounterService;
-import org.operaton.bpm.integrationtest.functional.ejb.request.beans.InvocationCounterServiceBean;
-import org.operaton.bpm.integrationtest.functional.ejb.request.beans.InvocationCounterServiceLocal;
-import org.operaton.bpm.integrationtest.functional.ejb.request.beans.RequestScopedSFSBDelegate;
-import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
-import org.operaton.bpm.integrationtest.util.TestContainer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -36,6 +24,12 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.task.Task;
+import org.operaton.bpm.integrationtest.functional.cdi.beans.RequestScopedDelegateBean;
+import org.operaton.bpm.integrationtest.functional.ejb.request.beans.*;
+import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+import org.operaton.bpm.integrationtest.util.TestContainer;
 
 
 /**
@@ -81,7 +75,7 @@ public class JobExecutorRequestContextLocalInvocationTest extends AbstractFoxPla
 
   @Test
   @OperateOnDeployment("pa")
-  public void testRequestContextPropagationEjbLocal() throws Exception{
+  public void testRequestContextPropagationEjbLocal() {
 
     // This fails with  WELD-001303 No active contexts for scope type javax.enterprise.context.RequestScoped as well
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/event/beans/ExecutionListenerProcessApplication.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/event/beans/ExecutionListenerProcessApplication.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.integrationtest.functional.event.beans;
 
 import org.operaton.bpm.application.ProcessApplication;
-import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.ExecutionListener;
 
 /**
@@ -30,20 +29,19 @@ public class ExecutionListenerProcessApplication extends org.operaton.bpm.applic
 
   public static final String LISTENER_INVOCATION_COUNT = "listenerInvocationCount";
 
+  @Override
   public ExecutionListener getExecutionListener() {
-    return new ExecutionListener() {
-      public void notify(DelegateExecution execution) throws Exception {
+    return execution -> {
 
-        int listenerInvocationCount = 0;
+      int listenerInvocationCount = 0;
 
-        if(execution.hasVariable(LISTENER_INVOCATION_COUNT)) {
-          listenerInvocationCount = (Integer) execution.getVariable(LISTENER_INVOCATION_COUNT);
-        }
-
-        listenerInvocationCount += 1;
-
-        execution.setVariable(LISTENER_INVOCATION_COUNT, listenerInvocationCount);
+      if(execution.hasVariable(LISTENER_INVOCATION_COUNT)) {
+        listenerInvocationCount = (Integer) execution.getVariable(LISTENER_INVOCATION_COUNT);
       }
+
+      listenerInvocationCount += 1;
+
+      execution.setVariable(LISTENER_INVOCATION_COUNT, listenerInvocationCount);
     };
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/message/IntermediateMessageCatchEventTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/message/IntermediateMessageCatchEventTest.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.integrationtest.functional.message;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import org.operaton.bpm.engine.runtime.Execution;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -38,7 +37,7 @@ public class IntermediateMessageCatchEventTest extends AbstractFoxPlatformIntegr
 
   @Test
   public void test() {
-    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testProcess");
+    runtimeService.startProcessInstanceByKey("testProcess");
 
     long eventSubscriptionCount = runtimeService.createEventSubscriptionQuery().count();
     assertEquals(1, eventSubscriptionCount);
@@ -47,7 +46,6 @@ public class IntermediateMessageCatchEventTest extends AbstractFoxPlatformIntegr
 
     assertNotNull(execution);
 
-    //runtimeService.messageEventReceived("Test Message", execution.getId());
     runtimeService.createMessageCorrelation("Test Message").correlate();
 
     eventSubscriptionCount = runtimeService.createEventSubscriptionQuery().count();

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/AsyncIntermediateThrowSignalEventTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/AsyncIntermediateThrowSignalEventTest.java
@@ -38,7 +38,7 @@ public class AsyncIntermediateThrowSignalEventTest extends AbstractFoxPlatformIn
   }
 
   @Test
-  public void testAsyncSignalEvent() throws InterruptedException {
+  public void testAsyncSignalEvent() {
     ProcessInstance piCatchSignal = runtimeService.startProcessInstanceByKey("catchSignal");
 
     ProcessInstance piThrowSignal = runtimeService.startProcessInstanceByKey("throwSignal");

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/FailingJobBoundaryTimerWithDelegateVariablesTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/FailingJobBoundaryTimerWithDelegateVariablesTest.java
@@ -51,7 +51,7 @@ public class FailingJobBoundaryTimerWithDelegateVariablesTest extends AbstractFo
   }
 
   @Test
-  public void testFailingJobBoundaryTimerWithDelegateVariables() throws InterruptedException {
+  public void testFailingJobBoundaryTimerWithDelegateVariables() {
     ProcessInstance pi = runtimeService.startProcessInstanceByKey("ImmediatelyFailing");
 
     List<Job> jobs = managementService.createJobQuery().processInstanceId(pi.getProcessInstanceId()).list();

--- a/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/util/EngineDataGenerator.java
+++ b/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/util/EngineDataGenerator.java
@@ -17,12 +17,7 @@
 package org.operaton.bpm.qa.largedata.util;
 
 import com.google.common.collect.Lists;
-import org.operaton.bpm.engine.DecisionService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ProcessEngine;
-import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.identity.Group;
 import org.operaton.bpm.engine.identity.User;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -35,16 +30,11 @@ import org.operaton.bpm.model.dmn.DmnModelInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.operaton.bpm.qa.largedata.util.DmnHelper.createSimpleDmnModel;
-
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static org.operaton.bpm.qa.largedata.util.DmnHelper.createSimpleDmnModel;
 
 public class EngineDataGenerator {
 
@@ -216,8 +206,7 @@ public class EngineDataGenerator {
   }
 
   protected List<Integer> createSequenceNumberList() {
-    return IntStream.range(0, numberOfInstancesToGenerate)
-      .boxed().collect(Collectors.toList());
+    return IntStream.range(0, numberOfInstancesToGenerate).boxed().toList();
   }
 
 

--- a/spring-boot-starter/starter-qa/integration-test-webapp/invoice-example/src/main/java/org/operaton/bpm/qa/Application.java
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/invoice-example/src/main/java/org/operaton/bpm/qa/Application.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.qa;
 
+import jakarta.annotation.PostConstruct;
 import org.apache.catalina.webresources.TomcatURLStreamHandlerFactory;
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.example.invoice.InvoiceProcessApplication;
@@ -26,14 +27,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.event.EventListener;
 
-import jakarta.annotation.PostConstruct;
-
 @SpringBootApplication
 @EnableProcessApplication("myProcessApplication")
 public class Application {
 
-  @Autowired
-  protected ProcessEngine processEngine;
+  protected final ProcessEngine processEngine;
 
   protected InvoiceProcessApplication invoicePa = new InvoiceProcessApplication();
 
@@ -42,6 +40,11 @@ public class Application {
     TomcatURLStreamHandlerFactory.disable();
 
     SpringApplication.run(Application.class, args);
+  }
+
+  @Autowired
+  public Application (ProcessEngine processEngine) {
+    this.processEngine = processEngine;
   }
 
   @PostConstruct

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/OAuth2IdentityProvider.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/OAuth2IdentityProvider.java
@@ -16,13 +16,7 @@
  */
 package org.operaton.bpm.spring.boot.starter.security.oauth2.impl;
 
-import org.operaton.bpm.engine.identity.Group;
-import org.operaton.bpm.engine.identity.GroupQuery;
-import org.operaton.bpm.engine.identity.NativeUserQuery;
-import org.operaton.bpm.engine.identity.Tenant;
-import org.operaton.bpm.engine.identity.TenantQuery;
-import org.operaton.bpm.engine.identity.User;
-import org.operaton.bpm.engine.identity.UserQuery;
+import org.operaton.bpm.engine.identity.*;
 import org.operaton.bpm.engine.impl.GroupQueryImpl;
 import org.operaton.bpm.engine.impl.Page;
 import org.operaton.bpm.engine.impl.TenantQueryImpl;
@@ -72,7 +66,7 @@ public class OAuth2IdentityProvider extends DbIdentityServiceProvider {
    */
   protected static boolean nullOrContainsIgnoreCase(String searchLike, String value) {
     return searchLike == null || value == null || value.toLowerCase()
-        .contains(searchLike.replaceAll("%", "").toLowerCase());
+        .contains(searchLike.replace("%", "").toLowerCase());
   }
 
   /**
@@ -95,8 +89,7 @@ public class OAuth2IdentityProvider extends DbIdentityServiceProvider {
     String userId = authentication.getName();
     UserEntity user = new UserEntity();
     user.setId(userId);
-    if (principal instanceof OidcUser) {
-      var oidcUser = (OidcUser) principal;
+    if (principal instanceof OidcUser oidcUser) {
       user.setFirstName(oidcUser.getGivenName());
       user.setLastName(oidcUser.getFamilyName());
       user.setEmail(oidcUser.getEmail());
@@ -197,7 +190,7 @@ public class OAuth2IdentityProvider extends DbIdentityServiceProvider {
             var user = transformUser();
             return this.userId == null || user == null || this.userId.equals(user.getId());
           })
-          .collect(Collectors.toList());
+          .toList();
     }
   }
 

--- a/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/bpmn/AbstractAssertions.java
+++ b/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/bpmn/AbstractAssertions.java
@@ -16,14 +16,17 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import java.util.Map;
-
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.ProcessEngines;
+
+import java.util.Map;
 
 public abstract class AbstractAssertions {
 
   static ThreadLocal<ProcessEngine> processEngine = new ThreadLocal<>();
+
+  protected AbstractAssertions () {
+  }
 
   /**
    * Retrieve the processEngine bound to the current testing thread
@@ -46,10 +49,8 @@ public abstract class AbstractAssertions {
       init(processEngine);
       return processEngine;
     }
-    String message = processEngines.size() == 0 ? "No ProcessEngine found to be " +
-      "registered with " + ProcessEngines.class.getSimpleName() + "!"
-      : String.format(processEngines.size() + " ProcessEngines initialized. Call %s.init" +
-      "(ProcessEngine processEngine) first!", BpmnAwareTests.class.getSimpleName());
+    String message = processEngines.isEmpty() ? String.format("No ProcessEngine found to be registered with %s!", ProcessEngines.class.getSimpleName())
+      : String.format("%d ProcessEngines initialized. Call %s.init(ProcessEngine processEngine) first!", processEngines.size(), BpmnAwareTests.class.getSimpleName());
     throw new IllegalStateException(message);
   }
 

--- a/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/bpmn/BpmnAwareTests.java
+++ b/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/bpmn/BpmnAwareTests.java
@@ -17,42 +17,26 @@
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
 
-import static java.lang.String.format;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.assertj.core.api.Assertions;
-import org.operaton.bpm.engine.AuthorizationService;
-import org.operaton.bpm.engine.DecisionService;
-import org.operaton.bpm.engine.ExternalTaskService;
-import org.operaton.bpm.engine.FormService;
-import org.operaton.bpm.engine.HistoryService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ManagementService;
-import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.exception.NotFoundException;
 import org.operaton.bpm.engine.externaltask.ExternalTask;
 import org.operaton.bpm.engine.externaltask.ExternalTaskQuery;
 import org.operaton.bpm.engine.externaltask.LockedExternalTask;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.repository.ProcessDefinitionQuery;
-import org.operaton.bpm.engine.runtime.ExecutionQuery;
-import org.operaton.bpm.engine.runtime.Job;
-import org.operaton.bpm.engine.runtime.JobQuery;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.runtime.ProcessInstanceQuery;
+import org.operaton.bpm.engine.runtime.*;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.task.TaskQuery;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.bpmn.instance.Activity;
 import org.operaton.bpm.model.bpmn.instance.Event;
 import org.operaton.bpm.model.bpmn.instance.Gateway;
+
+import java.util.*;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
 
 /**
  * Convenience class to access only operaton *BPMN* related Assertions
@@ -406,10 +390,7 @@ public class BpmnAwareTests extends AbstractAssertions {
   public static Task task(TaskQuery taskQuery) {
     ProcessInstanceAssert lastAssert = AbstractProcessAssert.getLastAssert(ProcessInstanceAssert.class);
     if (lastAssert == null)
-      throw new IllegalStateException(
-        "Call a process instance assertion first - " +
-          "e.g. assertThat(processInstance)... !"
-      );
+      throw new IllegalStateException("Call a process instance assertion first - e.g. assertThat(processInstance)... !");
     return task(taskQuery, lastAssert.getActual());
   }
 
@@ -952,7 +933,7 @@ public class BpmnAwareTests extends AbstractAssertions {
     if (externalTask == null || variables == null) {
       throw new IllegalArgumentException(format("Illegal call of completeExternalTask(externalTask = '%s', variables = '%s') - both must not be null!", externalTask, variables));
     }
-    complete(externalTask, variables, Collections.EMPTY_MAP);
+    complete(externalTask, variables, emptyMap());
   }
 
   /**
@@ -1039,7 +1020,7 @@ public class BpmnAwareTests extends AbstractAssertions {
     if (lockedExternalTask == null || variables == null) {
       throw new IllegalArgumentException(format("Illegal call of completeExternalTask(lockedExternalTask = '%s', variables = '%s') - both must not be null!", lockedExternalTask, variables));
     }
-    complete(lockedExternalTask, variables, Collections.EMPTY_MAP);
+    complete(lockedExternalTask, variables, emptyMap());
   }
 
   /**

--- a/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/cmmn/AbstractCaseAssert.java
+++ b/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/cmmn/AbstractCaseAssert.java
@@ -16,9 +16,6 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import java.util.Arrays;
-import java.util.Map;
-
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.MapAssert;
 import org.operaton.bpm.engine.ProcessEngine;
@@ -33,6 +30,9 @@ import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.assertions.bpmn.AbstractProcessAssert;
 import org.operaton.bpm.engine.test.assertions.bpmn.TaskAssert;
 import org.operaton.bpm.model.cmmn.impl.CmmnModelConstants;
+
+import java.util.Arrays;
+import java.util.Map;
 
 public abstract class AbstractCaseAssert<S extends AbstractCaseAssert<S, A>, A extends CaseExecution> extends AbstractProcessAssert<S, A> {
 
@@ -594,7 +594,7 @@ public abstract class AbstractCaseAssert<S extends AbstractCaseAssert<S, A>, A e
   protected String toString(A caseExecution) {
     if (caseExecution != null) {
       return !actual.getCaseInstanceId().equals(actual.getId()) ? String.format(
-          "%s {id='%s', activityId='%s' }",
+          "%s {id='%s', activityId='%s', caseInstanceId='%s'}",
           caseExecution.getActivityType(),
           caseExecution.getId(),
           caseExecution.getActivityId(),
@@ -640,7 +640,7 @@ public abstract class AbstractCaseAssert<S extends AbstractCaseAssert<S, A>, A e
     boolean shouldHaveSpecificVariables = names != null && names.length > 0;
 
     Map<String, Object> vars = vars();
-    StringBuffer message = new StringBuffer();
+    StringBuilder message = new StringBuilder();
     message.append("Expecting %s to hold ");
     message.append(shouldHaveVariables ? "case variables" + (shouldHaveSpecificVariables ? " %s, "
         : ", ")


### PR DESCRIPTION
- rename variables that hide fields
- remove obsolete public modifier
- refactor lamdas in assertThatThrownBy() to have only one invocation throwing a runtime exception
- replace isAfterOrEqualsTo by isAfterOrEqualTo
- replace isBeforeOrEqualsTo by isBeforeOrEqualTo
- add missing `@Override` annotations
- Remove unnecessary public modifiers from tests
- Use replace() instead of replaceAll() where no regexp replacement is needed
- refactor string concatenation
- remove obsolete throws declaration