### PR TITLE
chore(testing): Remove `public` modifier from JUnit 5 test classes and test methods

### DIFF
--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/BusinessProcessContextTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/BusinessProcessContextTest.java
@@ -32,7 +32,7 @@ import jakarta.inject.Named;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class BusinessProcessContextTest {
+class BusinessProcessContextTest {
 
   @RegisterExtension
   protected static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
@@ -40,7 +40,7 @@ public class BusinessProcessContextTest {
       .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
   @Test
-  public void shouldThrowUnsupportedOperationExceptionOnInjectableContextDestroy() {
+  void shouldThrowUnsupportedOperationExceptionOnInjectableContextDestroy() {
     InjectableContext businessProcessContext = Arc.container()
         .getActiveContext(BusinessProcessScoped.class);
 
@@ -50,7 +50,7 @@ public class BusinessProcessContextTest {
   }
 
   @Test
-  public void shouldThrowUnsupportedOperationExceptionOnInjectableContextGetState() {
+  void shouldThrowUnsupportedOperationExceptionOnInjectableContextGetState() {
     InjectableContext businessProcessContext = Arc.container()
         .getActiveContext(BusinessProcessScoped.class);
 
@@ -60,7 +60,7 @@ public class BusinessProcessContextTest {
   }
 
   @Test
-  public void shouldThrowUnsupportedOperationExceptionOnInjectableContextDestroyContextual() {
+  void shouldThrowUnsupportedOperationExceptionOnInjectableContextDestroyContextual() {
     Bean<?> bean = Arc.container()
         .beanManager()
         .getBeans(BusinessProcessScopedBean.class)
@@ -77,7 +77,7 @@ public class BusinessProcessContextTest {
   }
 
   @Test
-  public void shouldThrowUnsupportedOperationExceptionOnDestroyInjectableInstance() {
+  void shouldThrowUnsupportedOperationExceptionOnDestroyInjectableInstance() {
     InjectableInstance<BusinessProcessScopedBean> instance = Arc.container()
         .select(BusinessProcessScopedBean.class);
     BusinessProcessScopedBean businessProcessScopedBean = instance.get();

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/ConfigurableProcessEngineTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/ConfigurableProcessEngineTest.java
@@ -57,7 +57,7 @@ public class ConfigurableProcessEngineTest {
   public ProcessEngine processEngine;
 
   @Test
-  public void shouldProvideCustomEmbeddedProcessEngine() {
+  void shouldProvideCustomEmbeddedProcessEngine() {
     // given a custom process engine configuration
 
     // then

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/EmbeddedProcessEngineTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/EmbeddedProcessEngineTest.java
@@ -38,7 +38,7 @@ public class EmbeddedProcessEngineTest {
   public ProcessEngine processEngine;
 
   @Test
-  public void shouldProvideDefaultEmbeddedProcessEngine() {
+  void shouldProvideDefaultEmbeddedProcessEngine() {
     // given no process engine configuration
 
     // then

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/ManagedJobExecutorTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/ManagedJobExecutorTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ManagedJobExecutorTest {
+class ManagedJobExecutorTest {
 
   @RegisterExtension
   static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
@@ -79,13 +79,13 @@ public class ManagedJobExecutorTest {
   }
 
   @Test
-  public void shouldActivateJobExecutorByDefault() {
+  void shouldActivateJobExecutorByDefault() {
     // then
     assertThat(processEngineConfiguration.isJobExecutorActivate()).isTrue();
   }
 
   @Test
-  public void shouldCreateManagedExecutor() {
+  void shouldCreateManagedExecutor() {
     // given a process engine configuration
 
     // then
@@ -96,7 +96,7 @@ public class ManagedJobExecutorTest {
   }
 
   @Test
-  public void shouldUseCustomJobAcquisitionProperties() {
+  void shouldUseCustomJobAcquisitionProperties() {
     // given a custom application.properties file
     JobExecutor jobExecutor = processEngineConfiguration.getJobExecutor();
 
@@ -112,7 +112,7 @@ public class ManagedJobExecutorTest {
   }
 
   @Test
-  public void shouldNotReuseManagedExecutor() {
+  void shouldNotReuseManagedExecutor() {
     // given a process engine configuration
     ProcessEngineConfigurationImpl configuration =
         (ProcessEngineConfigurationImpl) processEngine.getProcessEngineConfiguration();
@@ -126,7 +126,7 @@ public class ManagedJobExecutorTest {
 
   @Test
   @Deployment
-  public void shouldExecuteJob() {
+  void shouldExecuteJob() {
     // given
     processEngineConfiguration.getJobExecutor().shutdown();
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("asyncTaskProcess");

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineConfigFileTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineConfigFileTest.java
@@ -32,7 +32,7 @@ import java.sql.SQLException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OperatonEngineConfigFileTest {
+class OperatonEngineConfigFileTest {
 
   @RegisterExtension
   static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
@@ -46,7 +46,7 @@ public class OperatonEngineConfigFileTest {
   ProcessEngine processEngine;
 
   @Test
-  public void shouldLoadAllConfigProperties() throws SQLException {
+  void shouldLoadAllConfigProperties() throws SQLException {
     // given
     // a .properties file with process engine and job executor configuration
 

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineConfigurationConfigTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineConfigurationConfigTest.java
@@ -29,7 +29,7 @@ import org.operaton.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OperatonEngineConfigurationConfigTest {
+class OperatonEngineConfigurationConfigTest {
 
   @RegisterExtension
   static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
@@ -44,7 +44,7 @@ public class OperatonEngineConfigurationConfigTest {
   ProcessEngine processEngine;
 
   @Test
-  public void shouldLoadProcessEngineConfigurationProperties() {
+  void shouldLoadProcessEngineConfigurationProperties() {
     // given a custom application.properties file
 
     // then
@@ -54,7 +54,7 @@ public class OperatonEngineConfigurationConfigTest {
   }
 
   @Test
-  public void shouldApplyProcessEngineConfigurationProperties() {
+  void shouldApplyProcessEngineConfigurationProperties() {
     // given
     // a ProcessEngineConfiguration instance
     QuarkusProcessEngineConfiguration configuration

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineDefaultConfigTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineDefaultConfigTest.java
@@ -54,7 +54,7 @@ public class OperatonEngineDefaultConfigTest {
   }
 
   @Test
-  public void shouldApplyDefaults() {
+  void shouldApplyDefaults() {
     // given
     // a ProcessEngineConfiguration instance
     QuarkusProcessEngineConfiguration configuration

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineJobExecutorConfigTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineJobExecutorConfigTest.java
@@ -27,7 +27,7 @@ import org.operaton.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OperatonEngineJobExecutorConfigTest {
+class OperatonEngineJobExecutorConfigTest {
 
   @RegisterExtension
   static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
@@ -39,7 +39,7 @@ public class OperatonEngineJobExecutorConfigTest {
   OperatonEngineConfig config;
 
   @Test
-  public void shouldLoadJobExecutorThreadPoolProperties() {
+  void shouldLoadJobExecutorThreadPoolProperties() {
     // given a custom application.properties file
 
     // then
@@ -48,7 +48,7 @@ public class OperatonEngineJobExecutorConfigTest {
   }
 
   @Test
-  public void shouldLoadJobAcquisitionProperties() {
+  void shouldLoadJobAcquisitionProperties() {
     // given a custom application.properties file
 
     // then

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineProgrammaticAndConfigFileTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineProgrammaticAndConfigFileTest.java
@@ -35,7 +35,7 @@ import java.sql.SQLException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class OperatonEngineProgrammaticAndConfigFileTest {
+class OperatonEngineProgrammaticAndConfigFileTest {
 
   @RegisterExtension
   static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
@@ -64,7 +64,7 @@ public class OperatonEngineProgrammaticAndConfigFileTest {
   }
 
   @Test
-  public void shouldUseProvidedConfigurationAndConfigProperties() throws SQLException {
+  void shouldUseProvidedConfigurationAndConfigProperties() throws SQLException {
     // given
     // a .properties file with process engine and job executor configuration
 

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/deployment/ProcessEngineMultipleDeploymentTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/deployment/ProcessEngineMultipleDeploymentTest.java
@@ -85,7 +85,7 @@ public class ProcessEngineMultipleDeploymentTest {
   public ProcessEngine processEngine;
 
   @Test
-  public void shouldHaveDeployedResources() {
+  void shouldHaveDeployedResources() {
     // given
     RepositoryService repositoryService = processEngine.getRepositoryService();
 

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/deployment/ProcessEngineSingleDeploymentTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/deployment/ProcessEngineSingleDeploymentTest.java
@@ -60,7 +60,7 @@ public class ProcessEngineSingleDeploymentTest {
   public ProcessEngine processEngine;
 
   @Test
-  public void shouldHaveDeployedResources() {
+  void shouldHaveDeployedResources() {
     // given
     RepositoryService repositoryService = processEngine.getRepositoryService();
 

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/id/DefaultIdGeneratorTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/id/DefaultIdGeneratorTest.java
@@ -46,7 +46,7 @@ public class DefaultIdGeneratorTest {
   protected ProcessEngine processEngine;
 
   @Test
-  public void shouldConfigureStrongIdGenerator() {
+  void shouldConfigureStrongIdGenerator() {
     Task task = taskService.newTask();
     taskService.saveTask(task);
 

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/lookup/ProgrammaticBeanLookupTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/lookup/ProgrammaticBeanLookupTest.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * This test is copied and adjusted from the engine-cdi module to work with Quarkus.
  * See https://jira.camunda.com/browse/CAM-13747 for the reasoning.
  */
-public class ProgrammaticBeanLookupTest {
+class ProgrammaticBeanLookupTest {
 
   @RegisterExtension
   static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
@@ -50,26 +50,26 @@ public class ProgrammaticBeanLookupTest {
           .addClass(BeanWithProducerMethods.class));
 
   @Test
-  public void shouldLookupBean() {
+  void shouldLookupBean() {
     Object lookup = ProgrammaticBeanLookup.lookup("testBean");
     assertThat(lookup).isInstanceOf(TestBean.class);
   }
 
   @Test
-  public void shouldFindAlternative() {
+  void shouldFindAlternative() {
     Object lookup = ProgrammaticBeanLookup.lookup("otherTestBean");
     assertThat(lookup).isInstanceOf(AlternativeTestBean.class);
   }
 
   @Test
   @Disabled("specialization not supported")
-  public void shouldFindSpecialization() {
+  void shouldFindSpecialization() {
     Object lookup = ProgrammaticBeanLookup.lookup("specializedTestBean");
     assertThat(lookup).isInstanceOf(SpecializedTestBean.class);
   }
 
   @Test
-  public void shouldSupportProducerMethods() {
+  void shouldSupportProducerMethods() {
     assertThat(ProgrammaticBeanLookup.lookup("producedString")).isEqualTo("exampleString");
   }
 

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.java
@@ -57,7 +57,7 @@ import java.sql.Statement;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-public class TransactionIntegrationTest {
+class TransactionIntegrationTest {
 
   @RegisterExtension
   static QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
@@ -84,7 +84,7 @@ public class TransactionIntegrationTest {
   protected ProcessEngineConfigurationImpl configuration;
 
   @BeforeEach
-  public void assignConfig() {
+  void assignConfig() {
     configuration = (ProcessEngineConfigurationImpl) processEngine.getProcessEngineConfiguration();
   }
 
@@ -94,7 +94,7 @@ public class TransactionIntegrationTest {
    */
   @Test
   @Deployment
-  public void shouldSucceed() {
+  void shouldSucceed() {
     userBean.hello();
 
     ProcessInstance processInstance = runtimeService.createProcessInstanceQuery().singleResult();
@@ -107,7 +107,7 @@ public class TransactionIntegrationTest {
    */
   @Test
   @Deployment
-  public void shouldRollbackOnException() {
+  void shouldRollbackOnException() {
     // given
     try {
       try (Connection connection = dataSource.getConnection()) {
@@ -157,12 +157,12 @@ public class TransactionIntegrationTest {
     }
   }
 
-  @Deployment(resources={
-      "org/operaton/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldPropagateErrorOnException.bpmn20.xml",
-      "org/operaton/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldThrowException.bpmn20.xml"
+  @Deployment(resources = {
+    "org/operaton/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldPropagateErrorOnException.bpmn20.xml",
+    "org/operaton/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldThrowException.bpmn20.xml"
   })
   @Test
-  public void shouldPropagateErrorOnException() {
+  void shouldPropagateErrorOnException() {
     // given
     runtimeService.startProcessInstanceByKey("process");
 
@@ -176,7 +176,7 @@ public class TransactionIntegrationTest {
 
   @Deployment
   @Test
-  public void shouldRollbackInServiceTask() {
+  void shouldRollbackInServiceTask() {
     // given
     runtimeService.startProcessInstanceByKey("txRollbackServiceTask");
 
@@ -195,7 +195,7 @@ public class TransactionIntegrationTest {
 
   @Deployment
   @Test
-  public void shouldRollbackInServiceTaskWithCustomRetryCycle() {
+  void shouldRollbackInServiceTaskWithCustomRetryCycle() {
     // given
     runtimeService.startProcessInstanceByKey("txRollbackServiceTaskWithCustomRetryCycle");
 
@@ -214,7 +214,7 @@ public class TransactionIntegrationTest {
 
   @Deployment
   @Test
-  public void shouldRollbackOnExceptionInTransactionListener() {
+  void shouldRollbackOnExceptionInTransactionListener() {
     // given
     runtimeService.startProcessInstanceByKey("failingTransactionListener");
 

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/UserTransactionIntegrationTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/UserTransactionIntegrationTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class UserTransactionIntegrationTest {
+class UserTransactionIntegrationTest {
 
   @RegisterExtension
   static QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
@@ -53,7 +53,7 @@ public class UserTransactionIntegrationTest {
 
   @Test
   @Deployment
-  public void shouldSucceed() throws Exception {
+  void shouldSucceed() throws Exception {
 
     try {
       userTransactionManager.begin();
@@ -88,7 +88,7 @@ public class UserTransactionIntegrationTest {
 
   @Test
   @Deployment
-  public void shouldMarkAsRollbackOnly() throws Exception {
+  void shouldMarkAsRollbackOnly() throws Exception {
 
     /* if we start a transaction here and then start
      * a process instance which synchronously invokes a java delegate,
@@ -121,7 +121,7 @@ public class UserTransactionIntegrationTest {
 
   @Test
   @Deployment
-  public void shouldNotStoreProcessInstance() throws Exception {
+  void shouldNotStoreProcessInstance() throws Exception {
 
     /* if we start a transaction here and then successfully start
      * a process instance, if our transaction is rolled back,

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/conf/ChooseDatasourceConfigurationTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/conf/ChooseDatasourceConfigurationTest.java
@@ -30,7 +30,7 @@ import java.sql.SQLException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ChooseDatasourceConfigurationTest {
+class ChooseDatasourceConfigurationTest {
 
   @RegisterExtension
   static QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
@@ -42,7 +42,7 @@ public class ChooseDatasourceConfigurationTest {
   protected ProcessEngine processEngine;
 
   @Test
-  public void shouldChooseDatasource() throws SQLException {
+  void shouldChooseDatasource() throws SQLException {
     ProcessEngineConfiguration configuration = processEngine.getProcessEngineConfiguration();
     assertThat(configuration.getDataSource().getConnection()).asString().contains("jdbc:h2:mem:secondary");
   }

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/conf/ChooseNotExistingDatasourceConfigurationTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/conf/ChooseNotExistingDatasourceConfigurationTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ChooseNotExistingDatasourceConfigurationTest {
+class ChooseNotExistingDatasourceConfigurationTest {
 
   @RegisterExtension
   static QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
@@ -37,7 +37,7 @@ public class ChooseNotExistingDatasourceConfigurationTest {
       .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
   @Test
-  public void shouldExpectException() {
+  void shouldExpectException() {
     // Exception is raised during application bootstrap.
     // See assertion in the extension registration above.
   }

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/conf/DatasourceConfigurationTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/conf/DatasourceConfigurationTest.java
@@ -31,7 +31,7 @@ import java.sql.SQLException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DatasourceConfigurationTest {
+class DatasourceConfigurationTest {
 
   @RegisterExtension
   static QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
@@ -42,7 +42,7 @@ public class DatasourceConfigurationTest {
   protected ProcessEngine processEngine;
 
   @Test
-  public void shouldOverrideDefaultDatasource() throws SQLException {
+  void shouldOverrideDefaultDatasource() throws SQLException {
     ProcessEngineConfiguration configuration = processEngine.getProcessEngineConfiguration();
     assertThat(configuration.getDataSource().getConnection()).asString().contains("jdbc:h2:mem:primary");
   }

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/conf/NoDefaultDatasourceConfigurationTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/conf/NoDefaultDatasourceConfigurationTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import jakarta.inject.Inject;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class NoDefaultDatasourceConfigurationTest {
+class NoDefaultDatasourceConfigurationTest {
 
   @RegisterExtension
   static QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
@@ -41,7 +41,7 @@ public class NoDefaultDatasourceConfigurationTest {
   protected ProcessEngine processEngine;
 
   @Test
-  public void shouldExpectException() {
+  void shouldExpectException() {
   }
 
 }

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionClassDeploymentTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionClassDeploymentTest.java
@@ -25,17 +25,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ProcessEngineExtension.class)
 @Deployment
-public class ProcessEngineExtensionClassDeploymentTest {
+class ProcessEngineExtensionClassDeploymentTest {
 
   @Test
-  public void testDeploymentOnClassLevel(ProcessEngine processEngine) {
+  void testDeploymentOnClassLevel(ProcessEngine processEngine) {
     assertNotNull(processEngine.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTest").singleResult(),
         "No process deployed with class annotation");
   }
 
   @Test
   @Deployment
-  public void testDeploymentOnMethodOverridesClass(ProcessEngine processEngine) {
+  void testDeploymentOnMethodOverridesClass(ProcessEngine processEngine) {
     assertNotNull(processEngine.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTestOverride").singleResult(),
         "No process deployed for method");
   }

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionJunit5Test.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionJunit5Test.java
@@ -30,13 +30,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ProcessEngineExtension.class)
-public class ProcessEngineExtensionJunit5Test {
+class ProcessEngineExtensionJunit5Test {
 
   ProcessEngine engine;
 
   @Test
   @Deployment
-  public void extensionUsageExample() {
+  void extensionUsageExample() {
     RuntimeService runtimeService = engine.getRuntimeService();
     runtimeService.startProcessInstanceByKey("extensionUsage");
 
@@ -52,13 +52,13 @@ public class ProcessEngineExtensionJunit5Test {
    * The extension should work with tests that have no deployment annotation
    */
   @Test
-  public void testWithoutDeploymentAnnotation() {
+  void testWithoutDeploymentAnnotation() {
     assertEquals("aString", "aString");
   }
 
   @Test
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_AUDIT)
-  public void requiredHistoryLevelAudit() {
+  void requiredHistoryLevelAudit() {
 
     assertThat(currentHistoryLevel()).isIn(
         ProcessEngineConfiguration.HISTORY_AUDIT, ProcessEngineConfiguration.HISTORY_FULL);
@@ -66,7 +66,7 @@ public class ProcessEngineExtensionJunit5Test {
 
   @Test
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_ACTIVITY)
-  public void requiredHistoryLevelActivity() {
+  void requiredHistoryLevelActivity() {
 
     assertThat(currentHistoryLevel()).isIn(
         ProcessEngineConfiguration.HISTORY_ACTIVITY,
@@ -76,7 +76,7 @@ public class ProcessEngineExtensionJunit5Test {
 
   @Test
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
-  public void requiredHistoryLevelFull() {
+  void requiredHistoryLevelFull() {
 
     assertThat(currentHistoryLevel()).isEqualTo(ProcessEngineConfiguration.HISTORY_FULL);
   }

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionParentClassDeploymentTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionParentClassDeploymentTest.java
@@ -23,10 +23,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ProcessEngineExtension.class)
-public class ProcessEngineExtensionParentClassDeploymentTest extends ProcessEngineExtensionParentClassDeployment {
+class ProcessEngineExtensionParentClassDeploymentTest extends ProcessEngineExtensionParentClassDeployment {
 
   @Test
-  public void testDeploymentOnParentClassLevel(ProcessEngine processEngine) {
+  void testDeploymentOnParentClassLevel(ProcessEngine processEngine) {
     assertNotNull(processEngine.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTest").singleResult(),
         "process is not deployed");
   }

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionParentClassResourceDeploymentTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionParentClassResourceDeploymentTest.java
@@ -25,12 +25,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ProcessEngineExtension.class)
-public class ProcessEngineExtensionParentClassResourceDeploymentTest extends ProcessEngineExtensionParentClass {
+class ProcessEngineExtensionParentClassResourceDeploymentTest extends ProcessEngineExtensionParentClass {
   
   ProcessEngine processEngine;
 
   @Test
-  public void testSuperClassResourcesDeployment() {
+  void testSuperClassResourcesDeployment() {
     List<ProcessDefinition> processDefinitions = processEngine.getRepositoryService().createProcessDefinitionQuery().list();
     Assertions.assertThat(processDefinitions).hasSize(2);
   }

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionRequiredDatabaseTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionRequiredDatabaseTest.java
@@ -25,20 +25,20 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ProcessEngineExtension.class)
-public class ProcessEngineExtensionRequiredDatabaseTest {
+class ProcessEngineExtensionRequiredDatabaseTest {
 
   ProcessEngine engine;
 
   @Test
   @RequiredDatabase(includes = DbSqlSessionFactory.H2)
-  public void shouldRequireH2() {
+  void shouldRequireH2() {
 
     assertThat(engine.getProcessEngineConfiguration().getDatabaseType()).isEqualTo(DbSqlSessionFactory.H2);
   }
 
   @Test
   @RequiredDatabase(excludes = DbSqlSessionFactory.H2)
-  public void shouldRequireAnyDbButH2() {
+  void shouldRequireAnyDbButH2() {
 
     assertThat(engine.getProcessEngineConfiguration().getDatabaseType()).isNotEqualTo(DbSqlSessionFactory.H2);
     assertThat(engine.getProcessEngineConfiguration().getDatabaseType()).isIn((Object) DbSqlSessionFactory.SUPPORTED_DATABASES);

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionRequiredHistoryLevelAuditTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionRequiredHistoryLevelAuditTest.java
@@ -24,7 +24,7 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ProcessEngineExtensionRequiredHistoryLevelAuditTest {
+class ProcessEngineExtensionRequiredHistoryLevelAuditTest {
 
   @RegisterExtension
   ProcessEngineExtension extension = ProcessEngineExtension.builder()
@@ -33,13 +33,13 @@ public class ProcessEngineExtensionRequiredHistoryLevelAuditTest {
 
   @Test
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
-  public void testRequiredHistoryIgnored() {
+  void testRequiredHistoryIgnored() {
     fail("the configured history level is too high");
   }
 
   @Test
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_AUDIT)
-  public void testRequiredHistoryLevelMatch() {
+  void testRequiredHistoryLevelMatch() {
     assertEquals(extension.getProcessEngineConfiguration().getHistoryLevel().getName(),
         ProcessEngineConfiguration.HISTORY_AUDIT);
   }

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionSetTimeTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionSetTimeTest.java
@@ -24,13 +24,13 @@ import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ProcessEngineExtensionSetTimeTest {
+class ProcessEngineExtensionSetTimeTest {
 
   @RegisterExtension
   ProcessEngineExtension extension = ProcessEngineExtension.builder().build();
 
   @Test
-  public void shouldSetTime() {
+  void shouldSetTime() {
     // when
     extension.setCurrentTime(new Date(0));
 

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/deployment/EnsureDbCleanTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/deployment/EnsureDbCleanTest.java
@@ -38,17 +38,17 @@ public class EnsureDbCleanTest {
   public static final String SUB_PROCESS = "processes/subProcess.bpmn";
 
   @BeforeAll
-  public static void setup() {
+  static void setup() {
     ClassUnderTest.isEnabled = true;
   }
 
   @AfterAll
-  public static void tearDown() {
+  static void tearDown() {
     ClassUnderTest.isEnabled = false;
   }
 
   @Test
-  public void shouldFailTestsThatExpectCleanDbWhenDbIsDirty() {
+  void shouldFailTestsThatExpectCleanDbWhenDbIsDirty() {
     EngineExecutionResults results = EngineTestKit
       .engine("junit-jupiter")
       .selectors(
@@ -85,7 +85,7 @@ public class EnsureDbCleanTest {
       .build();
 
     @Test
-    public void shouldRaiseExceptionIfDbNotClean() {
+    void shouldRaiseExceptionIfDbNotClean() {
       // when
       extension.getRepositoryService()
           .createDeployment()

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/deployment/ProcessEngineExtensionDeploymentIdAccess.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/deployment/ProcessEngineExtensionDeploymentIdAccess.java
@@ -20,10 +20,10 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class ProcessEngineExtensionDeploymentIdAccess {
+class ProcessEngineExtensionDeploymentIdAccess {
 
   @Test
-  public void testDeploymentIdWriteableForExtensions() {
+  void testDeploymentIdWriteableForExtensions() {
 
     class ProcessEngineExtensionExtension extends ProcessEngineExtension {
 
@@ -41,7 +41,7 @@ public class ProcessEngineExtensionDeploymentIdAccess {
 
 
   @Test
-  public void testDeploymentIdReadableForExtensionsAndWrappers() {
+  void testDeploymentIdReadableForExtensionsAndWrappers() {
 
     class ProcessEngineExtensionExtension extends ProcessEngineExtension {
 

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/deployment/ProcessEngineExtensionDeploymentIdTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/deployment/ProcessEngineExtensionDeploymentIdTest.java
@@ -21,14 +21,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ProcessEngineExtensionDeploymentIdTest {
+class ProcessEngineExtensionDeploymentIdTest {
 
   @RegisterExtension
   CustomProcessEngineExtension extension =
       (CustomProcessEngineExtension) CustomProcessEngineExtension.builder().build();
 
   @Test
-  public void testDeploymentId() {
+  void testDeploymentId() {
     assertEquals("mockedDeploymentId", extension.getDeploymentId());
   }
 

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/deployment/ProcessEngineExtensionManageDeploymentsTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/deployment/ProcessEngineExtensionManageDeploymentsTest.java
@@ -32,7 +32,7 @@ public class ProcessEngineExtensionManageDeploymentsTest {
     .build();
 
   @Test
-  public void shouldCleanUpManagedDeployments() {
+  void shouldCleanUpManagedDeployments() {
     // given
     Deployment deployment = extension.getRepositoryService().createDeployment().addClasspathResource(SUB_PROCESS).deploy();
 

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/deployment/ProcessEngineExtensionResourcesDeploymentTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/deployment/ProcessEngineExtensionResourcesDeploymentTest.java
@@ -28,22 +28,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ProcessEngineExtension.class)
 @Deployment(resources = {"processes/superProcess.bpmn", "processes/subProcess.bpmn"})
-public class ProcessEngineExtensionResourcesDeploymentTest {
+class ProcessEngineExtensionResourcesDeploymentTest {
 
   ProcessEngine processEngine;
 
   @Test
   @Deployment(resources = {
-      "processes/superProcess.bpmn",
-      "processes/subProcess.bpmn"
-      })
-  public void testDeployTwoDiagrams() {
+    "processes/superProcess.bpmn",
+    "processes/subProcess.bpmn"
+  })
+  void testDeployTwoDiagrams() {
     List<ProcessDefinition> processDefinitions = processEngine.getRepositoryService().createProcessDefinitionQuery().list();
     Assertions.assertThat(processDefinitions).hasSize(2);
   }
 
   @Test
-  public void testDeployTwoDiagramsFromClassLevel() {
+  void testDeployTwoDiagramsFromClassLevel() {
     List<ProcessDefinition> processDefinitions = processEngine.getRepositoryService().createProcessDefinitionQuery().list();
     Assertions.assertThat(processDefinitions).hasSize(2);
   }

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/registerExtension/RegisterNewProcessEngineTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/registerExtension/RegisterNewProcessEngineTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class RegisterNewProcessEngineTest {
+class RegisterNewProcessEngineTest {
 
   private static ProcessEngine testEngine = ((ProcessEngineConfigurationImpl)ProcessEngineConfiguration
       .createStandaloneInMemProcessEngineConfiguration())
@@ -45,13 +45,13 @@ public class RegisterNewProcessEngineTest {
       .build();
 
   @AfterAll
-  public static void closeProcessEngine() {
+  static void closeProcessEngine() {
     testEngine.close();
   }
 
   @Test
   @Deployment(resources = "processes/subProcess.bpmn")
-  public void testUseProcessEngine() {
+  void testUseProcessEngine() {
     // given
     RuntimeService runtimeService = testEngine.getRuntimeService();
     runtimeService.startProcessInstanceByKey("subProcess");
@@ -65,7 +65,7 @@ public class RegisterNewProcessEngineTest {
   }
 
   @Test
-  public void shouldUpdateServiceReferences() {
+  void shouldUpdateServiceReferences() {
 
     assertThat(extension.getRuntimeService()).isEqualTo(testEngine.getRuntimeService());
   }

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/registerExtension/RegisterProcessEngineExtensionTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/registerExtension/RegisterProcessEngineExtensionTest.java
@@ -26,14 +26,14 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class RegisterProcessEngineExtensionTest {
+class RegisterProcessEngineExtensionTest {
 
   @RegisterExtension
   ProcessEngineExtension extension = ProcessEngineExtension.builder().build();
 
   @Test
   @Deployment
-  public void registeredExtensionUsageExample() {
+  void registeredExtensionUsageExample() {
     RuntimeService runtimeService = extension.getProcessEngine()
         .getRuntimeService();
     runtimeService.startProcessInstanceByKey("registeredExtensionUsage");


### PR DESCRIPTION
Refactored with OpenRewrite recipe org.openrewrite.java.testing.cleanup.TestsShouldNotBePublic

related to #88