### PR TITLE
refactor(build): Introduce `install.skip` property

### DIFF
--- a/distro/run/qa/integration-tests/pom.xml
+++ b/distro/run/qa/integration-tests/pom.xml
@@ -12,6 +12,10 @@
   <name>Operaton - Run - QA - Integration Tests</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <install.skip>true</install.skip>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -15,6 +15,7 @@
   <properties>
     <run-home>${project.build.directory}/run/operaton-bpm-run-distro</run-home>
     <example-plugin-home>${project.build.directory}/run/example-plugin</example-plugin-home>
+    <install.skip>true</install.skip>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
     <sonar.coverage.jacoco.xmlReportPaths>**/target/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     <!-- Set to false for each module that must be deployed -->
     <deploy.skip>true</deploy.skip>
+    <!-- Set to true for each module with packaging default/jar that does not have 'main' sources -->
+    <install.skip>false</install.skip>
   </properties>
 
   <build>
@@ -175,6 +177,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
           <version>3.1.3</version>
+          <configuration>
+            <skip>${install.skip}</skip>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/qa/integration-tests-engine-jakarta/pom.xml
+++ b/qa/integration-tests-engine-jakarta/pom.xml
@@ -22,6 +22,7 @@
     <redirect.test.output>true</redirect.test.output>
 
     <weld.version>5.1.0.Final</weld.version>
+    <install.skip>true</install.skip>
   </properties>
 
   <!-- import shrinkwrap and arquillian bom for artifact versions,
@@ -291,18 +292,6 @@
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-install-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -16,6 +16,7 @@
     <wildfly.container.adapter.version>2.2.0.Final</wildfly.container.adapter.version>
 
     <redirect.test.output>true</redirect.test.output>
+    <install.skip>true</install.skip>
   </properties>
 
   <!-- import shrinkwrap and arquillian bom for artifact versions,
@@ -259,17 +260,6 @@
         </excludes>
       </testResource>
     </testResources>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-install-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/qa/integration-tests-webapps/shared-engine/pom.xml
+++ b/qa/integration-tests-webapps/shared-engine/pom.xml
@@ -10,6 +10,10 @@
     <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
 
+  <properties>
+    <install.skip>true</install.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.operaton.bpm.qa</groupId>
@@ -650,13 +654,6 @@
                 </pluginExecution>
               </pluginExecutions>
             </lifecycleMappingMetadata>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-install-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
           </configuration>
         </plugin>
       </plugins>

--- a/qa/large-data-tests/pom.xml
+++ b/qa/large-data-tests/pom.xml
@@ -14,6 +14,7 @@
     <skipTests>true</skipTests>
     <jdbcBatchProcessing>true</jdbcBatchProcessing>
     <surefire.memArgs>-Xmx2048m</surefire.memArgs>
+    <install.skip>true</install.skip>
   </properties>
 
   <dependencies>
@@ -89,17 +90,6 @@
         </includes>
       </testResource>
     </testResources>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-install-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
 
   <profiles>

--- a/quarkus-extension/engine/qa/pom.xml
+++ b/quarkus-extension/engine/qa/pom.xml
@@ -13,6 +13,7 @@
   <properties>
     <arquillian.version>1.7.0.Final</arquillian.version>
     <deploy.skip>true</deploy.skip>
+    <install.skip>true</install.skip>
   </properties>
 
   <dependencyManagement>
@@ -65,13 +66,6 @@
             <!-- See https://github.com/camunda/camunda-bpm-platform/issues/3419 -->
             <exclude>**/TaskFormTest.java</exclude>
           </excludes>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-plugins/spin/spin-dataformat-all/pom.xml
@@ -12,6 +12,10 @@
   <artifactId>qa-plugins-spin-dataformat-all</artifactId>
   <name>Operaton - Spring Boot Starter - QA - Plugins - Spin All</name>
 
+  <properties>
+    <install.skip>true</install.skip>
+  </properties>
+
   <dependencies>
 
     <dependency>
@@ -68,20 +72,6 @@
       </build>
     </profile>
   </profiles>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-install-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 
   <description>${project.name}</description>
 </project>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
@@ -22,6 +22,7 @@
     <http.port>58080</http.port>
     <http.ctx-path.webapp>operaton/</http.ctx-path.webapp>
     <http.ctx-path.rest>engine-rest/</http.ctx-path.rest>
+    <install.skip>true</install.skip>
   </properties>
 
   <profiles>
@@ -207,20 +208,6 @@
       </build>
     </profile>
   </profiles>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-install-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 
   <description>${project.name}</description>
 </project>

--- a/test-utils/assert/qa/pom.xml
+++ b/test-utils/assert/qa/pom.xml
@@ -11,6 +11,10 @@
     <version>1.0.0-beta-3-SNAPSHOT</version>
   </parent>
 
+  <properties>
+    <install.skip>true</install.skip>
+  </properties>
+
   <dependencies>
     <!-- managed by spring-boot-dependencies -->
     <dependency>
@@ -58,18 +62,5 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-install-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
   <description>${project.name}</description>
 </project>


### PR DESCRIPTION
Property `install.skip` is added to the root POM with value `false`, and used to configure the `skip` property for the maven-install-plugin.

All modules that require skipping the install plugin because they do not produce a 'main' jar override the property value. This makes the definition of the maven-install-plugin in these POMs obsolete and therefore the files smaller.

Additionally skipping install for distro/run qa modules.

fixes #342