### PR TITLE
chore(build): Use JReleaser for nightly releases

### DIFF
--- a/.github/jreleaser/changelog.tpl
+++ b/.github/jreleaser/changelog.tpl
@@ -4,13 +4,6 @@
 
 {{changelogNewAndNoteworthy}}
 
-### Breaking Changes
-
-- Operaton removed the compatibility layer for Activiti. If you need to use Activiti models you will have to convert them (see the following [blog post](https://camunda.com/blog/2016/10/migrate-from-activiti-to-camunda/) for details).
-- The support for the `javax.el` expression language has been removed. Application servers that ship this library are
-incompatible with Operaton. If you are running Operaton on an application server, make sure that it supports
-`jakarta-el` in version 4.0.0 or newer (e.g. Wildfly 21 or newer).
-
 {{changelogContributors}}
 
 ## Changelog

--- a/.github/scripts/jacoco-create-flag-files.sh
+++ b/.github/scripts/jacoco-create-flag-files.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+echo "Creating a flag file 'executeJacoco' for each module containing tests. \
+This triggers activation of the 'coverage' profile."
+find . -type d | while read -r dir; do
+if [[ -d "$dir/src/test/java" || -d "$dir/target/generated-test-sources/java" ]]; then
+  # Create an empty file target/executeJacoco if the condition is met
+  mkdir -p "$dir/target"
+  touch "$dir/target/executeJacoco"
+fi
+done
+echo "🚩 Created flag files for Jacoco"

--- a/.github/scripts/prepare-reports.sh
+++ b/.github/scripts/prepare-reports.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-SLOC_FILES=$(find . -name sloc.txt | paste -sd ',' -)
 TARGET_DIR=target/reports/sloc
 
 echo "📦 Collecting sloc.txt files"
+SLOC_FILES=$(find . -name sloc.txt | paste -sd ',' -)
 mkdir -p $TARGET_DIR
 for FILE in $(echo $SLOC_FILES | tr "," "\n"); do
   TARGET_FILE_NAME=$(echo $FILE | sed 's/\.\///g' | sed 's/target\///g' | sed 's/\//_/g' )
   mv -v $FILE $TARGET_DIR/$TARGET_FILE_NAME
 done
+
+zip -rq target/project-reports.zip target/reports/*
+echo "📦 Created project-reports.zip"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - '.github/workflows/**'
       - '!.github/workflows/build.yml'
+      - '.github/jreleaser/changelog.tpl'
       - '**/*.md'
       - 'distro/**'
       - 'settings/**'
@@ -18,6 +19,7 @@ on:
     paths-ignore:
       - '.github/workflows/**'
       - '!.github/workflows/build.yml'
+      - '.github/jreleaser/changelog.tpl'
       - '**/*.md'
       - 'distro/**'
       - 'settings/**'
@@ -59,15 +61,7 @@ jobs:
         id: maven-build
         shell: bash
         run: |
-          echo "Creating a flag file 'executeJacoco' for each module containing tests. \
-          This triggers activation of the 'coverage' profile."
-          find . -type d | while read -r dir; do
-          if [[ -d "$dir/src/test/java" || -d "$dir/target/generated-test-sources/java" ]]; then
-            # Create an empty file target/executeJacoco if the condition is met
-            mkdir -p "$dir/target"
-            touch "$dir/target/executeJacoco"
-          fi
-          done
+          .github/scripts/jacoco-create-flag-files.sh
           ./mvnw verify
           ./mvnw --non-recursive org.jacoco:jacoco-maven-plugin:report-aggregate
       - name: Publish Test Report

--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -4,6 +4,21 @@ on:
   schedule:
     - cron: "0 3 * * *"     # Runs at 3:00 AM UTC daily
   workflow_dispatch:        # Allows manual trigger
+    inputs:
+      java_version:
+        description: 'Java version to use'
+        type: choice
+        required: true
+        default: '["17", "21"]'
+        options:
+          - '["17"]'
+          - '["21"]'
+          - '["17", "21"]'
+      dry_run:
+        description: 'Dry-Run: Skips remote operations when true'
+        type: boolean
+        required: true
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,8 +30,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        java: [17, 21]
+        java: ${{ fromJson(github.event.inputs.java_version || '["17", "21"]') }}
     runs-on: ubuntu-24.04
+    outputs:
+      version: ${{steps.maven-build.outputs.version}}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -32,17 +49,32 @@ jobs:
         id: maven-build
         shell: bash
         run: |
-          echo "Creating a flag file 'executeJacoco' for each module containing tests. \
-          This triggers activation of the 'coverage' profile."
-          find . -type d | while read -r dir; do
-          if [[ -d "$dir/src/test/java" || -d "$dir/target/generated-test-sources/java" ]]; then
-            # Create an empty file target/executeJacoco if the condition is met
-            mkdir -p "$dir/target"
-            touch "$dir/target/executeJacoco"
-          fi
-          done
-          ./mvnw -Pdistro,distro-tomcat,distro-wildfly,distro-webjar,distro-starter,distro-serverless,distro-run,h2-in-memory verify
+          PROJECT_ROOT=$(pwd)
+          .github/scripts/jacoco-create-flag-files.sh
+          RELEASE_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1)
+          echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          ./mvnw \
+            -Pdistro,distro-run,distro-tomcat,distro-wildfly,distro-webjar,distro-starter,distro-serverless,h2-in-memory \
+            install \
+            versions:dependency-updates-aggregate-report \
+            versions:plugin-updates-aggregate-report \
+            -Dsave=true -Ddisplay=false io.github.orhankupusoglu:sloc-maven-plugin:sloc \
+            -Dbuildplan.appendOutput=true -Dbuildplan.outputFile=$PROJECT_ROOT/target/reports/buildplan.txt fr.jcgay.maven.plugins:buildplan-maven-plugin:list
+          .github/scripts/prepare-reports.sh
+          ./mvnw -Psonatype-oss-release -DskipTests=true -Dskip.frontend.build=true deploy
+          find target -name maven-metadata.* -delete
           ./mvnw --non-recursive org.jacoco:jacoco-maven-plugin:report-aggregate
+      - name: Cache build artifacts
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            distro/**/*.tar.gz
+            distro/webjar/target/operaton-webapp-webjar-*.jar
+            ./*/staging-deploy/**
+            **/target/reports/**
+            **/target/surefire-reports/*.xml
+            target/project-reports.zip
+          key: ${{ github.run_id }}-build-artifacts
       - name: Publish Test Report
         if: always()
         #https://github.com/marketplace/actions/junit-report-action
@@ -50,107 +82,41 @@ jobs:
         with:
           report_paths: ${{ github.workspace }}/**/target/surefire-reports/*.xml
           require_passed_tests: true
-      - name: Cache build artifacts
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            distro/**/target/operaton-*.gz
-            distro/webjar/target/operaton-webapp-webjar-*.jar
-          key: ${{ github.run_id }}-build-artifacts
 
-  report:
-    name: Generate Reports
+  release:
+    name: Release
+    needs:
+      - build
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout Code
+      - name: Check out the code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Cache Maven packages
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-      - name: Generate Reports
-        run: |
-          PROJECT_ROOT=$(pwd)
-          ./mvnw verify\
-            versions:dependency-updates-aggregate-report \
-            versions:plugin-updates-aggregate-report \
-            -Dsave=true -Ddisplay=false io.github.orhankupusoglu:sloc-maven-plugin:sloc \
-            -Dbuildplan.appendOutput=true -Dbuildplan.outputFile=$PROJECT_ROOT/target/reports/buildplan.txt fr.jcgay.maven.plugins:buildplan-maven-plugin:list
-          .github/scripts/prepare-reports.sh
-      - name: Archive Reports
-        uses: actions/upload-artifact@v4
-        with:
-          name: reports
-          path: |
-            **/target/reports/**
+          ref: ${{github.event.inputs.release_branch}}
 
-  publish:
-    name: Publish
-    needs: build
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Restore build artifacts cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache@v4
         with:
           path: |
-            distro/**/target/operaton-*.gz
+            distro/**/*.tar.gz
             distro/webjar/target/operaton-webapp-webjar-*.jar
+            ./*/staging-deploy/**
+            **/target/reports/**
+            **/target/surefire-reports/*.xml
+            target/project-reports.zip
           key: ${{ github.run_id }}-build-artifacts
           fail-on-cache-miss: true
-      - run: |
-          sudo apt-get update > /dev/null
-          sudo apt-get install -y xq > /dev/null
-          PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1)
-          TOMCAT_VERSION=$(xq --xpath project/properties/version.tomcat parent/pom.xml)
-          WILDFLY_VERSION=$(xq --xpath project/properties/version.wildfly parent/pom.xml)
-          echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
-          echo "TOMCAT_VERSION=$TOMCAT_VERSION" >> $GITHUB_ENV
-          echo "WILDFLY_VERSION=$WILDFLY_VERSION" >> $GITHUB_ENV
-      - name: Upload distro Tomcat
-        id: upload-distro-tomcat
-        uses: actions/upload-artifact@v4
-        with:
-          name: Operaton (Tomcat ${{ env.TOMCAT_VERSION }} Bundle)
-          path: distro/tomcat/distro/target/operaton-bpm-tomcat-${{ env.PROJECT_VERSION }}.tar.gz
-          if-no-files-found: error
-          retention-days: 30
-      - name: Upload distro Run
-        id: upload-distro-run
-        uses: actions/upload-artifact@v4
-        with:
-          name: Operaton Run
-          path: distro/run/distro/target/operaton-bpm-run-${{ env.PROJECT_VERSION }}.tar.gz
-          if-no-files-found: error
-          retention-days: 30
-      - name: Upload distro Wildfly
-        id: upload-distro-wildfly
-        uses: actions/upload-artifact@v4
-        with:
-          name: Operaton (Wildfly ${{ env.WILDFLY_VERSION }} Bundle)
-          path: distro/wildfly/distro/target/operaton-bpm-wildfly-${{ env.PROJECT_VERSION }}.tar.gz
-          if-no-files-found: error
-          retention-days: 30
-      - name: Upload distro WebJar
-        id: upload-distro-webjar
-        uses: actions/upload-artifact@v4
-        with:
-          name: Operaton (WebJar Bundle)
-          path: distro/webjar/target/operaton-webapp-webjar-${{ env.PROJECT_VERSION }}.jar
-          if-no-files-found: error
-          retention-days: 30
-      - name: Upload distro sql-scripts
-        id: upload-distro-sql-scripts
-        uses: actions/upload-artifact@v4
-        with:
-          name: Operaton SQL Scripts
-          path: distro/sql-script/target/operaton-sql-scripts-${{ env.PROJECT_VERSION }}.tar.gz
-          if-no-files-found: error
-          retention-days: 30
+
+      - name: Release with JReleaser
+        uses: jreleaser/release-action@v2
+        env:
+          JRELEASER_PROJECT_VERSION: ${{needs.build.outputs.version}}
+          JRELEASER_GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          JRELEASER_GPG_PUBLIC_KEY: ${{secrets.GPG_PUBLIC_KEY}}
+          JRELEASER_GPG_SECRET_KEY: ${{secrets.GPG_PRIVATE_KEY}}
+          JRELEASER_GPG_PASSPHRASE: ${{secrets.GPG_PASSPHRASE}}
+          JRELEASER_MAVENCENTRAL_USERNAME: ${{secrets.OSSRH_USERNAME}}
+          JRELEASER_MAVENCENTRAL_PASSWORD: ${{secrets.OSSRH_PASSWORD}}
+          JRELEASER_DRY_RUN: ${{ github.event_name == 'schedule' && false || github.event.inputs.dry_run }}
+          JRELEASER_PRERELEASE_ENABLED: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   precheck:
     name: Precheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       version: ${{steps.version.outputs.version}}
       is_prerelease: ${{steps.version.outputs.is_prerelease}}
@@ -29,7 +29,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{github.event.inputs.release_branch}}
-
       - name: Version
         id: version
         shell: bash
@@ -54,7 +53,7 @@ jobs:
   release_build:
     name: Release Build
     needs: precheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       output1: ${{steps.upload-release-artifacts.outputs.artifact-id}}
     steps:
@@ -75,7 +74,7 @@ jobs:
           PROJECT_ROOT=$(pwd)
           # Make a verification build. Also the deploy step will need the tomcat distro for building, but we don't want to deploy it.
           ./mvnw \
-            -Pdistro,distro-tomcat,distro-wildfly,distro-webjar,distro-starter,distro-serverless,h2-in-memory \
+            -Pdistro,distro-run,distro-tomcat,distro-wildfly,distro-webjar,distro-starter,distro-serverless,h2-in-memory \
             install \
             versions:dependency-updates-aggregate-report \
             versions:plugin-updates-aggregate-report \
@@ -93,6 +92,7 @@ jobs:
             ./*/staging-deploy/**
             **/target/reports/**
             **/target/surefire-reports/*.xml
+            target/project-reports.zip
           key: ${{ github.run_id }}-build-artifacts
 
   release:
@@ -100,7 +100,7 @@ jobs:
     needs:
       - precheck
       - release_build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the code
         uses: actions/checkout@v4
@@ -117,6 +117,7 @@ jobs:
             ./*/staging-deploy/**
             **/target/reports/**
             **/target/surefire-reports/*.xml
+            target/project-reports.zip
           key: ${{ github.run_id }}-build-artifacts
           fail-on-cache-miss: true
 
@@ -131,7 +132,7 @@ jobs:
           JRELEASER_MAVENCENTRAL_USERNAME: ${{secrets.OSSRH_USERNAME}}
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{secrets.OSSRH_PASSWORD}}
           JRELEASER_DRY_RUN: ${{github.event.inputs.dry_run}}
-          JRELEASER_PRERELEASE_ENABLED: ${{needs.precheck.outputs.is_prerelease}}
+          JRELEASER_PRERELEASE_ENABLED: false
 
       - name: Publish Test Report
         if: always()
@@ -159,7 +160,7 @@ jobs:
   post_release:
     name: Post-Release
     needs: release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the code
         uses: actions/checkout@v4

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -38,6 +38,8 @@ files:
     - path: 'distro/wildfly/distro/target/operaton-bpm-wildfly-{{projectVersion}}.tar.gz'
     - path: 'distro/sql-script/target/operaton-sql-scripts-{{projectVersion}}.tar.gz'
     - path: 'distro/webjar/target/operaton-webapp-webjar-{{projectVersion}}.jar'
+    - path: 'distro/run/distro/target/operaton-bpm-run-{{projectVersion}}.tar.gz'
+    - path: 'target/project-reports.zip'
 
 release: # https://jreleaser.org/guide/latest/reference/release/github.html
   github:
@@ -46,7 +48,7 @@ release: # https://jreleaser.org/guide/latest/reference/release/github.html
     owner: operaton
     draft: false
     skipTag: false
-    previousTagName: 1.0.0-beta-1
+    previousTagName: 1.0.0-beta-2
     releaseName: Release {{tagName}}
     prerelease: # TODO Evaluate JRELEASER_PRERELEASE_ENABLED
       enabled: true


### PR DESCRIPTION
This change makes the Nightly Build workflow use JReleaser to produce a preliminary release. The Nightly Build is now more aligned to the Release workflow.

For manual runs, the Nightly Build allows to specify the Java versions to build against.

Project Reports are attached as zip file to the release artifacts.

jreleaser.yml:
- include 'run' distro as artifacts
- package project reports as zip and attach as release artifacts
- set previousTagName: 1.0.0-beta-2

nightly-build.yml:
- use jacoco-create-flag-files.sh
- add `release` job
- include 'distro-run'

release.yml:
- set JRELEASER_PRERELEASE_ENABLED: false
- include 'distro-run'

prepare-reports.sh:
- package reports as zip

jacoco-create-flag-files.sh:
- extract shell script from nightly-build.yml

build.yml:
- use jacoco-create-flag-files.sh

closes #347

