### PR TITLE
Cleanup: Use StandardCharsets

### DIFF
--- a/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.client.rule;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.client.util.PropertyUtil.DEFAULT_PROPERTIES_PATH;
 import static org.operaton.bpm.client.util.PropertyUtil.loadProperties;
@@ -172,7 +173,7 @@ public class EngineRule implements BeforeEachCallback, AfterEachCallback  {
       String processAsString = Bpmn.convertToString(process);
       builder.addBinaryBody(
           String.format("data %d", i),
-          processAsString.getBytes(StandardCharsets.UTF_8), ContentType.APPLICATION_OCTET_STREAM,
+          processAsString.getBytes(UTF_8), ContentType.APPLICATION_OCTET_STREAM,
           String.format("test%d.bpmn", i));
     }
 

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/FileSerializationIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/FileSerializationIT.java
@@ -48,8 +48,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.client.util.ProcessModels.EXTERNAL_TASK_TOPIC_BAR;
@@ -67,7 +67,7 @@ public class FileSerializationIT {
   protected static final byte[] VARIABLE_VALUE_FILE_VALUE = "ABC".getBytes();
   protected static final String LOCAL_VARIABLE_NAME_FILE = "localFileName.txt";
 
-  protected static final String VARIABLE_VALUE_FILE_ENCODING = "UTF-8";
+  protected static final String VARIABLE_VALUE_FILE_ENCODING = UTF_8.name();
   protected static final String VARIABLE_VALUE_FILE_MIME_TYPE = "text/plain";
 
   protected static final String ANOTHER_VARIABLE_NAME_FILE = "anotherFileVariable";

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/format/xml/DomXmlDataFormat.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/format/xml/DomXmlDataFormat.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.client.variable.impl.format.xml;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.operaton.commons.utils.EnsureUtil.ensureNotNull;
 
 import java.beans.Introspector;
@@ -188,7 +189,7 @@ public class DomXmlDataFormat implements DataFormat {
   protected Transformer getTransformer() {
     try {
       Transformer transformer = transformerFactory.newTransformer();
-      transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+      transformer.setOutputProperty(OutputKeys.ENCODING, UTF_8.name());
       transformer.setOutputProperty(OutputKeys.INDENT, "yes");
       transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
       return transformer;

--- a/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
+++ b/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Scanner;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -204,7 +205,7 @@ class FileValueTypeImplTest {
     InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
     String fileName = "simpleFile.txt";
     String fileType = "text/plain";
-    Charset encoding = StandardCharsets.UTF_8;
+    Charset encoding = UTF_8;
     FileValue fileValue = Variables.fileValue(fileName).file(file).mimeType(fileType).encoding(encoding).setTransient(true).create();
     Map<String, Object> info = type.getValueInfo(fileValue);
 
@@ -219,7 +220,7 @@ class FileValueTypeImplTest {
     InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
     String fileName = "simpleFile.txt";
     String fileType = "text/plain";
-    String encoding = "UTF-8";
+    String encoding = UTF_8.name();
     FileValue fileValue = Variables.fileValue(fileName).file(file).mimeType(fileType).encoding(encoding).create();
     Map<String, Object> info = type.getValueInfo(fileValue);
 

--- a/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
+++ b/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
@@ -203,7 +204,7 @@ class FileValueTypeImplTest {
     InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
     String fileName = "simpleFile.txt";
     String fileType = "text/plain";
-    Charset encoding = Charset.forName("UTF-8");
+    Charset encoding = StandardCharsets.UTF_8;
     FileValue fileValue = Variables.fileValue(fileName).file(file).mimeType(fileType).encoding(encoding).setTransient(true).create();
     Map<String, Object> info = type.getValueInfo(fileValue);
 

--- a/commons/utils/src/main/java/org/operaton/commons/utils/IoUtil.java
+++ b/commons/utils/src/main/java/org/operaton/commons/utils/IoUtil.java
@@ -20,6 +20,7 @@ import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author Sebastian Menski
@@ -27,7 +28,7 @@ import java.nio.charset.Charset;
 public class IoUtil {
 
   private static final IoUtilLogger LOG = UtilsLogger.IO_UTIL_LOGGER;
-  public static final Charset ENCODING_CHARSET = Charset.forName("UTF-8");
+  public static final Charset ENCODING_CHARSET = StandardCharsets.UTF_8;
 
   /**
    * Returns the input stream as String.

--- a/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/AbstractHttpConnector.java
+++ b/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/AbstractHttpConnector.java
@@ -18,6 +18,7 @@ package org.operaton.connect.httpclient.impl;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 
@@ -52,7 +53,7 @@ public abstract class AbstractHttpConnector<Q extends HttpBaseRequest<Q, R>, R e
   public AbstractHttpConnector(String connectorId) {
     super(connectorId);
     httpClient = createClient();
-    charset = Charset.forName("utf-8");
+    charset = StandardCharsets.UTF_8;
   }
 
   protected CloseableHttpClient createClient() {

--- a/engine-plugins/spin-plugin/src/test/java/org/operaton/spin/plugin/variables/TypedValueAssert.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/operaton/spin/plugin/variables/TypedValueAssert.java
@@ -22,7 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.nio.charset.Charset;
-
+import java.nio.charset.StandardCharsets;
 import org.operaton.bpm.engine.impl.digest._apacheCommonsCodec.Base64;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.type.ValueType;
@@ -72,7 +72,7 @@ public class TypedValueAssert {
     try {
       // validate this is the base 64 encoded string representation of the serialized value of the java object
       String valueSerialized = typedValue.getValueSerialized();
-      byte[] decodedObject = Base64.decodeBase64(valueSerialized.getBytes(Charset.forName("UTF-8")));
+      byte[] decodedObject = Base64.decodeBase64(valueSerialized.getBytes(StandardCharsets.UTF_8));
       ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(decodedObject));
       assertEquals(value, objectInputStream.readObject());
     }

--- a/engine-rest/engine-rest-openapi-generator/src/main/java/org/operaton/bpm/engine/rest/openapi/generator/impl/TemplateParser.java
+++ b/engine-rest/engine-rest-openapi-generator/src/main/java/org/operaton/bpm/engine/rest/openapi/generator/impl/TemplateParser.java
@@ -44,6 +44,8 @@ import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class TemplateParser {
 
   public static void main(String[] args) throws IOException, TemplateException {
@@ -65,7 +67,7 @@ public class TemplateParser {
     Configuration cfg = new Configuration(Configuration.VERSION_2_3_29);
 
     cfg.setDirectoryForTemplateLoading(new File(sourceDirectory));
-    cfg.setDefaultEncoding("UTF-8");
+    cfg.setDefaultEncoding(UTF_8.name());
 
     Template template = cfg.getTemplate(mainTemplate);
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/impl/AbstractVariablesResource.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/impl/AbstractVariablesResource.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.rest.sub.impl;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -169,7 +170,7 @@ public abstract class AbstractVariablesResource implements VariableResource {
     try {
       JavaType type = TypeFactory.defaultInstance().constructFromCanonical(className);
       validateType(type);
-      return objectMapper.readValue(new String(data, Charset.forName("UTF-8")), type);
+      return objectMapper.readValue(new String(data, StandardCharsets.UTF_8), type);
     } catch(Exception e) {
       throw new InvalidRequestException(Status.INTERNAL_SERVER_ERROR, "Could not deserialize JSON object: "+e.getMessage());
     }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/CaseDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/CaseDefinitionResourceImpl.java
@@ -48,6 +48,8 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  *
  * @author Roman Smirnov
@@ -75,16 +77,12 @@ public class CaseDefinitionResourceImpl implements CaseDefinitionResource {
 
     try {
       definition = repositoryService.getCaseDefinition(caseDefinitionId);
-
     } catch (NotFoundException e) {
       throw new InvalidRequestException(Status.NOT_FOUND, e, e.getMessage());
-
     } catch (NotValidException e) {
       throw new InvalidRequestException(Status.BAD_REQUEST, e, e.getMessage());
-
     } catch (ProcessEngineException e) {
       throw new RestException(Status.INTERNAL_SERVER_ERROR, e);
-
     }
 
     return CaseDefinitionDto.fromCaseDefinition(definition);
@@ -97,11 +95,9 @@ public class CaseDefinitionResourceImpl implements CaseDefinitionResource {
       caseModelInputStream = engine.getRepositoryService().getCaseModel(caseDefinitionId);
 
       byte[] caseModel = IoUtil.readInputStream(caseModelInputStream, "caseModelCmmnXml");
-      return CaseDefinitionDiagramDto.create(caseDefinitionId, new String(caseModel, "UTF-8"));
-
+      return CaseDefinitionDiagramDto.create(caseDefinitionId, new String(caseModel, UTF_8));
     } catch (NotFoundException e) {
       throw new InvalidRequestException(Status.NOT_FOUND, e, e.getMessage());
-
     } catch (NotValidException e) {
       throw new InvalidRequestException(Status.BAD_REQUEST, e, e.getMessage());
 
@@ -110,7 +106,6 @@ public class CaseDefinitionResourceImpl implements CaseDefinitionResource {
 
     } catch (UnsupportedEncodingException e) {
       throw new RestException(Status.INTERNAL_SERVER_ERROR, e);
-
     } finally {
       IoUtil.closeSilently(caseModelInputStream);
     }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/CaseDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/CaseDefinitionResourceImpl.java
@@ -45,7 +45,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -100,11 +99,7 @@ public class CaseDefinitionResourceImpl implements CaseDefinitionResource {
       throw new InvalidRequestException(Status.NOT_FOUND, e, e.getMessage());
     } catch (NotValidException e) {
       throw new InvalidRequestException(Status.BAD_REQUEST, e, e.getMessage());
-
     } catch (ProcessEngineException e) {
-      throw new RestException(Status.INTERNAL_SERVER_ERROR, e);
-
-    } catch (UnsupportedEncodingException e) {
       throw new RestException(Status.INTERNAL_SERVER_ERROR, e);
     } finally {
       IoUtil.closeSilently(caseModelInputStream);

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/DecisionDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/DecisionDefinitionResourceImpl.java
@@ -53,6 +53,8 @@ import org.operaton.bpm.engine.variable.value.TypedValue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class DecisionDefinitionResourceImpl implements DecisionDefinitionResource {
 
   protected ProcessEngine engine;
@@ -97,7 +99,7 @@ public class DecisionDefinitionResourceImpl implements DecisionDefinitionResourc
       decisionModelInputStream = engine.getRepositoryService().getDecisionModel(decisionDefinitionId);
 
       byte[] decisionModel = IoUtil.readInputStream(decisionModelInputStream, "decisionModelDmnXml");
-      return DecisionDefinitionDiagramDto.create(decisionDefinitionId, new String(decisionModel, "UTF-8"));
+      return DecisionDefinitionDiagramDto.create(decisionDefinitionId, new String(decisionModel, UTF_8));
 
     } catch (NotFoundException e) {
       throw new InvalidRequestException(Status.NOT_FOUND, e, e.getMessage());

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/DecisionDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/DecisionDefinitionResourceImpl.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.rest.sub.repository.impl;
 
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -100,19 +99,12 @@ public class DecisionDefinitionResourceImpl implements DecisionDefinitionResourc
 
       byte[] decisionModel = IoUtil.readInputStream(decisionModelInputStream, "decisionModelDmnXml");
       return DecisionDefinitionDiagramDto.create(decisionDefinitionId, new String(decisionModel, UTF_8));
-
     } catch (NotFoundException e) {
       throw new InvalidRequestException(Status.NOT_FOUND, e, e.getMessage());
-
     } catch (NotValidException e) {
       throw new InvalidRequestException(Status.BAD_REQUEST, e, e.getMessage());
-
     } catch (ProcessEngineException e) {
       throw new RestException(Status.INTERNAL_SERVER_ERROR, e);
-
-    } catch (UnsupportedEncodingException e) {
-      throw new RestException(Status.INTERNAL_SERVER_ERROR, e);
-
     } finally {
       IoUtil.closeSilently(decisionModelInputStream);
     }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/DecisionRequirementsDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/DecisionRequirementsDefinitionResourceImpl.java
@@ -36,6 +36,8 @@ import org.operaton.bpm.engine.rest.exception.RestException;
 import org.operaton.bpm.engine.rest.sub.repository.DecisionRequirementsDefinitionResource;
 import org.operaton.bpm.engine.rest.util.URLEncodingUtil;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * 
  * @author Deivarayan Azhagappan
@@ -81,7 +83,7 @@ public class DecisionRequirementsDefinitionResourceImpl implements DecisionRequi
       decisionRequirementsModelInputStream = engine.getRepositoryService().getDecisionRequirementsModel(decisionRequirementsDefinitionId);
 
       byte[] decisionRequirementsModel = IoUtil.readInputStream(decisionRequirementsModelInputStream, "decisionRequirementsModelDmnXml");
-      return DecisionRequirementsDefinitionXmlDto.create(decisionRequirementsDefinitionId, new String(decisionRequirementsModel, "UTF-8"));
+      return DecisionRequirementsDefinitionXmlDto.create(decisionRequirementsDefinitionId, new String(decisionRequirementsModel, UTF_8));
 
     } catch (NotFoundException e) {
       throw new InvalidRequestException(Status.NOT_FOUND, e, e.getMessage());

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/DecisionRequirementsDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/DecisionRequirementsDefinitionResourceImpl.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.rest.sub.repository.impl;
 
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -84,19 +83,12 @@ public class DecisionRequirementsDefinitionResourceImpl implements DecisionRequi
 
       byte[] decisionRequirementsModel = IoUtil.readInputStream(decisionRequirementsModelInputStream, "decisionRequirementsModelDmnXml");
       return DecisionRequirementsDefinitionXmlDto.create(decisionRequirementsDefinitionId, new String(decisionRequirementsModel, UTF_8));
-
     } catch (NotFoundException e) {
       throw new InvalidRequestException(Status.NOT_FOUND, e, e.getMessage());
-
     } catch (NotValidException e) {
       throw new InvalidRequestException(Status.BAD_REQUEST, e, e.getMessage());
-
     } catch (ProcessEngineException e) {
       throw new RestException(Status.INTERNAL_SERVER_ERROR, e);
-
-    } catch (UnsupportedEncodingException e) {
-      throw new RestException(Status.INTERNAL_SERVER_ERROR, e);
-
     } finally {
       IoUtil.closeSilently(decisionRequirementsModelInputStream);
     }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/ProcessDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/ProcessDefinitionResourceImpl.java
@@ -73,7 +73,6 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -267,8 +266,6 @@ public class ProcessDefinitionResourceImpl implements ProcessDefinitionResource 
       throw e;
     } catch (NotFoundException e) {
       throw new InvalidRequestException(Status.NOT_FOUND, e, "No matching definition with id " + processDefinitionId);
-    } catch (UnsupportedEncodingException e) {
-      throw new RestException(Status.INTERNAL_SERVER_ERROR, e);
     } finally {
       IoUtil.closeSilently(processModelIn);
     }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/ProcessDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/ProcessDefinitionResourceImpl.java
@@ -80,6 +80,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class ProcessDefinitionResourceImpl implements ProcessDefinitionResource {
 
   protected ProcessEngine engine;
@@ -260,7 +262,7 @@ public class ProcessDefinitionResourceImpl implements ProcessDefinitionResource 
     try {
       processModelIn = engine.getRepositoryService().getProcessModel(processDefinitionId);
       byte[] processModel = IoUtil.readInputStream(processModelIn, "processModelBpmn20Xml");
-      return ProcessDefinitionDiagramDto.create(processDefinitionId, new String(processModel, "UTF-8"));
+      return ProcessDefinitionDiagramDto.create(processDefinitionId, new String(processModel, UTF_8));
     } catch (AuthorizationException e) {
       throw e;
     } catch (NotFoundException e) {

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/EncodingUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/EncodingUtil.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.rest.util;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author: Johannes Heinemann
@@ -28,7 +29,7 @@ public class EncodingUtil {
   protected static Charset getDefaultEncoding() {
     Charset charset = null;
     try {
-      charset = Charset.forName("UTF-8");
+      charset = StandardCharsets.UTF_8;
     }catch (Exception e){
       charset = Charset.defaultCharset();
     }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/AbstractRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/AbstractRestServiceTest.java
@@ -48,6 +48,8 @@ import org.junit.Before;
 import io.restassured.RestAssured;
 import io.restassured.http.Header;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public abstract class AbstractRestServiceTest {
 
   protected static ProcessEngine processEngine;
@@ -58,7 +60,7 @@ public abstract class AbstractRestServiceTest {
   protected static final Header ACCEPT_JSON_HEADER = new Header("Accept", MediaType.APPLICATION_JSON);
   protected static final Header ACCEPT_HAL_HEADER = new Header("Accept", Hal.APPLICATION_HAL_JSON);
 
-  protected static final String POST_JSON_CONTENT_TYPE = ContentType.create(MediaType.APPLICATION_JSON, "UTF-8").toString();
+  protected static final String POST_JSON_CONTENT_TYPE = ContentType.create(MediaType.APPLICATION_JSON, UTF_8).toString();
   protected static final String XHTML_XML_CONTENT_TYPE = ContentType.create(MediaType.APPLICATION_XHTML_XML).toString();
 
   protected static final String EMPTY_JSON_OBJECT = "{}";

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseExecutionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseExecutionRestServiceInteractionTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.util.DateTimeUtils.DATE_FORMAT_WITH_TIMEZONE;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -1562,7 +1563,7 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
     String variableKey = "aVariableKey";
     final byte[] byteContent = "some bytes".getBytes();
     String filename = "test.txt";
-    String encoding = "UTF-8";
+    String encoding = UTF_8.name();
     FileValue variableValue = Variables.fileValue(filename).file(byteContent).mimeType(ContentType.TEXT.toString()).encoding(encoding).create();
 
     when(caseServiceMock.getVariableTyped(eq(MockProvider.EXAMPLE_CASE_INSTANCE_ID), eq(variableKey), anyBoolean()))
@@ -2933,7 +2934,7 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
 
     byte[] value = "some text".getBytes();
     String variableKey = "aVariableKey";
-    String encoding = "utf-8";
+    String encoding = UTF_8.name();
     String filename = "test.txt";
     String mimetype = MediaType.TEXT_PLAIN;
 
@@ -2992,7 +2993,7 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
 
     byte[] value = "some text".getBytes();
     String variableKey = "aVariableKey";
-    String encoding = "utf-8";
+    String encoding = UTF_8.name();
     String filename = "test.txt";
 
     given()
@@ -3039,7 +3040,7 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
 
     byte[] value = "some text".getBytes();
     String variableKey = "aVariableKey";
-    String encoding = "utf-8";
+    String encoding = UTF_8.name();
     String filename = "test.txt";
     String mimetype = MediaType.TEXT_PLAIN;
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseInstanceRestServiceInteractionTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_TASK_ID;
 import static org.operaton.bpm.engine.rest.util.DateTimeUtils.DATE_FORMAT_WITH_TIMEZONE;
@@ -656,7 +657,7 @@ public class CaseInstanceRestServiceInteractionTest extends AbstractRestServiceT
     String variableKey = "aVariableKey";
     final byte[] byteContent = "some bytes".getBytes();
     String filename = "test.txt";
-    String encoding = "UTF-8";
+    String encoding = UTF_8.name();
     FileValue variableValue = Variables.fileValue(filename).file(byteContent).mimeType(ContentType.TEXT.toString()).encoding(encoding).create();
 
     when(caseServiceMock.getVariableTyped(eq(MockProvider.EXAMPLE_CASE_INSTANCE_ID), eq(variableKey), anyBoolean()))
@@ -1114,7 +1115,7 @@ public class CaseInstanceRestServiceInteractionTest extends AbstractRestServiceT
   public void testPostSingleFileVariableWithEncodingAndMimeType() {
     byte[] value = "some text".getBytes();
     String variableKey = "aVariableKey";
-    String encoding = "utf-8";
+    String encoding = UTF_8.name();
     String filename = "test.txt";
     String mimetype = MediaType.TEXT_PLAIN;
 
@@ -1170,7 +1171,7 @@ public class CaseInstanceRestServiceInteractionTest extends AbstractRestServiceT
 
     byte[] value = "some text".getBytes();
     String variableKey = "aVariableKey";
-    String encoding = "utf-8";
+    String encoding = UTF_8.name();
     String filename = "test.txt";
 
     given()

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExecutionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExecutionRestServiceInteractionTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_TASK_ID;
 import static org.operaton.bpm.engine.rest.util.DateTimeUtils.DATE_FORMAT_WITH_TIMEZONE;
@@ -732,7 +733,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     String variableKey = "aVariableKey";
     final byte[] byteContent = "some bytes".getBytes();
     String filename = "test.txt";
-    String encoding = "UTF-8";
+    String encoding = UTF_8.name();
     FileValue variableValue = Variables.fileValue(filename).file(byteContent).mimeType(ContentType.TEXT.toString()).encoding(encoding).create();
 
     when(runtimeServiceMock.getVariableLocalTyped(eq(MockProvider.EXAMPLE_EXECUTION_ID), eq(variableKey), anyBoolean())).thenReturn(variableValue);
@@ -1386,7 +1387,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
 
     byte[] value = "some text".getBytes();
     String variableKey = "aVariableKey";
-    String encoding = "utf-8";
+    String encoding = UTF_8.name();
     String filename = "test.txt";
     String mimetype = MediaType.TEXT_PLAIN;
 
@@ -1443,7 +1444,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
 
     byte[] value = "some text".getBytes();
     String variableKey = "aVariableKey";
-    String encoding = "utf-8";
+    String encoding = UTF_8.name();
     String filename = "test.txt";
 
     given()

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessEngineRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessEngineRestServiceTest.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.expect;
 import static io.restassured.RestAssured.given;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItems;
@@ -661,7 +662,7 @@ public class ProcessEngineRestServiceTest extends
     HistoricVariableInstance instance = mock(HistoricVariableInstance.class);
     String filename = "test.txt";
     byte[] byteContent = "test".getBytes();
-    String encoding = "UTF-8";
+    String encoding = UTF_8.name();
     FileValue variableValue = Variables.fileValue(filename).file(byteContent).mimeType(ContentType.TEXT.toString()).encoding(encoding).create();
     when(instance.getTypedValue()).thenReturn(variableValue);
     when(query.singleResult()).thenReturn(instance);
@@ -735,7 +736,7 @@ public class ProcessEngineRestServiceTest extends
     HistoricVariableUpdate instance = mock(HistoricVariableUpdate.class);
     String filename = "test.txt";
     byte[] byteContent = "test".getBytes();
-    String encoding = "UTF-8";
+    String encoding = UTF_8.name();
     FileValue variableValue = Variables.fileValue(filename).file(byteContent).mimeType(ContentType.TEXT.toString()).encoding(encoding).create();
     when(instance.getTypedValue()).thenReturn(variableValue);
     when(query.singleResult()).thenReturn(instance);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_TASK_ID;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.createMockBatch;
@@ -909,7 +910,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
     String variableKey = "aVariableKey";
     final byte[] byteContent = "some bytes".getBytes();
     String filename = "test.txt";
-    String encoding = "UTF-8";
+    String encoding = UTF_8.name();
     FileValue variableValue = Variables.fileValue(filename).file(byteContent).mimeType(ContentType.TEXT.toString()).encoding(encoding).create();
 
     when(runtimeServiceMock.getVariableTyped(eq(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID), eq(variableKey), anyBoolean()))
@@ -2074,7 +2075,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
 
     byte[] value = "some text".getBytes();
     String variableKey = "aVariableKey";
-    String encoding = "utf-8";
+    String encoding = UTF_8.name();
     String filename = "test.txt";
     String mimetype = MediaType.TEXT_PLAIN;
 
@@ -2131,7 +2132,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
 
     byte[] value = "some text".getBytes();
     String variableKey = "aVariableKey";
-    String encoding = "utf-8";
+    String encoding = UTF_8.name();
     String filename = "test.txt";
 
     given()

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableLocalRestResourceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableLocalRestResourceInteractionTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_TASK_ID;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.NON_EXISTING_ID;
@@ -549,7 +550,7 @@ public class TaskVariableLocalRestResourceInteractionTest extends
     String variableKey = "aVariableKey";
     final byte[] byteContent = "some bytes".getBytes();
     String filename = "test.txt";
-    String encoding = "UTF-8";
+    String encoding = UTF_8.name();
     FileValue variableValue = Variables.fileValue(filename).file(byteContent).mimeType(ContentType.TEXT.toString()).encoding(encoding).create();
 
     when(taskServiceMock.getVariableLocalTyped(eq(EXAMPLE_TASK_ID), eq(variableKey), anyBoolean())).thenReturn(variableValue);
@@ -1030,7 +1031,7 @@ public class TaskVariableLocalRestResourceInteractionTest extends
 
     byte[] value = "some text".getBytes();
     String variableKey = "aVariableKey";
-    String encoding = "utf-8";
+    String encoding = UTF_8.name();
     String filename = "test.txt";
     String mimetype = MediaType.TEXT_PLAIN;
 
@@ -1088,7 +1089,7 @@ public class TaskVariableLocalRestResourceInteractionTest extends
 
     byte[] value = "some text".getBytes();
     String variableKey = "aVariableKey";
-    String encoding = "utf-8";
+    String encoding = UTF_8.name();
     String filename = "test.txt";
 
     given()

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableRestResourceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableRestResourceInteractionTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_TASK_ID;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.NON_EXISTING_ID;
@@ -573,7 +574,7 @@ public class TaskVariableRestResourceInteractionTest extends
     String variableKey = "aVariableKey";
     final byte[] byteContent = "some bytes".getBytes();
     String filename = "test.txt";
-    String encoding = "UTF-8";
+    String encoding = UTF_8.name();
     FileValue variableValue = Variables.fileValue(filename).file(byteContent).mimeType(ContentType.TEXT.toString()).encoding(encoding).create();
 
     when(taskServiceMock.getVariableTyped(eq(EXAMPLE_TASK_ID), eq(variableKey), anyBoolean())).thenReturn(variableValue);
@@ -1055,7 +1056,7 @@ public class TaskVariableRestResourceInteractionTest extends
 
     byte[] value = "some text".getBytes();
     String variableKey = "aVariableKey";
-    String encoding = "utf-8";
+    String encoding = UTF_8.name();
     String filename = "test.txt";
     String mimetype = MediaType.TEXT_PLAIN;
 
@@ -1113,7 +1114,7 @@ public class TaskVariableRestResourceInteractionTest extends
 
     byte[] value = "some text".getBytes();
     String variableKey = "aVariableKey";
-    String encoding = "utf-8";
+    String encoding = UTF_8.name();
     String filename = "test.txt";
 
     given()

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/VariableInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/VariableInstanceRestServiceInteractionTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -295,7 +296,7 @@ public class VariableInstanceRestServiceInteractionTest extends AbstractRestServ
   public void testGetBinaryDataForFileVariable() {
     String filename = "test.txt";
     byte[] byteContent = "test".getBytes();
-    String encoding = "UTF-8";
+    String encoding = UTF_8.name();
     FileValue variableValue = Variables.fileValue(filename).file(byteContent).mimeType(ContentType.TEXT.toString()).encoding(encoding).create();
 
     MockVariableInstanceBuilder builder = MockProvider.mockVariableInstance();

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDetailRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDetailRestServiceInteractionTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.rest.history;
 
 import static io.restassured.RestAssured.given;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -293,7 +294,7 @@ public class HistoricDetailRestServiceInteractionTest extends AbstractRestServic
   public void testBinaryDataForFileVariable() {
     String filename = "test.txt";
     byte[] byteContent = "test".getBytes();
-    String encoding = "UTF-8";
+    String encoding = UTF_8.name();
     FileValue variableValue = Variables.fileValue(filename).file(byteContent).mimeType(ContentType.TEXT.toString()).encoding(encoding).create();
 
     MockHistoricVariableUpdateBuilder builder = MockProvider.mockHistoricVariableUpdate();

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricVariableInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricVariableInstanceRestServiceInteractionTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.rest.history;
 
 import static io.restassured.RestAssured.given;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsString;
@@ -276,7 +277,7 @@ public class HistoricVariableInstanceRestServiceInteractionTest extends Abstract
   public void testGetBinaryDataForFileVariable() {
     String filename = "test.txt";
     byte[] byteContent = "test".getBytes();
-    String encoding = "UTF-8";
+    String encoding = UTF_8.name();
     FileValue variableValue = Variables.fileValue(filename).file(byteContent).mimeType(ContentType.TEXT.toString()).encoding(encoding).create();
     HistoricVariableInstance variableInstanceMock = MockProvider.mockHistoricVariableInstance().typedValue(variableValue).build();
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/AbstractEmptyBodyFilterTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/AbstractEmptyBodyFilterTest.java
@@ -40,7 +40,9 @@ import org.junit.Test;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
@@ -101,7 +103,7 @@ public abstract class AbstractEmptyBodyFilterTest extends AbstractRestServiceTes
 
   @Test
   public void testBodyIsEmpty() throws IOException {
-    evaluatePostRequest(new ByteArrayEntity("".getBytes("UTF-8")), ContentType.create(MediaType.APPLICATION_JSON).toString(), 200, true);
+    evaluatePostRequest(new ByteArrayEntity("".getBytes(UTF_8)), ContentType.create(MediaType.APPLICATION_JSON).toString(), 200, true);
   }
 
   @Test
@@ -116,12 +118,12 @@ public abstract class AbstractEmptyBodyFilterTest extends AbstractRestServiceTes
 
   @Test
   public void testBodyIsNullAndContentTypeHasISOCharset() throws IOException {
-    evaluatePostRequest(null, ContentType.create(MediaType.APPLICATION_JSON, "iso-8859-1").toString(), 200, true);
+    evaluatePostRequest(null, ContentType.create(MediaType.APPLICATION_JSON, StandardCharsets.ISO_8859_1).toString(), 200, true);
   }
 
   @Test
   public void testBodyIsEmptyJSONObject() throws IOException {
-    evaluatePostRequest(new ByteArrayEntity(EMPTY_JSON_OBJECT.getBytes("UTF-8")), ContentType.create(MediaType.APPLICATION_JSON).toString(), 200, true);
+    evaluatePostRequest(new ByteArrayEntity(EMPTY_JSON_OBJECT.getBytes(UTF_8)), ContentType.create(MediaType.APPLICATION_JSON).toString(), 200, true);
   }
 
   private void evaluatePostRequest(HttpEntity reqBody, String reqContentType, int expectedStatusCode, boolean assertResponseBody) throws IOException {
@@ -139,7 +141,7 @@ public abstract class AbstractEmptyBodyFilterTest extends AbstractRestServiceTes
     assertEquals(expectedStatusCode, response.getStatusLine().getStatusCode());
 
     if(assertResponseBody) {
-      assertThat(EntityUtils.toString(response.getEntity(), "UTF-8")).contains(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID);
+      assertThat(EntityUtils.toString(response.getEntity(), UTF_8)).contains(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID);
     }
 
     response.close();

--- a/engine/src/main/java/org/operaton/bpm/container/impl/ContainerIntegrationLogger.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/ContainerIntegrationLogger.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.container.impl;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -64,7 +63,7 @@ public class ContainerIntegrationLogger extends ProcessEngineLogger {
         urlPath);
   }
 
-  public ProcessEngineException cannotDecodePathName(UnsupportedEncodingException e) {
+  public ProcessEngineException cannotDecodePathName(IllegalArgumentException e) {
     return new ProcessEngineException(exceptionMessage(
         "005",
         "Could not decode pathname using utf-8 decoder."), e);

--- a/engine/src/main/java/org/operaton/bpm/container/impl/deployment/scanning/ClassPathProcessApplicationScanner.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/deployment/scanning/ClassPathProcessApplicationScanner.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -129,7 +130,7 @@ public class ClassPathProcessApplicationScanner implements ProcessApplicationSca
     }
 
     try {
-      urlPath = URLDecoder.decode(urlPath, "UTF-8");
+      urlPath = URLDecoder.decode(urlPath, StandardCharsets.UTF_8);
     }
     catch (UnsupportedEncodingException e) {
       throw LOG.cannotDecodePathName(e);

--- a/engine/src/main/java/org/operaton/bpm/container/impl/deployment/scanning/ClassPathProcessApplicationScanner.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/deployment/scanning/ClassPathProcessApplicationScanner.java
@@ -20,10 +20,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,6 +32,8 @@ import org.operaton.bpm.container.impl.ContainerIntegrationLogger;
 import org.operaton.bpm.container.impl.deployment.scanning.spi.ProcessApplicationScanner;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.util.IoUtil;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * <p>Scans for bpmn20.xml files in the classpath of the given classloader.</p>
@@ -130,9 +130,9 @@ public class ClassPathProcessApplicationScanner implements ProcessApplicationSca
     }
 
     try {
-      urlPath = URLDecoder.decode(urlPath, StandardCharsets.UTF_8);
+      urlPath = URLDecoder.decode(urlPath, UTF_8);
     }
-    catch (UnsupportedEncodingException e) {
+    catch (IllegalArgumentException e) {
       throw LOG.cannotDecodePathName(e);
     }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ShellActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ShellActivityBehavior.java
@@ -24,6 +24,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,8 @@ import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.Expression;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class ShellActivityBehavior extends AbstractBpmnActivityBehavior {
 
@@ -144,7 +147,7 @@ public class ShellActivityBehavior extends AbstractBpmnActivityBehavior {
 
       char[] buffer = new char[1024];
       try {
-        Reader reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+        Reader reader = new BufferedReader(new InputStreamReader(is, UTF_8));
         int n;
         while ((n = reader.read(buffer)) != -1) {
           writer.write(buffer, 0, n);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ShellActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ShellActivityBehavior.java
@@ -24,7 +24,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.impl.cfg;
 
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.operaton.bpm.engine.impl.cmd.HistoryCleanupCmd.MAX_THREADS_NUMBER;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
@@ -2504,7 +2505,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected void initDefaultCharset() {
     if (defaultCharset == null) {
       if (defaultCharsetName == null) {
-        defaultCharsetName = "UTF-8";
+        defaultCharsetName = UTF_8.name();
       }
       defaultCharset = Charset.forName(defaultCharsetName);
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/digest/Base64EncodedHashDigest.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/digest/Base64EncodedHashDigest.java
@@ -23,6 +23,8 @@ import java.security.NoSuchAlgorithmException;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.digest._apacheCommonsCodec.Base64;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * @author Daniel Meyer
  *
@@ -46,7 +48,7 @@ public abstract class Base64EncodedHashDigest {
   protected byte[] createByteHash(String password) {
     MessageDigest digest = createDigestInstance();
     try {
-      digest.update(password.getBytes("UTF-8"));
+      digest.update(password.getBytes(UTF_8));
       return digest.digest();
 
     } catch (UnsupportedEncodingException e) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/digest/Base64EncodedHashDigest.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/digest/Base64EncodedHashDigest.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.digest;
 
-import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -47,13 +46,8 @@ public abstract class Base64EncodedHashDigest {
 
   protected byte[] createByteHash(String password) {
     MessageDigest digest = createDigestInstance();
-    try {
-      digest.update(password.getBytes(UTF_8));
-      return digest.digest();
-
-    } catch (UnsupportedEncodingException e) {
-      throw new ProcessEngineException("UnsupportedEncodingException while calculating password digest");
-    }
+    digest.update(password.getBytes(UTF_8));
+    return digest.digest();
   }
 
   protected MessageDigest createDigestInstance() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/digest/_apacheCommonsCodec/StringUtils.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/digest/_apacheCommonsCodec/StringUtils.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.impl.digest._apacheCommonsCodec;
 
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Converts String to and from bytes using the encodings required by the Java specification. These encodings are specified in <a
@@ -30,7 +31,7 @@ import java.io.UnsupportedEncodingException;
  */
 public class StringUtils {
 
-    public static final String UTF_8 = "UTF-8";
+    public static final String UTF_8 = StandardCharsets.UTF_8.name();
 
     /**
      * Constructs a new <code>String</code> by decoding the specified array of bytes using the given charset.

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/form/engine/JuelFormEngine.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/form/engine/JuelFormEngine.java
@@ -19,8 +19,6 @@ package org.operaton.bpm.engine.impl.form.engine;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
-import java.io.UnsupportedEncodingException;
-
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.delegate.VariableScope;
 import org.operaton.bpm.engine.form.FormData;
@@ -93,12 +91,6 @@ public class JuelFormEngine implements FormEngine {
     ensureNotNull("Form with formKey '" + formKey + "' does not exist", "resourceStream", resourceStream);
 
     byte[] resourceBytes = resourceStream.getBytes();
-    String formTemplateString = "";
-    try {
-      formTemplateString = new String(resourceBytes, UTF_8);
-    } catch (UnsupportedEncodingException e) {
-      throw new ProcessEngineException("Unsupported encoding of :" + UTF_8, e);
-    }
-    return formTemplateString;
+    return new String(resourceBytes, UTF_8);
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/form/engine/JuelFormEngine.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/form/engine/JuelFormEngine.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.form.engine;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 import java.io.UnsupportedEncodingException;
@@ -92,12 +93,11 @@ public class JuelFormEngine implements FormEngine {
     ensureNotNull("Form with formKey '" + formKey + "' does not exist", "resourceStream", resourceStream);
 
     byte[] resourceBytes = resourceStream.getBytes();
-    String encoding = "UTF-8";
     String formTemplateString = "";
     try {
-      formTemplateString = new String(resourceBytes, encoding);
+      formTemplateString = new String(resourceBytes, UTF_8);
     } catch (UnsupportedEncodingException e) {
-      throw new ProcessEngineException("Unsupported encoding of :" + encoding, e);
+      throw new ProcessEngineException("Unsupported encoding of :" + UTF_8, e);
     }
     return formTemplateString;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/IoUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/IoUtil.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.Charset;
-
+import java.nio.charset.StandardCharsets;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 
@@ -88,7 +88,7 @@ public class IoUtil {
       IoUtil.closeSilently(inputStream);
       IoUtil.closeSilently(outStream);
     }
-    return new String(result, Charset.forName("UTF-8"));
+    return new String(result, StandardCharsets.UTF_8);
   }
 
   public static File getFile(String filePath) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/IoUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/IoUtil.java
@@ -26,8 +26,8 @@ import java.io.Flushable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ResourceUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ResourceUtil.java
@@ -18,7 +18,7 @@ package org.operaton.bpm.engine.impl.util;
 
 import java.io.InputStream;
 import java.nio.charset.Charset;
-
+import java.nio.charset.StandardCharsets;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.persistence.entity.DeploymentEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.ResourceEntity;
@@ -72,7 +72,7 @@ public final class ResourceUtil {
     }
 
     if (resourceBytes != null) {
-      return new String(resourceBytes, Charset.forName("UTF-8"));
+      return new String(resourceBytes, StandardCharsets.UTF_8);
     }
     else {
       throw LOG.cannotFindResource(resourcePath);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ResourceUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ResourceUtil.java
@@ -17,8 +17,8 @@
 package org.operaton.bpm.engine.impl.util;
 
 import java.io.InputStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.persistence.entity.DeploymentEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.ResourceEntity;

--- a/engine/src/test/java/org/operaton/bpm/container/impl/jmx/deployment/BpmPlatformXmlLocationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/jmx/deployment/BpmPlatformXmlLocationTest.java
@@ -16,29 +16,28 @@
  */
 package org.operaton.bpm.container.impl.jmx.deployment;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.operaton.bpm.container.impl.deployment.AbstractParseBpmPlatformXmlStep.BPM_PLATFORM_XML_FILE;
-import static org.operaton.bpm.container.impl.deployment.AbstractParseBpmPlatformXmlStep.BPM_PLATFORM_XML_LOCATION;
-import static org.operaton.bpm.container.impl.deployment.AbstractParseBpmPlatformXmlStep.BPM_PLATFORM_XML_SYSTEM_PROPERTY;
-import static org.operaton.bpm.container.impl.tomcat.deployment.TomcatParseBpmPlatformXmlStep.CATALINA_HOME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
-import java.io.File;
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLDecoder;
-
-import org.operaton.bpm.container.impl.tomcat.deployment.TomcatParseBpmPlatformXmlStep;
 import org.junit.Rule;
 import org.junit.Test;
+import org.operaton.bpm.container.impl.tomcat.deployment.TomcatParseBpmPlatformXmlStep;
 import org.springframework.mock.jndi.SimpleNamingContext;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.operaton.bpm.container.impl.deployment.AbstractParseBpmPlatformXmlStep.BPM_PLATFORM_XML_FILE;
+import static org.operaton.bpm.container.impl.deployment.AbstractParseBpmPlatformXmlStep.BPM_PLATFORM_XML_LOCATION;
+import static org.operaton.bpm.container.impl.deployment.AbstractParseBpmPlatformXmlStep.BPM_PLATFORM_XML_SYSTEM_PROPERTY;
+import static org.operaton.bpm.container.impl.tomcat.deployment.TomcatParseBpmPlatformXmlStep.CATALINA_HOME;
 
 /**
  * Checks the correct retrieval of bpm-platform.xml file through JNDI,

--- a/engine/src/test/java/org/operaton/bpm/container/impl/jmx/deployment/BpmPlatformXmlLocationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/jmx/deployment/BpmPlatformXmlLocationTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.container.impl.jmx.deployment;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.operaton.bpm.container.impl.deployment.AbstractParseBpmPlatformXmlStep.BPM_PLATFORM_XML_FILE;
 import static org.operaton.bpm.container.impl.deployment.AbstractParseBpmPlatformXmlStep.BPM_PLATFORM_XML_LOCATION;
 import static org.operaton.bpm.container.impl.deployment.AbstractParseBpmPlatformXmlStep.BPM_PLATFORM_XML_SYSTEM_PROPERTY;
@@ -196,8 +197,8 @@ public class BpmPlatformXmlLocationTest {
     String baseDir = BpmPlatformXmlLocationTest.class.getProtectionDomain().getCodeSource().getLocation().getFile();
     try {
       // replace escaped whitespaces in path
-      baseDir = URLDecoder.decode(baseDir, "UTF-8");
-    } catch (UnsupportedEncodingException e) {
+      baseDir = URLDecoder.decode(baseDir, UTF_8);
+    } catch (IllegalArgumentException | NullPointerException e) {
       e.printStackTrace();
     }
     return baseDir

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
@@ -16,17 +16,6 @@
  */
 package org.operaton.bpm.engine.test.api.repository;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -40,7 +29,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import org.assertj.core.groups.Tuple;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.EntityTypes;
 import org.operaton.bpm.engine.ProcessEngine;
@@ -90,11 +85,17 @@ import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.operaton.bpm.engine.test.util.TestExecutionListener;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Frederik Heremans
@@ -563,7 +564,7 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/repository/one.cmmn" })
   @Test
-  public void testGetCaseModel() throws Exception {
+  public void testGetCaseModel() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
     CaseDefinition caseDefinition = query.singleResult();
@@ -661,7 +662,7 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/repository/one.dmn" })
   @Test
-  public void testGetDecisionModel() throws Exception {
+  public void testGetDecisionModel() {
     DecisionDefinitionQuery query = repositoryService.createDecisionDefinitionQuery();
 
     DecisionDefinition decisionDefinition = query.singleResult();
@@ -697,7 +698,7 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/repository/drg.dmn" })
   @Test
-  public void testGetDecisionRequirementsModel() throws Exception {
+  public void testGetDecisionRequirementsModel() {
     DecisionRequirementsDefinitionQuery query = repositoryService.createDecisionRequirementsDefinitionQuery();
 
     DecisionRequirementsDefinition decisionRequirementsDefinition = query.singleResult();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -135,7 +136,7 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
   @Test
   public void testUTF8DeploymentMethod() throws IOException {
     //given utf8 charset
-    Charset utf8Charset = Charset.forName("UTF-8");
+    Charset utf8Charset = StandardCharsets.UTF_8;
     Charset defaultCharset = processEngineConfiguration.getDefaultCharset();
     processEngineConfiguration.setDefaultCharset(utf8Charset);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.repository;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
@@ -573,7 +574,7 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
     assertNotNull(caseModel);
 
     byte[] readInputStream = IoUtil.readInputStream(caseModel, "caseModel");
-    String model = new String(readInputStream, "UTF-8");
+    String model = new String(readInputStream, UTF_8);
 
     assertTrue(model.contains("<case id=\"one\" name=\"One\">"));
 
@@ -671,7 +672,7 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
     assertNotNull(decisionModel);
 
     byte[] readInputStream = IoUtil.readInputStream(decisionModel, "decisionModel");
-    String model = new String(readInputStream, "UTF-8");
+    String model = new String(readInputStream, UTF_8);
 
     assertTrue(model.contains("<decision id=\"one\" name=\"One\">"));
 
@@ -707,7 +708,7 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
     assertNotNull(decisionRequirementsModel);
 
     byte[] readInputStream = IoUtil.readInputStream(decisionRequirementsModel, "decisionRequirementsModel");
-    String model = new String(readInputStream, "UTF-8");
+    String model = new String(readInputStream, UTF_8);
 
     assertTrue(model.contains("<definitions id=\"dish\" name=\"Dish\" namespace=\"test-drg\""));
     IoUtil.closeSilently(decisionRequirementsModel);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/variables/FileValueProcessSerializationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/variables/FileValueProcessSerializationTest.java
@@ -16,12 +16,11 @@
  */
 package org.operaton.bpm.engine.test.api.variables;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 import org.operaton.bpm.engine.runtime.ProcessInstance;
@@ -51,7 +50,7 @@ public class FileValueProcessSerializationTest extends PluggableProcessEngineTes
     VariableMap variables = Variables.createVariables();
     String filename = "test.txt";
     String type = "text/plain";
-    FileValue fileValue = Variables.fileValue(filename).file("ABC".getBytes()).encoding("UTF-8").mimeType(type).create();
+    FileValue fileValue = Variables.fileValue(filename).file("ABC".getBytes()).encoding(UTF_8.name()).mimeType(type).create();
     variables.put("file", fileValue);
     runtimeService.startProcessInstanceByKey("process", variables);
     Task task = taskService.createTaskQuery().singleResult();
@@ -60,8 +59,8 @@ public class FileValueProcessSerializationTest extends PluggableProcessEngineTes
 
     assertThat(value.getFilename()).isEqualTo(filename);
     assertThat(value.getMimeType()).isEqualTo(type);
-    assertThat(value.getEncoding()).isEqualTo("UTF-8");
-    assertThat(value.getEncodingAsCharset()).isEqualTo(StandardCharsets.UTF_8);
+    assertThat(value.getEncoding()).isEqualTo(UTF_8.name());
+    assertThat(value.getEncodingAsCharset()).isEqualTo(UTF_8);
     try (Scanner scanner = new Scanner(value.getValue())) {
       assertThat(scanner.nextLine()).isEqualTo("ABC");
     }
@@ -74,7 +73,7 @@ public class FileValueProcessSerializationTest extends PluggableProcessEngineTes
   @Deployment(resources = ONE_TASK_PROCESS)
   public void testSerializeNullMimeType() {
     ProcessInstance pi = runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Variables.createVariables().putValue("fileVar", Variables.fileValue("test.txt").file("ABC".getBytes()).encoding("UTF-8").create()));
+        Variables.createVariables().putValue("fileVar", Variables.fileValue("test.txt").file("ABC".getBytes()).encoding(UTF_8.name()).create()));
 
     FileValue fileVar = runtimeService.getVariableTyped(pi.getId(), "fileVar");
     assertNull(fileVar.getMimeType());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/variables/FileValueProcessSerializationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/variables/FileValueProcessSerializationTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 import org.operaton.bpm.engine.runtime.ProcessInstance;
@@ -60,7 +61,7 @@ public class FileValueProcessSerializationTest extends PluggableProcessEngineTes
     assertThat(value.getFilename()).isEqualTo(filename);
     assertThat(value.getMimeType()).isEqualTo(type);
     assertThat(value.getEncoding()).isEqualTo("UTF-8");
-    assertThat(value.getEncodingAsCharset()).isEqualTo(Charset.forName("UTF-8"));
+    assertThat(value.getEncodingAsCharset()).isEqualTo(StandardCharsets.UTF_8);
     try (Scanner scanner = new Scanner(value.getValue())) {
       assertThat(scanner.nextLine()).isEqualTo("ABC");
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/variables/FileValueSerializerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/variables/FileValueSerializerTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.test.standalone.variables;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.DataInputStream;
@@ -107,7 +108,7 @@ public class FileValueSerializerTest {
 
     serializer.writeValue(fileValue, valueFields);
 
-    assertThat(new String(valueFields.getByteArrayValue(), "UTF-8")).isEqualTo("text");
+    assertThat(new String(valueFields.getByteArrayValue(), UTF_8)).isEqualTo("text");
     assertThat(valueFields.getTextValue()).isEqualTo(filename);
     assertThat(valueFields.getTextValue2()).isEqualTo(mimeType + SEPARATOR);
   }
@@ -116,14 +117,14 @@ public class FileValueSerializerTest {
   public void testWriteMimetypeFilenameBytesValueAndEncoding() throws UnsupportedEncodingException {
     String filename = "test.txt";
     String mimeType = "text/json";
-    Charset encoding = StandardCharsets.UTF_8;
+    Charset encoding = UTF_8;
     InputStream is = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/standalone/variables/simpleFile.txt");
     FileValue fileValue = Variables.fileValue(filename).mimeType(mimeType).encoding(encoding).file(is).create();
     ValueFields valueFields = new MockValueFields();
 
     serializer.writeValue(fileValue, valueFields);
 
-    assertThat(new String(valueFields.getByteArrayValue(), "UTF-8")).isEqualTo("text");
+    assertThat(new String(valueFields.getByteArrayValue(), UTF_8)).isEqualTo("text");
     assertThat(valueFields.getTextValue()).isEqualTo(filename);
     assertThat(valueFields.getTextValue2()).isEqualTo(mimeType + SEPARATOR + encoding.name());
   }
@@ -136,7 +137,7 @@ public class FileValueSerializerTest {
 
     serializer.writeValue(fileValue, valueFields);
 
-    assertThat(new String(valueFields.getByteArrayValue(), "UTF-8")).isEqualTo("text");
+    assertThat(new String(valueFields.getByteArrayValue(), UTF_8)).isEqualTo("text");
     assertThat(valueFields.getTextValue()).isEqualTo("simpleFile.txt");
     assertThat(valueFields.getTextValue2()).isEqualTo("text/plain" + SEPARATOR);
   }
@@ -178,14 +179,14 @@ public class FileValueSerializerTest {
     String filename = "file.txt";
     valueFields.setTextValue(filename);
     valueFields.setByteArrayValue(data);
-    String encoding = SEPARATOR + "UTF-8";
+    String encoding = SEPARATOR + UTF_8;
     valueFields.setTextValue2(encoding);
 
     FileValue fileValue = serializer.readValue(valueFields, true, false);
 
     assertThat(fileValue.getFilename()).isEqualTo(filename);
-    assertThat(fileValue.getEncoding()).isEqualTo("UTF-8");
-    assertThat(fileValue.getEncodingAsCharset()).isEqualTo(StandardCharsets.UTF_8);
+    assertThat(fileValue.getEncoding()).isEqualTo(UTF_8.name());
+    assertThat(fileValue.getEncodingAsCharset()).isEqualTo(UTF_8);
     checkStreamFromValue(fileValue, "text");
   }
 
@@ -279,7 +280,7 @@ public class FileValueSerializerTest {
   @Test
   public void testWriteFilenameAndEncodingValue() {
     String filename = "test.txt";
-    String encoding = "UTF-8";
+    String encoding = UTF_8.name();
     FileValue fileValue = Variables.fileValue(filename).encoding(encoding).create();
     ValueFields valueFields = new MockValueFields();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/variables/FileValueSerializerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/variables/FileValueSerializerTest.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
 
 import org.operaton.bpm.engine.impl.variable.serializer.FileValueSerializer;
@@ -115,7 +116,7 @@ public class FileValueSerializerTest {
   public void testWriteMimetypeFilenameBytesValueAndEncoding() throws UnsupportedEncodingException {
     String filename = "test.txt";
     String mimeType = "text/json";
-    Charset encoding = Charset.forName("UTF-8");
+    Charset encoding = StandardCharsets.UTF_8;
     InputStream is = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/standalone/variables/simpleFile.txt");
     FileValue fileValue = Variables.fileValue(filename).mimeType(mimeType).encoding(encoding).file(is).create();
     ValueFields valueFields = new MockValueFields();
@@ -184,7 +185,7 @@ public class FileValueSerializerTest {
 
     assertThat(fileValue.getFilename()).isEqualTo(filename);
     assertThat(fileValue.getEncoding()).isEqualTo("UTF-8");
-    assertThat(fileValue.getEncodingAsCharset()).isEqualTo(Charset.forName("UTF-8"));
+    assertThat(fileValue.getEncodingAsCharset()).isEqualTo(StandardCharsets.UTF_8);
     checkStreamFromValue(fileValue, "text");
   }
 
@@ -208,7 +209,7 @@ public class FileValueSerializerTest {
     assertThat(fileValue.getFilename()).isEqualTo(filename);
     assertThat(fileValue.getMimeType()).isEqualTo(mimeType);
     assertThat(fileValue.getEncoding()).isEqualTo("UTF-16");
-    assertThat(fileValue.getEncodingAsCharset()).isEqualTo(Charset.forName("UTF-16"));
+    assertThat(fileValue.getEncodingAsCharset()).isEqualTo(StandardCharsets.UTF_16);
     checkStreamFromValue(fileValue, "text");
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/util/TypedValueAssert.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/util/TypedValueAssert.java
@@ -26,7 +26,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.nio.charset.Charset;
-
+import java.nio.charset.StandardCharsets;
 import org.operaton.bpm.engine.impl.digest._apacheCommonsCodec.Base64;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.type.ValueType;
@@ -76,7 +76,7 @@ public class TypedValueAssert {
     try {
       // validate this is the base 64 encoded string representation of the serialized value of the java object
       String valueSerialized = typedValue.getValueSerialized();
-      byte[] decodedObject = Base64.decodeBase64(valueSerialized.getBytes(Charset.forName("UTF-8")));
+      byte[] decodedObject = Base64.decodeBase64(valueSerialized.getBytes(StandardCharsets.UTF_8));
       ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(decodedObject));
       assertEquals(value, objectInputStream.readObject());
     }

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/IoUtil.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/IoUtil.java
@@ -22,6 +22,8 @@ import javax.xml.transform.*;
 import javax.xml.transform.stream.StreamResult;
 import java.io.*;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * @author Daniel Meyer
  * @author Sebastian Menski
@@ -125,7 +127,7 @@ public final class IoUtil {
     TransformerFactory transformerFactory = TransformerFactory.newInstance();
     try {
       Transformer transformer = transformerFactory.newTransformer();
-      transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+      transformer.setOutputProperty(OutputKeys.ENCODING, UTF_8.name());
       transformer.setOutputProperty(OutputKeys.INDENT, "yes");
       transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/beans/DemoDelegate.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/beans/DemoDelegate.java
@@ -25,6 +25,8 @@ import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.Expression;
 import org.operaton.bpm.engine.delegate.JavaDelegate;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class DemoDelegate implements JavaDelegate {
 
   Logger log = Logger.getLogger(DemoDelegate.class.getName());
@@ -64,9 +66,9 @@ public class DemoDelegate implements JavaDelegate {
     insertVariable("characterObjectArray", characterObjectArray);
     
     String byteString = "mycooltextcontentasbyteyesyes!!!";
-    insertVariable("byteArrayVar", byteString.getBytes("UTF-8"));
+    insertVariable("byteArrayVar", byteString.getBytes(UTF_8));
     Byte[] ByteArray = new Byte[byteString.length()];
-    byte[] bytes = byteString.getBytes("UTF-8");
+    byte[] bytes = byteString.getBytes(UTF_8);
 
     for (int i = 0; i < bytes.length; i++) {
       byte b = bytes[i];

--- a/spin/core/src/main/java/org/operaton/spin/impl/util/SpinIoUtil.java
+++ b/spin/core/src/main/java/org/operaton/spin/impl/util/SpinIoUtil.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 package org.operaton.spin.impl.util;
-
+import java.nio.charset.StandardCharsets;
 import org.operaton.commons.utils.IoUtil;
 import org.operaton.spin.impl.logging.SpinCoreLogger;
 import org.operaton.spin.impl.logging.SpinLogger;
@@ -29,7 +29,7 @@ import java.nio.charset.Charset;
  */
 public class SpinIoUtil extends IoUtil {
 
-  public static final Charset ENCODING_CHARSET = Charset.forName("UTF-8");
+  public static final Charset ENCODING_CHARSET = StandardCharsets.UTF_8;
 
   private static final SpinCoreLogger LOG = SpinLogger.CORE_LOGGER;
 

--- a/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/format/DomXmlDataFormatWriter.java
+++ b/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/format/DomXmlDataFormatWriter.java
@@ -33,6 +33,8 @@ import org.operaton.spin.spi.DataFormatWriter;
 import org.operaton.spin.xml.SpinXmlElementException;
 import org.w3c.dom.Node;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * A writer for XML DOM.
  *
@@ -118,7 +120,7 @@ public class DomXmlDataFormatWriter implements DataFormatWriter {
   protected Transformer getFormattingTransformer() {
     try {
       Transformer transformer = formattingTemplates.newTransformer();
-      transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+      transformer.setOutputProperty(OutputKeys.ENCODING, UTF_8.name());
       transformer.setOutputProperty(OutputKeys.INDENT, "yes");
       transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
       return transformer;
@@ -137,7 +139,7 @@ public class DomXmlDataFormatWriter implements DataFormatWriter {
     TransformerFactory transformerFactory = domXmlDataFormat.getTransformerFactory();
     try {
       Transformer transformer = transformerFactory.newTransformer();
-      transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+      transformer.setOutputProperty(OutputKeys.ENCODING, UTF_8.name());
       return transformer;
     } catch (TransformerConfigurationException e) {
       throw LOG.unableToCreateTransformer(e);

--- a/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/impl/xml/dom/format/DomXmlDataFormatWriterTest.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/impl/xml/dom/format/DomXmlDataFormatWriterTest.java
@@ -25,6 +25,7 @@ import org.operaton.spin.xml.SpinXmlElement;
 
 import java.io.*;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -56,7 +57,7 @@ public class DomXmlDataFormatWriterTest {
   // see https://github.com/operaton/operaton/blob/main/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/impl/SpinValueSerializer.java
   private byte[] serializeValue(SpinXmlElement spinXml) throws UnsupportedEncodingException {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
-    OutputStreamWriter outWriter = new OutputStreamWriter(out, "UTF-8");
+    OutputStreamWriter outWriter = new OutputStreamWriter(out, UTF_8);
     BufferedWriter bufferedWriter = new BufferedWriter(outWriter);
 
     spinXml.writeToWriter(bufferedWriter);
@@ -66,7 +67,7 @@ public class DomXmlDataFormatWriterTest {
   public SpinXmlElement deserializeValue(byte[] serialized, DataFormat<SpinXmlElement> dataFormat)
       throws UnsupportedEncodingException {
     ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
-    InputStreamReader inReader = new InputStreamReader(bais, "UTF-8");
+    InputStreamReader inReader = new InputStreamReader(bais, UTF_8);
     BufferedReader bufferedReader = new BufferedReader(inReader);
 
     Object wrapper = dataFormat.getReader().readInput(bufferedReader);
@@ -104,7 +105,7 @@ public class DomXmlDataFormatWriterTest {
 
     // then
     // assert that there are now new lines in the serialized value:
-    assertThat(new String(serializedValue, "UTF-8")).isEqualTo(getExpectedFormattedXML());
+    assertThat(new String(serializedValue, UTF_8)).isEqualTo(getExpectedFormattedXML());
 
     // when
     // this is what execution.getVariable("test"); does
@@ -130,7 +131,7 @@ public class DomXmlDataFormatWriterTest {
 
     // then
     // assert that there are no new lines in the serialized value:
-    assertThat(new String(serializedValue, "UTF-8")).isEqualTo(getExpectedFormattedXML());
+    assertThat(new String(serializedValue, UTF_8)).isEqualTo(getExpectedFormattedXML());
 
     // when
     // this is what execution.getVariable("test"); does
@@ -156,7 +157,7 @@ public class DomXmlDataFormatWriterTest {
 
     // then
     // assert that xml has not been formatted
-    assertThat(new String(serializedValue, "UTF-8")).isEqualTo(xml);
+    assertThat(new String(serializedValue, UTF_8)).isEqualTo(xml);
 
     // when
     // this is what execution.getVariable("test"); does
@@ -189,7 +190,7 @@ public class DomXmlDataFormatWriterTest {
 
     // then
     // assert that xml has not been formatted
-    assertThat(new String(serializedValue, "UTF-8")).isEqualTo(expectedXml);
+    assertThat(new String(serializedValue, UTF_8)).isEqualTo(expectedXml);
 
     // when
     // this is what execution.getVariable("test"); does
@@ -219,7 +220,7 @@ public class DomXmlDataFormatWriterTest {
 
     // then
     // assert that xml has not been formatted
-    assertThat(new String(serializedValue, "UTF-8")).isEqualTo(getExpectedFormattedXML(true));
+    assertThat(new String(serializedValue, UTF_8)).isEqualTo(getExpectedFormattedXML(true));
 
     // when
     // this is what execution.getVariable("test"); does

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/redirect/ResourceLoadingProcessEnginesAppPathRootTest.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/redirect/ResourceLoadingProcessEnginesAppPathRootTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.spring.boot.starter.webapp.filter.redirect;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -55,7 +56,7 @@ public class ResourceLoadingProcessEnginesAppPathRootTest {
 
     // when
     // get content returned by the request
-    String body = IOUtils.toString(con.getInputStream(), "UTF-8");
+    String body = IOUtils.toString(con.getInputStream(), UTF_8);
 
     // then
     assertThat(con.getResponseCode()).isEqualTo(200);

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/util/HttpClientRule.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/util/HttpClientRule.java
@@ -31,6 +31,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class HttpClientRule extends ExternalResource {
 
   public static final String PORT_PLACEHOLDER_WEBAPP_URL = "{PORT}";
@@ -178,7 +180,7 @@ public class HttpClientRule extends ExternalResource {
   public String getContent() {
     try {
       StringWriter writer = new StringWriter();
-      IOUtils.copy(connection.getInputStream(), writer, "UTF-8");
+      IOUtils.copy(connection.getInputStream(), writer, UTF_8);
       return writer.toString();
     } catch (IOException e) {
       e.printStackTrace();
@@ -190,7 +192,7 @@ public class HttpClientRule extends ExternalResource {
     getContent();
     try {
       StringWriter writer = new StringWriter();
-      IOUtils.copy(connection.getErrorStream(), writer, "UTF-8");
+      IOUtils.copy(connection.getErrorStream(), writer, UTF_8);
       return writer.toString();
     } catch (IOException e) {
       e.printStackTrace();


### PR DESCRIPTION
- replace Charset.forName("UTF-8") by StandardCharsets.UTF_8

- Used Open Rewrite Recipe org.openrewrite.staticanalysis.UseStandardCharset
- replace "UTF" by StandardCharsets.UTF_8
- refactor exception handling implications

related to #88 
closes #348 