### PR TITLE
chore(build): Ignore alpha/beta/4.0.0 versions in plugin-updates report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,9 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
           <version>2.18.0</version>
+          <configuration>
+            <ignoredVersions>.*alpha.*,.*beta.*,4\.0\.0-.*</ignoredVersions>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.mortbay.jetty</groupId>


### PR DESCRIPTION
Report does not contain unwanted plugin version updates:

![Screenshot 336](https://github.com/user-attachments/assets/ef4120da-97ff-4ddd-8141-0985ee9b6145)


closes #352