### PR TITLE
Add Homebrew distribution

### DIFF
--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -9,7 +9,7 @@ on:
         description: 'Java version to use'
         type: choice
         required: true
-        default: '["17", "21"]'
+        default: '["17"]'
         options:
           - '["17"]'
           - '["21"]'
@@ -19,6 +19,11 @@ on:
         type: boolean
         required: true
         default: true
+      skip_tests:
+        description: 'Skip test execution for faster build'
+        type: boolean
+        required: true
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -49,17 +54,19 @@ jobs:
         id: maven-build
         shell: bash
         run: |
-          PROJECT_ROOT=$(pwd)
           .github/scripts/jacoco-create-flag-files.sh
           RELEASE_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1)
+          SKIP_TESTS=${{ github.event.inputs.skip_tests || (github.event_name == 'schedule' && false) }}
           echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          echo "skip_tests=$SKIP_TESTS"
           ./mvnw \
             -Pdistro,distro-run,distro-tomcat,distro-wildfly,distro-webjar,distro-starter,distro-serverless,h2-in-memory \
             install \
             versions:dependency-updates-aggregate-report \
             versions:plugin-updates-aggregate-report \
             -Dsave=true -Ddisplay=false io.github.orhankupusoglu:sloc-maven-plugin:sloc \
-            -Dbuildplan.appendOutput=true -Dbuildplan.outputFile=$PROJECT_ROOT/target/reports/buildplan.txt fr.jcgay.maven.plugins:buildplan-maven-plugin:list
+            -Dbuildplan.appendOutput=true -Dbuildplan.outputFile=$PROJECT_ROOT/target/reports/buildplan.txt fr.jcgay.maven.plugins:buildplan-maven-plugin:list \
+            -DskipTests=$SKIP_TESTS
           .github/scripts/prepare-reports.sh
           ./mvnw -Psonatype-oss-release -DskipTests=true -Dskip.frontend.build=true deploy
           find target -name maven-metadata.* -delete
@@ -69,6 +76,7 @@ jobs:
         with:
           path: |
             distro/**/*.tar.gz
+            distro/**/*.zip
             distro/webjar/target/operaton-webapp-webjar-*.jar
             ./*/staging-deploy/**
             **/target/reports/**
@@ -76,8 +84,8 @@ jobs:
             target/project-reports.zip
           key: ${{ github.run_id }}-build-artifacts
       - name: Publish Test Report
-        if: always()
-        #https://github.com/marketplace/actions/junit-report-action
+        if: ${{ github.event.inputs.skip_tests == 'false' || github.event_name == 'schedule' }}
+        # https://github.com/marketplace/actions/junit-report-action
         uses: mikepenz/action-junit-report@v4
         with:
           report_paths: ${{ github.workspace }}/**/target/surefire-reports/*.xml
@@ -100,6 +108,7 @@ jobs:
         with:
           path: |
             distro/**/*.tar.gz
+            distro/**/*.zip
             distro/webjar/target/operaton-webapp-webjar-*.jar
             ./*/staging-deploy/**
             **/target/reports/**

--- a/distro/run/assembly/assembly.xml
+++ b/distro/run/assembly/assembly.xml
@@ -7,6 +7,7 @@
 
   <formats>
     <format>tar.gz</format>
+    <format>zip</format>
   </formats>
 
   <includeBaseDirectory>false</includeBaseDirectory>

--- a/distro/tomcat/assembly/assembly.xml
+++ b/distro/tomcat/assembly/assembly.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<assembly xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<assembly
   xmlns="urn:maven:assembly:1.1.0-SNAPSHOT">
     
   <id>assemble</id>
     
   <formats>
     <format>tar.gz</format>
+    <format>zip</format>
   </formats>
 
   <includeBaseDirectory>false</includeBaseDirectory>

--- a/distro/wildfly/assembly/assembly.xml
+++ b/distro/wildfly/assembly/assembly.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<assembly xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<assembly
   xmlns="urn:maven:assembly:1.1.0-SNAPSHOT">
   
   <id>assemble</id>
   
   <formats>
     <format>tar.gz</format>
+    <format>zip</format>
   </formats>
 
   <includeBaseDirectory>false</includeBaseDirectory>

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DeploymentRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DeploymentRestServiceInteractionTest.java
@@ -2036,47 +2036,47 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
   }
 
   private void verifyBpmnDeployment(HashMap<String, Object> dto) {
-    assertEquals(dto.get("id"), MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
-    assertEquals(dto.get("category"), EXAMPLE_PROCESS_DEFINITION_CATEGORY);
-    assertEquals(dto.get("name"), EXAMPLE_PROCESS_DEFINITION_NAME);
-    assertEquals(dto.get("key"), EXAMPLE_PROCESS_DEFINITION_KEY);
-    assertEquals(dto.get("description"), EXAMPLE_PROCESS_DEFINITION_DESCRIPTION);
-    assertEquals(dto.get("version"), EXAMPLE_PROCESS_DEFINITION_VERSION);
-    assertEquals(dto.get("resource"), EXAMPLE_PROCESS_DEFINITION_RESOURCE_NAME);
-    assertEquals(dto.get("deploymentId"), EXAMPLE_DEPLOYMENT_ID);
-    assertEquals(dto.get("diagram"), EXAMPLE_PROCESS_DEFINITION_DIAGRAM_RESOURCE_NAME);
-    assertEquals(dto.get("suspended"), EXAMPLE_PROCESS_DEFINITION_IS_SUSPENDED);
+    assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, dto.get("id"));
+    assertEquals(EXAMPLE_PROCESS_DEFINITION_CATEGORY, dto.get("category"));
+    assertEquals(EXAMPLE_PROCESS_DEFINITION_NAME, dto.get("name"));
+    assertEquals(EXAMPLE_PROCESS_DEFINITION_KEY, dto.get("key"));
+    assertEquals(EXAMPLE_PROCESS_DEFINITION_DESCRIPTION, dto.get("description"));
+    assertEquals(EXAMPLE_PROCESS_DEFINITION_VERSION, dto.get("version"));
+    assertEquals(EXAMPLE_PROCESS_DEFINITION_RESOURCE_NAME, dto.get("resource"));
+    assertEquals(EXAMPLE_DEPLOYMENT_ID, dto.get("deploymentId"));
+    assertEquals(EXAMPLE_PROCESS_DEFINITION_DIAGRAM_RESOURCE_NAME, dto.get("diagram"));
+    assertEquals(EXAMPLE_PROCESS_DEFINITION_IS_SUSPENDED, dto.get("suspended"));
   }
   private void verifyCmnDeployment(HashMap<String, Object> dto) {
-    assertEquals(dto.get("id"), EXAMPLE_CASE_DEFINITION_ID);
-    assertEquals(dto.get("category"), EXAMPLE_CASE_DEFINITION_CATEGORY);
-    assertEquals(dto.get("name"), EXAMPLE_CASE_DEFINITION_NAME);
-    assertEquals(dto.get("key"), EXAMPLE_CASE_DEFINITION_KEY);
-    assertEquals(dto.get("version"), EXAMPLE_CASE_DEFINITION_VERSION);
-    assertEquals(dto.get("resource"), EXAMPLE_CASE_DEFINITION_RESOURCE_NAME);
-    assertEquals(dto.get("deploymentId"), EXAMPLE_DEPLOYMENT_ID);
+    assertEquals(EXAMPLE_CASE_DEFINITION_ID, dto.get("id"));
+    assertEquals(EXAMPLE_CASE_DEFINITION_CATEGORY, dto.get("category"));
+    assertEquals(EXAMPLE_CASE_DEFINITION_NAME, dto.get("name"));
+    assertEquals(EXAMPLE_CASE_DEFINITION_KEY, dto.get("key"));
+    assertEquals(EXAMPLE_CASE_DEFINITION_VERSION, dto.get("version"));
+    assertEquals(EXAMPLE_CASE_DEFINITION_RESOURCE_NAME, dto.get("resource"));
+    assertEquals(EXAMPLE_DEPLOYMENT_ID, dto.get("deploymentId"));
   }
 
   private void verifyDmnDeployment(HashMap<String, Object> dto) {
-    assertEquals(dto.get("id"), EXAMPLE_DECISION_DEFINITION_ID);
-    assertEquals(dto.get("category"), EXAMPLE_DECISION_DEFINITION_CATEGORY);
-    assertEquals(dto.get("name"), EXAMPLE_DECISION_DEFINITION_NAME);
-    assertEquals(dto.get("key"), EXAMPLE_DECISION_DEFINITION_KEY);
-    assertEquals(dto.get("version"), EXAMPLE_DECISION_DEFINITION_VERSION);
-    assertEquals(dto.get("resource"), EXAMPLE_DECISION_DEFINITION_RESOURCE_NAME);
-    assertEquals(dto.get("deploymentId"), EXAMPLE_DEPLOYMENT_ID);
-    assertEquals(dto.get("decisionRequirementsDefinitionId"), EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID);
-    assertEquals(dto.get("decisionRequirementsDefinitionKey"), EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_KEY);
+    assertEquals(EXAMPLE_DECISION_DEFINITION_ID, dto.get("id"));
+    assertEquals(EXAMPLE_DECISION_DEFINITION_CATEGORY, dto.get("category"));
+    assertEquals(EXAMPLE_DECISION_DEFINITION_NAME, dto.get("name"));
+    assertEquals(EXAMPLE_DECISION_DEFINITION_KEY, dto.get("key"));
+    assertEquals(EXAMPLE_DECISION_DEFINITION_VERSION, dto.get("version"));
+    assertEquals(EXAMPLE_DECISION_DEFINITION_RESOURCE_NAME, dto.get("resource"));
+    assertEquals(EXAMPLE_DEPLOYMENT_ID, dto.get("deploymentId"));
+    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID, dto.get("decisionRequirementsDefinitionId"));
+    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_KEY, dto.get("decisionRequirementsDefinitionKey"));
   }
 
   private void verifyDrdDeployment(HashMap<String, Object> dto) {
-    assertEquals(dto.get("id"), EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID);
-    assertEquals(dto.get("category"), EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_CATEGORY);
-    assertEquals(dto.get("name"), EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_NAME);
-    assertEquals(dto.get("key"), EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_KEY);
-    assertEquals(dto.get("version"), EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_VERSION);
-    assertEquals(dto.get("resource"), EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_RESOURCE_NAME);
-    assertEquals(dto.get("deploymentId"), EXAMPLE_DEPLOYMENT_ID);
+    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID, dto.get("id"));
+    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_CATEGORY, dto.get("category"));
+    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_NAME, dto.get("name"));
+    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_KEY, dto.get("key"));
+    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_VERSION, dto.get("version"));
+    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_RESOURCE_NAME, dto.get("resource"));
+    assertEquals(EXAMPLE_DEPLOYMENT_ID, dto.get("deploymentId"));
   }
 
   private void verifyDeploymentValuesEmptyDefinitions(Deployment mockDeployment, String responseContent) {

--- a/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/components/ProcessStartingBeanPostProcessorTest.java
+++ b/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/components/ProcessStartingBeanPostProcessorTest.java
@@ -82,11 +82,11 @@ public class ProcessStartingBeanPostProcessorTest {
 
 		this.processInitiatingPojo.reset();
 
-		assertEquals(this.processInitiatingPojo.getMethodState(), 0);
+    assertEquals(0, this.processInitiatingPojo.getMethodState());
 
 		this.processInitiatingPojo.startProcess(53);
 
-		assertEquals(this.processInitiatingPojo.getMethodState(), 1);
+    assertEquals(1, this.processInitiatingPojo.getMethodState());
 	}
 
 	@Test

--- a/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/components/scope/ScopingTest.java
+++ b/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/components/scope/ScopingTest.java
@@ -100,14 +100,14 @@ public class ScopingTest {
 		StatefulObject scopedObject = (StatefulObject) processEngine.getRuntimeService().getVariable(processInstance.getId(), "scopedTarget.c1");
 		Assert.assertNotNull("the scopedObject can't be null", scopedObject);
 		Assert.assertTrue("the 'name' property can't be null.", StringUtils.hasText(scopedObject.getName()));
-		Assert.assertEquals(scopedObject.getVisitedCount(), 2);
+    Assert.assertEquals(2, scopedObject.getVisitedCount());
 
 		// the process has paused
 		String procId = processInstance.getProcessInstanceId();
 
 		List<Task> tasks = taskService.createTaskQuery().executionId(procId).list();
 
-		Assert.assertEquals("there should be 1 (one) task enqueued at this point.", tasks.size(), 1);
+    Assert.assertEquals("there should be 1 (one) task enqueued at this point.", 1, tasks.size());
 
 		Task t = tasks.iterator().next();
 
@@ -121,7 +121,7 @@ public class ScopingTest {
 		this.taskService.complete(t.getId());
 
 		scopedObject = (StatefulObject) processEngine.getRuntimeService().getVariable(processInstance.getId(), "scopedTarget.c1");
-		Assert.assertEquals(scopedObject.getVisitedCount(), 3);
+    Assert.assertEquals(3, scopedObject.getVisitedCount());
 
 		Assert.assertEquals( "the customerId injected should " +
 					"be what was given as a processVariable parameter." ,

--- a/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/plugin/SpringProcessEnginePluginTest.java
+++ b/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/plugin/SpringProcessEnginePluginTest.java
@@ -42,6 +42,6 @@ public class SpringProcessEnginePluginTest {
 
   @Test
   public void verifyToString() {
-    Assert.assertEquals(plugin.toString(), "theBeanName");
+    Assert.assertEquals("theBeanName", plugin.toString());
   }
 }

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -32,15 +32,6 @@ platform:
   replacements:
     aarch_64: aarch64
 
-files:
-  artifacts:
-    - path: 'distro/tomcat/distro/target/operaton-bpm-tomcat-{{projectVersion}}.tar.gz'
-    - path: 'distro/wildfly/distro/target/operaton-bpm-wildfly-{{projectVersion}}.tar.gz'
-    - path: 'distro/sql-script/target/operaton-sql-scripts-{{projectVersion}}.tar.gz'
-    - path: 'distro/webjar/target/operaton-webapp-webjar-{{projectVersion}}.jar'
-    - path: 'distro/run/distro/target/operaton-bpm-run-{{projectVersion}}.tar.gz'
-    - path: 'target/project-reports.zip'
-
 release: # https://jreleaser.org/guide/latest/reference/release/github.html
   github:
     overwrite: true
@@ -178,7 +169,7 @@ deploy:
   maven:
     mavenCentral:
       MavenCentral:
-        active: ALWAYS
+        active: RELEASE
         applyMavenCentralRules: true
         url: https://central.sonatype.com/api/v1/publisher
         stagingRepositories:
@@ -198,3 +189,97 @@ catalog:
 signing:
   active: ALWAYS
   armored: true
+
+files:
+  artifacts:
+    - path: 'distro/run/distro/target/operaton-bpm-run-{{projectVersion}}.tar.gz'
+    - path: 'distro/run/distro/target/operaton-bpm-run-{{projectVersion}}.zip'
+    - path: 'distro/tomcat/distro/target/operaton-bpm-tomcat-{{projectVersion}}.tar.gz'
+    - path: 'distro/tomcat/distro/target/operaton-bpm-tomcat-{{projectVersion}}.zip'
+    - path: 'distro/wildfly/distro/target/operaton-bpm-wildfly-{{projectVersion}}.tar.gz'
+    - path: 'distro/wildfly/distro/target/operaton-bpm-wildfly-{{projectVersion}}.zip'
+    - path: 'distro/sql-script/target/operaton-sql-scripts-{{projectVersion}}.tar.gz'
+    - path: 'distro/webjar/target/operaton-webapp-webjar-{{projectVersion}}.jar'
+    - path: 'target/project-reports.zip'
+
+distributions:
+  operaton:
+    type: BINARY
+    executable:
+      name: start
+    tags:
+      - 'operaton'
+      - 'bpmn'
+      - 'process automation'
+    artifacts:
+      - path: 'distro/run/distro/target/operaton-bpm-run-{{projectVersion}}.zip'
+        platform: linux
+      - path: 'distro/run/distro/target/operaton-bpm-run-{{projectVersion}}.zip'
+        platform: osx
+      - path: 'distro/run/distro/target/operaton-bpm-run-{{projectVersion}}.zip'
+        platform: windows
+    brew:
+      active: RELEASE
+      continueOnError: true
+      formulaName: operaton
+      multiPlatform: true
+      repository:
+        active: RELEASE
+        commitMessage: 'Operaton {{tagName}}'
+      commitAuthor:
+        name: GitHub Actions
+        email: github-actions[bot]@users.noreply.github.com
+  operaton-tomcat:
+    type: BINARY
+    executable:
+      name: start
+    tags:
+      - 'operaton'
+      - 'bpmn'
+      - 'process automation'
+      - 'tomcat'
+    artifacts:
+      - path: 'distro/tomcat/distro/target/operaton-bpm-tomcat-{{projectVersion}}.zip'
+        platform: linux
+      - path: 'distro/tomcat/distro/target/operaton-bpm-tomcat-{{projectVersion}}.zip'
+        platform: osx
+      - path: 'distro/tomcat/distro/target/operaton-bpm-tomcat-{{projectVersion}}.zip'
+        platform: windows
+    brew:
+      active: RELEASE
+      continueOnError: true
+      formulaName: operaton-tomcat
+      multiPlatform: true
+      repository:
+        active: RELEASE
+        commitMessage: 'Operaton Tomcat 10 {{tagName}}'
+      commitAuthor:
+        name: GitHub Actions
+        email: github-actions[bot]@users.noreply.github.com
+  operaton-wildfly:
+    type: BINARY
+    executable:
+      name: start
+    tags:
+      - 'operaton'
+      - 'bpmn'
+      - 'process automation'
+      - 'wildfly'
+    artifacts:
+      - path: 'distro/wildfly/distro/target/operaton-bpm-wildfly-{{projectVersion}}.zip'
+        platform: linux
+      - path: 'distro/wildfly/distro/target/operaton-bpm-wildfly-{{projectVersion}}.zip'
+        platform: osx
+      - path: 'distro/wildfly/distro/target/operaton-bpm-wildfly-{{projectVersion}}.zip'
+        platform: windows
+    brew:
+      active: RELEASE
+      continueOnError: true
+      formulaName: operaton-wildfly
+      multiPlatform: true
+      repository:
+        active: RELEASE
+        commitMessage: 'Operaton Wildfly 33 {{tagName}}'
+      commitAuthor:
+        name: GitHub Actions
+        email: github-actions[bot]@users.noreply.github.com

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/local/LocalSFSBInvocationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/local/LocalSFSBInvocationTest.java
@@ -77,7 +77,7 @@ public class LocalSFSBInvocationTest extends AbstractFoxPlatformIntegrationTest 
 
     ProcessInstance pi = runtimeService.startProcessInstanceByKey("testInvokeBean");
 
-    Assert.assertEquals(runtimeService.getVariable(pi.getId(), "result"), true);
+    Assert.assertEquals(true, runtimeService.getVariable(pi.getId(), "result"));
 
     runtimeService.setVariable(pi.getId(), "result", false);
 
@@ -85,7 +85,7 @@ public class LocalSFSBInvocationTest extends AbstractFoxPlatformIntegrationTest 
 
     waitForJobExecutorToProcessAllJobs();
 
-    Assert.assertEquals(runtimeService.getVariable(pi.getId(), "result"), true);
+    Assert.assertEquals(true, runtimeService.getVariable(pi.getId(), "result"));
 
     taskService.complete(taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult().getId());
   }
@@ -99,7 +99,7 @@ public class LocalSFSBInvocationTest extends AbstractFoxPlatformIntegrationTest 
 
     for(int i=0; i<instances; i++) {
       ids[i] = runtimeService.startProcessInstanceByKey("testInvokeBean").getId();
-      Assert.assertEquals(runtimeService.getVariable(ids[i], "result"), true);
+      Assert.assertEquals(true, runtimeService.getVariable(ids[i], "result"));
       runtimeService.setVariable(ids[i], "result", false);
       taskService.complete(taskService.createTaskQuery().processInstanceId(ids[i]).singleResult().getId());
     }
@@ -107,7 +107,7 @@ public class LocalSFSBInvocationTest extends AbstractFoxPlatformIntegrationTest 
     waitForJobExecutorToProcessAllJobs(60*1000);
 
     for(int i=0; i<instances; i++) {
-      Assert.assertEquals(runtimeService.getVariable(ids[i], "result"), true);
+      Assert.assertEquals(true, runtimeService.getVariable(ids[i], "result"));
       taskService.complete(taskService.createTaskQuery().processInstanceId(ids[i]).singleResult().getId());
     }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/local/LocalSLSBInvocationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/local/LocalSLSBInvocationTest.java
@@ -77,7 +77,7 @@ public class LocalSLSBInvocationTest extends AbstractFoxPlatformIntegrationTest 
 
     ProcessInstance pi = runtimeService.startProcessInstanceByKey("testInvokeBean");
 
-    Assert.assertEquals(runtimeService.getVariable(pi.getId(), "result"), true);
+    Assert.assertEquals(true, runtimeService.getVariable(pi.getId(), "result"));
 
     runtimeService.setVariable(pi.getId(), "result", false);
 
@@ -85,7 +85,7 @@ public class LocalSLSBInvocationTest extends AbstractFoxPlatformIntegrationTest 
 
     waitForJobExecutorToProcessAllJobs();
 
-    Assert.assertEquals(runtimeService.getVariable(pi.getId(), "result"), true);
+    Assert.assertEquals(true, runtimeService.getVariable(pi.getId(), "result"));
 
     taskService.complete(taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult().getId());
   }
@@ -99,7 +99,7 @@ public class LocalSLSBInvocationTest extends AbstractFoxPlatformIntegrationTest 
 
     for(int i=0; i<instances; i++) {
       ids[i] = runtimeService.startProcessInstanceByKey("testInvokeBean").getId();
-      Assert.assertEquals(runtimeService.getVariable(ids[i], "result"), true);
+      Assert.assertEquals(true, runtimeService.getVariable(ids[i], "result"));
       runtimeService.setVariable(ids[i], "result", false);
       taskService.complete(taskService.createTaskQuery().processInstanceId(ids[i]).singleResult().getId());
     }
@@ -107,7 +107,7 @@ public class LocalSLSBInvocationTest extends AbstractFoxPlatformIntegrationTest 
     waitForJobExecutorToProcessAllJobs(60*1000);
 
     for(int i=0; i<instances; i++) {
-      Assert.assertEquals(runtimeService.getVariable(ids[i], "result"), true);
+      Assert.assertEquals(true, runtimeService.getVariable(ids[i], "result"));
       taskService.complete(taskService.createTaskQuery().processInstanceId(ids[i]).singleResult().getId());
     }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/local/LocalSingletonBeanInvocationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/local/LocalSingletonBeanInvocationTest.java
@@ -78,7 +78,7 @@ public class LocalSingletonBeanInvocationTest extends AbstractFoxPlatformIntegra
 
     ProcessInstance pi = runtimeService.startProcessInstanceByKey("testInvokeBean");
 
-    Assert.assertEquals(runtimeService.getVariable(pi.getId(), "result"), true);
+    Assert.assertEquals(true, runtimeService.getVariable(pi.getId(), "result"));
 
     runtimeService.setVariable(pi.getId(), "result", false);
 
@@ -86,7 +86,7 @@ public class LocalSingletonBeanInvocationTest extends AbstractFoxPlatformIntegra
 
     waitForJobExecutorToProcessAllJobs();
 
-    Assert.assertEquals(runtimeService.getVariable(pi.getId(), "result"), true);
+    Assert.assertEquals(true, runtimeService.getVariable(pi.getId(), "result"));
 
     taskService.complete(taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult().getId());
   }
@@ -100,7 +100,7 @@ public class LocalSingletonBeanInvocationTest extends AbstractFoxPlatformIntegra
 
     for(int i=0; i<instances; i++) {
       ids[i] = runtimeService.startProcessInstanceByKey("testInvokeBean").getId();
-      Assert.assertEquals(runtimeService.getVariable(ids[i], "result"), true);
+      Assert.assertEquals(true, runtimeService.getVariable(ids[i], "result"));
       runtimeService.setVariable(ids[i], "result", false);
       taskService.complete(taskService.createTaskQuery().processInstanceId(ids[i]).singleResult().getId());
     }
@@ -108,7 +108,7 @@ public class LocalSingletonBeanInvocationTest extends AbstractFoxPlatformIntegra
     waitForJobExecutorToProcessAllJobs(60*1000);
 
     for(int i=0; i<instances; i++) {
-      Assert.assertEquals(runtimeService.getVariable(ids[i], "result"), true);
+      Assert.assertEquals(true, runtimeService.getVariable(ids[i], "result"));
       taskService.complete(taskService.createTaskQuery().processInstanceId(ids[i]).singleResult().getId());
     }
 

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionRequiredHistoryLevelAuditTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionRequiredHistoryLevelAuditTest.java
@@ -40,7 +40,7 @@ class ProcessEngineExtensionRequiredHistoryLevelAuditTest {
   @Test
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_AUDIT)
   void testRequiredHistoryLevelMatch() {
-    assertEquals(extension.getProcessEngineConfiguration().getHistoryLevel().getName(),
-        ProcessEngineConfiguration.HISTORY_AUDIT);
+    assertEquals(
+      ProcessEngineConfiguration.HISTORY_AUDIT, extension.getProcessEngineConfiguration().getHistoryLevel().getName());
   }
 }


### PR DESCRIPTION
Extend nightly & release build to publish distributions to Homebrew.

- Extend `jreleaser.yml`

Exended "Nightly Build" workflow
- Allow skipping of tests for manual execution
- Make Java 17 only as default

related to #358 