### PR TITLE
chore: resolve deprecation org.junit.Assert.assertThat

### DIFF
--- a/engine-cdi/core/src/test/java/org/operaton/bpm/engine/cdi/test/impl/event/EventNotificationTest.java
+++ b/engine-cdi/core/src/test/java/org/operaton/bpm/engine/cdi/test/impl/event/EventNotificationTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(Arquillian.class)
 public class EventNotificationTest extends CdiProcessEngineTestCase {

--- a/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/configuration/JavaBasedProcessEngineConfigTest.java
+++ b/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/configuration/JavaBasedProcessEngineConfigTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.spring.test.configuration;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.spring.SpringProcessEngineServicesConfiguration;

--- a/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/transaction/SpringTransactionIntegrationTest.java
+++ b/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/transaction/SpringTransactionIntegrationTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.spring.test.transaction;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.TimeUnit;
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageEventSubprocessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageEventSubprocessTest.java
@@ -25,7 +25,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestDeploymentTenantId.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestDeploymentTenantId.java
@@ -18,7 +18,7 @@ package org.operaton.bpm.integrationtest.deployment.cfg;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePreviousOnDeploymentName.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePreviousOnDeploymentName.java
@@ -18,7 +18,7 @@ package org.operaton.bpm.integrationtest.deployment.war;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.List;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePreviousOnProcessDefinitionKey.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePreviousOnProcessDefinitionKey.java
@@ -18,7 +18,7 @@ package org.operaton.bpm.integrationtest.deployment.war;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.List;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/InvocationContextTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/InvocationContextTest.java
@@ -37,7 +37,7 @@ import org.junit.runner.RunWith;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Checks if the process application is invoked with an invocation context.

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/dmn/DmnHistoryTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/dmn/DmnHistoryTest.java
@@ -18,7 +18,7 @@ package org.operaton.bpm.integrationtest.functional.dmn;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.operaton.bpm.engine.history.HistoricDecisionInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstance;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/SLSBExceptionInDelegateTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/SLSBExceptionInDelegateTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.integrationtest.functional.ejb;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.operaton.bpm.engine.runtime.Incident;
 import org.operaton.bpm.engine.runtime.Job;

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/ProcessInstanceModificationTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/ProcessInstanceModificationTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tassilo Weidner

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/TimerChangeJobDefinitionTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/TimerChangeJobDefinitionTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tassilo Weidner

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/TimerChangeProcessDefinitionTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/TimerChangeProcessDefinitionTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tassilo Weidner

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/DeleteHistoricDecisionsBatchTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/DeleteHistoricDecisionsBatchTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tassilo Weidner

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/DeleteHistoricProcessInstancesBatchTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/DeleteHistoricProcessInstancesBatchTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tassilo Weidner

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/DeleteProcessInstancesBatchTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/DeleteProcessInstancesBatchTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tassilo Weidner

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/MigrationBatchTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/MigrationBatchTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tassilo Weidner

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/ModificationBatchTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/ModificationBatchTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tassilo Weidner

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/RestartProcessInstanceBatchTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/RestartProcessInstanceBatchTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tassilo Weidner

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/SetExternalTaskRetriesBatchTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/SetExternalTaskRetriesBatchTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tassilo Weidner

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/SetJobRetriesBatchTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/SetJobRetriesBatchTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.qa.upgrade.scenarios7110.gson.batch;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/UpdateProcessInstanceSuspendStateBatchTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/gson/batch/UpdateProcessInstanceSuspendStateBatchTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tassilo Weidner

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/removaltime/RemovalTimeBatchTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/removaltime/RemovalTimeBatchTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Tassilo Weidner

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/AbstractTimestampMigrationTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/AbstractTimestampMigrationTest.java
@@ -31,7 +31,7 @@ import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Nikola Koevski

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/DeploymentDeployTimeTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/DeploymentDeployTimeTest.java
@@ -22,7 +22,7 @@ import org.operaton.bpm.qa.upgrade.ScenarioUnderTest;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Nikola Koevski

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/EventSubscriptionCreateTimeTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/EventSubscriptionCreateTimeTest.java
@@ -22,7 +22,7 @@ import org.operaton.bpm.qa.upgrade.ScenarioUnderTest;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Nikola Koevski

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/ExternalTaskLockExpTimeTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/ExternalTaskLockExpTimeTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Nikola Koevski

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/HistoricJobLogTimestampsTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/HistoricJobLogTimestampsTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Nikola Koevski

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/IncidentTimestampTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/IncidentTimestampTest.java
@@ -22,7 +22,7 @@ import org.operaton.bpm.qa.upgrade.ScenarioUnderTest;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Nikola Koevski

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/JobTimestampsTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/JobTimestampsTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Nikola Koevski

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/MeterLogTimestampTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/MeterLogTimestampTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Nikola Koevski

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/TaskCreateTimeTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/TaskCreateTimeTest.java
@@ -22,7 +22,7 @@ import org.operaton.bpm.qa.upgrade.ScenarioUnderTest;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Nikola Koevski

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/UserLockExpTimeTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7110/timestamp/UserLockExpTimeTest.java
@@ -22,7 +22,7 @@ import org.operaton.bpm.qa.upgrade.ScenarioUnderTest;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Nikola Koevski

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7120/useroperationlog/annotation/SetAnnotationAuthorizationTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7120/useroperationlog/annotation/SetAnnotationAuthorizationTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SetAnnotationAuthorizationTest {
 

--- a/qa/test-db-rolling-update/test-old-engine/src/test/java/org/operaton/bpm/qa/rolling/update/timestamp/AbstractTimestampUpdateTest.java
+++ b/qa/test-db-rolling-update/test-old-engine/src/test/java/org/operaton/bpm/qa/rolling/update/timestamp/AbstractTimestampUpdateTest.java
@@ -32,7 +32,7 @@ import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Nikola Koevski

--- a/qa/test-db-rolling-update/test-old-engine/src/test/java/org/operaton/bpm/qa/rolling/update/timestamp/IncidentTimestampUpdateTest.java
+++ b/qa/test-db-rolling-update/test-old-engine/src/test/java/org/operaton/bpm/qa/rolling/update/timestamp/IncidentTimestampUpdateTest.java
@@ -22,7 +22,7 @@ import org.operaton.bpm.qa.upgrade.ScenarioUnderTest;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Nikola Koevski

--- a/qa/test-db-rolling-update/test-old-engine/src/test/java/org/operaton/bpm/qa/rolling/update/timestamp/JobTimestampsUpdateTest.java
+++ b/qa/test-db-rolling-update/test-old-engine/src/test/java/org/operaton/bpm/qa/rolling/update/timestamp/JobTimestampsUpdateTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Nikola Koevski

--- a/qa/test-db-rolling-update/test-old-engine/src/test/java/org/operaton/bpm/qa/rolling/update/variable/EmptyStringVariableTest.java
+++ b/qa/test-db-rolling-update/test-old-engine/src/test/java/org/operaton/bpm/qa/rolling/update/variable/EmptyStringVariableTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.qa.rolling.update.variable;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.operaton.bpm.engine.runtime.VariableInstance;
 import org.operaton.bpm.engine.runtime.VariableInstanceQuery;


### PR DESCRIPTION
- replaced usages by org.hamcrest.MatcherAssert.assertThat;

related to #144