### PR TITLE
chore: Hide utility class constructor

### DIFF
--- a/commons/logging/src/main/java/org/operaton/commons/logging/MdcAccess.java
+++ b/commons/logging/src/main/java/org/operaton/commons/logging/MdcAccess.java
@@ -23,6 +23,9 @@ import org.slf4j.MDC;
  */
 public class MdcAccess {
 
+  private MdcAccess() {
+  }
+
   /**
    * see {@link MDC#remove(String)}
    */

--- a/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/Variables.java
+++ b/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/Variables.java
@@ -16,50 +16,29 @@
  */
 package org.operaton.bpm.engine.variable;
 
-import java.io.File;
-import java.io.Serializable;
-import java.util.Date;
-import java.util.Map;
-
-import javax.activation.MimetypesFileTypeMap;
-
 import org.operaton.bpm.engine.variable.context.VariableContext;
 import org.operaton.bpm.engine.variable.impl.VariableMapImpl;
 import org.operaton.bpm.engine.variable.impl.context.EmptyVariableContext;
 import org.operaton.bpm.engine.variable.impl.value.AbstractTypedValue;
 import org.operaton.bpm.engine.variable.impl.value.FileValueImpl;
 import org.operaton.bpm.engine.variable.impl.value.NullValueImpl;
+import org.operaton.bpm.engine.variable.impl.value.PrimitiveTypeValueImpl.*;
 import org.operaton.bpm.engine.variable.impl.value.UntypedValueImpl;
-import org.operaton.bpm.engine.variable.impl.value.PrimitiveTypeValueImpl.BooleanValueImpl;
-import org.operaton.bpm.engine.variable.impl.value.PrimitiveTypeValueImpl.BytesValueImpl;
-import org.operaton.bpm.engine.variable.impl.value.PrimitiveTypeValueImpl.DateValueImpl;
-import org.operaton.bpm.engine.variable.impl.value.PrimitiveTypeValueImpl.DoubleValueImpl;
-import org.operaton.bpm.engine.variable.impl.value.PrimitiveTypeValueImpl.IntegerValueImpl;
-import org.operaton.bpm.engine.variable.impl.value.PrimitiveTypeValueImpl.LongValueImpl;
-import org.operaton.bpm.engine.variable.impl.value.PrimitiveTypeValueImpl.NumberValueImpl;
-import org.operaton.bpm.engine.variable.impl.value.PrimitiveTypeValueImpl.ShortValueImpl;
-import org.operaton.bpm.engine.variable.impl.value.PrimitiveTypeValueImpl.StringValueImpl;
 import org.operaton.bpm.engine.variable.impl.value.builder.FileValueBuilderImpl;
 import org.operaton.bpm.engine.variable.impl.value.builder.ObjectVariableBuilderImpl;
 import org.operaton.bpm.engine.variable.impl.value.builder.SerializedObjectValueBuilderImpl;
 import org.operaton.bpm.engine.variable.type.ValueType;
-import org.operaton.bpm.engine.variable.value.BooleanValue;
-import org.operaton.bpm.engine.variable.value.BytesValue;
-import org.operaton.bpm.engine.variable.value.DateValue;
-import org.operaton.bpm.engine.variable.value.DoubleValue;
-import org.operaton.bpm.engine.variable.value.FileValue;
-import org.operaton.bpm.engine.variable.value.IntegerValue;
-import org.operaton.bpm.engine.variable.value.LongValue;
-import org.operaton.bpm.engine.variable.value.NumberValue;
-import org.operaton.bpm.engine.variable.value.ObjectValue;
-import org.operaton.bpm.engine.variable.value.SerializationDataFormat;
-import org.operaton.bpm.engine.variable.value.ShortValue;
-import org.operaton.bpm.engine.variable.value.StringValue;
-import org.operaton.bpm.engine.variable.value.TypedValue;
+import org.operaton.bpm.engine.variable.value.*;
 import org.operaton.bpm.engine.variable.value.builder.FileValueBuilder;
 import org.operaton.bpm.engine.variable.value.builder.ObjectValueBuilder;
 import org.operaton.bpm.engine.variable.value.builder.SerializedObjectValueBuilder;
 import org.operaton.bpm.engine.variable.value.builder.TypedValueBuilder;
+
+import javax.activation.MimetypesFileTypeMap;
+import java.io.File;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Map;
 
 /**
  * <p>This class is the entry point to the process engine's typed variables API.
@@ -127,7 +106,6 @@ public class Variables {
     SerializationDataFormats(String name) {
       this.name = name;
     }
-
     @Override
     public String getName() {
       return name;
@@ -436,5 +414,4 @@ public class Variables {
   public static VariableContext emptyVariableContext() {
     return EmptyVariableContext.INSTANCE;
   }
-
 }

--- a/commons/utils/src/main/java/org/operaton/commons/utils/EnsureUtil.java
+++ b/commons/utils/src/main/java/org/operaton/commons/utils/EnsureUtil.java
@@ -21,6 +21,9 @@ package org.operaton.commons.utils;
  */
 public class EnsureUtil {
 
+  protected EnsureUtil() {
+  }
+
   private static final EnsureUtilLogger LOG = UtilsLogger.ENSURE_UTIL_LOGGER;
 
   /**

--- a/commons/utils/src/main/java/org/operaton/commons/utils/IoUtil.java
+++ b/commons/utils/src/main/java/org/operaton/commons/utils/IoUtil.java
@@ -26,9 +26,11 @@ import java.nio.charset.StandardCharsets;
  * @author Sebastian Menski
  */
 public class IoUtil {
-
   private static final IoUtilLogger LOG = UtilsLogger.IO_UTIL_LOGGER;
   public static final Charset ENCODING_CHARSET = StandardCharsets.UTF_8;
+
+  protected IoUtil() {
+  }
 
   /**
    * Returns the input stream as String.
@@ -232,5 +234,4 @@ public class IoUtil {
       throw LOG.fileNotFoundException(filename, e);
     }
   }
-
 }

--- a/commons/utils/src/main/java/org/operaton/commons/utils/StringUtil.java
+++ b/commons/utils/src/main/java/org/operaton/commons/utils/StringUtil.java
@@ -24,6 +24,9 @@ import java.io.StringWriter;
  */
 public final class StringUtil {
 
+  private StringUtil() {
+  }
+
   /**
    * Checks whether a String seams to be an expression or not
    *
@@ -114,5 +117,4 @@ public final class StringUtil {
     throwable.printStackTrace(new PrintWriter(sw, true));
     return sw.toString();
   }
-
 }

--- a/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/util/ParseUtil.java
+++ b/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/util/ParseUtil.java
@@ -16,16 +16,20 @@
  */
 package org.operaton.connect.httpclient.impl.util;
 
+import org.operaton.connect.httpclient.impl.HttpConnectorLogger;
+import org.operaton.connect.httpclient.impl.HttpLogger;
+import org.operaton.connect.httpclient.impl.RequestConfigOption;
+
 import java.util.Map;
 
 import org.apache.http.client.config.RequestConfig.Builder;
-import org.operaton.connect.httpclient.impl.RequestConfigOption;
-import org.operaton.connect.httpclient.impl.HttpConnectorLogger;
-import org.operaton.connect.httpclient.impl.HttpLogger;
 
 public class ParseUtil {
 
   protected static HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
+
+  private ParseUtil() {
+  }
 
   public static void parseConfigOptions(Map<String, Object> configOptions, Builder configBuilder) {
     for (RequestConfigOption option : RequestConfigOption.values()) {

--- a/distro/run/core/src/main/java/org/operaton/bpm/run/utils/OperatonBpmRunProcessEnginePluginHelper.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/utils/OperatonBpmRunProcessEnginePluginHelper.java
@@ -31,6 +31,9 @@ public class OperatonBpmRunProcessEnginePluginHelper {
 
   protected static final OperatonBpmRunLogger LOG = OperatonBpmRunLogger.LOG;
 
+  private OperatonBpmRunProcessEnginePluginHelper() {
+  }
+
   public static void registerYamlPlugins(List<ProcessEnginePlugin> processEnginePlugins,
                                          List<OperatonBpmRunProcessEnginePluginProperty> pluginsInfo) {
 

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/util/TestUtils.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/util/TestUtils.java
@@ -25,6 +25,9 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
 public class TestUtils {
+  private TestUtils() {
+  }
+
   public static void trustSelfSignedSSL() throws NoSuchAlgorithmException, KeyManagementException {
     SSLContext ctx = SSLContext.getInstance("SSL");
     X509TrustManager tm = new X509TrustManager() {

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/extension/SubsystemAttributeDefinitons.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/extension/SubsystemAttributeDefinitons.java
@@ -174,4 +174,7 @@ public class SubsystemAttributeDefinitons {
         PLUGINS
     };
 
+  private SubsystemAttributeDefinitons() {
+  }
+
 }

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/ServiceNames.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/ServiceNames.java
@@ -41,6 +41,9 @@ public class ServiceNames {
 
   private static final ServiceName BPM_PLATFORM_PLUGINS = BPM_PLATFORM.append("bpm-platform-plugins");
 
+  private ServiceNames() {
+  }
+
   /**
    * Returns the service name for a {@link MscManagedProcessEngine}.
    *
@@ -160,5 +163,4 @@ public class ServiceNames {
   public static ServiceName forThreadFactoryService(String threadFactoryName) {
     return ThreadsServices.threadFactoryName(threadFactoryName);
   }
-
 }

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/util/BindingUtil.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/util/BindingUtil.java
@@ -31,7 +31,10 @@ import org.jboss.msc.service.ServiceTarget;
  *
  */
 public class BindingUtil {
-  
+
+  private BindingUtil() {
+  }
+
   public static ServiceController<ManagedReferenceFactory> createJndiBindings(ServiceTarget target, ServiceName serviceName, String binderServiceName,  ManagedReferenceFactory managedReferenceFactory) {
 
     BinderService binderService = new BinderService(binderServiceName);
@@ -39,7 +42,7 @@ public class BindingUtil {
             .addService(serviceName, binderService)
             .addDependency(ContextNames.GLOBAL_CONTEXT_SERVICE_NAME, ServiceBasedNamingStore.class, binderService.getNamingStoreInjector());
     binderService.getManagedObjectInjector().inject(managedReferenceFactory);
-            
+
     return serviceBuilder.install();
   }
   

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/util/CustomMarshaller.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/util/CustomMarshaller.java
@@ -29,6 +29,8 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 
 public class CustomMarshaller {
+  private CustomMarshaller() {
+  }
 
   /**
    * Obtain the 'valueTypes' of the ObjectTypeAttributeDefinition through reflection because they are private in Wildfly 8.
@@ -181,4 +183,5 @@ public class CustomMarshaller {
   public static final PluginObjectTypeMarshaller OBJECT_AS_ELEMENT = new PluginObjectTypeMarshaller();
   public static final ObjectListMarshaller OBJECT_LIST = new ObjectListMarshaller();
   public static final PropertiesAttributeMarshaller PROPERTIES_MARSHALLER = new PropertiesAttributeMarshaller();
+
 }

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/util/JBossCompatibilityExtension.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/util/JBossCompatibilityExtension.java
@@ -40,6 +40,9 @@ public class JBossCompatibilityExtension {
    */
   static final ServiceName JBOSS_SERVER_EXECUTOR = JBOSS_AS.append("server-executor");
 
+  private JBossCompatibilityExtension() {
+  }
+
   /**
    * Adds the JBoss server executor as a dependency to the given service.
    * Copied from org.jboss.as.server.Services - JBoss 7.2.0.Final

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/util/Tccl.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/util/Tccl.java
@@ -25,6 +25,8 @@ import java.security.PrivilegedAction;
  * @author Daniel Meyer
  */
 public class Tccl {
+  private Tccl() {
+  }
 
   public static interface Operation<T> {
     T run();
@@ -41,7 +43,7 @@ public class Tccl {
             throw new RuntimeException(e);
           }
         }
-      });     
+      });
     } else {
       return runWithTccl(operation, classLoader);
     }
@@ -56,5 +58,4 @@ public class Tccl {
       Thread.currentThread().setContextClassLoader(cl);
     }
   }
-
 }

--- a/distro/wildfly/subsystem/src/test/java/org/operaton/bpm/container/impl/jboss/test/FileUtils.java
+++ b/distro/wildfly/subsystem/src/test/java/org/operaton/bpm/container/impl/jboss/test/FileUtils.java
@@ -25,13 +25,16 @@ import java.io.InputStreamReader;
  * @author nico.rehwaldt
  */
 public class FileUtils {
-  
+
+  private FileUtils() {
+  }
+
   public static String readFile(String name) throws Exception {
     InputStream is = null;
     BufferedReader reader = null;
-    
+
     StringBuilder fileContents = new StringBuilder();
-    
+
     try {
       is = Thread.currentThread().getContextClassLoader().getResourceAsStream(name);
       reader = new BufferedReader(new InputStreamReader(is));
@@ -41,7 +44,7 @@ public class FileUtils {
         if (line == null) {
           break;
         }
-        
+
         fileContents.append(line);
       }
     } finally {
@@ -51,7 +54,7 @@ public class FileUtils {
         ; // Cannot handle exception
       }
     }
-    
+
     return fileContents.toString();
   }
 }

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/util/BeanManagerLookup.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/util/BeanManagerLookup.java
@@ -30,13 +30,16 @@ public class BeanManagerLookup {
   /** provide a custom jndi lookup name */
   public static String jndiName;
 
+  private BeanManagerLookup() {
+  }
+
   public static BeanManager getBeanManager() {
-    
+
     BeanManager beanManager = lookupBeanManagerInJndi();
-    
+
     if(beanManager != null) {
       return beanManager;
-      
+
     } else {
       if (localInstance != null) {
         return localInstance;
@@ -63,15 +66,15 @@ public class BeanManagerLookup {
     } catch (NamingException e) {
       // silently ignore
     }
-    
+
     try {
       // in a servlet container
       return (BeanManager) InitialContext.doLookup("java:comp/env/BeanManager");
     } catch (NamingException e) {
       // silently ignore
     }
-    
+
     return null;
-   
+
   }
 }

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/util/ProgrammaticBeanLookup.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/util/ProgrammaticBeanLookup.java
@@ -37,6 +37,9 @@ public class ProgrammaticBeanLookup {
 
   public static final Logger LOG = Logger.getLogger(ProgrammaticBeanLookup.class.getName());
 
+  private ProgrammaticBeanLookup() {
+  }
+
   public static <T> T lookup(Class<T> clazz, BeanManager bm) {
     return lookup(clazz, bm, true);
   }
@@ -135,5 +138,4 @@ public class ProgrammaticBeanLookup {
 
     }
   }
-
 }

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/transform/DmnExpressionTransformHelper.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/transform/DmnExpressionTransformHelper.java
@@ -29,6 +29,9 @@ import org.operaton.bpm.model.dmn.instance.UnaryTests;
 
 public class DmnExpressionTransformHelper {
 
+  private DmnExpressionTransformHelper() {
+  }
+
   public static DmnTypeDefinition createTypeDefinition(DmnElementTransformContext context, LiteralExpression expression) {
     return createTypeDefinition(context, expression.getTypeRef());
   }
@@ -95,6 +98,4 @@ public class DmnExpressionTransformHelper {
     }
     return null;
   }
-
-
 }

--- a/engine-plugins/identity-ldap/src/main/java/org/operaton/bpm/identity/impl/ldap/util/CertificateHelper.java
+++ b/engine-plugins/identity-ldap/src/main/java/org/operaton/bpm/identity/impl/ldap/util/CertificateHelper.java
@@ -27,7 +27,9 @@ import javax.net.ssl.X509TrustManager;
 
 
 public class CertificateHelper {
-  
+  private CertificateHelper() {
+  }
+
   public static void acceptUntrusted() {
     try {
       SSLContext sslContext = SSLContext.getInstance("TLS");
@@ -37,8 +39,8 @@ public class CertificateHelper {
       throw new RuntimeException("Could not change SSL TrustManager to accept arbitrary certificates", ex);
     }
   }
-
   private static class DefaultTrustManager implements X509TrustManager {
+
 
     @Override
     public void checkClientTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
@@ -47,7 +49,6 @@ public class CertificateHelper {
     @Override
     public void checkServerTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
     }
-
     @Override
     public X509Certificate[] getAcceptedIssuers() {
       return null;

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/impl/SpinFunctions.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/impl/SpinFunctions.java
@@ -32,4 +32,7 @@ public class SpinFunctions {
   public static final String S = "S";
   public static final String XML = "XML";
   public static final String JSON = "JSON";
+
+  private SpinFunctions() {
+  }
 }

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/impl/SpinVariableSerializers.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/impl/SpinVariableSerializers.java
@@ -32,6 +32,9 @@ import org.operaton.spin.xml.SpinXmlElement;
  */
 public class SpinVariableSerializers {
 
+  private SpinVariableSerializers() {
+  }
+
   public static List<TypedValueSerializer<?>> createObjectValueSerializers(DataFormats dataFormats) {
     List<TypedValueSerializer<?>> serializers = new ArrayList<TypedValueSerializer<?>>();
 

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/SpinValues.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/SpinValues.java
@@ -29,6 +29,9 @@ import org.operaton.spin.xml.SpinXmlElement;
  */
 public class SpinValues {
 
+  private SpinValues() {
+  }
+
   public static JsonValueBuilder jsonValue(SpinJsonNode value) {
     return jsonValue(value, false);
   }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/converter/ReportResultToCsvConverter.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/converter/ReportResultToCsvConverter.java
@@ -18,20 +18,20 @@ package org.operaton.bpm.engine.rest.dto.converter;
 
 import java.util.List;
 
+import javax.ws.rs.core.Response.Status;
+
 import org.operaton.bpm.engine.history.DurationReportResult;
 import org.operaton.bpm.engine.history.ReportResult;
 import org.operaton.bpm.engine.rest.dto.history.HistoricProcessInstanceReportDto;
 import org.operaton.bpm.engine.rest.exception.InvalidRequestException;
-
-import javax.ws.rs.core.Response.Status;
 
 /**
  * @author Roman Smirnov
  *
  */
 public class ReportResultToCsvConverter {
-
   protected static String DELIMITER = ",";
+
   protected static String NEW_LINE_SEPARATOR = "\n";
 
   public static String DURATION_HEADER = "PERIOD"
@@ -39,6 +39,9 @@ public class ReportResultToCsvConverter {
                               + DELIMITER + "MINIMUM"
                               + DELIMITER + "MAXIMUM"
                               + DELIMITER + "AVERAGE";
+
+  private ReportResultToCsvConverter() {
+  }
 
   public static String convertReportResult(List<ReportResult> reports, String reportType) {
     if (HistoricProcessInstanceReportDto.REPORT_TYPE_DURATION.equals(reportType)) {
@@ -69,5 +72,4 @@ public class ReportResultToCsvConverter {
 
     return buffer.toString();
   }
-
 }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/converter/TaskReportResultToCsvConverter.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/converter/TaskReportResultToCsvConverter.java
@@ -33,6 +33,9 @@ public class TaskReportResultToCsvConverter {
                                                 + DELIMITER
                                                 + "TASK_COUNT";
 
+  private TaskReportResultToCsvConverter() {
+  }
+
   public static String convertCandidateGroupReportResult(List<TaskCountByCandidateGroupResult> reports) {
     StringBuilder buffer = new StringBuilder();
 
@@ -47,5 +50,4 @@ public class TaskReportResultToCsvConverter {
 
     return buffer.toString();
   }
-
 }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/OperatonRestResources.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/OperatonRestResources.java
@@ -16,8 +16,10 @@
  */
 package org.operaton.bpm.engine.rest.impl;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import java.util.HashSet;
+import java.util.Set;
 
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import org.operaton.bpm.engine.rest.exception.ExceptionHandler;
 import org.operaton.bpm.engine.rest.exception.JsonMappingExceptionHandler;
 import org.operaton.bpm.engine.rest.exception.JsonParseExceptionHandler;
@@ -26,9 +28,6 @@ import org.operaton.bpm.engine.rest.exception.RestExceptionHandler;
 import org.operaton.bpm.engine.rest.hal.JacksonHalJsonProvider;
 import org.operaton.bpm.engine.rest.mapper.JacksonConfigurator;
 import org.operaton.bpm.engine.rest.mapper.MultipartPayloadProvider;
-
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * <p>Class providing static methods returning all the resource classes provided by Operaton.</p>
@@ -57,6 +56,9 @@ public class OperatonRestResources {
     CONFIGURATION_CLASSES.add(ExceptionHandler.class);
   }
 
+  private OperatonRestResources() {
+  }
+
   /**
    * Returns a set containing all resource classes provided by Operaton.
    * @return a set of resource classes.
@@ -73,5 +75,4 @@ public class OperatonRestResources {
   public static Set<Class<?>> getConfigurationClasses() {
     return CONFIGURATION_CLASSES;
   }
-
 }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/ApplicationContextPathUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/ApplicationContextPathUtil.java
@@ -26,6 +26,8 @@ import org.operaton.bpm.engine.repository.CaseDefinition;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 
 public class ApplicationContextPathUtil {
+  private ApplicationContextPathUtil() {
+  }
 
   public static String getApplicationPathByProcessDefinitionId(ProcessEngine engine, String processDefinitionId) {
     ProcessDefinition processDefinition = engine.getRepositoryService().getProcessDefinition(processDefinitionId);

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/ContentTypeUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/ContentTypeUtil.java
@@ -24,6 +24,9 @@ public class ContentTypeUtil {
 
   private static final String SUFFIX_FORM_FILE = ".form";
 
+  private ContentTypeUtil() {
+  }
+
   /**
    * @return the content type to use for the provided form's key
    *

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/EncodingUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/EncodingUtil.java
@@ -26,6 +26,9 @@ public class EncodingUtil {
 
   public static final Charset DEFAULT_ENCODING = getDefaultEncoding();
 
+  private EncodingUtil() {
+  }
+
   protected static Charset getDefaultEncoding() {
     Charset charset = null;
     try {

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/EngineUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/EngineUtil.java
@@ -26,6 +26,9 @@ import java.util.ServiceLoader;
 
 public class EngineUtil {
 
+  private EngineUtil() {
+  }
+
   /**
    * Look up the process engine from the {@link ProcessEngineProvider}. If engineName is null, the default engine is returned.
    * @param engineName

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/PathUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/PathUtil.java
@@ -22,6 +22,9 @@ package org.operaton.bpm.engine.rest.util;
  */
 public class PathUtil {
 
+  private PathUtil() {
+  }
+
   public static String decodePathParam(String param) {
 
     return param

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/ProvidersUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/ProvidersUtil.java
@@ -28,6 +28,9 @@ import javax.ws.rs.ext.Providers;
  */
 public class ProvidersUtil {
 
+  private ProvidersUtil() {
+  }
+
   public static <T> T resolveFromContext(Providers providers, Class<T> clazz) {
     return resolveFromContext(providers, clazz, null);
   }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/URLEncodingUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/URLEncodingUtil.java
@@ -24,6 +24,9 @@ import static java.text.MessageFormat.format;
 
 public class URLEncodingUtil {
 
+  private URLEncodingUtil() {
+  }
+
   /**
    * Encode a string value using `UTF-8` encoding scheme
    */
@@ -43,5 +46,4 @@ public class URLEncodingUtil {
   public static String buildAttachmentValue(String attachmentFileName) {
     return format("attachment; filename=\"{0}\"; filename*=UTF-8''''{1}", attachmentFileName, encode(attachmentFileName));
   }
-
 }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/WebApplicationUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/WebApplicationUtil.java
@@ -16,14 +16,16 @@
  */
 package org.operaton.bpm.engine.rest.util;
 
-import static org.operaton.bpm.engine.rest.util.EngineUtil.getProcessEngineProvider;
-
 import org.operaton.bpm.engine.impl.ManagementServiceImpl;
 import org.operaton.bpm.engine.impl.diagnostics.PlatformDiagnosticsRegistry;
 import org.operaton.bpm.engine.impl.telemetry.dto.LicenseKeyDataImpl;
 import org.operaton.bpm.engine.rest.spi.ProcessEngineProvider;
+import static org.operaton.bpm.engine.rest.util.EngineUtil.getProcessEngineProvider;
 
 public class WebApplicationUtil {
+
+  private WebApplicationUtil() {
+  }
 
   public static void setApplicationServer(String serverInfo) {
     if (serverInfo != null && !serverInfo.isEmpty() ) {

--- a/engine-spring/core/src/main/java/org/operaton/bpm/engine/spring/SpringConfigurationHelper.java
+++ b/engine-spring/core/src/main/java/org/operaton/bpm/engine/spring/SpringConfigurationHelper.java
@@ -16,12 +16,13 @@
  */
 package org.operaton.bpm.engine.spring;
 
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.ProcessEngineException;
+
 import java.net.URL;
 import java.util.Map;
 import java.util.logging.Logger;
 
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.ProcessEngine;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.GenericXmlApplicationContext;
 import org.springframework.core.io.UrlResource;
@@ -34,9 +35,12 @@ public class SpringConfigurationHelper {
 
   private static final Logger log = Logger.getLogger(SpringConfigurationHelper.class.getName());
 
+  private SpringConfigurationHelper() {
+  }
+
   public static ProcessEngine buildProcessEngine(URL resource) {
     log.fine("==== BUILDING SPRING APPLICATION CONTEXT AND PROCESS ENGINE =========================================");
-    
+
     ApplicationContext applicationContext = new GenericXmlApplicationContext(new UrlResource(resource));
     Map<String, ProcessEngine> beansOfType = applicationContext.getBeansOfType(ProcessEngine.class);
     if ( (beansOfType==null)
@@ -44,12 +48,10 @@ public class SpringConfigurationHelper {
        ) {
       throw new ProcessEngineException("no "+ProcessEngine.class.getName()+" defined in the application context "+resource.toString());
     }
-    
+
     ProcessEngine processEngine = beansOfType.values().iterator().next();
 
     log.fine("==== SPRING PROCESS ENGINE CREATED ==================================================================");
     return processEngine;
   }
-
-
 }

--- a/engine-spring/core/src/main/java/org/operaton/bpm/engine/spring/components/ActivitiContextUtils.java
+++ b/engine-spring/core/src/main/java/org/operaton/bpm/engine/spring/components/ActivitiContextUtils.java
@@ -31,5 +31,8 @@ public class ActivitiContextUtils {
 	 */
 	public static final String ACTIVITI_REGISTRY_BEAN_NAME = "activitiComponentRegistry" ;
 
+  private ActivitiContextUtils() {
+  }
+
 
 }

--- a/engine/src/main/java/org/operaton/bpm/BpmPlatform.java
+++ b/engine/src/main/java/org/operaton/bpm/BpmPlatform.java
@@ -38,6 +38,9 @@ public final class BpmPlatform {
   public static final String PROCESS_ENGINE_SERVICE_JNDI_NAME = JNDI_NAME_PREFIX + "/" + APP_JNDI_NAME + "/" + MODULE_JNDI_NAME + "/" + PROCESS_ENGINE_SERVICE_NAME;
   public static final String PROCESS_APPLICATION_SERVICE_JNDI_NAME = JNDI_NAME_PREFIX + "/" + APP_JNDI_NAME + "/" + MODULE_JNDI_NAME + "/" + PROCESS_APPLICATION_SERVICE_NAME;
 
+  private BpmPlatform() {
+  }
+
   public static ProcessEngineService getProcessEngineService() {
     return RuntimeContainerDelegate.INSTANCE.get().getProcessEngineService();
   }
@@ -49,5 +52,4 @@ public final class BpmPlatform {
   public static ProcessEngine getDefaultProcessEngine() {
     return getProcessEngineService().getDefaultProcessEngine();
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/application/ProcessApplicationContext.java
+++ b/engine/src/main/java/org/operaton/bpm/application/ProcessApplicationContext.java
@@ -57,6 +57,9 @@ import org.operaton.bpm.application.impl.ProcessApplicationIdentifier;
  */
 public class ProcessApplicationContext {
 
+  private ProcessApplicationContext() {
+  }
+
   /**
    * Declares the context process application for all subsequent engine API invocations
    * until {@link #clear()} is called. The context is bound to the current thread.

--- a/engine/src/main/java/org/operaton/bpm/application/impl/DefaultElResolverLookup.java
+++ b/engine/src/main/java/org/operaton/bpm/application/impl/DefaultElResolverLookup.java
@@ -16,16 +16,16 @@
  */
 package org.operaton.bpm.application.impl;
 
+import org.operaton.bpm.application.AbstractProcessApplication;
+import org.operaton.bpm.application.ProcessApplicationElResolver;
+import org.operaton.bpm.engine.impl.ProcessEngineLogger;
+
+import jakarta.el.CompositeELResolver;
+import jakarta.el.ELResolver;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.ServiceLoader;
-
-import org.operaton.bpm.application.AbstractProcessApplication;
-import org.operaton.bpm.application.ProcessApplicationElResolver;
-import org.operaton.bpm.engine.impl.ProcessEngineLogger;
-import jakarta.el.CompositeELResolver;
-import jakarta.el.ELResolver;
 
 /**
  * @author Daniel Meyer
@@ -34,6 +34,9 @@ import jakarta.el.ELResolver;
 public class DefaultElResolverLookup {
 
   private static final ProcessApplicationLogger LOG = ProcessEngineLogger.PROCESS_APPLICATION_LOGGER;
+
+  private DefaultElResolverLookup() {
+  }
 
   public static final ELResolver lookupResolver(AbstractProcessApplication processApplication) {
 
@@ -73,5 +76,4 @@ public class DefaultElResolverLookup {
     }
 
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/application/impl/ProcessApplicationContextImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/application/impl/ProcessApplicationContextImpl.java
@@ -25,6 +25,9 @@ public class ProcessApplicationContextImpl {
   protected static ThreadLocal<ProcessApplicationIdentifier> currentProcessApplication =
       new ThreadLocal<>();
 
+  private ProcessApplicationContextImpl() {
+  }
+
   public static ProcessApplicationIdentifier get() {
     return currentProcessApplication.get();
   }

--- a/engine/src/main/java/org/operaton/bpm/container/impl/deployment/Attachments.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/deployment/Attachments.java
@@ -30,4 +30,7 @@ public class Attachments {
   public static final String PROCESS_ARCHIVE_DEPLOYMENT_MAP = "processArchiveDeploymentMap";
   public static final String BPM_PLATFORM_XML = "bpmPlatformXml";
 
+  private Attachments() {
+  }
+
 }

--- a/engine/src/main/java/org/operaton/bpm/container/impl/deployment/scanning/ProcessApplicationScanningUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/deployment/scanning/ProcessApplicationScanningUtil.java
@@ -27,6 +27,9 @@ import org.operaton.bpm.engine.impl.dmn.deployer.DecisionDefinitionDeployer;
 
 public class ProcessApplicationScanningUtil {
 
+  private ProcessApplicationScanningUtil() {
+  }
+
   /**
    *
    * @param classLoader

--- a/engine/src/main/java/org/operaton/bpm/container/impl/deployment/util/InjectionUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/deployment/util/InjectionUtil.java
@@ -16,6 +16,18 @@
  */
 package org.operaton.bpm.container.impl.deployment.util;
 
+import org.operaton.bpm.application.AbstractProcessApplication;
+import org.operaton.bpm.application.ProcessApplicationDeploymentInfo;
+import org.operaton.bpm.application.ProcessApplicationInfo;
+import org.operaton.bpm.container.impl.ContainerIntegrationLogger;
+import org.operaton.bpm.container.impl.deployment.Attachments;
+import org.operaton.bpm.container.impl.jmx.services.JmxManagedProcessApplication;
+import org.operaton.bpm.container.impl.spi.DeploymentOperation;
+import org.operaton.bpm.container.impl.spi.PlatformServiceContainer;
+import org.operaton.bpm.container.impl.spi.ServiceTypes;
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.impl.ProcessEngineLogger;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -23,23 +35,14 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.operaton.bpm.application.AbstractProcessApplication;
-import org.operaton.bpm.application.ProcessApplicationDeploymentInfo;
-import org.operaton.bpm.application.ProcessApplicationInfo;
-import org.operaton.bpm.container.impl.ContainerIntegrationLogger;
-import org.operaton.bpm.container.impl.deployment.Attachments;
-import org.operaton.bpm.container.impl.jmx.services.JmxManagedProcessApplication;
-import org.operaton.bpm.container.impl.spi.PlatformServiceContainer;
-import org.operaton.bpm.container.impl.spi.DeploymentOperation;
-import org.operaton.bpm.container.impl.spi.ServiceTypes;
-import org.operaton.bpm.engine.ProcessEngine;
-import org.operaton.bpm.engine.impl.ProcessEngineLogger;
-
 /**
  * @author Daniel Meyer
  *
  */
 public class InjectionUtil {
+
+  private InjectionUtil() {
+  }
 
   private static final ContainerIntegrationLogger LOG = ProcessEngineLogger.CONTAINER_INTEGRATION_LOGGER;
 
@@ -130,5 +133,4 @@ public class InjectionUtil {
     final PlatformServiceContainer serviceContainer = operationContext.getServiceContainer();
     return serviceContainer.getServiceValue(ServiceTypes.PROCESS_ENGINE, "default");
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/container/impl/metadata/DeploymentMetadataConstants.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/metadata/DeploymentMetadataConstants.java
@@ -48,4 +48,6 @@ public class DeploymentMetadataConstants {
   public static final String PROCESS = "process";
   public static final String RESOURCE = "resource";
 
+  private DeploymentMetadataConstants() {
+  }
 }

--- a/engine/src/main/java/org/operaton/bpm/container/impl/metadata/PropertyHelper.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/metadata/PropertyHelper.java
@@ -40,6 +40,9 @@ public class PropertyHelper {
   public static final String SNAKE_CASE = "_";
   public static final String CAMEL_CASE = "";
 
+  private PropertyHelper() {
+  }
+
   /**
    * Regex for Ant-style property placeholders
    */
@@ -165,5 +168,4 @@ public class PropertyHelper {
     }
     return value;
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/container/impl/tomcat/deployment/TomcatAttachments.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/tomcat/deployment/TomcatAttachments.java
@@ -26,4 +26,6 @@ public class TomcatAttachments {
 
   public static final String SERVER = "server";
 
+  private TomcatAttachments() {
+  }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/EntityTypes.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/EntityTypes.java
@@ -58,4 +58,7 @@ public class EntityTypes {
   public static final String INCIDENT = "Incident";
   public static final String SYSTEM = "System";
   public static final String COMMENT = "Comment";
+
+  private EntityTypes() {
+  }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/context/DelegateExecutionContext.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/context/DelegateExecutionContext.java
@@ -29,6 +29,9 @@ import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
  */
 public class DelegateExecutionContext {
 
+  private DelegateExecutionContext() {
+  }
+
   /**
    * Returns the current delegation execution or null if the
    * execution is not available.

--- a/engine/src/main/java/org/operaton/bpm/engine/context/ProcessEngineContext.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/context/ProcessEngineContext.java
@@ -60,6 +60,9 @@ import java.util.concurrent.Callable;
  */
 public class ProcessEngineContext {
 
+  private ProcessEngineContext() {
+  }
+
   /**
    * Declares to the Process Engine that a new, separate context,
    * bound to the current thread, needs to be created for all subsequent

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/OperationLogQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/OperationLogQueryProperty.java
@@ -28,4 +28,7 @@ public class OperationLogQueryProperty {
 
   public static final QueryProperty TIMESTAMP = new QueryPropertyImpl("TIMESTAMP_");
 
+  private OperationLogQueryProperty() {
+  }
+
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/BpmnExceptionHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/BpmnExceptionHandler.java
@@ -38,6 +38,9 @@ public class BpmnExceptionHandler {
 
   private static final BpmnBehaviorLogger LOG = ProcessEngineLogger.BPMN_BEHAVIOR_LOGGER;
 
+  private BpmnExceptionHandler() {
+  }
+
   /**
    * Decides how to propagate the exception properly, e.g. as bpmn error or "normal" error.
    * @param execution the current execution
@@ -154,6 +157,4 @@ public class BpmnExceptionHandler {
       errorHandlingExecution.executeActivity(errorHandlingActivity);
     }
   }
-
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/BpmnProperties.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/BpmnProperties.java
@@ -79,4 +79,7 @@ public class BpmnProperties {
   public static final PropertyKey<Map<String, String>> EXTENSION_PROPERTIES = new PropertyKey<>("extensionProperties");
 
   public static final PropertyListKey<OperatonErrorEventDefinition> CAMUNDA_ERROR_EVENT_DEFINITION = new PropertyListKey<>("operatonErrorEventDefinition");
+
+  private BpmnProperties() {
+  }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/CmmnProperties.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/CmmnProperties.java
@@ -26,4 +26,7 @@ public class CmmnProperties {
 
   public static final PropertyListKey<String> REPEAT_ON_STANDARD_EVENTS = new PropertyListKey<>("repeatOnStandardEvents");
 
+  private CmmnProperties() {
+  }
+
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/CompensationUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/CompensationUtil.java
@@ -16,15 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.helper;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
 import org.operaton.bpm.engine.impl.bpmn.parser.BpmnParse;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.event.EventType;
@@ -34,14 +25,20 @@ import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.operaton.bpm.engine.impl.pvm.process.ActivityImpl;
 import org.operaton.bpm.engine.impl.pvm.process.ScopeImpl;
 import org.operaton.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
-import org.operaton.bpm.engine.impl.tree.TreeVisitor;
 import org.operaton.bpm.engine.impl.tree.FlowScopeWalker;
 import org.operaton.bpm.engine.impl.tree.ReferenceWalker;
+import org.operaton.bpm.engine.impl.tree.TreeVisitor;
+
+import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * @author Daniel Meyer
  */
 public class CompensationUtil {
+
+  private CompensationUtil() {
+  }
 
   /**
    * name of the signal that is thrown when a compensation handler completed
@@ -253,5 +250,4 @@ public class CompensationUtil {
       }
     }
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/EscalationHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/EscalationHandler.java
@@ -35,6 +35,9 @@ public class EscalationHandler {
 
   private static final BpmnBehaviorLogger LOG = ProcessEngineLogger.BPMN_BEHAVIOR_LOGGER;
 
+  private EscalationHandler() {
+  }
+
   public static void propagateEscalation(ActivityExecution execution, String escalationCode) {
     EscalationEventDefinition escalationEventDefinition = executeEscalation(execution, escalationCode);
 
@@ -95,5 +98,4 @@ public class EscalationHandler {
       return escalationHandler.getFlowScope();
     }
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/BpmnParseUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/BpmnParseUtil.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+
 import org.operaton.bpm.engine.BpmnParseException;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.context.Context;
@@ -42,6 +43,9 @@ import org.operaton.bpm.engine.impl.util.xml.Element;
  * Helper methods to reused for common parsing tasks.
  */
 public final class BpmnParseUtil {
+
+  private BpmnParseUtil() {
+  }
 
   /**
    * Returns the operaton extension element in the operaton namespace
@@ -255,5 +259,4 @@ public final class BpmnParseUtil {
   protected static ExpressionManager getExpressionManager() {
     return Context.getProcessEngineConfiguration().getExpressionManager();
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/DateTimeUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/DateTimeUtil.java
@@ -43,6 +43,9 @@ public class DateTimeUtil {
 
   private static DateTimeFormatter DATE_TIME_FORMATER;
 
+  private DateTimeUtil() {
+  }
+
   private static DateTimeFormatter getDataTimeFormater() {
     if (DATE_TIME_FORMATER == null) {
       DATE_TIME_FORMATER = ISODateTimeFormat.dateTimeParser().withZone(JVM_DEFAULT_DATE_TIME_ZONE);
@@ -62,5 +65,4 @@ public class DateTimeUtil {
   public static Date parseDate(String date) {
     return parseDateTime(date).toDate();
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/BeansConfigurationHelper.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/BeansConfigurationHelper.java
@@ -31,6 +31,9 @@ import org.springframework.core.io.Resource;
  */
 public class BeansConfigurationHelper {
 
+  private BeansConfigurationHelper() {
+  }
+
   public static ProcessEngineConfiguration parseProcessEngineConfiguration(Resource springResource, String beanName) {
     DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
     XmlBeanDefinitionReader xmlBeanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/LicenseCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/LicenseCmd.java
@@ -19,5 +19,4 @@ package org.operaton.bpm.engine.impl.cmd;
 public class LicenseCmd {
   public static final String LICENSE_KEY_PROPERTY_NAME = "operaton-license-key";
   public static final String LICENSE_KEY_BYTE_ARRAY_ID = "operaton-license-key-id";
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/context/Context.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/context/Context.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.context;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.concurrent.Callable;
+
 import org.operaton.bpm.application.InvocationContext;
 import org.operaton.bpm.application.ProcessApplicationInterface;
 import org.operaton.bpm.application.ProcessApplicationReference;
@@ -39,14 +40,17 @@ import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
  * @author Thorben Lindhauer
  */
 public class Context {
-
   protected static ThreadLocal<Deque<CommandContext>> commandContextThreadLocal = new ThreadLocal<>();
+
   protected static ThreadLocal<Deque<CommandInvocationContext>> commandInvocationContextThreadLocal = new ThreadLocal<>();
 
   protected static ThreadLocal<Deque<ProcessEngineConfigurationImpl>> processEngineConfigurationStackThreadLocal = new ThreadLocal<>();
   protected static ThreadLocal<Deque<CoreExecutionContext<? extends CoreExecution>>> executionContextStackThreadLocal = new ThreadLocal<>();
   protected static ThreadLocal<JobExecutorContext> jobExecutorContextThreadLocal = new ThreadLocal<>();
   protected static ThreadLocal<Deque<ProcessApplicationReference>> processApplicationContext = new ThreadLocal<>();
+
+  private Context() {
+  }
 
   public static CommandContext getCommandContext() {
     Deque<CommandContext> stack = getStack(commandContextThreadLocal);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/context/ProcessApplicationContextUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/context/ProcessApplicationContextUtil.java
@@ -35,6 +35,9 @@ public class ProcessApplicationContextUtil {
 
   private static final ProcessApplicationLogger LOG = ProcessApplicationLogger.PROCESS_APPLICATION_LOGGER;
 
+  private ProcessApplicationContextUtil() {
+  }
+
   public static ProcessApplicationReference getTargetProcessApplication(CoreExecution execution) {
     if (execution instanceof ExecutionEntity executionEntity) {
       return getTargetProcessApplication(executionEntity);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/context/ProcessEngineContextImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/context/ProcessEngineContextImpl.java
@@ -18,6 +18,9 @@ package org.operaton.bpm.engine.impl.context;
 
 public class ProcessEngineContextImpl {
 
+  private ProcessEngineContextImpl() {
+  }
+
   protected static ThreadLocal<Boolean> commandContextNew = new ThreadLocal<>() {
     @Override
     protected Boolean initialValue() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/VariableUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/VariableUtil.java
@@ -37,11 +37,12 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 public class VariableUtil {
-
   public static final CommandLogger CMD_LOGGER = ProcessEngineLogger.CMD_LOGGER;
   public static final CoreLogger CORE_LOGGER = ProcessEngineLogger.CORE_LOGGER;
-
   public static final String ERROR_MSG = "Cannot set variable with name {0}. Java serialization format is prohibited";
+
+  private VariableUtil() {
+  }
 
   /**
    * Checks, if Java serialization will be used and if it is allowed to be used.
@@ -136,10 +137,9 @@ public class VariableUtil {
   protected static TypedValue getSerializedValue(VariableInstanceEntity variableInstanceEntity) {
     return variableInstanceEntity.getTypedValue(false);
   }
-
   @FunctionalInterface
   public interface SetVariableFunction {
     void apply(String variableName, Object variableValue);
-  }
 
+  }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/MybatisJoinHelper.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/MybatisJoinHelper.java
@@ -28,8 +28,8 @@ import org.operaton.bpm.engine.query.QueryProperty;
  * @author Thorben Lindhauer
  */
 public class MybatisJoinHelper {
-
   protected static final EnginePersistenceLogger LOG = ProcessEngineLogger.PERSISTENCE_LOGGER;
+
   protected static final String DEFAULT_ORDER = "RES.ID_ asc";
   public static Map<String, MyBatisTableMapping> mappings = new HashMap<>();
 
@@ -38,6 +38,9 @@ public class MybatisJoinHelper {
     mappings.put(QueryOrderingProperty.RELATION_PROCESS_DEFINITION, new ProcessDefinitionTableMapping());
     mappings.put(QueryOrderingProperty.RELATION_CASE_DEFINITION, new CaseDefinitionTableMapping());
     mappings.put(QueryOrderingProperty.RELATION_DEPLOYMENT, new DeploymentTableMapping());
+  }
+
+  private MybatisJoinHelper() {
   }
 
   public static String tableAlias(String relation, int index) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/diagnostics/OperatonIntegration.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/diagnostics/OperatonIntegration.java
@@ -24,4 +24,6 @@ public class OperatonIntegration {
   public static final String JBOSS_SUBSYSTEM = "jboss-subsystem";
   public static final String CAMUNDA_EJB_SERVICE = "operaton-ejb-service";
 
+  private OperatonIntegration() {
+  }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/diagnostics/PlatformDiagnosticsRegistry.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/diagnostics/PlatformDiagnosticsRegistry.java
@@ -22,6 +22,9 @@ public class PlatformDiagnosticsRegistry {
 
   protected static ApplicationServerImpl applicationServer;
 
+  private PlatformDiagnosticsRegistry() {
+  }
+
   public static synchronized ApplicationServerImpl getApplicationServer() {
     return applicationServer;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/digest/_apacheCommonsCodec/StringUtils.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/digest/_apacheCommonsCodec/StringUtils.java
@@ -33,6 +33,9 @@ public class StringUtils {
 
     public static final String UTF_8 = StandardCharsets.UTF_8.name();
 
+    private StringUtils() {
+    }
+
     /**
      * Constructs a new <code>String</code> by decoding the specified array of bytes using the given charset.
      * <p>

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/el/CommandContextFunctions.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/el/CommandContextFunctions.java
@@ -28,6 +28,9 @@ public class CommandContextFunctions {
   public static final String CURRENT_USER = "currentUser";
   public static final String CURRENT_USER_GROUPS = "currentUserGroups";
 
+  private CommandContextFunctions() {
+  }
+
   public static String currentUser() {
     CommandContext commandContext = Context.getCommandContext();
     if (commandContext != null) {
@@ -47,5 +50,4 @@ public class CommandContextFunctions {
       return null;
     }
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/el/DateTimeFunctions.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/el/DateTimeFunctions.java
@@ -16,9 +16,10 @@
  */
 package org.operaton.bpm.engine.impl.el;
 
+import org.operaton.bpm.engine.impl.util.ClockUtil;
+
 import java.util.Date;
 
-import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.joda.time.DateTime;
 
 /**
@@ -27,6 +28,9 @@ import org.joda.time.DateTime;
 public class DateTimeFunctions {
   public static final String NOW = "now";
   public static final String DATE_TIME = "dateTime";
+
+  private DateTimeFunctions() {
+  }
 
   public static Date now() {
     return ClockUtil.getCurrentTime();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/form/FormPropertyHelper.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/form/FormPropertyHelper.java
@@ -28,10 +28,12 @@ import org.operaton.bpm.engine.variable.VariableMap;
  */
 public class FormPropertyHelper {
 
+  private FormPropertyHelper() {
+  }
+
   public static void initFormPropertiesOnScope(VariableMap variables, PvmExecutionImpl execution) {
     ProcessDefinitionEntity pd = (ProcessDefinitionEntity) execution.getProcessDefinition();
     StartFormHandler startFormHandler = pd.getStartFormHandler();
     startFormHandler.submitFormVariables(variables, execution);
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/event/HistoryEventProcessor.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/event/HistoryEventProcessor.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.history.event;
 
 import java.util.Collections;
 import java.util.List;
+
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.history.handler.HistoryEventHandler;
@@ -36,6 +37,9 @@ import org.operaton.bpm.engine.impl.history.producer.HistoryEventProducer;
  * @since 7.5
  */
 public class HistoryEventProcessor {
+
+  private HistoryEventProcessor() {
+  }
 
   /**
    * The {@link HistoryEventCreator} interface which is used to interchange the implementation

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/incident/IncidentHandling.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/incident/IncidentHandling.java
@@ -21,6 +21,9 @@ import org.operaton.bpm.engine.runtime.Incident;
 
 public class IncidentHandling {
 
+  private IncidentHandling() {
+  }
+
   public static Incident createIncident(String incidentType,
       IncidentContext context,
       String message) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/ExecuteJobHelper.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/ExecuteJobHelper.java
@@ -39,6 +39,9 @@ public class ExecuteJobHelper {
 
   };
 
+  private ExecuteJobHelper() {
+  }
+
   public static void executeJob(String jobId, CommandExecutor commandExecutor) {
 
     JobFailureCollector jobFailureCollector = new JobFailureCollector(jobId);
@@ -132,9 +135,8 @@ public class ExecuteJobHelper {
   protected static SuccessfulJobListener createSuccessfulJobListener(CommandExecutor commandExecutor) {
     return new SuccessfulJobListener();
   }
-
   public interface ExceptionLoggingHandler {
     void exceptionWhileExecutingJob(String jobId, Throwable exception);
-  }
 
+  }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/metrics/util/MetricsUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/metrics/util/MetricsUtil.java
@@ -20,6 +20,9 @@ import org.operaton.bpm.engine.management.Metrics;
 
 public class MetricsUtil {
 
+  private MetricsUtil() {
+  }
+
   /**
    * Resolves the internal name of the metric by the public name.
    *
@@ -53,5 +56,4 @@ public class MetricsUtil {
     default -> internalName;
     };
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/util/AuthManagerUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/util/AuthManagerUtil.java
@@ -22,6 +22,9 @@ import org.operaton.bpm.engine.authorization.ProcessDefinitionPermissions;
 
 public class AuthManagerUtil {
 
+  private AuthManagerUtil() {
+  }
+
   public static VariablePermissions getVariablePermissions(boolean ensureSpecificVariablePermission) {
     return new VariablePermissions(ensureSpecificVariablePermission);
   }
@@ -50,6 +53,6 @@ public class AuthManagerUtil {
     public Permission getHistoricTaskPermission() {
       return historicTaskPermission;
     }
-  }
 
+  }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/PvmEvent.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/PvmEvent.java
@@ -26,4 +26,6 @@ public class PvmEvent {
   public static final String EVENTNAME_END = "end";
   public static final String EVENTNAME_TAKE = "take";
 
+  private PvmEvent() {
+  }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/CompensationBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/CompensationBehavior.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.engine.impl.pvm.process.ScopeImpl;
  */
 public class CompensationBehavior {
 
+  private CompensationBehavior() {
+  }
+
   /**
    * With compensation, we have a dedicated scope execution for every handler, even if the handler is not
    * a scope activity; this must be respected when invoking end listeners, etc.
@@ -84,5 +87,4 @@ public class CompensationBehavior {
 
     return parentScopeExecution.getParentActivityInstanceId();
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/LegacyBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/LegacyBehavior.java
@@ -16,36 +16,13 @@
  */
 package org.operaton.bpm.engine.impl.pvm.runtime;
 
-import static org.operaton.bpm.engine.impl.bpmn.helper.CompensationUtil.SIGNAL_COMPENSATION_DONE;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
-import org.operaton.bpm.engine.impl.bpmn.behavior.BpmnBehaviorLogger;
-import org.operaton.bpm.engine.impl.bpmn.behavior.CancelBoundaryEventActivityBehavior;
-import org.operaton.bpm.engine.impl.bpmn.behavior.CancelEndEventActivityBehavior;
-import org.operaton.bpm.engine.impl.bpmn.behavior.CompensationEventActivityBehavior;
-import org.operaton.bpm.engine.impl.bpmn.behavior.EventSubProcessActivityBehavior;
-import org.operaton.bpm.engine.impl.bpmn.behavior.MultiInstanceActivityBehavior;
-import org.operaton.bpm.engine.impl.bpmn.behavior.ReceiveTaskActivityBehavior;
-import org.operaton.bpm.engine.impl.bpmn.behavior.SequentialMultiInstanceActivityBehavior;
-import org.operaton.bpm.engine.impl.bpmn.behavior.SubProcessActivityBehavior;
+import org.operaton.bpm.engine.impl.bpmn.behavior.*;
 import org.operaton.bpm.engine.impl.bpmn.parser.BpmnParse;
 import org.operaton.bpm.engine.impl.cmd.GetActivityInstanceCmd;
 import org.operaton.bpm.engine.impl.jobexecutor.AsyncContinuationJobHandler;
-import org.operaton.bpm.engine.impl.persistence.entity.ActivityInstanceImpl;
-import org.operaton.bpm.engine.impl.persistence.entity.EventSubscriptionEntity;
-import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
-import org.operaton.bpm.engine.impl.persistence.entity.JobDefinitionEntity;
-import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
-import org.operaton.bpm.engine.impl.persistence.entity.VariableInstanceEntity;
-import org.operaton.bpm.engine.impl.persistence.entity.VariableInstanceHistoryListener;
+import org.operaton.bpm.engine.impl.persistence.entity.*;
 import org.operaton.bpm.engine.impl.pvm.PvmActivity;
 import org.operaton.bpm.engine.impl.pvm.PvmScope;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityBehavior;
@@ -55,6 +32,9 @@ import org.operaton.bpm.engine.impl.pvm.process.ActivityImpl;
 import org.operaton.bpm.engine.impl.pvm.process.ScopeImpl;
 import org.operaton.bpm.engine.impl.tree.ExecutionWalker;
 import org.operaton.bpm.engine.impl.tree.ReferenceWalker;
+import static org.operaton.bpm.engine.impl.bpmn.helper.CompensationUtil.SIGNAL_COMPENSATION_DONE;
+
+import java.util.*;
 
 /**
  * This class encapsulates legacy runtime behavior for the process engine.
@@ -84,6 +64,9 @@ import org.operaton.bpm.engine.impl.tree.ReferenceWalker;
 public class LegacyBehavior {
 
   private static final BpmnBehaviorLogger LOG = ProcessEngineLogger.BPMN_BEHAVIOR_LOGGER;
+
+  private LegacyBehavior() {
+  }
 
   // concurrent scopes ///////////////////////////////////////////
 
@@ -660,5 +643,4 @@ public class LegacyBehavior {
       }
     }
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/test/ProcessEngineAssert.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/test/ProcessEngineAssert.java
@@ -20,14 +20,17 @@ import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 
 public class ProcessEngineAssert {
-  
+
+  private ProcessEngineAssert() {
+  }
+
   public static void assertProcessEnded(ProcessEngine processEngine, String processInstanceId) {
     ProcessInstance processInstance = processEngine
       .getRuntimeService()
       .createProcessInstanceQuery()
       .processInstanceId(processInstanceId)
       .singleResult();
-    
+
     if (processInstance!=null) {
       throw new AssertionError("expected finished process instance '"+processInstanceId+"' but it was still in the db");
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ActivityBehaviorUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ActivityBehaviorUtil.java
@@ -16,8 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.util;
 
-import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
-
 import org.operaton.bpm.engine.impl.cmmn.behavior.CmmnActivityBehavior;
 import org.operaton.bpm.engine.impl.cmmn.execution.CmmnExecution;
 import org.operaton.bpm.engine.impl.cmmn.model.CmmnActivity;
@@ -25,12 +23,16 @@ import org.operaton.bpm.engine.impl.pvm.PvmActivity;
 import org.operaton.bpm.engine.impl.pvm.PvmException;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityBehavior;
 import org.operaton.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
+import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * @author Roman Smirnov
  *
  */
 public class ActivityBehaviorUtil {
+
+  private ActivityBehaviorUtil() {
+  }
 
   public static CmmnActivityBehavior getActivityBehavior(CmmnExecution execution) {
     String id = execution.getId();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/BitMaskUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/BitMaskUtil.java
@@ -43,6 +43,9 @@ public class BitMaskUtil {
 
   private static final int[] MASKS = {FLAG_BIT_1, FLAG_BIT_2, FLAG_BIT_3, FLAG_BIT_4, FLAG_BIT_5, FLAG_BIT_6, FLAG_BIT_7, FLAG_BIT_8};
 
+  private BitMaskUtil() {
+  }
+
   /**
    * Set bit to '1' in the given int.
    * @param current integer value

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/CallableElementUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/CallableElementUtil.java
@@ -16,8 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.util;
 
-import static org.operaton.bpm.engine.impl.ProcessEngineLogger.UTIL_LOGGER;
-
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.delegate.VariableScope;
 import org.operaton.bpm.engine.impl.cmmn.model.CmmnCaseDefinition;
@@ -29,12 +27,16 @@ import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.operaton.bpm.engine.impl.pvm.process.ProcessDefinitionImpl;
 import org.operaton.bpm.engine.repository.DecisionDefinition;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
+import static org.operaton.bpm.engine.impl.ProcessEngineLogger.UTIL_LOGGER;
 
 /**
  * @author Roman Smirnov
  *
  */
 public class CallableElementUtil {
+
+  private CallableElementUtil() {
+  }
 
   public static DeploymentCache getDeploymentCache() {
     return Context
@@ -149,5 +151,4 @@ public class CallableElementUtil {
 
     return decisionDefinition;
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ClassDelegateUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ClassDelegateUtil.java
@@ -16,16 +16,15 @@
  */
 package org.operaton.bpm.engine.impl.util;
 
+import org.operaton.bpm.engine.ArtifactFactory;
+import org.operaton.bpm.engine.impl.ProcessEngineLogger;
+import org.operaton.bpm.engine.impl.bpmn.parser.FieldDeclaration;
+import org.operaton.bpm.engine.impl.context.Context;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.List;
-
-import org.operaton.bpm.engine.ArtifactFactory;
-import org.operaton.bpm.engine.impl.ProcessEngineLogger;
-import org.operaton.bpm.engine.impl.bpmn.parser.FieldDeclaration;
-import org.operaton.bpm.engine.impl.context.Context;
 
 /**
  * @author Roman Smirnov
@@ -34,6 +33,9 @@ import org.operaton.bpm.engine.impl.context.Context;
 public class ClassDelegateUtil {
 
   private static final EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
+
+  private ClassDelegateUtil() {
+  }
 
   public static Object instantiateDelegate(Class<?> clazz, List<FieldDeclaration> fieldDeclarations) {
     return instantiateDelegate(clazz.getName(), fieldDeclarations);
@@ -95,5 +97,4 @@ public class ClassDelegateUtil {
       return true;
     }
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ClassLoaderUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ClassLoaderUtil.java
@@ -18,7 +18,9 @@ package org.operaton.bpm.engine.impl.util;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+
 import javax.servlet.ServletContextEvent;
+
 import org.operaton.bpm.engine.ProcessEngine;
 
 /**
@@ -91,5 +93,4 @@ public class ClassLoaderUtil {
     Thread.currentThread().setContextClassLoader(ProcessEngine.class.getClassLoader());
     return currentClassloader;
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ClockUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ClockUtil.java
@@ -26,6 +26,9 @@ import org.joda.time.DateTimeUtils;
  */
 public class ClockUtil {
 
+  private ClockUtil() {
+  }
+
   /**
    * Freezes the clock to a specified Date that will be returned by
    * {@link #now()} and {@link #getCurrentTime()}
@@ -66,5 +69,4 @@ public class ClockUtil {
     DateTimeUtils.setCurrentMillisSystem();
     return new Date(DateTimeUtils.currentTimeMillis());
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/CompareUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/CompareUtil.java
@@ -27,6 +27,9 @@ import java.util.List;
  */
 public class CompareUtil {
 
+  private CompareUtil() {
+  }
+
   /**
    * Checks if any of the values are not in an ascending order. The check is done based on the {@link Comparable#compareTo(Object)} method.
    *

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/DatabaseUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/DatabaseUtil.java
@@ -17,11 +17,15 @@
 package org.operaton.bpm.engine.impl.util;
 
 import java.util.Arrays;
+
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.db.sql.DbSqlSessionFactory;
 
 public class DatabaseUtil {
+
+  private DatabaseUtil() {
+  }
 
   /**
    * Checks if the currently used database is of a given database type.

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/DecisionEvaluationUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/DecisionEvaluationUtil.java
@@ -43,6 +43,9 @@ public class DecisionEvaluationUtil {
 
   public static final String DECISION_RESULT_VARIABLE = "decisionResult";
 
+  private DecisionEvaluationUtil() {
+  }
+
   public static DecisionResultMapper getDecisionResultMapperForName(String mapDecisionResult) {
     if ("singleEntry".equals(mapDecisionResult)) {
       return new SingleEntryDecisionResultMapper();
@@ -121,5 +124,4 @@ public class DecisionEvaluationUtil {
   protected static DecisionDefinition resolveDecisionDefinition(BaseCallableElement callableElement, AbstractVariableScope execution, String defaultTenantId) {
     return CallableElementUtil.getDecisionDefinitionToCall(execution, defaultTenantId, callableElement);
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/EncryptionUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/EncryptionUtil.java
@@ -18,6 +18,9 @@ package org.operaton.bpm.engine.impl.util;
 
 public final class EncryptionUtil {
 
+  private EncryptionUtil() {
+  }
+
   public static String saltPassword(String password, String salt) {
     // Before version 7.7 no salt was used. Thus, if no salt
     // is available an empty salt should be used.

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/EnsureUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/EnsureUtil.java
@@ -36,6 +36,9 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
  */
 public final class EnsureUtil {
 
+  private EnsureUtil() {
+  }
+
   private static final EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
 
   public static void ensureNotNull(String variableName, Object value) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ExceptionUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ExceptionUtil.java
@@ -16,6 +16,11 @@
  */
 package org.operaton.bpm.engine.impl.util;
 
+import org.operaton.bpm.engine.ProcessEngineException;
+import org.operaton.bpm.engine.ProcessEnginePersistenceException;
+import org.operaton.bpm.engine.impl.context.Context;
+import org.operaton.bpm.engine.impl.persistence.entity.ByteArrayEntity;
+import org.operaton.bpm.engine.repository.ResourceType;
 import static org.operaton.bpm.engine.impl.util.ExceptionUtil.DEADLOCK_CODES.DB2;
 import static org.operaton.bpm.engine.impl.util.ExceptionUtil.DEADLOCK_CODES.H2;
 import static org.operaton.bpm.engine.impl.util.ExceptionUtil.DEADLOCK_CODES.MARIADB_MYSQL;
@@ -27,13 +32,9 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.sql.SQLException;
 import java.util.function.Supplier;
+
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.executor.BatchExecutorException;
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.ProcessEnginePersistenceException;
-import org.operaton.bpm.engine.impl.context.Context;
-import org.operaton.bpm.engine.impl.persistence.entity.ByteArrayEntity;
-import org.operaton.bpm.engine.repository.ResourceType;
 
 /**
  * @author Roman Smirnov
@@ -46,6 +47,9 @@ public class ExceptionUtil {
       "exception stack trace.";
 
   public static final String PERSISTENCE_CONNECTION_ERROR_CLASS = "08";
+
+  private ExceptionUtil() {
+  }
 
   public static String getExceptionStacktrace(Throwable exception) {
     StringWriter stringWriter = new StringWriter();
@@ -260,8 +264,8 @@ public class ExceptionUtil {
     ORACLE(60, "61000"),
     POSTGRES(0, "40P01"),
     H2(40001, "40001");
-
     protected final int errorCode;
+
     protected final String sqlState;
 
     DEADLOCK_CODES(int errorCode, String sqlState) {
@@ -337,5 +341,4 @@ public class ExceptionUtil {
   public static ProcessEnginePersistenceException wrapPersistenceException(Exception ex) {
     return new ProcessEnginePersistenceException(PERSISTENCE_EXCEPTION_MESSAGE, ex);
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/IoUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/IoUtil.java
@@ -41,6 +41,9 @@ public class IoUtil {
 
   private static final EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
 
+  private IoUtil() {
+  }
+
   public static byte[] readInputStream(InputStream inputStream, String inputStreamName) {
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     byte[] buffer = new byte[16*1024];

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/JsonUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/JsonUtil.java
@@ -16,31 +16,14 @@
  */
 package org.operaton.bpm.engine.impl.util;
 
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.json.JsonObjectConverter;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonIOException;
-import com.google.gson.JsonNull;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSyntaxException;
+import java.lang.reflect.Type;
+import java.util.*;
+import java.util.function.Supplier;
+
+import com.google.gson.*;
 import com.google.gson.internal.LazilyParsedNumber;
 
 /**
@@ -51,6 +34,9 @@ public final class JsonUtil {
   private static final EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
 
   protected static Gson gsonMapper = createGsonMapper();
+
+  private JsonUtil() {
+  }
 
   public static void addFieldRawValue(JsonObject jsonObject, String memberName, Object rawValue) {
     if (rawValue != null) {
@@ -757,5 +743,4 @@ public final class JsonUtil {
       })
       .create();
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/LogUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/LogUtil.java
@@ -39,13 +39,17 @@ import org.operaton.bpm.engine.impl.pvm.PvmException;
 @Deprecated
 public class LogUtil {
 
-  public static enum ThreadLogMode {
-    NONE, INDENT, PRINT_ID
-  }
 
+  public static enum ThreadLogMode {
+    NONE, INDENT, PRINT_ID;
+
+  }
   private static final String LINE_SEPARATOR = System.getProperty("line.separator");
   private static Map<Integer, String> threadIndents = new HashMap<>();
   private static ThreadLogMode threadLogMode = ThreadLogMode.NONE;
+
+  private LogUtil() {
+  }
 
   public static ThreadLogMode getThreadLogMode() {
     return threadLogMode;
@@ -76,8 +80,8 @@ public class LogUtil {
   }
 
   private static Format dateFormat = new SimpleDateFormat("HH:mm:ss,SSS");
-
   public static class LogFormatter extends Formatter {
+
 
     @Override
     public String format(LogRecord record) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ParseUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ParseUtil.java
@@ -36,6 +36,9 @@ public class ParseUtil {
 
   protected static final Pattern REGEX_TTL_ISO = Pattern.compile("^P(\\d+)D$");
 
+  private ParseUtil() {
+  }
+
   /**
    * Parse History Time To Live in ISO-8601 format to integer and set into the given entity
    * @param historyTimeToLive

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/PermissionConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/PermissionConverter.java
@@ -37,15 +37,18 @@ import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
  */
 public class PermissionConverter {
 
+  private PermissionConverter() {
+  }
+
   public static Permission[] getPermissionsForNames(String[] names, int resourceType, ProcessEngineConfiguration engineConfiguration) {
-    
+
     final Permission[] permissions = new Permission[names.length];
-    
+
     for (int i = 0; i < names.length; i++) {
       permissions[i] = ((ProcessEngineConfigurationImpl) engineConfiguration).getPermissionProvider().getPermissionForName(names[i], resourceType);
     }
-        
-    return permissions;    
+
+    return permissions;
   }
 
   public static String[] getNamesForPermissions(Authorization authorization, Permission[] permissions) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/PropertiesUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/PropertiesUtil.java
@@ -26,6 +26,9 @@ public class PropertiesUtil {
 
   protected static final EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
 
+  private PropertiesUtil() {
+  }
+
   /**
    * Reads a <code>.properties</code> file from the classpath and provides a {@link Properties} object.
    */

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/QueryMaxResultsLimitUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/QueryMaxResultsLimitUtil.java
@@ -25,6 +25,9 @@ import org.operaton.bpm.engine.impl.identity.Authentication;
 
 public class QueryMaxResultsLimitUtil {
 
+  private QueryMaxResultsLimitUtil() {
+  }
+
   public static void checkMaxResultsLimit(int resultsCount, int maxResultsLimit,
                                           boolean isUserAuthenticated) {
     if (isUserAuthenticated && maxResultsLimit < Integer.MAX_VALUE) {
@@ -75,5 +78,4 @@ public class QueryMaxResultsLimitUtil {
   protected static int getMaxResultsLimit(ProcessEngineConfigurationImpl processEngineConfig) {
     return processEngineConfig.getQueryMaxResultsLimit();
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ResourceTypeUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ResourceTypeUtil.java
@@ -16,35 +16,17 @@
  */
 package org.operaton.bpm.engine.impl.util;
 
-import static org.operaton.bpm.engine.authorization.Resources.BATCH;
-import static org.operaton.bpm.engine.authorization.Resources.HISTORIC_PROCESS_INSTANCE;
-import static org.operaton.bpm.engine.authorization.Resources.HISTORIC_TASK;
-import static org.operaton.bpm.engine.authorization.Resources.OPERATION_LOG_CATEGORY;
-import static org.operaton.bpm.engine.authorization.Resources.OPTIMIZE;
-import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
-import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
-import static org.operaton.bpm.engine.authorization.Resources.TASK;
-import static org.operaton.bpm.engine.authorization.Resources.SYSTEM;
+import org.operaton.bpm.engine.BadUserRequestException;
+import org.operaton.bpm.engine.authorization.*;
+import static org.operaton.bpm.engine.authorization.Resources.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.operaton.bpm.engine.BadUserRequestException;
-import org.operaton.bpm.engine.authorization.BatchPermissions;
-import org.operaton.bpm.engine.authorization.HistoricProcessInstancePermissions;
-import org.operaton.bpm.engine.authorization.HistoricTaskPermissions;
-import org.operaton.bpm.engine.authorization.OptimizePermissions;
-import org.operaton.bpm.engine.authorization.Permission;
-import org.operaton.bpm.engine.authorization.Permissions;
-import org.operaton.bpm.engine.authorization.ProcessDefinitionPermissions;
-import org.operaton.bpm.engine.authorization.ProcessInstancePermissions;
-import org.operaton.bpm.engine.authorization.Resource;
-import org.operaton.bpm.engine.authorization.Resources;
-import org.operaton.bpm.engine.authorization.SystemPermissions;
-import org.operaton.bpm.engine.authorization.TaskPermissions;
-import org.operaton.bpm.engine.authorization.UserOperationLogCategoryPermissions;
-
 public class ResourceTypeUtil {
+
+  private ResourceTypeUtil() {
+  }
 
   /**
    * A map containing all {@link Resources} as a key and

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ResourceUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ResourceUtil.java
@@ -30,6 +30,9 @@ public final class ResourceUtil {
 
   private static final EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
 
+  private ResourceUtil() {
+  }
+
   /**
    * Parse a operaton:resource attribute and loads the resource depending on the url scheme.
    * Supported URL schemes are <code>classpath://</code> and <code>deployment://</code>.
@@ -78,5 +81,4 @@ public final class ResourceUtil {
       throw LOG.cannotFindResource(resourcePath);
     }
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ScriptUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ScriptUtil.java
@@ -16,10 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.util;
 
-import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureAtLeastOneNotNull;
-import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotEmpty;
-import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
-
 import org.operaton.bpm.engine.delegate.Expression;
 import org.operaton.bpm.engine.exception.NotValidException;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -28,11 +24,17 @@ import org.operaton.bpm.engine.impl.el.ExpressionManager;
 import org.operaton.bpm.engine.impl.scripting.ExecutableScript;
 import org.operaton.bpm.engine.impl.scripting.ScriptFactory;
 import org.operaton.bpm.engine.impl.scripting.engine.JuelScriptEngineFactory;
+import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureAtLeastOneNotNull;
+import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotEmpty;
+import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 /**
  * @author Sebastian Menski
  */
 public final class ScriptUtil {
+
+  private ScriptUtil() {
+  }
 
   /**
    * Creates a new {@link ExecutableScript} from a source or resource. It excepts static and

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/StringUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/StringUtil.java
@@ -38,7 +38,10 @@ import org.operaton.bpm.engine.runtime.ProcessElementInstance;
  * @author Sebastian Menski
  */
 public final class StringUtil {
-  
+
+  private StringUtil() {
+  }
+
   /**
    * Note: {@link String#length()} counts Unicode supplementary
    * characters twice, so for a String consisting only of those,
@@ -168,9 +171,9 @@ public final class StringUtil {
     Charset charset = processEngineConfiguration.getDefaultCharset();
     return string.getBytes(charset);
   }
-  
+
   /**
-   * Trims the input to the {@link #DB_MAX_STRING_LENGTH maxium length allowed} for persistence with our default database schema 
+   * Trims the input to the {@link #DB_MAX_STRING_LENGTH maxium length allowed} for persistence with our default database schema
    *
    * @param string the input that might be trimmed if maximum length is exceeded
    * @return the input, eventually trimmed to {@link #DB_MAX_STRING_LENGTH}
@@ -221,8 +224,8 @@ public final class StringUtil {
 
     return builder.toString();
   }
-
   public abstract static class StringIterator<T> implements Iterator<String> {
+
 
     protected Iterator<? extends T> iterator;
 
@@ -240,5 +243,4 @@ public final class StringUtil {
       iterator.remove();
     }
   }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/management/Metrics.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/management/Metrics.java
@@ -83,4 +83,7 @@ public class Metrics {
    */
   public static final String UNIQUE_TASK_WORKERS = "unique-task-workers";
   public static final String TASK_USERS = "task-users";
+
+  private Metrics() {
+  }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/task/IdentityLinkType.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/task/IdentityLinkType.java
@@ -38,4 +38,7 @@ public class IdentityLinkType {
 
   public static final String OWNER = "owner";
 
+  private IdentityLinkType() {
+  }
+
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/test/mock/Mocks.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/test/mock/Mocks.java
@@ -33,6 +33,9 @@ public class Mocks {
 
   private static final ThreadLocal<Map<String, Object>> mockContainer = new ThreadLocal<>();
 
+  private Mocks() {
+  }
+
   public static Map<String, Object> getMocks() {
     Map<String, Object> mocks = mockContainer.get();
     if (mocks == null) {
@@ -45,7 +48,7 @@ public class Mocks {
   /**
    * This method lets you register a mock object. Make sure to register the
    * {@link MockExpressionManager} with your process engine configuration.
-   * 
+   *
    * @param key
    *          the key under which the mock object will be registered
    * @param value
@@ -58,7 +61,7 @@ public class Mocks {
   /**
    * This method returns the mock object registered under the provided key or
    * null if there is no object for the provided key.
-   * 
+   *
    * @param key
    *          the key of the requested object
    * @return the mock object registered under the provided key or null if there
@@ -76,5 +79,4 @@ public class Mocks {
       getMocks().clear();
     }
   }
-
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/models/AsyncProcessModels.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/models/AsyncProcessModels.java
@@ -16,15 +16,16 @@
  */
 package org.operaton.bpm.engine.test.api.runtime.migration.models;
 
-import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
-
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
+import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
 
 /**
  * @author Thorben Lindhauer
  *
  */
 public class AsyncProcessModels {
+  private AsyncProcessModels() {
+  }
 
   public static final BpmnModelInstance ASYNC_BEFORE_USER_TASK_PROCESS =
     modify(ProcessModels.ONE_TASK_PROCESS)

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/models/CallActivityModels.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/models/CallActivityModels.java
@@ -24,6 +24,9 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
  */
 public class CallActivityModels {
 
+  private CallActivityModels() {
+  }
+
   public static BpmnModelInstance oneBpmnCallActivityProcess(String calledProcessKey) {
     return ProcessModels.newModel()
         .startEvent()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/models/CompensationModels.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/models/CompensationModels.java
@@ -16,20 +16,21 @@
  */
 package org.operaton.bpm.engine.test.api.runtime.migration.models;
 
-import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
-
 import org.operaton.bpm.model.bpmn.AssociationDirection;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.bpmn.instance.Association;
 import org.operaton.bpm.model.bpmn.instance.BaseElement;
 import org.operaton.bpm.model.bpmn.instance.BoundaryEvent;
 import org.operaton.bpm.model.bpmn.instance.UserTask;
+import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
 
 /**
  * @author Thorben Lindhauer
  *
  */
 public class CompensationModels {
+  private CompensationModels() {
+  }
 
   public static final BpmnModelInstance ONE_COMPENSATION_TASK_MODEL = ProcessModels.newModel()
     .startEvent()
@@ -45,6 +46,7 @@ public class CompensationModels {
       .compensateEventDefinitionDone()
     .endEvent()
     .done();
+
   static {
     addUserTaskCompensationHandler(ONE_COMPENSATION_TASK_MODEL, "compensationBoundary", "compensationHandler");
   }
@@ -120,6 +122,7 @@ public static final BpmnModelInstance COMPENSATION_ONE_TASK_SUBPROCESS_MODEL =  
           .compensateEventDefinitionDone()
         .endEvent()
         .done();
+
   static {
     CompensationModels.addUserTaskCompensationHandler(DOUBLE_SUBPROCESS_MODEL, "compensationBoundary", "compensationHandler");
   }
@@ -147,6 +150,7 @@ public static final BpmnModelInstance COMPENSATION_ONE_TASK_SUBPROCESS_MODEL =  
       .compensateEventDefinition()
       .compensateEventDefinitionDone()
     .done();
+
   static {
     addUserTaskCompensationHandler(TRANSACTION_COMPENSATION_MODEL, "compensationBoundary", "compensationHandler");
   }
@@ -185,6 +189,4 @@ public static final BpmnModelInstance COMPENSATION_ONE_TASK_SUBPROCESS_MODEL =  
     scope.addChildElement(association);
 
   }
-
-
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/models/ConditionalModels.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/models/ConditionalModels.java
@@ -30,4 +30,7 @@ public class ConditionalModels {
   public static final String CONDITION_ID = "conditionCatch";
   public static final String VAR_CONDITION = "${variable == 1}";
   public static final String USER_TASK_ID = "userTask";
+
+  private ConditionalModels() {
+  }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/util/ActivityInstanceAssert.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/util/ActivityInstanceAssert.java
@@ -233,4 +233,7 @@ public class ActivityInstanceAssert {
     return new ActivityInstanceAssertThatClause(actual);
   }
 
+  private ActivityInstanceAssert() {
+  }
+
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/util/AssertUtil.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/util/AssertUtil.java
@@ -26,6 +26,9 @@ import org.junit.Assert;
  */
 public class AssertUtil {
 
+  private AssertUtil() {
+  }
+
   /**
    * Drop milliseconds since older MySQL versions cannot store them
    */

--- a/engine/src/test/java/org/operaton/bpm/engine/test/util/ClockTestUtil.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/util/ClockTestUtil.java
@@ -19,9 +19,13 @@ package org.operaton.bpm.engine.test.util;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 
 public final class ClockTestUtil {
+
+  private ClockTestUtil() {
+  }
 
   /**
    * Increments the current time by the given seconds.
@@ -46,5 +50,4 @@ public final class ClockTestUtil {
     ClockUtil.setCurrentTime(new GregorianCalendar(2023, Calendar.AUGUST, 18, 8, 0, 0).getTime());
     return ClockUtil.getCurrentTime();
   }
-
 }

--- a/examples/invoice/src/main/java/org/operaton/bpm/example/invoice/InvoiceApplicationHelper.java
+++ b/examples/invoice/src/main/java/org/operaton/bpm/example/invoice/InvoiceApplicationHelper.java
@@ -16,13 +16,6 @@
  */
 package org.operaton.bpm.example.invoice;
 
-import static org.operaton.bpm.engine.variable.Variables.createVariables;
-import static org.operaton.bpm.engine.variable.Variables.fileValue;
-
-import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.logging.Logger;
 import org.operaton.bpm.application.ProcessApplicationReference;
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.RepositoryService;
@@ -34,10 +27,20 @@ import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.repository.ProcessDefinitionQuery;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
+import static org.operaton.bpm.engine.variable.Variables.createVariables;
+import static org.operaton.bpm.engine.variable.Variables.fileValue;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.logging.Logger;
 
 public class InvoiceApplicationHelper {
 
   private static final Logger LOGGER = Logger.getLogger(InvoiceApplicationHelper.class.getName());
+
+  private InvoiceApplicationHelper() {
+  }
 
   public static void startFirstProcess(ProcessEngine processEngine) {
     createUsers(processEngine);

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/BooleanOperations.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/BooleanOperations.java
@@ -25,8 +25,8 @@ import java.util.Set;
 import jakarta.el.ELException;
 
 public class BooleanOperations {
-	private static Set<Class<? extends Number>> SIMPLE_INTEGER_TYPES = new HashSet<>();
-	private static Set<Class<? extends Number>> SIMPLE_FLOAT_TYPES = new HashSet<>();
+	private static final Set<Class<? extends Number>> SIMPLE_INTEGER_TYPES = new HashSet<>();
+	private static final Set<Class<? extends Number>> SIMPLE_FLOAT_TYPES = new HashSet<>();
 
 	static {
 		SIMPLE_INTEGER_TYPES.add(Byte.class);

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/BooleanOperations.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/BooleanOperations.java
@@ -25,9 +25,9 @@ import java.util.Set;
 import jakarta.el.ELException;
 
 public class BooleanOperations {
-	private static final Set<Class<? extends Number>> SIMPLE_INTEGER_TYPES = new HashSet<>();
-	private static final Set<Class<? extends Number>> SIMPLE_FLOAT_TYPES = new HashSet<>();
-	
+	private static Set<Class<? extends Number>> SIMPLE_INTEGER_TYPES = new HashSet<>();
+	private static Set<Class<? extends Number>> SIMPLE_FLOAT_TYPES = new HashSet<>();
+
 	static {
 		SIMPLE_INTEGER_TYPES.add(Byte.class);
 		SIMPLE_INTEGER_TYPES.add(Short.class);
@@ -37,8 +37,11 @@ public class BooleanOperations {
 		SIMPLE_FLOAT_TYPES.add(Double.class);
 	}
 
+	private BooleanOperations() {
+	}
+
 	@SuppressWarnings("unchecked")
-	private static final boolean lt0(TypeConverter converter, Object o1, Object o2) {
+	private static boolean lt0(TypeConverter converter, Object o1, Object o2) {
 		Class<?> t1 = o1.getClass();
 		Class<?> t2 = o2.getClass();
 		if (BigDecimal.class.isAssignableFrom(t1) || BigDecimal.class.isAssignableFrom(t2)) {
@@ -66,7 +69,7 @@ public class BooleanOperations {
 	}
 
 	@SuppressWarnings("unchecked")
-	private static final boolean gt0(TypeConverter converter, Object o1, Object o2) {		
+	private static boolean gt0(TypeConverter converter, Object o1, Object o2) {
 		Class<?> t1 = o1.getClass();
 		Class<?> t2 = o2.getClass();
 		if (BigDecimal.class.isAssignableFrom(t1) || BigDecimal.class.isAssignableFrom(t2)) {

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/LocalMessages.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/LocalMessages.java
@@ -23,6 +23,9 @@ public final class LocalMessages {
 	private static final String BUNDLE_NAME = "org.operaton.bpm.impl.juel.misc.LocalStrings";
 	private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
 
+	private LocalMessages() {
+	}
+
 	public static String get(String key, Object... args) {
 		String template = null;
 		try {

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/NodePrinter.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/NodePrinter.java
@@ -24,13 +24,16 @@ import java.util.Stack;
  * @author Christoph Beck
  */
 public class NodePrinter {
+	private NodePrinter() {
+	}
+
 	private static boolean isLastSibling(Node node, Node parent) {
 		if (parent != null) {
 			return node == parent.getChild(parent.getCardinality() - 1);
 		}
 		return true;
 	}
-	
+
 	private static void dump(PrintWriter writer, Node node, Stack<Node> predecessors) {
 		if (!predecessors.isEmpty()) {
 			Node parent = null;

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/NumberOperations.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/NumberOperations.java
@@ -26,9 +26,12 @@ import java.math.RoundingMode;
  * @author Christoph Beck
  */
 public class NumberOperations {
-	private static final Long LONG_ZERO = 0L;
+	private static Long LONG_ZERO = 0L;
 
-	private static final boolean isDotEe(String value) {
+	private NumberOperations() {
+	}
+
+	private static boolean isDotEe(String value) {
 		int length = value.length();
 		for (int i = 0; i < length; i++) {
 			switch (value.charAt(i)) {
@@ -38,23 +41,23 @@ public class NumberOperations {
 		return false;
 	}
 
-	private static final boolean isDotEe(Object value) {
+	private static boolean isDotEe(Object value) {
 		return value instanceof String stringValue && isDotEe(stringValue);
 	}
 
-	private static final boolean isFloatOrDouble(Object value) {
+	private static boolean isFloatOrDouble(Object value) {
 		return value instanceof Float || value instanceof Double;
 	}
 
-	private static final boolean isFloatOrDoubleOrDotEe(Object value) {
+	private static boolean isFloatOrDoubleOrDotEe(Object value) {
 		return isFloatOrDouble(value) || isDotEe(value);
 	}
 
-	private static final boolean isBigDecimalOrBigInteger(Object value) {
+	private static boolean isBigDecimalOrBigInteger(Object value) {
 		return value instanceof BigDecimal || value instanceof BigInteger;
 	}
 
-	private static final boolean isBigDecimalOrFloatOrDoubleOrDotEe(Object value) {
+	private static boolean isBigDecimalOrFloatOrDoubleOrDotEe(Object value) {
 		return value instanceof BigDecimal || isFloatOrDoubleOrDotEe(value);
 	}
 

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/NumberOperations.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/NumberOperations.java
@@ -26,7 +26,7 @@ import java.math.RoundingMode;
  * @author Christoph Beck
  */
 public class NumberOperations {
-	private static Long LONG_ZERO = 0L;
+	private static final Long LONG_ZERO = 0L;
 
 	private NumberOperations() {
 	}

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/BpmnModelConstants.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/BpmnModelConstants.java
@@ -488,4 +488,7 @@ public final class BpmnModelConstants {
   public static final String OPERATON_ATTRIBUTE_HISTORY_TIME_TO_LIVE = "historyTimeToLive";
   public static final String OPERATON_ATTRIBUTE_IS_STARTABLE_IN_TASKLIST = "isStartableInTasklist";
   public static final String OPERATON_ATTRIBUTE_VERSION_TAG = "versionTag";
+
+  private BpmnModelConstants() {
+  }
 }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnTestConstants.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnTestConstants.java
@@ -93,4 +93,7 @@ public final class BpmnTestConstants {
   public static final String TEST_STRING_FORM_REF_BINDING = "version";
   public static final String TEST_STRING_FORM_REF_VERSION = "2";
 
+  private BpmnTestConstants() {
+  }
+
 }

--- a/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/impl/CmmnModelConstants.java
+++ b/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/impl/CmmnModelConstants.java
@@ -263,4 +263,7 @@ public class CmmnModelConstants {
   public static final String OPERATON_ATTRIBUTE_VARIABLE_NAME = "variableName";
   public static final String OPERATON_ATTRIBUTE_HISTORY_TIME_TO_LIVE = "historyTimeToLive";
 
+  private CmmnModelConstants() {
+  }
+
 }

--- a/model-api/dmn-model/src/main/java/org/operaton/bpm/model/dmn/impl/DmnModelConstants.java
+++ b/model-api/dmn-model/src/main/java/org/operaton/bpm/model/dmn/impl/DmnModelConstants.java
@@ -179,4 +179,7 @@ public final class DmnModelConstants {
   public static final String OPERATON_ATTRIBUTE_HISTORY_TIME_TO_LIVE = "historyTimeToLive";
   public static final String OPERATON_ATTRIBUTE_VERSION_TAG = "versionTag";
 
+  private DmnModelConstants() {
+  }
+
 }

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/DomUtil.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/DomUtil.java
@@ -23,12 +23,6 @@ import org.operaton.bpm.model.xml.impl.instance.DomElementImpl;
 import org.operaton.bpm.model.xml.instance.DomDocument;
 import org.operaton.bpm.model.xml.instance.DomElement;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.xml.sax.ErrorHandler;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -38,6 +32,13 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 /**
  * Helper methods which abstract some gruesome DOM specifics.
@@ -49,6 +50,8 @@ import java.util.logging.Logger;
  *
  */
 public final class DomUtil {
+  private DomUtil() {
+  }
 
   /**
    * A {@link NodeListFilter} allows to filter a {@link NodeList},
@@ -253,5 +256,4 @@ public final class DomUtil {
 
     }
   }
-
 }

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/IoUtil.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/IoUtil.java
@@ -31,6 +31,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public final class IoUtil {
 
+  private IoUtil() {
+  }
+
   public static void closeSilently(Closeable closeable) {
     try {
       if (closeable != null) {
@@ -140,5 +143,4 @@ public final class IoUtil {
       throw new ModelIoException("Unable to transform model to xml", e);
     }
   }
-
 }

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/ModelUtil.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/ModelUtil.java
@@ -39,6 +39,9 @@ public final class ModelUtil {
 
   private static final String ID_ATTRIBUTE_NAME = "id";
 
+  private ModelUtil() {
+  }
+
   /**
    * Returns the {@link ModelElementInstanceImpl ModelElement} for a DOM element.
    * If the model element does not yet exist, it is created and linked to the DOM.
@@ -267,5 +270,4 @@ public final class ModelUtil {
   public static String getUniqueIdentifier(ModelElementType type) {
     return type.getTypeName() + "_" + UUID.randomUUID();
   }
-
 }

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/StringUtil.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/StringUtil.java
@@ -30,6 +30,9 @@ public final class StringUtil {
 
   private static final Pattern pattern = Pattern.compile("(\\w[^,]*)|([#$]\\{[^}]*})");
 
+  private StringUtil() {
+  }
+
   /**
    * Splits a comma separated list in to single Strings. The list can
    * contain expressions with commas in it.

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,9 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>clirr-maven-plugin</artifactId>
           <version>2.8</version>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/qa/integration-tests-engine/src/test/java-tomcat/org/operaton/bpm/integrationtest/util/TestContainer.java
+++ b/qa/integration-tests-engine/src/test/java-tomcat/org/operaton/bpm/integrationtest/util/TestContainer.java
@@ -25,6 +25,9 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
  */
 public class TestContainer {
 
+  private TestContainer() {
+  }
+
   /**
    * In some scenarios, Tomcat 10 and Weld 5 have issues when the Weld library is embedded into the WAR.
    * To solve these issues, Weld is added to the Tomcat server libs folder.
@@ -84,5 +87,4 @@ public class TestContainer {
   public static void addCommonLoggingDependency(WebArchive webArchive) {
     // nothing to do
   }
-
 }

--- a/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/junit/AuthHelper.java
+++ b/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/junit/AuthHelper.java
@@ -27,6 +27,9 @@ import org.operaton.bpm.engine.ProcessEngine;
  */
 public class AuthHelper {
 
+  private AuthHelper() {
+  }
+
   public static <T> T withAuthentication(Callable<T> callable, ProcessEngine processEngine, String userId, String... groupIds) {
     try {
       processEngine.getProcessEngineConfiguration().setAuthorizationEnabled(true);

--- a/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/junit/PerfTestProcessEngine.java
+++ b/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/junit/PerfTestProcessEngine.java
@@ -42,6 +42,9 @@ public class PerfTestProcessEngine {
 
   protected static ProcessEngine processEngine;
 
+  private PerfTestProcessEngine() {
+  }
+
   public static ProcessEngine getInstance() {
     if(processEngine == null) {
 

--- a/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/util/CsvUtil.java
+++ b/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/util/CsvUtil.java
@@ -29,17 +29,20 @@ import org.operaton.bpm.qa.performance.engine.framework.aggregate.TabularResultS
  */
 public class CsvUtil {
 
+  private CsvUtil() {
+  }
+
   public static String resultSetAsCsv(TabularResultSet resultSet) {
     return resultSetAsCsv(resultSet, true);
   }
-  
+
   public static String resultSetAsCsvLine(TabularResultSet resultSet) {
     return resultSetAsCsv(resultSet, false);
   }
 
   private static String resultSetAsCsv(TabularResultSet resultSet, boolean writeHeadline) {
     StringBuilder builder = new StringBuilder();
-  
+
     if (writeHeadline) {
       // write headline
       List<String> resultColumnNames = resultSet.getResultColumnNames();
@@ -66,5 +69,4 @@ public class CsvUtil {
   public static void saveResultSetToFile(String fileName, TabularResultSet resultSet) {
     FileUtil.writeStringToFile(resultSetAsCsv(resultSet), fileName);
   }
-
 }

--- a/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/util/FileUtil.java
+++ b/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/util/FileUtil.java
@@ -29,6 +29,9 @@ import org.operaton.bpm.qa.performance.engine.framework.PerfTestException;
  */
 public class FileUtil {
 
+  private FileUtil() {
+  }
+
   public static void writeStringToFile(String value, String filePath) {
     writeStringToFile(value, filePath, true);
   }
@@ -53,9 +56,8 @@ public class FileUtil {
     }
 
   }
-  
+
   public static void appendStringToFile(String value, String filePath) {
     writeStringToFile(value, filePath, false);
   }
-
 }

--- a/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/util/JsonUtil.java
+++ b/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/util/JsonUtil.java
@@ -16,9 +16,10 @@
  */
 package org.operaton.bpm.qa.performance.engine.util;
 
+import org.operaton.bpm.qa.performance.engine.framework.PerfTestException;
+
 import java.io.File;
 
-import org.operaton.bpm.qa.performance.engine.framework.PerfTestException;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.SerializationConfig;
 import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
@@ -30,6 +31,9 @@ import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 public class JsonUtil {
 
   private static ObjectMapper mapper;
+
+  private JsonUtil() {
+  }
 
   public static void writeObjectToFile(String filename, Object object) {
 

--- a/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/util/ReportUtil.java
+++ b/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/util/ReportUtil.java
@@ -28,6 +28,9 @@ import org.operaton.bpm.qa.performance.engine.framework.report.HtmlReportBuilder
  */
 public class ReportUtil {
 
+  private ReportUtil() {
+  }
+
   public static void writeReport(String resultsFolder,
       String reportsFolder,
       String benchmarkName,
@@ -67,5 +70,4 @@ public class ReportUtil {
     // write CSV report
     CsvUtil.saveResultSetToFile(csvReportPath, aggregatedResults);
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/ProcessInstanceModificationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/ProcessInstanceModificationScenario.java
@@ -27,6 +27,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
  */
 public class ProcessInstanceModificationScenario {
 
+  private ProcessInstanceModificationScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/gson/oneTaskProcessInstanceModification.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/TaskFilterPropertiesScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/TaskFilterPropertiesScenario.java
@@ -33,6 +33,9 @@ import java.util.Map;
  */
 public class TaskFilterPropertiesScenario {
 
+  private TaskFilterPropertiesScenario() {
+  }
+
   @DescribesScenario("initTaskFilterProperties")
   public static ScenarioSetup initTaskFilterProperties() {
     return new ScenarioSetup() {

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/TaskFilterScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/TaskFilterScenario.java
@@ -33,6 +33,9 @@ import java.util.List;
  */
 public class TaskFilterScenario {
 
+  private TaskFilterScenario() {
+  }
+
   @DescribesScenario("initTaskFilter")
   public static ScenarioSetup initTaskFilter() {
     return new ScenarioSetup() {

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/TaskFilterVariablesScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/TaskFilterVariablesScenario.java
@@ -29,6 +29,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
  */
 public class TaskFilterVariablesScenario {
 
+  private TaskFilterVariablesScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/gson/oneTaskProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/TimerChangeJobDefinitionScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/TimerChangeJobDefinitionScenario.java
@@ -27,11 +27,13 @@ import java.util.Date;
  * @author Tassilo Weidner
  */
 public class TimerChangeJobDefinitionScenario {
-
   protected static final Date FIXED_DATE_ONE = new Date(1363607000000L);
   protected static final Date FIXED_DATE_TWO = new Date(1363607500000L);
   protected static final Date FIXED_DATE_THREE = new Date(1363607600000L);
   protected static final Date FIXED_DATE_FOUR = new Date(1363607700000L);
+
+  private TimerChangeJobDefinitionScenario() {
+  }
 
   @DescribesScenario("initTimerChangeJobDefinition")
   public static ScenarioSetup initTimerChangeJobDefinition() {

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/TimerChangeProcessDefinitionScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/TimerChangeProcessDefinitionScenario.java
@@ -31,6 +31,9 @@ public class TimerChangeProcessDefinitionScenario {
   protected static final Date FIXED_DATE_TWO = new Date(1363608500000L);
   protected static final Date FIXED_DATE_THREE = new Date(1363608600000L);
 
+  private TimerChangeProcessDefinitionScenario() {
+  }
+
   @DescribesScenario("initTimerChangeProcessDefinition")
   public static ScenarioSetup initTimerChangeProcessDefinition() {
     return new ScenarioSetup() {

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/DeleteHistoricDecisionsBatchScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/DeleteHistoricDecisionsBatchScenario.java
@@ -32,6 +32,9 @@ import java.util.List;
  */
 public class DeleteHistoricDecisionsBatchScenario {
 
+  private DeleteHistoricDecisionsBatchScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/gson/Example.dmn";

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/DeleteHistoricProcessInstancesBatchScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/DeleteHistoricProcessInstancesBatchScenario.java
@@ -30,6 +30,9 @@ import java.util.List;
  */
 public class DeleteHistoricProcessInstancesBatchScenario {
 
+  private DeleteHistoricProcessInstancesBatchScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/gson/oneTaskProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/DeleteProcessInstancesBatchScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/DeleteProcessInstancesBatchScenario.java
@@ -31,6 +31,9 @@ import java.util.List;
  */
 public class DeleteProcessInstancesBatchScenario {
 
+  private DeleteProcessInstancesBatchScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/gson/oneTaskProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/MigrationBatchScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/MigrationBatchScenario.java
@@ -30,6 +30,9 @@ import java.util.List;
  */
 public class MigrationBatchScenario {
 
+  private MigrationBatchScenario() {
+  }
+
   @DescribesScenario("initMigrationBatch")
   public static ScenarioSetup initMigrationBatch() {
     return new ScenarioSetup() {

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/ModificationBatchScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/ModificationBatchScenario.java
@@ -29,6 +29,9 @@ import java.util.List;
  */
 public class ModificationBatchScenario {
 
+  private ModificationBatchScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/gson/oneTaskProcessModification.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/RestartProcessInstanceBatchScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/RestartProcessInstanceBatchScenario.java
@@ -31,6 +31,9 @@ import java.util.List;
  */
 public class RestartProcessInstanceBatchScenario {
 
+  private RestartProcessInstanceBatchScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/gson/oneTaskProcessRestart.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/SetExternalTaskRetriesBatchScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/SetExternalTaskRetriesBatchScenario.java
@@ -29,6 +29,9 @@ import java.util.List;
  */
 public class SetExternalTaskRetriesBatchScenario {
 
+  private SetExternalTaskRetriesBatchScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/gson/externalTaskProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/SetJobRetriesBatchScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/SetJobRetriesBatchScenario.java
@@ -31,6 +31,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
  */
 public class SetJobRetriesBatchScenario {
 
+  private SetJobRetriesBatchScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/gson/oneTaskProcessAsync.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/UpdateProcessInstanceSuspendStateBatchScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/gson/batch/UpdateProcessInstanceSuspendStateBatchScenario.java
@@ -30,6 +30,9 @@ import java.util.List;
  */
 public class UpdateProcessInstanceSuspendStateBatchScenario {
 
+  private UpdateProcessInstanceSuspendStateBatchScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/gson/oneTaskProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/useroperationlog/CreateStandaloneTaskDeleteScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/useroperationlog/CreateStandaloneTaskDeleteScenario.java
@@ -29,6 +29,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
  */
 public class CreateStandaloneTaskDeleteScenario {
 
+  private CreateStandaloneTaskDeleteScenario() {
+  }
+
   @DescribesScenario("createUserOperationLogEntriesForDelete")
   public static ScenarioSetup createUserOperationLogEntries() {
     return new ScenarioSetup() {

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/useroperationlog/CreateStandaloneTaskScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/useroperationlog/CreateStandaloneTaskScenario.java
@@ -29,6 +29,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
  */
 public class CreateStandaloneTaskScenario {
 
+  private CreateStandaloneTaskScenario() {
+  }
+
   @DescribesScenario("createUserOperationLogEntries")
   public static ScenarioSetup createUserOperationLogEntries() {
     return new ScenarioSetup() {

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/useroperationlog/SetAssigneeProcessInstanceTaskScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/useroperationlog/SetAssigneeProcessInstanceTaskScenario.java
@@ -32,6 +32,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
  */
 public class SetAssigneeProcessInstanceTaskScenario {
 
+  private SetAssigneeProcessInstanceTaskScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/useroperationlog/oneTaskProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/useroperationlog/SuspendProcessDefinitionDeleteScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/useroperationlog/SuspendProcessDefinitionDeleteScenario.java
@@ -32,6 +32,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
  */
 public class SuspendProcessDefinitionDeleteScenario {
 
+  private SuspendProcessDefinitionDeleteScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/useroperationlog/timerBoundaryEventProcess.bpmn20.xml";
@@ -45,7 +48,7 @@ public class SuspendProcessDefinitionDeleteScenario {
         ProcessInstance processInstance1 = engine.getRuntimeService().startProcessInstanceByKey("timerBoundaryProcess", processInstanceBusinessKey);
         ProcessInstance processInstance2 = engine.getRuntimeService().startProcessInstanceByKey("timerBoundaryProcess", processInstanceBusinessKey);
         ProcessInstance processInstance3 = engine.getRuntimeService().startProcessInstanceByKey("timerBoundaryProcess", processInstanceBusinessKey);
-        
+
         IdentityService identityService = engine.getIdentityService();
         identityService.setAuthentication("jane01", null);
 

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/useroperationlog/annotation/AuthorizationCheckProcessDefinitionScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/useroperationlog/annotation/AuthorizationCheckProcessDefinitionScenario.java
@@ -23,6 +23,8 @@ import org.operaton.bpm.qa.upgrade.DescribesScenario;
 import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class AuthorizationCheckProcessDefinitionScenario {
+  private AuthorizationCheckProcessDefinitionScenario() {
+  }
 
   @Deployment
   public static String deploy() {

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/useroperationlog/annotation/NoAuthorizationCheckScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/useroperationlog/annotation/NoAuthorizationCheckScenario.java
@@ -23,24 +23,27 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class NoAuthorizationCheckScenario {
 
+  private NoAuthorizationCheckScenario() {
+  }
+
   @DescribesScenario("prepareNoAuthorizationCheck")
   public static ScenarioSetup prepareNoAuthorizationCheck() {
-    
+
     return new ScenarioSetup() {
       public void execute(ProcessEngine engine, String scenarioName) {
-        
+
         engine.getIdentityService()
             .setAuthentication("demo", null);
-        
+
         Task task = engine.getTaskService()
             .newTask("myTaskForUserOperationLogUpdate");
-        
+
         engine.getTaskService()
             .saveTask(task);
 
         engine.getIdentityService()
             .clearAuthentication();
-        
+
       }
     };
   }

--- a/qa/test-db-instance-migration/test-fixture-712/src/main/java/org/operaton/bpm/qa/upgrade/batch/deploymentaware/DeploymentAwareBatchesScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-712/src/main/java/org/operaton/bpm/qa/upgrade/batch/deploymentaware/DeploymentAwareBatchesScenario.java
@@ -31,6 +31,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class DeploymentAwareBatchesScenario {
 
+  private DeploymentAwareBatchesScenario() {
+  }
+
   @Deployment
   public static String deployOneTask() {
     return "org/operaton/bpm/qa/upgrade/batch/deploymentaware/oneTaskProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-712/src/main/java/org/operaton/bpm/qa/upgrade/customretries/FailingIntermediateBoundaryTimerJobScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-712/src/main/java/org/operaton/bpm/qa/upgrade/customretries/FailingIntermediateBoundaryTimerJobScenario.java
@@ -32,6 +32,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class FailingIntermediateBoundaryTimerJobScenario {
 
+  private FailingIntermediateBoundaryTimerJobScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/customretries/failingTimerJob.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-712/src/main/java/org/operaton/bpm/qa/upgrade/restart/SetVariablesScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-712/src/main/java/org/operaton/bpm/qa/upgrade/restart/SetVariablesScenario.java
@@ -27,6 +27,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class SetVariablesScenario {
 
+  private SetVariablesScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/async/oneAsyncTaskProcess.bpmn20.xml";
@@ -62,5 +65,4 @@ public class SetVariablesScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-712/src/main/java/org/operaton/bpm/qa/upgrade/restart/StartProcessIntanceWithInitialVariablesScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-712/src/main/java/org/operaton/bpm/qa/upgrade/restart/StartProcessIntanceWithInitialVariablesScenario.java
@@ -25,6 +25,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class StartProcessIntanceWithInitialVariablesScenario {
 
+  private StartProcessIntanceWithInitialVariablesScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/async/oneAsyncTaskProcess.bpmn20.xml";
@@ -54,5 +57,4 @@ public class StartProcessIntanceWithInitialVariablesScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-714/src/main/java/org/operaton/bpm/qa/upgrade/variable/EmptyStringVariableScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-714/src/main/java/org/operaton/bpm/qa/upgrade/variable/EmptyStringVariableScenario.java
@@ -25,6 +25,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class EmptyStringVariableScenario {
 
+  private EmptyStringVariableScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/variable/oneTaskProcess.bpmn20.xml";
@@ -41,5 +44,4 @@ public class EmptyStringVariableScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-715/src/main/java/org/operaton/bpm/qa/upgrade/batch/CreateSetProcessInstanceVariablesBatchScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-715/src/main/java/org/operaton/bpm/qa/upgrade/batch/CreateSetProcessInstanceVariablesBatchScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class CreateSetProcessInstanceVariablesBatchScenario {
 
+  private CreateSetProcessInstanceVariablesBatchScenario() {
+  }
+
   @Deployment
   public static String modelDeployment() {
     return "org/operaton/bpm/qa/upgrade/batch/oneTaskProcess.bpmn20.xml";
@@ -84,5 +87,4 @@ public class CreateSetProcessInstanceVariablesBatchScenario {
           processInstanceIdTwo);
     };
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-715/src/main/java/org/operaton/bpm/qa/upgrade/migration/CreateSetVariablesMigrationBatchScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-715/src/main/java/org/operaton/bpm/qa/upgrade/migration/CreateSetVariablesMigrationBatchScenario.java
@@ -24,6 +24,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class CreateSetVariablesMigrationBatchScenario {
 
+  private CreateSetVariablesMigrationBatchScenario() {
+  }
+
   @Deployment
   public static String sourceDeployment() {
     return "org/operaton/bpm/qa/upgrade/migration/oneTaskProcess-source.bpmn20.xml";
@@ -67,5 +70,4 @@ public class CreateSetVariablesMigrationBatchScenario {
           .setProperty("CreateSetVariablesMigrationBatchScenario.batch.id", batchId);
     };
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-716/src/main/java/org/operaton/bpm/qa/upgrade/externaltask/ExternalTaskFailureLogScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-716/src/main/java/org/operaton/bpm/qa/upgrade/externaltask/ExternalTaskFailureLogScenario.java
@@ -25,6 +25,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class ExternalTaskFailureLogScenario {
 
+  private ExternalTaskFailureLogScenario() {
+  }
+
   @Deployment
   public static String modelDeployment() {
     return "org/operaton/bpm/qa/upgrade/externaltask/oneTaskProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-716/src/main/java/org/operaton/bpm/qa/upgrade/job/JobFailureLogScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-716/src/main/java/org/operaton/bpm/qa/upgrade/job/JobFailureLogScenario.java
@@ -25,6 +25,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class JobFailureLogScenario {
 
+  private JobFailureLogScenario() {
+  }
+
   @Deployment
   public static String modelDeployment() {
     return "org/operaton/bpm/qa/upgrade/job/oneTaskProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-716/src/main/java/org/operaton/bpm/qa/upgrade/pvm/AsyncJoinScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-716/src/main/java/org/operaton/bpm/qa/upgrade/pvm/AsyncJoinScenario.java
@@ -21,12 +21,14 @@ import org.operaton.bpm.qa.upgrade.DescribesScenario;
 import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class AsyncJoinScenario {
+  private AsyncJoinScenario() {
+  }
 
   @Deployment
   public static String modelParallelDeployment() {
     return "org/operaton/bpm/qa/upgrade/pvm/asyncParallelGateway.bpmn20.xml";
   }
-  
+
   @Deployment
   public static String modelInclusiveDeployment() {
     return "org/operaton/bpm/qa/upgrade/pvm/asyncInclusiveGateway.bpmn20.xml";
@@ -41,7 +43,7 @@ public class AsyncJoinScenario {
       // reaching the parallel join gateway
     };
   }
-  
+
   @DescribesScenario("asyncJoinInclusive")
   public static ScenarioSetup createJobsForInclusiveJoin() {
     return (engine, scenarioName) -> {

--- a/qa/test-db-instance-migration/test-fixture-718/src/main/java/org/operaton/bpm/qa/upgrade/job/SetJobRetriesWithDueDateScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-718/src/main/java/org/operaton/bpm/qa/upgrade/job/SetJobRetriesWithDueDateScenario.java
@@ -31,6 +31,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class SetJobRetriesWithDueDateScenario {
 
+  private SetJobRetriesWithDueDateScenario() {
+  }
+
   @Deployment
   public static String deployOneTask() {
     return "org/operaton/bpm/qa/upgrade/job/SetJobRetriesWithDueDateScenario.oneTaskProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-719/src/main/java/org/operaton/bpm/qa/upgrade/batch/SetRemovalTimeToProcessInstanceScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-719/src/main/java/org/operaton/bpm/qa/upgrade/batch/SetRemovalTimeToProcessInstanceScenario.java
@@ -29,6 +29,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class SetRemovalTimeToProcessInstanceScenario {
 
+  private SetRemovalTimeToProcessInstanceScenario() {
+  }
+
   @Deployment
   public static String deployOneTask() {
     return "org/operaton/bpm/qa/upgrade/batch/SetRemovalTimeToProcessInstanceScenario.oneTaskProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-719/src/main/java/org/operaton/bpm/qa/upgrade/httl/EnforceHistoryTimeToLiveScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-719/src/main/java/org/operaton/bpm/qa/upgrade/httl/EnforceHistoryTimeToLiveScenario.java
@@ -21,6 +21,9 @@ import org.operaton.bpm.engine.test.Deployment;
 
 public class EnforceHistoryTimeToLiveScenario {
 
+  private EnforceHistoryTimeToLiveScenario() {
+  }
+
   @Deployment
   public static String processWithoutHTTL() {
     return "org/operaton/bpm/qa/upgrade/httl/process_without_httl.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-719/src/main/java/org/operaton/bpm/qa/upgrade/variables/JpaVariableScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-719/src/main/java/org/operaton/bpm/qa/upgrade/variables/JpaVariableScenario.java
@@ -34,6 +34,9 @@ public class JpaVariableScenario {
   protected static FieldAccessJPAEntity simpleEntityFieldAccess;
   protected static EntityManagerFactory entityManagerFactory;
 
+  private JpaVariableScenario() {
+  }
+
   @Deployment
   public static String deployOneTask() {
     return "org/operaton/bpm/qa/upgrade/variables/JpaEntitiesScenario.oneTaskProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/boundary/NestedNonInterruptingBoundaryEventOnInnerSubprocessScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/boundary/NestedNonInterruptingBoundaryEventOnInnerSubprocessScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class NestedNonInterruptingBoundaryEventOnInnerSubprocessScenario {
 
+  private NestedNonInterruptingBoundaryEventOnInnerSubprocessScenario() {
+  }
+
   @Deployment
   public static String deployTimerBoundary() {
     return "org/operaton/bpm/qa/upgrade/boundary/nestedNonInterruptingTimerBoundaryEventOnInnerSubprocess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/boundary/NestedNonInterruptingBoundaryEventOnOuterSubprocessScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/boundary/NestedNonInterruptingBoundaryEventOnOuterSubprocessScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class NestedNonInterruptingBoundaryEventOnOuterSubprocessScenario {
 
+  private NestedNonInterruptingBoundaryEventOnOuterSubprocessScenario() {
+  }
+
   @Deployment
   public static String deployTimerBoundary() {
     return "org/operaton/bpm/qa/upgrade/boundary/nestedNonInterruptingTimerBoundaryEventOnOuterSubprocess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/boundary/NonInterruptingBoundaryEventScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/boundary/NonInterruptingBoundaryEventScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class NonInterruptingBoundaryEventScenario {
 
+  private NonInterruptingBoundaryEventScenario() {
+  }
+
   @Deployment
   public static String deployTimerBoundary() {
     return "org/operaton/bpm/qa/upgrade/boundary/nonInterruptingTimerBoundaryEvent.bpmn20.xml";
@@ -69,6 +72,4 @@ public class NonInterruptingBoundaryEventScenario {
       }
     };
   }
-
-
 }

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/InterruptingEventSubprocessCompensationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/InterruptingEventSubprocessCompensationScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class InterruptingEventSubprocessCompensationScenario {
 
+  private InterruptingEventSubprocessCompensationScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/compensation/interruptingEventSubprocessCompensationProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/SingleActivityCompensationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/SingleActivityCompensationScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class SingleActivityCompensationScenario {
 
+  private SingleActivityCompensationScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/compensation/simpleCompensationProcess.bpmn20.xml";
@@ -65,5 +68,4 @@ public class SingleActivityCompensationScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/SubprocessCompensationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/SubprocessCompensationScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class SubprocessCompensationScenario {
 
+  private SubprocessCompensationScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/compensation/subprocessCompensationProcess.bpmn20.xml";
@@ -105,5 +108,4 @@ public class SubprocessCompensationScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/SubprocessParallelCreateCompensationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/SubprocessParallelCreateCompensationScenario.java
@@ -29,6 +29,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class SubprocessParallelCreateCompensationScenario {
 
+  private SubprocessParallelCreateCompensationScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/compensation/subprocessParallelCreateCompensationProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/SubprocessParallelThrowCompensationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/SubprocessParallelThrowCompensationScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class SubprocessParallelThrowCompensationScenario {
 
+  private SubprocessParallelThrowCompensationScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/compensation/subprocessParallelThrowCompensationProcess.bpmn20.xml";
@@ -65,5 +68,4 @@ public class SubprocessParallelThrowCompensationScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/TransactionCancelCompensationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/TransactionCancelCompensationScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class TransactionCancelCompensationScenario {
 
+  private TransactionCancelCompensationScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/compensation/transactionCancelCompensationProcess.bpmn20.xml";
@@ -66,5 +69,4 @@ public class TransactionCancelCompensationScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/InterruptingEventSubprocessScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/InterruptingEventSubprocessScenario.java
@@ -28,6 +28,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class InterruptingEventSubprocessScenario {
 
+  private InterruptingEventSubprocessScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/eventsubprocess/interruptingMessageEventSubprocess.bpmn20.xml";
@@ -49,5 +52,4 @@ public class InterruptingEventSubprocessScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/NestedInterruptingErrorEventSubprocessScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/NestedInterruptingErrorEventSubprocessScenario.java
@@ -28,6 +28,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class NestedInterruptingErrorEventSubprocessScenario {
 
+  private NestedInterruptingErrorEventSubprocessScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/eventsubprocess/nestedInterruptingErrorEventSubprocess.bpmn20.xml";
@@ -50,5 +53,4 @@ public class NestedInterruptingErrorEventSubprocessScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/NestedInterruptingEventSubprocessParallelScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/NestedInterruptingEventSubprocessParallelScenario.java
@@ -28,6 +28,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class NestedInterruptingEventSubprocessParallelScenario {
 
+  private NestedInterruptingEventSubprocessParallelScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/eventsubprocess/nestedInterruptingMessageEventSubprocessParallel.bpmn20.xml";
@@ -49,5 +52,4 @@ public class NestedInterruptingEventSubprocessParallelScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/NestedNonInterruptingEventSubprocessNestedSubprocessScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/NestedNonInterruptingEventSubprocessNestedSubprocessScenario.java
@@ -31,6 +31,9 @@ import org.operaton.bpm.qa.upgrade.Times;
 public class NestedNonInterruptingEventSubprocessNestedSubprocessScenario {
 
 
+  private NestedNonInterruptingEventSubprocessNestedSubprocessScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/eventsubprocess/nestedNonInterruptingMessageEventSubprocessNestedSubprocess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/NestedNonInterruptingEventSubprocessScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/NestedNonInterruptingEventSubprocessScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class NestedNonInterruptingEventSubprocessScenario {
 
+  private NestedNonInterruptingEventSubprocessScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/eventsubprocess/nestedNonInterruptingMessageEventSubprocess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/NestedParallelNonInterruptingEventSubprocessScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/NestedParallelNonInterruptingEventSubprocessScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class NestedParallelNonInterruptingEventSubprocessScenario {
 
+  private NestedParallelNonInterruptingEventSubprocessScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/eventsubprocess/nestedParallelNonInterruptingMessageEventSubprocess.bpmn20.xml";
@@ -69,6 +72,4 @@ public class NestedParallelNonInterruptingEventSubprocessScenario {
       }
     };
   }
-
-
 }

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/NonInterruptingEventSubprocessScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/NonInterruptingEventSubprocessScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class NonInterruptingEventSubprocessScenario {
 
+  private NonInterruptingEventSubprocessScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/eventsubprocess/nonInterruptingMessageEventSubprocess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/ParallelNestedNonInterruptingEventSubprocessScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/ParallelNestedNonInterruptingEventSubprocessScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class ParallelNestedNonInterruptingEventSubprocessScenario {
 
+  private ParallelNestedNonInterruptingEventSubprocessScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/eventsubprocess/parallelNestedNonInterruptingMessageEventSubprocess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/TwoLevelNestedNonInterruptingEventSubprocessScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/eventsubprocess/TwoLevelNestedNonInterruptingEventSubprocessScenario.java
@@ -30,6 +30,8 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class TwoLevelNestedNonInterruptingEventSubprocessScenario {
 
+  private TwoLevelNestedNonInterruptingEventSubprocessScenario() {
+  }
 
   @Deployment
   public static String deployProcess() {

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/gateway/EventBasedGatewayScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/gateway/EventBasedGatewayScenario.java
@@ -28,6 +28,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class EventBasedGatewayScenario {
 
+  private EventBasedGatewayScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/gateway/eventBasedGatewayProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/histperms/HistoricInstancePermissionsWithoutProcDefKeyScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/histperms/HistoricInstancePermissionsWithoutProcDefKeyScenario.java
@@ -24,6 +24,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class HistoricInstancePermissionsWithoutProcDefKeyScenario {
 
+  private HistoricInstancePermissionsWithoutProcDefKeyScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/upgrade/oneTaskProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/job/AsyncParallelMultiInstanceScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/job/AsyncParallelMultiInstanceScenario.java
@@ -27,6 +27,8 @@ import org.operaton.bpm.qa.upgrade.Times;
  *
  */
 public class AsyncParallelMultiInstanceScenario {
+  private AsyncParallelMultiInstanceScenario() {
+  }
 
   @Deployment
   public static String deployAsyncBeforeSubprocessProcess() {

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/job/AsyncSequentialMultiInstanceScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/job/AsyncSequentialMultiInstanceScenario.java
@@ -27,6 +27,8 @@ import org.operaton.bpm.qa.upgrade.Times;
  *
  */
 public class AsyncSequentialMultiInstanceScenario {
+  private AsyncSequentialMultiInstanceScenario() {
+  }
 
   @Deployment
   public static String deployAsyncBeforeProcess() {

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/multiinstance/MultiInstanceReceiveTaskScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/multiinstance/MultiInstanceReceiveTaskScenario.java
@@ -28,6 +28,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class MultiInstanceReceiveTaskScenario {
 
+  private MultiInstanceReceiveTaskScenario() {
+  }
+
   @Deployment
   public static String deployProcessParallel() {
     return "org/operaton/bpm/qa/upgrade/multiinstance/parallelMultiInstanceReceiveTask.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/multiinstance/NestedSequentialMultiInstanceSubprocessScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/multiinstance/NestedSequentialMultiInstanceSubprocessScenario.java
@@ -28,6 +28,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class NestedSequentialMultiInstanceSubprocessScenario {
 
+  private NestedSequentialMultiInstanceSubprocessScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/multiinstance/nestedSequentialMultiInstanceSubprocess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/multiinstance/ParallelMultiInstanceSubprocessScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/multiinstance/ParallelMultiInstanceSubprocessScenario.java
@@ -28,6 +28,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class ParallelMultiInstanceSubprocessScenario {
 
+  private ParallelMultiInstanceSubprocessScenario() {
+  }
+
   @Deployment
   public static String deployProcessWithNonInterruptingBoundaryEvent() {
     return "org/operaton/bpm/qa/upgrade/multiinstance/parallelMultiInstanceSubprocessNonInterruptingBoundaryEvent.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/multiinstance/SequentialMultiInstanceSubprocessScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/multiinstance/SequentialMultiInstanceSubprocessScenario.java
@@ -28,6 +28,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class SequentialMultiInstanceSubprocessScenario {
 
+  private SequentialMultiInstanceSubprocessScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/multiinstance/sequentialMultiInstanceSubprocess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/task/OneScopeTaskScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/task/OneScopeTaskScenario.java
@@ -28,6 +28,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class OneScopeTaskScenario {
 
+  private OneScopeTaskScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/task/oneScopeTaskProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/task/OneTaskScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/task/OneTaskScenario.java
@@ -28,6 +28,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class OneTaskScenario {
 
+  private OneTaskScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/task/oneTaskProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/task/ParallelScopeTasksScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/task/ParallelScopeTasksScenario.java
@@ -28,6 +28,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class ParallelScopeTasksScenario {
 
+  private ParallelScopeTasksScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/task/parallelScopeTasksProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/task/ParallelTasksScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-72/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/task/ParallelTasksScenario.java
@@ -28,6 +28,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class ParallelTasksScenario {
 
+  private ParallelTasksScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/task/parallelTasksProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-720/src/main/java/org/operaton/bpm/qa/upgrade/jobexecutor/ExclusiveOverProcessHierarchiesScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-720/src/main/java/org/operaton/bpm/qa/upgrade/jobexecutor/ExclusiveOverProcessHierarchiesScenario.java
@@ -24,6 +24,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class ExclusiveOverProcessHierarchiesScenario {
 
+    private ExclusiveOverProcessHierarchiesScenario() {
+    }
+
     @DescribesScenario("createRootProcessInstancesWithHierarchies")
     public static ScenarioSetup createRootProcessInstancesWithHierarchies() {
         return (engine, scenarioName) -> {

--- a/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/boundary/NonInterruptingBoundaryEventScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/boundary/NonInterruptingBoundaryEventScenario.java
@@ -28,6 +28,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class NonInterruptingBoundaryEventScenario {
 
+  private NonInterruptingBoundaryEventScenario() {
+  }
+
   @Deployment
   public static String deployMessageBoundary() {
     return "org/operaton/bpm/qa/upgrade/boundary/nonInterruptingMessageBoundaryEvent.bpmn20.xml";
@@ -46,6 +49,4 @@ public class NonInterruptingBoundaryEventScenario {
       }
     };
   }
-
-
 }

--- a/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/InterruptingEventSubProcessCompensationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/InterruptingEventSubProcessCompensationScenario.java
@@ -29,6 +29,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class InterruptingEventSubProcessCompensationScenario {
 
+  private InterruptingEventSubProcessCompensationScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/compensation/interruptingEventSubProcessCompensationProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/InterruptingEventSubProcessNestedCompensationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/InterruptingEventSubProcessNestedCompensationScenario.java
@@ -29,6 +29,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class InterruptingEventSubProcessNestedCompensationScenario {
 
+  private InterruptingEventSubProcessNestedCompensationScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/compensation/interruptingEventSubProcessNestedCompensationProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/NestedCompensationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/NestedCompensationScenario.java
@@ -29,6 +29,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class NestedCompensationScenario {
 
+  private NestedCompensationScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/compensation/nestedCompensationProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/NestedMultiInstanceCompensationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/NestedMultiInstanceCompensationScenario.java
@@ -31,6 +31,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class NestedMultiInstanceCompensationScenario {
 
+  private NestedMultiInstanceCompensationScenario() {
+  }
+
   @Deployment
   public static String deployThrowInnerProcess() {
     return "org/operaton/bpm/qa/upgrade/compensation/nestedMultiInstanceCompensationThrowInnerProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/NonInterruptingEventSubProcessCompensationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/NonInterruptingEventSubProcessCompensationScenario.java
@@ -29,6 +29,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class NonInterruptingEventSubProcessCompensationScenario {
 
+  private NonInterruptingEventSubProcessCompensationScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/compensation/nonInterruptingEventSubProcessCompensationProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/ParallelMultiInstanceCompensationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/ParallelMultiInstanceCompensationScenario.java
@@ -32,6 +32,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class ParallelMultiInstanceCompensationScenario {
 
+  private ParallelMultiInstanceCompensationScenario() {
+  }
+
   @Deployment
   public static String deploySingleActivityHandler() {
     return "org/operaton/bpm/qa/upgrade/compensation/parallelMultiInstanceCompensationSingleActivityHandlerProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/SequentialMultiInstanceCompensationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/SequentialMultiInstanceCompensationScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class SequentialMultiInstanceCompensationScenario {
 
+  private SequentialMultiInstanceCompensationScenario() {
+  }
+
   @Deployment
   public static String deploySingleActivityHandler() {
     return "org/operaton/bpm/qa/upgrade/compensation/sequentialMultiInstanceCompensationSingleActivityHandlerProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/SingleActivityCompensationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/SingleActivityCompensationScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class SingleActivityCompensationScenario {
 
+  private SingleActivityCompensationScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/compensation/simpleCompensationProcess.bpmn20.xml";
@@ -65,5 +68,4 @@ public class SingleActivityCompensationScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/SingleActivityConcurrentCompensationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/compensation/SingleActivityConcurrentCompensationScenario.java
@@ -30,6 +30,9 @@ import org.operaton.bpm.qa.upgrade.Times;
  */
 public class SingleActivityConcurrentCompensationScenario {
 
+  private SingleActivityConcurrentCompensationScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/compensation/concurrentCompensationProcess.bpmn20.xml";
@@ -69,5 +72,4 @@ public class SingleActivityConcurrentCompensationScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/job/JobMigrationScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/job/JobMigrationScenario.java
@@ -40,6 +40,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
  */
 public class JobMigrationScenario {
 
+  private JobMigrationScenario() {
+  }
+
   @DescribesScenario("createJob")
   public static ScenarioSetup triggerEntryCriterion() {
     return new ScenarioSetup() {

--- a/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/sentry/SentryScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-73/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/sentry/SentryScenario.java
@@ -29,7 +29,10 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
  *
  */
 public class SentryScenario {
-  
+
+  private SentryScenario() {
+  }
+
   @Deployment
   public static String deployOneTaskProcess() {
     return "org/operaton/bpm/qa/upgrade/sentry/sentry.cmmn";
@@ -52,7 +55,7 @@ public class SentryScenario {
         CaseService caseService = engine.getCaseService();
         CaseInstance caseInstance = caseService.createCaseInstanceByKey("case", scenarioName);
         String caseInstanceId = caseInstance.getId();
-        
+
         CaseExecutionQuery query = caseService.createCaseExecutionQuery().caseInstanceId(caseInstanceId);
 
         String firstHumanTaskId = query.activityId("PI_HumanTask_1").singleResult().getId();
@@ -64,7 +67,7 @@ public class SentryScenario {
       }
     };
   }
-  
+
   @DescribesScenario("newSentryInstance")
   public static ScenarioSetup newSentryInstance() {
     return new ScenarioSetup() {
@@ -72,7 +75,7 @@ public class SentryScenario {
         CaseService caseService = engine.getCaseService();
         CaseInstance caseInstance = caseService.createCaseInstanceByKey("case", scenarioName);
         String caseInstanceId = caseInstance.getId();
-        
+
         CaseExecutionQuery query = caseService.createCaseExecutionQuery().caseInstanceId(caseInstanceId);
 
         String firstHumanTaskId = query.activityId("PI_HumanTask_1").singleResult().getId();
@@ -85,7 +88,7 @@ public class SentryScenario {
       }
     };
   }
-  
+
   @DescribesScenario("completeInstance")
   public static ScenarioSetup completeInstance() {
     return new ScenarioSetup() {
@@ -95,5 +98,4 @@ public class SentryScenario {
       }
     };
   }
-  
 }

--- a/qa/test-db-instance-migration/test-fixture-75/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/deployment/DeployProcessWithoutIsExecutableAttributeScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-75/src/main/java/org/operaton/bpm/qa/upgrade/scenarios/deployment/DeployProcessWithoutIsExecutableAttributeScenario.java
@@ -24,6 +24,9 @@ import org.operaton.bpm.engine.test.Deployment;
  */
 public class DeployProcessWithoutIsExecutableAttributeScenario {
 
+  private DeployProcessWithoutIsExecutableAttributeScenario() {
+  }
+
   @Deployment
   public static String deployNonExecutableProcess() {
     return "org/operaton/bpm/qa/upgrade/deployment/processWithoutIsExecutableAttribute.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-76/src/main/java/org/operaton/bpm/qa/upgrade/user/creation/DeployUserWithoutSaltForPasswordHashingScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-76/src/main/java/org/operaton/bpm/qa/upgrade/user/creation/DeployUserWithoutSaltForPasswordHashingScenario.java
@@ -28,6 +28,9 @@ public class DeployUserWithoutSaltForPasswordHashingScenario {
   protected static final String USER_NAME = "kermit";
   protected static final String USER_PWD = "password";
 
+  private DeployUserWithoutSaltForPasswordHashingScenario() {
+  }
+
   @DescribesScenario("initUser")
   @Times(1)
   public static ScenarioSetup initUser() {

--- a/qa/test-db-instance-migration/test-fixture-77/src/main/java/org/operaton/bpm/qa/upgrade/variable/CreateProcessInstanceWithVariableScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-77/src/main/java/org/operaton/bpm/qa/upgrade/variable/CreateProcessInstanceWithVariableScenario.java
@@ -25,6 +25,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
 
 public class CreateProcessInstanceWithVariableScenario {
 
+  private CreateProcessInstanceWithVariableScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/variable/simpleProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-fixture-78/src/main/java/org/operaton/bpm/qa/upgrade/json/CreateProcessInstanceWithJsonVariablesScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-78/src/main/java/org/operaton/bpm/qa/upgrade/json/CreateProcessInstanceWithJsonVariablesScenario.java
@@ -34,6 +34,9 @@ import static org.operaton.bpm.engine.variable.Variables.serializedObjectValue;
 
 public class CreateProcessInstanceWithJsonVariablesScenario {
 
+  private CreateProcessInstanceWithJsonVariablesScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/json/simpleProcess.bpmn20.xml";
@@ -99,5 +102,4 @@ public class CreateProcessInstanceWithJsonVariablesScenario {
   public static SerializedObjectValueBuilder createSerializedMap(){
     return serializedObjectValue("{\"foo\": \"bar\"}").serializationDataFormat("application/json").objectTypeName(HashMap.class.getName());
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-79/src/main/java/org/operaton/bpm/qa/removaltime/CreateRootProcessInstanceWithoutRootIdScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-79/src/main/java/org/operaton/bpm/qa/removaltime/CreateRootProcessInstanceWithoutRootIdScenario.java
@@ -26,6 +26,9 @@ import org.operaton.bpm.qa.upgrade.ScenarioSetup;
  */
 public class CreateRootProcessInstanceWithoutRootIdScenario {
 
+  private CreateRootProcessInstanceWithoutRootIdScenario() {
+  }
+
   @DescribesScenario("initRootProcessInstanceWithoutRootId")
   public static ScenarioSetup initRootProcessInstance() {
     return new ScenarioSetup() {
@@ -52,5 +55,4 @@ public class CreateRootProcessInstanceWithoutRootIdScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-instance-migration/test-fixture-79/src/main/java/org/operaton/bpm/qa/upgrade/json/CreateProcessInstanceWithJsonVariablesScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-79/src/main/java/org/operaton/bpm/qa/upgrade/json/CreateProcessInstanceWithJsonVariablesScenario.java
@@ -35,6 +35,9 @@ import static org.junit.Assert.assertEquals;
 
 public class CreateProcessInstanceWithJsonVariablesScenario {
 
+  private CreateProcessInstanceWithJsonVariablesScenario() {
+  }
+
   @Deployment
   public static String deployProcess() {
     return "org/operaton/bpm/qa/upgrade/json/simpleProcess.bpmn20.xml";

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7190/httl/EnforceHistoryTimeToLiveTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7190/httl/EnforceHistoryTimeToLiveTest.java
@@ -115,10 +115,13 @@ public class EnforceHistoryTimeToLiveTest {
   }
 
   static class Assert {
+    private Assert() {
+    }
 
     @FunctionalInterface
     interface FailingRunnable {
       void run() throws Exception;
+
     }
 
     static void assertDoesNotThrow(FailingRunnable runnable) {

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/util/ActivityInstanceAssert.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/util/ActivityInstanceAssert.java
@@ -31,6 +31,8 @@ import org.junit.Assert;
  *
  */
 public class ActivityInstanceAssert {
+  private ActivityInstanceAssert() {
+  }
 
   public static class ActivityInstanceAssertThatClause {
 
@@ -103,10 +105,10 @@ public class ActivityInstanceAssert {
     }
 
   }
-
   public static class ActivityInstanceTreeBuilder {
 
     protected ExpectedActivityInstance rootInstance = null;
+
     protected Stack<ExpectedActivityInstance> activityInstanceStack = new Stack<>();
 
     public ActivityInstanceTreeBuilder() {
@@ -163,10 +165,10 @@ public class ActivityInstanceAssert {
       activityInstanceStack.pop();
       return this;
     }
-
     public ExpectedActivityInstance done() {
       return rootInstance;
     }
+
   }
 
   public static ActivityInstanceTreeBuilder describeActivityInstanceTree() {

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/RollingUpdateConstants.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/RollingUpdateConstants.java
@@ -24,4 +24,7 @@ package org.operaton.bpm.qa.rolling.update;
 public final class RollingUpdateConstants {
   public static final String OLD_ENGINE_TAG = "OLD";
   public static final String NEW_ENGINE_TAG = "CURRENT";
+
+  private RollingUpdateConstants() {
+  }
 }

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/DeploymentWhichShouldBeDeletedScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/DeploymentWhichShouldBeDeletedScenario.java
@@ -30,6 +30,9 @@ public class DeploymentWhichShouldBeDeletedScenario {
 
   public static final String PROCESS_DEF_KEY = "processWithAsyncServiceTask";
 
+  private DeploymentWhichShouldBeDeletedScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/rolling/update/processWithAsyncServiceTask.bpmn20.xml";
@@ -44,5 +47,4 @@ public class DeploymentWhichShouldBeDeletedScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/batch/SetRemovalTimeToProcessInstanceScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/batch/SetRemovalTimeToProcessInstanceScenario.java
@@ -29,6 +29,9 @@ public class SetRemovalTimeToProcessInstanceScenario {
 
   public static final String PROCESS_DEF_KEY = "oneTaskProcess";
 
+  private SetRemovalTimeToProcessInstanceScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/rolling/update/oneTaskProcess.bpmn20.xml";
@@ -65,5 +68,4 @@ public class SetRemovalTimeToProcessInstanceScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/callactivity/ProcessWithCallActivityScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/callactivity/ProcessWithCallActivityScenario.java
@@ -32,6 +32,9 @@ public class ProcessWithCallActivityScenario {
 
   public static final String PROCESS_DEF_KEY = "processWithCallActivity";
 
+  private ProcessWithCallActivityScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/rolling/update/processWithCallActivity.bpmn20.xml";
@@ -63,5 +66,4 @@ public class ProcessWithCallActivityScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/cleanup/HistoryCleanupScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/cleanup/HistoryCleanupScenario.java
@@ -36,6 +36,9 @@ public class HistoryCleanupScenario {
 
   static final Date FIXED_DATE = new Date(1363608000000L);
 
+  private HistoryCleanupScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/rolling/update/cleanup/oneTaskProcess.bpmn20.xml";
@@ -99,5 +102,4 @@ public class HistoryCleanupScenario {
     calendar.add(Calendar.MINUTE, minutes);
     return calendar.getTime();
   }
-
 }

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/eventSubProcess/ProcessWithEventSubProcessScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/eventSubProcess/ProcessWithEventSubProcessScenario.java
@@ -32,6 +32,9 @@ public class ProcessWithEventSubProcessScenario {
 
   public static final String PROCESS_DEF_KEY = "processWithEventSubProcess";
 
+  private ProcessWithEventSubProcessScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/rolling/update/processWithEventSubProcess.bpmn20.xml";
@@ -63,5 +66,4 @@ public class ProcessWithEventSubProcessScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/externalTask/ProcessWithExternalTaskScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/externalTask/ProcessWithExternalTaskScenario.java
@@ -28,11 +28,13 @@ import org.operaton.bpm.qa.upgrade.Times;
  * @author Christopher Zell <christopher.zell@camunda.com>
  */
 public class ProcessWithExternalTaskScenario {
-
   public static final String PROCESS_DEF_KEY = "processWithExternalTask";
   public static final String EXTERNAL_TASK = "externalTask";
   public static final String EXTERNAL_TASK_TYPE = "external";
   public static final long LOCK_TIME = 5 * 60 * 1000;
+
+  private ProcessWithExternalTaskScenario() {
+  }
 
   /**
    * Deploy a process model, which contains an external task. The topic is

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/mulltiInstance/ProcessWithMultiInstanceCallActivityScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/mulltiInstance/ProcessWithMultiInstanceCallActivityScenario.java
@@ -32,6 +32,9 @@ public class ProcessWithMultiInstanceCallActivityScenario {
 
   public static final String PROCESS_DEF_KEY = "processWithMultiInstanceCallActivity";
 
+  private ProcessWithMultiInstanceCallActivityScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/rolling/update/processWithMultiInstanceCallActivity.bpmn20.xml";
@@ -63,6 +66,4 @@ public class ProcessWithMultiInstanceCallActivityScenario {
       }
     };
   }
-
-
 }

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/task/ProcessWithAsyncServiceTaskScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/task/ProcessWithAsyncServiceTaskScenario.java
@@ -30,6 +30,9 @@ public class ProcessWithAsyncServiceTaskScenario {
 
   public static final String PROCESS_DEF_KEY = "processWithAsyncServiceTask";
 
+  private ProcessWithAsyncServiceTaskScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/rolling/update/processWithAsyncServiceTask.bpmn20.xml";
@@ -44,5 +47,4 @@ public class ProcessWithAsyncServiceTaskScenario {
       }
     };
   }
-
 }

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/task/ProcessWithParallelGatewayAndServiceTaskScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/task/ProcessWithParallelGatewayAndServiceTaskScenario.java
@@ -35,6 +35,9 @@ public class ProcessWithParallelGatewayAndServiceTaskScenario {
 
   public static final String PROCESS_DEF_KEY_2 = "processWithParallelGatewayAndAsyncServiceTask";
 
+  private ProcessWithParallelGatewayAndServiceTaskScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/rolling/update/processWithParallelGatewayAndServiceTask.bpmn20.xml";

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/task/ProcessWithParallelGatewayScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/task/ProcessWithParallelGatewayScenario.java
@@ -34,6 +34,9 @@ public class ProcessWithParallelGatewayScenario {
 
   public static final String PROCESS_DEF_KEY = "processWithParallelGateway";
 
+  private ProcessWithParallelGatewayScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/rolling/update/processWithParallelGateway.bpmn20.xml";

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/task/ProcessWithUserTaskAndTimerScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/task/ProcessWithUserTaskAndTimerScenario.java
@@ -31,6 +31,9 @@ public class ProcessWithUserTaskAndTimerScenario {
 
   public static final String PROCESS_DEF_KEY = "processWithUserTaskAndTimer";
 
+  private ProcessWithUserTaskAndTimerScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/rolling/update/processWithUserTaskAndTimer.bpmn20.xml";

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/task/ProcessWithUserTaskScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/task/ProcessWithUserTaskScenario.java
@@ -31,6 +31,9 @@ public class ProcessWithUserTaskScenario {
 
   public static final String PROCESS_DEF_KEY = "processWithUserTask";
 
+  private ProcessWithUserTaskScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/rolling/update/processWithUserTask.bpmn20.xml";

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/variable/EmptyStringVariableScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/variable/EmptyStringVariableScenario.java
@@ -27,6 +27,9 @@ public class EmptyStringVariableScenario {
 
   public static final String PROCESS_DEF_KEY = "oneTaskProcess";
 
+  private EmptyStringVariableScenario() {
+  }
+
   @Deployment
   public static String deploy() {
     return "org/operaton/bpm/qa/rolling/update/oneTaskProcess.bpmn20.xml";
@@ -42,5 +45,4 @@ public class EmptyStringVariableScenario {
       }
     };
   }
-
 }

--- a/spin/core/src/main/java/org/operaton/spin/impl/util/SpinReflectUtil.java
+++ b/spin/core/src/main/java/org/operaton/spin/impl/util/SpinReflectUtil.java
@@ -27,6 +27,9 @@ public class SpinReflectUtil {
 
   private static final SpinCoreLogger LOG = SpinCoreLogger.CORE_LOGGER;
 
+  private SpinReflectUtil() {
+  }
+
   /**
    * Used by dataformats if they need to load a class
    *
@@ -59,5 +62,4 @@ public class SpinReflectUtil {
     }
 
   }
-
 }

--- a/spin/core/src/main/java/org/operaton/spin/scripting/SpinScriptEnv.java
+++ b/spin/core/src/main/java/org/operaton/spin/scripting/SpinScriptEnv.java
@@ -22,7 +22,6 @@ import org.operaton.spin.impl.logging.SpinLogger;
 import org.operaton.spin.impl.util.SpinIoUtil;
 
 import javax.script.ScriptEngine;
-
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,6 +50,9 @@ public class SpinScriptEnv {
     extensions.put("javascript", "js");
     extensions.put("groovy", "groovy");
     extensions.put("ruby", "rb");
+  }
+
+  private SpinScriptEnv() {
   }
 
   /**
@@ -107,5 +109,4 @@ public class SpinScriptEnv {
       }
     }
   }
-
 }

--- a/spin/dataformat-json-jackson/src/main/java/org/operaton/spin/impl/json/jackson/format/TypeHelper.java
+++ b/spin/dataformat-json-jackson/src/main/java/org/operaton/spin/impl/json/jackson/format/TypeHelper.java
@@ -16,19 +16,22 @@
  */
 package org.operaton.spin.impl.json.jackson.format;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.type.TypeFactory;
-
 import java.lang.reflect.TypeVariable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
 /**
  * Collection of helper methods to construct types.
  */
 public class TypeHelper {
+
+  private TypeHelper() {
+  }
 
   /**
    * Checks if the erased type has the correct number of type bindings.
@@ -125,5 +128,4 @@ public class TypeHelper {
           "Could not detect class for " + value + " of type " + value.getClass().getName());
     }
   }
-
 }

--- a/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/util/AnnotationUtil.java
+++ b/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/util/AnnotationUtil.java
@@ -16,14 +16,17 @@
  */
 package org.operaton.bpm.client.spring.impl.util;
 
+import java.lang.annotation.Annotation;
+import java.util.NoSuchElementException;
+
 import org.springframework.core.annotation.MergedAnnotation;
 import org.springframework.core.annotation.MergedAnnotations;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
-import java.lang.annotation.Annotation;
-import java.util.NoSuchElementException;
-
 public class AnnotationUtil {
+
+  private AnnotationUtil() {
+  }
 
   public static <T extends Annotation> T get(Class<T> annotationClass,
                                              AnnotatedTypeMetadata metadata) {

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/plugin/SsoLogoutPluginConstants.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/plugin/SsoLogoutPluginConstants.java
@@ -20,4 +20,6 @@ public class SsoLogoutPluginConstants {
 
   public static final String ID = "sso-logout-plugin";
 
+  private SsoLogoutPluginConstants() {
+  }
 }

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/util/SpringBootStarterPropertyHelper.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/util/SpringBootStarterPropertyHelper.java
@@ -30,6 +30,9 @@ public class SpringBootStarterPropertyHelper {
 
   protected static final SpringBootProcessEngineLogger LOG = SpringBootProcessEngineLogger.LOG;
 
+  private SpringBootStarterPropertyHelper() {
+  }
+
   public static <T> void applyProperties(T target, Map<String, Object> sourceMap, boolean ignoreUnknownFields) {
     ConfigurationPropertySource source = new MapConfigurationPropertySource(sourceMap);
     Binder binder = new Binder(source);
@@ -43,5 +46,4 @@ public class SpringBootStarterPropertyHelper {
       throw LOG.exceptionDuringBinding(e.getMessage());
     }
   }
-
 }

--- a/test-utils/archunit/src/main/java/org/operaton/bpm/engine/test/archunit/ArchRulesTest.java
+++ b/test-utils/archunit/src/main/java/org/operaton/bpm/engine/test/archunit/ArchRulesTest.java
@@ -35,6 +35,9 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 )
 public class ArchRulesTest {
 
+  private ArchRulesTest() {
+  }
+
   @ArchTest
   public static final ArchRule publicApiShouldNotExposeImplementation = classes().that()
       .areInterfaces().and().resideOutsideOfPackages("..impl..")

--- a/test-utils/testcontainers/src/main/java/org/operaton/impl/test/utils/testcontainers/TestcontainersHelper.java
+++ b/test-utils/testcontainers/src/main/java/org/operaton/impl/test/utils/testcontainers/TestcontainersHelper.java
@@ -21,6 +21,9 @@ import org.testcontainers.utility.TestcontainersConfiguration;
 
 public class TestcontainersHelper {
 
+  private TestcontainersHelper() {
+  }
+
   public static String resolveImageName(String imageProperty, String defaultImage) {
     String image = TestcontainersConfiguration.getInstance().getEnvVarOrProperty(imageProperty, defaultImage);
     if (image == null) {
@@ -37,5 +40,4 @@ public class TestcontainersHelper {
     String dockerImageString = resolveImageName(imageProperty, defaultDbImage) + ":" + tag;
     return DockerImageName.parse(dockerImageString).asCompatibleSubstituteFor(defaultDbImage);
   }
-
 }

--- a/webapps/assembly/src/main/java/org/operaton/bpm/admin/Admin.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/admin/Admin.java
@@ -23,7 +23,9 @@ package org.operaton.bpm.admin;
  *
  */
 public class Admin {
-
+  private Admin() {
+  }
+  
   /**
    * The {@link AdminRuntimeDelegate} is an delegate that will be
    * initialized by bootstrapping operaton admin with an specific

--- a/webapps/assembly/src/main/java/org/operaton/bpm/cockpit/Cockpit.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/cockpit/Cockpit.java
@@ -28,6 +28,9 @@ import org.operaton.bpm.engine.ProcessEngine;
  */
 public class Cockpit {
 
+  private Cockpit() {
+  }
+
   /**
    * The {@link CockpitRuntimeDelegate} is an delegate that will be
    * initialized by bootstrapping operaton cockpit with an specific
@@ -79,5 +82,4 @@ public class Cockpit {
   public static void setCockpitRuntimeDelegate(CockpitRuntimeDelegate cockpitRuntimeDelegate) {
     COCKPIT_RUNTIME_DELEGATE = cockpitRuntimeDelegate;
   }
-
 }

--- a/webapps/assembly/src/main/java/org/operaton/bpm/tasklist/Tasklist.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/tasklist/Tasklist.java
@@ -30,6 +30,10 @@ public class Tasklist {
    * instance
    */
   protected static TasklistRuntimeDelegate TASKLIST_RUNTIME_DELEGATE;
+
+  private Tasklist() {
+  }
+
   /**
    * Returns an instance of {@link TasklistRuntimeDelegate}
    *
@@ -46,5 +50,4 @@ public class Tasklist {
   public static void setTasklistRuntimeDelegate(TasklistRuntimeDelegate tasklistRuntimeDelegate) {
     TASKLIST_RUNTIME_DELEGATE = tasklistRuntimeDelegate;
   }
-
 }

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/SecurityActions.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/SecurityActions.java
@@ -16,10 +16,6 @@
  */
 package org.operaton.bpm.webapp.impl.security;
 
-import javax.servlet.ServletException;
-import java.io.IOException;
-import java.util.List;
-
 import org.operaton.bpm.cockpit.Cockpit;
 import org.operaton.bpm.engine.IdentityService;
 import org.operaton.bpm.engine.ProcessEngine;
@@ -27,11 +23,18 @@ import org.operaton.bpm.webapp.impl.security.auth.Authentication;
 import org.operaton.bpm.webapp.impl.security.auth.Authentications;
 import org.operaton.bpm.webapp.impl.security.auth.UserAuthentication;
 
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.List;
+
 /**
  * @author Daniel Meyer
  *
  */
 public class SecurityActions {
+
+  private SecurityActions() {
+  }
 
   public static <T> T runWithAuthentications(SecurityAction<T> action, Authentications authentications) throws IOException, ServletException {
 
@@ -90,9 +93,8 @@ public class SecurityActions {
     }
 
   }
-
   public static interface SecurityAction<T> {
     public T execute() throws IOException, ServletException;
-  }
 
+  }
 }

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/auth/AuthenticationUtil.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/auth/AuthenticationUtil.java
@@ -16,17 +16,6 @@
  */
 package org.operaton.bpm.webapp.impl.security.auth;
 
-import static org.operaton.bpm.engine.authorization.Permissions.ACCESS;
-import static org.operaton.bpm.engine.authorization.Resources.APPLICATION;
-import static org.operaton.bpm.webapp.impl.security.filter.util.HttpSessionMutexListener.AUTH_TIME_SESSION_MUTEX;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
 import org.operaton.bpm.engine.AuthorizationService;
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.identity.Group;
@@ -35,6 +24,13 @@ import org.operaton.bpm.engine.identity.User;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.webapp.impl.WebappLogger;
 import org.operaton.bpm.webapp.impl.util.ProcessEngineUtil;
+import static org.operaton.bpm.engine.authorization.Permissions.ACCESS;
+import static org.operaton.bpm.engine.authorization.Resources.APPLICATION;
+import static org.operaton.bpm.webapp.impl.security.filter.util.HttpSessionMutexListener.AUTH_TIME_SESSION_MUTEX;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+import java.util.*;
 
 public class AuthenticationUtil {
 
@@ -44,6 +40,9 @@ public class AuthenticationUtil {
 
   public static final String[] APPS = new String[]{"cockpit", "tasklist", "admin"};
   public static final String APP_WELCOME = "welcome";
+
+  private AuthenticationUtil() {
+  }
 
   public static UserAuthentication createAuthentication(String engineName, String username) {
     return createAuthentication(engineName, username, null, null);

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/util/CookieConstants.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/util/CookieConstants.java
@@ -30,4 +30,7 @@ public final class CookieConstants {
 
   public static final String SECURE_FLAG_NAME = ";Secure";
   public static final Pattern SECURE_FLAG_NAME_REGEX = Pattern.compile(";\\w*Secure");
+
+  private CookieConstants() {
+  }
 }

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/util/CsrfConstants.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/util/CsrfConstants.java
@@ -37,4 +37,7 @@ public final class CsrfConstants {
 
   public static final String CSRF_PATH_FIELD_NAME = ";Path=";
 
+  private CsrfConstants() {
+  }
+
 }

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/util/FilterRules.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/util/FilterRules.java
@@ -16,23 +16,17 @@
  */
 package org.operaton.bpm.webapp.impl.security.filter.util;
 
+import org.operaton.bpm.engine.impl.util.ReflectUtil;
+import org.operaton.bpm.webapp.impl.security.auth.Authentication;
+import org.operaton.bpm.webapp.impl.security.filter.*;
+import org.operaton.bpm.webapp.impl.security.filter.SecurityFilterConfig.PathFilterConfig;
+import org.operaton.bpm.webapp.impl.security.filter.SecurityFilterConfig.PathMatcherConfig;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import org.operaton.bpm.engine.impl.util.ReflectUtil;
-import org.operaton.bpm.webapp.impl.security.auth.Authentication;
-import org.operaton.bpm.webapp.impl.security.filter.Authorization;
-import org.operaton.bpm.webapp.impl.security.filter.PathFilterRule;
-import org.operaton.bpm.webapp.impl.security.filter.RequestAuthorizer;
-import org.operaton.bpm.webapp.impl.security.filter.RequestFilter;
-import org.operaton.bpm.webapp.impl.security.filter.RequestMatcher;
-import org.operaton.bpm.webapp.impl.security.filter.SecurityFilterConfig;
-import org.operaton.bpm.webapp.impl.security.filter.SecurityFilterConfig.PathFilterConfig;
-import org.operaton.bpm.webapp.impl.security.filter.SecurityFilterConfig.PathMatcherConfig;
-import org.operaton.bpm.webapp.impl.security.filter.SecurityFilterRule;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -42,6 +36,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author nico.rehwaldt
  */
 public class FilterRules {
+
+  private FilterRules() {
+  }
 
   public static List<SecurityFilterRule> load(InputStream configFileResource,
                                               String applicationPath) throws IOException {

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/util/ProcessEngineUtil.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/util/ProcessEngineUtil.java
@@ -27,6 +27,9 @@ import org.operaton.bpm.engine.rest.spi.ProcessEngineProvider;
 
 public class ProcessEngineUtil {
 
+  private ProcessEngineUtil() {
+  }
+
   public static ProcessEngine lookupProcessEngine(String engineName) {
     ServiceLoader<ProcessEngineProvider> serviceLoader = ServiceLoader.load(ProcessEngineProvider.class);
     Iterator<ProcessEngineProvider> iterator = serviceLoader.iterator();

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/util/ServletContextUtil.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/util/ServletContextUtil.java
@@ -43,6 +43,9 @@ public class ServletContextUtil {
   protected static final String AUTH_CACHE_TTL_ATTR_NAME =
     "org.operaton.bpm.webapp.auth.cache.ttl";
 
+  private ServletContextUtil() {
+  }
+
   /**
    * Consumed by Operaton CE & EE Webapp:
    * Retrieves the application path from Spring Boot's servlet context.
@@ -116,5 +119,4 @@ public class ServletContextUtil {
 
     }
   }
-
 }

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/util/ServletFilterUtil.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/util/ServletFilterUtil.java
@@ -20,6 +20,8 @@ package org.operaton.bpm.webapp.impl.util;
  * Common logic that is used in servlet filters.
  */
 public class ServletFilterUtil {
+  private ServletFilterUtil() {
+  }
 
   /**
    * Checks if servlet filter init parameter is empty.
@@ -27,5 +29,4 @@ public class ServletFilterUtil {
   public static boolean isEmpty(String string) {
     return string == null || string.trim().isEmpty();
   }
-
 }

--- a/webapps/assembly/src/main/java/org/operaton/bpm/welcome/Welcome.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/welcome/Welcome.java
@@ -24,6 +24,9 @@ package org.operaton.bpm.welcome;
  */
 public class Welcome {
 
+  private Welcome() {
+  }
+
   /**
    * The {@link WelcomeRuntimeDelegate} is an delegate that will be
    * initialized by bootstrapping operaton welcome with an specific
@@ -47,5 +50,4 @@ public class Welcome {
   public static void setRuntimeDelegate(WelcomeRuntimeDelegate welcomeRuntimeDelegate) {
     WELCOME_RUNTIME_DELEGATE = welcomeRuntimeDelegate;
   }
-
 }


### PR DESCRIPTION
Ensures utility classes (classes containing only static methods or fields in their API) do not have a public constructor.

Performed cleanup with Open Rewrite recipe org.openrewrite.staticanalysis.HideUtilityClassConstructor and manually adjusted order

related to #88