### PR TITLE
chore(engine,parent): Bump GraalVM to 21.3.12

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -44,7 +44,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import javax.naming.InitialContext;
-import javax.script.ScriptEngineManager;
 import javax.sql.DataSource;
 import org.apache.ibatis.builder.xml.XMLConfigBuilder;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
@@ -342,6 +341,7 @@ import org.operaton.bpm.engine.impl.runtime.DefaultCorrelationHandler;
 import org.operaton.bpm.engine.impl.runtime.DefaultDeserializationTypeValidator;
 import org.operaton.bpm.engine.impl.scripting.ScriptFactory;
 import org.operaton.bpm.engine.impl.scripting.engine.BeansResolverFactory;
+import org.operaton.bpm.engine.impl.scripting.engine.OperatonScriptEngineManager;
 import org.operaton.bpm.engine.impl.scripting.engine.DefaultScriptEngineResolver;
 import org.operaton.bpm.engine.impl.scripting.engine.ResolverFactory;
 import org.operaton.bpm.engine.impl.scripting.engine.ScriptBindingsFactory;
@@ -2644,7 +2644,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       resolverFactories.add(new BeansResolverFactory());
     }
     if (scriptEngineResolver == null) {
-      scriptEngineResolver = new DefaultScriptEngineResolver(new ScriptEngineManager());
+      scriptEngineResolver = new DefaultScriptEngineResolver(new OperatonScriptEngineManager());
     }
     if (scriptingEngines == null) {
       scriptingEngines = new ScriptingEngines(new ScriptBindingsFactory(resolverFactories), scriptEngineResolver);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/OperatonScriptEngineManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/OperatonScriptEngineManager.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.scripting.engine;
+
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptEngineManager;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.operaton.bpm.engine.impl.scripting.engine.ScriptingEngines.GRAAL_JS_SCRIPT_ENGINE_NAME;
+
+/**
+ * Custom Script Engine Manager that can execute custom logic:
+ * <p>
+ * a) after the discovery of the engines on the classpath; the respective engine factories are created
+ * b) before the engines are created.
+ *
+ * If custom logic is needed for a specific engine after the classpath detection, before the engine creation,
+ * it can be added to the classes map.
+ */
+public class OperatonScriptEngineManager extends ScriptEngineManager {
+
+  protected final Map<String, Runnable> engineNameToInitLogicMappings = Map.of(
+      GRAAL_JS_SCRIPT_ENGINE_NAME, this::disableGraalVMInterpreterOnlyModeWarnings
+  );
+
+  public OperatonScriptEngineManager() {
+    super(); // creates engine factories after classpath discovery
+    applyConfigOnEnginesAfterClasspathDiscovery();
+  }
+
+  protected void applyConfigOnEnginesAfterClasspathDiscovery() {
+    var engineNames = getEngineNamesFoundInClasspath();
+
+    for (var engineName : engineNames) {
+      executeConfigurationBeforeEngineCreation(engineName);
+    }
+  }
+
+  protected List<String> getEngineNamesFoundInClasspath() {
+    var engineFactories = getEngineFactories();
+
+    return engineFactories.stream()
+        .map(ScriptEngineFactory::getEngineName)
+        .collect(Collectors.toList());
+
+  }
+
+  /**
+   * Fetches the config logic of a given engine from the mappings and executes it in case it exists.
+   *
+   * @param engineName the given engine name
+   */
+  protected void executeConfigurationBeforeEngineCreation(String engineName) {
+    var config = engineNameToInitLogicMappings.get(engineName);
+    if (config != null) {
+      config.run();
+    }
+  }
+
+  protected void disableGraalVMInterpreterOnlyModeWarnings() {
+    System.setProperty("polyglot.engine.WarnInterpreterOnly", "false");
+  }
+
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -26,8 +26,8 @@
     <!-- use minimum version of resteasy and jersey -->
     <version.jaxrs.api>2.0.1.Final</version.jaxrs.api>
     <version.groovy>4.0.22</version.groovy>
-    <version.graal.js>21.1.0</version.graal.js>
-    <version.icu.icu4j>68.2</version.icu.icu4j>
+    <version.graal.js>21.3.12</version.graal.js>
+    <version.icu.icu4j>71.1</version.icu.icu4j>
     <!-- json-smart and accessors-smart are runtime dependencies of json-path -->
     <version.json-path>2.9.0</version.json-path>
     <version.json-smart>2.5.0</version.json-smart>


### PR DESCRIPTION
Notes

- Bumps icu:icu4j to version 71.1

Introduces:

OperatonScriptEngineManager - Class that allows to parameterise behaviour needed for a given JS engine: a) After the engines are detected from the classpath b) Before the engines are created

GraalVM Warnings

The commit sets the System property to disable the respective warnings introduced by bumping GraalVM to version 21.3.10.

- The system property is always set when a GraalJS script engine is found on the classpath
- The above applies by default to all distros

Related-to: https://github.com/camunda/camunda-bpm-platform/issues/4299

Backported commit 14a704b522 from the camunda-bpm-platform repository.
Original author: psavidis <69160690+psavidis@users.noreply.github.com>