### PR TITLE
chore(engine): Resolve & document deprecations in TransitionImpl, ScopeImpl

### DIFF
--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/event/CdiEventSupportBpmnParseListener.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/event/CdiEventSupportBpmnParseListener.java
@@ -40,11 +40,11 @@ import org.operaton.bpm.engine.impl.variable.VariableDeclaration;
 public class CdiEventSupportBpmnParseListener implements BpmnParseListener {
 
   protected void addEndEventListener(ActivityImpl activity) {
-    activity.addExecutionListener(ExecutionListener.EVENTNAME_END, new CdiEventListener());
+    activity.addListener(ExecutionListener.EVENTNAME_END, new CdiEventListener());
   }
 
   protected void addStartEventListener(ActivityImpl activity) {
-    activity.addExecutionListener(ExecutionListener.EVENTNAME_START, new CdiEventListener());
+    activity.addListener(ExecutionListener.EVENTNAME_START, new CdiEventListener());
   }
 
   protected void addTaskCreateListeners(TaskDefinition taskDefinition) {

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/event/CdiEventSupportBpmnParseListener.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/event/CdiEventSupportBpmnParseListener.java
@@ -174,7 +174,7 @@ public class CdiEventSupportBpmnParseListener implements BpmnParseListener {
 
   @Override
   public void parseSequenceFlow(Element sequenceFlowElement, ScopeImpl scopeElement, TransitionImpl transition) {
-    transition.addExecutionListener(new CdiEventListener());
+    transition.addListener(ExecutionListener.EVENTNAME_TAKE, new CdiEventListener());
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/application/impl/event/ProcessApplicationEventParseListener.java
+++ b/engine/src/main/java/org/operaton/bpm/application/impl/event/ProcessApplicationEventParseListener.java
@@ -42,15 +42,15 @@ public class ProcessApplicationEventParseListener implements BpmnParseListener {
   public static final TaskListener TASK_LISTENER = new ProcessApplicationEventListenerDelegate();
 
   protected void addEndEventListener(ScopeImpl activity) {
-    activity.addExecutionListener(ExecutionListener.EVENTNAME_END, EXECUTION_LISTENER);
+    activity.addListener(ExecutionListener.EVENTNAME_END, EXECUTION_LISTENER);
   }
 
   protected void addStartEventListener(ScopeImpl activity) {
-    activity.addExecutionListener(ExecutionListener.EVENTNAME_START, EXECUTION_LISTENER);
+    activity.addListener(ExecutionListener.EVENTNAME_START, EXECUTION_LISTENER);
   }
 
   protected void addTakeEventListener(TransitionImpl transition) {
-    transition.addExecutionListener(EXECUTION_LISTENER);
+    transition.addListener(ExecutionListener.EVENTNAME_TAKE, EXECUTION_LISTENER);
   }
 
   protected void addTaskAssignmentListeners(TaskDefinition taskDefinition) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -4439,7 +4439,7 @@ public class BpmnParse extends Parse {
         if (isValidEventNameForScope(eventName, listenerElement, scopeElementId)) {
           ExecutionListener listener = parseExecutionListener(listenerElement, scopeElementId);
           if (listener != null) {
-            scope.addExecutionListener(eventName, listener);
+            scope.addListener(eventName, listener);
           }
         }
       }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -4472,7 +4472,7 @@ public class BpmnParse extends Parse {
         if (listener != null) {
           // Since a transition only fires event 'take', we don't parse the
           // event attribute, it is ignored
-          activity.addExecutionListener(listener);
+          activity.addListener(ExecutionListener.EVENTNAME_TAKE, listener);
         }
       }
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/ProcessDefinitionBuilder.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/ProcessDefinitionBuilder.java
@@ -156,7 +156,7 @@ public class ProcessDefinitionBuilder {
 
   public ProcessDefinitionBuilder executionListener(ExecutionListener executionListener) {
     if (transition!=null) {
-      transition.addExecutionListener(executionListener);
+      transition.addListener(ExecutionListener.EVENTNAME_TAKE, executionListener);
     } else {
       throw new PvmException("not in a transition scope");
     }
@@ -165,9 +165,9 @@ public class ProcessDefinitionBuilder {
 
   public ProcessDefinitionBuilder executionListener(String eventName, ExecutionListener executionListener) {
     if (transition==null) {
-      scopeStack.peek().addExecutionListener(eventName, executionListener);
+      scopeStack.peek().addListener(eventName, executionListener);
     } else {
-      transition.addExecutionListener(executionListener);
+      transition.addListener(ExecutionListener.EVENTNAME_TAKE, executionListener);
     }
     return this;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/process/ScopeImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/process/ScopeImpl.java
@@ -200,24 +200,36 @@ public abstract class ScopeImpl extends CoreActivity implements PvmScope {
 
   // event listeners //////////////////////////////////////////////////////////
 
+  /**
+   * @deprecated Use {@link #getListeners(String)} instead
+   */
   @SuppressWarnings("unchecked")
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public List<ExecutionListener> getExecutionListeners(String eventName) {
     return (List) super.getListeners(eventName);
   }
 
-  @Deprecated
+  /**
+   * @deprecated Use {@link #addListener(String, org.operaton.bpm.engine.delegate.DelegateListener)} instead
+   */
+  @Deprecated(forRemoval = true)
   public void addExecutionListener(String eventName, ExecutionListener executionListener) {
     super.addListener(eventName, executionListener);
   }
 
-  @Deprecated
+  /**
+   * @deprecated Use {@link #addListener(String, org.operaton.bpm.engine.delegate.DelegateListener, int)} instead
+   */
+  @Deprecated(forRemoval = true)
   public void addExecutionListener(String eventName, ExecutionListener executionListener, int index) {
     super.addListener(eventName, executionListener, index);
   }
 
+  /**
+   * @deprecated Use {@link #getListeners()} instead
+   */
   @SuppressWarnings({ "rawtypes", "unchecked" })
-  @Deprecated
+  @Deprecated(forRemoval = true)
   public Map<String, List<ExecutionListener>> getExecutionListeners() {
     return (Map) super.getListeners();
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/process/TransitionImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/process/TransitionImpl.java
@@ -57,7 +57,10 @@ public class TransitionImpl extends CoreModelElement implements PvmTransition {
     destination.getIncomingTransitions().add(this);
   }
 
-  @Deprecated
+  /**
+   * @deprecated Use {@link #addListener(ExecutionListener.EVENTNAME_TAKE, executionListener)} instead
+   */
+  @Deprecated(forRemoval = true)
   public void addExecutionListener(ExecutionListener executionListener) {
     super.addListener(ExecutionListener.EVENTNAME_TAKE, executionListener);
   }
@@ -71,7 +74,7 @@ public class TransitionImpl extends CoreModelElement implements PvmTransition {
   @Deprecated
   public void setExecutionListeners(List<ExecutionListener> executionListeners) {
     for (ExecutionListener executionListener : executionListeners) {
-      addExecutionListener(executionListener);
+      addListener(ExecutionListener.EVENTNAME_TAKE, executionListener);
     }
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/process/TransitionImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/process/TransitionImpl.java
@@ -65,6 +65,10 @@ public class TransitionImpl extends CoreModelElement implements PvmTransition {
     super.addListener(ExecutionListener.EVENTNAME_TAKE, executionListener);
   }
 
+  /**
+   * @deprecated Use {@link #getListeners(ExecutionListener.EVENTNAME_TAKE)} instead
+   * @return
+   */
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @Deprecated
   public List<ExecutionListener> getExecutionListeners() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/process/TransitionImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/process/TransitionImpl.java
@@ -67,7 +67,6 @@ public class TransitionImpl extends CoreModelElement implements PvmTransition {
 
   /**
    * @deprecated Use {@link #getListeners(ExecutionListener.EVENTNAME_TAKE)} instead
-   * @return
    */
   @SuppressWarnings({ "rawtypes", "unchecked" })
   @Deprecated
@@ -75,7 +74,10 @@ public class TransitionImpl extends CoreModelElement implements PvmTransition {
     return (List) super.getListeners(ExecutionListener.EVENTNAME_TAKE);
   }
 
-  @Deprecated
+  /**
+   * @deprecated Use {@link #addListener(ExecutionListener.EVENTNAME_TAKE, executionListener)} in a loop instead
+   */
+  @Deprecated(forRemoval=true)
   public void setExecutionListeners(List<ExecutionListener> executionListeners) {
     for (ExecutionListener executionListener : executionListeners) {
       addListener(ExecutionListener.EVENTNAME_TAKE, executionListener);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/process/TransitionImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/process/TransitionImpl.java
@@ -69,7 +69,7 @@ public class TransitionImpl extends CoreModelElement implements PvmTransition {
    * @deprecated Use {@link #getListeners(ExecutionListener.EVENTNAME_TAKE)} instead
    */
   @SuppressWarnings({ "rawtypes", "unchecked" })
-  @Deprecated
+  @Deprecated(forRemoval=true)
   public List<ExecutionListener> getExecutionListeners() {
     return (List) super.getListeners(ExecutionListener.EVENTNAME_TAKE);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/entity/EntitySerializationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/entity/EntitySerializationTest.java
@@ -69,11 +69,11 @@ public class EntitySerializationTest {
    ExecutionEntity execution = new ExecutionEntity();
 
    ActivityImpl activityImpl = new ActivityImpl("test", null);
-   activityImpl.getExecutionListeners().put("start", Collections.<ExecutionListener>singletonList(new TestExecutionListener()));
+   activityImpl.addListener("start", new TestExecutionListener());
    execution.setActivity(activityImpl);
 
    ProcessDefinitionImpl processDefinitionImpl = new ProcessDefinitionImpl("test");
-   processDefinitionImpl.getExecutionListeners().put("start", Collections.<ExecutionListener>singletonList(new TestExecutionListener()));
+   processDefinitionImpl.addListener("start", new TestExecutionListener());
    execution.setProcessDefinition(processDefinitionImpl);
 
    TransitionImpl transitionImpl = new TransitionImpl("test", new ProcessDefinitionImpl("test"));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/entity/EntitySerializationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/entity/EntitySerializationTest.java
@@ -77,7 +77,7 @@ public class EntitySerializationTest {
    execution.setProcessDefinition(processDefinitionImpl);
 
    TransitionImpl transitionImpl = new TransitionImpl("test", new ProcessDefinitionImpl("test"));
-   transitionImpl.addExecutionListener(new TestExecutionListener());
+   transitionImpl.addListener(ExecutionListener.EVENTNAME_TAKE, new TestExecutionListener());
    execution.setTransition(transitionImpl);
 
    execution.setSuperExecution(new ExecutionEntity());


### PR DESCRIPTION
Methods in `TransitionImpl` & `ScopeImpl` regarding execution listeners have been deprecated. Documented in Javadoc their replacement, resolved usages of the deprecated methods and marked those methods for removal.

related to #144 