### PR TITLE
fix(tests): Fix SqlScriptTest

### DIFF
--- a/database/pom.xml
+++ b/database/pom.xml
@@ -152,6 +152,7 @@
       </activation>
       <properties>
         <database.url>jdbc:h2:mem:operaton;DB_CLOSE_DELAY=1000;LOCK_TIMEOUT=10000</database.url>
+        <database.type>h2</database.type>
         <database.driver>org.h2.Driver</database.driver>
         <database.username>sa</database.username>
         <database.password />

--- a/distro/sql-script/pom.xml
+++ b/distro/sql-script/pom.xml
@@ -40,9 +40,8 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>


### PR DESCRIPTION
Fix the test when `h2-in-memory` profile is enabled by adding property `database.type` in the profile in `database/pom.xml`.

Migrate SqlScriptTest to JUnit 5. Using `@EnabledIf` feature and check for the existence of files in target/test-classes/scripts-old, which is populated when the `check-sql` profile is active.

closes #376
related to #27

## Test Instruction

Execute 
```
./mvnw -f distro/sql-script -DskipTests=false -Ph2-in-memory
```

before and after change.

With the change the tests that need `scripts-old` are skipped.