### PR TITLE
Resolve deprecations: MockitoAnnotations & AbstractDateAssert

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/HistoryCleanupSchedulerCmdTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/HistoryCleanupSchedulerCmdTest.java
@@ -16,25 +16,30 @@
  */
 package org.operaton.bpm.engine.impl.jobexecutor.historycleanup;
 
-import org.operaton.bpm.engine.impl.persistence.entity.JobEntity;
-import org.operaton.bpm.engine.impl.interceptor.CommandContext;
-import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.operaton.bpm.engine.impl.metrics.reporter.DbMetricsReporter;
-import org.operaton.bpm.engine.impl.persistence.entity.JobManager;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
-
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.operaton.bpm.engine.impl.interceptor.CommandContext;
+import org.operaton.bpm.engine.impl.metrics.reporter.DbMetricsReporter;
+import org.operaton.bpm.engine.impl.persistence.entity.JobEntity;
+import org.operaton.bpm.engine.impl.persistence.entity.JobManager;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class HistoryCleanupSchedulerCmdTest {
 
@@ -58,10 +63,11 @@ public class HistoryCleanupSchedulerCmdTest {
 
     String METRICS_KEY = "Key";
     Long METRICS_VALUE = 123L;
+    private AutoCloseable closeable;
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         when(commandContext.getProcessEngineConfiguration()).thenReturn(engineConfigurationSpy);
         when(commandContext.getJobManager()).thenReturn(jobManager);
@@ -74,13 +80,12 @@ public class HistoryCleanupSchedulerCmdTest {
         configuration = new HistoryCleanupJobHandlerConfiguration();
 
         // Mocking static methods
-        mockedHistoryCleanupHelper = mockStatic(HistoryCleanupHelper.class);
         mockedHistoryCleanupHelper.when(() -> HistoryCleanupHelper.isWithinBatchWindow(any(Date.class), any(ProcessEngineConfigurationImpl.class))).thenReturn(false);
     }
 
     @After
-    public void tearDown() {
-        mockedHistoryCleanupHelper.close();
+    public void tearDown() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskConditionsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskConditionsTest.java
@@ -56,7 +56,7 @@ public class ExternalTaskConditionsTest {
   @Before
   public void setUp() {
 
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
 
     ProcessEngineImpl.EXT_TASK_CONDITIONS.addConsumer(condition);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionTest.java
@@ -641,8 +641,8 @@ public class BatchHistoricDecisionInstanceDeletionTest {
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery().singleResult();
     batch = rule.getManagementService().createBatchQuery().singleResult();
 
-    Assertions.assertThat(batch.getExecutionStartTime()).isEqualToIgnoringMillis(TEST_DATE);
-    Assertions.assertThat(historicBatch.getExecutionStartTime()).isEqualToIgnoringMillis(TEST_DATE);
+    Assertions.assertThat(batch.getExecutionStartTime()).isCloseTo(TEST_DATE, 1000);
+    Assertions.assertThat(historicBatch.getExecutionStartTime()).isCloseTo(TEST_DATE, 1000);
   }
 
   protected void assertBatchCreated(Batch batch, int decisionInstanceCount) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeTest.java
@@ -2821,8 +2821,8 @@ public class BatchSetRemovalTimeTest {
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery().singleResult();
     batch = managementService.createBatchQuery().singleResult();
 
-    assertThat(batch.getExecutionStartTime()).isEqualToIgnoringMillis(CURRENT_DATE);
-    assertThat(historicBatch.getExecutionStartTime()).isEqualToIgnoringMillis(CURRENT_DATE);
+    assertThat(batch.getExecutionStartTime()).isCloseTo(CURRENT_DATE, 1000);
+    assertThat(historicBatch.getExecutionStartTime()).isCloseTo(CURRENT_DATE, 1000);
   }
 
   @Test
@@ -2850,8 +2850,8 @@ public class BatchSetRemovalTimeTest {
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery().singleResult();
     batch = managementService.createBatchQuery().singleResult();
 
-    assertThat(batch.getExecutionStartTime()).isEqualToIgnoringMillis(CURRENT_DATE);
-    assertThat(historicBatch.getExecutionStartTime()).isEqualToIgnoringMillis(CURRENT_DATE);
+    assertThat(batch.getExecutionStartTime()).isCloseTo(CURRENT_DATE, 1000);
+    assertThat(historicBatch.getExecutionStartTime()).isCloseTo(CURRENT_DATE, 1000);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeUserOperationLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeUserOperationLogTest.java
@@ -16,13 +16,16 @@
  */
 package org.operaton.bpm.engine.test.api.history.removaltime.batch;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_FULL;
-
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.DecisionService;
 import org.operaton.bpm.engine.HistoryService;
 import org.operaton.bpm.engine.IdentityService;
@@ -40,11 +43,9 @@ import org.operaton.bpm.engine.test.api.history.removaltime.batch.helper.BatchSe
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.engine.variable.Variables;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_FULL;
 
 /**
  * @author Tassilo Weidner

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeUserOperationLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeUserOperationLogTest.java
@@ -190,7 +190,7 @@ public class BatchSetRemovalTimeUserOperationLogTest {
 
     // then
     assertThat(userOperationLogEntry.getOrgValue()).isNull();
-    assertThat(fromMillis(userOperationLogEntry.getNewValue())).isEqualToIgnoringMillis(removalTime);
+    assertThat(fromMillis(userOperationLogEntry.getNewValue())).isCloseTo(removalTime, 1000);
   }
 
   @Test
@@ -521,7 +521,7 @@ public class BatchSetRemovalTimeUserOperationLogTest {
 
     // then
     assertThat(userOperationLogEntry.getOrgValue()).isNull();
-    assertThat(fromMillis(userOperationLogEntry.getNewValue())).isEqualToIgnoringMillis(removalTime);
+    assertThat(fromMillis(userOperationLogEntry.getNewValue())).isCloseTo(removalTime, 1000);
   }
 
   @Test
@@ -755,7 +755,7 @@ public class BatchSetRemovalTimeUserOperationLogTest {
 
     // then
     assertThat(userOperationLogEntry.getOrgValue()).isNull();
-    assertThat(fromMillis(userOperationLogEntry.getNewValue())).isEqualToIgnoringMillis(removalTime);
+    assertThat(fromMillis(userOperationLogEntry.getNewValue())).isCloseTo(removalTime, 1000);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/BatchQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/BatchQueryTest.java
@@ -119,8 +119,8 @@ public class BatchQueryTest {
     Assert.assertEquals(batch.getTotalJobs(), resultBatch.getTotalJobs());
     Assert.assertEquals(batch.getJobsCreated(), resultBatch.getJobsCreated());
     Assert.assertEquals(batch.isSuspended(), resultBatch.isSuspended());
-    Assertions.assertThat(batch.getStartTime()).isEqualToIgnoringMillis(resultBatch.getStartTime());
-    Assertions.assertThat(batch.getStartTime()).isEqualToIgnoringMillis(ClockUtil.getCurrentTime());
+    Assertions.assertThat(batch.getStartTime()).isCloseTo(resultBatch.getStartTime(), 1000);
+    Assertions.assertThat(batch.getStartTime()).isCloseTo(ClockUtil.getCurrentTime(), 1000);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/BatchStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/BatchStatisticsQueryTest.java
@@ -689,7 +689,7 @@ public class BatchStatisticsQueryTest {
     // then
     final List<BatchStatistics> batchStatistics = query1.list();
     assertThat(batchStatistics.get(0).getId()).isEqualTo(batch.getId());
-    assertThat(batchStatistics.get(0).getStartTime()).isEqualToIgnoringMillis(ClockUtil.getCurrentTime());
+    assertThat(batchStatistics.get(0).getStartTime()).isCloseTo(ClockUtil.getCurrentTime(), 1000);
     assertThat(batchStatistics).hasSize(1);
     assertThat(query1.count()).isEqualTo(1);
 
@@ -716,7 +716,7 @@ public class BatchStatisticsQueryTest {
 
     final List<BatchStatistics> batchStatistics = query2.list();
     assertThat(batchStatistics.get(0).getId()).isEqualTo(batch.getId());
-    assertThat(batchStatistics.get(0).getStartTime()).isEqualToIgnoringMillis(ClockUtil.getCurrentTime());
+    assertThat(batchStatistics.get(0).getStartTime()).isCloseTo(ClockUtil.getCurrentTime(), 1000);
     assertThat(batchStatistics).hasSize(1);
     assertThat(query2.count()).isEqualTo(1);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceAsyncOperationsTest.java
@@ -406,7 +406,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     for (String id : ids) {
       Job job = managementService.createJobQuery().jobId(id).singleResult();
       assertThat(job.getRetries()).isEqualTo(RETRIES);
-      assertThat(job.getDuedate()).isEqualToIgnoringMillis(TEST_DUE_DATE);
+      assertThat(job.getDuedate()).isCloseTo(TEST_DUE_DATE, 1000);
     }
   }
 
@@ -427,7 +427,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     for (String id : processInstanceIds) {
       Job job = managementService.createJobQuery().processInstanceId(id).singleResult();
       assertThat(job.getRetries()).isEqualTo(RETRIES);
-      assertThat(job.getDuedate()).isEqualToIgnoringMillis(TEST_DUE_DATE);
+      assertThat(job.getDuedate()).isCloseTo(TEST_DUE_DATE, 1000);
     }
   }
 
@@ -446,7 +446,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     for (String id : ids) {
       Job jobResult = managementService.createJobQuery().jobId(id).singleResult();
       assertThat(jobResult.getRetries()).isEqualTo(RETRIES);
-      assertThat(jobResult.getDuedate()).isEqualToIgnoringMillis(TEST_DUE_DATE);
+      assertThat(jobResult.getDuedate()).isCloseTo(TEST_DUE_DATE, 1000);
     }
   }
 
@@ -470,7 +470,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     for (String id : ids) {
       Job jobResult = managementService.createJobQuery().jobId(id).singleResult();
       assertThat(jobResult.getRetries()).isEqualTo(RETRIES);
-      assertThat(jobResult.getDuedate()).isEqualToIgnoringMillis(TEST_DUE_DATE);
+      assertThat(jobResult.getDuedate()).isCloseTo(TEST_DUE_DATE, 1000);
     }
   }
 
@@ -517,7 +517,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
     for (String id : ids) {
       Job jobResult = managementService.createJobQuery().jobId(id).singleResult();
       assertThat(jobResult.getRetries()).isEqualTo(RETRIES);
-      assertThat(jobResult.getDuedate()).isEqualToIgnoringMillis(TEST_DUE_DATE);
+      assertThat(jobResult.getDuedate()).isCloseTo(TEST_DUE_DATE, 1000);
     }
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.java
@@ -244,7 +244,7 @@ public class ManagementServiceTest extends PluggableProcessEngineTest {
     List<Job> jobs = managementService.createJobQuery().list();
     for (Job job : jobs) {
       assertThat(job.getRetries()).isEqualTo(5);
-      assertThat(job.getDuedate()).isEqualToIgnoringMillis(TEST_DUE_DATE);
+      assertThat(job.getDuedate()).isCloseTo(TEST_DUE_DATE, 1000);
     }
   }
 
@@ -263,7 +263,7 @@ public class ManagementServiceTest extends PluggableProcessEngineTest {
     // then
     Job job = managementService.createJobQuery().jobId(jobId).singleResult();
     assertThat(job.getRetries()).isEqualTo(5);
-    assertThat(job.getDuedate()).isEqualToIgnoringMillis(TEST_DUE_DATE);
+    assertThat(job.getDuedate()).isCloseTo(TEST_DUE_DATE, 1000);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml"})
@@ -301,7 +301,7 @@ public class ManagementServiceTest extends PluggableProcessEngineTest {
     // then
     job = managementService.createJobQuery().jobDefinitionId(job.getJobDefinitionId()).singleResult();
     assertThat(job.getRetries()).isEqualTo(5);
-    assertThat(job.getDuedate()).isEqualToIgnoringMillis(TEST_DUE_DATE);
+    assertThat(job.getDuedate()).isCloseTo(TEST_DUE_DATE, 1000);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CorrelateAllMessageBatchTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CorrelateAllMessageBatchTest.java
@@ -628,8 +628,8 @@ public class CorrelateAllMessageBatchTest {
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery().singleResult();
     batch = managementService.createBatchQuery().singleResult();
 
-    Assertions.assertThat(batch.getExecutionStartTime()).isEqualToIgnoringMillis(TEST_DATE);
-    Assertions.assertThat(historicBatch.getExecutionStartTime()).isEqualToIgnoringMillis(TEST_DATE);
+    Assertions.assertThat(batch.getExecutionStartTime()).isCloseTo(TEST_DATE, 1000);
+    Assertions.assertThat(historicBatch.getExecutionStartTime()).isCloseTo(TEST_DATE, 1000);
 
     // clear
     managementService.deleteBatch(batch.getId(), true);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionAsyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionAsyncTest.java
@@ -1468,8 +1468,8 @@ public class ModificationExecutionAsyncTest {
     HistoricBatch historicBatch = rule.getHistoryService().createHistoricBatchQuery().singleResult();
     batch = rule.getManagementService().createBatchQuery().singleResult();
 
-    Assertions.assertThat(batch.getExecutionStartTime()).isEqualToIgnoringMillis(START_DATE);
-    Assertions.assertThat(historicBatch.getExecutionStartTime()).isEqualToIgnoringMillis(START_DATE);
+    Assertions.assertThat(batch.getExecutionStartTime()).isCloseTo(START_DATE, 1000);
+    Assertions.assertThat(historicBatch.getExecutionStartTime()).isCloseTo(START_DATE, 1000);
 
     // clear
     configuration.setInvocationsPerBatchJobByBatchType(new HashMap<>());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RestartProcessInstanceAsyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RestartProcessInstanceAsyncTest.java
@@ -1187,8 +1187,8 @@ public class RestartProcessInstanceAsyncTest {
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery().singleResult();
     batch = managementService.createBatchQuery().singleResult();
 
-    Assertions.assertThat(batch.getExecutionStartTime()).isEqualToIgnoringMillis(TEST_DATE);
-    Assertions.assertThat(historicBatch.getExecutionStartTime()).isEqualToIgnoringMillis(TEST_DATE);
+    Assertions.assertThat(batch.getExecutionStartTime()).isCloseTo(TEST_DATE, 1000);
+    Assertions.assertThat(historicBatch.getExecutionStartTime()).isCloseTo(TEST_DATE, 1000);
   }
 
   protected void assertBatchCreated(Batch batch, int processInstanceCount) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/SetVariablesBatchTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/SetVariablesBatchTest.java
@@ -725,8 +725,8 @@ public class SetVariablesBatchTest {
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery().singleResult();
     batch = managementService.createBatchQuery().singleResult();
 
-    Assertions.assertThat(batch.getExecutionStartTime()).isEqualToIgnoringMillis(TEST_DATE);
-    Assertions.assertThat(historicBatch.getExecutionStartTime()).isEqualToIgnoringMillis(TEST_DATE);
+    Assertions.assertThat(batch.getExecutionStartTime()).isCloseTo(TEST_DATE, 1000);
+    Assertions.assertThat(historicBatch.getExecutionStartTime()).isCloseTo(TEST_DATE, 1000);
 
     // clear
     managementService.deleteBatch(batch.getId(), true);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/UpdateProcessInstancesSuspendStateAsyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/UpdateProcessInstancesSuspendStateAsyncTest.java
@@ -375,8 +375,8 @@ public class UpdateProcessInstancesSuspendStateAsyncTest {
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery().singleResult();
     batch = engineRule.getManagementService().createBatchQuery().singleResult();
 
-    Assertions.assertThat(batch.getExecutionStartTime()).isEqualToIgnoringMillis(TEST_DATE);
-    Assertions.assertThat(historicBatch.getExecutionStartTime()).isEqualToIgnoringMillis(TEST_DATE);
+    Assertions.assertThat(batch.getExecutionStartTime()).isCloseTo(TEST_DATE, 1000);
+    Assertions.assertThat(historicBatch.getExecutionStartTime()).isCloseTo(TEST_DATE, 1000);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/VariableInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/VariableInstanceQueryTest.java
@@ -16,15 +16,6 @@
  */
 package org.operaton.bpm.engine.test.api.runtime;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.assertj.core.groups.Tuple.tuple;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,6 +25,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.junit.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.runtime.ActivityInstance;
@@ -52,7 +45,10 @@ import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.type.ValueType;
 import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
-import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.junit.Assert.*;
 
 /**
  * @author roman.smirnov

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationTransitionInstancesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationTransitionInstancesTest.java
@@ -529,7 +529,7 @@ public class MigrationTransitionInstancesTest {
     Job job = testHelper.snapshotAfterMigration.getJobs().get(0);
 
     assertThat(job.getPriority()).isEqualTo(42);
-    assertThat(job.getDuedate()).isEqualToIgnoringMillis(newDueDate);
+    assertThat(job.getDuedate()).isCloseTo(newDueDate, 1000);
     assertThat(job.getRetries()).isEqualTo(52);
     assertThat(job.isSuspended()).isTrue();
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/batch/BatchMigrationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/batch/BatchMigrationTest.java
@@ -936,8 +936,8 @@ public class BatchMigrationTest {
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery().singleResult();
     batch = managementService.createBatchQuery().singleResult();
 
-    Assertions.assertThat(batch.getExecutionStartTime()).isEqualToIgnoringMillis(TEST_DATE);
-    Assertions.assertThat(historicBatch.getExecutionStartTime()).isEqualToIgnoringMillis(TEST_DATE);
+    Assertions.assertThat(batch.getExecutionStartTime()).isCloseTo(TEST_DATE, 1000);
+    Assertions.assertThat(historicBatch.getExecutionStartTime()).isCloseTo(TEST_DATE, 1000);
   }
 
   protected void assertBatchCreated(Batch batch, int processInstanceCount) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskLastUpdatedTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskLastUpdatedTest.java
@@ -128,7 +128,7 @@ public class TaskLastUpdatedTest {
     assertThat(task.getLastUpdated()).isNull();
     Task taskResult = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskUpdatedAfter(beforeUpdate).singleResult();
     assertThat(taskResult).isNotNull();
-    assertThat(taskResult.getLastUpdated()).isEqualToIgnoringMillis(now);
+    assertThat(taskResult.getLastUpdated()).isCloseTo(now, 1000);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/logging/TestMdcFacade.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/logging/TestMdcFacade.java
@@ -17,11 +17,12 @@
 
 package org.operaton.bpm.engine.test.logging;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
-
 import java.util.HashMap;
 import java.util.Map;
+
 import org.operaton.commons.logging.MdcAccess;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Class that encapsulates the creation of MDC properties such as Logging Context Parameters or any other third party

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7190/job/SetJobRetriesWithDueDateTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7190/job/SetJobRetriesWithDueDateTest.java
@@ -70,7 +70,7 @@ public class SetJobRetriesWithDueDateTest {
 
     // then
     Job timerJobAfterBatch = managementService.createJobQuery().processDefinitionKey("createProcessForSetRetriesWithDueDate_718").singleResult();
-    assertThat(timerJob.getDuedate()).isEqualToIgnoringMillis(timerJobAfterBatch.getDuedate());
+    assertThat(timerJob.getDuedate()).isCloseTo(timerJobAfterBatch.getDuedate(), 1000);
     assertThat(timerJob.getRetries()).isEqualTo(3);
     assertThat(timerJobAfterBatch.getRetries()).isEqualTo(5);
   }

--- a/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/ProcessApplicationIT.java
+++ b/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/ProcessApplicationIT.java
@@ -16,17 +16,18 @@
  */
 package org.operaton.bpm.spring.boot.starter;
 
-import org.operaton.bpm.spring.boot.starter.event.PostDeployEvent;
-import org.operaton.bpm.spring.boot.starter.test.pa.TestProcessApplication;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.operaton.bpm.spring.boot.starter.event.PostDeployEvent;
+import org.operaton.bpm.spring.boot.starter.test.pa.TestProcessApplication;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
-import static org.assertj.core.api.Java6Assertions.assertThat;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Svetlana Dorokhova.


### PR DESCRIPTION
This change resolves 3 deprecations:

- Replace `MockitoAnnotations.initMocks()` by `openMocks()`
- Replace `AbstractDateAssert#isEqualToIgnoringMillis` by `isCloseTo()`
- Replace `Java6Assertions.assertThat` by `Assertions.assertThat`

related to #144 