### PR TITLE
[WIP] refactor(tests): Testing exceptions with only one possible invocation throwing

### DIFF
--- a/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
+++ b/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
@@ -16,8 +16,6 @@
  */
 package org.operaton.bpm.engine.test.variables;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.impl.type.FileValueTypeImpl;
 import org.operaton.bpm.engine.variable.value.FileValue;
@@ -35,10 +33,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Scanner;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Ronny Bräunlich
@@ -81,8 +82,8 @@ class FileValueTypeImplTest {
 
   @Test
   void convertingThrowsException() {
-    assertThrows(IllegalArgumentException.class, () ->
-      type.convertFromTypedValue(Variables.untypedNullValue()));
+    TypedValue untypedValue = Variables.untypedNullValue();
+    assertThrows(IllegalArgumentException.class, () -> type.convertFromTypedValue(untypedValue));
   }
 
   @Test
@@ -114,8 +115,9 @@ class FileValueTypeImplTest {
 
   @Test
   void createValueFromObject() {
-    assertThrows(IllegalArgumentException.class, () ->
-      type.createValue(new Object(), Collections.<String, Object>singletonMap(FileValueTypeImpl.VALUE_INFO_FILE_NAME, "simpleFile.txt")));
+    Object value = new Object();
+    Map<String, Object> valueInfo = Collections.singletonMap(FileValueTypeImpl.VALUE_INFO_FILE_NAME, "simpleFile.txt");
+    assertThrows(IllegalArgumentException.class, () -> type.createValue(value, valueInfo));
   }
 
   @Test
@@ -174,15 +176,14 @@ class FileValueTypeImplTest {
   @Test
   void cannotCreateFileWithoutName() {
     InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
-    assertThrows(IllegalArgumentException.class, () ->
-      type.createValue(file, Collections.<String, Object>emptyMap()));
+    Map<String, Object> valueInfo = emptyMap();
+    assertThrows(IllegalArgumentException.class, () -> type.createValue(file, valueInfo));
   }
 
   @Test
   void cannotCreateFileWithoutValueInfo() {
     InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
-    assertThrows(IllegalArgumentException.class, () ->
-      type.createValue(file, null));
+    assertThrows(IllegalArgumentException.class, () -> type.createValue(file, null));
   }
 
   @Test

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorTest.java
@@ -16,29 +16,22 @@
  */
 package org.operaton.connect.httpclient;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
-
-import java.io.IOException;
-
-import org.apache.http.Header;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.methods.HttpTrace;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.operaton.commons.utils.IoUtil;
 import org.operaton.connect.ConnectorRequestException;
 import org.operaton.connect.Connectors;
 import org.operaton.connect.httpclient.impl.HttpConnectorImpl;
 import org.operaton.connect.impl.DebugRequestInterceptor;
 import org.operaton.connect.spi.Connector;
+
+import java.io.IOException;
+
+import org.apache.http.Header;
+import org.apache.http.client.methods.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class HttpConnectorTest {
 
@@ -64,24 +57,15 @@ public class HttpConnectorTest {
 
   @Test
   void shouldFailWithoutMethod() {
-    try {
-      connector.createRequest().url("localhost").execute();
-      fail("No method specified");
-    }
-    catch (ConnectorRequestException e) {
-      // expected
-    }
+    HttpRequest request = connector.createRequest().url("localhost");
+    assertThatThrownBy(request::execute).isInstanceOf(ConnectorRequestException.class);
   }
 
   @Test
   void shouldFailWithoutUrl() {
-    try {
-      connector.createRequest().execute();
-      fail("No url specified");
-    }
-    catch (ConnectorRequestException e) {
-      // expected
-    }
+    HttpRequest request = connector.createRequest();
+    assertThatThrownBy(request::execute)
+      .isInstanceOf(ConnectorRequestException.class);
   }
 
   @Test

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpResponseTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpResponseTest.java
@@ -16,13 +16,16 @@
  */
 package org.operaton.connect.httpclient;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.assertj.core.api.Assertions;
 import org.operaton.connect.ConnectorRequestException;
 import org.operaton.connect.httpclient.impl.HttpConnectorImpl;
 import org.operaton.connect.impl.DebugRequestInterceptor;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class HttpResponseTest {
 
@@ -124,14 +127,10 @@ class HttpResponseTest {
   void testServerErrorResponseWithConfigOptionSet() {
     // given
     testResponse.statusCode(500);
-    try {
-      // when
-      connector.createRequest().configOption("throw-http-error", "TRUE").url("http://camunda.com").get().execute();
-      Assertions.fail("ConnectorRequestException should be thrown");
-    } catch (ConnectorRequestException e) {
-      // then
-      assertThat(e).hasMessageContaining("HTTP request failed with Status Code: 500");
-    }
+    HttpRequest request = connector.createRequest().configOption("throw-http-error", "TRUE").url("https://operaton.org").get();
+    assertThatThrownBy(request::execute)
+      .isInstanceOf(ConnectorRequestException.class)
+      .hasMessageContaining("HTTP request failed with Status Code: 500");
   }
 
   @Test

--- a/engine-dmn/feel-juel/src/test/java/org/operaton/bpm/dmn/feel/impl/FeelExceptionTest.java
+++ b/engine-dmn/feel-juel/src/test/java/org/operaton/bpm/dmn/feel/impl/FeelExceptionTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.dmn.feel.impl;
 import org.operaton.bpm.dmn.feel.impl.juel.FeelEngineFactoryImpl;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
+import org.operaton.bpm.engine.variable.context.VariableContext;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 public class FeelExceptionTest {
@@ -45,13 +47,10 @@ public class FeelExceptionTest {
 
   @Test
   void simpleExpressionNotSupported() {
-    try {
-      feelEngine.evaluateSimpleExpression("12 == 12", Variables.emptyVariableContext());
-      failBecauseExceptionWasNotThrown(UnsupportedOperationException.class);
-    }
-    catch (UnsupportedOperationException e) {
-      assertThat(e).hasMessageStartingWith("FEEL-01016");
-    }
+    VariableContext emptyVariableContext = Variables.emptyVariableContext();
+    assertThatThrownBy(() -> feelEngine.evaluateSimpleExpression("12 == 12", emptyVariableContext))
+      .isInstanceOf(UnsupportedOperationException.class)
+      .hasMessageStartingWith("FEEL-01016");
   }
 
   @BeforeEach

--- a/engine-plugins/connect-plugin/src/test/java/org/operaton/connect/plugin/ConnectProcessEnginePluginTest.java
+++ b/engine-plugins/connect-plugin/src/test/java/org/operaton/connect/plugin/ConnectProcessEnginePluginTest.java
@@ -16,16 +16,6 @@
  */
 package org.operaton.connect.plugin;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.operaton.bpm.engine.impl.test.ProcessEngineAssert.assertProcessEnded;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.delegate.BpmnError;
 import org.operaton.bpm.engine.history.HistoricVariableInstance;
@@ -40,6 +30,18 @@ import org.operaton.connect.httpclient.HttpConnector;
 import org.operaton.connect.httpclient.soap.SoapHttpConnector;
 import org.operaton.connect.plugin.util.TestConnector;
 import org.operaton.connect.spi.Connector;
+import static org.operaton.bpm.engine.impl.test.ProcessEngineAssert.assertProcessEnded;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
 
 class ConnectProcessEnginePluginTest {
 
@@ -75,14 +77,11 @@ class ConnectProcessEnginePluginTest {
 
   @Test
   void connectorIdMissing() {
-    try {
-      repositoryService.createDeployment().addClasspathResource("org/operaton/connect/plugin/ConnectProcessEnginePluginTest.connectorIdMissing.bpmn")
-        .deploy();
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      assertFalse(e instanceof BpmnParseException);
-    }
+    var deployment = repositoryService.createDeployment()
+        .addClasspathResource("org/operaton/connect/plugin/ConnectProcessEnginePluginTest.connectorIdMissing.bpmn");
+    assertThatThrownBy(deployment::deploy)
+      .isInstanceOf(ProcessEngineException.class)
+      .isNotInstanceOf(BpmnParseException.class);
   }
 
   @Deployment

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/HalResourceCacheTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/HalResourceCacheTest.java
@@ -44,6 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -138,13 +139,10 @@ public class HalResourceCacheTest extends AbstractRestServiceTest {
 
   @Test
   public void testCacheImplementationNotImplementingCache() {
-    try {
-      contextListener.configureCaches("{\"" + CONFIG_CACHE_IMPLEMENTATION +"\": \"" + getClass().getName() + "\" }");
-      fail("Exception expected");
-    }
-    catch (HalRelationCacheConfigurationException e) {
-      assertTrue(e.getMessage().contains(Cache.class.getName()));
-    }
+    String contextParameter = "{\"" + CONFIG_CACHE_IMPLEMENTATION + "\": \"" + getClass().getName() + "\" }";
+    assertThatThrownBy(() -> contextListener.configureCaches(contextParameter))
+      .isInstanceOf(HalRelationCacheConfigurationException.class)
+      .hasMessageContaining(Cache.class.getName());
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/NoIntermediaryInvocationTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/NoIntermediaryInvocationTest.java
@@ -18,16 +18,18 @@ package org.operaton.bpm.engine.rest.util;
 
 import static org.operaton.bpm.engine.rest.helper.NoIntermediaryInvocation.immediatelyAfter;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoAssertionError;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 /**
  * @author Thorben Lindhauer
  */
+@SuppressWarnings("java:S5778")
 public class NoIntermediaryInvocationTest {
 
   protected Foo foo;
@@ -38,7 +40,7 @@ public class NoIntermediaryInvocationTest {
   }
 
   @Test
-  public void testSucceess() {
+  public void testSucceeds() {
 
     // given
     foo.getFoo();
@@ -64,12 +66,8 @@ public class NoIntermediaryInvocationTest {
     inOrder.verify(foo).getFoo();
 
     // then
-    try {
-      inOrder.verify(foo, immediatelyAfter()).getBar();
-      Assert.fail("should not verify");
-    } catch (MockitoAssertionError e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> inOrder.verify(foo, immediatelyAfter()).getBar())
+      .isInstanceOf(MockitoAssertionError.class);
   }
 
   @Test
@@ -82,12 +80,8 @@ public class NoIntermediaryInvocationTest {
     inOrder.verify(foo).getFoo();
 
     // then
-    try {
-      inOrder.verify(foo, immediatelyAfter()).getBar();
-      Assert.fail("should not verify");
-    } catch (MockitoAssertionError e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> inOrder.verify(foo, immediatelyAfter()).getBar())
+      .isInstanceOf(MockitoAssertionError.class);
   }
 
   @Test
@@ -101,12 +95,8 @@ public class NoIntermediaryInvocationTest {
     inOrder.verify(foo).getFoo();
 
     // then
-    try {
-      inOrder.verify(foo, immediatelyAfter()).getBar();
-      Assert.fail("should not verify");
-    } catch (MockitoAssertionError e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> inOrder.verify(foo, immediatelyAfter()).getBar())
+      .isInstanceOf(MockitoAssertionError.class);
   }
 
   @Test
@@ -121,12 +111,8 @@ public class NoIntermediaryInvocationTest {
     inOrder.verify(foo).getFoo();
 
     // then
-    try {
-      inOrder.verify(foo, immediatelyAfter()).getBar();
-      Assert.fail("should not verify");
-    } catch (MockitoAssertionError e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> inOrder.verify(foo, immediatelyAfter()).getBar())
+      .isInstanceOf(MockitoAssertionError.class);
   }
 
   public static interface Foo {

--- a/engine/src/test/java/org/operaton/bpm/application/impl/context/ProcessApplicationContextTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/context/ProcessApplicationContextTest.java
@@ -16,16 +16,6 @@
  */
 package org.operaton.bpm.application.impl.context;
 
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.concurrent.Callable;
-
 import org.operaton.bpm.application.InvocationContext;
 import org.operaton.bpm.application.ProcessApplicationContext;
 import org.operaton.bpm.application.ProcessApplicationReference;
@@ -36,10 +26,22 @@ import org.operaton.bpm.engine.delegate.BaseDelegateExecution;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
+
+import java.util.concurrent.Callable;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Thorben Lindhauer
@@ -167,20 +169,16 @@ public class ProcessApplicationContextTest extends PluggableProcessEngineTest {
   }
 
   @Test
-  public void testCannotExecuteInUnregisteredPaContext() throws Exception {
+  public void testCannotExecuteInUnregisteredPaContext() {
     String nonExistingName = pa.getName() + pa.getName();
 
-    try {
-      ProcessApplicationContext.withProcessApplicationContext((Callable<Void>) () -> {
-        getCurrentContextApplication();
-        return null;
-      }, nonExistingName);
-      fail("should not succeed");
-
-    } catch (ProcessEngineException e) {
-      testRule.assertTextPresent("A process application with name '" + nonExistingName + "' is not registered", e.getMessage());
-    }
-
+    Callable<Void> voidCallable = () -> {
+      getCurrentContextApplication();
+      return null;
+    };
+    assertThatThrownBy(() -> ProcessApplicationContext.withProcessApplicationContext(voidCallable, nonExistingName))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("A process application with name '" + nonExistingName + "' is not registered");
   }
 
   @SuppressWarnings("unchecked")

--- a/engine/src/test/java/org/operaton/bpm/application/impl/deployment/parser/ProcessesXmlParserTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/deployment/parser/ProcessesXmlParserTest.java
@@ -16,22 +16,24 @@
  */
 package org.operaton.bpm.application.impl.deployment.parser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-
-import java.net.URL;
-import java.util.List;
-import java.util.Map;
-
+import org.operaton.bpm.application.impl.metadata.ProcessesXmlParse;
 import org.operaton.bpm.application.impl.metadata.ProcessesXmlParser;
 import org.operaton.bpm.application.impl.metadata.spi.ProcessArchiveXml;
 import org.operaton.bpm.application.impl.metadata.spi.ProcessesXml;
 import org.operaton.bpm.container.impl.metadata.spi.ProcessEngineXml;
 import org.operaton.bpm.engine.ProcessEngineException;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * <p>The testcases for the {@link ProcessesXmlParser}</p>
@@ -267,17 +269,10 @@ public class ProcessesXmlParserTest {
   public void testParseProcessesXmlEngineNoName() {
 
     // this test is to make sure that XML Schema Validation works.
-    try {
-      parser.createParse()
-        .sourceUrl(getStreamUrl("process_xml_engine_no_name.xml"))
-        .execute();
-
-      fail("exception expected");
-
-    } catch(ProcessEngineException e) {
-      // expected
-    }
-
+    ProcessesXmlParse processesXmlParse = parser.createParse()
+        .sourceUrl(getStreamUrl("process_xml_engine_no_name.xml"));
+    assertThatThrownBy(processesXmlParse::execute)
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   public void FAILING_testParseProcessesXmlClassLineBreak() {

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/incident/CompositeIncidentHandlerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/incident/CompositeIncidentHandlerTest.java
@@ -19,13 +19,15 @@ package org.operaton.bpm.engine.impl.incident;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.exception.NullValueException;
 import org.operaton.bpm.engine.runtime.Incident;
-import org.junit.Test;
-import org.mockito.internal.verification.Times;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.Test;
+import org.mockito.internal.verification.Times;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
@@ -134,14 +136,10 @@ public class CompositeIncidentHandlerTest {
   public void shouldUseCompositeIncidentHandlerWithAnotherIncidentType() {
     CompositeIncidentHandler compositeIncidentHandler = new CompositeIncidentHandler(
         new DefaultIncidentHandler("failedJob"));
-    try {
-      compositeIncidentHandler.add(new DefaultIncidentHandler("failedExternalTask"));
-      fail("Non expected message expected");
-    } catch (ProcessEngineException e) {
-      assertThat(e.getMessage()).containsIgnoringCase(
-          "Incorrect incident type handler in composite handler with type: failedJob");
-    }
-  }
+    DefaultIncidentHandler incidentHandler = new DefaultIncidentHandler("failedExternalTask");
+    assertThatThrownBy(() -> compositeIncidentHandler.add(incidentHandler))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("Incorrect incident type handler in composite handler with type: failedJob");  }
 
   @Test
   public void shouldCallAllHandlersWhenCreatingIncident() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ActivityStatisticsAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ActivityStatisticsAuthorizationTest.java
@@ -16,25 +16,27 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
+import org.operaton.bpm.engine.AuthorizationException;
+import org.operaton.bpm.engine.management.ActivityStatistics;
+import org.operaton.bpm.engine.management.ActivityStatisticsQuery;
+import org.operaton.bpm.engine.management.IncidentStatistics;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.READ;
 import static org.operaton.bpm.engine.authorization.Permissions.READ_INSTANCE;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.List;
-import org.operaton.bpm.engine.AuthorizationException;
-import org.operaton.bpm.engine.management.ActivityStatistics;
-import org.operaton.bpm.engine.management.ActivityStatisticsQuery;
-import org.operaton.bpm.engine.management.IncidentStatistics;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -61,18 +63,14 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
-    try {
-      // when
-      managementService.createActivityStatisticsQuery(processDefinitionId).list();
-      fail("Exception expected: It should not be possible to execute the activity statistics query");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(ONE_INCIDENT_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    // when
+    ActivityStatisticsQuery activityStatisticsQuery = managementService.createActivityStatisticsQuery(processDefinitionId);
+    assertThatThrownBy(activityStatisticsQuery::list)
+      .isInstanceOf(AuthorizationException.class)
+      .hasMessageContaining(userId)
+      .hasMessageContaining(READ.getName())
+      .hasMessageContaining(ONE_INCIDENT_PROCESS_KEY)
+      .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   // including instances //////////////////////////////////////////////////////////////

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ConditionStartEventAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ConditionStartEventAuthorizationTest.java
@@ -16,23 +16,24 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
+import org.operaton.bpm.engine.AuthorizationException;
+import org.operaton.bpm.engine.ProcessEngineException;
+import org.operaton.bpm.engine.runtime.ConditionEvaluationBuilder;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.Deployment;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.CREATE;
 import static org.operaton.bpm.engine.authorization.Permissions.CREATE_INSTANCE;
 import static org.operaton.bpm.engine.authorization.Permissions.READ;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.List;
 
-import org.operaton.bpm.engine.AuthorizationException;
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.test.Deployment;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
 
 public class ConditionStartEventAuthorizationTest extends AuthorizationTest {
 
@@ -69,16 +70,12 @@ public class ConditionStartEventAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
 
     // when
-    try {
-      runtimeService
-          .createConditionEvaluation()
-          .setVariable("foo", 42)
-          .evaluateStartConditions();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      assertTrue(e.getMessage().contains("No subscriptions were found during evaluation of the conditional start events."));
-    }
-
+    ConditionEvaluationBuilder evaluationBuilder = runtimeService
+        .createConditionEvaluation()
+        .setVariable("foo", 42);
+    assertThatThrownBy(evaluationBuilder::evaluateStartConditions)
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("No subscriptions were found during evaluation of the conditional start events.");
   }
 
   @Deployment(resources = { SINGLE_CONDITIONAL_XML })
@@ -91,37 +88,29 @@ public class ConditionStartEventAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
 
     // when
-    try {
-      runtimeService
-          .createConditionEvaluation()
-          .setVariable("foo", 42)
-          .evaluateStartConditions();
-      fail("expected exception");
-    } catch (AuthorizationException e) {
-      assertTrue(e.getMessage().contains("The user with id 'test' does not have 'CREATE_INSTANCE' permission on resource 'conditionalEventProcess' of type 'ProcessDefinition'."));
-    }
-
+    ConditionEvaluationBuilder evaluationBuilder = runtimeService
+        .createConditionEvaluation()
+        .setVariable("foo", 42);
+    assertThatThrownBy(evaluationBuilder::evaluateStartConditions)
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have 'CREATE_INSTANCE' permission on resource 'conditionalEventProcess' of type 'ProcessDefinition'.");
   }
 
   @Deployment(resources = { SINGLE_CONDITIONAL_XML })
   @Test
-  public void testWithoutProcessInstanccePermission() {
+  public void testWithoutProcessInstancePermission() {
     // given deployed process with conditional start event
 
     // the user doesn't have CREATE permission for process instances
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ, CREATE_INSTANCE);
 
     // when
-    try {
-      runtimeService
-          .createConditionEvaluation()
-          .setVariable("foo", 42)
-          .evaluateStartConditions();
-      fail("expected exception");
-    } catch (AuthorizationException e) {
-      assertTrue(e.getMessage().contains("The user with id 'test' does not have 'CREATE' permission on resource 'ProcessInstance'."));
-    }
-
+    var evaluationBuilder = runtimeService
+        .createConditionEvaluation()
+        .setVariable("foo", 42);
+    assertThatThrownBy(evaluationBuilder::evaluateStartConditions)
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have 'CREATE' permission on resource 'ProcessInstance'.");
   }
 
   @Deployment(resources = { SINGLE_CONDITIONAL_XML })
@@ -134,14 +123,11 @@ public class ConditionStartEventAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
 
     // when
-    try {
-      runtimeService
-          .createConditionEvaluation()
-          .setVariable("foo", 42)
-          .evaluateStartConditions();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      assertTrue(e.getMessage().contains("No subscriptions were found during evaluation of the conditional start events."));
-    }
+    var evaluationBuilder = runtimeService
+        .createConditionEvaluation()
+        .setVariable("foo", 42);
+    assertThatThrownBy(evaluationBuilder::evaluateStartConditions)
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("No subscriptions were found during evaluation of the conditional start events.");
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/IncidentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/IncidentAuthorizationTest.java
@@ -372,7 +372,8 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     // when & then
-    assertThatThrownBy(() -> runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation"))
+    String incidentId = incident.getId();
+    assertThatThrownBy(() -> runtimeService.setAnnotationForIncidentById(incidentId, "my annotation"))
       .isInstanceOf(AuthorizationException.class)
       .hasMessageMatching(getMissingPermissionMessageRegex(UPDATE, PROCESS_INSTANCE))
       .hasMessageMatching(getMissingPermissionMessageRegex(UPDATE_INSTANCE, PROCESS_DEFINITION));
@@ -451,7 +452,8 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     // when & then
-    assertThatThrownBy(() -> runtimeService.clearAnnotationForIncidentById(incident.getId()))
+    String incidentId = incident.getId();
+    assertThatThrownBy(() -> runtimeService.clearAnnotationForIncidentById(incidentId))
       .isInstanceOf(AuthorizationException.class)
       .hasMessageMatching(getMissingPermissionMessageRegex(UPDATE, PROCESS_INSTANCE))
       .hasMessageMatching(getMissingPermissionMessageRegex(UPDATE_INSTANCE, PROCESS_DEFINITION));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceCommentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceCommentAuthorizationTest.java
@@ -16,18 +16,21 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
-import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
-import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
-
-import java.util.Collections;
-import java.util.List;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.task.Comment;
 import org.operaton.bpm.engine.test.Deployment;
+import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
+import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
+
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
   protected static final String ONE_TASK_PROCESS_KEY = "oneTaskProcess";
@@ -41,15 +44,10 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
 
     Comment createdComment = createComment(TASK_ID, processInstanceId, "aComment");
 
-    try {
-      // when
-      taskService.deleteProcessInstanceComment(processInstanceId, createdComment.getId());
-      fail("Exception expected: It should not be possible to delete a task.");
-    } catch (AuthorizationException e) {
-      // then
-      testRule.assertTextPresent("The user with id 'test' does not have one of the following permissions: 'UPDATE'",
-          e.getMessage());
-    }
+    String commentId = createdComment.getId();
+    assertThatThrownBy(() -> taskService.deleteProcessInstanceComment(processInstanceId, commentId))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'UPDATE'");
 
     // triggers a db clean up
     deleteTask(TASK_ID, true);
@@ -127,15 +125,10 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     Comment createdComment = createComment(TASK_ID, processInstanceId, "originalComment");
 
-    try {
-      // when
-      taskService.updateProcessInstanceComment(processInstanceId, createdComment.getId(), "updateMessage");
-      fail("Exception expected: It should not be possible to delete a task.");
-    } catch (AuthorizationException e) {
-      // then
-      testRule.assertTextPresent("The user with id 'test' does not have one of the following permissions: 'UPDATE'",
-          e.getMessage());
-    }
+    String commentId = createdComment.getId();
+    assertThatThrownBy(() -> taskService.updateProcessInstanceComment(processInstanceId, commentId, "updateMessage"))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'UPDATE'");
 
     deleteTask(TASK_ID, true);
   }
@@ -173,15 +166,10 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
 
     Comment createdComment = createComment(null, processInstanceId, "aComment");
 
-    try {
-      // when
-      taskService.deleteProcessInstanceComment(processInstanceId, createdComment.getId());
-      fail("Exception expected: It should not be possible to delete a task.");
-    } catch (AuthorizationException e) {
-      // then
-      testRule.assertTextPresent("The user with id 'test' does not have one of the following permissions: 'UPDATE'",
-          e.getMessage());
-    }
+    String commentId = createdComment.getId();
+    assertThatThrownBy(() -> taskService.deleteProcessInstanceComment(processInstanceId, commentId))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'UPDATE'");
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
@@ -243,15 +231,10 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     Comment createdComment = createComment(null, processInstanceId, "originalComment");
 
-    try {
-      // when
-      taskService.updateProcessInstanceComment(processInstanceId, createdComment.getId(), "updateMessage");
-      fail("Exception expected: It should not be possible to delete a task.");
-    } catch (AuthorizationException e) {
-      // then
-      testRule.assertTextPresent("The user with id 'test' does not have one of the following permissions: 'UPDATE'",
-          e.getMessage());
-    }
+    String commentId = createdComment.getId();
+    assertThatThrownBy(() -> taskService.updateProcessInstanceComment(processInstanceId, commentId, "updateMessage"))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'UPDATE'");
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SingleProcessInstanceModificationAsyncAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SingleProcessInstanceModificationAsyncAuthorizationTest.java
@@ -16,6 +16,16 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
+import org.operaton.bpm.engine.ProcessEngineException;
+import org.operaton.bpm.engine.batch.Batch;
+import org.operaton.bpm.engine.repository.ProcessDefinition;
+import org.operaton.bpm.engine.runtime.ActivityInstance;
+import org.operaton.bpm.engine.runtime.Job;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.runtime.ProcessInstanceModificationBuilder;
+import org.operaton.bpm.engine.task.Task;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.util.ExecutionTree;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.BatchPermissions.CREATE_BATCH_MODIFY_PROCESS_INSTANCES;
 import static org.operaton.bpm.engine.authorization.Permissions.CREATE;
@@ -29,24 +39,16 @@ import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.assertTha
 import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.describeActivityInstanceTree;
 import static org.operaton.bpm.engine.test.util.ExecutionAssert.assertThat;
 import static org.operaton.bpm.engine.test.util.ExecutionAssert.describeExecutionTree;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.List;
 
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.batch.Batch;
-import org.operaton.bpm.engine.repository.ProcessDefinition;
-import org.operaton.bpm.engine.runtime.ActivityInstance;
-import org.operaton.bpm.engine.runtime.Job;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.task.Task;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.ExecutionTree;
 import org.junit.After;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class SingleProcessInstanceModificationAsyncAuthorizationTest extends AuthorizationTest {
 
@@ -128,19 +130,15 @@ public class SingleProcessInstanceModificationAsyncAuthorizationTest extends Aut
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelGateway");
 
     ActivityInstance tree = runtimeService.getActivityInstance(processInstance.getId());
-    try {
-      // when
-      runtimeService
+    // when
+    ProcessInstanceModificationBuilder builder = runtimeService
         .createProcessInstanceModification(processInstance.getId())
-        .cancelActivityInstance(getInstanceIdForActivity(tree, "task1"))
-        .executeAsync();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // then
-      assertTrue(e.getMessage().contains("The user with id 'test' does not have"));
-      assertTrue(e.getMessage().contains("'CREATE' permission on resource 'Batch'"));
-      assertTrue(e.getMessage().contains("'CREATE_BATCH_MODIFY_PROCESS_INSTANCES' permission on resource 'Batch'"));
-    }
+        .cancelActivityInstance(getInstanceIdForActivity(tree, "task1"));
+    assertThatThrownBy(builder::executeAsync)
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("The user with id 'test' does not have")
+        .hasMessageContaining("'CREATE' permission on resource 'Batch'")
+        .hasMessageContaining("'CREATE_BATCH_MODIFY_PROCESS_INSTANCES' permission on resource 'Batch'");
   }
 
   @Deployment(resources = PARALLEL_GATEWAY_PROCESS)
@@ -155,19 +153,15 @@ public class SingleProcessInstanceModificationAsyncAuthorizationTest extends Aut
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelGateway");
 
     ActivityInstance tree = runtimeService.getActivityInstance(processInstance.getId());
-    try {
-      // when
-      runtimeService
+    // when
+    ProcessInstanceModificationBuilder builder = runtimeService
         .createProcessInstanceModification(processInstance.getId())
-        .cancelActivityInstance(getInstanceIdForActivity(tree, "task1"))
-        .executeAsync();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // then
-      assertTrue(e.getMessage().contains("The user with id 'test' does not have"));
-      assertTrue(e.getMessage().contains("'CREATE' permission on resource 'Batch'"));
-      assertTrue(e.getMessage().contains("'CREATE_BATCH_MODIFY_PROCESS_INSTANCES' permission on resource 'Batch'"));
-    }
+        .cancelActivityInstance(getInstanceIdForActivity(tree, "task1"));
+    assertThatThrownBy(builder::executeAsync)
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("The user with id 'test' does not have")
+        .hasMessageContaining("'CREATE' permission on resource 'Batch'")
+        .hasMessageContaining("'CREATE_BATCH_MODIFY_PROCESS_INSTANCES' permission on resource 'Batch'");
   }
 
   protected String getInstanceIdForActivity(ActivityInstance activityInstance, String activityId) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDecisionInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDecisionInstanceAuthorizationTest.java
@@ -16,19 +16,6 @@
  */
 package org.operaton.bpm.engine.test.api.authorization.history;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.authorization.Authorization.ANY;
-import static org.operaton.bpm.engine.authorization.Permissions.DELETE_HISTORY;
-import static org.operaton.bpm.engine.authorization.Permissions.READ_HISTORY;
-import static org.operaton.bpm.engine.authorization.Resources.DECISION_DEFINITION;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import org.apache.commons.lang3.time.DateUtils;
 import org.operaton.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
@@ -42,9 +29,25 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
 import org.operaton.bpm.engine.test.util.ResetDmnConfigUtil;
 import org.operaton.bpm.engine.variable.Variables;
+import static org.operaton.bpm.engine.authorization.Authorization.ANY;
+import static org.operaton.bpm.engine.authorization.Permissions.DELETE_HISTORY;
+import static org.operaton.bpm.engine.authorization.Permissions.READ_HISTORY;
+import static org.operaton.bpm.engine.authorization.Resources.DECISION_DEFINITION;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.time.DateUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * @author Philipp Ossler
@@ -209,15 +212,10 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
     HistoricDecisionInstance historicDecisionInstance = query.includeInputs().includeOutputs().singleResult();
 
-    try {
-      // when
-      historyService.deleteHistoricDecisionInstanceByInstanceId(historicDecisionInstance.getId());
-      fail("expect authorization exception");
-    } catch (AuthorizationException e) {
-      // then
-      assertThat(e.getMessage()).isEqualTo(
-          "The user with id 'test' does not have 'DELETE_HISTORY' permission on resource 'testDecision' of type 'DecisionDefinition'.");
-    }
+    String historicDecisionInstanceId = historicDecisionInstance.getId();
+    assertThatThrownBy(() -> historyService.deleteHistoricDecisionInstanceByInstanceId(historicDecisionInstanceId))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessage("The user with id 'test' does not have 'DELETE_HISTORY' permission on resource 'testDecision' of type 'DecisionDefinition'.");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricVariableInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricVariableInstanceAuthorizationTest.java
@@ -16,18 +16,6 @@
  */
 package org.operaton.bpm.engine.test.api.authorization.history;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.authorization.Authorization.ANY;
-import static org.operaton.bpm.engine.authorization.Permissions.DELETE_HISTORY;
-import static org.operaton.bpm.engine.authorization.Permissions.READ_HISTORY;
-import static org.operaton.bpm.engine.authorization.ProcessDefinitionPermissions.READ_HISTORY_VARIABLE;
-import static org.operaton.bpm.engine.authorization.Resources.HISTORIC_PROCESS_INSTANCE;
-import static org.operaton.bpm.engine.authorization.Resources.HISTORIC_TASK;
-import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.util.List;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.authorization.HistoricProcessInstancePermissions;
@@ -40,9 +28,24 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
+import static org.operaton.bpm.engine.authorization.Authorization.ANY;
+import static org.operaton.bpm.engine.authorization.Permissions.DELETE_HISTORY;
+import static org.operaton.bpm.engine.authorization.Permissions.READ_HISTORY;
+import static org.operaton.bpm.engine.authorization.ProcessDefinitionPermissions.READ_HISTORY_VARIABLE;
+import static org.operaton.bpm.engine.authorization.Resources.HISTORIC_PROCESS_INSTANCE;
+import static org.operaton.bpm.engine.authorization.Resources.HISTORIC_TASK;
+import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
+
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * @author Roman Smirnov
@@ -588,18 +591,15 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY, getVariables());
     verifyVariablesCreated();
 
-    try {
-      // when
-      historyService.deleteHistoricVariableInstancesByProcessInstanceId(instance.getId());
-      fail("Exception expected: It should not be possible to delete the historic variable instance");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(DELETE_HISTORY.getName(), message);
-      testRule.assertTextPresent(PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    // when
+    String instanceId = instance.getId();
+    assertThatThrownBy(() -> historyService.deleteHistoricVariableInstancesByProcessInstanceId(instanceId))
+        // then
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(DELETE_HISTORY.getName())
+        .hasMessageContaining(PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoryCleanupAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoryCleanupAuthorizationTest.java
@@ -48,8 +48,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 public class HistoryCleanupAuthorizationTest extends AuthorizationTest {
@@ -99,15 +99,9 @@ public class HistoryCleanupAuthorizationTest extends AuthorizationTest {
 
     ClockUtil.setCurrentTime(new Date());
 
-    try {
-      // when
-      historyService.cleanUpHistoryAsync(true).getId();
-      fail("Exception expected: It should not be possible to execute the history cleanup");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent("ENGINE-03029 Required admin authenticated group or user.", message);
-    }
+    assertThatThrownBy(() -> historyService.cleanUpHistoryAsync(true))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("ENGINE-03029 Required admin authenticated group or user.");
   }
 
   protected void prepareInstances(Integer processInstanceTimeToLive, Integer decisionTimeToLive, Integer caseTimeToLive) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseHistoryPropertyAutoTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseHistoryPropertyAutoTest.java
@@ -59,7 +59,8 @@ public class DatabaseHistoryPropertyAutoTest {
   public void failWhenSecondEngineDoesNotHaveTheSameHistoryLevel() {
     buildEngine(config("true", ProcessEngineConfiguration.HISTORY_FULL));
 
-    assertThatThrownBy(() -> buildEngine(config(ProcessEngineConfiguration.HISTORY_AUDIT)))
+    ProcessEngineConfigurationImpl config = config(ProcessEngineConfiguration.HISTORY_AUDIT);
+    assertThatThrownBy(() -> buildEngine(config))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("historyLevel mismatch: configuration says HistoryLevelAudit(name=audit, id=2) and database says HistoryLevelFull(name=full, id=3)");
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseTableSchemaTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseTableSchemaTest.java
@@ -34,8 +34,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * @author Ronny Bräunlich
@@ -121,30 +121,23 @@ public class DatabaseTableSchemaTest {
 
   @Test
   public void testCreateConfigurationWithMismatchtingSchemaAndPrefix() {
-    try {
-      StandaloneInMemProcessEngineConfiguration configuration = new StandaloneInMemProcessEngineConfiguration();
-      configuration.setDatabaseSchema("foo");
-      configuration.setDatabaseTablePrefix("bar");
-      configuration.buildProcessEngine();
-      fail("Should throw exception");
-    } catch (ProcessEngineException e) {
-      // as expected
-      assertTrue(e.getMessage().contains("When setting a schema the prefix has to be schema + '.'"));
-    }
+    StandaloneInMemProcessEngineConfiguration configuration = new StandaloneInMemProcessEngineConfiguration();
+    configuration.setDatabaseSchema("foo");
+    configuration.setDatabaseTablePrefix("bar");
+
+    assertThatThrownBy(configuration::buildProcessEngine)
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("When setting a schema the prefix has to be schema + '.'");
   }
 
   @Test
   public void testCreateConfigurationWithMissingDotInSchemaAndPrefix() {
-    try {
-      StandaloneInMemProcessEngineConfiguration configuration = new StandaloneInMemProcessEngineConfiguration();
-      configuration.setDatabaseSchema("foo");
-      configuration.setDatabaseTablePrefix("foo");
-      configuration.buildProcessEngine();
-      fail("Should throw exception");
-    } catch (ProcessEngineException e) {
-      // as expected
-      assertTrue(e.getMessage().contains("When setting a schema the prefix has to be schema + '.'"));
-    }
+    StandaloneInMemProcessEngineConfiguration configuration = new StandaloneInMemProcessEngineConfiguration();
+    configuration.setDatabaseSchema("foo");
+    configuration.setDatabaseTablePrefix("foo");
+
+    assertThatThrownBy(configuration::buildProcessEngine).isInstanceOf(ProcessEngineException.class)
+  .hasMessageContaining("When setting a schema the prefix has to be schema + '.'");
   }
 
   // ----------------------- TEST HELPERS -----------------------

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/PersistenceExceptionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/PersistenceExceptionTest.java
@@ -16,9 +16,6 @@
  */
 package org.operaton.bpm.engine.test.api.cfg;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
-
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.RuntimeService;
@@ -29,11 +26,14 @@ import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
+
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Svetlana Dorokhova.
@@ -63,13 +63,13 @@ public class PersistenceExceptionTest {
     }
     final BpmnModelInstance modelInstance = Bpmn.createExecutableProcess("process1").operatonHistoryTimeToLive(180).startEvent().userTask(longString.toString()).endEvent().done();
     testRule.deploy(modelInstance);
-    try {
-      runtimeService.startProcessInstanceByKey("process1").getId();
-      fail("persistence exception is expected");
-    } catch (ProcessEngineException ex) {
-      Throwable cause = ex.getCause();
-      assertThat(cause.getMessage()).contains("insertHistoricTaskInstanceEvent");
-    }
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("process1"))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasCauseInstanceOf(Throwable.class)
+            .extracting(Throwable::getCause)
+            .extracting(Throwable::getMessage)
+            .asString()
+            .contains("insertHistoricTaskInstanceEvent");
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceCaseInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceCaseInstanceTest.java
@@ -16,28 +16,27 @@
  */
 package org.operaton.bpm.engine.test.api.cmmn;
 
+import org.operaton.bpm.engine.ProcessEngineException;
+import org.operaton.bpm.engine.exception.NotAllowedException;
+import org.operaton.bpm.engine.exception.NotFoundException;
+import org.operaton.bpm.engine.exception.NotValidException;
+import org.operaton.bpm.engine.runtime.*;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.exception.NotAllowedException;
-import org.operaton.bpm.engine.exception.NotFoundException;
-import org.operaton.bpm.engine.exception.NotValidException;
-import org.operaton.bpm.engine.runtime.CaseExecution;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.VariableInstance;
-import org.operaton.bpm.engine.runtime.VariableInstanceQuery;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -85,20 +84,14 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
 
   @Test
   public void testCreateByInvalidKey() {
-    try {
-      caseService
-          .withCaseDefinitionByKey("invalid")
-          .create();
-      fail();
-    } catch (NotFoundException e) { }
+    CaseInstanceBuilder builder = caseService.withCaseDefinitionByKey("invalid");
+    assertThatThrownBy(builder::create)
+        .isInstanceOf(NotFoundException.class);
 
-    try {
-      caseService
-          .withCaseDefinitionByKey(null)
-          .create();
-      fail();
-    } catch (NotValidException e) { }
-
+    CaseInstanceBuilder builder2 = caseService
+        .withCaseDefinitionByKey(null);
+    assertThatThrownBy(builder2::create)
+        .isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -142,20 +135,14 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
 
   @Test
   public void testCreateByInvalidId() {
-    try {
-      caseService
-          .withCaseDefinition("invalid")
-          .create();
-      fail();
-    } catch (NotFoundException e) { }
+    CaseInstanceBuilder builder = caseService.withCaseDefinition("invalid");
+    assertThatThrownBy(builder::create)
+        .isInstanceOf(NotFoundException.class);
 
-    try {
-      caseService
-          .withCaseDefinition(null)
-          .create();
-      fail();
-    } catch (NotValidException e) { }
-
+    CaseInstanceBuilder builder2 = caseService
+        .withCaseDefinition(null);
+    assertThatThrownBy(builder2::create)
+        .isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -438,13 +425,11 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
         .getId();
 
     // when
-    try {
-      caseService
-        .withCaseExecution(caseInstanceId)
-        .manualStart();
-      fail("It should not be possible to start a case instance manually.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder builder = caseService
+        .withCaseExecution(caseInstanceId);
+    assertThatThrownBy(builder::manualStart)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to start a case instance manually.");
 
   }
 
@@ -465,13 +450,11 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
         .getId();
 
     // when
-    try {
-      caseService
-        .withCaseExecution(caseInstanceId)
-        .disable();
-      fail("It should not be possible to disable a case instance.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder builder = caseService
+        .withCaseExecution(caseInstanceId);
+    assertThatThrownBy(builder::disable)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to disable a case instance.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -491,13 +474,11 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
         .getId();
 
     // when
-    try {
-      caseService
-        .withCaseExecution(caseInstanceId)
-        .reenable();
-      fail("It should not be possible to re-enable a case instance.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder builder = caseService
+        .withCaseExecution(caseInstanceId);
+    assertThatThrownBy(builder::reenable)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to re-enable a case instance.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCaseWithManualActivation.cmmn"})
@@ -614,12 +595,10 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
 
     // when
 
-    try {
-      caseService
-        .withCaseExecution(caseInstanceId)
-        .complete();
-      fail("It should not be possible to complete a case instance containing an active task.");
-    } catch (ProcessEngineException e) {}
+    CaseExecutionCommandBuilder builder = caseService.withCaseExecution(caseInstanceId);
+    assertThatThrownBy(builder::complete)
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("It should not be possible to complete a case instance containing an active task.");
 
     // then
 
@@ -664,12 +643,10 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
 
     // when
 
-    try {
-      caseService
-        .withCaseExecution(caseInstanceId)
-        .complete();
-      fail("It should not be possible to complete a case instance containing an active stage.");
-    } catch (ProcessEngineException e) {}
+    CaseExecutionCommandBuilder builder = caseService.withCaseExecution(caseInstanceId);
+    assertThatThrownBy(builder::complete)
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("It should not be possible to complete a case instance containing an active stage.");
 
     // then
 
@@ -731,14 +708,9 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
        .create()
        .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseInstanceId)
-        .close();
-      fail("It should not be possible to close an active case instance.");
-    } catch (ProcessEngineException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseInstanceId);
+    assertThatThrownBy(commandBuilder::close)
+        .isInstanceOf(ProcessEngineException.class);
 
     // then
     CaseInstance caseInstance = caseService

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceHumanTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceHumanTaskTest.java
@@ -16,28 +16,27 @@
  */
 package org.operaton.bpm.engine.test.api.cmmn;
 
+import org.operaton.bpm.engine.exception.NotAllowedException;
+import org.operaton.bpm.engine.runtime.*;
+import org.operaton.bpm.engine.task.Task;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
+import org.operaton.bpm.engine.variable.VariableMap;
+import org.operaton.bpm.engine.variable.Variables;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.operaton.bpm.engine.exception.NotAllowedException;
-import org.operaton.bpm.engine.runtime.CaseExecution;
-import org.operaton.bpm.engine.runtime.CaseExecutionQuery;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.VariableInstance;
-import org.operaton.bpm.engine.task.Task;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
-import org.operaton.bpm.engine.variable.VariableMap;
-import org.operaton.bpm.engine.variable.Variables;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -623,14 +622,12 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .reenable();
-      fail("It should not be possible to re-enable an enabled human task.");
-    } catch (NotAllowedException e) {
-    }
+    // when
+    CaseExecutionCommandBuilder commandBuilder = caseService
+        .withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::reenable)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to re-enable an enabled human task.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/twoTaskCase.cmmn"})
@@ -696,13 +693,11 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
         .getId();
 
     // when
-    try {
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .reenable();
-      fail("It should not be possible to re-enable an active human task.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService
+        .withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::reenable)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to re-enable an active human task.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/twoTaskCase.cmmn"})
@@ -764,18 +759,13 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
         .getId();
 
     // the human task is disabled
-    caseService
-      .withCaseExecution(caseExecutionId)
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    commandBuilder
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .disable();
-      fail("It should not be possible to disable a already disabled human task.");
-    } catch (NotAllowedException e) {
-    }
+    assertThatThrownBy(commandBuilder::disable)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to disable a already disabled human task.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -800,13 +790,10 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
         .getId();
 
     // when
-    try {
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .disable();
-      fail("It should not be possible to disable an active human task.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::disable)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to disable an active human task.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/twoTaskCase.cmmn"})
@@ -834,14 +821,10 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
       .withCaseExecution(caseExecutionId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .manualStart();
-      fail("It should not be possible to start a disabled human task manually.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::manualStart)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to start a disabled human task manually.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -865,14 +848,10 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .manualStart();
-      fail("It should not be possible to start an already active human task manually.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::manualStart)
+      .isInstanceOf(NotAllowedException.class)
+      .hasMessageContaining("It should not be possible to start an already active human task manually.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/twoTaskCase.cmmn"})
@@ -1137,13 +1116,10 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .complete();
-      fail("Should not be able to complete task.");
-    } catch (NotAllowedException e) {}
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::complete)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("Should not be able to complete task.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/twoTaskCase.cmmn"})
@@ -1171,13 +1147,10 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
       .withCaseExecution(caseExecutionId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .complete();
-      fail("Should not be able to complete task.");
-    } catch (NotAllowedException e) {}
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::complete)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("Should not be able to complete task.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/twoTaskCase.cmmn"})
@@ -1519,16 +1492,10 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .close();
-      fail("It should not be possible to close a task.");
-    } catch (NotAllowedException e) {
-
-    }
-
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::close)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to close a task.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -1599,14 +1566,10 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
 
     CaseExecution taskExecution = queryCaseExecutionByActivityId("PI_HumanTask_1");
 
-    try {
-      // when
-      caseService.terminateCaseExecution(taskExecution.getId());
-      fail("It should not be possible to terminate a task.");
-    } catch (NotAllowedException e) {
-      boolean result = e.getMessage().contains("The case execution must be in state 'active' to terminate");
-      assertTrue(result);
-    }
+    String taskExecutionId = taskExecution.getId();
+    assertThatThrownBy(() -> caseService.terminateCaseExecution(taskExecutionId))
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("The case execution must be in state 'active' to terminate");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceMilestoneTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceMilestoneTest.java
@@ -16,17 +16,19 @@
  */
 package org.operaton.bpm.engine.test.api.cmmn;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-
 import org.operaton.bpm.engine.exception.NotAllowedException;
 import org.operaton.bpm.engine.runtime.CaseExecution;
+import org.operaton.bpm.engine.runtime.CaseExecutionCommandBuilder;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
+
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Roman Smirnov
@@ -37,85 +39,55 @@ public class CaseServiceMilestoneTest extends PluggableProcessEngineTest {
   protected final String DEFINITION_KEY = "oneMilestoneCase";
   protected final String MILESTONE_KEY = "PI_Milestone_1";
 
-  @Deployment(resources={
-      "org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"
-      })
+  @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"})
   @Test
   public void testManualStart() {
     // given
     createCaseInstance(DEFINITION_KEY).getId();
     String caseTaskId = queryCaseExecutionByActivityId(MILESTONE_KEY).getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .manualStart();
-      fail();
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
+    assertThatThrownBy(commandBuilder::manualStart)
+        .isInstanceOf(NotAllowedException.class);
   }
 
-  @Deployment(resources={
-      "org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"
-      })
+  @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"})
   @Test
   public void testDisable() {
     // given
     createCaseInstance(DEFINITION_KEY).getId();
     String caseTaskId = queryCaseExecutionByActivityId(MILESTONE_KEY).getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .disable();
-      fail();
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
+    assertThatThrownBy(commandBuilder::disable)
+        .isInstanceOf(NotAllowedException.class);
   }
 
-  @Deployment(resources={
-      "org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"
-      })
+  @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"})
   @Test
   public void testReenable() {
     // given
     createCaseInstance(DEFINITION_KEY).getId();
     String caseTaskId = queryCaseExecutionByActivityId(MILESTONE_KEY).getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .reenable();
-      fail();
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
+    assertThatThrownBy(commandBuilder::reenable)
+        .isInstanceOf(NotAllowedException.class);
   }
 
-  @Deployment(resources={
-      "org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"
-      })
+  @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"})
   @Test
   public void testComplete() {
     // given
     createCaseInstance(DEFINITION_KEY).getId();
     String caseTaskId = queryCaseExecutionByActivityId(MILESTONE_KEY).getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .complete();
-      fail();
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
+    assertThatThrownBy(commandBuilder::complete)
+        .isInstanceOf(NotAllowedException.class);
   }
 
-  @Deployment(resources={
-      "org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"
-      })
+  @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"})
   @Test
   public void testTerminate() {
     // given

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceProcessTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceProcessTaskTest.java
@@ -16,26 +16,25 @@
  */
 package org.operaton.bpm.engine.test.api.cmmn;
 
+import org.operaton.bpm.engine.exception.NotAllowedException;
+import org.operaton.bpm.engine.runtime.*;
+import org.operaton.bpm.engine.task.Task;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.operaton.bpm.engine.exception.NotAllowedException;
-import org.operaton.bpm.engine.runtime.CaseExecution;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.runtime.VariableInstance;
-import org.operaton.bpm.engine.task.Task;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -229,14 +228,12 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
     ProcessInstance processInstance = queryProcessInstance();
     assertNull(processInstance);
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .reenable();
-      fail("It should not be possible to re-enable an enabled process task.");
-    } catch (NotAllowedException e) {
-    }
+    // when
+    CaseExecutionCommandBuilder commandBuilder = caseService
+        .withCaseExecution(processTaskId);
+    assertThatThrownBy(commandBuilder::reenable)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to re-enable an enabled process task.");
   }
 
   @Deployment(resources={
@@ -276,14 +273,10 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
     createCaseInstance(DEFINITION_KEY);
     String processTaskId = queryCaseExecutionByActivityId(PROCESS_TASK_KEY).getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .reenable();
-      fail("It should not be possible to re-enable an active process task.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
+    assertThatThrownBy(commandBuilder::reenable)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to re-enable an active process task.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneProcessTaskWithManualActivationAndOneHumanTaskCase.cmmn"})
@@ -317,14 +310,11 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
       .withCaseExecution(processTaskId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .disable();
-      fail("It should not be possible to disable a already disabled process task.");
-    } catch (NotAllowedException e) {
-    }
+    // when
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
+    assertThatThrownBy(commandBuilder::disable)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to disable a already disabled process task.");
   }
 
   @Deployment(resources={
@@ -338,13 +328,10 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
     String processTaskId = queryCaseExecutionByActivityId(PROCESS_TASK_KEY).getId();
 
     // when
-    try {
-      caseService
-        .withCaseExecution(processTaskId)
-        .disable();
-      fail("It should not be possible to disable an active process task.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
+    assertThatThrownBy(commandBuilder::disable)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to disable an active process task.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneProcessTaskWithManualActivationAndOneHumanTaskCase.cmmn"})
@@ -358,14 +345,11 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
       .withCaseExecution(processTaskId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .manualStart();
-      fail("It should not be possible to start a disabled process task manually.");
-    } catch (NotAllowedException e) {
-    }
+    // when
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
+    assertThatThrownBy(commandBuilder::manualStart)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to start a disabled process task manually.");
   }
 
   @Deployment(resources={
@@ -378,14 +362,10 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
     createCaseInstance(DEFINITION_KEY);
     String processTaskId = queryCaseExecutionByActivityId(PROCESS_TASK_KEY).getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .manualStart();
-      fail("It should not be possible to start an already active process task manually.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
+    assertThatThrownBy(commandBuilder::manualStart)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to start an already active process task manually.");
   }
 
   @Deployment(resources={
@@ -398,14 +378,10 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
     createCaseInstance(DEFINITION_KEY);
     String processTaskId = queryCaseExecutionByActivityId(PROCESS_TASK_KEY).getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .complete();
-      fail("It should not be possible to complete a process task, while the process instance is still running.");
-    } catch (NotAllowedException e) {}
-
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
+    assertThatThrownBy(commandBuilder::complete)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to complete a process task, while the process instance is still running.");
   }
 
   @Deployment(resources={
@@ -470,13 +446,10 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
     createCaseInstance(DEFINITION_KEY);
     String processTaskId = queryCaseExecutionByActivityId(PROCESS_TASK_KEY).getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .complete();
-      fail("Should not be able to complete an enabled process task.");
-    } catch (NotAllowedException e) {}
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
+    assertThatThrownBy(commandBuilder::complete)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to complete an enabled process task.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneProcessTaskWithManualActivationAndOneHumanTaskCase.cmmn"})
@@ -490,13 +463,11 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
       .withCaseExecution(processTaskId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .complete();
-      fail("Should not be able to complete a disabled process task.");
-    } catch (NotAllowedException e) {}
+    // when
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
+    assertThatThrownBy(commandBuilder::complete)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to complete a disabled process task.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneProcessTaskCaseWithManualActivation.cmmn"})
@@ -506,16 +477,10 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
     createCaseInstance(DEFINITION_KEY);
     String processTaskId = queryCaseExecutionByActivityId(PROCESS_TASK_KEY).getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .close();
-      fail("It should not be possible to close a process task.");
-    } catch (NotAllowedException e) {
-
-    }
-
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
+    assertThatThrownBy(commandBuilder::close)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to close a process task.");
   }
 
   @Deployment(resources={
@@ -568,15 +533,11 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
     createCaseInstance(DEFINITION_KEY);
     CaseExecution processTask = queryCaseExecutionByActivityId(PROCESS_TASK_KEY);
     assertTrue(processTask.isEnabled());
-    
-    try {
-      // when
-      caseService.terminateCaseExecution(processTask.getId());
-      fail("It should not be possible to terminate a task.");
-    } catch (NotAllowedException e) {
-      boolean result = e.getMessage().contains("The case execution must be in state 'active' to terminate");
-      assertTrue(result);
-    }
+
+    String taskId = processTask.getId();
+    assertThatThrownBy(() -> caseService.terminateCaseExecution(taskId))
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("The case execution must be in state 'active' to terminate");
   }
 
   protected CaseInstance createCaseInstance(String caseDefinitionKey) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceStageTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceStageTest.java
@@ -16,25 +16,24 @@
  */
 package org.operaton.bpm.engine.test.api.cmmn;
 
+import org.operaton.bpm.engine.exception.NotAllowedException;
+import org.operaton.bpm.engine.runtime.*;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.operaton.bpm.engine.exception.NotAllowedException;
-import org.operaton.bpm.engine.runtime.CaseExecution;
-import org.operaton.bpm.engine.runtime.CaseExecutionQuery;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.VariableInstance;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -414,14 +413,11 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .reenable();
-      fail("It should not be possible to re-enable an enabled stage.");
-    } catch (NotAllowedException e) {
-    }
+    // when
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::reenable)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to re-enable an enabled stage.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskAndOneStageWithManualActivationCase.cmmn"})
@@ -487,13 +483,10 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
         .getId();
 
     // when
-    try {
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .reenable();
-      fail("It should not be possible to re-enable an active human task.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::reenable)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to re-enable an active human task.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskAndOneStageWithManualActivationCase.cmmn"})
@@ -559,14 +552,10 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
       .withCaseExecution(caseExecutionId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .disable();
-      fail("It should not be possible to disable a already disabled human task.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::disable)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to disable a already disabled human task.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneStageCase.cmmn"})
@@ -591,13 +580,10 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
         .getId();
 
     // when
-    try {
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .disable();
-      fail("It should not be possible to disable an active human task.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::disable)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to disable an active human task.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskAndOneStageWithManualActivationCase.cmmn"})
@@ -625,14 +611,10 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
       .withCaseExecution(caseExecutionId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .manualStart();
-      fail("It should not be possible to start a disabled human task manually.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::manualStart)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to start a disabled human task manually.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneStageCase.cmmn"})
@@ -656,14 +638,11 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .manualStart();
-      fail("It should not be possible to start an already active human task manually.");
-    } catch (NotAllowedException e) {
-    }
+    // when
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::manualStart)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to start an already active human task manually.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneStageCaseWithManualActivation.cmmn"})
@@ -840,13 +819,10 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .complete();
-      fail("Should not be able to complete stage.");
-    } catch (NotAllowedException e) {}
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::complete)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("Should not be able to complete stage.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskAndOneStageWithManualActivationCase.cmmn"})
@@ -874,13 +850,11 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
       .withCaseExecution(caseExecutionId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .complete();
-      fail("Should not be able to complete stage.");
-    } catch (NotAllowedException e) {}
+    // when
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::complete)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("Should not be able to complete stage.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/emptyStageCase.cmmn"})
@@ -935,16 +909,11 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .close();
-      fail("It should not be possible to close a stage.");
-    } catch (NotAllowedException e) {
-
-    }
-
+    // when
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    assertThatThrownBy(commandBuilder::close)
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("It should not be possible to close a stage.");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneStageCase.cmmn"})
@@ -1029,15 +998,10 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
     CaseExecution stageExecution = queryCaseExecutionByActivityId("PI_Stage_1");
 
     // when
-    try {
-      // when
-      caseService.terminateCaseExecution(stageExecution.getId());
-      fail("It should not be possible to terminate a task.");
-    } catch (NotAllowedException e) {
-      boolean result = e.getMessage().contains("The case execution must be in state 'active' to terminate");
-      assertTrue(result);
-    }
-    
+    String executionId = stageExecution.getId();
+    assertThatThrownBy(() -> caseService.terminateCaseExecution(executionId))
+      .isInstanceOf(NotAllowedException.class)
+      .hasMessageContaining("The case execution must be in state 'active' to terminate");
   }
 
   protected CaseExecution queryCaseExecutionByActivityId(String activityId) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceTest.java
@@ -16,38 +16,31 @@
  */
 package org.operaton.bpm.engine.test.api.cmmn;
 
-import static org.operaton.bpm.engine.variable.Variables.booleanValue;
-import static org.operaton.bpm.engine.variable.Variables.createVariables;
-import static org.operaton.bpm.engine.variable.Variables.integerValue;
-import static org.operaton.bpm.engine.variable.Variables.stringValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.operaton.bpm.engine.exception.NotFoundException;
 import org.operaton.bpm.engine.exception.NotValidException;
 import org.operaton.bpm.engine.repository.CaseDefinition;
-import org.operaton.bpm.engine.runtime.CaseExecution;
-import org.operaton.bpm.engine.runtime.CaseExecutionCommandBuilder;
-import org.operaton.bpm.engine.runtime.CaseExecutionQuery;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.CaseInstanceQuery;
-import org.operaton.bpm.engine.runtime.VariableInstance;
+import org.operaton.bpm.engine.runtime.*;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
 import org.operaton.bpm.engine.variable.value.StringValue;
+import static org.operaton.bpm.engine.variable.Variables.booleanValue;
+import static org.operaton.bpm.engine.variable.Variables.createVariables;
+import static org.operaton.bpm.engine.variable.Variables.integerValue;
+import static org.operaton.bpm.engine.variable.Variables.stringValue;
+
+import java.util.*;
+
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Roman Smirnov
@@ -78,83 +71,49 @@ public class CaseServiceTest extends PluggableProcessEngineTest {
 
   @Test
   public void testManualStartInvalidCaseExecution() {
-    try {
-      caseService
-          .withCaseExecution("invalid")
-          .manualStart();
-      fail();
-    } catch (NotFoundException e) { }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution("invalid");
+    assertThatThrownBy(commandBuilder::manualStart)
+        .isInstanceOf(NotFoundException.class);
 
-    try {
-      caseService
-        .withCaseExecution(null)
-        .manualStart();
-      fail();
-    } catch (NotValidException e) { }
-
+    CaseExecutionCommandBuilder commandBuilder1 = caseService.withCaseExecution(null);
+    assertThatThrownBy(commandBuilder1::manualStart)
+        .isInstanceOf(NotValidException.class);
   }
 
   @Test
   public void testCompleteInvalidCaseExeuction() {
-    try {
-      caseService
-        .withCaseExecution("invalid")
-        .complete();
-      fail("The case execution should not be found.");
-    } catch (NotFoundException e) {
+    CaseExecutionCommandBuilder commandBuilder = caseService
+        .withCaseExecution("invalid");
+    assertThatThrownBy(commandBuilder::complete)
+        .isInstanceOf(NotFoundException.class);
 
-    }
-
-    try {
-      caseService
-        .withCaseExecution(null)
-        .complete();
-      fail("The case execution should not be found.");
-    } catch (NotValidException e) {
-
-    }
+    CaseExecutionCommandBuilder commandBuilder1 = caseService
+        .withCaseExecution(null);
+    assertThatThrownBy(commandBuilder1::complete)
+        .isInstanceOf(NotValidException.class);
   }
 
   @Test
   public void testCloseInvalidCaseExeuction() {
-    try {
-      caseService
-        .withCaseExecution("invalid")
-        .close();
-      fail("The case execution should not be found.");
-    } catch (NotFoundException e) {
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution("invalid");
+    assertThatThrownBy(commandBuilder::close)
+        .isInstanceOf(NotFoundException.class);
 
-    }
-
-    try {
-      caseService
-        .withCaseExecution(null)
-        .close();
-      fail("The case execution should not be found.");
-    } catch (NotValidException e) {
-
-    }
+    CaseExecutionCommandBuilder commandBuilder1 = caseService
+        .withCaseExecution(null);
+    assertThatThrownBy(commandBuilder1::close)
+        .isInstanceOf(NotValidException.class);
   }
 
   @Test
   public void testTerminateInvalidCaseExeuction() {
-    try {
-      caseService
-        .withCaseExecution("invalid")
-        .terminate();
-      fail("The case execution should not be found.");
-    } catch (NotFoundException e) {
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution("invalid");
+    assertThatThrownBy(commandBuilder::terminate)
+        .isInstanceOf(NotFoundException.class);
 
-    }
-
-    try {
-      caseService
-        .withCaseExecution(null)
-        .terminate();
-      fail("The case execution should not be found.");
-    } catch (NotValidException e) {
-
-    }
+    CaseExecutionCommandBuilder commandBuilder1 = caseService.withCaseExecution(null);
+    assertThatThrownBy(commandBuilder1::terminate)
+        .isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/dmn/DecisionServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/dmn/DecisionServiceTest.java
@@ -16,14 +16,12 @@
  */
 package org.operaton.bpm.engine.test.api.dmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import org.operaton.bpm.dmn.engine.DmnDecisionResult;
 import org.operaton.bpm.dmn.engine.DmnDecisionTableResult;
 import org.operaton.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
 import org.operaton.bpm.engine.DecisionService;
 import org.operaton.bpm.engine.RepositoryService;
+import org.operaton.bpm.engine.dmn.DecisionsEvaluationBuilder;
 import org.operaton.bpm.engine.exception.NotFoundException;
 import org.operaton.bpm.engine.exception.NotValidException;
 import org.operaton.bpm.engine.repository.DecisionDefinition;
@@ -34,11 +32,15 @@ import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.engine.test.util.ResetDmnConfigUtil;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Philipp Ossler
@@ -177,9 +179,10 @@ public class DecisionServiceTest {
 	public void evaluateDecisionTableByKeyWithNonExistingVersion() {
     DecisionDefinition decisionDefinition = repositoryService.createDecisionDefinitionQuery().singleResult();
 
-    assertThatThrownBy(() -> decisionService.evaluateDecisionTableByKeyAndVersion(decisionDefinition.getKey(), 42, null))
-      .isInstanceOf(NotFoundException.class)
-      .hasMessageContaining("no decision definition deployed with key = 'decision' and version = '42'");
+    String key = decisionDefinition.getKey();
+    assertThatThrownBy(() -> decisionService.evaluateDecisionTableByKeyAndVersion(key, 42, null))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("no decision definition deployed with key = 'decision' and version = '42'");
   }
 
   @Deployment(resources = DMN_DECISION_LITERAL_EXPRESSION)
@@ -249,28 +252,32 @@ public class DecisionServiceTest {
 
   @Test
   public void evaluateDecisionByNullId() {
-    assertThatThrownBy(() -> decisionService.evaluateDecisionById(null).evaluate())
+    DecisionsEvaluationBuilder builder = decisionService.evaluateDecisionById(null);
+    assertThatThrownBy(builder::evaluate)
       .isInstanceOf(NotValidException.class)
       .hasMessageContaining("either decision definition id or key must be set");
   }
 
   @Test
   public void evaluateDecisionByNonExistingId() {
-    assertThatThrownBy(() -> decisionService.evaluateDecisionById("unknown").evaluate())
+    DecisionsEvaluationBuilder builder = decisionService.evaluateDecisionById("unknown");
+    assertThatThrownBy(builder::evaluate)
       .isInstanceOf(NotFoundException.class)
       .hasMessageContaining("no deployed decision definition found with id 'unknown'");
   }
 
   @Test
   public void evaluateDecisionByNullKey() {
-    assertThatThrownBy(() -> decisionService.evaluateDecisionByKey(null).evaluate())
+    DecisionsEvaluationBuilder builder = decisionService.evaluateDecisionByKey(null);
+    assertThatThrownBy(builder::evaluate)
       .isInstanceOf(NotValidException.class)
       .hasMessageContaining("either decision definition id or key must be set");
   }
 
   @Test
   public void evaluateDecisionByNonExistingKey() {
-    assertThatThrownBy(() -> decisionService.evaluateDecisionByKey("unknown").evaluate())
+    DecisionsEvaluationBuilder builder = decisionService.evaluateDecisionByKey("unknown");
+    assertThatThrownBy(builder::evaluate)
       .isInstanceOf(NotFoundException.class)
       .hasMessageContaining("no decision definition deployed with key 'unknown'");
   }
@@ -280,10 +287,10 @@ public class DecisionServiceTest {
   public void evaluateDecisionByKeyWithNonExistingVersion() {
     DecisionDefinition decisionDefinition = repositoryService.createDecisionDefinitionQuery().singleResult();
 
-    assertThatThrownBy(() -> decisionService
+    DecisionsEvaluationBuilder builder = decisionService
         .evaluateDecisionByKey(decisionDefinition.getKey())
-        .version(42)
-        .evaluate())
+        .version(42);
+    assertThatThrownBy(builder::evaluate)
       .isInstanceOf(NotFoundException.class)
       .hasMessageContaining("no decision definition deployed with key = 'decision' and version = '42'");
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskQueryTest.java
@@ -16,29 +16,6 @@
  */
 package org.operaton.bpm.engine.test.api.externaltask;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.externalTaskById;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.externalTaskByLockExpirationTime;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.externalTaskByProcessDefinitionId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.externalTaskByProcessDefinitionKey;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.externalTaskByProcessInstanceId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.exception.NullValueException;
 import org.operaton.bpm.engine.externaltask.ExternalTask;
@@ -52,9 +29,21 @@ import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
+import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.*;
+
+import java.util.*;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Thorben Lindhauer
@@ -218,12 +207,9 @@ public class ExternalTaskQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testFailQueryByActivityIdInNull() {
-    try {
-      externalTaskService.createExternalTaskQuery()
-          .activityIdIn((String) null);
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    ExternalTaskQuery externalTaskQuery = externalTaskService.createExternalTaskQuery();
+    assertThatThrownBy(() -> externalTaskQuery.activityIdIn((String) null))
+        .isInstanceOf(NullValueException.class);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/parallelExternalTaskProcess.bpmn20.xml")
@@ -318,13 +304,9 @@ public class ExternalTaskQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryByProcessInstanceIdNull() {
-    try {
-      externalTaskService.createExternalTaskQuery()
-        .processInstanceIdIn((String) null);
-
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    ExternalTaskQuery externalTaskQuery = externalTaskService.createExternalTaskQuery();
+    assertThatThrownBy(() -> externalTaskQuery.processInstanceIdIn((String) null))
+        .isInstanceOf(NullValueException.class);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
@@ -408,68 +390,50 @@ public class ExternalTaskQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryWithNullValues() {
-    try {
-      externalTaskService.createExternalTaskQuery().externalTaskId(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("externalTaskId is null", e.getMessage());
-    }
+    ExternalTaskQuery externalTaskQuery = externalTaskService.createExternalTaskQuery().externalTaskId(null);
+    assertThatThrownBy(externalTaskQuery::list)
+        .isInstanceOf(NullValueException.class)
+        .hasMessageContaining("externalTaskId is null");
 
-    try {
-      externalTaskService.createExternalTaskQuery().activityId(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("activityId is null", e.getMessage());
-    }
+    ExternalTaskQuery externalTaskQuery1 = externalTaskService.createExternalTaskQuery().activityId(null);
+    assertThatThrownBy(externalTaskQuery1::list)
+        .isInstanceOf(NullValueException.class)
+        .hasMessageContaining("activityId is null");
 
-    try {
-      externalTaskService.createExternalTaskQuery().executionId(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("executionId is null", e.getMessage());
-    }
+    ExternalTaskQuery externalTaskQuery2 = externalTaskService.createExternalTaskQuery().executionId(null);
+    assertThatThrownBy(externalTaskQuery2::list)
+        .isInstanceOf(NullValueException.class)
+        .hasMessageContaining("executionId is null");
 
-    try {
-      externalTaskService.createExternalTaskQuery().lockExpirationAfter(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("lockExpirationAfter is null", e.getMessage());
-    }
+    ExternalTaskQuery externalTaskQuery3 = externalTaskService.createExternalTaskQuery().lockExpirationAfter(null);
+    assertThatThrownBy(externalTaskQuery3::list)
+        .isInstanceOf(NullValueException.class)
+        .hasMessageContaining("lockExpirationAfter is null");
 
-    try {
-      externalTaskService.createExternalTaskQuery().lockExpirationBefore(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("lockExpirationBefore is null", e.getMessage());
-    }
+    ExternalTaskQuery externalTaskQuery4 = externalTaskService.createExternalTaskQuery().lockExpirationBefore(null);
+    assertThatThrownBy(externalTaskQuery4::list)
+        .isInstanceOf(NullValueException.class)
+        .hasMessageContaining("lockExpirationBefore is null");
 
-    try {
-      externalTaskService.createExternalTaskQuery().processDefinitionId(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("processDefinitionId is null", e.getMessage());
-    }
+    ExternalTaskQuery externalTaskQuery5 = externalTaskService.createExternalTaskQuery().processDefinitionId(null);
+    assertThatThrownBy(externalTaskQuery5::list)
+        .isInstanceOf(NullValueException.class)
+        .hasMessageContaining("processDefinitionId is null");
 
-    try {
-      externalTaskService.createExternalTaskQuery().processInstanceId(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("processInstanceId is null", e.getMessage());
-    }
+    ExternalTaskQuery externalTaskQuery6 = externalTaskService.createExternalTaskQuery().processInstanceId(null);
+    assertThatThrownBy(externalTaskQuery6::list)
+        .isInstanceOf(NullValueException.class)
+        .hasMessageContaining("processInstanceId is null");
 
-    try {
-      externalTaskService.createExternalTaskQuery().topicName(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("topicName is null", e.getMessage());
-    }
+    ExternalTaskQuery externalTaskQuery7 = externalTaskService.createExternalTaskQuery().topicName(null);
+    assertThatThrownBy(externalTaskQuery7::list)
+        .isInstanceOf(NullValueException.class)
+        .hasMessageContaining("topicName is null");
 
-    try {
-      externalTaskService.createExternalTaskQuery().workerId(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("workerId is null", e.getMessage());
-    }
+    ExternalTaskQuery externalTaskQuery8 = externalTaskService.createExternalTaskQuery().workerId(null);
+    assertThatThrownBy(externalTaskQuery8::list)
+        .isInstanceOf(NullValueException.class)
+        .hasMessageContaining("workerId is null");
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml",

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/SetExternalTasksRetriesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/SetExternalTasksRetriesTest.java
@@ -16,20 +16,6 @@
  */
 package org.operaton.bpm.engine.test.api.externaltask;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.ExternalTaskService;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
@@ -47,6 +33,19 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.AbstractAsyncOperationsTest;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.*;
+import org.junit.rules.RuleChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
 
@@ -191,25 +190,19 @@ public class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
     }
 
     externalTaskIds.add(null);
-    Batch batch = null;
+    Batch batch = externalTaskService.setRetriesAsync(externalTaskIds, null, 10);
 
-    try {
-      batch = externalTaskService.setRetriesAsync(externalTaskIds, null, 10);
-      executeSeedAndBatchJobs(batch);
-      fail("exception expected");
-    } catch (BadUserRequestException e) {
-      assertThat(e.getMessage()).contains("External task id cannot be null");
-    }
+    assertThatThrownBy(() -> executeSeedAndBatchJobs(batch))
+      .isInstanceOf(BadUserRequestException.class)
+      .hasMessageContaining("External task id cannot be null");
   }
 
   @Test
   public void shouldFailForNullExternalTaskIdsAsync() {
-    try {
-      externalTaskService.setRetriesAsync((List<String>) null, null, 10);
-      fail("exception expected");
-    } catch (BadUserRequestException e) {
-      assertThat(e.getMessage()).contains("externalTaskIds is empty");
-    }
+    List<String> externalTaskIds = null;
+    assertThatThrownBy(() -> externalTaskService.setRetriesAsync(externalTaskIds, null, 10))
+      .isInstanceOf(BadUserRequestException.class)
+      .hasMessageContaining("externalTaskIds is empty");
   }
 
   @Test
@@ -227,16 +220,12 @@ public class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
 
   @Test
   public void shouldFailForNegativeRetriesAsync() {
-
     List<String> externalTaskIds = Arrays.asList("externalTaskId");
 
-    try {
-      Batch batch = externalTaskService.setRetriesAsync(externalTaskIds, null, -10);
-      executeSeedAndBatchJobs(batch);
-      fail("exception expected");
-    } catch (BadUserRequestException e) {
-      assertThat(e.getMessage()).contains("The number of retries cannot be negative");
-    }
+    Batch batch = externalTaskService.setRetriesAsync(externalTaskIds, null, -10);
+    assertThatThrownBy(() -> executeSeedAndBatchJobs(batch))
+      .isInstanceOf(BadUserRequestException.class)
+      .hasMessageContaining("The number of retries cannot be negative");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterAuthorizationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterAuthorizationsTest.java
@@ -16,12 +16,6 @@
  */
 package org.operaton.bpm.engine.test.api.filter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-
-import java.util.List;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.EntityTypes;
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -35,10 +29,19 @@ import org.operaton.bpm.engine.impl.persistence.entity.AuthorizationEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.FilterEntity;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
+
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 /**
  * @author Sebastian Menski
@@ -152,13 +155,9 @@ public class FilterAuthorizationsTest extends PluggableProcessEngineTest {
   public void testDeleteFilterNotPermitted() {
     Filter filter = createTestFilter();
 
-    try {
-      filterService.deleteFilter(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId = filter.getId();
+    assertThatThrownBy(() -> filterService.deleteFilter(filterId))
+      .isInstanceOf(AuthorizationException.class);
   }
 
   @Test
@@ -183,45 +182,25 @@ public class FilterAuthorizationsTest extends PluggableProcessEngineTest {
     Filter returnedFilter = filterService.createFilterQuery().filterId(filter.getId()).singleResult();
     assertNull(returnedFilter);
 
-    try {
-      filterService.getFilter(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId = filter.getId();
+    assertThatThrownBy(() -> filterService.getFilter(filterId))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.singleResult(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId1 = filter.getId();
+    assertThatThrownBy(() -> filterService.singleResult(filterId1))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.list(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId2 = filter.getId();
+    assertThatThrownBy(() -> filterService.list(filterId2))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.listPage(filter.getId(), 1, 2);
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId3 = filter.getId();
+    assertThatThrownBy(() -> filterService.listPage(filterId3, 1, 2))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.count(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId4 = filter.getId();
+    assertThatThrownBy(() -> filterService.count(filterId4))
+      .isInstanceOf(AuthorizationException.class);
   }
 
   @Test
@@ -277,45 +256,25 @@ public class FilterAuthorizationsTest extends PluggableProcessEngineTest {
     Filter returnedFilter = filterService.createFilterQuery().filterId(filter.getId()).singleResult();
     assertNull(returnedFilter);
 
-    try {
-      filterService.getFilter(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId1 = filter.getId();
+    assertThatThrownBy(() -> filterService.getFilter(filterId1))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.singleResult(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId2 = filter.getId();
+    assertThatThrownBy(() -> filterService.singleResult(filterId2))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.list(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId3 = filter.getId();
+    assertThatThrownBy(() -> filterService.list(filterId3))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.listPage(filter.getId(), 1, 2);
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId4 = filter.getId();
+    assertThatThrownBy(() -> filterService.listPage(filterId4, 1, 2))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.count(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId5 = filter.getId();
+    assertThatThrownBy(() -> filterService.count(filterId5))
+      .isInstanceOf(AuthorizationException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterQueryTest.java
@@ -16,24 +16,27 @@
  */
 package org.operaton.bpm.engine.test.api.filter;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.operaton.bpm.engine.EntityTypes;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.filter.Filter;
 import org.operaton.bpm.engine.filter.FilterQuery;
 import org.operaton.bpm.engine.impl.persistence.entity.FilterEntity;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 /**
  * @author Sebastian Menski
@@ -95,13 +98,9 @@ public class FilterQueryTest extends PluggableProcessEngineTest {
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
 
-    try {
-      filterService.createFilterQuery().filterId(null);
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    FilterQuery filterQuery = filterService.createFilterQuery();
+    assertThatThrownBy(() -> filterQuery.filterId(null))
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -125,13 +124,9 @@ public class FilterQueryTest extends PluggableProcessEngineTest {
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
 
-    try {
-      filterService.createFilterQuery().filterResourceType(null);
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    FilterQuery filterQuery = filterService.createFilterQuery();
+    assertThatThrownBy(() -> filterQuery.filterResourceType(null))
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -157,13 +152,9 @@ public class FilterQueryTest extends PluggableProcessEngineTest {
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
 
-    try {
-      filterService.createFilterQuery().filterName(null);
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    FilterQuery filterQuery = filterService.createFilterQuery();
+    assertThatThrownBy(() -> filterQuery.filterName(null))
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -181,13 +172,9 @@ public class FilterQueryTest extends PluggableProcessEngineTest {
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
 
-    try {
-      filterService.createFilterQuery().filterOwner(null);
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    FilterQuery filterQuery = filterService.createFilterQuery();
+    assertThatThrownBy(() -> filterQuery.filterOwner(null))
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterServiceTest.java
@@ -30,6 +30,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -172,13 +173,9 @@ public class FilterServiceTest extends PluggableProcessEngineTest {
     long count = filterService.createFilterQuery().count();
     assertEquals(0, count);
 
-    try {
-      filterService.deleteFilter(filter.getId());
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    String filterId = filter.getId();
+    assertThatThrownBy(() -> filterService.deleteFilter(filterId))
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   public static void compareFilter(Filter filter1, Filter filter2) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterTaskQueryTest.java
@@ -48,6 +48,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -1116,13 +1117,9 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
 
     saveQuery(query);
 
-    try {
-      filterService.singleResult(testFilter.getId());
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    String filterId = testFilter.getId();
+    assertThatThrownBy(() -> filterService.singleResult(filterId))
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/form/BuiltInValidatorsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/form/BuiltInValidatorsTest.java
@@ -16,31 +16,24 @@
  */
 package org.operaton.bpm.engine.test.api.form;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Map;
-
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.VariableScope;
 import org.operaton.bpm.engine.impl.ProcessEngineImpl;
 import org.operaton.bpm.engine.impl.el.FixedValue;
 import org.operaton.bpm.engine.impl.form.FormException;
 import org.operaton.bpm.engine.impl.form.handler.FormFieldHandler;
-import org.operaton.bpm.engine.impl.form.validator.FormFieldValidator;
-import org.operaton.bpm.engine.impl.form.validator.FormFieldValidatorContext;
-import org.operaton.bpm.engine.impl.form.validator.FormValidators;
-import org.operaton.bpm.engine.impl.form.validator.MaxLengthValidator;
-import org.operaton.bpm.engine.impl.form.validator.MaxValidator;
-import org.operaton.bpm.engine.impl.form.validator.MinLengthValidator;
-import org.operaton.bpm.engine.impl.form.validator.MinValidator;
-import org.operaton.bpm.engine.impl.form.validator.ReadOnlyValidator;
-import org.operaton.bpm.engine.impl.form.validator.RequiredValidator;
+import org.operaton.bpm.engine.impl.form.validator.*;
 import org.operaton.bpm.engine.test.api.runtime.util.TestVariableScope;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
+
+import java.util.Map;
+
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Daniel Meyer
@@ -109,12 +102,10 @@ public class BuiltInValidatorsTest extends PluggableProcessEngineTest {
     assertTrue(validator.validate(4, new TestValidatorContext("4")));
     assertFalse(validator.validate(4, new TestValidatorContext("5")));
 
-    try {
-      validator.validate(4, new TestValidatorContext("4.4"));
-      fail("exception expected");
-    } catch (FormException e) {
-      assertTrue(e.getMessage().contains("Cannot validate Integer value 4: configuration 4.4 cannot be parsed as Integer."));
-    }
+    TestValidatorContext validatorContext = new TestValidatorContext("4.4");
+    assertThatThrownBy(() -> validator.validate(4, validatorContext))
+      .isInstanceOf(FormException.class)
+      .hasMessageContaining("Cannot validate Integer value 4: configuration 4.4 cannot be parsed as Integer.");
 
     assertFalse(validator.validate(4d, new TestValidatorContext("4.1")));
     assertTrue(validator.validate(4.1d, new TestValidatorContext("4.1")));
@@ -133,12 +124,10 @@ public class BuiltInValidatorsTest extends PluggableProcessEngineTest {
     assertTrue(validator.validate(3, new TestValidatorContext("4")));
     assertFalse(validator.validate(4, new TestValidatorContext("3")));
 
-    try {
-      validator.validate(4, new TestValidatorContext("4.4"));
-      fail("exception expected");
-    } catch (FormException e) {
-      assertTrue(e.getMessage().contains("Cannot validate Integer value 4: configuration 4.4 cannot be parsed as Integer."));
-    }
+    TestValidatorContext validatorContext = new TestValidatorContext("4.4");
+    assertThatThrownBy(() -> validator.validate(4, validatorContext))
+      .isInstanceOf(FormException.class)
+      .hasMessageContaining("Cannot validate Integer value 4: configuration 4.4 cannot be parsed as Integer.");
 
     assertFalse(validator.validate(4.1d, new TestValidatorContext("4")));
     assertTrue(validator.validate(4.1d, new TestValidatorContext("4.2")));
@@ -157,12 +146,10 @@ public class BuiltInValidatorsTest extends PluggableProcessEngineTest {
     assertTrue(validator.validate("test", new TestValidatorContext("4")));
     assertFalse(validator.validate("test", new TestValidatorContext("3")));
 
-    try {
-      validator.validate("test", new TestValidatorContext("4.4"));
-      fail("exception expected");
-    } catch (FormException e) {
-      assertTrue(e.getMessage().contains("Cannot validate \"maxlength\": configuration 4.4 cannot be interpreted as Integer"));
-    }
+    TestValidatorContext validatorContext = new TestValidatorContext("4.4");
+    assertThatThrownBy(() -> validator.validate("test", validatorContext))
+      .isInstanceOf(FormException.class)
+      .hasMessageContaining("Cannot validate \"maxlength\": configuration 4.4 cannot be interpreted as Integer");
   }
 
   @Test
@@ -174,12 +161,10 @@ public class BuiltInValidatorsTest extends PluggableProcessEngineTest {
     assertTrue(validator.validate("test", new TestValidatorContext("4")));
     assertFalse(validator.validate("test", new TestValidatorContext("5")));
 
-    try {
-      validator.validate("test", new TestValidatorContext("4.4"));
-      fail("exception expected");
-    } catch (FormException e) {
-      assertTrue(e.getMessage().contains("Cannot validate \"minlength\": configuration 4.4 cannot be interpreted as Integer"));
-    }
+    TestValidatorContext validatorContext = new TestValidatorContext("4.4");
+    assertThatThrownBy(() -> validator.validate("test", validatorContext))
+      .isInstanceOf(FormException.class)
+      .hasMessageContaining("Cannot validate \"minlength\": configuration 4.4 cannot be interpreted as Integer");
   }
 
   protected static class TestValidatorContext implements FormFieldValidatorContext {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
@@ -16,45 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.form;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.entry;
-import static org.operaton.bpm.engine.test.util.OperatonFormUtils.findAllOperatonFormDefinitionEntities;
-import static org.operaton.bpm.engine.variable.Variables.booleanValue;
-import static org.operaton.bpm.engine.variable.Variables.createVariables;
-import static org.operaton.bpm.engine.variable.Variables.objectValue;
-import static org.operaton.bpm.engine.variable.Variables.serializedObjectValue;
-import static org.operaton.bpm.engine.variable.Variables.stringValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import org.operaton.bpm.engine.BadUserRequestException;
-import org.operaton.bpm.engine.CaseService;
-import org.operaton.bpm.engine.FormService;
-import org.operaton.bpm.engine.HistoryService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ManagementService;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.ExecutionListener;
 import org.operaton.bpm.engine.exception.NotFoundException;
@@ -87,12 +49,30 @@ import org.operaton.bpm.engine.variable.value.ObjectValue;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.commons.utils.IoUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.operaton.bpm.engine.test.util.OperatonFormUtils.findAllOperatonFormDefinitionEntities;
+import static org.operaton.bpm.engine.variable.Variables.booleanValue;
+import static org.operaton.bpm.engine.variable.Variables.createVariables;
+import static org.operaton.bpm.engine.variable.Variables.objectValue;
+import static org.operaton.bpm.engine.variable.Variables.serializedObjectValue;
+import static org.operaton.bpm.engine.variable.Variables.stringValue;
+
+import java.io.InputStream;
+import java.util.*;
+import java.util.Map.Entry;
+
+import org.apache.groovy.util.Maps;
+import org.junit.*;
 import org.junit.rules.RuleChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Joram Barrez
@@ -322,21 +302,17 @@ public class FormServiceTest {
 
     assertEquals(5, formProperties.size());
 
-    try {
-      formService.submitTaskFormData(taskId, new HashMap<>());
-      fail("expected exception about required form property 'street'");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    HashMap<String, String> properties1 = new HashMap<>();
+    assertThatThrownBy(() -> formService.submitTaskFormData(taskId, properties1))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("required form property 'street'");
 
-    try {
-      properties = new HashMap<>();
-      properties.put("speaker", "its not allowed to update speaker!");
-      formService.submitTaskFormData(taskId, properties);
-      fail("expected exception about a non writable form property 'speaker'");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    properties = new HashMap<>();
+    properties.put("speaker", "its not allowed to update speaker!");
+    var finalProperties = properties;
+    assertThatThrownBy(() -> formService.submitTaskFormData(taskId, finalProperties))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("non writable form property 'speaker'");
 
     properties = new HashMap<>();
     properties.put("street", "rubensstraat");
@@ -405,16 +381,13 @@ public class FormServiceTest {
 
     assertEquals(5, formProperties.size());
 
-    try {
-      formService.submitTaskForm(taskId, new HashMap<>());
-      fail("expected exception about required form property 'street'");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    HashMap<String, Object> emptyProperties = new HashMap<>();
+    assertThatThrownBy(() -> formService.submitTaskForm(taskId, emptyProperties))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("required form property 'street'");
 
+    properties = Maps.of("speaker", "its not allowed to update speaker!");
     try {
-      properties = new HashMap<>();
-      properties.put("speaker", "its not allowed to update speaker!");
       formService.submitTaskForm(taskId, properties);
       fail("expected exception about a non writable form property 'speaker'");
     } catch (ProcessEngineException e) {


### PR DESCRIPTION
Refactor tests that check for exceptions to have only a single call in the calling code that could throw a RuntimeException.

Refactor to use `assertThatThrownBy()` for checking code for exceptions thrown.

related to #88, #27