### PR TITLE
refactor: Resolve Sonar Warnings 

### DIFF
--- a/clients/java/client/src/main/java/org/operaton/bpm/client/task/OrderingConfig.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/task/OrderingConfig.java
@@ -103,7 +103,7 @@ public class OrderingConfig {
   public List<SortingDto> toSortingDtos() {
     return orderingProperties.stream()
         .map(SortingDto::fromOrderingProperty)
-        .collect(Collectors.toList());
+        .toList();
   }
 
   /**

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/task/OrderingConfig.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/task/OrderingConfig.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.client.task;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.operaton.bpm.client.impl.ExternalTaskClientLogger;
 
 /**

--- a/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/function/CustomFunctionTransformer.java
+++ b/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/function/CustomFunctionTransformer.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class CustomFunctionTransformer extends JavaFunctionProvider {
 

--- a/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/function/CustomFunctionTransformer.java
+++ b/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/function/CustomFunctionTransformer.java
@@ -83,7 +83,7 @@ public class CustomFunctionTransformer extends JavaFunctionProvider {
   protected List<Object> unpackVals(List<Val> args) {
     return args.stream()
       .map(this::unpackVal)
-      .collect(Collectors.toList());
+      .toList();
   }
 
   protected Val toVal(Object rawResult) {

--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapEnableSortControlSupportTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapEnableSortControlSupportTest.java
@@ -65,7 +65,7 @@ public class LdapEnableSortControlSupportTest {
         .list()
         .stream()
         .sorted(Comparator.comparing(User::getFirstName))
-        .collect(Collectors.toList());
+        .toList();
 
     assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
@@ -82,7 +82,7 @@ public class LdapEnableSortControlSupportTest {
         .list()
         .stream()
         .sorted(Comparator.comparing(User::getFirstName).reversed())
-        .collect(Collectors.toList());
+        .toList();
 
     assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
@@ -102,7 +102,7 @@ public class LdapEnableSortControlSupportTest {
         .list()
         .stream()
         .sorted(Comparator.comparing(User::getLastName))
-        .collect(Collectors.toList());
+        .toList();
 
     assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
@@ -119,7 +119,7 @@ public class LdapEnableSortControlSupportTest {
         .list()
         .stream()
         .sorted(Comparator.comparing(User::getLastName).reversed())
-        .collect(Collectors.toList());
+        .toList();
 
     assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
@@ -138,7 +138,7 @@ public class LdapEnableSortControlSupportTest {
         .list()
         .stream()
         .sorted(Comparator.comparing(User::getEmail))
-        .collect(Collectors.toList());
+        .toList();
 
     assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
@@ -155,7 +155,7 @@ public class LdapEnableSortControlSupportTest {
         .list()
         .stream()
         .sorted(Comparator.comparing(User::getEmail).reversed())
-        .collect(Collectors.toList());
+        .toList();
 
     assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
@@ -174,7 +174,7 @@ public class LdapEnableSortControlSupportTest {
         .list()
         .stream()
         .sorted(Comparator.comparing(User::getId))
-        .collect(Collectors.toList());
+        .toList();
 
     assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
@@ -191,7 +191,7 @@ public class LdapEnableSortControlSupportTest {
         .list()
         .stream()
         .sorted(Comparator.comparing(User::getId).reversed())
-        .collect(Collectors.toList());
+        .toList();
 
     assertThat(orderedUsers).hasSize(manualOrderedUsers.size());
 
@@ -210,7 +210,7 @@ public class LdapEnableSortControlSupportTest {
         .list()
         .stream()
         .sorted(Comparator.comparing(Group::getId))
-        .collect(Collectors.toList());
+        .toList();
 
     assertThat(orderedGroup).hasSize(manualOrderedGroups.size());
 
@@ -226,7 +226,7 @@ public class LdapEnableSortControlSupportTest {
         .list()
         .stream()
         .sorted(Comparator.comparing(Group::getId).reversed())
-        .collect(Collectors.toList());
+        .toList();
 
     assertThat(orderedGroup).hasSize(manualOrderedGroups.size());
 
@@ -245,7 +245,7 @@ public class LdapEnableSortControlSupportTest {
         .list()
         .stream()
         .sorted(Comparator.comparing(Group::getName))
-        .collect(Collectors.toList());
+        .toList();
 
     assertThat(orderedGroup).hasSize(manualOrderedGroups.size());
 
@@ -261,7 +261,7 @@ public class LdapEnableSortControlSupportTest {
         .list()
         .stream()
         .sorted(Comparator.comparing(Group::getName).reversed())
-        .collect(Collectors.toList());
+        .toList();
 
     assertThat(orderedGroup).hasSize(manualOrderedGroups.size());
 

--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapEnableSortControlSupportTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapEnableSortControlSupportTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.operaton.bpm.engine.IdentityService;
 import org.operaton.bpm.engine.identity.Group;

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/impl/feel/integration/SpinValueMapper.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/impl/feel/integration/SpinValueMapper.java
@@ -74,7 +74,7 @@ public class SpinValueMapper extends JavaCustomValueMapper {
     } else if (node.isArray()) {
       List<Val> values = node.elements()
           .stream()
-          .map(e -> spinJsonToVal(e, innerValueMapper)).collect(toList());
+          .map(e -> spinJsonToVal(e, innerValueMapper)).toList();
       return innerValueMapper.apply(values);
 
     } else if (node.isNull()) {

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/TaskRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/TaskRestServiceImpl.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.engine.rest.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/TaskRestServiceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/TaskRestServiceImpl.java
@@ -99,10 +99,10 @@ public class TaskRestServiceImpl extends AbstractRestProcessEngineAware implemen
 
     List<TaskDto> tasks = new ArrayList<>();
     if (Boolean.TRUE.equals(queryDto.getWithCommentAttachmentInfo())) {
-      tasks = matchingTasks.stream().map(TaskWithAttachmentAndCommentDto::fromEntity).collect(Collectors.toList());
+      tasks = matchingTasks.stream().map(TaskWithAttachmentAndCommentDto::fromEntity).toList();
     }
     else {
-      tasks = matchingTasks.stream().map(TaskDto::fromEntity).collect(Collectors.toList());
+      tasks = matchingTasks.stream().map(TaskDto::fromEntity).toList();
     }
     return tasks;
   }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/ProcessDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/ProcessDefinitionResourceImpl.java
@@ -77,12 +77,12 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class ProcessDefinitionResourceImpl implements ProcessDefinitionResource {
 
+  public static final String MSG_CANNOT_INSTANTIATE_PROCESS_DEF = "Cannot instantiate process definition %s: %s";
   protected ProcessEngine engine;
   protected String processDefinitionId;
   protected String rootResourcePath;
@@ -106,9 +106,7 @@ public class ProcessDefinitionResourceImpl implements ProcessDefinitionResource 
       throw new InvalidRequestException(Status.NOT_FOUND, e, "No matching definition with id " + processDefinitionId);
     }
 
-    ProcessDefinitionDto result = ProcessDefinitionDto.fromProcessDefinition(definition);
-
-    return result;
+    return ProcessDefinitionDto.fromProcessDefinition(definition);
   }
 
   @Override
@@ -125,18 +123,18 @@ public class ProcessDefinitionResourceImpl implements ProcessDefinitionResource 
 
   @Override
   public ProcessInstanceDto startProcessInstance(UriInfo context, StartProcessInstanceDto parameters) {
-    ProcessInstanceWithVariables instance = null;
+    ProcessInstanceWithVariables instance;
     try {
       instance = startProcessInstanceAtActivities(parameters);
     } catch (AuthorizationException e) {
       throw e;
 
     } catch (ProcessEngineException e) {
-      String errorMessage = String.format("Cannot instantiate process definition %s: %s", processDefinitionId, e.getMessage());
+      String errorMessage = String.format(MSG_CANNOT_INSTANTIATE_PROCESS_DEF, processDefinitionId, e.getMessage());
       throw new RestException(Status.INTERNAL_SERVER_ERROR, e, errorMessage);
 
     } catch (RestException e) {
-      String errorMessage = String.format("Cannot instantiate process definition %s: %s", processDefinitionId, e.getMessage());
+      String errorMessage = String.format(MSG_CANNOT_INSTANTIATE_PROCESS_DEF, processDefinitionId, e.getMessage());
       throw new InvalidRequestException(e.getStatus(), e, errorMessage);
 
     }
@@ -184,7 +182,7 @@ public class ProcessDefinitionResourceImpl implements ProcessDefinitionResource 
   public ProcessInstanceDto submitForm(UriInfo context, StartProcessInstanceDto parameters) {
     FormService formService = engine.getFormService();
 
-    ProcessInstance instance = null;
+    ProcessInstance instance;
     try {
       Map<String, Object> variables = VariableValueDto.toMap(parameters.getVariables(), engine, objectMapper);
       String businessKey = parameters.getBusinessKey();
@@ -193,22 +191,17 @@ public class ProcessDefinitionResourceImpl implements ProcessDefinitionResource 
       } else {
         instance = formService.submitStartForm(processDefinitionId, variables);
       }
-
     } catch (AuthorizationException e) {
       throw e;
-
     } catch (FormFieldValidationException e) {
-      String errorMessage = String.format("Cannot instantiate process definition %s: %s", processDefinitionId, e.getMessage());
+      String errorMessage = String.format(MSG_CANNOT_INSTANTIATE_PROCESS_DEF, processDefinitionId, e.getMessage());
       throw new RestException(Status.BAD_REQUEST, e, errorMessage);
-
     } catch (ProcessEngineException e) {
-      String errorMessage = String.format("Cannot instantiate process definition %s: %s", processDefinitionId, e.getMessage());
+      String errorMessage = String.format(MSG_CANNOT_INSTANTIATE_PROCESS_DEF, processDefinitionId, e.getMessage());
       throw new RestException(Status.INTERNAL_SERVER_ERROR, e, errorMessage);
-
     } catch (RestException e) {
-      String errorMessage = String.format("Cannot instantiate process definition %s: %s", processDefinitionId, e.getMessage());
+      String errorMessage = String.format(MSG_CANNOT_INSTANTIATE_PROCESS_DEF, processDefinitionId, e.getMessage());
       throw new InvalidRequestException(e.getStatus(), e, errorMessage);
-
     }
 
     ProcessInstanceDto result = ProcessInstanceDto.fromProcessInstance(instance);
@@ -324,11 +317,11 @@ public class ProcessDefinitionResourceImpl implements ProcessDefinitionResource 
       throw new InvalidRequestException(Status.BAD_REQUEST, e, "Cannot get start form data for process definition " + processDefinitionId);
     }
     FormDto dto = FormDto.fromFormData(formData);
-    if((dto.getKey() == null || dto.getKey().isEmpty()) && dto.getOperatonFormRef() == null) {
-      if(formData != null && formData.getFormFields() != null && !formData.getFormFields().isEmpty()) {
+    if((dto.getKey() == null || dto.getKey().isEmpty()) && dto.getOperatonFormRef() == null
+        && formData != null && formData.getFormFields() != null && !formData.getFormFields().isEmpty()) {
         dto.setKey("embedded:engine://engine/:engine/process-definition/"+processDefinitionId+"/rendered-form");
       }
-    }
+
     dto.setContextPath(ApplicationContextPathUtil.getApplicationPathByProcessDefinitionId(engine, processDefinitionId));
 
     return dto;
@@ -406,13 +399,12 @@ public class ProcessDefinitionResourceImpl implements ProcessDefinitionResource 
 
   @Override
   public BatchDto restartProcessInstanceAsync(RestartProcessInstanceDto restartProcessInstanceDto) {
-    Batch batch = null;
     try {
-       batch = createRestartProcessInstanceBuilder(restartProcessInstanceDto).executeAsync();
+      Batch batch = createRestartProcessInstanceBuilder(restartProcessInstanceDto).executeAsync();
+      return BatchDto.fromBatch(batch);
     } catch (BadUserRequestException e) {
       throw new InvalidRequestException(Status.BAD_REQUEST, e.getMessage());
     }
-    return BatchDto.fromBatch(batch);
   }
 
   private RestartProcessInstanceBuilder createRestartProcessInstanceBuilder(RestartProcessInstanceDto restartProcessInstanceDto) {
@@ -454,12 +446,10 @@ public class ProcessDefinitionResourceImpl implements ProcessDefinitionResource 
       return Response.ok(deployedStartForm, getStartFormMediaType(processDefinitionId)).build();
     } catch (NotFoundException e) {
       throw new InvalidRequestException(Status.NOT_FOUND, e.getMessage());
-    } catch (NullValueException e) {
+    } catch (NullValueException | BadUserRequestException e) {
       throw new InvalidRequestException(Status.BAD_REQUEST, e.getMessage());
     } catch (AuthorizationException e) {
       throw new InvalidRequestException(Status.FORBIDDEN, e.getMessage());
-    } catch (BadUserRequestException e) {
-      throw new InvalidRequestException(Status.BAD_REQUEST, e.getMessage());
     }
   }
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/ProcessDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/ProcessDefinitionResourceImpl.java
@@ -389,7 +389,7 @@ public class ProcessDefinitionResourceImpl implements ProcessDefinitionResource 
     try {
       return engine.getRepositoryService().getStaticCalledProcessDefinitions(processDefinitionId).stream()
         .map(CalledProcessDefinitionDto::from)
-        .collect(Collectors.toList());
+        .toList();
     } catch (NotFoundException e) {
       throw new InvalidRequestException(Status.NOT_FOUND, e.getMessage());
     }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/BatchRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/BatchRestServiceInteractionTest.java
@@ -23,7 +23,6 @@ import static org.operaton.bpm.engine.rest.util.JsonPathUtil.from;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -67,7 +66,7 @@ public class BatchRestServiceInteractionTest extends AbstractRestServiceTest {
     Batch batchMock = MockProvider.createMockBatch();
 
     queryMock = mock(BatchQuery.class);
-    when(queryMock.batchId(eq(MockProvider.EXAMPLE_BATCH_ID))).thenReturn(queryMock);
+    when(queryMock.batchId(MockProvider.EXAMPLE_BATCH_ID)).thenReturn(queryMock);
     when(queryMock.singleResult()).thenReturn(batchMock);
 
     managementServiceMock = mock(ManagementService.class);
@@ -120,7 +119,7 @@ public class BatchRestServiceInteractionTest extends AbstractRestServiceTest {
     .when()
       .delete(SINGLE_BATCH_RESOURCE_URL);
 
-    verify(managementServiceMock).deleteBatch(eq(MockProvider.EXAMPLE_BATCH_ID), eq(false));
+    verify(managementServiceMock).deleteBatch(MockProvider.EXAMPLE_BATCH_ID, false);
     verifyNoMoreInteractions(managementServiceMock);
   }
 
@@ -134,7 +133,7 @@ public class BatchRestServiceInteractionTest extends AbstractRestServiceTest {
     .when()
       .delete(SINGLE_BATCH_RESOURCE_URL);
 
-    verify(managementServiceMock).deleteBatch(eq(MockProvider.EXAMPLE_BATCH_ID), eq(false));
+    verify(managementServiceMock).deleteBatch(MockProvider.EXAMPLE_BATCH_ID, false);
     verifyNoMoreInteractions(managementServiceMock);
   }
 
@@ -148,7 +147,7 @@ public class BatchRestServiceInteractionTest extends AbstractRestServiceTest {
     .when()
       .delete(SINGLE_BATCH_RESOURCE_URL);
 
-    verify(managementServiceMock).deleteBatch(eq(MockProvider.EXAMPLE_BATCH_ID), eq(true));
+    verify(managementServiceMock).deleteBatch(MockProvider.EXAMPLE_BATCH_ID, true);
     verifyNoMoreInteractions(managementServiceMock);
   }
 
@@ -157,7 +156,7 @@ public class BatchRestServiceInteractionTest extends AbstractRestServiceTest {
     String nonExistingId = MockProvider.NON_EXISTING_ID;
 
     doThrow(new BadUserRequestException("Batch for id '" + nonExistingId + "' cannot be found"))
-      .when(managementServiceMock).deleteBatch(eq(nonExistingId), eq(false));
+      .when(managementServiceMock).deleteBatch(nonExistingId, false);
 
     given()
       .pathParam("id", nonExistingId)
@@ -174,7 +173,7 @@ public class BatchRestServiceInteractionTest extends AbstractRestServiceTest {
     String nonExistingId = MockProvider.NON_EXISTING_ID;
 
     doThrow(new BadUserRequestException("Batch for id '" + nonExistingId + "' cannot be found"))
-      .when(managementServiceMock).deleteBatch(eq(nonExistingId), eq(false));
+      .when(managementServiceMock).deleteBatch(nonExistingId, false);
 
     given()
       .pathParam("id", nonExistingId)
@@ -192,7 +191,7 @@ public class BatchRestServiceInteractionTest extends AbstractRestServiceTest {
     String nonExistingId = MockProvider.NON_EXISTING_ID;
 
     doThrow(new BadUserRequestException("Batch for id '" + nonExistingId + "' cannot be found"))
-      .when(managementServiceMock).deleteBatch(eq(nonExistingId), eq(true));
+      .when(managementServiceMock).deleteBatch(nonExistingId, true);
 
     given()
       .pathParam("id", nonExistingId)
@@ -216,7 +215,7 @@ public class BatchRestServiceInteractionTest extends AbstractRestServiceTest {
     .when()
       .put(SUSPENDED_BATCH_RESOURCE_URL);
 
-    verify(managementServiceMock).suspendBatchById(eq(MockProvider.EXAMPLE_BATCH_ID));
+    verify(managementServiceMock).suspendBatchById(MockProvider.EXAMPLE_BATCH_ID);
     verifyNoMoreInteractions(managementServiceMock);
   }
 
@@ -225,7 +224,7 @@ public class BatchRestServiceInteractionTest extends AbstractRestServiceTest {
     String nonExistingId = MockProvider.NON_EXISTING_ID;
 
     doThrow(new BadUserRequestException("Batch for id '" + nonExistingId + "' cannot be found"))
-      .when(managementServiceMock).suspendBatchById(eq(nonExistingId));
+      .when(managementServiceMock).suspendBatchById(nonExistingId);
 
     given()
       .pathParam("id", nonExistingId)
@@ -245,7 +244,7 @@ public class BatchRestServiceInteractionTest extends AbstractRestServiceTest {
     String expectedMessage = "The user with id 'userId' does not have 'UPDATE' permission on resource '" + batchId + "' of type 'Batch'.";
 
     doThrow(new AuthorizationException(expectedMessage))
-      .when(managementServiceMock).suspendBatchById(eq(batchId));
+      .when(managementServiceMock).suspendBatchById(batchId);
 
     given()
       .pathParam("id", batchId)
@@ -271,7 +270,7 @@ public class BatchRestServiceInteractionTest extends AbstractRestServiceTest {
     .when()
       .put(SUSPENDED_BATCH_RESOURCE_URL);
 
-    verify(managementServiceMock).activateBatchById(eq(MockProvider.EXAMPLE_BATCH_ID));
+    verify(managementServiceMock).activateBatchById(MockProvider.EXAMPLE_BATCH_ID);
     verifyNoMoreInteractions(managementServiceMock);
   }
 
@@ -280,7 +279,7 @@ public class BatchRestServiceInteractionTest extends AbstractRestServiceTest {
     String nonExistingId = MockProvider.NON_EXISTING_ID;
 
     doThrow(new BadUserRequestException("Batch for id '" + nonExistingId + "' cannot be found"))
-      .when(managementServiceMock).activateBatchById(eq(nonExistingId));
+      .when(managementServiceMock).activateBatchById(nonExistingId);
 
     given()
       .pathParam("id", nonExistingId)
@@ -300,7 +299,7 @@ public class BatchRestServiceInteractionTest extends AbstractRestServiceTest {
     String expectedMessage = "The user with id 'userId' does not have 'UPDATE' permission on resource '" + batchId + "' of type 'Batch'.";
 
     doThrow(new AuthorizationException(expectedMessage))
-      .when(managementServiceMock).activateBatchById(eq(batchId));
+      .when(managementServiceMock).activateBatchById(batchId);
 
     given()
       .pathParam("id", batchId)

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.any;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -122,8 +121,8 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
     repositoryServiceMock = mock(RepositoryService.class);
 
     when(processEngine.getRepositoryService()).thenReturn(repositoryServiceMock);
-    when(repositoryServiceMock.getCaseDefinition(eq(MockProvider.EXAMPLE_CASE_DEFINITION_ID))).thenReturn(mockCaseDefinition);
-    when(repositoryServiceMock.getCaseModel(eq(MockProvider.EXAMPLE_CASE_DEFINITION_ID))).thenReturn(createMockCaseDefinitionCmmnXml());
+    when(repositoryServiceMock.getCaseDefinition(MockProvider.EXAMPLE_CASE_DEFINITION_ID)).thenReturn(mockCaseDefinition);
+    when(repositoryServiceMock.getCaseModel(MockProvider.EXAMPLE_CASE_DEFINITION_ID)).thenReturn(createMockCaseDefinitionCmmnXml());
 
     caseDefinitionQueryMock = mock(CaseDefinitionQuery.class);
     when(caseDefinitionQueryMock.caseDefinitionKey(MockProvider.EXAMPLE_CASE_DEFINITION_KEY)).thenReturn(caseDefinitionQueryMock);
@@ -667,7 +666,7 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
 
     doThrow(new BadUserRequestException(expectedMessage))
         .when(repositoryServiceMock)
-        .updateCaseDefinitionHistoryTimeToLive(eq(MockProvider.EXAMPLE_CASE_DEFINITION_ID), eq(-1));
+        .updateCaseDefinitionHistoryTimeToLive(MockProvider.EXAMPLE_CASE_DEFINITION_ID, -1);
 
     given()
       .pathParam("id", MockProvider.EXAMPLE_CASE_DEFINITION_ID)
@@ -690,7 +689,7 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
 
     doThrow(new AuthorizationException(expectedMessage))
         .when(repositoryServiceMock)
-        .updateCaseDefinitionHistoryTimeToLive(eq(MockProvider.EXAMPLE_CASE_DEFINITION_ID), eq(5));
+        .updateCaseDefinitionHistoryTimeToLive(MockProvider.EXAMPLE_CASE_DEFINITION_ID, 5);
 
     given()
       .pathParam("id", MockProvider.EXAMPLE_CASE_DEFINITION_ID)

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseExecutionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseExecutionRestServiceInteractionTest.java
@@ -1648,8 +1648,8 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
     expectedMap.put(variableKey, variableValue);
 
     verify(caseServiceMock).withCaseExecution(MockProvider.EXAMPLE_CASE_EXECUTION_ID);
-    verify(caseExecutionCommandBuilderMock).removeVariablesLocal(eq(deletions));
-    verify(caseExecutionCommandBuilderMock).setVariablesLocal(eq(expectedMap));
+    verify(caseExecutionCommandBuilderMock).removeVariablesLocal(deletions);
+    verify(caseExecutionCommandBuilderMock).setVariablesLocal(expectedMap);
     verify(caseExecutionCommandBuilderMock).execute();
   }
 
@@ -1681,8 +1681,8 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
     expectedMap.put(variableKey, variableValue);
 
     verify(caseServiceMock).withCaseExecution(MockProvider.EXAMPLE_CASE_EXECUTION_ID);
-    verify(caseExecutionCommandBuilderMock).removeVariables(eq(deletions));
-    verify(caseExecutionCommandBuilderMock).setVariables(eq(expectedMap));
+    verify(caseExecutionCommandBuilderMock).removeVariables(deletions);
+    verify(caseExecutionCommandBuilderMock).setVariables(expectedMap);
     verify(caseExecutionCommandBuilderMock).execute();
   }
 
@@ -1722,7 +1722,7 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
 
     verify(caseServiceMock).withCaseExecution("aNonExistingExecutionId");
     verify(caseExecutionCommandBuilderMock).removeVariablesLocal(null);
-    verify(caseExecutionCommandBuilderMock).setVariablesLocal(eq(expectedMap));
+    verify(caseExecutionCommandBuilderMock).setVariablesLocal(expectedMap);
     verify(caseExecutionCommandBuilderMock).execute();
   }
 
@@ -1762,7 +1762,7 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
 
     verify(caseServiceMock).withCaseExecution("aNonExistingExecutionId");
     verify(caseExecutionCommandBuilderMock).removeVariables(null);
-    verify(caseExecutionCommandBuilderMock).setVariables(eq(expectedMap));
+    verify(caseExecutionCommandBuilderMock).setVariables(expectedMap);
     verify(caseExecutionCommandBuilderMock).execute();
   }
 
@@ -1941,7 +1941,7 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
 
   @Test
   public void testNonExistingLocalVariable() {
-    when(caseServiceMock.getVariableLocalTyped(eq(MockProvider.EXAMPLE_CASE_EXECUTION_ID), eq(EXAMPLE_VARIABLE_KEY), eq(true)))
+    when(caseServiceMock.getVariableLocalTyped(MockProvider.EXAMPLE_CASE_EXECUTION_ID, EXAMPLE_VARIABLE_KEY, true))
       .thenReturn(null);
 
     given()
@@ -1958,7 +1958,7 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
 
   @Test
   public void testNonExistingVariable() {
-    when(caseServiceMock.getVariableTyped(eq(MockProvider.EXAMPLE_CASE_EXECUTION_ID), eq(EXAMPLE_VARIABLE_KEY), eq(true)))
+    when(caseServiceMock.getVariableTyped(MockProvider.EXAMPLE_CASE_EXECUTION_ID, EXAMPLE_VARIABLE_KEY, true))
       .thenReturn(null);
 
     given()
@@ -1975,8 +1975,8 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
 
   @Test
   public void testGetLocalVariableForNonExistingExecution() {
-    when(caseServiceMock.getVariableLocalTyped(eq(MockProvider.EXAMPLE_CASE_EXECUTION_ID),
-        eq(EXAMPLE_VARIABLE_KEY), eq(true)))
+    when(caseServiceMock.getVariableLocalTyped(MockProvider.EXAMPLE_CASE_EXECUTION_ID,
+        EXAMPLE_VARIABLE_KEY, true))
       .thenThrow(new ProcessEngineException("expected exception"));
 
     given()
@@ -1993,7 +1993,7 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
 
   @Test
   public void testGetVariableForNonExistingExecution() {
-    when(caseServiceMock.getVariableTyped(eq(MockProvider.EXAMPLE_CASE_EXECUTION_ID), eq(EXAMPLE_VARIABLE_KEY), eq(true)))
+    when(caseServiceMock.getVariableTyped(MockProvider.EXAMPLE_CASE_EXECUTION_ID, EXAMPLE_VARIABLE_KEY, true))
       .thenThrow(new ProcessEngineException("expected exception"));
 
     given()

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseInstanceRestServiceInteractionTest.java
@@ -291,8 +291,8 @@ public class CaseInstanceRestServiceInteractionTest extends AbstractRestServiceT
     expectedModifications.put(variableKey, variableValue);
 
     verify(caseServiceMock).withCaseExecution(MockProvider.EXAMPLE_CASE_INSTANCE_ID);
-    verify(caseExecutionCommandBuilderMock).setVariables(eq(expectedModifications));
-    verify(caseExecutionCommandBuilderMock).removeVariables(eq(deletions));
+    verify(caseExecutionCommandBuilderMock).setVariables(expectedModifications);
+    verify(caseExecutionCommandBuilderMock).removeVariables(deletions);
     verify(caseExecutionCommandBuilderMock).execute();
 
   }
@@ -458,7 +458,7 @@ public class CaseInstanceRestServiceInteractionTest extends AbstractRestServiceT
   public void testNonExistingVariable() {
     String variableKey = "aVariableKey";
 
-    when(caseServiceMock.getVariableTyped(eq(MockProvider.EXAMPLE_CASE_INSTANCE_ID), eq(variableKey), eq(true))).thenReturn(null);
+    when(caseServiceMock.getVariableTyped(MockProvider.EXAMPLE_CASE_INSTANCE_ID, variableKey, true)).thenReturn(null);
 
     given().pathParam("id", MockProvider.EXAMPLE_CASE_INSTANCE_ID).pathParam("varId", variableKey)
       .then().expect().statusCode(Status.NOT_FOUND.getStatusCode())
@@ -577,7 +577,7 @@ public class CaseInstanceRestServiceInteractionTest extends AbstractRestServiceT
   public void testGetVariableForNonExistingInstance() {
     String variableKey = "aVariableKey";
 
-    when(caseServiceMock.getVariableTyped(eq(MockProvider.EXAMPLE_CASE_INSTANCE_ID), eq(variableKey), eq(true)))
+    when(caseServiceMock.getVariableTyped(MockProvider.EXAMPLE_CASE_INSTANCE_ID, variableKey, true))
       .thenThrow(new ProcessEngineException("expected exception"));
 
     given().pathParam("id", MockProvider.EXAMPLE_CASE_INSTANCE_ID).pathParam("varId", variableKey)

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ConditionRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ConditionRestServiceTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -131,7 +130,7 @@ public class ConditionRestServiceTest extends AbstractRestServiceTest {
       .post(CONDITION_URL);
 
     verify(runtimeServiceMock).createConditionEvaluation();
-    verify(conditionEvaluationBuilderMock).processDefinitionId(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(conditionEvaluationBuilderMock).processDefinitionId(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
     verify(conditionEvaluationBuilderMock).evaluateStartConditions();
   }
 
@@ -154,7 +153,7 @@ public class ConditionRestServiceTest extends AbstractRestServiceTest {
       .post(CONDITION_URL);
 
     verify(runtimeServiceMock).createConditionEvaluation();
-    verify(conditionEvaluationBuilderMock).processInstanceBusinessKey(eq(MockProvider.EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY));
+    verify(conditionEvaluationBuilderMock).processInstanceBusinessKey(MockProvider.EXAMPLE_PROCESS_INSTANCE_BUSINESS_KEY);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CustomJacksonDateFormatTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CustomJacksonDateFormatTest.java
@@ -65,7 +65,7 @@ public class CustomJacksonDateFormatTest extends AbstractRestServiceTest {
   public void setUpRuntimeData() {
     runtimeServiceMock = mock(RuntimeServiceImpl.class);
 
-    when(runtimeServiceMock.getVariableTyped(eq(EXAMPLE_PROCESS_INSTANCE_ID), eq(EXAMPLE_VARIABLE_KEY), eq(true)))
+    when(runtimeServiceMock.getVariableTyped(EXAMPLE_PROCESS_INSTANCE_ID, EXAMPLE_VARIABLE_KEY, true))
       .thenReturn(Variables.dateValue(testDate));
 
     when(processEngine.getRuntimeService()).thenReturn(runtimeServiceMock);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DecisionDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DecisionDefinitionRestServiceInteractionTest.java
@@ -24,7 +24,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -109,8 +108,8 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
     repositoryServiceMock = mock(RepositoryService.class);
 
     when(processEngine.getRepositoryService()).thenReturn(repositoryServiceMock);
-    when(repositoryServiceMock.getDecisionDefinition(eq(MockProvider.EXAMPLE_DECISION_DEFINITION_ID))).thenReturn(mockDecisionDefinition);
-    when(repositoryServiceMock.getDecisionModel(eq(MockProvider.EXAMPLE_DECISION_DEFINITION_ID))).thenReturn(createMockDecisionDefinitionDmnXml());
+    when(repositoryServiceMock.getDecisionDefinition(MockProvider.EXAMPLE_DECISION_DEFINITION_ID)).thenReturn(mockDecisionDefinition);
+    when(repositoryServiceMock.getDecisionModel(MockProvider.EXAMPLE_DECISION_DEFINITION_ID)).thenReturn(createMockDecisionDefinitionDmnXml());
 
     decisionDefinitionQueryMock = mock(DecisionDefinitionQuery.class);
     when(decisionDefinitionQueryMock.decisionDefinitionKey(MockProvider.EXAMPLE_DECISION_DEFINITION_KEY)).thenReturn(decisionDefinitionQueryMock);
@@ -749,7 +748,7 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
 
     doThrow(new BadUserRequestException(expectedMessage))
         .when(repositoryServiceMock)
-        .updateDecisionDefinitionHistoryTimeToLive(eq(MockProvider.EXAMPLE_DECISION_DEFINITION_ID), eq(-1));
+        .updateDecisionDefinitionHistoryTimeToLive(MockProvider.EXAMPLE_DECISION_DEFINITION_ID, -1);
 
     given()
         .pathParam("id", MockProvider.EXAMPLE_DECISION_DEFINITION_ID)
@@ -771,7 +770,7 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
 
     doThrow(new AuthorizationException(expectedMessage))
         .when(repositoryServiceMock)
-        .updateDecisionDefinitionHistoryTimeToLive(eq(MockProvider.EXAMPLE_DECISION_DEFINITION_ID), eq(5));
+        .updateDecisionDefinitionHistoryTimeToLive(MockProvider.EXAMPLE_DECISION_DEFINITION_ID, 5);
 
     given()
         .pathParam("id", MockProvider.EXAMPLE_DECISION_DEFINITION_ID)

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DecisionRequirementsDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DecisionRequirementsDefinitionRestServiceInteractionTest.java
@@ -22,7 +22,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -111,7 +110,7 @@ public class DecisionRequirementsDefinitionRestServiceInteractionTest extends Ab
   public void nonExistingDecisionRequirementsDefinitionRetrieval() {
     String nonExistingId = "aNonExistingDefinitionId";
 
-    when(repositoryServiceMock.getDecisionRequirementsDefinition(eq(nonExistingId))).thenThrow(new ProcessEngineException("No matching decision requirements definition"));
+    when(repositoryServiceMock.getDecisionRequirementsDefinition(nonExistingId)).thenThrow(new ProcessEngineException("No matching decision requirements definition"));
 
     given()
       .pathParam("id", "aNonExistingDefinitionId")
@@ -253,8 +252,8 @@ public class DecisionRequirementsDefinitionRestServiceInteractionTest extends Ab
     repositoryServiceMock = mock(RepositoryService.class);
 
     when(processEngine.getRepositoryService()).thenReturn(repositoryServiceMock);
-    when(repositoryServiceMock.getDecisionRequirementsDefinition(eq(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID))).thenReturn(mockDecisionRequirementsDefinition);
-    when(repositoryServiceMock.getDecisionRequirementsModel(eq(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID))).thenReturn(createMockDecisionRequirementsDefinitionDmnXml());
+    when(repositoryServiceMock.getDecisionRequirementsDefinition(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID)).thenReturn(mockDecisionRequirementsDefinition);
+    when(repositoryServiceMock.getDecisionRequirementsModel(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID)).thenReturn(createMockDecisionRequirementsDefinitionDmnXml());
     when(repositoryServiceMock.getDecisionRequirementsDiagram(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID)).thenReturn(createMockDecisionRequirementsDiagram());
 
     decisionRequirementsDefinitionQueryMock = mock(DecisionRequirementsDefinitionQuery.class);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DeploymentRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DeploymentRestServiceInteractionTest.java
@@ -91,11 +91,11 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
     when(mockRepositoryService.createDeploymentQuery()).thenReturn(mockDeploymentQuery);
 
     mockDeploymentResources = MockProvider.createMockDeploymentResources();
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(mockDeploymentResources);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(mockDeploymentResources);
 
     mockDeploymentResource = MockProvider.createMockDeploymentResource();
 
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_RESOURCE_ID))).thenReturn(createMockDeploymentResourceBpmnData());
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_RESOURCE_ID)).thenReturn(createMockDeploymentResourceBpmnData());
 
     mockDeploymentBuilder = mock(DeploymentBuilder.class);
     when(mockRepositoryService.createDeployment()).thenReturn(mockDeploymentBuilder);
@@ -285,8 +285,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
     List<Resource> resources = new ArrayList<>();
     resources.add(resource);
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_SVG_RESOURCE_ID))).thenReturn(createMockDeploymentResourceSvgData());
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_SVG_RESOURCE_ID)).thenReturn(createMockDeploymentResourceSvgData());
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -313,8 +313,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_PNG_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_PNG_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -341,8 +341,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_GIF_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_GIF_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -369,8 +369,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_JPG_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_JPG_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -397,8 +397,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_JPEG_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_JPEG_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -425,8 +425,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_JPE_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_JPE_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -453,8 +453,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_TIF_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_TIF_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -481,8 +481,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_TIFF_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_TIFF_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -507,8 +507,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
     List<Resource> resources = new ArrayList<>();
     resources.add(resource);
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_BPMN_RESOURCE_ID))).thenReturn(createMockDeploymentResourceBpmnData());
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_BPMN_RESOURCE_ID)).thenReturn(createMockDeploymentResourceBpmnData());
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -533,8 +533,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
     List<Resource> resources = new ArrayList<>();
     resources.add(resource);
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_BPMN_XML_RESOURCE_ID))).thenReturn(createMockDeploymentResourceBpmnData());
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_BPMN_XML_RESOURCE_ID)).thenReturn(createMockDeploymentResourceBpmnData());
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -561,8 +561,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_CMMN_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_CMMN_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -589,8 +589,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_CMMN_XML_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_CMMN_XML_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -617,8 +617,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_DMN_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_DMN_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -645,8 +645,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_DMN_XML_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_DMN_XML_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -673,8 +673,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_XML_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_XML_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -701,8 +701,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_JSON_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_JSON_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -729,8 +729,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_GROOVY_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_GROOVY_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -757,8 +757,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_JAVA_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_JAVA_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -785,8 +785,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_JS_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_JS_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -813,8 +813,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_PYTHON_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_PYTHON_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -841,8 +841,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_RUBY_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_RUBY_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -869,8 +869,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_PHP_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_PHP_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -897,8 +897,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_HTML_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_HTML_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -925,8 +925,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_TXT_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_TXT_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -953,8 +953,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_CAMFORM_RESOURCE_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_CAMFORM_RESOURCE_ID)).thenReturn(input);
 
     Response response = given()
           .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -981,8 +981,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_RESOURCE_FILENAME_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_RESOURCE_FILENAME_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -1009,8 +1009,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     InputStream input = new ByteArrayInputStream(createMockDeploymentResourceByteData());
 
-    when(mockRepositoryService.getDeploymentResources(eq(EXAMPLE_DEPLOYMENT_ID))).thenReturn(resources);
-    when(mockRepositoryService.getResourceAsStreamById(eq(EXAMPLE_DEPLOYMENT_ID), eq(EXAMPLE_DEPLOYMENT_RESOURCE_FILENAME_ID))).thenReturn(input);
+    when(mockRepositoryService.getDeploymentResources(EXAMPLE_DEPLOYMENT_ID)).thenReturn(resources);
+    when(mockRepositoryService.getResourceAsStreamById(EXAMPLE_DEPLOYMENT_ID, EXAMPLE_DEPLOYMENT_RESOURCE_FILENAME_ID)).thenReturn(input);
 
     Response response = given()
         .pathParam("id", EXAMPLE_DEPLOYMENT_ID)
@@ -1643,11 +1643,11 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .post(REDEPLOY_DEPLOYMENT_URL);
 
     verify(mockDeploymentBuilder, never()).addDeploymentResources(anyString());
-    verify(mockDeploymentBuilder).nameFromDeployment(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID));
+    verify(mockDeploymentBuilder).nameFromDeployment(MockProvider.EXAMPLE_DEPLOYMENT_ID);
     verify(mockDeploymentBuilder, never()).addDeploymentResourceById(anyString(), anyString());
-    verify(mockDeploymentBuilder).addDeploymentResourcesById(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID), eq(resourceIds));
+    verify(mockDeploymentBuilder).addDeploymentResourcesById(MockProvider.EXAMPLE_DEPLOYMENT_ID, resourceIds);
     verify(mockDeploymentBuilder, never()).addDeploymentResourceByName(anyString(), anyString());
-    verify(mockDeploymentBuilder).addDeploymentResourcesByName(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID), eq(resources));
+    verify(mockDeploymentBuilder).addDeploymentResourcesByName(MockProvider.EXAMPLE_DEPLOYMENT_ID, resources);
     verify(mockDeploymentBuilder).source(MockProvider.EXAMPLE_DEPLOYMENT_SOURCE);
     verify(mockDeploymentBuilder).deployWithResult();
 
@@ -1665,8 +1665,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
     .when()
       .post(REDEPLOY_DEPLOYMENT_URL);
 
-    verify(mockDeploymentBuilder).addDeploymentResources(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID));
-    verify(mockDeploymentBuilder).nameFromDeployment(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID));
+    verify(mockDeploymentBuilder).addDeploymentResources(MockProvider.EXAMPLE_DEPLOYMENT_ID);
+    verify(mockDeploymentBuilder).nameFromDeployment(MockProvider.EXAMPLE_DEPLOYMENT_ID);
     verify(mockDeploymentBuilder, never()).addDeploymentResourceById(anyString(), anyString());
     verify(mockDeploymentBuilder, never()).addDeploymentResourcesById(anyString(), anyList());
     verify(mockDeploymentBuilder, never()).addDeploymentResourceByName(anyString(), anyString());
@@ -1689,8 +1689,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
     .when()
       .post(REDEPLOY_DEPLOYMENT_URL);
 
-    verify(mockDeploymentBuilder).addDeploymentResources(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID));
-    verify(mockDeploymentBuilder).nameFromDeployment(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID));
+    verify(mockDeploymentBuilder).addDeploymentResources(MockProvider.EXAMPLE_DEPLOYMENT_ID);
+    verify(mockDeploymentBuilder).nameFromDeployment(MockProvider.EXAMPLE_DEPLOYMENT_ID);
     verify(mockDeploymentBuilder, never()).addDeploymentResourceById(anyString(), anyString());
     verify(mockDeploymentBuilder, never()).addDeploymentResourcesById(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID), anyList());
     verify(mockDeploymentBuilder, never()).addDeploymentResourceByName(anyString(), anyString());
@@ -1721,9 +1721,9 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .post(REDEPLOY_DEPLOYMENT_URL);
 
     verify(mockDeploymentBuilder, never()).addDeploymentResources(anyString());
-    verify(mockDeploymentBuilder).nameFromDeployment(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID));
+    verify(mockDeploymentBuilder).nameFromDeployment(MockProvider.EXAMPLE_DEPLOYMENT_ID);
     verify(mockDeploymentBuilder, never()).addDeploymentResourceById(anyString(), anyString());
-    verify(mockDeploymentBuilder).addDeploymentResourcesById(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID), eq(resourceIds));
+    verify(mockDeploymentBuilder).addDeploymentResourcesById(MockProvider.EXAMPLE_DEPLOYMENT_ID, resourceIds);
     verify(mockDeploymentBuilder, never()).addDeploymentResourceByName(anyString(), anyString());
     verify(mockDeploymentBuilder, never()).addDeploymentResourcesByName(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID), anyList());
     verify(mockDeploymentBuilder).source(null);
@@ -1752,11 +1752,11 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .post(REDEPLOY_DEPLOYMENT_URL);
 
     verify(mockDeploymentBuilder, never()).addDeploymentResources(anyString());
-    verify(mockDeploymentBuilder).nameFromDeployment(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID));
+    verify(mockDeploymentBuilder).nameFromDeployment(MockProvider.EXAMPLE_DEPLOYMENT_ID);
     verify(mockDeploymentBuilder, never()).addDeploymentResourceById(anyString(), anyString());
     verify(mockDeploymentBuilder, never()).addDeploymentResourcesById(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID), anyList());
     verify(mockDeploymentBuilder, never()).addDeploymentResourceByName(anyString(), anyString());
-    verify(mockDeploymentBuilder).addDeploymentResourcesByName(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID), eq(resources));
+    verify(mockDeploymentBuilder).addDeploymentResourcesByName(MockProvider.EXAMPLE_DEPLOYMENT_ID, resources);
     verify(mockDeploymentBuilder).source(null);
     verify(mockDeploymentBuilder).deployWithResult();
 
@@ -1778,13 +1778,13 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
     .when()
       .post(REDEPLOY_DEPLOYMENT_URL);
 
-    verify(mockDeploymentBuilder).addDeploymentResources(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID));
-    verify(mockDeploymentBuilder).nameFromDeployment(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID));
+    verify(mockDeploymentBuilder).addDeploymentResources(MockProvider.EXAMPLE_DEPLOYMENT_ID);
+    verify(mockDeploymentBuilder).nameFromDeployment(MockProvider.EXAMPLE_DEPLOYMENT_ID);
     verify(mockDeploymentBuilder, never()).addDeploymentResourceById(anyString(), anyString());
     verify(mockDeploymentBuilder, never()).addDeploymentResourcesById(anyString(), anyList());
     verify(mockDeploymentBuilder, never()).addDeploymentResourceByName(anyString(), anyString());
     verify(mockDeploymentBuilder, never()).addDeploymentResourcesByName(anyString(), anyList());
-    verify(mockDeploymentBuilder).source(eq(MockProvider.EXAMPLE_DEPLOYMENT_SOURCE));
+    verify(mockDeploymentBuilder).source(MockProvider.EXAMPLE_DEPLOYMENT_SOURCE);
     verify(mockDeploymentBuilder).deployWithResult();
 
     verifyDeployment(mockDeployment, response);
@@ -1803,7 +1803,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
     .when()
       .post(REDEPLOY_DEPLOYMENT_URL);
 
-    verify(mockDeploymentBuilder).addDeploymentResources(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID));
+    verify(mockDeploymentBuilder).addDeploymentResources(MockProvider.EXAMPLE_DEPLOYMENT_ID);
     verify(mockDeploymentBuilder, never()).tenantId(any(String.class));
     verify(mockDeploymentBuilder).deployWithResult();
 
@@ -1823,8 +1823,8 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
     .when()
       .post(REDEPLOY_DEPLOYMENT_URL);
 
-    verify(mockDeploymentBuilder).addDeploymentResources(eq(MockProvider.EXAMPLE_DEPLOYMENT_ID));
-    verify(mockDeploymentBuilder).tenantId(eq(MockProvider.EXAMPLE_TENANT_ID));
+    verify(mockDeploymentBuilder).addDeploymentResources(MockProvider.EXAMPLE_DEPLOYMENT_ID);
+    verify(mockDeploymentBuilder).tenantId(MockProvider.EXAMPLE_TENANT_ID);
     verify(mockDeploymentBuilder).deployWithResult();
 
     verifyDeployment(mockDeployment, response);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExecutionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExecutionRestServiceInteractionTest.java
@@ -117,9 +117,9 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     EventSubscription mockSubscription = MockProvider.createMockEventSubscription();
     EventSubscriptionQuery mockQuery = mock(EventSubscriptionQuery.class);
     when(runtimeServiceMock.createEventSubscriptionQuery()).thenReturn(mockQuery);
-    when(mockQuery.executionId(eq(MockProvider.EXAMPLE_EXECUTION_ID))).thenReturn(mockQuery);
-    when(mockQuery.eventType(eq(MockProvider.EXAMPLE_EVENT_SUBSCRIPTION_TYPE))).thenReturn(mockQuery);
-    when(mockQuery.eventName(eq(MockProvider.EXAMPLE_EVENT_SUBSCRIPTION_NAME))).thenReturn(mockQuery);
+    when(mockQuery.executionId(MockProvider.EXAMPLE_EXECUTION_ID)).thenReturn(mockQuery);
+    when(mockQuery.eventType(MockProvider.EXAMPLE_EVENT_SUBSCRIPTION_TYPE)).thenReturn(mockQuery);
+    when(mockQuery.eventName(MockProvider.EXAMPLE_EVENT_SUBSCRIPTION_NAME)).thenReturn(mockQuery);
     when(mockQuery.singleResult()).thenReturn(mockSubscription);
   }
 
@@ -622,7 +622,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
   public void testNonExistingLocalVariable() {
     String variableKey = "aVariableKey";
 
-    when(runtimeServiceMock.getVariableLocal(eq(MockProvider.EXAMPLE_EXECUTION_ID), eq(variableKey))).thenReturn(null);
+    when(runtimeServiceMock.getVariableLocal(MockProvider.EXAMPLE_EXECUTION_ID, variableKey)).thenReturn(null);
 
     given().pathParam("id", MockProvider.EXAMPLE_EXECUTION_ID).pathParam("varId", variableKey)
       .then().expect().statusCode(Status.NOT_FOUND.getStatusCode())
@@ -635,7 +635,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
   public void testGetLocalVariableForNonExistingExecution() {
     String variableKey = "aVariableKey";
 
-    when(runtimeServiceMock.getVariableLocalTyped(eq(MockProvider.EXAMPLE_EXECUTION_ID), eq(variableKey), eq(true)))
+    when(runtimeServiceMock.getVariableLocalTyped(MockProvider.EXAMPLE_EXECUTION_ID, variableKey, true))
       .thenThrow(new ProcessEngineException("expected exception"));
 
     given().pathParam("id", MockProvider.EXAMPLE_EXECUTION_ID).pathParam("varId", variableKey)
@@ -1249,8 +1249,8 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     .when()
       .post(SINGLE_EXECUTION_LOCAL_BINARY_VARIABLE_URL);
 
-    verify(runtimeServiceMock, never()).setVariableLocal(eq(MockProvider.EXAMPLE_EXECUTION_ID), eq(variableKey),
-        eq(serializable));
+    verify(runtimeServiceMock, never()).setVariableLocal(MockProvider.EXAMPLE_EXECUTION_ID, variableKey,
+        serializable);
   }
 
   @Test
@@ -1379,7 +1379,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
       .then().expect().statusCode(Status.NO_CONTENT.getStatusCode())
       .when().delete(SINGLE_EXECUTION_LOCAL_VARIABLE_URL);
 
-    verify(runtimeServiceMock).removeVariableLocal(eq(MockProvider.EXAMPLE_EXECUTION_ID), eq(variableKey));
+    verify(runtimeServiceMock).removeVariableLocal(MockProvider.EXAMPLE_EXECUTION_ID, variableKey);
   }
 
   @Test
@@ -1490,7 +1490,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
     String variableKey = "aVariableKey";
 
     doThrow(new ProcessEngineException("expected exception"))
-      .when(runtimeServiceMock).removeVariableLocal(eq(MockProvider.EXAMPLE_EXECUTION_ID), eq(variableKey));
+      .when(runtimeServiceMock).removeVariableLocal(MockProvider.EXAMPLE_EXECUTION_ID, variableKey);
 
     given().pathParam("id", MockProvider.EXAMPLE_EXECUTION_ID).pathParam("varId", variableKey)
       .then().expect().statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/FilterRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/FilterRestServiceInteractionTest.java
@@ -165,17 +165,17 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     filterMock = MockProvider.createMockFilter();
 
     when(filterServiceMock.newTaskFilter()).thenReturn(filterMock);
-    when(filterServiceMock.saveFilter(eq(filterMock))).thenReturn(filterMock);
-    when(filterServiceMock.getFilter(eq(EXAMPLE_FILTER_ID))).thenReturn(filterMock);
-    when(filterServiceMock.getFilter(eq(MockProvider.NON_EXISTING_ID))).thenReturn(null);
+    when(filterServiceMock.saveFilter(filterMock)).thenReturn(filterMock);
+    when(filterServiceMock.getFilter(EXAMPLE_FILTER_ID)).thenReturn(filterMock);
+    when(filterServiceMock.getFilter(MockProvider.NON_EXISTING_ID)).thenReturn(null);
 
     List<Object> mockTasks = Collections.singletonList(new TaskEntity());
 
-    when(filterServiceMock.singleResult(eq(EXAMPLE_FILTER_ID)))
+    when(filterServiceMock.singleResult(EXAMPLE_FILTER_ID))
       .thenReturn(mockTasks.get(0));
     when(filterServiceMock.singleResult(eq(EXAMPLE_FILTER_ID), any()))
       .thenReturn(mockTasks.get(0));
-    when(filterServiceMock.list(eq(EXAMPLE_FILTER_ID)))
+    when(filterServiceMock.list(EXAMPLE_FILTER_ID))
       .thenReturn(mockTasks);
     when(filterServiceMock.list(eq(EXAMPLE_FILTER_ID), any()))
       .thenReturn(mockTasks);
@@ -183,17 +183,17 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
       .thenReturn(mockTasks);
     when(filterServiceMock.listPage(eq(EXAMPLE_FILTER_ID), any(), anyInt(), anyInt()))
       .thenReturn(mockTasks);
-    when(filterServiceMock.count(eq(EXAMPLE_FILTER_ID)))
+    when(filterServiceMock.count(EXAMPLE_FILTER_ID))
       .thenReturn((long) 1);
     when(filterServiceMock.count(eq(EXAMPLE_FILTER_ID), any()))
       .thenReturn((long) 1);
 
     doThrow(new NullValueException("No filter found with given id"))
-      .when(filterServiceMock).singleResult(eq(MockProvider.NON_EXISTING_ID));
+      .when(filterServiceMock).singleResult(MockProvider.NON_EXISTING_ID);
     doThrow(new NullValueException("No filter found with given id"))
       .when(filterServiceMock).singleResult(eq(MockProvider.NON_EXISTING_ID), any());
     doThrow(new NullValueException("No filter found with given id"))
-      .when(filterServiceMock).list(eq(MockProvider.NON_EXISTING_ID));
+      .when(filterServiceMock).list(MockProvider.NON_EXISTING_ID);
     doThrow(new NullValueException("No filter found with given id"))
       .when(filterServiceMock).list(eq(MockProvider.NON_EXISTING_ID), any());
     doThrow(new NullValueException("No filter found with given id"))
@@ -201,11 +201,11 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     doThrow(new NullValueException("No filter found with given id"))
       .when(filterServiceMock).listPage(eq(MockProvider.NON_EXISTING_ID), any(), anyInt(), anyInt());
     doThrow(new NullValueException("No filter found with given id"))
-      .when(filterServiceMock).count(eq(MockProvider.NON_EXISTING_ID));
+      .when(filterServiceMock).count(MockProvider.NON_EXISTING_ID);
     doThrow(new NullValueException("No filter found with given id"))
       .when(filterServiceMock).count(eq(MockProvider.NON_EXISTING_ID), any());
     doThrow(new NullValueException("No filter found with given id"))
-      .when(filterServiceMock).deleteFilter(eq(MockProvider.NON_EXISTING_ID));
+      .when(filterServiceMock).deleteFilter(MockProvider.NON_EXISTING_ID);
 
     authorizationServiceMock = mock(AuthorizationServiceImpl.class);
     identityServiceMock = mock(IdentityServiceImpl.class);
@@ -239,7 +239,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     .when()
       .get(SINGLE_FILTER_URL);
 
-    verify(filterServiceMock).getFilter(eq(EXAMPLE_FILTER_ID));
+    verify(filterServiceMock).getFilter(EXAMPLE_FILTER_ID);
   }
 
   @Test
@@ -251,7 +251,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     .when()
       .get(SINGLE_FILTER_URL);
 
-    verify(filterServiceMock).getFilter(eq(MockProvider.NON_EXISTING_ID));
+    verify(filterServiceMock).getFilter(MockProvider.NON_EXISTING_ID);
   }
 
   @Test
@@ -680,7 +680,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
       .post(CREATE_FILTER_URL);
 
     verify(filterServiceMock).newTaskFilter();
-    verify(filterServiceMock).saveFilter(eq(filterMock));
+    verify(filterServiceMock).saveFilter(filterMock);
   }
 
   @Test
@@ -707,8 +707,8 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     .when()
       .put(SINGLE_FILTER_URL);
 
-    verify(filterServiceMock).getFilter(eq(EXAMPLE_FILTER_ID));
-    verify(filterServiceMock).saveFilter(eq(filterMock));
+    verify(filterServiceMock).getFilter(EXAMPLE_FILTER_ID);
+    verify(filterServiceMock).saveFilter(filterMock);
   }
 
   @Test
@@ -774,7 +774,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     .when()
       .delete(SINGLE_FILTER_URL);
 
-    verify(filterServiceMock).deleteFilter(eq(EXAMPLE_FILTER_ID));
+    verify(filterServiceMock).deleteFilter(EXAMPLE_FILTER_ID);
   }
 
   @Test
@@ -1532,7 +1532,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     Map<String, Object> properties = new HashMap<>();
     properties.put("variables", "foo");
     Filter filter =  mockFilter().properties(properties).build();
-    when(filterServiceMock.getFilter(eq(EXAMPLE_FILTER_ID))).thenReturn(filter);
+    when(filterServiceMock.getFilter(EXAMPLE_FILTER_ID)).thenReturn(filter);
 
     given()
       .pathParam("id", EXAMPLE_FILTER_ID)
@@ -1542,7 +1542,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     .when()
       .get(EXECUTE_SINGLE_RESULT_FILTER_URL);
 
-    verify(filterServiceMock, times(1)).getFilter(eq(EXAMPLE_FILTER_ID));
+    verify(filterServiceMock, times(1)).getFilter(EXAMPLE_FILTER_ID);
     verify(variableInstanceQueryMock, never()).variableScopeIdIn(any());
     verify(variableInstanceQueryMock, never()).variableNameIn(any());
     verify(variableInstanceQueryMock, never()).list();
@@ -1555,7 +1555,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     Map<String, Object> properties = new HashMap<>();
     properties.put("variables", Collections.emptyList());
     Filter filter =  mockFilter().properties(properties).build();
-    when(filterServiceMock.getFilter(eq(EXAMPLE_FILTER_ID))).thenReturn(filter);
+    when(filterServiceMock.getFilter(EXAMPLE_FILTER_ID)).thenReturn(filter);
 
     given()
       .pathParam("id", EXAMPLE_FILTER_ID)
@@ -1566,7 +1566,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     .when()
       .get(EXECUTE_SINGLE_RESULT_FILTER_URL);
 
-    verify(filterServiceMock, times(1)).getFilter(eq(EXAMPLE_FILTER_ID));
+    verify(filterServiceMock, times(1)).getFilter(EXAMPLE_FILTER_ID);
     verify(variableInstanceQueryMock, never()).variableScopeIdIn(any());
     verify(variableInstanceQueryMock, never()).variableNameIn(any());
     verify(variableInstanceQueryMock, never()).list();
@@ -1600,7 +1600,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     .when()
       .get(EXECUTE_SINGLE_RESULT_FILTER_URL);
 
-    verify(filterServiceMock, times(1)).getFilter(eq(EXAMPLE_FILTER_ID));
+    verify(filterServiceMock, times(1)).getFilter(EXAMPLE_FILTER_ID);
     verify(variableInstanceQueryMock, times(1)).variableScopeIdIn(any(String[].class));
     verify(variableInstanceQueryMock).variableScopeIdIn(TASK_A_ID, EXECUTION_A_ID, PROCESS_INSTANCE_A_ID);
     verify(variableInstanceQueryMock, times(1)).variableNameIn(any(String[].class));
@@ -1642,7 +1642,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     .when()
       .get(EXECUTE_SINGLE_RESULT_FILTER_URL);
 
-    verify(filterServiceMock, times(1)).getFilter(eq(EXAMPLE_FILTER_ID));
+    verify(filterServiceMock, times(1)).getFilter(EXAMPLE_FILTER_ID);
     verify(variableInstanceQueryMock, times(1)).variableScopeIdIn(any(String[].class));
     verify(variableInstanceQueryMock).variableScopeIdIn(TASK_A_ID, EXECUTION_A_ID, PROCESS_INSTANCE_A_ID, CASE_EXECUTION_A_ID, CASE_INSTANCE_A_ID);
     verify(variableInstanceQueryMock, times(1)).variableNameIn(any(String[].class));
@@ -1712,7 +1712,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     .when()
       .get(EXECUTE_LIST_FILTER_URL);
 
-    verify(filterServiceMock, times(1)).getFilter(eq(EXAMPLE_FILTER_ID));
+    verify(filterServiceMock, times(1)).getFilter(EXAMPLE_FILTER_ID);
     verify(variableInstanceQueryMock, times(1)).variableScopeIdIn(any(String[].class));
     verify(variableInstanceQueryMock).variableScopeIdIn(TASK_A_ID, EXECUTION_A_ID, PROCESS_INSTANCE_A_ID, TASK_B_ID, EXECUTION_B_ID, TASK_C_ID, CASE_EXECUTION_A_ID, CASE_INSTANCE_A_ID);
     verify(variableInstanceQueryMock, times(1)).variableNameIn(any(String[].class));
@@ -1831,7 +1831,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
     properties.put("variables", variables);
 
     Filter filter = mockFilter().properties(properties).build();
-    when(filterServiceMock.getFilter(eq(EXAMPLE_FILTER_ID))).thenReturn(filter);
+    when(filterServiceMock.getFilter(EXAMPLE_FILTER_ID)).thenReturn(filter);
 
     return filter;
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/FilterRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/FilterRestServiceQueryTest.java
@@ -23,7 +23,6 @@ import static io.restassured.path.json.JsonPath.from;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -76,10 +75,10 @@ public class FilterRestServiceQueryTest extends AbstractRestServiceTest {
     FilterService filterService = processEngine.getFilterService();
 
     when(filterService.createFilterQuery()).thenReturn(mockedQuery);
-    when(filterService.getFilter(eq(MockProvider.EXAMPLE_FILTER_ID))).thenReturn(mockedFilter);
-    when(filterService.count(eq(MockProvider.EXAMPLE_FILTER_ID))).thenReturn((long) mockedFilterItemCount);
-    when(filterService.getFilter(eq(MockProvider.ANOTHER_EXAMPLE_FILTER_ID))).thenReturn(anotherMockedFilter);
-    when(filterService.count(eq(MockProvider.ANOTHER_EXAMPLE_FILTER_ID))).thenReturn((long) anotherMockedFilterItemCount);
+    when(filterService.getFilter(MockProvider.EXAMPLE_FILTER_ID)).thenReturn(mockedFilter);
+    when(filterService.count(MockProvider.EXAMPLE_FILTER_ID)).thenReturn((long) mockedFilterItemCount);
+    when(filterService.getFilter(MockProvider.ANOTHER_EXAMPLE_FILTER_ID)).thenReturn(anotherMockedFilter);
+    when(filterService.count(MockProvider.ANOTHER_EXAMPLE_FILTER_ID)).thenReturn((long) anotherMockedFilterItemCount);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/JobRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/JobRestServiceInteractionTest.java
@@ -26,7 +26,6 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -1524,7 +1523,7 @@ public class JobRestServiceInteractionTest extends AbstractRestServiceTest {
     verifyBatchJson(response.asString());
 
     verify(mockManagementService, times(1)).setJobRetriesByJobsAsync(5);
-    verify(mockSetJobRetriesByJobsAsyncBuilder, times(1)).jobIds(eq(ids));
+    verify(mockSetJobRetriesByJobsAsyncBuilder, times(1)).jobIds(ids);
     verify(mockSetJobRetriesByJobsAsyncBuilder, times(1)).jobQuery(null);
     verify(mockSetJobRetriesByJobsAsyncBuilder, times(1)).executeAsync();
     verifyNoMoreInteractions(mockSetJobRetriesByJobsAsyncBuilder);
@@ -1551,8 +1550,8 @@ public class JobRestServiceInteractionTest extends AbstractRestServiceTest {
 
     verifyBatchJson(response.asString());
 
-    verify(mockManagementService, times(1)).setJobRetriesByJobsAsync(eq(5));
-    verify(mockSetJobRetriesByJobsAsyncBuilder, times(1)).jobIds(eq(ids));
+    verify(mockManagementService, times(1)).setJobRetriesByJobsAsync(5);
+    verify(mockSetJobRetriesByJobsAsyncBuilder, times(1)).jobIds(ids);
     verify(mockSetJobRetriesByJobsAsyncBuilder, times(1)).jobQuery(null);
     verify(mockSetJobRetriesByJobsAsyncBuilder, times(1)).dueDate(newDueDate);
     verify(mockSetJobRetriesByJobsAsyncBuilder, times(1)).executeAsync();
@@ -1579,8 +1578,8 @@ public class JobRestServiceInteractionTest extends AbstractRestServiceTest {
 
     verifyBatchJson(response.asString());
 
-    verify(mockManagementService, times(1)).setJobRetriesByJobsAsync(eq(5));
-    verify(mockSetJobRetriesByJobsAsyncBuilder, times(1)).jobIds(eq(ids));
+    verify(mockManagementService, times(1)).setJobRetriesByJobsAsync(5);
+    verify(mockSetJobRetriesByJobsAsyncBuilder, times(1)).jobIds(ids);
     verify(mockSetJobRetriesByJobsAsyncBuilder, times(1)).jobQuery(null);
     verify(mockSetJobRetriesByJobsAsyncBuilder, times(1)).dueDate(null);
     verify(mockSetJobRetriesByJobsAsyncBuilder, times(1)).executeAsync();
@@ -1669,7 +1668,7 @@ public class JobRestServiceInteractionTest extends AbstractRestServiceTest {
   @Test
   public void testSetRetriesWithBadRequestQuery() {
     doThrow(new BadUserRequestException("job ids are empty"))
-        .when(mockSetJobRetriesByJobsAsyncBuilder).jobQuery(eq((JobQuery) null));
+        .when(mockSetJobRetriesByJobsAsyncBuilder).jobQuery((JobQuery) null);
 
     Map<String, Object> messageBodyJson = new HashMap<>();
     messageBodyJson.put(RETRIES, 5);
@@ -1696,7 +1695,7 @@ public class JobRestServiceInteractionTest extends AbstractRestServiceTest {
   @Test
   public void testSetRetriesWithNegativeRetries() {
     doThrow(new BadUserRequestException("retries are negative"))
-        .when(mockManagementService).setJobRetriesByJobsAsync(eq(MockProvider.EXAMPLE_NEGATIVE_JOB_RETRIES));
+        .when(mockManagementService).setJobRetriesByJobsAsync(MockProvider.EXAMPLE_NEGATIVE_JOB_RETRIES);
 
     Map<String, Object> messageBodyJson = new HashMap<>();
     messageBodyJson.put(RETRIES, MockProvider.EXAMPLE_NEGATIVE_JOB_RETRIES);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/MessageRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/MessageRestServiceTest.java
@@ -66,7 +66,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -168,8 +167,8 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     Map<String, Object> expectedVariablesToTriggeredScope = new HashMap<>();
     expectedVariablesToTriggeredScope.put("aKeyToTriggeredScope", "aValueToTriggeredScope");
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
-    verify(messageCorrelationBuilderMock).processInstanceBusinessKey(eq(businessKey));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
+    verify(messageCorrelationBuilderMock).processInstanceBusinessKey(businessKey);
     verify(messageCorrelationBuilderMock).setVariables(argThat(new EqualsMap(expectedVariables)));
     verify(messageCorrelationBuilderMock).setVariablesLocal(argThat(new EqualsMap(expectedVariablesLocal)));
     verify(messageCorrelationBuilderMock).setVariablesToTriggeredScope(argThat(new EqualsMap(expectedVariablesToTriggeredScope)));
@@ -213,7 +212,7 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     assertTrue(!content.isEmpty());
     checkExecutionResult(content, 0);
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
     verify(messageCorrelationBuilderMock).correlateWithResult();
   }
 
@@ -251,7 +250,7 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     assertTrue(!content.isEmpty());
     checkProcessInstanceResult(content, 0);
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
     verify(messageCorrelationBuilderMock).correlateWithResult();
   }
 
@@ -315,8 +314,8 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     Map<String, Object> expectedVariablesToTriggeredScope = new HashMap<>();
     expectedVariablesToTriggeredScope.put("aKeyToTriggeredScope", "aValueToTriggeredScope");
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
-    verify(messageCorrelationBuilderMock).processInstanceBusinessKey(eq(businessKey));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
+    verify(messageCorrelationBuilderMock).processInstanceBusinessKey(businessKey);
     verify(messageCorrelationBuilderMock).setVariables(argThat(new EqualsMap(expectedVariables)));
     verify(messageCorrelationBuilderMock).setVariablesLocal(argThat(new EqualsMap(expectedVariablesLocal)));
     verify(messageCorrelationBuilderMock).setVariablesToTriggeredScope(argThat(new EqualsMap(expectedVariablesToTriggeredScope)));
@@ -366,7 +365,7 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
       checkExecutionResult(content, i);
     }
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
     verify(messageCorrelationBuilderMock).correlateAllWithResult();
   }
 
@@ -400,7 +399,7 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
       checkProcessInstanceResult(content, i);
     }
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
     verify(messageCorrelationBuilderMock).correlateAllWithResult();
   }
 
@@ -440,7 +439,7 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
       }
     }
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
     verify(messageCorrelationBuilderMock).correlateAllWithResult();
   }
 
@@ -467,7 +466,7 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     String content = response.asString();
     assertTrue(content.isEmpty());
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
     verify(messageCorrelationBuilderMock).correlateAllWithResult();
   }
 
@@ -482,7 +481,7 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
       .then().expect().statusCode(Status.NO_CONTENT.getStatusCode())
       .when().post(MESSAGE_URL);
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
     verify(messageCorrelationBuilderMock).correlateWithResult();
     verifyNoMoreInteractions(messageCorrelationBuilderMock);
   }
@@ -500,8 +499,8 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
       .then().expect().statusCode(Status.NO_CONTENT.getStatusCode())
       .when().post(MESSAGE_URL);
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
-    verify(messageCorrelationBuilderMock).processInstanceBusinessKey(eq(businessKey));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
+    verify(messageCorrelationBuilderMock).processInstanceBusinessKey(businessKey);
     verify(messageCorrelationBuilderMock).correlateWithResult();
     verifyNoMoreInteractions(messageCorrelationBuilderMock);
 
@@ -521,8 +520,8 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
       .then().expect().statusCode(Status.NO_CONTENT.getStatusCode())
       .when().post(MESSAGE_URL);
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
-    verify(messageCorrelationBuilderMock).processInstanceBusinessKey(eq(businessKey));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
+    verify(messageCorrelationBuilderMock).processInstanceBusinessKey(businessKey);
     verify(messageCorrelationBuilderMock).correlateAllWithResult();
     verifyNoMoreInteractions(messageCorrelationBuilderMock);
 
@@ -582,7 +581,7 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
       .then().expect().statusCode(Status.NO_CONTENT.getStatusCode())
       .when().post(MESSAGE_URL);
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
     verify(messageCorrelationBuilderMock).tenantId(MockProvider.EXAMPLE_TENANT_ID);
     verify(messageCorrelationBuilderMock).correlateWithResult();
     verifyNoMoreInteractions(messageCorrelationBuilderMock);
@@ -600,7 +599,7 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
       .then().expect().statusCode(Status.NO_CONTENT.getStatusCode())
       .when().post(MESSAGE_URL);
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
     verify(messageCorrelationBuilderMock).withoutTenantId();
     verify(messageCorrelationBuilderMock).correlateWithResult();
     verifyNoMoreInteractions(messageCorrelationBuilderMock);
@@ -1207,8 +1206,8 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
       .expect().statusCode(Status.NO_CONTENT.getStatusCode())
     .when().post(MESSAGE_URL);
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
-    verify(messageCorrelationBuilderMock).processInstanceId(eq(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
+    verify(messageCorrelationBuilderMock).processInstanceId(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID);
 
     verify(messageCorrelationBuilderMock).correlateWithResult();
   }
@@ -1230,7 +1229,7 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
       .expect().statusCode(Status.NO_CONTENT.getStatusCode())
     .when().post(MESSAGE_URL);
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
 
     verify(messageCorrelationBuilderMock, Mockito.never()).processInstanceBusinessKey(anyString());
     verify(messageCorrelationBuilderMock).correlateWithResult();
@@ -1263,7 +1262,7 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     checkVariablesInResult(content, 0);
     checkExecutionResult(content, 0);
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
     verify(messageCorrelationBuilderMock).correlateWithResultAndVariables(false);
   }
 
@@ -1296,7 +1295,7 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     assertEquals(1, results.size());
     checkVariablesInResult(content, 0);
 
-    verify(runtimeServiceMock).createMessageCorrelation(eq(messageName));
+    verify(runtimeServiceMock).createMessageCorrelation(messageName);
     verify(messageCorrelationBuilderMock).correlateAllWithResultAndVariables(false);
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/MigrationRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/MigrationRestServiceInteractionTest.java
@@ -126,7 +126,7 @@ public class MigrationRestServiceInteractionTest extends AbstractRestServiceTest
       .instruction(ANOTHER_EXAMPLE_ACTIVITY_ID, EXAMPLE_ACTIVITY_ID)
       .builder();
 
-    when(runtimeServiceMock.createMigrationPlan(eq(EXAMPLE_PROCESS_DEFINITION_ID), eq(ANOTHER_EXAMPLE_PROCESS_DEFINITION_ID)))
+    when(runtimeServiceMock.createMigrationPlan(EXAMPLE_PROCESS_DEFINITION_ID, ANOTHER_EXAMPLE_PROCESS_DEFINITION_ID))
       .thenReturn(migrationPlanBuilderMock);
 
     migrationPlanExecutionBuilderMock = mock(MigrationPlanExecutionBuilder.class);
@@ -325,7 +325,7 @@ public class MigrationRestServiceInteractionTest extends AbstractRestServiceTest
     .when()
       .post(GENERATE_MIGRATION_URL);
 
-    verify(runtimeServiceMock).createMigrationPlan(eq(EXAMPLE_PROCESS_DEFINITION_ID), eq(ANOTHER_EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createMigrationPlan(EXAMPLE_PROCESS_DEFINITION_ID, ANOTHER_EXAMPLE_PROCESS_DEFINITION_ID);
 
     InOrder inOrder = Mockito.inOrder(migrationPlanBuilderMock);
 
@@ -401,7 +401,7 @@ public class MigrationRestServiceInteractionTest extends AbstractRestServiceTest
     .when()
       .post(GENERATE_MIGRATION_URL);
 
-    verify(runtimeServiceMock).createMigrationPlan(eq(EXAMPLE_PROCESS_DEFINITION_ID), eq(ANOTHER_EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createMigrationPlan(EXAMPLE_PROCESS_DEFINITION_ID, ANOTHER_EXAMPLE_PROCESS_DEFINITION_ID);
 
     InOrder inOrder = Mockito.inOrder(migrationPlanBuilderMock);
 
@@ -1519,8 +1519,8 @@ public class MigrationRestServiceInteractionTest extends AbstractRestServiceTest
   }
 
   protected void verifyGenerateMigrationPlanInteraction(MigrationPlanBuilder migrationPlanBuilderMock, Map<String, Object> initialMigrationPlan) {
-    verify(runtimeServiceMock).createMigrationPlan(eq(initialMigrationPlan.get(MigrationPlanDtoBuilder.PROP_SOURCE_PROCESS_DEFINITION_ID).toString()),
-                                                   eq(initialMigrationPlan.get(MigrationPlanDtoBuilder.PROP_TARGET_PROCESS_DEFINITION_ID).toString()));
+    verify(runtimeServiceMock).createMigrationPlan(initialMigrationPlan.get(MigrationPlanDtoBuilder.PROP_SOURCE_PROCESS_DEFINITION_ID).toString(),
+                                                   initialMigrationPlan.get(MigrationPlanDtoBuilder.PROP_TARGET_PROCESS_DEFINITION_ID).toString());
     // the map equal activities method should be called
     verify(migrationPlanBuilderMock).mapEqualActivities();
     // other instructions are ignored

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ModificationRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ModificationRestServiceInteractionTest.java
@@ -110,7 +110,7 @@ public class ModificationRestServiceInteractionTest extends AbstractRestServiceT
       .post(EXECUTE_MODIFICATION_SYNC_URL);
 
     verify(runtimeServiceMock).createModification("processDefinitionId");
-    verify(modificationBuilderMock).processInstanceIds(eq(Arrays.asList("100", "20")));
+    verify(modificationBuilderMock).processInstanceIds(Arrays.asList("100", "20"));
     verify(modificationBuilderMock).cancelAllForActivity("activityId");
     verify(modificationBuilderMock).startBeforeActivity("activityId");
     verify(modificationBuilderMock).startAfterActivity("activityId");
@@ -148,7 +148,7 @@ public class ModificationRestServiceInteractionTest extends AbstractRestServiceT
       .post(EXECUTE_MODIFICATION_ASYNC_URL);
 
     verify(runtimeServiceMock).createModification(null);
-    verify(modificationBuilderMock).processInstanceIds(eq(Arrays.asList("100", "20")));
+    verify(modificationBuilderMock).processInstanceIds(Arrays.asList("100", "20"));
     verify(modificationBuilderMock).cancelAllForActivity("activityId");
     verify(modificationBuilderMock).startBeforeActivity("activityId");
     verify(modificationBuilderMock).startAfterActivity("activityId");
@@ -186,7 +186,7 @@ public class ModificationRestServiceInteractionTest extends AbstractRestServiceT
       .post(EXECUTE_MODIFICATION_SYNC_URL);
 
     verify(runtimeServiceMock).createModification(null);
-    verify(modificationBuilderMock).processInstanceIds(eq(Arrays.asList("100", "20")));
+    verify(modificationBuilderMock).processInstanceIds(Arrays.asList("100", "20"));
     verify(modificationBuilderMock).cancelAllForActivity("activityId");
     verify(modificationBuilderMock).startBeforeActivity("activityId");
     verify(modificationBuilderMock).startAfterActivity("activityId");
@@ -242,7 +242,7 @@ public class ModificationRestServiceInteractionTest extends AbstractRestServiceT
       .post(EXECUTE_MODIFICATION_ASYNC_URL);
 
     verify(runtimeServiceMock).createModification("processDefinitionId");
-    verify(modificationBuilderMock).processInstanceIds(eq(Arrays.asList("100", "20")));
+    verify(modificationBuilderMock).processInstanceIds(Arrays.asList("100", "20"));
     verify(modificationBuilderMock).cancelAllForActivity("activityId");
     verify(modificationBuilderMock).startBeforeActivity("activityId");
     verify(modificationBuilderMock).startAfterActivity("activityId");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/PersistenceConnectionExceptionLoggingTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/PersistenceConnectionExceptionLoggingTest.java
@@ -73,7 +73,7 @@ public class PersistenceConnectionExceptionLoggingTest extends AbstractRestServi
 
     return Arrays.stream(values)
         .map(c -> new Object[] {c})
-        .collect(Collectors.toList());
+        .toList();
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/PersistenceConnectionExceptionLoggingTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/PersistenceConnectionExceptionLoggingTest.java
@@ -33,7 +33,6 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.operaton.bpm.engine.ProcessEnginePersistenceException;
 import org.operaton.bpm.engine.identity.UserQuery;

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
@@ -160,8 +160,8 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
 
     repositoryServiceMock = mock(RepositoryService.class);
     when(processEngine.getRepositoryService()).thenReturn(repositoryServiceMock);
-    when(repositoryServiceMock.getProcessDefinition(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))).thenReturn(mockDefinition);
-    when(repositoryServiceMock.getProcessModel(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))).thenReturn(createMockProcessDefinionBpmn20Xml());
+    when(repositoryServiceMock.getProcessDefinition(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID)).thenReturn(mockDefinition);
+    when(repositoryServiceMock.getProcessModel(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID)).thenReturn(createMockProcessDefinionBpmn20Xml());
 
     DeleteProcessDefinitionsSelectBuilder deleteProcessDefinitionsSelectBuilder = mock(DeleteProcessDefinitionsSelectBuilder.class, RETURNS_DEEP_STUBS);
     when(repositoryServiceMock.deleteProcessDefinitions()).thenReturn(deleteProcessDefinitionsSelectBuilder);
@@ -171,8 +171,8 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
     StartFormData formDataMock = MockProvider.createMockStartFormData(mockDefinition);
     formServiceMock = mock(FormService.class);
     when(processEngine.getFormService()).thenReturn(formServiceMock);
-    when(formServiceMock.getStartFormData(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))).thenReturn(formDataMock);
-    when(formServiceMock.getStartFormKey(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))).thenReturn(MockProvider.EXAMPLE_FORM_KEY);
+    when(formServiceMock.getStartFormData(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID)).thenReturn(formDataMock);
+    when(formServiceMock.getStartFormKey(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID)).thenReturn(MockProvider.EXAMPLE_FORM_KEY);
     when(formServiceMock.submitStartForm(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID), any())).thenReturn(mockInstance);
     when(formServiceMock.submitStartForm(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID), any(), any())).thenReturn(mockInstance);
 
@@ -964,7 +964,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
                     equalTo(MockProvider.FORMAT_APPLICATION_JSON))
             .when().post(START_PROCESS_INSTANCE_URL);
 
-    verify(runtimeServiceMock).createProcessInstanceById(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createProcessInstanceById(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
     verify(mockProcessInstantiationBuilder).executeWithVariablesInReturn(anyBoolean(), anyBoolean());
 
   }
@@ -991,7 +991,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
     expectedParameters.put("aString", "aStringVariableValue");
     expectedParameters.put("anInteger", 42);
 
-    verify(runtimeServiceMock).createProcessInstanceById(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createProcessInstanceById(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
     verify(mockInstantiationBuilder).setVariables(argThat(new EqualsMap(expectedParameters)));
     verify(mockInstantiationBuilder).executeWithVariablesInReturn(anyBoolean(), anyBoolean());
   }
@@ -1008,7 +1008,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
         .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
       .when().post(START_PROCESS_INSTANCE_URL);
 
-    verify(runtimeServiceMock).createProcessInstanceById(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createProcessInstanceById(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
     verify(mockInstantiationBuilder).businessKey("myBusinessKey");
     verify(mockInstantiationBuilder).executeWithVariablesInReturn(anyBoolean(), anyBoolean());
   }
@@ -1037,7 +1037,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
     expectedParameters.put("aString", "aStringVariableValue");
     expectedParameters.put("anInteger", 42);
 
-    verify(runtimeServiceMock).createProcessInstanceById(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createProcessInstanceById(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
     verify(mockInstantiationBuilder).businessKey("myBusinessKey");
     verify(mockInstantiationBuilder).setVariables(argThat(new EqualsMap(expectedParameters)));
     verify(mockInstantiationBuilder).executeWithVariablesInReturn(anyBoolean(), anyBoolean());
@@ -1067,7 +1067,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
       .when().post(START_PROCESS_INSTANCE_URL);
 
     VariableMap expectedVariables = Variables.createVariables().putValueTyped("foo", Variables.stringValue("bar", true));
-    verify(runtimeServiceMock).createProcessInstanceById(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createProcessInstanceById(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
     verify(mockInstantiationBuilder).setVariables(expectedVariables);
     assertEquals(expectedVariables.getValueTyped("foo").isTransient(), varMap.getValueTyped("foo").isTransient());
     verify(mockInstantiationBuilder).executeWithVariablesInReturn(anyBoolean(), anyBoolean());
@@ -1119,7 +1119,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
         .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
       .when().post(START_PROCESS_INSTANCE_URL);
 
-    verify(runtimeServiceMock).createProcessInstanceById(eq(EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createProcessInstanceById(EXAMPLE_PROCESS_DEFINITION_ID);
 
     InOrder inOrder = inOrder(mockInstantiationBuilder);
 
@@ -1217,7 +1217,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
             .body("variables.varLocal.value", equalTo("valueLocal"))
             .when().post(START_PROCESS_INSTANCE_URL);
 
-    verify(runtimeServiceMock).createProcessInstanceById(eq(EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createProcessInstanceById(EXAMPLE_PROCESS_DEFINITION_ID);
   }
 
   @Test
@@ -1268,7 +1268,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
         .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
       .when().post(START_PROCESS_INSTANCE_BY_KEY_URL);
 
-    verify(runtimeServiceMock).createProcessInstanceById(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createProcessInstanceById(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
 
     InOrder inOrder = inOrder(mockProcessInstantiationBuilder);
 
@@ -1322,7 +1322,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
         .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
       .when().post(START_PROCESS_INSTANCE_URL);
 
-    verify(runtimeServiceMock).createProcessInstanceById(eq(EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createProcessInstanceById(EXAMPLE_PROCESS_DEFINITION_ID);
 
     InOrder inOrder = inOrder(mockProcessInstantiationBuilder);
 
@@ -1468,7 +1468,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
   @Test
   public void testNonExistingProcessDefinitionRetrieval() {
     String nonExistingId = "aNonExistingDefinitionId";
-    when(repositoryServiceMock.getProcessDefinition(eq(nonExistingId))).thenThrow(new ProcessEngineException("no matching definition"));
+    when(repositoryServiceMock.getProcessDefinition(nonExistingId)).thenThrow(new ProcessEngineException("no matching definition"));
 
     given().pathParam("id", "aNonExistingDefinitionId")
     .then().expect()
@@ -1481,7 +1481,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
   @Test
   public void testNonExistingProcessDefinitionBpmn20XmlRetrieval() {
     String nonExistingId = "aNonExistingDefinitionId";
-    when(repositoryServiceMock.getProcessModel(eq(nonExistingId))).thenThrow(new NotFoundException("no matching process definition found."));
+    when(repositoryServiceMock.getProcessModel(nonExistingId)).thenThrow(new NotFoundException("no matching process definition found."));
 
     given().pathParam("id", nonExistingId)
     .then().expect()
@@ -1494,7 +1494,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
   @Test
   public void testGetProcessDefinitionBpmn20XmlThrowsProcessEngineException() {
     String processDefinitionId = "someId";
-    when(repositoryServiceMock.getProcessModel(eq(processDefinitionId))).thenThrow(new ProcessEngineException("generic message"));
+    when(repositoryServiceMock.getProcessModel(processDefinitionId)).thenThrow(new ProcessEngineException("generic message"));
 
     given().pathParam("id", processDefinitionId)
     .then().expect()
@@ -1507,7 +1507,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
   @Test
   public void testGetProcessDefinitionBpmn20XmlThrowsAuthorizationException() {
     String message = "expected exception";
-    when(repositoryServiceMock.getProcessModel(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))).thenThrow(new AuthorizationException(message));
+    when(repositoryServiceMock.getProcessModel(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID)).thenThrow(new AuthorizationException(message));
 
     given()
       .pathParam("id", MockProvider.EXAMPLE_PROCESS_DEFINITION_ID)
@@ -2772,7 +2772,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
   @Test
   public void testGetProcessDefinitionBpmn20XmlThrowsAuthorizationException_ByKey() {
     String message = "expected exception";
-    when(repositoryServiceMock.getProcessModel(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))).thenThrow(new AuthorizationException(message));
+    when(repositoryServiceMock.getProcessModel(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID)).thenThrow(new AuthorizationException(message));
 
     given()
       .pathParam("key", MockProvider.EXAMPLE_PROCESS_DEFINITION_KEY)
@@ -3169,7 +3169,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
     expectedParameters.put("aString", "aStringVariableValue");
     expectedParameters.put("anInteger", 42);
 
-    verify(runtimeServiceMock).createProcessInstanceById(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createProcessInstanceById(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
     verify(mockInstantiationBuilder).setVariables(argThat(new EqualsMap(expectedParameters)));
     verify(mockInstantiationBuilder).executeWithVariablesInReturn(anyBoolean(), anyBoolean());
   }
@@ -3186,7 +3186,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
         .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
       .when().post(START_PROCESS_INSTANCE_BY_KEY_URL);
 
-    verify(runtimeServiceMock).createProcessInstanceById(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createProcessInstanceById(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
     verify(mockInstantiationBuilder).businessKey("myBusinessKey");
     verify(mockInstantiationBuilder).executeWithVariablesInReturn(anyBoolean(), anyBoolean());
   }
@@ -3215,7 +3215,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
     expectedParameters.put("aString", "aStringVariableValue");
     expectedParameters.put("anInteger", 42);
 
-    verify(runtimeServiceMock).createProcessInstanceById(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createProcessInstanceById(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
     verify(mockInstantiationBuilder).businessKey("myBusinessKey");
     verify(mockInstantiationBuilder).setVariables(argThat(new EqualsMap(expectedParameters)));
     verify(mockInstantiationBuilder).executeWithVariablesInReturn(anyBoolean(), anyBoolean());
@@ -3518,7 +3518,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
 
     doThrow(new BadUserRequestException(expectedMessage))
         .when(repositoryServiceMock)
-        .updateProcessDefinitionHistoryTimeToLive(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID), eq(-1));
+        .updateProcessDefinitionHistoryTimeToLive(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, -1);
 
     given()
         .pathParam("id", MockProvider.EXAMPLE_PROCESS_DEFINITION_ID)
@@ -3540,7 +3540,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
 
     doThrow(new AuthorizationException(expectedMessage))
         .when(repositoryServiceMock)
-        .updateProcessDefinitionHistoryTimeToLive(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID), eq(5));
+        .updateProcessDefinitionHistoryTimeToLive(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, 5);
 
     given()
         .pathParam("id", MockProvider.EXAMPLE_PROCESS_DEFINITION_ID)
@@ -3872,7 +3872,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
         .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
       .when().post(START_PROCESS_INSTANCE_URL);
 
-    verify(runtimeServiceMock).createProcessInstanceById(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createProcessInstanceById(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
     verify(mockInstantiationBuilder).caseInstanceId("myCaseInstanceId");
     verify(mockInstantiationBuilder).executeWithVariablesInReturn(anyBoolean(), anyBoolean());
   }
@@ -3890,7 +3890,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
         .body("id", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))
       .when().post(START_PROCESS_INSTANCE_URL);
 
-    verify(runtimeServiceMock).createProcessInstanceById(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createProcessInstanceById(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
     verify(mockInstantiationBuilder).businessKey("myBusinessKey");
     verify(mockInstantiationBuilder).caseInstanceId("myCaseInstanceId");
     verify(mockInstantiationBuilder).executeWithVariablesInReturn(anyBoolean(), anyBoolean());
@@ -3921,7 +3921,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
     expectedParameters.put("aString", "aStringVariableValue");
     expectedParameters.put("anInteger", 42);
 
-    verify(runtimeServiceMock).createProcessInstanceById(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(runtimeServiceMock).createProcessInstanceById(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
     verify(mockInstantiationBuilder).businessKey("myBusinessKey");
     verify(mockInstantiationBuilder).caseInstanceId("myCaseInstanceId");
     verify(mockInstantiationBuilder).setVariables(argThat(new EqualsMap(expectedParameters)));

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessEngineRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessEngineRestServiceTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -229,7 +228,7 @@ public class ProcessEngineRestServiceTest extends
   private void createProcessDefinitionMock() {
     ProcessDefinition mockDefinition = MockProvider.createMockDefinition();
 
-    when(mockRepoService.getProcessDefinition(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))).thenReturn(mockDefinition);
+    when(mockRepoService.getProcessDefinition(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID)).thenReturn(mockDefinition);
   }
 
 
@@ -267,7 +266,7 @@ public class ProcessEngineRestServiceTest extends
     ProcessInstance mockInstance = MockProvider.createMockInstance();
 
     ProcessInstanceQuery mockInstanceQuery = mock(ProcessInstanceQuery.class);
-    when(mockInstanceQuery.processInstanceId(eq(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))).thenReturn(mockInstanceQuery);
+    when(mockInstanceQuery.processInstanceId(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID)).thenReturn(mockInstanceQuery);
     when(mockInstanceQuery.singleResult()).thenReturn(mockInstance);
     when(mockRuntimeService.createProcessInstanceQuery()).thenReturn(mockInstanceQuery);
   }
@@ -276,7 +275,7 @@ public class ProcessEngineRestServiceTest extends
     Execution mockExecution = MockProvider.createMockExecution();
 
     ExecutionQuery mockExecutionQuery = mock(ExecutionQuery.class);
-    when(mockExecutionQuery.processInstanceId(eq(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID))).thenReturn(mockExecutionQuery);
+    when(mockExecutionQuery.processInstanceId(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID)).thenReturn(mockExecutionQuery);
     when(mockExecutionQuery.singleResult()).thenReturn(mockExecution);
     when(mockRuntimeService.createExecutionQuery()).thenReturn(mockExecutionQuery);
   }
@@ -285,7 +284,7 @@ public class ProcessEngineRestServiceTest extends
     Task mockTask = MockProvider.createMockTask();
 
     TaskQuery mockTaskQuery = mock(TaskQuery.class);
-    when(mockTaskQuery.taskId(eq(MockProvider.EXAMPLE_TASK_ID))).thenReturn(mockTaskQuery);
+    when(mockTaskQuery.taskId(MockProvider.EXAMPLE_TASK_ID)).thenReturn(mockTaskQuery);
     when(mockTaskQuery.initializeFormKeys()).thenReturn(mockTaskQuery);
     when(mockTaskQuery.singleResult()).thenReturn(mockTask);
     when(mockTaskService.createTaskQuery()).thenReturn(mockTaskQuery);
@@ -485,7 +484,7 @@ public class ProcessEngineRestServiceTest extends
       .statusCode(Status.OK.getStatusCode())
     .when().get(PROCESS_DEFINITION_URL);
 
-    verify(mockRepoService).getProcessDefinition(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
+    verify(mockRepoService).getProcessDefinition(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
     verifyNoInteractions(processEngine);
   }
 
@@ -536,7 +535,7 @@ public class ProcessEngineRestServiceTest extends
       .then().expect().statusCode(Status.NO_CONTENT.getStatusCode())
       .when().post(MESSAGE_URL);
 
-    verify(mockRuntimeService).createMessageCorrelation(eq(messageName));
+    verify(mockRuntimeService).createMessageCorrelation(messageName);
     verify(mockMessageCorrelationBuilder).correlateWithResult();
     verifyNoMoreInteractions(mockMessageCorrelationBuilder);
     verifyNoInteractions(processEngine);
@@ -553,7 +552,7 @@ public class ProcessEngineRestServiceTest extends
       .then().expect().contentType(ContentType.JSON).statusCode(Status.OK.getStatusCode())
       .when().post(MESSAGE_URL);
 
-    verify(mockRuntimeService).createMessageCorrelation(eq(messageName));
+    verify(mockRuntimeService).createMessageCorrelation(messageName);
     verify(mockMessageCorrelationBuilder).correlateWithResult();
     verifyNoMoreInteractions(mockMessageCorrelationBuilder);
     verifyNoInteractions(processEngine);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
@@ -235,7 +235,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
 
     historicProcessInstanceQueryMock = mock(HistoricProcessInstanceQuery.class);
     when(historyServiceMock.createHistoricProcessInstanceQuery()).thenReturn(historicProcessInstanceQueryMock);
-    when(historicProcessInstanceQueryMock.processInstanceId(eq(EXAMPLE_PROCESS_INSTANCE_ID))).thenReturn(historicProcessInstanceQueryMock);
+    when(historicProcessInstanceQueryMock.processInstanceId(EXAMPLE_PROCESS_INSTANCE_ID)).thenReturn(historicProcessInstanceQueryMock);
     HistoricProcessInstance historicProcessInstanceMock = createMockHistoricProcessInstance();
     when(historicProcessInstanceQueryMock.singleResult()).thenReturn(historicProcessInstanceMock);
 
@@ -930,7 +930,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
     mockHistoryFull();
     historicProcessInstanceQueryMock = mock(HistoricProcessInstanceQuery.class);
     when(historyServiceMock.createHistoricProcessInstanceQuery()).thenReturn(historicProcessInstanceQueryMock);
-    when(historicProcessInstanceQueryMock.processInstanceId(eq(NON_EXISTING_ID))).thenReturn(
+    when(historicProcessInstanceQueryMock.processInstanceId(NON_EXISTING_ID)).thenReturn(
         historicProcessInstanceQueryMock);
     when(historicProcessInstanceQueryMock.singleResult()).thenReturn(null);
 
@@ -1008,7 +1008,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
     mockHistoryFull();
     historicProcessInstanceQueryMock = mock(HistoricProcessInstanceQuery.class);
     when(historyServiceMock.createHistoricProcessInstanceQuery()).thenReturn(historicProcessInstanceQueryMock);
-    when(historicProcessInstanceQueryMock.processInstanceId(eq(NON_EXISTING_ID))).thenReturn(
+    when(historicProcessInstanceQueryMock.processInstanceId(NON_EXISTING_ID)).thenReturn(
         historicProcessInstanceQueryMock);
     when(historicProcessInstanceQueryMock.singleResult()).thenReturn(null);
 
@@ -1134,7 +1134,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
     mockHistoryFull();
     historicProcessInstanceQueryMock = mock(HistoricProcessInstanceQuery.class);
     when(historyServiceMock.createHistoricProcessInstanceQuery()).thenReturn(historicProcessInstanceQueryMock);
-    when(historicProcessInstanceQueryMock.processInstanceId(eq(NON_EXISTING_ID))).thenReturn(
+    when(historicProcessInstanceQueryMock.processInstanceId(NON_EXISTING_ID)).thenReturn(
         historicProcessInstanceQueryMock);
     when(historicProcessInstanceQueryMock.singleResult()).thenReturn(null);
 
@@ -1188,7 +1188,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
     String mimeType = "text/plain";
     FileValue variableValue = Variables.fileValue(filename).file(byteContent).mimeType(mimeType).create();
 
-    when(runtimeServiceMock.getVariableTyped(eq(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID), eq(variableKey), eq(true)))
+    when(runtimeServiceMock.getVariableTyped(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID, variableKey, true))
     .thenReturn(variableValue);
 
     given()
@@ -1738,7 +1738,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
     String variableKey = "aVariableKey";
     int variableValue = 123;
 
-    when(runtimeServiceMock.getVariableTyped(eq(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID), eq(variableKey), eq(true)))
+    when(runtimeServiceMock.getVariableTyped(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID, variableKey, true))
       .thenReturn(Variables.integerValue(variableValue));
 
     given().pathParam("id", MockProvider.EXAMPLE_PROCESS_INSTANCE_ID).pathParam("varId", variableKey)
@@ -1897,7 +1897,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
   public void testGetVariableForNonExistingInstance() {
     String variableKey = "aVariableKey";
 
-    when(runtimeServiceMock.getVariableTyped(eq(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID), eq(variableKey), eq(true)))
+    when(runtimeServiceMock.getVariableTyped(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID, variableKey, true))
       .thenThrow(new ProcessEngineException("expected exception"));
 
     given().pathParam("id", MockProvider.EXAMPLE_PROCESS_INSTANCE_ID).pathParam("varId", variableKey)
@@ -2293,8 +2293,8 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
     .when()
       .post(SINGLE_PROCESS_INSTANCE_BINARY_VARIABLE_URL);
 
-    verify(runtimeServiceMock, never()).setVariable(eq(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID), eq(variableKey),
-        eq(serializable));
+    verify(runtimeServiceMock, never()).setVariable(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID, variableKey,
+        serializable);
   }
 
   @Test
@@ -2522,7 +2522,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
       .then().expect().statusCode(Status.NO_CONTENT.getStatusCode())
       .when().delete(SINGLE_PROCESS_INSTANCE_VARIABLE_URL);
 
-    verify(runtimeServiceMock).removeVariable(eq(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID), eq(variableKey));
+    verify(runtimeServiceMock).removeVariable(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID, variableKey);
   }
 
   @Test
@@ -2530,7 +2530,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
     String variableKey = "aVariableKey";
 
     doThrow(new ProcessEngineException("expected exception"))
-      .when(runtimeServiceMock).removeVariable(eq(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID), eq(variableKey));
+      .when(runtimeServiceMock).removeVariable(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID, variableKey);
 
     given().pathParam("id", MockProvider.EXAMPLE_PROCESS_INSTANCE_ID).pathParam("varId", variableKey)
       .then().expect().statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())
@@ -3475,7 +3475,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
       .when()
         .post(PROCESS_INSTANCE_MODIFICATION_URL);
 
-    verify(runtimeServiceMock).createProcessInstanceModification(eq(EXAMPLE_PROCESS_INSTANCE_ID));
+    verify(runtimeServiceMock).createProcessInstanceModification(EXAMPLE_PROCESS_INSTANCE_ID);
 
     InOrder inOrder = inOrder(mockModificationBuilder);
     inOrder.verify(mockModificationBuilder).cancelAllForActivity("activityId");
@@ -3531,7 +3531,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
       .when()
         .post(PROCESS_INSTANCE_MODIFICATION_URL);
 
-    verify(runtimeServiceMock).createProcessInstanceModification(eq(EXAMPLE_PROCESS_INSTANCE_ID));
+    verify(runtimeServiceMock).createProcessInstanceModification(EXAMPLE_PROCESS_INSTANCE_ID);
 
     InOrder inOrder = inOrder(mockModificationBuilder);
     inOrder.verify(mockModificationBuilder).startBeforeActivity("activityId");
@@ -3712,7 +3712,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
       .when()
         .post(PROCESS_INSTANCE_MODIFICATION_URL);
 
-    verify(runtimeServiceMock).createProcessInstanceModification(eq(EXAMPLE_PROCESS_INSTANCE_ID));
+    verify(runtimeServiceMock).createProcessInstanceModification(EXAMPLE_PROCESS_INSTANCE_ID);
 
     InOrder inOrder = inOrder(mockModificationBuilder);
     inOrder.verify(mockModificationBuilder).startBeforeActivity("activityId");
@@ -3742,7 +3742,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
 
     verifyBatchJson(response.asString());
 
-    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_JOB_RETRIES));
+    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_JOB_RETRIES);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceIds(Arrays.asList(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID));
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceQuery(null);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).executeAsync();
@@ -3769,10 +3769,10 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
 
     verifyBatchJson(response.asString());
 
-    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_JOB_RETRIES));
+    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_JOB_RETRIES);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceIds(Arrays.asList(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID));
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceQuery(null);
-    verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).dueDate(eq(newDueDate));
+    verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).dueDate(newDueDate);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).executeAsync();
     verifyNoMoreInteractions(mockSetJobRetriesByProcessAsyncBuilder);
   }
@@ -3796,7 +3796,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
 
     verifyBatchJson(response.asString());
 
-    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_JOB_RETRIES));
+    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_JOB_RETRIES);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceIds(Arrays.asList(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID));
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceQuery(null);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).dueDate(null);
@@ -3822,7 +3822,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
 
     verifyBatchJson(response.asString());
 
-    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_JOB_RETRIES));
+    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_JOB_RETRIES);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceIds(null);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceQuery(any(ProcessInstanceQuery.class));
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).dueDate(newDueDate);
@@ -3848,7 +3848,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
 
     verifyBatchJson(response.asString());
 
-    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_JOB_RETRIES));
+    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_JOB_RETRIES);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceIds(null);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceQuery(any(ProcessInstanceQuery.class));
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).executeAsync();
@@ -3869,7 +3869,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
         .statusCode(Status.BAD_REQUEST.getStatusCode())
         .when().post(SET_JOB_RETRIES_ASYNC_URL);
 
-    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_JOB_RETRIES));
+    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_JOB_RETRIES);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceIds(null);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceQuery(null);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).executeAsync();
@@ -3892,7 +3892,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
   @Test
   public void testSetRetriesByProcessWithNegativeRetries() {
     doThrow(new BadUserRequestException("retries are negative"))
-        .when(mockManagementService).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_NEGATIVE_JOB_RETRIES));
+        .when(mockManagementService).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_NEGATIVE_JOB_RETRIES);
 
     Map<String, Object> messageBodyJson = new HashMap<>();
     messageBodyJson.put(RETRIES, MockProvider.EXAMPLE_NEGATIVE_JOB_RETRIES);
@@ -3907,7 +3907,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
     .when()
       .post(SET_JOB_RETRIES_ASYNC_URL);
 
-    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_NEGATIVE_JOB_RETRIES));
+    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_NEGATIVE_JOB_RETRIES);
     verifyNoMoreInteractions(mockSetJobRetriesByProcessAsyncBuilder);
   }
 
@@ -3931,7 +3931,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
 
     verifyBatchJson(response.asString());
 
-    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_JOB_RETRIES));
+    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_JOB_RETRIES);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceIds(null);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).historicProcessInstanceQuery(any());
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).executeAsync();
@@ -3961,7 +3961,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
 
     verifyBatchJson(response.asString());
 
-    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_JOB_RETRIES));
+    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_JOB_RETRIES);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceIds(null);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).historicProcessInstanceQuery(any());
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).dueDate(newDueDate);
@@ -3991,7 +3991,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
 
     verifyBatchJson(response.asString());
 
-    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_JOB_RETRIES));
+    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_JOB_RETRIES);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceIds(null);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).historicProcessInstanceQuery(any());
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).dueDate(null);
@@ -4011,7 +4011,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
       .statusCode(Status.OK.getStatusCode())
     .when().post(SET_JOB_RETRIES_ASYNC_HIST_QUERY_URL);
 
-    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_JOB_RETRIES));
+    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_JOB_RETRIES);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceIds(Arrays.asList(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID));
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).historicProcessInstanceQuery(null);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).executeAsync();
@@ -4033,7 +4033,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
     .when()
       .post(SET_JOB_RETRIES_ASYNC_HIST_QUERY_URL);
 
-    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_JOB_RETRIES));
+    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_JOB_RETRIES);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceIds(Arrays.asList(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID));
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).historicProcessInstanceQuery(null);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).dueDate(newDueDate);
@@ -4059,7 +4059,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
       .statusCode(Status.OK.getStatusCode())
     .when().post(SET_JOB_RETRIES_ASYNC_HIST_QUERY_URL);
 
-    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_JOB_RETRIES));
+    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_JOB_RETRIES);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceIds(Arrays.asList(MockProvider.ANOTHER_EXAMPLE_PROCESS_INSTANCE_ID));
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).historicProcessInstanceQuery(any());
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).executeAsync();
@@ -4080,7 +4080,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
       .statusCode(Status.BAD_REQUEST.getStatusCode())
     .when().post(SET_JOB_RETRIES_ASYNC_HIST_QUERY_URL);
 
-    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_JOB_RETRIES));
+    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_JOB_RETRIES);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).processInstanceIds(null);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).historicProcessInstanceQuery(null);
     verify(mockSetJobRetriesByProcessAsyncBuilder, times(1)).executeAsync();
@@ -4090,7 +4090,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
   @Test
   public void testSetRetriesByProcessAsyncHistoricQueryBasedWithNegativeRetries() {
     doThrow(new BadUserRequestException("retries are negative"))
-      .when(mockManagementService).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_NEGATIVE_JOB_RETRIES));
+      .when(mockManagementService).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_NEGATIVE_JOB_RETRIES);
 
     HistoricProcessInstanceQuery mockedHistoricProcessInstanceQuery = mock(HistoricProcessInstanceQuery.class);
     when(historyServiceMock.createHistoricProcessInstanceQuery()).thenReturn(mockedHistoricProcessInstanceQuery);
@@ -4107,7 +4107,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
       .statusCode(Status.BAD_REQUEST.getStatusCode())
     .when().post(SET_JOB_RETRIES_ASYNC_HIST_QUERY_URL);
 
-    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(eq(MockProvider.EXAMPLE_NEGATIVE_JOB_RETRIES));
+    verify(mockManagementService, times(1)).setJobRetriesByProcessAsync(MockProvider.EXAMPLE_NEGATIVE_JOB_RETRIES);
     verifyNoMoreInteractions(mockSetJobRetriesByProcessAsyncBuilder);
   }
 
@@ -4149,7 +4149,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
       .when()
         .post(PROCESS_INSTANCE_MODIFICATION_ASYNC_URL);
 
-    verify(runtimeServiceMock).createProcessInstanceModification(eq(EXAMPLE_PROCESS_INSTANCE_ID));
+    verify(runtimeServiceMock).createProcessInstanceModification(EXAMPLE_PROCESS_INSTANCE_ID);
 
     InOrder inOrder = inOrder(mockModificationBuilder);
     inOrder.verify(mockModificationBuilder).cancelAllForActivity("activityId");
@@ -4323,7 +4323,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
       .when()
         .post(PROCESS_INSTANCE_MODIFICATION_ASYNC_URL);
 
-    verify(runtimeServiceMock).createProcessInstanceModification(eq(EXAMPLE_PROCESS_INSTANCE_ID));
+    verify(runtimeServiceMock).createProcessInstanceModification(EXAMPLE_PROCESS_INSTANCE_ID);
 
     InOrder inOrder = inOrder(mockModificationBuilder);
     inOrder.verify(mockModificationBuilder).cancelAllForActivity("activityId");
@@ -4553,11 +4553,10 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
         .processDefinitionId("foo");
 
     verify(runtimeServiceMock).setVariablesAsync(
-        eq(null),
-        eq(mockedProcessInstanceQuery),
-        eq(null),
-        eq(null)
-    );
+        null,
+        mockedProcessInstanceQuery,
+        null,
+        null);
 
     verifyBatchJson(response.asString());
   }
@@ -4595,11 +4594,10 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
         .processDefinitionId("foo");
 
     verify(runtimeServiceMock).setVariablesAsync(
-        eq(null),
-        eq(null),
-        eq(mockedHistoricProcessInstanceQuery),
-        eq(null)
-    );
+        null,
+        null,
+        mockedHistoricProcessInstanceQuery,
+        null);
 
     verifyBatchJson(response.asString());
   }
@@ -4627,11 +4625,10 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
 
     // then
     verify(runtimeServiceMock).setVariablesAsync(
-        eq(processInstanceIds),
-        eq(null),
-        eq(null),
-        eq(null)
-    );
+        processInstanceIds,
+        null,
+        null,
+        null);
 
     verifyBatchJson(response.asString());
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceInteractionTest.java
@@ -266,7 +266,7 @@ public class TaskRestServiceInteractionTest extends
     when(processEngine.getHistoryService()).thenReturn(historyServiceMock);
     historicTaskInstanceQueryMock = mock(HistoricTaskInstanceQuery.class);
     when(historyServiceMock.createHistoricTaskInstanceQuery()).thenReturn(historicTaskInstanceQueryMock);
-    when(historicTaskInstanceQueryMock.taskId(eq(EXAMPLE_TASK_ID))).thenReturn(historicTaskInstanceQueryMock);
+    when(historicTaskInstanceQueryMock.taskId(EXAMPLE_TASK_ID)).thenReturn(historicTaskInstanceQueryMock);
     HistoricTaskInstance historicTaskInstanceMock = createMockHistoricTaskInstance();
     when(historicTaskInstanceQueryMock.singleResult()).thenReturn(historicTaskInstanceMock);
 
@@ -358,9 +358,9 @@ public class TaskRestServiceInteractionTest extends
       MockProvider.mockUser().id(EXAMPLE_TASK_OWNER).build()
     );
     UserQuery sampleUserQuery = mock(UserQuery.class);
-    when(sampleUserQuery.userIdIn(eq(EXAMPLE_TASK_ASSIGNEE_NAME), eq(EXAMPLE_TASK_OWNER))).thenReturn(sampleUserQuery);
-    when(sampleUserQuery.userIdIn(eq(EXAMPLE_TASK_OWNER), eq(EXAMPLE_TASK_ASSIGNEE_NAME))).thenReturn(sampleUserQuery);
-    when(sampleUserQuery.listPage(eq(0), eq(2))).thenReturn(mockUsers);
+    when(sampleUserQuery.userIdIn(EXAMPLE_TASK_ASSIGNEE_NAME, EXAMPLE_TASK_OWNER)).thenReturn(sampleUserQuery);
+    when(sampleUserQuery.userIdIn(EXAMPLE_TASK_OWNER, EXAMPLE_TASK_ASSIGNEE_NAME)).thenReturn(sampleUserQuery);
+    when(sampleUserQuery.listPage(0, 2)).thenReturn(mockUsers);
     when(sampleUserQuery.count()).thenReturn((long) mockUsers.size());
     when(processEngine.getIdentityService().createUserQuery()).thenReturn(sampleUserQuery);
 
@@ -370,9 +370,9 @@ public class TaskRestServiceInteractionTest extends
       MockProvider.mockGroup().id(mockCandidateGroup2IdentityLink.getGroupId()).build()
     );
     GroupQuery sampleGroupQuery = mock(GroupQuery.class);
-    when(sampleGroupQuery.groupIdIn(eq(EXAMPLE_GROUP_ID), eq(EXAMPLE_GROUP_ID2))).thenReturn(sampleGroupQuery);
-    when(sampleGroupQuery.groupIdIn(eq(EXAMPLE_GROUP_ID2), eq(EXAMPLE_GROUP_ID))).thenReturn(sampleGroupQuery);
-    when(sampleGroupQuery.listPage(eq(0), eq(2))).thenReturn(mockGroups);
+    when(sampleGroupQuery.groupIdIn(EXAMPLE_GROUP_ID, EXAMPLE_GROUP_ID2)).thenReturn(sampleGroupQuery);
+    when(sampleGroupQuery.groupIdIn(EXAMPLE_GROUP_ID2, EXAMPLE_GROUP_ID)).thenReturn(sampleGroupQuery);
+    when(sampleGroupQuery.listPage(0, 2)).thenReturn(mockGroups);
     when(sampleGroupQuery.count()).thenReturn((long) mockGroups.size());
     when(processEngine.getIdentityService().createGroupQuery()).thenReturn(sampleGroupQuery);
 
@@ -2390,7 +2390,7 @@ public class TaskRestServiceInteractionTest extends
 
   @Test
   public void testAddCommentToNonExistingTask() {
-    when(historicTaskInstanceQueryMock.taskId(eq(NON_EXISTING_ID))).thenReturn(historicTaskInstanceQueryMock);
+    when(historicTaskInstanceQueryMock.taskId(NON_EXISTING_ID)).thenReturn(historicTaskInstanceQueryMock);
     when(historicTaskInstanceQueryMock.singleResult()).thenReturn(null);
 
     Map<String, Object> json = new HashMap<>();
@@ -2644,7 +2644,7 @@ public class TaskRestServiceInteractionTest extends
 
   @Test
   public void testCreateTaskAttachmentWithContentToNonExistingTask() {
-    when(historicTaskInstanceQueryMock.taskId(eq(NON_EXISTING_ID))).thenReturn(historicTaskInstanceQueryMock);
+    when(historicTaskInstanceQueryMock.taskId(NON_EXISTING_ID)).thenReturn(historicTaskInstanceQueryMock);
     when(historicTaskInstanceQueryMock.singleResult()).thenReturn(null);
 
     given()
@@ -2699,7 +2699,7 @@ public class TaskRestServiceInteractionTest extends
 
   @Test
   public void testCreateTaskAttachmentWithUrlToNonExistingTask() {
-    when(historicTaskInstanceQueryMock.taskId(eq(NON_EXISTING_ID))).thenReturn(historicTaskInstanceQueryMock);
+    when(historicTaskInstanceQueryMock.taskId(NON_EXISTING_ID)).thenReturn(historicTaskInstanceQueryMock);
     when(historicTaskInstanceQueryMock.singleResult()).thenReturn(null);
 
     given()

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
@@ -58,7 +58,6 @@ import static io.restassured.path.json.JsonPath.from;
 import static junit.framework.TestCase.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.operaton.bpm.engine.rest.util.DateTimeUtils.withTimezone;

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableLocalRestResourceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableLocalRestResourceInteractionTest.java
@@ -421,7 +421,7 @@ public class TaskVariableLocalRestResourceInteractionTest extends
   public void testNonExistingLocalVariable() {
     String variableKey = "aVariableKey";
 
-    when(taskServiceMock.getVariableLocal(eq(EXAMPLE_TASK_ID), eq(variableKey))).thenReturn(null);
+    when(taskServiceMock.getVariableLocal(EXAMPLE_TASK_ID, variableKey)).thenReturn(null);
 
     given().pathParam("id", EXAMPLE_TASK_ID).pathParam("varId", variableKey)
       .header("accept", MediaType.APPLICATION_JSON)
@@ -1003,8 +1003,8 @@ public class TaskVariableLocalRestResourceInteractionTest extends
     .when()
       .post(SINGLE_TASK_SINGLE_BINARY_VARIABLE_URL);
 
-    verify(taskServiceMock, never()).setVariableLocal(eq(EXAMPLE_TASK_ID), eq(variableKey),
-        eq(serializable));
+    verify(taskServiceMock, never()).setVariableLocal(EXAMPLE_TASK_ID, variableKey,
+        serializable);
   }
 
   @Test
@@ -1183,7 +1183,7 @@ public class TaskVariableLocalRestResourceInteractionTest extends
       .then().expect().statusCode(Status.NO_CONTENT.getStatusCode())
       .when().delete(SINGLE_TASK_DELETE_SINGLE_VARIABLE_URL);
 
-    verify(taskServiceMock).removeVariableLocal(eq(EXAMPLE_TASK_ID), eq(variableKey));
+    verify(taskServiceMock).removeVariableLocal(EXAMPLE_TASK_ID, variableKey);
   }
 
   @Test
@@ -1191,7 +1191,7 @@ public class TaskVariableLocalRestResourceInteractionTest extends
     String variableKey = "aVariableKey";
 
     doThrow(new ProcessEngineException("Cannot find task with id " + NON_EXISTING_ID))
-      .when(taskServiceMock).removeVariableLocal(eq(NON_EXISTING_ID), eq(variableKey));
+      .when(taskServiceMock).removeVariableLocal(NON_EXISTING_ID, variableKey);
 
     given().pathParam("id", NON_EXISTING_ID).pathParam("varId", variableKey)
       .header("accept", MediaType.APPLICATION_JSON)

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableRestResourceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskVariableRestResourceInteractionTest.java
@@ -445,7 +445,7 @@ public class TaskVariableRestResourceInteractionTest extends
   public void testNonExistingVariable() {
     String variableKey = "aVariableKey";
 
-    when(taskServiceMock.getVariable(eq(EXAMPLE_TASK_ID), eq(variableKey))).thenReturn(null);
+    when(taskServiceMock.getVariable(EXAMPLE_TASK_ID, variableKey)).thenReturn(null);
 
     given().pathParam("id", EXAMPLE_TASK_ID).pathParam("varId", variableKey)
       .header("accept", MediaType.APPLICATION_JSON)
@@ -1028,8 +1028,8 @@ public class TaskVariableRestResourceInteractionTest extends
     .when()
       .post(SINGLE_TASK_SINGLE_BINARY_VARIABLE_URL);
 
-    verify(taskServiceMock, never()).setVariable(eq(EXAMPLE_TASK_ID), eq(variableKey),
-        eq(serializable));
+    verify(taskServiceMock, never()).setVariable(EXAMPLE_TASK_ID, variableKey,
+        serializable);
   }
 
   @Test
@@ -1208,7 +1208,7 @@ public class TaskVariableRestResourceInteractionTest extends
       .then().expect().statusCode(Status.NO_CONTENT.getStatusCode())
       .when().delete(SINGLE_TASK_DELETE_SINGLE_VARIABLE_URL);
 
-    verify(taskServiceMock).removeVariable(eq(EXAMPLE_TASK_ID), eq(variableKey));
+    verify(taskServiceMock).removeVariable(EXAMPLE_TASK_ID, variableKey);
   }
 
   @Test
@@ -1216,7 +1216,7 @@ public class TaskVariableRestResourceInteractionTest extends
     String variableKey = "aVariableKey";
 
     doThrow(new ProcessEngineException("Cannot find task with id " + NON_EXISTING_ID))
-      .when(taskServiceMock).removeVariable(eq(NON_EXISTING_ID), eq(variableKey));
+      .when(taskServiceMock).removeVariable(NON_EXISTING_ID, variableKey);
 
     given().pathParam("id", NON_EXISTING_ID).pathParam("varId", variableKey)
       .header("accept", MediaType.APPLICATION_JSON)

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricActivityStatisticsRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricActivityStatisticsRestServiceQueryTest.java
@@ -22,7 +22,6 @@ import static org.operaton.bpm.engine.rest.util.DateTimeUtils.DATE_FORMAT_WITH_T
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -74,7 +73,7 @@ public class HistoricActivityStatisticsRestServiceQueryTest extends AbstractRest
     List<HistoricActivityStatistics> mocks = MockProvider.createMockHistoricActivityStatistics();
 
     historicActivityStatisticsQuery = mock(HistoricActivityStatisticsQueryImpl.class);
-    when(processEngine.getHistoryService().createHistoricActivityStatisticsQuery(eq(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID))).thenReturn(historicActivityStatisticsQuery);
+    when(processEngine.getHistoryService().createHistoricActivityStatisticsQuery(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID)).thenReturn(historicActivityStatisticsQuery);
     when(historicActivityStatisticsQuery.unlimitedList()).thenReturn(mocks);
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricBatchRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricBatchRestServiceInteractionTest.java
@@ -22,7 +22,6 @@ import static org.operaton.bpm.engine.rest.util.JsonPathUtil.from;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
@@ -78,7 +77,7 @@ public class HistoricBatchRestServiceInteractionTest extends AbstractRestService
     HistoricBatch historicBatchMock = MockProvider.createMockHistoricBatch();
 
     queryMock = mock(HistoricBatchQuery.class);
-    when(queryMock.batchId(eq(MockProvider.EXAMPLE_BATCH_ID))).thenReturn(queryMock);
+    when(queryMock.batchId(MockProvider.EXAMPLE_BATCH_ID)).thenReturn(queryMock);
     when(queryMock.singleResult()).thenReturn(historicBatchMock);
 
     historyServiceMock = mock(HistoryService.class);
@@ -131,7 +130,7 @@ public class HistoricBatchRestServiceInteractionTest extends AbstractRestService
     .when()
       .delete(HISTORIC_SINGLE_BATCH_RESOURCE_URL);
 
-    verify(historyServiceMock).deleteHistoricBatch(eq(MockProvider.EXAMPLE_BATCH_ID));
+    verify(historyServiceMock).deleteHistoricBatch(MockProvider.EXAMPLE_BATCH_ID);
     verifyNoMoreInteractions(historyServiceMock);
   }
 
@@ -140,7 +139,7 @@ public class HistoricBatchRestServiceInteractionTest extends AbstractRestService
     String nonExistingId = MockProvider.NON_EXISTING_ID;
 
     doThrow(new BadUserRequestException("Historic batch for id '" + nonExistingId + "' cannot be found"))
-      .when(historyServiceMock).deleteHistoricBatch(eq(nonExistingId));
+      .when(historyServiceMock).deleteHistoricBatch(nonExistingId);
 
     given()
       .pathParam("id", nonExistingId)

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricCaseActivityStatisticsRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricCaseActivityStatisticsRestServiceQueryTest.java
@@ -20,7 +20,6 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -60,7 +59,7 @@ public class HistoricCaseActivityStatisticsRestServiceQueryTest extends Abstract
     List<HistoricCaseActivityStatistics> mocks = MockProvider.createMockHistoricCaseActivityStatistics();
 
     historicCaseActivityStatisticsQuery = mock(HistoricCaseActivityStatisticsQueryImpl.class);
-    when(processEngine.getHistoryService().createHistoricCaseActivityStatisticsQuery(eq(MockProvider.EXAMPLE_CASE_DEFINITION_ID))).thenReturn(historicCaseActivityStatisticsQuery);
+    when(processEngine.getHistoryService().createHistoricCaseActivityStatisticsQuery(MockProvider.EXAMPLE_CASE_DEFINITION_ID)).thenReturn(historicCaseActivityStatisticsQuery);
     when(historicCaseActivityStatisticsQuery.unlimitedList()).thenReturn(mocks);
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDecisionInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDecisionInstanceRestServiceInteractionTest.java
@@ -321,7 +321,7 @@ public class HistoricDecisionInstanceRestServiceInteractionTest extends Abstract
 
     verifyBatchJson(response.asString());
 
-    verify(historyServiceMock, times(1)).deleteHistoricDecisionInstancesAsync(eq(ids), eq((HistoricDecisionInstanceQuery) null), eq("a-delete-reason"));
+    verify(historyServiceMock, times(1)).deleteHistoricDecisionInstancesAsync(ids, (HistoricDecisionInstanceQuery) null, "a-delete-reason");
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDecisionStatisticsRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDecisionStatisticsRestServiceQueryTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -68,7 +67,7 @@ public class HistoricDecisionStatisticsRestServiceQueryTest extends AbstractRest
     historicDecisionInstanceStatisticsQuery =
         mock(HistoricDecisionInstanceStatisticsQueryImpl.class);
     when(processEngine.getHistoryService()
-        .createHistoricDecisionInstanceStatisticsQuery(eq(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID)))
+        .createHistoricDecisionInstanceStatisticsQuery(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID))
     .thenReturn(historicDecisionInstanceStatisticsQuery);
 
     when(historicDecisionInstanceStatisticsQuery.decisionInstanceId(MockProvider.EXAMPLE_DECISION_INSTANCE_ID)).thenReturn(historicDecisionInstanceStatisticsQuery);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceInteractionTest.java
@@ -223,7 +223,7 @@ public class HistoricProcessInstanceRestServiceInteractionTest extends AbstractR
     verifyBatchJson(response.asString());
 
     verify(historyServiceMock, times(1)).deleteHistoricProcessInstancesAsync(
-        eq(ids), eq((HistoricProcessInstanceQuery) null), eq(TEST_DELETE_REASON));
+        ids, (HistoricProcessInstanceQuery) null, TEST_DELETE_REASON);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockRestServiceInteractionTest.java
@@ -39,7 +39,6 @@ import io.restassured.http.ContentType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.servlet.ServletContextEvent;
 import javax.ws.rs.core.Response.Status;
 import org.operaton.bpm.engine.ExternalTaskService;

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/impl/FetchAndLockRestServiceInteractionTest.java
@@ -124,10 +124,10 @@ public class FetchAndLockRestServiceInteractionTest extends AbstractRestServiceT
     when(processEngine.getIdentityService()).thenReturn(identityServiceMock);
 
     List<Group> groupMocks = MockProvider.createMockGroups();
-    groupIds = groupMocks.stream().map(Group::getId).collect(Collectors.toList());
+    groupIds = groupMocks.stream().map(Group::getId).toList();
 
     List<Tenant> tenantMocks = Collections.singletonList(MockProvider.createMockTenant());
-    tenantIds = tenantMocks.stream().map(Tenant::getId).collect(Collectors.toList());
+    tenantIds = tenantMocks.stream().map(Tenant::getId).toList();
 
     new FetchAndLockContextListener().contextInitialized(mock(ServletContextEvent.class, RETURNS_DEEP_STUBS));
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/mapper/Java8DateTimeTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/mapper/Java8DateTimeTest.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.rest.mapper;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -50,7 +49,7 @@ public class Java8DateTimeTest extends AbstractRestServiceTest {
   public void setUpRuntimeData() {
     runtimeServiceMock = mock(RuntimeServiceImpl.class);
 
-    when(runtimeServiceMock.getVariableTyped(eq(EXAMPLE_PROCESS_INSTANCE_ID), eq(EXAMPLE_VARIABLE_KEY), eq(true)))
+    when(runtimeServiceMock.getVariableTyped(EXAMPLE_PROCESS_INSTANCE_ID, EXAMPLE_VARIABLE_KEY, true))
       .thenReturn(Variables.objectValue(new Java8DateTimePojo()).create());
 
     when(processEngine.getRuntimeService()).thenReturn(runtimeServiceMock);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -32,7 +32,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.ProcessEngineException;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -466,7 +466,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
     return queryVariableNameToValuesMap.values()
         .stream()
         .flatMap(Set::stream)
-        .collect(Collectors.toList());
+        .toList();
   }
 
   public Map<String, Set<QueryVariableValue>> getQueryVariableNameToValuesMap() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ProcessDefinitionQueryImpl.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.identity.Group;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ProcessDefinitionQueryImpl.java
@@ -600,7 +600,7 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
           .createGroupQuery()
           .groupMember(authorizationUserId)
           .list();
-      cachedCandidateGroups = groups.stream().map(Group::getId).collect(Collectors.toList());
+      cachedCandidateGroups = groups.stream().map(Group::getId).toList();
     }
 
     return cachedCandidateGroups;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -296,7 +296,7 @@ public class BpmnDeployer extends AbstractDefinitionDeployer<ProcessDefinitionEn
     return getEventSubscriptionManager().findStartEventSubscriptionsByConfigurationLike(configurationLike)
         .stream()
         .filter(this::isOrphan)
-        .collect(Collectors.toList());
+        .toList();
   }
 
   protected boolean isOrphan(EventSubscriptionEntity entity) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.operaton.bpm.engine.delegate.Expression;
 import org.operaton.bpm.engine.impl.AbstractDefinitionDeployer;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetIdentityLinksForTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetIdentityLinksForTaskCmd.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl.cmd;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -55,7 +56,7 @@ public class GetIdentityLinksForTaskCmd implements Command<List<IdentityLink>>, 
 
     checkGetIdentityLink(task, commandContext);
 
-    List<IdentityLink> identityLinks = task.getIdentityLinks().stream().collect(Collectors.toList());
+    List<IdentityLink> identityLinks = new ArrayList<>(task.getIdentityLinks());
 
     // assignee is not part of identity links in the db.
     // so if there is one, we add it here.

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetIdentityLinksForTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetIdentityLinksForTaskCmd.java
@@ -21,7 +21,6 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.operaton.bpm.engine.impl.cfg.CommandChecker;
 import org.operaton.bpm.engine.impl.interceptor.Command;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/OperatonScriptEngineManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/OperatonScriptEngineManager.java
@@ -57,7 +57,7 @@ public class OperatonScriptEngineManager extends ScriptEngineManager {
 
     return engineFactories.stream()
         .map(ScriptEngineFactory::getEngineName)
-        .collect(Collectors.toList());
+        .toList();
 
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/OperatonScriptEngineManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/OperatonScriptEngineManager.java
@@ -20,7 +20,6 @@ import javax.script.ScriptEngineFactory;
 import javax.script.ScriptEngineManager;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.operaton.bpm.engine.impl.scripting.engine.ScriptingEngines.GRAAL_JS_SCRIPT_ENGINE_NAME;
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/AbstractAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/AbstractAsyncOperationsTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractAsyncOperationsTest {
   }
 
   protected List<String> getJobIdsByDeployment(List<Job> jobs, String deploymentId) {
-    return jobs.stream().filter(j -> deploymentId.equals(j.getDeploymentId())).map(Job::getId).collect(Collectors.toList());
+    return jobs.stream().filter(j -> deploymentId.equals(j.getDeploymentId())).map(Job::getId).toList();
   }
 
   protected void completeSeedJobs(Batch batch) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/AbstractAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/AbstractAsyncOperationsTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNull;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.operaton.bpm.engine.HistoryService;
 import org.operaton.bpm.engine.ManagementService;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeTest.java
@@ -59,7 +59,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeTest.java
@@ -247,7 +247,7 @@ public class BatchSetRemovalTimeTest {
     List<String> deploymentIds = engineRule.getRepositoryService().createDeploymentQuery()
         .list().stream()
         .map(org.operaton.bpm.engine.repository.Deployment::getId)
-        .collect(Collectors.toList());
+        .toList();
 
     // when
     Batch batch = historyService.setRemovalTimeToHistoricProcessInstances()
@@ -292,7 +292,7 @@ public class BatchSetRemovalTimeTest {
     List<String> deploymentIds = engineRule.getRepositoryService().createDeploymentQuery()
         .list().stream()
         .map(org.operaton.bpm.engine.repository.Deployment::getId)
-        .collect(Collectors.toList());
+        .toList();
 
     // when
     Batch batch = historyService.setRemovalTimeToHistoricDecisionInstances()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
@@ -850,7 +850,8 @@ public class HistoryCleanupRemovalTimeTest {
 
     // when
     runHistoryCleanup();
-    List<String> initialHistoryCleanupJobLog = historyService.createHistoricJobLogQuery().list().stream().map(HistoricJobLog::getId).collect(Collectors.toList());
+    List<String> initialHistoryCleanupJobLog =
+        historyService.createHistoricJobLogQuery().list().stream().map(HistoricJobLog::getId).toList();
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
     runHistoryCleanup();
 
@@ -868,7 +869,8 @@ public class HistoryCleanupRemovalTimeTest {
 
     // when
     runHistoryCleanup();
-    List<String> initialHistoryCleanupJobLog = historyService.createHistoricJobLogQuery().list().stream().map(HistoricJobLog::getId).collect(Collectors.toList());
+    List<String> initialHistoryCleanupJobLog =
+        historyService.createHistoricJobLogQuery().list().stream().map(HistoricJobLog::getId).toList();
     ClockUtil.setCurrentTime(addDays(END_DATE, 5));
     runHistoryCleanup();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
@@ -52,7 +52,6 @@ import static org.operaton.bpm.engine.impl.jobexecutor.historycleanup.HistoryCle
 
 import java.util.*;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.junit.*;
 import org.junit.rules.RuleChain;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceAsyncOperationsTest.java
@@ -575,7 +575,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
   protected List<Job> getAllJobs() {
     return managementService.createJobQuery().list().stream()
         .filter(j -> j.getProcessInstanceId() != null)
-        .collect(Collectors.toList());
+        .toList();
   }
 
   protected List<String> startTestProcesses(int numberOfProcesses) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyJobDefinitionSuspensionStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyJobDefinitionSuspensionStateTest.java
@@ -549,7 +549,7 @@ public class MultiTenancyJobDefinitionSuspensionStateTest {
   }
 
   protected List<String> getDeploymentIds(JobDefinitionQuery jobDefinitionQuery){
-    return jobDefinitionQuery.list().stream().map(this::getDeploymentId).collect(Collectors.toList());
+    return jobDefinitionQuery.list().stream().map(this::getDeploymentId).toList();
   }
 
   protected String getDeploymentId(JobDefinition jobDefinition) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyJobDefinitionSuspensionStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyJobDefinitionSuspensionStateTest.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.After;
 import org.junit.Before;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyProcessDefinitionSuspensionStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyProcessDefinitionSuspensionStateTest.java
@@ -321,7 +321,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
     // when execute the job to suspend the process definitions
     Job job = engineRule.getManagementService().createJobQuery().timers().singleResult();
     assertThat(job).isNotNull();
-    List<String> expectedDeploymentIds = query.active().list().stream().map(ProcessDefinition::getDeploymentId).collect(Collectors.toList());
+    List<String> expectedDeploymentIds = query.active().list().stream().map(ProcessDefinition::getDeploymentId).toList();
     assertThat(expectedDeploymentIds).contains(job.getDeploymentId());
 
     engineRule.getManagementService().executeJob(job.getId());
@@ -409,7 +409,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
     // when execute the job to activate the process definitions
     Job job = engineRule.getManagementService().createJobQuery().timers().singleResult();
     assertThat(job).isNotNull();
-    List<String> expectedDeploymentIds = query.suspended().list().stream().map(ProcessDefinition::getDeploymentId).collect(Collectors.toList());
+    List<String> expectedDeploymentIds = query.suspended().list().stream().map(ProcessDefinition::getDeploymentId).toList();
     assertThat(expectedDeploymentIds).contains(job.getDeploymentId());
 
     engineRule.getManagementService().executeJob(job.getId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyProcessDefinitionSuspensionStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyProcessDefinitionSuspensionStateTest.java
@@ -36,7 +36,6 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.After;
 import org.junit.Before;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
@@ -28,7 +28,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.assertj.core.groups.Tuple;
 import org.junit.After;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
@@ -1373,7 +1373,7 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
     assertThat(mappings.stream()
       .filter(def -> def.getId().startsWith("process:1:"))
       .flatMap(def -> def.getCalledFromActivityIds().stream())
-      .collect(Collectors.toList()))
+      .toList())
       .containsExactlyInAnyOrder("deployment_1", "version_1");
 
     assertThat(mappings).extracting("name", "version", "key","calledFromActivityIds", "versionTag", "callingProcessDefinitionId")
@@ -1404,7 +1404,7 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
         CallableElement spy = Mockito.spy(callableElement);
         ((CallActivityBehavior) activity.getActivityBehavior()).setCallableElement(spy);
         return activity;
-      }).collect(Collectors.toList());
+      }).toList();
 
     //when
     Collection<CalledProcessDefinition> mappings = repositoryService.getStaticCalledProcessDefinitions(processDefinition.getId());
@@ -1457,7 +1457,7 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
     CalledProcessDefinition calledProcessDefinition = new ArrayList<>(calledProcessDefinitions).get(0);
     assertThat(calledProcessDefinition.getKey()).isEqualTo("failingProcess");
     assertThat(
-        calledProcessDefinition.getCalledFromActivityIds().stream().distinct().collect(Collectors.toList())).hasSize(8);
+        calledProcessDefinition.getCalledFromActivityIds().stream().distinct().toList()).hasSize(8);
   }
 
   @Test
@@ -1493,7 +1493,7 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
     assertThat(mappings.stream()
       .filter(def -> def.getId().equals(sameTenantProcessOne))
       .flatMap(def -> def.getCalledFromActivityIds().stream())
-      .collect(Collectors.toList()))
+      .toList())
       .containsExactlyInAnyOrder("null_tenant_reference_same_tenant", "explicit_same_tenant_reference");
 
     assertThat(mappings).extracting("id","calledFromActivityIds", "callingProcessDefinitionId")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -138,7 +138,7 @@ public class ProcessInstanceQueryTest {
     String deploymentId = repositoryService.createDeploymentQuery().singleResult().getId();
     ImmutablePair<String, String>[] expectedMappings = processInstanceIds.stream()
         .map(id -> new ImmutablePair<>(deploymentId, id))
-        .collect(Collectors.toList())
+        .toList()
         .toArray(new ImmutablePair[0]);
     // when
     List<ImmutablePair<String, String>> mappings = engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired().execute((c) -> {
@@ -229,7 +229,7 @@ public class ProcessInstanceQueryTest {
     });
     List<ImmutablePair<String, String>> expectedMappings = relevantIds.stream()
         .map(id -> new ImmutablePair<>(deploymentId, id))
-        .collect(Collectors.toList());
+        .toList();
     // when
     List<ImmutablePair<String, String>> mappings = engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired().execute((c) -> {
       ProcessInstanceQuery query = c.getProcessEngineConfiguration().getRuntimeService().createProcessInstanceQuery()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -38,7 +38,6 @@ import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySo
 
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
@@ -126,7 +126,7 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     assertEquals(1, query.count());
     List<Task> foundTasks = query.list();
     assertEquals(1, foundTasks.size());
-    List<String> foundTaskIds = foundTasks.stream().map(Task::getId).collect(Collectors.toList());
+    List<String> foundTaskIds = foundTasks.stream().map(Task::getId).toList();
     assertThat(foundTaskIds).containsOnly(taskId);
   }
 
@@ -138,7 +138,7 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     assertEquals(2, query.count());
     List<Task> foundTasks = query.list();
     assertEquals(2, foundTasks.size());
-    List<String> foundTaskIds = foundTasks.stream().map(Task::getId).collect(Collectors.toList());
+    List<String> foundTaskIds = foundTasks.stream().map(Task::getId).toList();
     assertThat(foundTaskIds).containsOnly(task0Id, task1Id);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
@@ -49,7 +49,6 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/CustomHistoryEventHandlerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/CustomHistoryEventHandlerTest.java
@@ -161,9 +161,8 @@ public class CustomHistoryEventHandlerTest {
 
     // then
     List<HistoryEvent> historyEvents = recorderHandler.getEvents().stream()
-        .filter(h -> h instanceof HistoricVariableUpdateEventEntity ||
-            h instanceof HistoricProcessInstanceEventEntity)
-        .collect(Collectors.toList());
+        .filter(h -> h instanceof HistoricVariableUpdateEventEntity || h instanceof HistoricProcessInstanceEventEntity)
+        .toList();
 
     assertThat(historyEvents).hasSize(2);
     HistoryEvent processInstanceEvent = historyEvents.get(0);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/CustomHistoryEventHandlerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/CustomHistoryEventHandlerTest.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.operaton.bpm.engine.FormService;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
@@ -54,7 +54,6 @@ import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySo
 import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.time.DateUtils;
 import org.junit.Before;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
@@ -2212,7 +2212,7 @@ public class HistoricProcessInstanceTest {
         .containsExactlyInAnyOrderElementsOf(
             processInstanceList.stream()
                 .map(HistoricProcessInstance::getId)
-                .collect(Collectors.toList()));
+                .toList());
   }
 
   @Test
@@ -2246,7 +2246,7 @@ public class HistoricProcessInstanceTest {
         .containsExactlyInAnyOrderElementsOf(
             processInstanceList.stream()
                 .map(HistoricProcessInstance::getId)
-                .collect(Collectors.toList()));
+                .toList());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/ExclusiveJobAcquisitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/ExclusiveJobAcquisitionTest.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.operaton.bpm.engine.ManagementService;
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.impl.ProcessEngineImpl;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/ExclusiveJobAcquisitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/ExclusiveJobAcquisitionTest.java
@@ -268,7 +268,7 @@ public class ExclusiveJobAcquisitionTest {
 
     return jobs.stream()
         .map(Job::getId)
-        .collect(Collectors.toList());
+        .toList();
   }
 
   /**

--- a/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextMultipleEnginesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextMultipleEnginesTest.java
@@ -84,9 +84,9 @@ public class ProcessDataLoggingContextMultipleEnginesTest {
 
     // then
     List<ILoggingEvent> filteredLog = loggingRule.getLog();
-    List<String> engineNames = filteredLog.stream().map(log -> log.getMDCPropertyMap().get("engineName")).collect(Collectors.toList());
+    List<String> engineNames = filteredLog.stream().map(log -> log.getMDCPropertyMap().get("engineName")).toList();
     assertThat(engineNames).hasSize(filteredLog.size());
-    assertThat(engineNames.stream().distinct().collect(Collectors.toList())).containsExactly("engine1");
+    assertThat(engineNames.stream().distinct().toList()).containsExactly("engine1");
   }
 
   @Test
@@ -101,20 +101,20 @@ public class ProcessDataLoggingContextMultipleEnginesTest {
 
     // then
     List<ILoggingEvent> log = loggingRule.getFilteredLog(LogEngineNameDelegate.LOG_MESSAGE);
-    List<String> engineNames = log.stream().map(l -> l.getMDCPropertyMap().get("engineName")).collect(Collectors.toList());
+    List<String> engineNames = log.stream().map(l -> l.getMDCPropertyMap().get("engineName")).toList();
     // make sure all log entries have access to the engineName MDC property
     assertThat(engineNames).hasSize(log.size());
-    assertThat(engineNames.stream().distinct().collect(Collectors.toList())).containsExactlyInAnyOrder("engine1", "engine2");
+    assertThat(engineNames.stream().distinct().toList()).containsExactlyInAnyOrder("engine1", "engine2");
 
     List<ILoggingEvent> filteredLogEngine1 = loggingRule.getFilteredLog("engine1");
-    List<String> engineNamesEngine1 = filteredLogEngine1.stream().map(l -> l.getMDCPropertyMap().get("engineName")).collect(Collectors.toList());
+    List<String> engineNamesEngine1 = filteredLogEngine1.stream().map(l -> l.getMDCPropertyMap().get("engineName")).toList();
     assertThat(engineNamesEngine1).hasSameSizeAs(filteredLogEngine1);
-    assertThat(engineNamesEngine1.stream().distinct().collect(Collectors.toList())).containsExactly("engine1");
+    assertThat(engineNamesEngine1.stream().distinct().toList()).containsExactly("engine1");
 
     List<ILoggingEvent> filteredLogEngine2 = loggingRule.getFilteredLog("engine2");
-    List<String> engineNamesEngine2 = filteredLogEngine2.stream().map(l -> l.getMDCPropertyMap().get("engineName")).collect(Collectors.toList());
+    List<String> engineNamesEngine2 = filteredLogEngine2.stream().map(l -> l.getMDCPropertyMap().get("engineName")).toList();
     assertThat(engineNamesEngine2).hasSameSizeAs(filteredLogEngine2);
-    assertThat(engineNamesEngine2.stream().distinct().collect(Collectors.toList())).containsExactly("engine2");
+    assertThat(engineNamesEngine2.stream().distinct().toList()).containsExactly("engine2");
   }
 
   private ProcessEngine createProcessEngine(String name) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextMultipleEnginesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextMultipleEnginesTest.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.engine.test.logging;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;

--- a/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/DeleteDeploymentCascadeTest.java
+++ b/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/DeleteDeploymentCascadeTest.java
@@ -31,7 +31,6 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.qa.largedata.util.EngineDataGenerator;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/DeleteDeploymentCascadeTest.java
+++ b/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/DeleteDeploymentCascadeTest.java
@@ -63,7 +63,7 @@ class DeleteDeploymentCascadeTest {
       List<HistoricProcessInstance> processInstances = historyService.createHistoricProcessInstanceQuery()
           .processDefinitionKey(generator.getAutoCompleteProcessKey()).list();
       if (!processInstances.isEmpty()) {
-        List<String> processInstanceIds = processInstances.stream().map(HistoricProcessInstance::getId).collect(Collectors.toList());
+        List<String> processInstanceIds = processInstances.stream().map(HistoricProcessInstance::getId).toList();
         List<List<String>> partitions = CollectionUtil.partition(processInstanceIds, DbSqlSessionFactory.MAXIMUM_NUMBER_PARAMS);
         for (List<String> partition : partitions) {
           historyService.deleteHistoricProcessInstances(partition);

--- a/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/SetJobRetriesAsyncTest.java
+++ b/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/SetJobRetriesAsyncTest.java
@@ -73,7 +73,7 @@ class SetJobRetriesAsyncTest {
         .list();
     List<String> processInstanceIds = processInstances.stream()
         .map(ProcessInstance::getId)
-        .collect(Collectors.toList());
+        .toList();
     int newJobRetriesNumber = 10;
     Batch jobRetriesBatch = managementService
         .setJobRetriesAsync(processInstanceIds, (ProcessInstanceQuery) null, newJobRetriesNumber);

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/deployment/ProcessEngineMultipleDeploymentTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/deployment/ProcessEngineMultipleDeploymentTest.java
@@ -22,7 +22,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.quarkus.test.QuarkusUnitTest;
 import org.operaton.bpm.engine.ProcessEngine;

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/deployment/ProcessEngineMultipleDeploymentTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/deployment/ProcessEngineMultipleDeploymentTest.java
@@ -99,7 +99,7 @@ public class ProcessEngineMultipleDeploymentTest {
 
     List<String> deploymentNames = deployments.stream()
         .map(Deployment::getName)
-        .collect(Collectors.toList());
+        .toList();
     assertThat(deploymentNames).contains("deployment-1", "deployment-2");
   }
 

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/UserTransactionIntegrationTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/UserTransactionIntegrationTest.java
@@ -34,7 +34,7 @@ import jakarta.inject.Named;
 import jakarta.transaction.Status;
 import jakarta.transaction.UserTransaction;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -61,7 +61,7 @@ class UserTransactionIntegrationTest {
       String id = runtimeService.startProcessInstanceByKey("testTxSuccess").getId();
 
       // assert that the transaction is in good shape:
-      assertEquals(Status.STATUS_ACTIVE, userTransactionManager.getStatus());
+      assertThat(userTransactionManager.getStatus()).isEqualTo(Status.STATUS_ACTIVE);
 
       // the process instance is visible form our tx:
       ProcessInstance processInstance = runtimeService.createProcessInstanceQuery()
@@ -111,7 +111,7 @@ class UserTransactionIntegrationTest {
       }
 
       // assert that now our transaction is marked rollback-only:
-      assertEquals(Status.STATUS_MARKED_ROLLBACK, userTransactionManager.getStatus());
+      assertThat(userTransactionManager.getStatus()).isEqualTo(Status.STATUS_MARKED_ROLLBACK);
 
     } finally {
       // make sure we always rollback
@@ -134,7 +134,7 @@ class UserTransactionIntegrationTest {
       String id = runtimeService.startProcessInstanceByKey("testApplicationFailure").getId();
 
       // assert that the transaction is in good shape:
-      assertEquals(Status.STATUS_ACTIVE, userTransactionManager.getStatus());
+      assertThat(userTransactionManager.getStatus()).isEqualTo(Status.STATUS_ACTIVE);
 
       // now rollback the transaction (simulating an application failure after the process engine is done).
       userTransactionManager.rollback();

--- a/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/client/ClientPostProcessor.java
+++ b/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/client/ClientPostProcessor.java
@@ -25,7 +25,6 @@ import org.operaton.bpm.client.spring.impl.util.LoggerUtil;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.ListableBeanFactory;

--- a/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/client/ClientPostProcessor.java
+++ b/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/client/ClientPostProcessor.java
@@ -88,7 +88,7 @@ public class ClientPostProcessor implements BeanDefinitionRegistryPostProcessor 
 
     List<String> classBeanNames = Arrays.stream(beanNames)
         .filter(isClassAnnotation(listableBeanFactory))
-        .collect(Collectors.toList());
+        .toList();
 
     int classBeanNameCount = classBeanNames.size();
     if (classBeanNameCount > 1) {

--- a/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssert.java
+++ b/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssert.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.Assertions;

--- a/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssert.java
+++ b/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssert.java
@@ -137,7 +137,7 @@ public class ProcessInstanceAssert extends AbstractProcessAssert<ProcessInstance
     List<String> decendentActivityIds = decendentActivityIdStream.filter(
         // remove the root id from the list
         activityId -> !activityId.equals(activityInstanceTree.getActivityId())
-    ).collect(Collectors.toList());
+    ).toList();
 
     final String message = "Expecting %s " +
       (isWaitingAt ? "to be waiting at " + (exactly ? "exactly " : "") + "%s, ": "NOT to be waiting at %s, ") +

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionJunit5Test.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionJunit5Test.java
@@ -44,7 +44,7 @@ class ProcessEngineExtensionJunit5Test {
     assertThat(task.getName()).isEqualTo("My Task");
 
     taskService.complete(task.getId());
-    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
   }
 
   /**
@@ -52,7 +52,7 @@ class ProcessEngineExtensionJunit5Test {
    */
   @Test
   void testWithoutDeploymentAnnotation() {
-    assertThat("aString").isEqualTo("aString");
+    assertThat(engine).isNotNull();
   }
 
   @Test

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionJunit5Test.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionJunit5Test.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.test.junit5;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
@@ -42,10 +41,10 @@ class ProcessEngineExtensionJunit5Test {
 
     TaskService taskService = engine.getTaskService();
     Task task = taskService.createTaskQuery().singleResult();
-    assertEquals("My Task", task.getName());
+    assertThat(task.getName()).isEqualTo("My Task");
 
     taskService.complete(task.getId());
-    assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
   }
 
   /**
@@ -53,7 +52,7 @@ class ProcessEngineExtensionJunit5Test {
    */
   @Test
   void testWithoutDeploymentAnnotation() {
-    assertEquals("aString", "aString");
+    assertThat("aString").isEqualTo("aString");
   }
 
   @Test

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionParameterizedJunit5Test.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionParameterizedJunit5Test.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.test.junit5;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -48,10 +47,10 @@ public class ProcessEngineExtensionParameterizedJunit5Test {
 
     TaskService taskService = engine.getTaskService();
     Task task = taskService.createTaskQuery().singleResult();
-    assertEquals("My Task", task.getName());
+    assertThat(task.getName()).isEqualTo("My Task");
 
     taskService.complete(task.getId());
-    assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
   }
 
   @ParameterizedTest
@@ -65,10 +64,10 @@ public class ProcessEngineExtensionParameterizedJunit5Test {
 
     TaskService taskService = engine.getTaskService();
     Task task = taskService.createTaskQuery().singleResult();
-    assertEquals("My Task", task.getName());
+    assertThat(task.getName()).isEqualTo("My Task");
 
     taskService.complete(task.getId());
-    assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
 
     HistoryService historyService = engine.getHistoryService();
     HistoricVariableInstance variableInstance = historyService.createHistoricVariableInstanceQuery().singleResult();
@@ -81,7 +80,7 @@ public class ProcessEngineExtensionParameterizedJunit5Test {
   @ParameterizedTest
   @EmptySource
   public void testWithoutDeploymentAnnotation(String argument) {
-    assertEquals("aString", "aString");
+    assertThat("aString").isEqualTo("aString");
   }
 
 }

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionParameterizedJunit5Test.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionParameterizedJunit5Test.java
@@ -50,7 +50,7 @@ public class ProcessEngineExtensionParameterizedJunit5Test {
     assertThat(task.getName()).isEqualTo("My Task");
 
     taskService.complete(task.getId());
-    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
   }
 
   @ParameterizedTest
@@ -67,7 +67,7 @@ public class ProcessEngineExtensionParameterizedJunit5Test {
     assertThat(task.getName()).isEqualTo("My Task");
 
     taskService.complete(task.getId());
-    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(0);
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isZero();
 
     HistoryService historyService = engine.getHistoryService();
     HistoricVariableInstance variableInstance = historyService.createHistoricVariableInstanceQuery().singleResult();
@@ -80,7 +80,7 @@ public class ProcessEngineExtensionParameterizedJunit5Test {
   @ParameterizedTest
   @EmptySource
   public void testWithoutDeploymentAnnotation(String argument) {
-    assertThat("aString").isEqualTo("aString");
+    assertThat(argument).isEmpty();
   }
 
 }

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionRequiredHistoryLevelAuditTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionRequiredHistoryLevelAuditTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.test.junit5;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
@@ -40,7 +40,6 @@ class ProcessEngineExtensionRequiredHistoryLevelAuditTest {
   @Test
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_AUDIT)
   void testRequiredHistoryLevelMatch() {
-    assertEquals(
-      ProcessEngineConfiguration.HISTORY_AUDIT, extension.getProcessEngineConfiguration().getHistoryLevel().getName());
+    assertThat(extension.getProcessEngineConfiguration().getHistoryLevel().getName()).isEqualTo(ProcessEngineConfiguration.HISTORY_AUDIT);
   }
 }

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/deployment/ProcessEngineExtensionDeploymentIdTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/deployment/ProcessEngineExtensionDeploymentIdTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.test.junit5.deployment;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -29,7 +29,7 @@ class ProcessEngineExtensionDeploymentIdTest {
 
   @Test
   void testDeploymentId() {
-    assertEquals("mockedDeploymentId", extension.getDeploymentId());
+    assertThat(extension.getDeploymentId()).isEqualTo("mockedDeploymentId");
   }
 
 }

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/registerExtension/RegisterProcessEngineExtensionTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/registerExtension/RegisterProcessEngineExtensionTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.test.junit5.registerExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.TaskService;
@@ -45,9 +45,9 @@ class RegisterProcessEngineExtensionTest {
     Task task = taskService
         .createTaskQuery()
         .singleResult();
-    assertEquals("Test something", task.getName());
+    assertThat(task.getName()).isEqualTo("Test something");
     taskService.complete(task.getId());
-    assertEquals(0, runtimeService.createProcessInstanceQuery().list().size());
+    assertThat(runtimeService.createProcessInstanceQuery().list().size()).isEqualTo(0);
   }
 
 }

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/registerExtension/RegisterProcessEngineExtensionTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/registerExtension/RegisterProcessEngineExtensionTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class RegisterProcessEngineExtensionTest {
 
   @RegisterExtension
-  ProcessEngineExtension extension = ProcessEngineExtension.builder().build();
+  static ProcessEngineExtension extension = ProcessEngineExtension.builder().build();
 
   @Test
   @Deployment
@@ -47,7 +47,7 @@ class RegisterProcessEngineExtensionTest {
         .singleResult();
     assertThat(task.getName()).isEqualTo("Test something");
     taskService.complete(task.getId());
-    assertThat(runtimeService.createProcessInstanceQuery().list().size()).isEqualTo(0);
+    assertThat(runtimeService.createProcessInstanceQuery().list()).isEmpty();
   }
 
 }


### PR DESCRIPTION
- replace assertEquals by assertThat().isEqualTo()
  Applied OpenRewrite recipe org.openrewrite.java.testing.assertj.JUnitAssertEqualsToAssertThat
- simplify Mockito matchers
  Applied OpenRewrite recipe org.openrewrite.java.testing.mockito.SimplifyMockitoVerifyWhenGiven
  This mainly removes obsolete Mockito.eq() calls
- replace Stream.collect(Collectors.toList()) by toList()

related to #88