### PR TITLE
refactor: Use StringUtils#hasText(), ObjectUtils#isEmpty, String#isEmpty

### DIFF
--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/ProcessVariables.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/ProcessVariables.java
@@ -50,7 +50,7 @@ public class ProcessVariables {
 
   protected String getVariableName(InjectionPoint ip) {
     String variableName = ip.getAnnotated().getAnnotation(ProcessVariable.class).value();
-    if (variableName.length() == 0) {
+    if (variableName.isEmpty()) {
       variableName = ip.getMember().getName();
     }
     return variableName;
@@ -58,7 +58,7 @@ public class ProcessVariables {
 
   protected String getVariableTypedName(InjectionPoint ip) {
     String variableName = ip.getAnnotated().getAnnotation(ProcessVariableTyped.class).value();
-    if (variableName.length() == 0) {
+    if (variableName.isEmpty()) {
       variableName = ip.getMember().getName();
     }
     return variableName;
@@ -108,7 +108,7 @@ public class ProcessVariables {
 
   protected String getVariableLocalName(InjectionPoint ip) {
     String variableName = ip.getAnnotated().getAnnotation(ProcessVariableLocal.class).value();
-    if (variableName.length() == 0) {
+    if (variableName.isEmpty()) {
       variableName = ip.getMember().getName();
     }
     return variableName;
@@ -116,7 +116,7 @@ public class ProcessVariables {
 
   protected String getVariableLocalTypedName(InjectionPoint ip) {
     String variableName = ip.getAnnotated().getAnnotation(ProcessVariableLocalTyped.class).value();
-    if (variableName.length() == 0) {
+    if (variableName.isEmpty()) {
       variableName = ip.getMember().getName();
     }
     return variableName;

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/NamedProcessEngineServicesProducer.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/NamedProcessEngineServicesProducer.java
@@ -37,6 +37,7 @@ import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.TaskService;
 import org.operaton.bpm.engine.cdi.annotation.ProcessEngineName;
 
+import static org.springframework.util.ObjectUtils.isEmpty;
 
 /**
  * This bean provides producers for the process engine services such
@@ -56,7 +57,7 @@ public class NamedProcessEngineServicesProducer {
 
     ProcessEngineName annotation = ip.getAnnotated().getAnnotation(ProcessEngineName.class);
     String processEngineName = annotation.value();
-    if(processEngineName == null || processEngineName.length() == 0) {
+    if(isEmpty(processEngineName)) {
      throw new ProcessEngineException("Cannot determine which process engine to inject: @ProcessEngineName must specify the name of a process engine.");
     }
     try {

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/annotation/StartProcessInterceptor.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/annotation/StartProcessInterceptor.java
@@ -34,6 +34,8 @@ import org.operaton.bpm.engine.cdi.annotation.StartProcess;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.impl.VariableMapImpl;
 
+import static org.springframework.util.ObjectUtils.isEmpty;
+
 /**
  * implementation of the {@link StartProcess} annotation
  *
@@ -92,7 +94,7 @@ public class StartProcessInterceptor implements Serializable {
         fieldName = processStartVariableTyped.value();
       }
 
-      if (fieldName == null || fieldName.length() == 0) {
+      if (isEmpty(fieldName)) {
         fieldName = field.getName();
       }
       Object value = field.get(ctx.getTarget());

--- a/engine/src/main/java/org/operaton/bpm/container/impl/jmx/MBeanServiceContainer.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/jmx/MBeanServiceContainer.java
@@ -52,15 +52,12 @@ public class MBeanServiceContainer implements PlatformServiceContainer {
 
   @Override
   public synchronized <S> void startService(ServiceType serviceType, String localName, PlatformService<S> service) {
-
     String serviceName = composeLocalName(serviceType, localName);
     startService(serviceName, service);
-
   }
 
   @Override
   public synchronized <S> void startService(String name, PlatformService<S> service) {
-
     ObjectName serviceName = getObjectName(name);
 
     if (getService(serviceName) != null) {
@@ -103,12 +100,10 @@ public class MBeanServiceContainer implements PlatformServiceContainer {
   public synchronized void stopService(ServiceType serviceType, String localName) {
     String globalName = composeLocalName(serviceType, localName);
     stopService(globalName);
-
   }
 
   @Override
   public synchronized void stopService(String name) {
-
     final MBeanServer beanServer = getmBeanServer();
 
     ObjectName serviceName = getObjectName(name);
@@ -130,7 +125,6 @@ public class MBeanServiceContainer implements PlatformServiceContainer {
         throw LOG.exceptionWhileUnregisteringService(serviceName.getCanonicalName(), t);
       }
     }
-
   }
 
   @Override
@@ -147,7 +141,6 @@ public class MBeanServiceContainer implements PlatformServiceContainer {
 
   @Override
   public void executeDeploymentOperation(DeploymentOperation operation) {
-
     Stack<DeploymentOperation> currentOperationContext = activeDeploymentOperations.get();
     if(currentOperationContext == null) {
       currentOperationContext = new Stack<>();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/JakartaTransactionProcessEngineConfiguration.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/JakartaTransactionProcessEngineConfiguration.java
@@ -24,6 +24,8 @@ import org.operaton.bpm.engine.impl.cfg.jta.JakartaTransactionContextFactory;
 import org.operaton.bpm.engine.impl.interceptor.CommandInterceptor;
 import org.operaton.bpm.engine.impl.interceptor.JakartaTransactionInterceptor;
 
+import static org.springframework.util.ObjectUtils.isEmpty;
+
 /**
  * Jakarta Transactions-based implementation of the {@link AbstractTransactionProcessEngineConfiguration}
  */
@@ -41,7 +43,7 @@ public class JakartaTransactionProcessEngineConfiguration extends AbstractTransa
   @Override
   protected void initTransactionManager() {
     if(transactionManager == null){
-      if(transactionManagerJndiName == null || transactionManagerJndiName.length() == 0) {
+      if(isEmpty(transactionManagerJndiName)) {
         throw LOG.invalidConfigTransactionManagerIsNull();
       }
       try {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/JtaProcessEngineConfiguration.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/JtaProcessEngineConfiguration.java
@@ -24,6 +24,7 @@ import org.operaton.bpm.engine.impl.cfg.jta.JtaTransactionContextFactory;
 import org.operaton.bpm.engine.impl.interceptor.CommandInterceptor;
 import org.operaton.bpm.engine.impl.interceptor.JtaTransactionInterceptor;
 
+import static org.springframework.util.ObjectUtils.isEmpty;
 
 /**
  * JTA-based implementation of the {@link AbstractTransactionProcessEngineConfiguration}
@@ -44,7 +45,7 @@ public class JtaProcessEngineConfiguration extends AbstractTransactionProcessEng
   @Override
   protected void initTransactionManager() {
     if(transactionManager == null){
-      if(transactionManagerJndiName == null || transactionManagerJndiName.length() == 0) {
+      if(isEmpty(transactionManagerJndiName)) {
         throw LOG.invalidConfigTransactionManagerIsNull();
       }
       try {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteTaskCmd.java
@@ -28,6 +28,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.TaskManager;
 import java.io.Serializable;
 import java.util.Collection;
 
+import static org.springframework.util.ObjectUtils.isEmpty;
 
 /**
  * @author Joram Barrez
@@ -80,7 +81,7 @@ public class DeleteTaskCmd implements Command<Void>, Serializable {
       checkDeleteTask(task, commandContext);
       task.logUserOperation(UserOperationLogEntry.OPERATION_TYPE_DELETE);
 
-      String reason = (deleteReason == null || deleteReason.length() == 0) ? TaskEntity.DELETE_REASON_DELETED : deleteReason;
+      String reason = isEmpty(deleteReason) ? TaskEntity.DELETE_REASON_DELETED : deleteReason;
       task.delete(reason, cascade);
     } else if (cascade) {
       Context

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentBpmnModelInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentBpmnModelInstanceCmd.java
@@ -30,6 +30,7 @@ import org.operaton.bpm.engine.impl.persistence.deploy.cache.DeploymentCache;
 import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
+import static org.springframework.util.ObjectUtils.isEmpty;
 
 /**
  * Gives access to a deploy BPMN model instance which can be accessed by
@@ -43,7 +44,7 @@ public class GetDeploymentBpmnModelInstanceCmd implements Command<BpmnModelInsta
   protected String processDefinitionId;
 
   public GetDeploymentBpmnModelInstanceCmd(String processDefinitionId) {
-    if (processDefinitionId == null || processDefinitionId.length() < 1) {
+    if (isEmpty(processDefinitionId)) {
       throw new ProcessEngineException("The process definition id is mandatory, but '" + processDefinitionId + "' has been provided.");
     }
     this.processDefinitionId = processDefinitionId;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramCmd.java
@@ -25,6 +25,7 @@ import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 
+import static org.springframework.util.ObjectUtils.isEmpty;
 
 /**
  * Gives access to a deployed process diagram, e.g., a PNG image, through a
@@ -39,7 +40,7 @@ public class GetDeploymentProcessDiagramCmd implements Command<InputStream>, Ser
   protected String processDefinitionId;
 
   public GetDeploymentProcessDiagramCmd(String processDefinitionId) {
-    if (processDefinitionId == null || processDefinitionId.length() < 1) {
+    if (isEmpty(processDefinitionId)) {
       throw new ProcessEngineException("The process definition id is mandatory, but '" + processDefinitionId + "' has been provided.");
     }
     this.processDefinitionId = processDefinitionId;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramLayoutCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramLayoutCmd.java
@@ -27,6 +27,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.operaton.bpm.engine.repository.DiagramLayout;
 
+import static org.springframework.util.ObjectUtils.isEmpty;
 
 /**
  * Provides positions and dimensions of elements in a process diagram as
@@ -41,7 +42,7 @@ public class GetDeploymentProcessDiagramLayoutCmd implements Command<DiagramLayo
   protected String processDefinitionId;
 
   public GetDeploymentProcessDiagramLayoutCmd(String processDefinitionId) {
-    if (processDefinitionId == null || processDefinitionId.length() < 1) {
+    if (isEmpty(processDefinitionId)) {
       throw new ProcessEngineException("The process definition id is mandatory, but '" + processDefinitionId + "' has been provided.");
     }
     this.processDefinitionId = processDefinitionId;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessModelCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessModelCmd.java
@@ -25,6 +25,7 @@ import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 
+import static org.springframework.util.ObjectUtils.isEmpty;
 
 /**
  * Gives access to a deployed process model, e.g., a BPMN 2.0 XML file, through
@@ -38,7 +39,7 @@ public class GetDeploymentProcessModelCmd implements Command<InputStream>, Seria
   protected String processDefinitionId;
 
   public GetDeploymentProcessModelCmd(String processDefinitionId) {
-    if (processDefinitionId == null || processDefinitionId.length() < 1) {
+    if (isEmpty(processDefinitionId)) {
       throw new ProcessEngineException("The process definition id is mandatory, but '" + processDefinitionId + "' has been provided.");
     }
     this.processDefinitionId = processDefinitionId;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetFormKeyCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetFormKeyCmd.java
@@ -28,6 +28,7 @@ import org.operaton.bpm.engine.impl.persistence.deploy.cache.DeploymentCache;
 import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.operaton.bpm.engine.impl.task.TaskDefinition;
 
+import static org.springframework.util.ObjectUtils.isEmpty;
 
 /**
  * Command for retrieving start or task form keys.
@@ -51,14 +52,14 @@ public class GetFormKeyCmd implements Command<String> {
    */
   public GetFormKeyCmd(String processDefinitionId, String taskDefinitionKey) {
     setProcessDefinitionId(processDefinitionId);
-    if (taskDefinitionKey == null || taskDefinitionKey.length() < 1) {
+    if (isEmpty(taskDefinitionKey)) {
       throw new ProcessEngineException("The task definition key is mandatory, but '" + taskDefinitionKey + "' has been provided.");
     }
     this.taskDefinitionKey = taskDefinitionKey;
   }
 
   protected void setProcessDefinitionId(String processDefinitionId) {
-    if (processDefinitionId == null || processDefinitionId.length() < 1) {
+    if (isEmpty(processDefinitionId)) {
       throw new ProcessEngineException("The process definition id is mandatory, but '" + processDefinitionId + "' has been provided.");
     }
     this.processDefinitionId = processDefinitionId;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetJobDuedateCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetJobDuedateCmd.java
@@ -29,6 +29,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.JobEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.PropertyChange;
 import org.operaton.bpm.engine.impl.persistence.entity.TimerEntity;
 
+import static org.springframework.util.ObjectUtils.isEmpty;
 
 /**
  * @author Kristin Polenz
@@ -42,7 +43,7 @@ public class SetJobDuedateCmd implements Command<Void>, Serializable {
   private final boolean cascade;
 
   public SetJobDuedateCmd(String jobId, Date newDuedate, boolean cascade) {
-    if (jobId == null || jobId.length() < 1) {
+    if (isEmpty(jobId)) {
       throw new ProcessEngineException("The job id is mandatory, but '" + jobId + "' has been provided.");
     }
     this.jobId = jobId;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/cmd/GetDeploymentCaseDiagramCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/cmd/GetDeploymentCaseDiagramCmd.java
@@ -26,6 +26,8 @@ import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 
+import static org.springframework.util.ObjectUtils.isEmpty;
+
 /**
  * Gives access to a deployed case diagram, e.g., a PNG image, through a stream
  * of bytes.
@@ -39,7 +41,7 @@ public class GetDeploymentCaseDiagramCmd implements Command<InputStream>, Serial
   protected String caseDefinitionId;
 
   public GetDeploymentCaseDiagramCmd(String caseDefinitionId) {
-    if (caseDefinitionId == null || caseDefinitionId.length() < 1) {
+    if (isEmpty(caseDefinitionId)) {
       throw new ProcessEngineException("The case definition id is mandatory, but '" + caseDefinitionId + "' has been provided.");
     }
     this.caseDefinitionId = caseDefinitionId;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/handler/CallingTaskItemHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/handler/CallingTaskItemHandler.java
@@ -31,6 +31,8 @@ import org.operaton.bpm.model.cmmn.instance.CmmnElement;
 
 import static org.operaton.bpm.engine.impl.util.StringUtil.isCompositeExpression;
 
+import static org.springframework.util.StringUtils.hasText;
+
 /**
  * @author Roman Smirnov
  *
@@ -102,7 +104,7 @@ public abstract class CallingTaskItemHandler extends TaskItemHandler {
 
     ExpressionManager expressionManager = context.getExpressionManager();
     String tenantId = getTenantId(element, activity, context);
-    if (tenantId != null && tenantId.length() > 0) {
+    if (hasText(tenantId)) {
       tenantIdProvider = createParameterValueProvider(tenantId, expressionManager);
     }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/DbSqlSession.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/DbSqlSession.java
@@ -760,7 +760,7 @@ public abstract class DbSqlSession extends AbstractPersistenceSession {
           logLines.add(line.substring(2));
         } else if (line.startsWith("-- ")) {
           logLines.add(line.substring(3));
-        } else if (line.length()>0) {
+        } else if (!line.isEmpty()) {
 
           if (line.endsWith(";")) {
             sqlStatement = addSqlStatementPiece(sqlStatement, line.substring(0, line.length()-1));

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/StringUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/StringUtil.java
@@ -207,7 +207,9 @@ public final class StringUtil {
   /**
    * @param string the String to check.
    * @return a boolean <code>TRUE</code> if the String is not null and not empty. <code>FALSE</code> otherwise.
+   * @deprecated use {@link org.springframework.util.StringUtils#hasText(String)} instead
    */
+  @Deprecated(forRemoval = true)
   public static boolean hasText(String string) {
     return string != null && !string.isEmpty();
   }

--- a/engine/src/test/java/org/operaton/bpm/application/impl/embedded/EmbeddedProcessApplicationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/embedded/EmbeddedProcessApplicationTest.java
@@ -34,10 +34,8 @@ import org.operaton.bpm.engine.repository.ProcessApplicationDeployment;
 import org.operaton.bpm.engine.repository.Resource;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.operaton.commons.testing.ProcessEngineLoggingRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.junit.*;
 
 /**
  * @author Daniel Meyer

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/diagram/ProcessDiagramRetrievalTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/diagram/ProcessDiagramRetrievalTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.springframework.util.StringUtils.hasText;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -242,7 +243,7 @@ public class ProcessDiagramRetrievalTest {
     html.append("        border: 2px dashed lightBlue;\n");
     html.append("        border-radius: 5px; -moz-border-radius: 5px;\n");
     html.append("      }\n");
-    if (highlightedActivityId != null && highlightedActivityId.length() > 0) {
+    if (hasText(highlightedActivityId)) {
       html.append("      #" + highlightedActivityId + " {border: 2px solid red;}\n");
     }
     html.append("    --></style>");

--- a/javaee/jobexecutor-ra/src/main/java/org/operaton/bpm/container/impl/threading/ra/JcaExecutorServiceConnector.java
+++ b/javaee/jobexecutor-ra/src/main/java/org/operaton/bpm/container/impl/threading/ra/JcaExecutorServiceConnector.java
@@ -36,6 +36,7 @@ import org.operaton.bpm.container.impl.threading.ra.inflow.JobExecutionHandler;
 import org.operaton.bpm.container.impl.threading.ra.inflow.JobExecutionHandlerActivation;
 import org.operaton.bpm.container.impl.threading.ra.inflow.JobExecutionHandlerActivationSpec;
 
+import static org.springframework.util.StringUtils.hasText;
 
 /**
  * <p>The {@link ResourceAdapter} responsible for bootstrapping the JcaExecutorService</p>
@@ -118,7 +119,7 @@ public class JcaExecutorServiceConnector implements ResourceAdapter, Serializabl
 
     // initialize the ExecutorService (CommonJ or JCA, depending on configuration)
     if(isUseCommonJWorkManager) {
-      if(commonJWorkManagerName != null & commonJWorkManagerName.length() > 0) {
+      if(hasText(commonJWorkManagerName)) {
         executorServiceWrapper.setExecutorService(new CommonJWorkManagerExecutorService(this, commonJWorkManagerName));
       } else {
         throw new RuntimeException("Resource Adapter configuration property 'isUseCommonJWorkManager' is set to true but 'commonJWorkManagerName' is not provided.");


### PR DESCRIPTION
resolve Sonar findings of type [java:7158](https://sonarcloud.io/project/issues?rules=java%3AS7158&issueStatuses=OPEN%2CCONFIRMED&id=operaton_operaton)

- use StringUtils#hasText() when checking for non-null and not-empty
- use ObjectUtils#isEmpty() when checking for null or empty
- use String#isEmpty() when the checked string is guaranteed non-null and only empty/not-empty is checked

Deprecate `org.operaton.bpm.engine.impl.util.StringUtil#hasText(String)`

related to #88
closes #410 