### PR TITLE
refactor(tests): Testing exceptions with only one possible invocation throwing

### DIFF
--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorTest.java
@@ -17,7 +17,6 @@
 package org.operaton.connect.httpclient;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 
@@ -39,6 +38,8 @@ import org.operaton.connect.Connectors;
 import org.operaton.connect.httpclient.impl.HttpConnectorImpl;
 import org.operaton.connect.impl.DebugRequestInterceptor;
 import org.operaton.connect.spi.Connector;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class HttpConnectorTest {
 
@@ -64,24 +65,16 @@ public class HttpConnectorTest {
 
   @Test
   void shouldFailWithoutMethod() {
-    try {
-      connector.createRequest().url("localhost").execute();
-      fail("No method specified");
-    }
-    catch (ConnectorRequestException e) {
-      // expected
-    }
+    HttpRequest request = connector.createRequest().url("localhost");
+    assertThatThrownBy(request::execute)
+      .isInstanceOf(ConnectorRequestException.class);
   }
 
   @Test
   void shouldFailWithoutUrl() {
-    try {
-      connector.createRequest().execute();
-      fail("No url specified");
-    }
-    catch (ConnectorRequestException e) {
-      // expected
-    }
+    HttpRequest request = connector.createRequest();
+    assertThatThrownBy(request::execute)
+      .isInstanceOf(ConnectorRequestException.class);
   }
 
   @Test

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpResponseTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpResponseTest.java
@@ -19,10 +19,11 @@ package org.operaton.connect.httpclient;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.assertj.core.api.Assertions;
 import org.operaton.connect.ConnectorRequestException;
 import org.operaton.connect.httpclient.impl.HttpConnectorImpl;
 import org.operaton.connect.impl.DebugRequestInterceptor;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class HttpResponseTest {
 
@@ -124,28 +125,26 @@ class HttpResponseTest {
   void testServerErrorResponseWithConfigOptionSet() {
     // given
     testResponse.statusCode(500);
-    try {
-      // when
-      connector.createRequest().configOption("throw-http-error", "TRUE").url("http://camunda.com").get().execute();
-      Assertions.fail("ConnectorRequestException should be thrown");
-    } catch (ConnectorRequestException e) {
+    HttpRequest request = connector.createRequest().configOption("throw-http-error", "TRUE").url("https://operaton.org").get();
+
+    // when
+    assertThatThrownBy(request::execute)
       // then
-      assertThat(e).hasMessageContaining("HTTP request failed with Status Code: 500");
-    }
+      .isInstanceOf(ConnectorRequestException.class)
+      .hasMessageContaining("HTTP request failed with Status Code: 500");
   }
 
   @Test
   void testMalformedRequestWithConfigOptionSet() {
     // given
     testResponse.statusCode(400);
-    try {
-      // when
-      connector.createRequest().configOption("throw-http-error", "TRUE").url("http://camunda.com").get().execute();
-      Assertions.fail("ConnectorRequestException should be thrown");
-    } catch (ConnectorRequestException e) {
+    HttpRequest request = connector.createRequest().configOption("throw-http-error", "TRUE").url("http://operaton.org").get();
+
+    // when
+    assertThatThrownBy(request::execute)
       // then
-      assertThat(e).hasMessageContaining("HTTP request failed with Status Code: 400");
-    }
+      .isInstanceOf(ConnectorRequestException.class)
+      .hasMessageContaining("HTTP request failed with Status Code: 400");
   }
 
   @Test
@@ -153,7 +152,7 @@ class HttpResponseTest {
     // given
     testResponse.statusCode(200);
     // when
-    connector.createRequest().configOption("throw-http-error", "TRUE").url("http://camunda.com").get().execute();
+    connector.createRequest().configOption("throw-http-error", "TRUE").url("http://operaton.org").get().execute();
     // then
     HttpResponse response = getResponse();
     assertThat(response.getStatusCode()).isEqualTo(200);
@@ -164,7 +163,7 @@ class HttpResponseTest {
     // given
     testResponse.statusCode(400);
     // when
-    connector.createRequest().configOption("throw-http-error", "FALSE").url("http://camunda.com").get().execute();
+    connector.createRequest().configOption("throw-http-error", "FALSE").url("http://operaton.org").get().execute();
     // then
     HttpResponse response = getResponse();
     assertThat(response.getStatusCode()).isEqualTo(400);

--- a/engine-plugins/connect-plugin/src/test/java/org/operaton/connect/plugin/ConnectProcessEnginePluginTest.java
+++ b/engine-plugins/connect-plugin/src/test/java/org/operaton/connect/plugin/ConnectProcessEnginePluginTest.java
@@ -41,6 +41,8 @@ import org.operaton.connect.httpclient.soap.SoapHttpConnector;
 import org.operaton.connect.plugin.util.TestConnector;
 import org.operaton.connect.spi.Connector;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 class ConnectProcessEnginePluginTest {
 
   @RegisterExtension
@@ -75,26 +77,18 @@ class ConnectProcessEnginePluginTest {
 
   @Test
   void connectorIdMissing() {
-    try {
-      repositoryService.createDeployment().addClasspathResource("org/operaton/connect/plugin/ConnectProcessEnginePluginTest.connectorIdMissing.bpmn")
-        .deploy();
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      assertFalse(e instanceof BpmnParseException);
-    }
+    var deployment = repositoryService.createDeployment()
+        .addClasspathResource("org/operaton/connect/plugin/ConnectProcessEnginePluginTest.connectorIdMissing.bpmn");
+    assertThatThrownBy(deployment::deploy)
+      .isInstanceOf(ProcessEngineException.class)
+      .isNotInstanceOf(BpmnParseException.class);
   }
 
   @Deployment
   @Test
   void connectorIdUnknown() {
-    try {
-      runtimeService.startProcessInstanceByKey("testProcess");
-      fail("Exception expected");
-    }
-    catch (ConnectorException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testProcess"))
+      .isInstanceOf(ConnectorException.class);
   }
 
   @Deployment
@@ -171,11 +165,10 @@ class ConnectProcessEnginePluginTest {
     Map<String, Object> variables = new HashMap<>();
     variables.put("throwInMapping", "in");
     variables.put("exception", new RuntimeException(exceptionMessage));
-    try {
-      runtimeService.startProcessInstanceByKey("testProcess", variables);
-    } catch(RuntimeException re){
-      assertThat(re.getMessage()).contains(exceptionMessage);
-    }
+
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testProcess", variables))
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining(exceptionMessage);
   }
 
   @Deployment(resources = "org/operaton/connect/plugin/ConnectProcessEnginePluginTest.connectorWithThrownExceptionInScriptInputOutputMapping.bpmn")
@@ -197,11 +190,10 @@ class ConnectProcessEnginePluginTest {
     Map<String, Object> variables = new HashMap<>();
     variables.put("throwInMapping", "out");
     variables.put("exception", new RuntimeException(exceptionMessage));
-    try {
-      runtimeService.startProcessInstanceByKey("testProcess", variables);
-    } catch(RuntimeException re){
-      assertThat(re.getMessage()).contains(exceptionMessage);
-    }
+
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testProcess", variables))
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining(exceptionMessage);
   }
 
   @Deployment(resources = "org/operaton/connect/plugin/ConnectProcessEnginePluginTest.connectorWithThrownExceptionInScriptResourceInputOutputMapping.bpmn")
@@ -223,11 +215,10 @@ class ConnectProcessEnginePluginTest {
     Map<String, Object> variables = new HashMap<>();
     variables.put("throwInMapping", "in");
     variables.put("exception", new RuntimeException(exceptionMessage));
-    try {
-      runtimeService.startProcessInstanceByKey("testProcess", variables);
-    } catch(RuntimeException re){
-      assertThat(re.getMessage()).contains(exceptionMessage);
-    }
+
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testProcess", variables))
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining(exceptionMessage);
   }
 
   @Deployment(resources = "org/operaton/connect/plugin/ConnectProcessEnginePluginTest.connectorWithThrownExceptionInScriptResourceInputOutputMapping.bpmn")
@@ -249,11 +240,10 @@ class ConnectProcessEnginePluginTest {
     Map<String, Object> variables = new HashMap<>();
     variables.put("throwInMapping", "out");
     variables.put("exception", new RuntimeException(exceptionMessage));
-    try {
-      runtimeService.startProcessInstanceByKey("testProcess", variables);
-    } catch(RuntimeException re){
-      assertThat(re.getMessage()).contains(exceptionMessage);
-    }
+
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testProcess", variables))
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining(exceptionMessage);
   }
 
   @Deployment(resources = "org/operaton/connect/plugin/ConnectProcessEnginePluginTest.connectorBpmnErrorThrownInScriptResourceNoAsyncAfterJobIsCreated.bpmn")
@@ -279,11 +269,9 @@ class ConnectProcessEnginePluginTest {
   @Deployment
   @Test
   void followingExceptionIsNotHandledByConnector() {
-    try {
-      runtimeService.startProcessInstanceByKey("testProcess");
-    } catch(RuntimeException re){
-      assertThat(re.getMessage()).contains("Invalid format");
-    }
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testProcess"))
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining("Invalid format");
   }
 
   @Deployment
@@ -296,8 +284,7 @@ class ConnectProcessEnginePluginTest {
 
     Map<String, Object> vars = new HashMap<>();
     vars.put("someInputVariable", inputVariableValue);
-    ProcessInstance processInstance = runtimeService
-        .startProcessInstanceByKey("process_sending_with_connector", vars);
+    runtimeService.startProcessInstanceByKey("process_sending_with_connector", vars);
 
     // validate input parameter
     assertNotNull(TestConnector.requestParameters.get("reqParam1"));
@@ -319,8 +306,7 @@ class ConnectProcessEnginePluginTest {
 
     Map<String, Object> vars = new HashMap<>();
     vars.put("someInputVariable", inputVariableValue);
-    ProcessInstance processInstance = runtimeService
-        .startProcessInstanceByKey("process_sending_with_connector", vars);
+    runtimeService.startProcessInstanceByKey("process_sending_with_connector", vars);
 
     // validate input parameter
     assertNotNull(TestConnector.requestParameters.get("reqParam1"));

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/HalResourceCacheTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/HalResourceCacheTest.java
@@ -44,11 +44,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
@@ -116,35 +116,24 @@ public class HalResourceCacheTest extends AbstractRestServiceTest {
 
   @Test
   public void testInvalidConfigurationFormat() {
-    try {
-      contextListener.configureCaches("<!xml>");
-      fail("Exception expected");
-    }
-    catch (HalRelationCacheConfigurationException e) {
-      assertTrue(e.getCause() instanceof IOException);
-    }
+    assertThatThrownBy(() -> contextListener.configureCaches("<!xml>"))
+      .isInstanceOf(HalRelationCacheConfigurationException.class)
+      .hasCauseInstanceOf(IOException.class);
   }
 
   @Test
   public void testUnknownCacheImplementationClass() {
-    try {
-      contextListener.configureCaches("{\"" + CONFIG_CACHE_IMPLEMENTATION +"\": \"org.operaton.bpm.UnknownCache\" }");
-      fail("Exception expected");
-    }
-    catch (HalRelationCacheConfigurationException e) {
-      assertTrue(e.getCause() instanceof ClassNotFoundException);
-    }
+    assertThatThrownBy(() -> contextListener.configureCaches("{\"" + CONFIG_CACHE_IMPLEMENTATION +"\": \"org.operaton.bpm.UnknownCache\" }"))
+      .isInstanceOf(HalRelationCacheConfigurationException.class)
+      .hasCauseInstanceOf(ClassNotFoundException.class);
   }
 
   @Test
   public void testCacheImplementationNotImplementingCache() {
-    try {
-      contextListener.configureCaches("{\"" + CONFIG_CACHE_IMPLEMENTATION +"\": \"" + getClass().getName() + "\" }");
-      fail("Exception expected");
-    }
-    catch (HalRelationCacheConfigurationException e) {
-      assertTrue(e.getMessage().contains(Cache.class.getName()));
-    }
+    String contextParameter = "{\"" + CONFIG_CACHE_IMPLEMENTATION + "\": \"" + getClass().getName() + "\" }";
+    assertThatThrownBy(() -> contextListener.configureCaches(contextParameter))
+      .isInstanceOf(HalRelationCacheConfigurationException.class)
+      .hasMessageContaining(Cache.class.getName());
   }
 
   @Test
@@ -172,13 +161,9 @@ public class HalResourceCacheTest extends AbstractRestServiceTest {
     configuration.setCacheImplementationClass(DefaultHalResourceCache.class);
     configuration.addCacheConfiguration(HalUser.class, Collections.<String, Object>singletonMap("unknown", "property"));
 
-    try {
-      contextListener.configureCaches(configuration);
-      fail("Exception expected");
-    }
-    catch (HalRelationCacheConfigurationException e) {
-      assertTrue(e.getMessage().contains("setter"));
-    }
+    assertThatThrownBy(() -> contextListener.configureCaches(configuration))
+      .isInstanceOf(HalRelationCacheConfigurationException.class)
+      .hasMessageContaining("setter");
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/NoIntermediaryInvocationTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/NoIntermediaryInvocationTest.java
@@ -18,16 +18,18 @@ package org.operaton.bpm.engine.rest.util;
 
 import static org.operaton.bpm.engine.rest.helper.NoIntermediaryInvocation.immediatelyAfter;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoAssertionError;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 /**
  * @author Thorben Lindhauer
  */
+@SuppressWarnings("java:S5778")
 public class NoIntermediaryInvocationTest {
 
   protected Foo foo;
@@ -38,7 +40,7 @@ public class NoIntermediaryInvocationTest {
   }
 
   @Test
-  public void testSucceess() {
+  public void testSucceeds() {
 
     // given
     foo.getFoo();
@@ -64,12 +66,8 @@ public class NoIntermediaryInvocationTest {
     inOrder.verify(foo).getFoo();
 
     // then
-    try {
-      inOrder.verify(foo, immediatelyAfter()).getBar();
-      Assert.fail("should not verify");
-    } catch (MockitoAssertionError e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> inOrder.verify(foo, immediatelyAfter()).getBar())
+      .isInstanceOf(MockitoAssertionError.class);
   }
 
   @Test
@@ -82,12 +80,8 @@ public class NoIntermediaryInvocationTest {
     inOrder.verify(foo).getFoo();
 
     // then
-    try {
-      inOrder.verify(foo, immediatelyAfter()).getBar();
-      Assert.fail("should not verify");
-    } catch (MockitoAssertionError e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> inOrder.verify(foo, immediatelyAfter()).getBar())
+      .isInstanceOf(MockitoAssertionError.class);
   }
 
   @Test
@@ -101,12 +95,8 @@ public class NoIntermediaryInvocationTest {
     inOrder.verify(foo).getFoo();
 
     // then
-    try {
-      inOrder.verify(foo, immediatelyAfter()).getBar();
-      Assert.fail("should not verify");
-    } catch (MockitoAssertionError e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> inOrder.verify(foo, immediatelyAfter()).getBar())
+      .isInstanceOf(MockitoAssertionError.class);
   }
 
   @Test
@@ -121,15 +111,11 @@ public class NoIntermediaryInvocationTest {
     inOrder.verify(foo).getFoo();
 
     // then
-    try {
-      inOrder.verify(foo, immediatelyAfter()).getBar();
-      Assert.fail("should not verify");
-    } catch (MockitoAssertionError e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> inOrder.verify(foo, immediatelyAfter()).getBar())
+      .isInstanceOf(MockitoAssertionError.class);
   }
 
-  public static interface Foo {
+  public interface Foo {
 
     String getFoo();
 


### PR DESCRIPTION
Refactor tests that check for exceptions to have only a single call in the calling code that could throw a RuntimeException.

Refactor to use `assertThatThrownBy()` for checking code for exceptions thrown.

Minor code cleanups: Removing unthrown exceptions, removed unused variable assignments etc.

related to #88, #27