### PR TITLE
refactor(tests): Testing exceptions with only one possible invocation throwing

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ActivityStatisticsAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ActivityStatisticsAuthorizationTest.java
@@ -21,12 +21,13 @@ import static org.operaton.bpm.engine.authorization.Permissions.READ;
 import static org.operaton.bpm.engine.authorization.Permissions.READ_INSTANCE;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.List;
 import org.operaton.bpm.engine.AuthorizationException;
@@ -61,18 +62,14 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
-    try {
-      // when
-      managementService.createActivityStatisticsQuery(processDefinitionId).list();
-      fail("Exception expected: It should not be possible to execute the activity statistics query");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(ONE_INCIDENT_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    // when
+    ActivityStatisticsQuery activityStatisticsQuery = managementService.createActivityStatisticsQuery(processDefinitionId);
+    assertThatThrownBy(activityStatisticsQuery::list)
+      .isInstanceOf(AuthorizationException.class)
+      .hasMessageContaining(userId)
+      .hasMessageContaining(READ.getName())
+      .hasMessageContaining(ONE_INCIDENT_PROCESS_KEY)
+      .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   // including instances //////////////////////////////////////////////////////////////

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ConditionStartEventAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ConditionStartEventAuthorizationTest.java
@@ -23,16 +23,17 @@ import static org.operaton.bpm.engine.authorization.Permissions.READ;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.List;
 
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.ProcessEngineException;
+import org.operaton.bpm.engine.runtime.ConditionEvaluationBuilder;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ConditionStartEventAuthorizationTest extends AuthorizationTest {
 
@@ -69,16 +70,12 @@ public class ConditionStartEventAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
 
     // when
-    try {
-      runtimeService
-          .createConditionEvaluation()
-          .setVariable("foo", 42)
-          .evaluateStartConditions();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      assertTrue(e.getMessage().contains("No subscriptions were found during evaluation of the conditional start events."));
-    }
-
+    ConditionEvaluationBuilder evaluationBuilder = runtimeService
+        .createConditionEvaluation()
+        .setVariable("foo", 42);
+    assertThatThrownBy(evaluationBuilder::evaluateStartConditions)
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("No subscriptions were found during evaluation of the conditional start events.");
   }
 
   @Deployment(resources = { SINGLE_CONDITIONAL_XML })
@@ -91,37 +88,29 @@ public class ConditionStartEventAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
 
     // when
-    try {
-      runtimeService
-          .createConditionEvaluation()
-          .setVariable("foo", 42)
-          .evaluateStartConditions();
-      fail("expected exception");
-    } catch (AuthorizationException e) {
-      assertTrue(e.getMessage().contains("The user with id 'test' does not have 'CREATE_INSTANCE' permission on resource 'conditionalEventProcess' of type 'ProcessDefinition'."));
-    }
-
+    ConditionEvaluationBuilder evaluationBuilder = runtimeService
+        .createConditionEvaluation()
+        .setVariable("foo", 42);
+    assertThatThrownBy(evaluationBuilder::evaluateStartConditions)
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have 'CREATE_INSTANCE' permission on resource 'conditionalEventProcess' of type 'ProcessDefinition'.");
   }
 
   @Deployment(resources = { SINGLE_CONDITIONAL_XML })
   @Test
-  public void testWithoutProcessInstanccePermission() {
+  public void testWithoutProcessInstancePermission() {
     // given deployed process with conditional start event
 
     // the user doesn't have CREATE permission for process instances
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ, CREATE_INSTANCE);
 
     // when
-    try {
-      runtimeService
-          .createConditionEvaluation()
-          .setVariable("foo", 42)
-          .evaluateStartConditions();
-      fail("expected exception");
-    } catch (AuthorizationException e) {
-      assertTrue(e.getMessage().contains("The user with id 'test' does not have 'CREATE' permission on resource 'ProcessInstance'."));
-    }
-
+    var evaluationBuilder = runtimeService
+        .createConditionEvaluation()
+        .setVariable("foo", 42);
+    assertThatThrownBy(evaluationBuilder::evaluateStartConditions)
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have 'CREATE' permission on resource 'ProcessInstance'.");
   }
 
   @Deployment(resources = { SINGLE_CONDITIONAL_XML })
@@ -134,14 +123,11 @@ public class ConditionStartEventAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
 
     // when
-    try {
-      runtimeService
-          .createConditionEvaluation()
-          .setVariable("foo", 42)
-          .evaluateStartConditions();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      assertTrue(e.getMessage().contains("No subscriptions were found during evaluation of the conditional start events."));
-    }
+    var evaluationBuilder = runtimeService
+        .createConditionEvaluation()
+        .setVariable("foo", 42);
+    assertThatThrownBy(evaluationBuilder::evaluateStartConditions)
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("No subscriptions were found during evaluation of the conditional start events.");
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DeploymentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DeploymentAuthorizationTest.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.InputStream;
 import java.util.Collections;
@@ -173,21 +172,17 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   @Test
   public void testCreateDeploymentWithoutAuthoriatzion() {
     // given
+    var deploymentBuilder = repositoryService
+        .createDeployment()
+        .addClasspathResource(FIRST_RESOURCE);
 
-    try {
-      // when
-      repositoryService
-          .createDeployment()
-          .addClasspathResource(FIRST_RESOURCE)
-          .deploy();
-      fail("Exception expected: It should not be possible to create a new deployment");
-    } catch (AuthorizationException e) {
+    // when
+    assertThatThrownBy(deploymentBuilder::deploy)
       // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(CREATE.getName(), message);
-      testRule.assertTextPresent(DEPLOYMENT.resourceName(), message);
-    }
+      .isInstanceOf(AuthorizationException.class)
+      .hasMessageContaining(userId)
+      .hasMessageContaining(CREATE.getName())
+      .hasMessageContaining(DEPLOYMENT.resourceName());
   }
 
   @Test
@@ -218,17 +213,13 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
     // given
     String deploymentId = createDeployment(null);
 
-    try {
-      // when
-      repositoryService.deleteDeployment(deploymentId);
-      fail("Exception expected: it should not be possible to delete a deployment");
-    } catch (AuthorizationException e) {
+    // when
+    assertThatThrownBy(() -> repositoryService.deleteDeployment(deploymentId))
       // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(DELETE.getName(), message);
-      testRule.assertTextPresent(DEPLOYMENT.resourceName(), message);
-    }
+      .isInstanceOf(AuthorizationException.class)
+      .hasMessageContaining(userId)
+      .hasMessageContaining(DELETE.getName())
+      .hasMessageContaining(DEPLOYMENT.resourceName());
   }
 
   @Test
@@ -270,17 +261,13 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
     // given
     String deploymentId = createDeployment(null);
 
-    try {
-      // when
-      repositoryService.getDeploymentResourceNames(deploymentId);
-      fail("Exception expected: it should not be possible to retrieve deployment resource names");
-    } catch (AuthorizationException e) {
+    // when
+    assertThatThrownBy(() -> repositoryService.getDeploymentResourceNames(deploymentId))
       // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(DEPLOYMENT.resourceName(), message);
-    }
+      .isInstanceOf(AuthorizationException.class)
+      .hasMessageContaining(userId)
+      .hasMessageContaining(READ.getName())
+      .hasMessageContaining(DEPLOYMENT.resourceName());
   }
 
   @Test
@@ -322,17 +309,12 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
     // given
     String deploymentId = createDeployment(null);
 
-    try {
-      // when
-      repositoryService.getDeploymentResources(deploymentId);
-      fail("Exception expected: it should not be possible to retrieve deployment resources");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(DEPLOYMENT.resourceName(), message);
-    }
+    // when
+    assertThatThrownBy(() -> repositoryService.getDeploymentResources(deploymentId))
+      .isInstanceOf(AuthorizationException.class)
+      .hasMessageContaining(userId)
+      .hasMessageContaining(READ.getName())
+      .hasMessageContaining(DEPLOYMENT.resourceName());
   }
 
   @Test
@@ -370,17 +352,11 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
     // given
     String deploymentId = createDeployment(null);
 
-    try {
-      // when
-      repositoryService.getResourceAsStream(deploymentId, FIRST_RESOURCE);
-      fail("Exception expected: it should not be possible to retrieve a resource as stream");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(DEPLOYMENT.resourceName(), message);
-    }
+    assertThatThrownBy(() -> repositoryService.getResourceAsStream(deploymentId, FIRST_RESOURCE))
+      .isInstanceOf(AuthorizationException.class)
+      .hasMessageContaining(userId)
+      .hasMessageContaining(READ.getName())
+      .hasMessageContaining(DEPLOYMENT.resourceName());
   }
 
   @Test
@@ -421,17 +397,11 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
     String resourceId = resources.get(0).getId();
 
-    try {
-      // when
-      repositoryService.getResourceAsStreamById(deploymentId, resourceId);
-      fail("Exception expected: it should not be possible to retrieve a resource as stream");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(DEPLOYMENT.resourceName(), message);
-    }
+    assertThatThrownBy(() -> repositoryService.getResourceAsStreamById(deploymentId, resourceId))
+      .isInstanceOf(AuthorizationException.class)
+      .hasMessageContaining(userId)
+      .hasMessageContaining(READ.getName())
+      .hasMessageContaining(DEPLOYMENT.resourceName());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/IncidentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/IncidentAuthorizationTest.java
@@ -372,7 +372,8 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     // when & then
-    assertThatThrownBy(() -> runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation"))
+    String incidentId = incident.getId();
+    assertThatThrownBy(() -> runtimeService.setAnnotationForIncidentById(incidentId, "my annotation"))
       .isInstanceOf(AuthorizationException.class)
       .hasMessageMatching(getMissingPermissionMessageRegex(UPDATE, PROCESS_INSTANCE))
       .hasMessageMatching(getMissingPermissionMessageRegex(UPDATE_INSTANCE, PROCESS_DEFINITION));
@@ -451,7 +452,8 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     // when & then
-    assertThatThrownBy(() -> runtimeService.clearAnnotationForIncidentById(incident.getId()))
+    String incidentId = incident.getId();
+    assertThatThrownBy(() -> runtimeService.clearAnnotationForIncidentById(incidentId))
       .isInstanceOf(AuthorizationException.class)
       .hasMessageMatching(getMissingPermissionMessageRegex(UPDATE, PROCESS_INSTANCE))
       .hasMessageMatching(getMissingPermissionMessageRegex(UPDATE_INSTANCE, PROCESS_DEFINITION));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessDefinitionAuthorizationTest.java
@@ -26,6 +26,8 @@ import static org.operaton.bpm.engine.authorization.Permissions.UPDATE_INSTANCE;
 import static org.operaton.bpm.engine.authorization.ProcessDefinitionPermissions.SUSPEND_INSTANCE;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -180,18 +182,15 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
-    try {
-      // when
-      repositoryService.getProcessDefinition(processDefinitionId);
-      fail("Exception expected: It should not be possible to get the process definition");
-    } catch (AuthorizationException e) {
+    // when
+    assertThatThrownBy(() -> repositoryService.getProcessDefinition(processDefinitionId))
       // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+      .withFailMessage("Exception expected: It should not be possible to get the process definition")
+      .isInstanceOf(AuthorizationException.class)
+      .hasMessageContaining(userId)
+      .hasMessageContaining(READ.getName())
+      .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+      .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -1222,19 +1221,16 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   @Test
   public void testDecisionDefinitionUpdateTimeToLiveWithoutAuthorizations() {
     //given
-    ProcessDefinition definition = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
-    try {
-      //when
-      repositoryService.updateProcessDefinitionHistoryTimeToLive(definition.getId(), 6);
-      fail("Exception expected");
-    } catch (AuthorizationException e) {
+    String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
+
+    // when
+    assertThatThrownBy(() -> repositoryService.updateProcessDefinitionHistoryTimeToLive(processDefinitionId, 6))
       // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceCommentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceCommentAuthorizationTest.java
@@ -29,6 +29,8 @@ import org.operaton.bpm.engine.task.Comment;
 import org.operaton.bpm.engine.test.Deployment;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
   protected static final String ONE_TASK_PROCESS_KEY = "oneTaskProcess";
 
@@ -39,17 +41,14 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createTask(TASK_ID);
 
-    Comment createdComment = createComment(TASK_ID, processInstanceId, "aComment");
+    String createdCommentId = createComment(TASK_ID, processInstanceId, "aComment").getId();
 
-    try {
-      // when
-      taskService.deleteProcessInstanceComment(processInstanceId, createdComment.getId());
-      fail("Exception expected: It should not be possible to delete a task.");
-    } catch (AuthorizationException e) {
+    // when
+    assertThatThrownBy(() -> taskService.deleteProcessInstanceComment(processInstanceId, createdCommentId))
       // then
-      testRule.assertTextPresent("The user with id 'test' does not have one of the following permissions: 'UPDATE'",
-          e.getMessage());
-    }
+      .withFailMessage("Exception expected: It should not be possible to delete a task.")
+      .isInstanceOf(AuthorizationException.class)
+      .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'UPDATE'");
 
     // triggers a db clean up
     deleteTask(TASK_ID, true);
@@ -125,17 +124,14 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
     // given
     createTask(TASK_ID);
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
-    Comment createdComment = createComment(TASK_ID, processInstanceId, "originalComment");
+    String createdCommentId = createComment(TASK_ID, processInstanceId, "originalComment").getId();
 
-    try {
-      // when
-      taskService.updateProcessInstanceComment(processInstanceId, createdComment.getId(), "updateMessage");
-      fail("Exception expected: It should not be possible to delete a task.");
-    } catch (AuthorizationException e) {
+    // when
+    assertThatThrownBy(() -> taskService.updateProcessInstanceComment(processInstanceId, createdCommentId, "updateMessage"))
       // then
-      testRule.assertTextPresent("The user with id 'test' does not have one of the following permissions: 'UPDATE'",
-          e.getMessage());
-    }
+      .withFailMessage("Exception expected: It should not be possible to delete a task.")
+      .isInstanceOf(AuthorizationException.class)
+      .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'UPDATE'");
 
     deleteTask(TASK_ID, true);
   }
@@ -170,18 +166,14 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
   public void testDeleteProcessInstanceCommentWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
+    String createdCommentId = createComment(null, processInstanceId, "aComment").getId();
 
-    Comment createdComment = createComment(null, processInstanceId, "aComment");
-
-    try {
-      // when
-      taskService.deleteProcessInstanceComment(processInstanceId, createdComment.getId());
-      fail("Exception expected: It should not be possible to delete a task.");
-    } catch (AuthorizationException e) {
+    // when
+    assertThatThrownBy(() -> taskService.deleteProcessInstanceComment(processInstanceId, createdCommentId))
       // then
-      testRule.assertTextPresent("The user with id 'test' does not have one of the following permissions: 'UPDATE'",
-          e.getMessage());
-    }
+      .withFailMessage("Exception expected: It should not be possible to delete a task.")
+      .isInstanceOf(AuthorizationException.class)
+      .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'UPDATE'");
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
@@ -241,17 +233,14 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
   public void testUpdateProcessInstanceCommentWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
-    Comment createdComment = createComment(null, processInstanceId, "originalComment");
+    String createdCommentId = createComment(null, processInstanceId, "originalComment").getId();
 
-    try {
-      // when
-      taskService.updateProcessInstanceComment(processInstanceId, createdComment.getId(), "updateMessage");
-      fail("Exception expected: It should not be possible to delete a task.");
-    } catch (AuthorizationException e) {
+    // when
+    assertThatThrownBy(() -> taskService.updateProcessInstanceComment(processInstanceId, createdCommentId, "updateMessage"))
       // then
-      testRule.assertTextPresent("The user with id 'test' does not have one of the following permissions: 'UPDATE'",
-          e.getMessage());
-    }
+      .withFailMessage("Exception expected: It should not be possible to delete a task.")
+      .isInstanceOf(AuthorizationException.class)
+      .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'UPDATE'");
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SingleProcessInstanceModificationAsyncAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SingleProcessInstanceModificationAsyncAuthorizationTest.java
@@ -32,7 +32,6 @@ import static org.operaton.bpm.engine.test.util.ExecutionAssert.describeExecutio
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.List;
 
@@ -47,6 +46,8 @@ import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.util.ExecutionTree;
 import org.junit.After;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SingleProcessInstanceModificationAsyncAuthorizationTest extends AuthorizationTest {
 
@@ -128,19 +129,17 @@ public class SingleProcessInstanceModificationAsyncAuthorizationTest extends Aut
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelGateway");
 
     ActivityInstance tree = runtimeService.getActivityInstance(processInstance.getId());
-    try {
-      // when
-      runtimeService
-        .createProcessInstanceModification(processInstance.getId())
-        .cancelActivityInstance(getInstanceIdForActivity(tree, "task1"))
-        .executeAsync();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
+    var processInstanceModificationBuilder = runtimeService
+      .createProcessInstanceModification(processInstance.getId())
+      .cancelActivityInstance(getInstanceIdForActivity(tree, "task1"));
+
+    // when
+    assertThatThrownBy(processInstanceModificationBuilder::executeAsync)
       // then
-      assertTrue(e.getMessage().contains("The user with id 'test' does not have"));
-      assertTrue(e.getMessage().contains("'CREATE' permission on resource 'Batch'"));
-      assertTrue(e.getMessage().contains("'CREATE_BATCH_MODIFY_PROCESS_INSTANCES' permission on resource 'Batch'"));
-    }
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("The user with id 'test' does not have")
+      .hasMessageContaining("'CREATE' permission on resource 'Batch'")
+      .hasMessageContaining("'CREATE_BATCH_MODIFY_PROCESS_INSTANCES' permission on resource 'Batch'");
   }
 
   @Deployment(resources = PARALLEL_GATEWAY_PROCESS)
@@ -155,19 +154,17 @@ public class SingleProcessInstanceModificationAsyncAuthorizationTest extends Aut
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelGateway");
 
     ActivityInstance tree = runtimeService.getActivityInstance(processInstance.getId());
-    try {
-      // when
-      runtimeService
-        .createProcessInstanceModification(processInstance.getId())
-        .cancelActivityInstance(getInstanceIdForActivity(tree, "task1"))
-        .executeAsync();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
+    var processInstanceModificationBuilder = runtimeService
+      .createProcessInstanceModification(processInstance.getId())
+      .cancelActivityInstance(getInstanceIdForActivity(tree, "task1"));
+
+    // when
+    assertThatThrownBy(processInstanceModificationBuilder::executeAsync)
       // then
-      assertTrue(e.getMessage().contains("The user with id 'test' does not have"));
-      assertTrue(e.getMessage().contains("'CREATE' permission on resource 'Batch'"));
-      assertTrue(e.getMessage().contains("'CREATE_BATCH_MODIFY_PROCESS_INSTANCES' permission on resource 'Batch'"));
-    }
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("The user with id 'test' does not have")
+      .hasMessageContaining("'CREATE' permission on resource 'Batch'")
+      .hasMessageContaining("'CREATE_BATCH_MODIFY_PROCESS_INSTANCES' permission on resource 'Batch'");
   }
 
   protected String getInstanceIdForActivity(ActivityInstance activityInstance, String activityId) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/HistoricBatchQueryAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/HistoricBatchQueryAuthorizationTest.java
@@ -35,6 +35,7 @@ import org.operaton.bpm.engine.authorization.Permissions;
 import org.operaton.bpm.engine.authorization.Resources;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.batch.history.HistoricBatch;
+import org.operaton.bpm.engine.history.CleanableHistoricBatchReport;
 import org.operaton.bpm.engine.history.CleanableHistoricBatchReportResult;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.engine.migration.MigrationPlan;
@@ -46,11 +47,8 @@ import org.operaton.bpm.engine.test.api.authorization.util.AuthorizationTestBase
 import org.operaton.bpm.engine.test.api.runtime.migration.models.ProcessModels;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.junit.*;
 import org.junit.rules.RuleChain;
 
 /**
@@ -239,19 +237,15 @@ public class HistoricBatchQueryAuthorizationTest {
     // given
     String migrationOperationsTTL = "P0D";
     prepareBatch(migrationOperationsTTL);
+    CleanableHistoricBatchReport batchReport = engineRule.getHistoryService().createCleanableHistoricBatchReport();
 
-    assertThatThrownBy(() -> {
-      authRule.enableAuthorization("user");
-      try {
-        // when
-        engineRule.getHistoryService().createCleanableHistoricBatchReport().list();
-      } finally {
-        authRule.disableAuthorization();
-      }
-    })
-    // then
-      .isInstanceOf(AuthorizationException.class);
-
+    authRule.enableAuthorization("user");
+    try {
+      assertThatThrownBy(batchReport::list)
+          .isInstanceOf(AuthorizationException.class);
+    } finally {
+      authRule.disableAuthorization();
+    }
   }
 
   private void prepareBatch(String migrationOperationsTTL) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDecisionInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDecisionInstanceAuthorizationTest.java
@@ -22,7 +22,6 @@ import static org.operaton.bpm.engine.authorization.Permissions.DELETE_HISTORY;
 import static org.operaton.bpm.engine.authorization.Permissions.READ_HISTORY;
 import static org.operaton.bpm.engine.authorization.Resources.DECISION_DEFINITION;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -45,6 +44,8 @@ import org.operaton.bpm.engine.variable.Variables;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Philipp Ossler
@@ -155,15 +156,9 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
     startProcessInstanceAndEvaluateDecision();
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
 
-    try {
-      // when
-      historyService.deleteHistoricDecisionInstanceByDefinitionId(decisionDefinitionId);
-      fail("expect authorization exception");
-    } catch (AuthorizationException e) {
-      // then
-      assertThat(e.getMessage()).isEqualTo(
-          "The user with id 'test' does not have 'DELETE_HISTORY' permission on resource 'testDecision' of type 'DecisionDefinition'.");
-    }
+    assertThatThrownBy(() -> historyService.deleteHistoricDecisionInstanceByDefinitionId(decisionDefinitionId))
+      .isInstanceOf(AuthorizationException.class)
+      .hasMessage("The user with id 'test' does not have 'DELETE_HISTORY' permission on resource 'testDecision' of type 'DecisionDefinition'.");
   }
 
   @Test
@@ -207,17 +202,11 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
     startProcessInstanceAndEvaluateDecision();
 
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
-    HistoricDecisionInstance historicDecisionInstance = query.includeInputs().includeOutputs().singleResult();
+    String historicDecisionInstanceId = query.includeInputs().includeOutputs().singleResult().getId();
 
-    try {
-      // when
-      historyService.deleteHistoricDecisionInstanceByInstanceId(historicDecisionInstance.getId());
-      fail("expect authorization exception");
-    } catch (AuthorizationException e) {
-      // then
-      assertThat(e.getMessage()).isEqualTo(
-          "The user with id 'test' does not have 'DELETE_HISTORY' permission on resource 'testDecision' of type 'DecisionDefinition'.");
-    }
+    assertThatThrownBy(() -> historyService.deleteHistoricDecisionInstanceByInstanceId(historicDecisionInstanceId))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessage("The user with id 'test' does not have 'DELETE_HISTORY' permission on resource 'testDecision' of type 'DecisionDefinition'.");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoryCleanupAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoryCleanupAuthorizationTest.java
@@ -48,8 +48,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 public class HistoryCleanupAuthorizationTest extends AuthorizationTest {
@@ -99,15 +99,10 @@ public class HistoryCleanupAuthorizationTest extends AuthorizationTest {
 
     ClockUtil.setCurrentTime(new Date());
 
-    try {
-      // when
-      historyService.cleanUpHistoryAsync(true).getId();
-      fail("Exception expected: It should not be possible to execute the history cleanup");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent("ENGINE-03029 Required admin authenticated group or user.", message);
-    }
+    assertThatThrownBy(() -> historyService.cleanUpHistoryAsync(true))
+        .withFailMessage("Exception expected: It should not be possible to execute the history cleanup")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("ENGINE-03029 Required admin authenticated group or user.");
   }
 
   protected void prepareInstances(Integer processInstanceTimeToLive, Integer decisionTimeToLive, Integer caseTimeToLive) {
@@ -172,7 +167,6 @@ public class HistoryCleanupAuthorizationTest extends AuthorizationTest {
     processEngineConfiguration.setHistoryCleanupBatchSize(defaultBatchSize);
 
     processEngineConfiguration.getCommandExecutorTxRequired().execute(commandContext -> {
-
       List<Job> jobs = managementService.createJobQuery().list();
       if (!jobs.isEmpty()) {
         assertEquals(1, jobs.size());


### PR DESCRIPTION
Refactor tests that check for exceptions to have only a single call in the calling code that could throw a RuntimeException.

Refactor to use `assertThatThrownBy()` for checking code for exceptions thrown.

related to #88, #27