### PR TITLE
refactor(tests): Testing exceptions with only one possible invocation throwing

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/application/impl/context/ProcessApplicationContextTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/context/ProcessApplicationContextTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.application.impl.context;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
@@ -167,20 +168,16 @@ public class ProcessApplicationContextTest extends PluggableProcessEngineTest {
   }
 
   @Test
-  public void testCannotExecuteInUnregisteredPaContext() throws Exception {
+  public void testCannotExecuteInUnregisteredPaContext() {
     String nonExistingName = pa.getName() + pa.getName();
+    Callable<Void> callable = () -> {
+      getCurrentContextApplication();
+      return null;
+    };
 
-    try {
-      ProcessApplicationContext.withProcessApplicationContext((Callable<Void>) () -> {
-        getCurrentContextApplication();
-        return null;
-      }, nonExistingName);
-      fail("should not succeed");
-
-    } catch (ProcessEngineException e) {
-      testRule.assertTextPresent("A process application with name '" + nonExistingName + "' is not registered", e.getMessage());
-    }
-
+    assertThatThrownBy(() -> ProcessApplicationContext.withProcessApplicationContext(callable, nonExistingName))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("A process application with name '" + nonExistingName + "' is not registered");
   }
 
   @SuppressWarnings("unchecked")

--- a/engine/src/test/java/org/operaton/bpm/application/impl/deployment/parser/ProcessesXmlParserTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/deployment/parser/ProcessesXmlParserTest.java
@@ -19,19 +19,22 @@ package org.operaton.bpm.application.impl.deployment.parser;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
 
+import org.operaton.bpm.application.impl.metadata.ProcessesXmlParse;
 import org.operaton.bpm.application.impl.metadata.ProcessesXmlParser;
 import org.operaton.bpm.application.impl.metadata.spi.ProcessArchiveXml;
 import org.operaton.bpm.application.impl.metadata.spi.ProcessesXml;
 import org.operaton.bpm.container.impl.metadata.spi.ProcessEngineXml;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * <p>The testcases for the {@link ProcessesXmlParser}</p>
@@ -194,8 +197,8 @@ public class ProcessesXmlParserTest {
   }
 
   @Test
+  @SuppressWarnings("java:S5961")
   public void testParseProcessesXmlTwoArchivesAndTwoEngines() {
-
     ProcessesXml processesXml = parser.createParse()
       .sourceUrl(getStreamUrl("process_xml_two_archives_two_engines.xml"))
       .execute()
@@ -267,21 +270,17 @@ public class ProcessesXmlParserTest {
   public void testParseProcessesXmlEngineNoName() {
 
     // this test is to make sure that XML Schema Validation works.
-    try {
-      parser.createParse()
-        .sourceUrl(getStreamUrl("process_xml_engine_no_name.xml"))
-        .execute();
+    ProcessesXmlParse processesXmlParse = parser
+      .createParse()
+      .sourceUrl(getStreamUrl("process_xml_engine_no_name.xml"));
 
-      fail("exception expected");
-
-    } catch(ProcessEngineException e) {
-      // expected
-    }
-
+    assertThatThrownBy(processesXmlParse::execute)
+      .isInstanceOf(ProcessEngineException.class);
   }
 
-  public void FAILING_testParseProcessesXmlClassLineBreak() {
-
+  @Test
+  @Ignore("FIXME")
+  public void testParseProcessesXmlClassLineBreak() {
     ProcessesXml processesXml = parser.createParse()
         .sourceUrl(getStreamUrl("process_xml_one_archive_with_line_break.xml"))
         .execute()

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/incident/CompositeIncidentHandlerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/incident/CompositeIncidentHandlerTest.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -37,81 +37,62 @@ public class CompositeIncidentHandlerTest {
   @Test
   public void shouldUseCompositeIncidentHandlerWithMainIncidentHandlerAddNullHandler() {
     CompositeIncidentHandler compositeIncidentHandler = new CompositeIncidentHandler(new DefaultIncidentHandler(""));
-    try {
-      compositeIncidentHandler.add(null);
-      fail("NullValueException expected");
-    } catch (NullValueException e) {
-      assertThat(e.getMessage()).containsIgnoringCase("Incident handler is null");
-    }
+
+    assertThatThrownBy(() -> compositeIncidentHandler.add(null))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("Incident handler is null");
   }
 
   @Test
   public void shouldUseCompositeIncidentHandlerArgumentConstructorWithNullMainHandler() {
-    try {
-      new CompositeIncidentHandler(null);
-      fail("NullValueException expected");
-    } catch (NullValueException e) {
-      assertThat(e.getMessage()).containsIgnoringCase("Incident handler is null");
-    }
+    assertThatThrownBy(() -> new CompositeIncidentHandler(null))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("Incident handler is null");
   }
 
   @Test
   public void shouldUseCompositeIncidentHandlerArgumentConstructorWithNullVarargs() {
     IncidentHandler incidentHandler = null;
-    try {
-      new CompositeIncidentHandler(null, incidentHandler);
-      fail("NullValueException expected");
-    } catch (NullValueException e) {
-      assertThat(e.getMessage()).containsIgnoringCase("Incident handlers contains null value");
-    }
+    assertThatThrownBy(() -> new CompositeIncidentHandler(null, incidentHandler))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("Incident handlers contains null value");
   }
 
   @Test
   public void shouldUseCompositeIncidentHandlerArgumentConstructorWithNullList() {
     List<IncidentHandler> incidentHandler = null;
-    try {
-      new CompositeIncidentHandler(null, incidentHandler);
-      fail("NullValueException expected");
-    } catch (NullValueException e) {
-      assertThat(e.getMessage()).containsIgnoringCase("Incident handler is null");
-    }
+    assertThatThrownBy(() -> new CompositeIncidentHandler(null, incidentHandler))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("Incident handler is null");
   }
 
   @Test
   public void shouldUseCompositeIncidentHandlerArgumentConstructorWithMainHandlersAndNullVarargValue() {
     IncidentHandler mainIncidentHandler = new DefaultIncidentHandler("failedJob");
     IncidentHandler incidentHandler = null;
-    try {
-      new CompositeIncidentHandler(mainIncidentHandler, incidentHandler);
-      fail("NullValueException expected");
-    } catch (NullValueException e) {
-      assertThat(e.getMessage()).containsIgnoringCase("Incident handlers contains null value");
-    }
+    assertThatThrownBy(() -> new CompositeIncidentHandler(mainIncidentHandler, incidentHandler))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("Incident handlers contains null value");
   }
 
   @Test
   public void shouldUseCompositeIncidentHandlerArgumentConstructorWithMainHandlersAndNullVarargs() {
     IncidentHandler mainIncidentHandler = new DefaultIncidentHandler("failedJob");
     IncidentHandler[] incidentHandler = null;
-    try {
-      new CompositeIncidentHandler(mainIncidentHandler, incidentHandler);
-      fail("NullValueException expected");
-    } catch (NullValueException e) {
-      assertThat(e.getMessage()).containsIgnoringCase("Incident handlers is null");
-    }
+
+    assertThatThrownBy(() -> new CompositeIncidentHandler(mainIncidentHandler, incidentHandler))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("Incident handlers is null");
   }
 
   @Test
   public void shouldUseCompositeIncidentHandlerArgumentConstructorWithMainHandlersAndNullList() {
     IncidentHandler mainIncidentHandler = new DefaultIncidentHandler("failedJob");
-
     List<IncidentHandler> incidentHandler = null;
-    try {
-      new CompositeIncidentHandler(mainIncidentHandler, incidentHandler);
-      fail("NullValueException expected");
-    } catch (NullValueException e) {
-      assertThat(e.getMessage()).containsIgnoringCase("Incident handlers is null");
-    }
+
+    assertThatThrownBy(() -> new CompositeIncidentHandler(mainIncidentHandler, incidentHandler))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("Incident handlers is null");
   }
 
   @Test
@@ -121,26 +102,20 @@ public class CompositeIncidentHandlerTest {
     List<IncidentHandler> incidentHandler = new ArrayList<>();
     incidentHandler.add(null);
     incidentHandler.add(null);
-    try {
-      new CompositeIncidentHandler(mainIncidentHandler, incidentHandler);
-      fail("NullValueException expected");
-    } catch (NullValueException e) {
-      assertThat(e.getMessage()).containsIgnoringCase("Incident handler is null");
-    }
+
+    assertThatThrownBy(() -> new CompositeIncidentHandler(mainIncidentHandler, incidentHandler))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("Incident handler is null");
   }
 
   @Test
   public void shouldUseCompositeIncidentHandlerWithAnotherIncidentType() {
-    CompositeIncidentHandler compositeIncidentHandler = new CompositeIncidentHandler(
-        new DefaultIncidentHandler("failedJob"));
-    try {
-      compositeIncidentHandler.add(new DefaultIncidentHandler("failedExternalTask"));
-      fail("Non expected message expected");
-    } catch (ProcessEngineException e) {
-      assertThat(e.getMessage()).containsIgnoringCase(
-          "Incorrect incident type handler in composite handler with type: failedJob");
-    }
-  }
+    CompositeIncidentHandler compositeIncidentHandler = new CompositeIncidentHandler(new DefaultIncidentHandler("failedJob"));
+    DefaultIncidentHandler incidentHandler = new DefaultIncidentHandler("failedExternalTask");
+
+    assertThatThrownBy(() -> compositeIncidentHandler.add(incidentHandler))
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining("Incorrect incident type handler in composite handler with type: failedJob");  }
 
   @Test
   public void shouldCallAllHandlersWhenCreatingIncident() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseHistoryPropertyAutoTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseHistoryPropertyAutoTest.java
@@ -58,8 +58,8 @@ public class DatabaseHistoryPropertyAutoTest {
   @Test
   public void failWhenSecondEngineDoesNotHaveTheSameHistoryLevel() {
     buildEngine(config("true", ProcessEngineConfiguration.HISTORY_FULL));
-
     ProcessEngineConfigurationImpl config = config(ProcessEngineConfiguration.HISTORY_AUDIT);
+
     assertThatThrownBy(() -> buildEngine(config))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("historyLevel mismatch: configuration says HistoryLevelAudit(name=audit, id=2) and database says HistoryLevelFull(name=full, id=3)");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/PersistenceExceptionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/PersistenceExceptionTest.java
@@ -26,6 +26,7 @@ import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
+
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterAuthorizationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterAuthorizationsTest.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.engine.test.api.filter;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 import java.util.List;
 import org.operaton.bpm.engine.AuthorizationException;
@@ -35,10 +34,13 @@ import org.operaton.bpm.engine.impl.persistence.entity.AuthorizationEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.FilterEntity;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Sebastian Menski
@@ -81,13 +83,8 @@ public class FilterAuthorizationsTest extends PluggableProcessEngineTest {
 
   @Test
   public void testCreateFilterNotPermitted() {
-    try {
-      filterService.newTaskFilter();
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> filterService.newTaskFilter())
+      .isInstanceOf(AuthorizationException.class);
   }
 
   @Test
@@ -100,13 +97,8 @@ public class FilterAuthorizationsTest extends PluggableProcessEngineTest {
   @Test
   public void testSaveFilterNotPermitted() {
     Filter filter = new FilterEntity(EntityTypes.TASK);
-    try {
-      filterService.saveFilter(filter);
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> filterService.saveFilter(filter))
+      .isInstanceOf(AuthorizationException.class);
   }
 
   @Test
@@ -127,13 +119,8 @@ public class FilterAuthorizationsTest extends PluggableProcessEngineTest {
 
     filter.setName("anotherName");
 
-    try {
-      filterService.saveFilter(filter);
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> filterService.saveFilter(filter))
+      .isInstanceOf(AuthorizationException.class);
   }
 
   @Test
@@ -150,15 +137,10 @@ public class FilterAuthorizationsTest extends PluggableProcessEngineTest {
 
   @Test
   public void testDeleteFilterNotPermitted() {
-    Filter filter = createTestFilter();
+    String filterId = createTestFilter().getId();
 
-    try {
-      filterService.deleteFilter(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> filterService.deleteFilter(filterId))
+      .isInstanceOf(AuthorizationException.class);
   }
 
   @Test
@@ -183,45 +165,25 @@ public class FilterAuthorizationsTest extends PluggableProcessEngineTest {
     Filter returnedFilter = filterService.createFilterQuery().filterId(filter.getId()).singleResult();
     assertNull(returnedFilter);
 
-    try {
-      filterService.getFilter(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId = filter.getId();
+    assertThatThrownBy(() -> filterService.getFilter(filterId))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.singleResult(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId1 = filter.getId();
+    assertThatThrownBy(() -> filterService.singleResult(filterId1))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.list(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId2 = filter.getId();
+    assertThatThrownBy(() -> filterService.list(filterId2))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.listPage(filter.getId(), 1, 2);
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId3 = filter.getId();
+    assertThatThrownBy(() -> filterService.listPage(filterId3, 1, 2))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.count(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId4 = filter.getId();
+    assertThatThrownBy(() -> filterService.count(filterId4))
+      .isInstanceOf(AuthorizationException.class);
   }
 
   @Test
@@ -277,45 +239,25 @@ public class FilterAuthorizationsTest extends PluggableProcessEngineTest {
     Filter returnedFilter = filterService.createFilterQuery().filterId(filter.getId()).singleResult();
     assertNull(returnedFilter);
 
-    try {
-      filterService.getFilter(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId1 = filter.getId();
+    assertThatThrownBy(() -> filterService.getFilter(filterId1))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.singleResult(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId2 = filter.getId();
+    assertThatThrownBy(() -> filterService.singleResult(filterId2))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.list(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId3 = filter.getId();
+    assertThatThrownBy(() -> filterService.list(filterId3))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.listPage(filter.getId(), 1, 2);
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId4 = filter.getId();
+    assertThatThrownBy(() -> filterService.listPage(filterId4, 1, 2))
+      .isInstanceOf(AuthorizationException.class);
 
-    try {
-      filterService.count(filter.getId());
-      fail("Exception expected");
-    }
-    catch (AuthorizationException e) {
-      // expected
-    }
+    String filterId5 = filter.getId();
+    assertThatThrownBy(() -> filterService.count(filterId5))
+      .isInstanceOf(AuthorizationException.class);
   }
 
   @Test
@@ -380,13 +322,9 @@ public class FilterAuthorizationsTest extends PluggableProcessEngineTest {
     Filter filter = filterService.newTaskFilter("someName");
     filter.setOwner("*");
 
-    try {
-      filterService.saveFilter(filter);
-      fail("exception expected");
-    } catch (ProcessEngineException e) {
-      testRule.assertTextPresent("Cannot create default authorization for filter owner *: "
-          + "id cannot be *. * is a reserved identifier.", e.getMessage());
-    }
+    assertThatThrownBy(() -> filterService.saveFilter(filter))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("Cannot create default authorization for filter owner *: id cannot be *. * is a reserved identifier.");
   }
 
   @Ignore("CAM-4889")
@@ -400,12 +338,10 @@ public class FilterAuthorizationsTest extends PluggableProcessEngineTest {
     grantUpdateFilter(filter.getId());
     filter.setOwner("*");
 
-    try {
-      filterService.saveFilter(filter);
-      fail("it should not be possible to save a filter with the generic owner id");
-    } catch (ProcessEngineException e) {
-      testRule.assertTextPresent("foo", e.getMessage());
-    }
+    assertThatThrownBy(() -> filterService.saveFilter(filter))
+      .withFailMessage("it should not be possible to save a filter with the generic owner id")
+      .isInstanceOf(AuthorizationException.class)
+      .hasMessageContaining("foo");
   }
 
   protected User createTestUser(String userId) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterQueryTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.test.api.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -94,14 +95,10 @@ public class FilterQueryTest extends PluggableProcessEngineTest {
     assertNull(query.singleResult());
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
+    FilterQuery filterQuery = filterService.createFilterQuery();
 
-    try {
-      filterService.createFilterQuery().filterId(null);
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> filterQuery.filterId(null))
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -124,14 +121,10 @@ public class FilterQueryTest extends PluggableProcessEngineTest {
     assertNull(query.singleResult());
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
+    FilterQuery filterQuery = filterService.createFilterQuery();
 
-    try {
-      filterService.createFilterQuery().filterResourceType(null);
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> filterQuery.filterResourceType(null))
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -156,14 +149,10 @@ public class FilterQueryTest extends PluggableProcessEngineTest {
     assertNull(query.singleResult());
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
+    FilterQuery filterQuery = filterService.createFilterQuery();
 
-    try {
-      filterService.createFilterQuery().filterName(null);
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> filterQuery.filterName(null))
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -180,14 +169,10 @@ public class FilterQueryTest extends PluggableProcessEngineTest {
     assertNull(query.singleResult());
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
+    FilterQuery filterQuery = filterService.createFilterQuery();
 
-    try {
-      filterService.createFilterQuery().filterOwner(null);
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> filterQuery.filterOwner(null))
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -211,7 +196,6 @@ public class FilterQueryTest extends PluggableProcessEngineTest {
     assertEquals(4, query.listPage(0, 15).size()); // there are only 4 tasks
   }
 
-  @SuppressWarnings({ "unchecked", "deprecation" })
   @Test
   public void testQuerySorting() {
     List<String> sortedIds = new ArrayList<>(filterIds);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterServiceTest.java
@@ -30,10 +30,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 /**
  * @author Sebastian Menski
@@ -72,29 +72,14 @@ public class FilterServiceTest extends PluggableProcessEngineTest {
 
   @Test
   public void testCreateInvalidFilter() {
-    try {
-      filter.setName(null);
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> filter.setName(null))
+      .isInstanceOf(ProcessEngineException.class);// when
 
-    try {
-      filter.setName("");
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> filter.setName(""))
+      .isInstanceOf(ProcessEngineException.class);// when
 
-    try {
-      filter.setQuery((Query<?, ?>) null);
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> filter.setQuery((Query<?, ?>) null))
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -172,13 +157,9 @@ public class FilterServiceTest extends PluggableProcessEngineTest {
     long count = filterService.createFilterQuery().count();
     assertEquals(0, count);
 
-    try {
-      filterService.deleteFilter(filter.getId());
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    String filterId = filter.getId();
+    assertThatThrownBy(() -> filterService.deleteFilter(filterId))
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   public static void compareFilter(Filter filter1, Filter filter2) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterTaskQueryTest.java
@@ -48,6 +48,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -1116,13 +1117,9 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
 
     saveQuery(query);
 
-    try {
-      filterService.singleResult(testFilter.getId());
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    String filterId = testFilter.getId();
+    assertThatThrownBy(() -> filterService.singleResult(filterId))
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/form/BuiltInValidatorsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/form/BuiltInValidatorsTest.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.engine.test.api.form;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Map;
 
@@ -29,18 +28,12 @@ import org.operaton.bpm.engine.impl.ProcessEngineImpl;
 import org.operaton.bpm.engine.impl.el.FixedValue;
 import org.operaton.bpm.engine.impl.form.FormException;
 import org.operaton.bpm.engine.impl.form.handler.FormFieldHandler;
-import org.operaton.bpm.engine.impl.form.validator.FormFieldValidator;
-import org.operaton.bpm.engine.impl.form.validator.FormFieldValidatorContext;
-import org.operaton.bpm.engine.impl.form.validator.FormValidators;
-import org.operaton.bpm.engine.impl.form.validator.MaxLengthValidator;
-import org.operaton.bpm.engine.impl.form.validator.MaxValidator;
-import org.operaton.bpm.engine.impl.form.validator.MinLengthValidator;
-import org.operaton.bpm.engine.impl.form.validator.MinValidator;
-import org.operaton.bpm.engine.impl.form.validator.ReadOnlyValidator;
-import org.operaton.bpm.engine.impl.form.validator.RequiredValidator;
+import org.operaton.bpm.engine.impl.form.validator.*;
 import org.operaton.bpm.engine.test.api.runtime.util.TestVariableScope;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Daniel Meyer
@@ -109,12 +102,10 @@ public class BuiltInValidatorsTest extends PluggableProcessEngineTest {
     assertTrue(validator.validate(4, new TestValidatorContext("4")));
     assertFalse(validator.validate(4, new TestValidatorContext("5")));
 
-    try {
-      validator.validate(4, new TestValidatorContext("4.4"));
-      fail("exception expected");
-    } catch (FormException e) {
-      assertTrue(e.getMessage().contains("Cannot validate Integer value 4: configuration 4.4 cannot be parsed as Integer."));
-    }
+    TestValidatorContext validatorContext = new TestValidatorContext("4.4");
+    assertThatThrownBy(() -> validator.validate(4, validatorContext))
+      .isInstanceOf(FormException.class)
+      .hasMessageContaining("Cannot validate Integer value 4: configuration 4.4 cannot be parsed as Integer.");
 
     assertFalse(validator.validate(4d, new TestValidatorContext("4.1")));
     assertTrue(validator.validate(4.1d, new TestValidatorContext("4.1")));
@@ -133,12 +124,10 @@ public class BuiltInValidatorsTest extends PluggableProcessEngineTest {
     assertTrue(validator.validate(3, new TestValidatorContext("4")));
     assertFalse(validator.validate(4, new TestValidatorContext("3")));
 
-    try {
-      validator.validate(4, new TestValidatorContext("4.4"));
-      fail("exception expected");
-    } catch (FormException e) {
-      assertTrue(e.getMessage().contains("Cannot validate Integer value 4: configuration 4.4 cannot be parsed as Integer."));
-    }
+    TestValidatorContext validatorContext = new TestValidatorContext("4.4");
+    assertThatThrownBy(() -> validator.validate(4, validatorContext))
+      .isInstanceOf(FormException.class)
+      .hasMessageContaining("Cannot validate Integer value 4: configuration 4.4 cannot be parsed as Integer.");
 
     assertFalse(validator.validate(4.1d, new TestValidatorContext("4")));
     assertTrue(validator.validate(4.1d, new TestValidatorContext("4.2")));
@@ -157,12 +146,10 @@ public class BuiltInValidatorsTest extends PluggableProcessEngineTest {
     assertTrue(validator.validate("test", new TestValidatorContext("4")));
     assertFalse(validator.validate("test", new TestValidatorContext("3")));
 
-    try {
-      validator.validate("test", new TestValidatorContext("4.4"));
-      fail("exception expected");
-    } catch (FormException e) {
-      assertTrue(e.getMessage().contains("Cannot validate \"maxlength\": configuration 4.4 cannot be interpreted as Integer"));
-    }
+    TestValidatorContext validatorContext = new TestValidatorContext("4.4");
+    assertThatThrownBy(() -> validator.validate("test", validatorContext))
+      .isInstanceOf(FormException.class)
+      .hasMessageContaining("Cannot validate \"maxlength\": configuration 4.4 cannot be interpreted as Integer");
   }
 
   @Test
@@ -174,12 +161,10 @@ public class BuiltInValidatorsTest extends PluggableProcessEngineTest {
     assertTrue(validator.validate("test", new TestValidatorContext("4")));
     assertFalse(validator.validate("test", new TestValidatorContext("5")));
 
-    try {
-      validator.validate("test", new TestValidatorContext("4.4"));
-      fail("exception expected");
-    } catch (FormException e) {
-      assertTrue(e.getMessage().contains("Cannot validate \"minlength\": configuration 4.4 cannot be interpreted as Integer"));
-    }
+    TestValidatorContext validatorContext = new TestValidatorContext("4.4");
+    assertThatThrownBy(() -> validator.validate("test", validatorContext))
+      .isInstanceOf(FormException.class)
+      .hasMessageContaining("Cannot validate \"minlength\": configuration 4.4 cannot be interpreted as Integer");
   }
 
   protected static class TestValidatorContext implements FormFieldValidatorContext {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
@@ -87,12 +87,12 @@ import org.operaton.bpm.engine.variable.value.ObjectValue;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.commons.utils.IoUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.apache.groovy.util.Maps;
+import org.junit.*;
 import org.junit.rules.RuleChain;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Joram Barrez
@@ -170,32 +170,21 @@ public class FormServiceTest {
 
   @Test
   public void testGetStartFormByKeyNullKey() {
-    try {
-      formService.getRenderedStartForm(null);
-      fail("ProcessEngineException expected");
-    } catch (ProcessEngineException ae) {
-      // Exception expected
-    }
+    assertThatThrownBy(() -> formService.getRenderedStartForm(null))
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   public void testGetStartFormByIdNullId() {
-    try {
-      formService.getRenderedStartForm(null);
-      fail("ProcessEngineException expected");
-    } catch (ProcessEngineException ae) {
-      // Exception expected
-    }
+    assertThatThrownBy(() -> formService.getRenderedStartForm(null))
+      .isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   public void testGetStartFormByIdUnexistingProcessDefinitionId() {
-    try {
-      formService.getRenderedStartForm("unexistingId");
-      fail("ProcessEngineException expected");
-    } catch (ProcessEngineException ae) {
-      testRule.assertTextPresent("no deployed process definition found with id", ae.getMessage());
-    }
+    assertThatThrownBy(() -> formService.getRenderedStartForm("unexistingId"))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("no deployed process definition found with id");
   }
 
   @Test
@@ -210,12 +199,9 @@ public class FormServiceTest {
 
   @Test
   public void testGetTaskFormUnexistingTaskId() {
-    try {
-      formService.getRenderedTaskForm("unexistingtask");
-      fail("ProcessEngineException expected");
-    } catch (ProcessEngineException ae) {
-      testRule.assertTextPresent("Task 'unexistingtask' not found", ae.getMessage());
-    }
+    assertThatThrownBy(() -> formService.getRenderedTaskForm("unexistingtask"))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("Task 'unexistingtask' not found");
   }
 
   @Test
@@ -273,6 +259,7 @@ public class FormServiceTest {
 
   @Deployment
   @Test
+  @SuppressWarnings("deprecation")
   public void testFormPropertyHandlingDeprecated() {
     Map<String, String> properties = new HashMap<>();
     properties.put("room", "5b"); // default
@@ -322,21 +309,19 @@ public class FormServiceTest {
 
     assertEquals(5, formProperties.size());
 
-    try {
-      formService.submitTaskFormData(taskId, new HashMap<>());
-      fail("expected exception about required form property 'street'");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    HashMap<String, String> emptyProperties = new HashMap<>();
+    assertThatThrownBy(() -> formService.submitTaskFormData(taskId, emptyProperties))
+      .withFailMessage("expected exception about required form property 'street'")
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("form property 'street' is required");
 
-    try {
-      properties = new HashMap<>();
-      properties.put("speaker", "its not allowed to update speaker!");
-      formService.submitTaskFormData(taskId, properties);
-      fail("expected exception about a non writable form property 'speaker'");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    properties = new HashMap<>();
+    properties.put("speaker", "its not allowed to update speaker!");
+    var finalProperties = properties;
+    assertThatThrownBy(() -> formService.submitTaskFormData(taskId, finalProperties))
+      .withFailMessage("expected exception about a non writable form property 'speaker'")
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("form property 'speaker' is not writable");
 
     properties = new HashMap<>();
     properties.put("street", "rubensstraat");
@@ -405,21 +390,16 @@ public class FormServiceTest {
 
     assertEquals(5, formProperties.size());
 
-    try {
-      formService.submitTaskForm(taskId, new HashMap<>());
-      fail("expected exception about required form property 'street'");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    HashMap<String, Object> emptyProperties = new HashMap<>();
+    assertThatThrownBy(() -> formService.submitTaskForm(taskId, emptyProperties))
+      .withFailMessage("expected exception about required form property 'street'")
+      .isInstanceOf(ProcessEngineException.class);
 
-    try {
-      properties = new HashMap<>();
-      properties.put("speaker", "its not allowed to update speaker!");
-      formService.submitTaskForm(taskId, properties);
-      fail("expected exception about a non writable form property 'speaker'");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    Map<String,Object> finalProperties = Maps.of("speaker", "its not allowed to update speaker!");
+
+    assertThatThrownBy(() -> formService.submitTaskForm(taskId, finalProperties))
+      .withFailMessage("expected exception about a non writable form property 'speaker'")
+      .isInstanceOf(ProcessEngineException.class);
 
     properties = new HashMap<>();
     properties.put("street", "rubensstraat");
@@ -488,23 +468,22 @@ public class FormServiceTest {
   @Deployment
   @Test
   public void testInvalidFormKeyReference() {
-    try {
-      formService.getRenderedStartForm(repositoryService.createProcessDefinitionQuery().singleResult().getId(), "juel");
-      fail();
-    } catch (ProcessEngineException e) {
-      testRule.assertTextPresent("Form with formKey 'IDoNotExist' does not exist", e.getMessage());
-    }
+    String processDefinitionId = repositoryService.createProcessDefinitionQuery().singleResult().getId();
+
+    assertThatThrownBy(() -> formService.getRenderedStartForm(processDefinitionId, "juel"))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("Form with formKey 'IDoNotExist' does not exist");
   }
 
   @Deployment
   @Test
   public void testSubmitStartFormDataWithBusinessKey() {
-    Map<String, String> properties = new HashMap<>();
+    Map<String, Object> properties = new HashMap<>();
     properties.put("duration", "45");
     properties.put("speaker", "Mike");
     String procDefId = repositoryService.createProcessDefinitionQuery().singleResult().getId();
 
-    ProcessInstance processInstance = formService.submitStartFormData(procDefId, "123", properties);
+    ProcessInstance processInstance = formService.submitStartForm(procDefId, "123", properties);
     assertEquals("123", processInstance.getBusinessKey());
 
     assertEquals(processInstance.getId(), runtimeService.createProcessInstanceQuery().processInstanceBusinessKey("123").singleResult().getId());
@@ -613,14 +592,17 @@ public class FormServiceTest {
     String stringValue = "some string";
     String serializedValue = "some value";
 
-    formService.submitTaskForm(task.getId(), createVariables()
-        .putValueTyped("boolean", booleanValue(null))
-        .putValueTyped("string", stringValue(stringValue))
-        .putValueTyped("serializedObject", serializedObjectValue(serializedValue)
-            .objectTypeName(String.class.getName())
-            .serializationDataFormat(Variables.SerializationDataFormats.JAVA)
-            .create())
-        .putValueTyped("object", objectValue(serializedValue).create()));
+    ObjectValue serializedObject = serializedObjectValue(serializedValue).objectTypeName(String.class.getName())
+      .serializationDataFormat(Variables.SerializationDataFormats.JAVA)
+      .create();
+    VariableMap variableMap = createVariables()
+      .putValueTyped("boolean", booleanValue(null))
+      .putValueTyped("string", stringValue(stringValue))
+      .putValueTyped("serializedObject", serializedObject)
+      .putValueTyped("object", objectValue(serializedValue).create());
+
+    assertThatCode(() -> formService.submitTaskForm(task.getId(), variableMap))
+      .doesNotThrowAnyException();
   }
 
 
@@ -763,19 +745,13 @@ public class FormServiceTest {
 
   @Test
   public void testGetStartFormKeyEmptyArgument() {
-    try {
-      formService.getStartFormKey(null);
-      fail("ProcessEngineException expected");
-    } catch (ProcessEngineException ae) {
-      testRule.assertTextPresent("The process definition id is mandatory, but 'null' has been provided.", ae.getMessage());
-    }
+    assertThatThrownBy(() -> formService.getStartFormKey(null))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("The process definition id is mandatory, but 'null' has been provided.");
 
-    try {
-      formService.getStartFormKey("");
-      fail("ProcessEngineException expected");
-    } catch (ProcessEngineException ae) {
-      testRule.assertTextPresent("The process definition id is mandatory, but '' has been provided.", ae.getMessage());
-    }
+    assertThatThrownBy(() -> formService.getStartFormKey(""))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("The process definition id is mandatory, but '' has been provided.");
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/form/FormsProcess.bpmn20.xml")
@@ -789,33 +765,21 @@ public class FormServiceTest {
 
   @Test
   public void testGetTaskFormKeyEmptyArguments() {
-    try {
-      formService.getTaskFormKey(null, "23");
-      fail("ProcessEngineException expected");
-    } catch (ProcessEngineException ae) {
-      testRule.assertTextPresent("The process definition id is mandatory, but 'null' has been provided.", ae.getMessage());
-    }
+    assertThatThrownBy(() -> formService.getTaskFormKey(null, "23"))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("The process definition id is mandatory, but 'null' has been provided.");
 
-    try {
-      formService.getTaskFormKey("", "23");
-      fail("ProcessEngineException expected");
-    } catch (ProcessEngineException ae) {
-      testRule.assertTextPresent("The process definition id is mandatory, but '' has been provided.", ae.getMessage());
-    }
+    assertThatThrownBy(() -> formService.getTaskFormKey("", "23"))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("The process definition id is mandatory, but '' has been provided.");
 
-    try {
-      formService.getTaskFormKey("42", null);
-      fail("ProcessEngineException expected");
-    } catch (ProcessEngineException ae) {
-      testRule.assertTextPresent("The task definition key is mandatory, but 'null' has been provided.", ae.getMessage());
-    }
+    assertThatThrownBy(() -> formService.getTaskFormKey("42", null))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("The task definition key is mandatory, but 'null' has been provided.");
 
-    try {
-      formService.getTaskFormKey("42", "");
-      fail("ProcessEngineException expected");
-    } catch (ProcessEngineException ae) {
-      testRule.assertTextPresent("The task definition key is mandatory, but '' has been provided.", ae.getMessage());
-    }
+    assertThatThrownBy(() -> formService.getTaskFormKey("42", ""))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("The task definition key is mandatory, but '' has been provided.");
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/form/FormsProcess.bpmn20.xml")
@@ -852,8 +816,8 @@ public class FormServiceTest {
     assertEquals("someString", variables.getValueTyped("stringField").getValue());
     assertEquals(ValueType.STRING, variables.getValueTyped("stringField").getType());
 
-    assertEquals(5l, variables.get("longField"));
-    assertEquals(5l, variables.getValueTyped("longField").getValue());
+    assertEquals(5L, variables.get("longField"));
+    assertEquals(5L, variables.getValueTyped("longField").getValue());
     assertEquals(ValueType.LONG, variables.getValueTyped("longField").getType());
 
     assertNull(variables.get("customField"));
@@ -873,14 +837,14 @@ public class FormServiceTest {
     assertEquals(2013, calendar.get(Calendar.YEAR));
 
     // get restricted set of variables:
-    variables = formService.getStartFormVariables(processDefinition.getId(), Arrays.asList("stringField"), true);
+    variables = formService.getStartFormVariables(processDefinition.getId(), List.of("stringField"), true);
     assertEquals(1, variables.size());
     assertEquals("someString", variables.get("stringField"));
     assertEquals("someString", variables.getValueTyped("stringField").getValue());
     assertEquals(ValueType.STRING, variables.getValueTyped("stringField").getType());
 
     // request non-existing variable
-    variables = formService.getStartFormVariables(processDefinition.getId(), Arrays.asList("non-existing!"), true);
+    variables = formService.getStartFormVariables(processDefinition.getId(), List.of("non-existing!"), true);
     assertEquals(0, variables.size());
 
     // null => all
@@ -906,7 +870,7 @@ public class FormServiceTest {
     Map<String, Object> processVars = new HashMap<>();
     processVars.put("someString", "initialValue");
     processVars.put("initialBooleanVariable", true);
-    processVars.put("initialLongVariable", 1l);
+    processVars.put("initialLongVariable", 1L);
     processVars.put("serializable", Arrays.asList("a", "b", "c"));
 
     runtimeService.startProcessInstanceByKey("testProcess", processVars);
@@ -919,8 +883,8 @@ public class FormServiceTest {
     assertEquals("someString", variables.getValueTyped("stringField").getValue());
     assertEquals(ValueType.STRING, variables.getValueTyped("stringField").getType());
 
-    assertEquals(5l, variables.get("longField"));
-    assertEquals(5l, variables.getValueTyped("longField").getValue());
+    assertEquals(5L, variables.get("longField"));
+    assertEquals(5L, variables.getValueTyped("longField").getValue());
     assertEquals(ValueType.LONG, variables.getValueTyped("longField").getType());
 
     assertNull(variables.get("customField"));
@@ -935,38 +899,38 @@ public class FormServiceTest {
     assertEquals(true, variables.getValueTyped("initialBooleanVariable").getValue());
     assertEquals(ValueType.BOOLEAN, variables.getValueTyped("initialBooleanVariable").getType());
 
-    assertEquals(1l, variables.get("initialLongVariable"));
-    assertEquals(1l, variables.getValueTyped("initialLongVariable").getValue());
+    assertEquals(1L, variables.get("initialLongVariable"));
+    assertEquals(1L, variables.getValueTyped("initialLongVariable").getValue());
     assertEquals(ValueType.LONG, variables.getValueTyped("initialLongVariable").getType());
 
     assertNotNull(variables.get("serializable"));
 
     // override the long variable
-    taskService.setVariableLocal(task.getId(), "initialLongVariable", 2l);
+    taskService.setVariableLocal(task.getId(), "initialLongVariable", 2L);
 
     variables = formService.getTaskFormVariables(task.getId());
     assertEquals(7, variables.size());
 
-    assertEquals(2l, variables.get("initialLongVariable"));
-    assertEquals(2l, variables.getValueTyped("initialLongVariable").getValue());
+    assertEquals(2L, variables.get("initialLongVariable"));
+    assertEquals(2L, variables.getValueTyped("initialLongVariable").getValue());
     assertEquals(ValueType.LONG, variables.getValueTyped("initialLongVariable").getType());
 
     // get restricted set of variables (form field):
-    variables = formService.getTaskFormVariables(task.getId(), Arrays.asList("someString"), true);
+    variables = formService.getTaskFormVariables(task.getId(), List.of("someString"), true);
     assertEquals(1, variables.size());
     assertEquals("initialValue", variables.get("someString"));
     assertEquals("initialValue", variables.getValueTyped("someString").getValue());
     assertEquals(ValueType.STRING, variables.getValueTyped("someString").getType());
 
     // get restricted set of variables (process variable):
-    variables = formService.getTaskFormVariables(task.getId(), Arrays.asList("initialBooleanVariable"), true);
+    variables = formService.getTaskFormVariables(task.getId(), List.of("initialBooleanVariable"), true);
     assertEquals(1, variables.size());
     assertEquals(true, variables.get("initialBooleanVariable"));
     assertEquals(true, variables.getValueTyped("initialBooleanVariable").getValue());
     assertEquals(ValueType.BOOLEAN, variables.getValueTyped("initialBooleanVariable").getType());
 
     // request non-existing variable
-    variables = formService.getTaskFormVariables(task.getId(), Arrays.asList("non-existing!"), true);
+    variables = formService.getTaskFormVariables(task.getId(), List.of("non-existing!"), true);
     assertEquals(0, variables.size());
 
     // null => all
@@ -981,7 +945,7 @@ public class FormServiceTest {
     Map<String, Object> processVars = new HashMap<>();
     processVars.put("someString", "initialValue");
     processVars.put("initialBooleanVariable", true);
-    processVars.put("initialLongVariable", 1l);
+    processVars.put("initialLongVariable", 1L);
     processVars.put("serializable", Arrays.asList("a", "b", "c"));
 
     // create new standalone task
@@ -1005,31 +969,31 @@ public class FormServiceTest {
     assertEquals(true, variables.getValueTyped("initialBooleanVariable").getValue());
     assertEquals(ValueType.BOOLEAN, variables.getValueTyped("initialBooleanVariable").getType());
 
-    assertEquals(1l, variables.get("initialLongVariable"));
-    assertEquals(1l, variables.getValueTyped("initialLongVariable").getValue());
+    assertEquals(1L, variables.get("initialLongVariable"));
+    assertEquals(1L, variables.getValueTyped("initialLongVariable").getValue());
     assertEquals(ValueType.LONG, variables.getValueTyped("initialLongVariable").getType());
 
     assertNotNull(variables.get("serializable"));
 
     // override the long variable
-    taskService.setVariable(task.getId(), "initialLongVariable", 2l);
+    taskService.setVariable(task.getId(), "initialLongVariable", 2L);
 
     variables = formService.getTaskFormVariables(task.getId());
     assertEquals(4, variables.size());
 
-    assertEquals(2l, variables.get("initialLongVariable"));
-    assertEquals(2l, variables.getValueTyped("initialLongVariable").getValue());
+    assertEquals(2L, variables.get("initialLongVariable"));
+    assertEquals(2L, variables.getValueTyped("initialLongVariable").getValue());
     assertEquals(ValueType.LONG, variables.getValueTyped("initialLongVariable").getType());
 
     // get restricted set of variables
-    variables = formService.getTaskFormVariables(task.getId(), Arrays.asList("someString"), true);
+    variables = formService.getTaskFormVariables(task.getId(), List.of("someString"), true);
     assertEquals(1, variables.size());
     assertEquals("initialValue", variables.get("someString"));
     assertEquals("initialValue", variables.getValueTyped("someString").getValue());
     assertEquals(ValueType.STRING, variables.getValueTyped("someString").getType());
 
     // request non-existing variable
-    variables = formService.getTaskFormVariables(task.getId(), Arrays.asList("non-existing!"), true);
+    variables = formService.getTaskFormVariables(task.getId(), List.of("non-existing!"), true);
     assertEquals(0, variables.size());
 
     // null => all
@@ -1052,9 +1016,9 @@ public class FormServiceTest {
     ProcessInstance processInstance = formService.submitStartForm(processDefinition.getId(), variables);
 
     // then the variable is available as a process variable
-    ArrayList<String> var = (ArrayList<String>) runtimeService.getVariable(processInstance.getId(), "var");
-    assertNotNull(var);
-    assertTrue(var.isEmpty());
+    ArrayList<String> variable = (ArrayList<String>) runtimeService.getVariable(processInstance.getId(), "var");
+    assertNotNull(variable);
+    assertTrue(variable.isEmpty());
 
     // then no historic form property event has been written since this is not supported for custom objects
     if(processEngineConfiguration.getHistoryLevel().getId() >= ProcessEngineConfigurationImpl.HISTORYLEVEL_FULL) {
@@ -1068,6 +1032,7 @@ public class FormServiceTest {
   public void testSubmitTaskFormWithObjectVariables() {
     // given
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
+    assertThat(processDefinition).isNotNull();
 
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
 
@@ -1080,9 +1045,9 @@ public class FormServiceTest {
     formService.submitTaskForm(task.getId(), variables);
 
     // then the variable is available as a process variable
-    ArrayList<String> var = (ArrayList<String>) runtimeService.getVariable(processInstance.getId(), "var");
-    assertNotNull(var);
-    assertTrue(var.isEmpty());
+    ArrayList<String> variable = (ArrayList<String>) runtimeService.getVariable(processInstance.getId(), "var");
+    assertNotNull(variable);
+    assertTrue(variable.isEmpty());
 
     // then no historic form property event has been written since this is not supported for custom objects
     if(processEngineConfiguration.getHistoryLevel().getId() >= ProcessEngineConfigurationImpl.HISTORYLEVEL_FULL) {
@@ -1298,14 +1263,13 @@ public class FormServiceTest {
 
   @Test
   public void testDeployTaskFormWithoutFieldTypes() {
-    try {
-      repositoryService
-        .createDeployment()
-        .addClasspathResource("org/operaton/bpm/engine/test/api/form/FormServiceTest.testDeployTaskFormWithoutFieldTypes.bpmn20.xml")
-        .deploy();
-    } catch (ProcessEngineException e) {
-      testRule.assertTextPresent("form field must have a 'type' attribute", e.getMessage());
-    }
+    var deploymentBuilder = repositoryService
+      .createDeployment()
+      .addClasspathResource("org/operaton/bpm/engine/test/api/form/FormServiceTest.testDeployTaskFormWithoutFieldTypes.bpmn20.xml");
+
+    assertThatThrownBy(deploymentBuilder::deploy)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("form field must have a 'type' attribute");
   }
 
   @Deployment
@@ -1335,14 +1299,15 @@ public class FormServiceTest {
 
   @Test
   public void testDeployStartFormWithoutFieldTypes() {
-    try {
-      repositoryService
-        .createDeployment()
-        .addClasspathResource("org/operaton/bpm/engine/test/api/form/FormServiceTest.testDeployStartFormWithoutFieldTypes.bpmn20.xml")
-        .deploy();
-    } catch (ProcessEngineException e) {
-      testRule.assertTextPresent("form field must have a 'type' attribute", e.getMessage());
-    }
+    // when
+    var deploymentBuilder = repositoryService
+      .createDeployment()
+      .addClasspathResource("org/operaton/bpm/engine/test/api/form/FormServiceTest.testDeployStartFormWithoutFieldTypes.bpmn20.xml");
+    // when
+    assertThatThrownBy(deploymentBuilder::deploy)
+    // then
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("form field must have a 'type' attribute");
   }
 
   @Deployment(resources = {
@@ -1475,12 +1440,9 @@ public class FormServiceTest {
 
   @Test
   public void testGetDeployedStartFormWithNullProcDefId() {
-    try {
-      formService.getDeployedStartForm(null);
-      fail("Exception expected");
-    } catch (BadUserRequestException e) {
-      assertEquals("Process definition id cannot be null: processDefinitionId is null", e.getMessage());
-    }
+    assertThatThrownBy(() -> formService.getDeployedStartForm(null))
+      .isInstanceOf(BadUserRequestException.class)
+      .hasMessageContaining("Process definition id cannot be null: processDefinitionId is null");
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/form/DeployedFormsProcess.bpmn20.xml",
@@ -1560,12 +1522,9 @@ public class FormServiceTest {
 
   @Test
   public void testGetDeployedTaskFormWithNullTaskId() {
-    try {
-      formService.getDeployedTaskForm(null);
-      fail("Exception expected");
-    } catch (BadUserRequestException e) {
-      assertEquals("Task id cannot be null: taskId is null", e.getMessage());
-    }
+    assertThatThrownBy(() -> formService.getDeployedTaskForm(null))
+      .isInstanceOf(BadUserRequestException.class)
+      .hasMessageContaining("Task id cannot be null: taskId is null");
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/form/DeployedFormsProcess.bpmn20.xml",
@@ -1576,10 +1535,9 @@ public class FormServiceTest {
     String procDefId = repositoryService.createProcessDefinitionQuery().singleResult().getId();
 
     // when
-    assertThatThrownBy(() -> {
-      formService.getDeployedStartForm(procDefId);
-    }).isInstanceOf(NotFoundException.class)
-    .hasMessageContaining("The form with the resource name 'org/operaton/bpm/engine/test/api/form/start.html' cannot be found in deployment");
+    assertThatThrownBy(() -> formService.getDeployedStartForm(procDefId))
+      .isInstanceOf(NotFoundException.class)
+      .hasMessageContaining("The form with the resource name 'org/operaton/bpm/engine/test/api/form/start.html' cannot be found in deployment");
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/form/DeployedFormsProcess.bpmn20.xml",
@@ -1591,10 +1549,9 @@ public class FormServiceTest {
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
     // when
-    assertThatThrownBy(() -> {
-      formService.getDeployedTaskForm(taskId);
-    }).isInstanceOf(NotFoundException.class)
-    .hasMessageContaining("The form with the resource name 'org/operaton/bpm/engine/test/api/form/task.html' cannot be found in deployment");
+    assertThatThrownBy(() -> formService.getDeployedTaskForm(taskId))
+      .isInstanceOf(NotFoundException.class)
+      .hasMessageContaining("The form with the resource name 'org/operaton/bpm/engine/test/api/form/task.html' cannot be found in deployment");
   }
 
   @Test
@@ -1604,10 +1561,9 @@ public class FormServiceTest {
     String processDefinitionId = repositoryService.createProcessDefinitionQuery().singleResult().getId();
 
     // when
-    assertThatThrownBy(() -> {
-      formService.getDeployedStartForm(processDefinitionId);
-    }).isInstanceOf(BadUserRequestException.class)
-    .hasMessage("One of the attributes 'formKey' and 'operaton:formRef' must be supplied but none were set.");
+    assertThatThrownBy(() -> formService.getDeployedStartForm(processDefinitionId))
+      .isInstanceOf(BadUserRequestException.class)
+      .hasMessage("One of the attributes 'formKey' and 'operaton:formRef' must be supplied but none were set.");
   }
 
   @Test
@@ -1618,10 +1574,9 @@ public class FormServiceTest {
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
     // when
-    assertThatThrownBy(() -> {
-      formService.getDeployedTaskForm(taskId);
-    }).isInstanceOf(BadUserRequestException.class)
-    .hasMessage("One of the attributes 'formKey' and 'operaton:formRef' must be supplied but none were set.");
+    assertThatThrownBy(() -> formService.getDeployedTaskForm(taskId))
+      .isInstanceOf(BadUserRequestException.class)
+      .hasMessage("One of the attributes 'formKey' and 'operaton:formRef' must be supplied but none were set.");
   }
 
   @Deployment(resources = {
@@ -1630,12 +1585,11 @@ public class FormServiceTest {
   public void testGetDeployedStartFormWithWrongKeyFormat() {
     String processDefinitionId = repositoryService.createProcessDefinitionQuery().singleResult().getId();
 
-    try {
-      formService.getDeployedStartForm(processDefinitionId);
-      fail("Exception expected");
-    } catch (BadUserRequestException e) {
-      testRule.assertTextPresent("The form key 'formKey' does not reference a deployed form.", e.getMessage());
-    }
+    // when
+    assertThatThrownBy(() -> formService.getDeployedStartForm(processDefinitionId))
+    // then
+      .isInstanceOf(BadUserRequestException.class)
+      .hasMessageContaining("The form key 'formKey' does not reference a deployed form.");
   }
 
   @Deployment(resources = {
@@ -1645,12 +1599,11 @@ public class FormServiceTest {
     runtimeService.startProcessInstanceByKey("FormsProcess");
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
-    try {
-      formService.getDeployedTaskForm(taskId);
-      fail("Exception expected");
-    } catch (BadUserRequestException e) {
-      testRule.assertTextPresent("The form key 'formKey' does not reference a deployed form.", e.getMessage());
-    }
+    // when
+    assertThatThrownBy(() -> formService.getDeployedTaskForm(taskId))
+    // then
+      .isInstanceOf(BadUserRequestException.class)
+      .hasMessageContaining("The form key 'formKey' does not reference a deployed form.");
   }
 
   @Deployment(resources = {


### PR DESCRIPTION
Refactor tests that check for exceptions to have only a single call in the calling code that could throw a RuntimeException.

Refactor to use `assertThatThrownBy()` for checking code for exceptions thrown.

Resolve usage of deprecated method FormService#submitTaskFormData by #submitForm

Cleanups:
- Replace lowercase 'l' by 'L' for long literals
- Replace `Arrays.asList` by `List.of()`
- Rename variables named `var`
- Replace statement lambda by expression lambda
- Remove obsolete usages of ArgumentsMatchers#eq

related to #88, #27