### PR TITLE
Cleanup/resolve sonar warnings 1

### DIFF
--- a/connect/core/src/main/java/org/operaton/connect/Connectors.java
+++ b/connect/core/src/main/java/org/operaton/connect/Connectors.java
@@ -126,7 +126,7 @@ public class Connectors {
    */
   public Set<Connector<? extends ConnectorRequest<?>>> getAllAvailableConnectors() {
     ensureConnectorProvidersInitialized();
-    return new HashSet<Connector<?>>(availableConnectors.values());
+    return new HashSet<>(availableConnectors.values());
   }
 
   /**

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorSystemPropertiesTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpConnectorSystemPropertiesTest.java
@@ -43,7 +43,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
  * @author Thorben Lindhauer
  */
 @WireMockTest
-public class HttpConnectorSystemPropertiesTest {
+class HttpConnectorSystemPropertiesTest {
 
   protected Set<String> updatedSystemProperties;
 

--- a/connect/soap-http-client/src/test/java/org/operaton/connect/soap/httpclient/SoapHttpConnectorSystemPropertiesTest.java
+++ b/connect/soap-http-client/src/test/java/org/operaton/connect/soap/httpclient/SoapHttpConnectorSystemPropertiesTest.java
@@ -44,7 +44,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
  * @author Thorben Lindhauer
  */
 @WireMockTest
-public class SoapHttpConnectorSystemPropertiesTest {
+class SoapHttpConnectorSystemPropertiesTest {
 
   protected Set<String> updatedSystemProperties;
 

--- a/connect/soap-http-client/src/test/java/org/operaton/connect/soap/httpclient/SoapHttpConnectorTest.java
+++ b/connect/soap-http-client/src/test/java/org/operaton/connect/soap/httpclient/SoapHttpConnectorTest.java
@@ -27,7 +27,7 @@ import org.operaton.connect.httpclient.soap.impl.SoapHttpConnectorImpl;
 import org.operaton.connect.impl.DebugRequestInterceptor;
 import org.operaton.connect.spi.Connector;
 
-public class SoapHttpConnectorTest {
+class SoapHttpConnectorTest {
 
   public SoapHttpConnector connector;
 

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/DmnDecisionImpl.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/DmnDecisionImpl.java
@@ -70,7 +70,7 @@ public class DmnDecisionImpl implements DmnDecision {
 
   @Override
   public boolean isDecisionTable() {
-    return decisionLogic != null && decisionLogic instanceof DmnDecisionTableImpl;
+    return decisionLogic instanceof DmnDecisionTableImpl;
   }
 
   @Override

--- a/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ConnectProcessEnginePlugin.java
+++ b/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ConnectProcessEnginePlugin.java
@@ -39,7 +39,7 @@ public class ConnectProcessEnginePlugin extends AbstractProcessEnginePlugin {
   private void addConnectorParseListener(ProcessEngineConfigurationImpl processEngineConfiguration) {
     List<BpmnParseListener> preParseListeners = processEngineConfiguration.getCustomPreBPMNParseListeners();
     if(preParseListeners == null) {
-      preParseListeners = new ArrayList<BpmnParseListener>();
+      preParseListeners = new ArrayList<>();
       processEngineConfiguration.setCustomPreBPMNParseListeners(preParseListeners);
     }
     preParseListeners.add(new ConnectorParseListener());

--- a/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ConnectorVariableScope.java
+++ b/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ConnectorVariableScope.java
@@ -47,7 +47,7 @@ public class ConnectorVariableScope extends AbstractVariableScope {
 
   public ConnectorVariableScope(AbstractVariableScope parent) {
     this.parent = parent;
-    this.variableStore = new VariableStore<SimpleVariableInstance>();
+    this.variableStore = new VariableStore<>();
   }
 
   public String getVariableScopeKey() {

--- a/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ConnectorVariableScope.java
+++ b/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ConnectorVariableScope.java
@@ -50,6 +50,7 @@ public class ConnectorVariableScope extends AbstractVariableScope {
     this.variableStore = new VariableStore<>();
   }
 
+  @Override
   public String getVariableScopeKey() {
     return "connector";
   }

--- a/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ServiceTaskConnectorActivityBehavior.java
+++ b/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ServiceTaskConnectorActivityBehavior.java
@@ -47,6 +47,7 @@ public class ServiceTaskConnectorActivityBehavior extends TaskActivityBehavior {
     this.ioMapping = ioMapping;
   }
 
+  @Override
   public void execute(final ActivityExecution execution) throws Exception {
     ensureConnectorInitialized();
 

--- a/engine-plugins/connect-plugin/src/test/java/org/operaton/connect/plugin/util/TestConnector.java
+++ b/engine-plugins/connect-plugin/src/test/java/org/operaton/connect/plugin/util/TestConnector.java
@@ -16,10 +16,10 @@
  */
 package org.operaton.connect.plugin.util;
 
-import java.lang.Exception;import java.lang.Object;import java.lang.RuntimeException;import java.lang.String;import java.util.HashMap;
-import java.util.Map;
-
 import org.operaton.connect.impl.AbstractConnector;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Daniel Meyer

--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapGroupQueryTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapGroupQueryTest.java
@@ -270,6 +270,7 @@ public class LdapGroupQueryTest {
 
     LdapIdentityProviderSession session = new LdapIdentityProviderSession(ldapConfiguration) {
       // mock getDnForUser
+      @Override
       protected String getDnForUser(String userId) {
         return userId+ ", fullDn";
       }

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/impl/SpinVariableSerializers.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/impl/SpinVariableSerializers.java
@@ -36,7 +36,7 @@ public class SpinVariableSerializers {
   }
 
   public static List<TypedValueSerializer<?>> createObjectValueSerializers(DataFormats dataFormats) {
-    List<TypedValueSerializer<?>> serializers = new ArrayList<TypedValueSerializer<?>>();
+    List<TypedValueSerializer<?>> serializers = new ArrayList<>();
 
     Set<DataFormat<?>> availableDataFormats = dataFormats.getAllAvailableDataFormats();
     for (DataFormat<?> dataFormat : availableDataFormats) {
@@ -47,7 +47,7 @@ public class SpinVariableSerializers {
   }
 
   public static List<TypedValueSerializer<?>> createSpinValueSerializers(DataFormats dataFormats) {
-    List<TypedValueSerializer<?>> serializers = new ArrayList<TypedValueSerializer<?>>();
+    List<TypedValueSerializer<?>> serializers = new ArrayList<>();
 
     if(dataFormats.getDataFormatByName(DataFormats.JSON_DATAFORMAT_NAME) != null) {
       DataFormat<SpinJsonNode> jsonDataFormat =

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/value/impl/SpinValueImpl.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/value/impl/SpinValueImpl.java
@@ -70,6 +70,7 @@ public abstract class SpinValueImpl extends AbstractTypedValue<Spin<?>> implemen
     }
   }
 
+  @Override
   public SpinValueType getType() {
     return (SpinValueType) super.getType();
   }

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/value/impl/builder/JsonValueBuilderImpl.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/value/impl/builder/JsonValueBuilderImpl.java
@@ -40,6 +40,7 @@ public class JsonValueBuilderImpl extends SpinValueBuilderImpl<JsonValue> implem
     this(new JsonValueImpl(value));
   }
 
+  @Override
   public JsonValueBuilder serializationDataFormat(SerializationDataFormat dataFormat) {
     return (JsonValueBuilderImpl) super.serializationDataFormat(dataFormat);
   }

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/value/impl/builder/XmlValueBuilderImpl.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/value/impl/builder/XmlValueBuilderImpl.java
@@ -40,6 +40,7 @@ public class XmlValueBuilderImpl extends SpinValueBuilderImpl<XmlValue> implemen
     this(new XmlValueImpl(value));
   }
 
+  @Override
   public XmlValueBuilder serializationDataFormat(SerializationDataFormat dataFormat) {
     return (XmlValueBuilder) super.serializationDataFormat(dataFormat);
   }

--- a/engine-plugins/spin-plugin/src/test/java/org/operaton/spin/plugin/script/SpinScriptTaskSupportWithAutoStoreScriptVariablesTest.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/operaton/spin/plugin/script/SpinScriptTaskSupportWithAutoStoreScriptVariablesTest.java
@@ -40,10 +40,12 @@ public class SpinScriptTaskSupportWithAutoStoreScriptVariablesTest extends Plugg
 
   protected ProcessInstance processInstance;
 
+  @Override
   public void setUp() {
     processEngineConfiguration.setAutoStoreScriptVariables(true);
   }
 
+  @Override
   public void tearDown() {
     processEngineConfiguration.setAutoStoreScriptVariables(false);
   }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/CaseExecutionQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/CaseExecutionQueryDto.java
@@ -229,21 +229,15 @@ public class CaseExecutionQueryDto extends AbstractQueryDto<CaseExecutionQuery> 
         String op = variableQueryParam.getOperator();
         Object variableValue = variableQueryParam.resolveValue(objectMapper);
 
-        if (op.equals(EQUALS_OPERATOR_NAME)) {
-          query.variableValueEquals(variableName, variableValue);
-        } else if (op.equals(GREATER_THAN_OPERATOR_NAME)) {
-          query.variableValueGreaterThan(variableName, variableValue);
-        } else if (op.equals(GREATER_THAN_OR_EQUALS_OPERATOR_NAME)) {
-          query.variableValueGreaterThanOrEqual(variableName, variableValue);
-        } else if (op.equals(LESS_THAN_OPERATOR_NAME)) {
-          query.variableValueLessThan(variableName, variableValue);
-        } else if (op.equals(LESS_THAN_OR_EQUALS_OPERATOR_NAME)) {
-          query.variableValueLessThanOrEqual(variableName, variableValue);
-        } else if (op.equals(NOT_EQUALS_OPERATOR_NAME)) {
-          query.variableValueNotEquals(variableName, variableValue);
-        } else if (op.equals(LIKE_OPERATOR_NAME)) {
-          query.variableValueLike(variableName, String.valueOf(variableValue));
-        } else {
+        switch (op) {
+        case EQUALS_OPERATOR_NAME -> query.variableValueEquals(variableName, variableValue);
+        case GREATER_THAN_OPERATOR_NAME -> query.variableValueGreaterThan(variableName, variableValue);
+        case GREATER_THAN_OR_EQUALS_OPERATOR_NAME -> query.variableValueGreaterThanOrEqual(variableName, variableValue);
+        case LESS_THAN_OPERATOR_NAME -> query.variableValueLessThan(variableName, variableValue);
+        case LESS_THAN_OR_EQUALS_OPERATOR_NAME -> query.variableValueLessThanOrEqual(variableName, variableValue);
+        case NOT_EQUALS_OPERATOR_NAME -> query.variableValueNotEquals(variableName, variableValue);
+        case LIKE_OPERATOR_NAME -> query.variableValueLike(variableName, String.valueOf(variableValue));
+        default ->
           throw new InvalidRequestException(Status.BAD_REQUEST, "Invalid variable comparator specified: " + op);
         }
       }
@@ -257,21 +251,17 @@ public class CaseExecutionQueryDto extends AbstractQueryDto<CaseExecutionQuery> 
         String op = variableQueryParam.getOperator();
         Object variableValue = variableQueryParam.resolveValue(objectMapper);
 
-        if (op.equals(EQUALS_OPERATOR_NAME)) {
-          query.caseInstanceVariableValueEquals(variableName, variableValue);
-        } else if (op.equals(GREATER_THAN_OPERATOR_NAME)) {
-          query.caseInstanceVariableValueGreaterThan(variableName, variableValue);
-        } else if (op.equals(GREATER_THAN_OR_EQUALS_OPERATOR_NAME)) {
+        switch (op) {
+        case EQUALS_OPERATOR_NAME -> query.caseInstanceVariableValueEquals(variableName, variableValue);
+        case GREATER_THAN_OPERATOR_NAME -> query.caseInstanceVariableValueGreaterThan(variableName, variableValue);
+        case GREATER_THAN_OR_EQUALS_OPERATOR_NAME ->
           query.caseInstanceVariableValueGreaterThanOrEqual(variableName, variableValue);
-        } else if (op.equals(LESS_THAN_OPERATOR_NAME)) {
-          query.caseInstanceVariableValueLessThan(variableName, variableValue);
-        } else if (op.equals(LESS_THAN_OR_EQUALS_OPERATOR_NAME)) {
+        case LESS_THAN_OPERATOR_NAME -> query.caseInstanceVariableValueLessThan(variableName, variableValue);
+        case LESS_THAN_OR_EQUALS_OPERATOR_NAME ->
           query.caseInstanceVariableValueLessThanOrEqual(variableName, variableValue);
-        } else if (op.equals(NOT_EQUALS_OPERATOR_NAME)) {
-          query.caseInstanceVariableValueNotEquals(variableName, variableValue);
-        } else if (op.equals(LIKE_OPERATOR_NAME)) {
-          query.caseInstanceVariableValueLike(variableName, String.valueOf(variableValue));
-        } else {
+        case NOT_EQUALS_OPERATOR_NAME -> query.caseInstanceVariableValueNotEquals(variableName, variableValue);
+        case LIKE_OPERATOR_NAME -> query.caseInstanceVariableValueLike(variableName, String.valueOf(variableValue));
+        default ->
           throw new InvalidRequestException(Status.BAD_REQUEST, "Invalid variable comparator specified: " + op);
         }
       }
@@ -279,14 +269,11 @@ public class CaseExecutionQueryDto extends AbstractQueryDto<CaseExecutionQuery> 
   }
 
   protected void applySortBy(CaseExecutionQuery query, String sortBy, Map<String, Object> parameters, ProcessEngine engine) {
-    if (sortBy.equals(SORT_BY_EXECUTION_ID_VALUE)) {
-      query.orderByCaseExecutionId();
-    } else if (sortBy.equals(SORT_BY_DEFINITION_KEY_VALUE)) {
-      query.orderByCaseDefinitionKey();
-    } else if (sortBy.equals(SORT_BY_DEFINITION_ID_VALUE)) {
-      query.orderByCaseDefinitionId();
-    } else if (sortBy.equals(SORT_BY_TENANT_ID)) {
-      query.orderByTenantId();
+    switch (sortBy) {
+    case SORT_BY_EXECUTION_ID_VALUE -> query.orderByCaseExecutionId();
+    case SORT_BY_DEFINITION_KEY_VALUE -> query.orderByCaseDefinitionKey();
+    case SORT_BY_DEFINITION_ID_VALUE -> query.orderByCaseDefinitionId();
+    case SORT_BY_TENANT_ID -> query.orderByTenantId();
     }
   }
 }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/CaseExecutionQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/CaseExecutionQueryDto.java
@@ -35,6 +35,8 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import static java.lang.Boolean.TRUE;
+
 /**
  * @author Roman Smirnov
  *
@@ -195,27 +197,27 @@ public class CaseExecutionQueryDto extends AbstractQueryDto<CaseExecutionQuery> 
       query.tenantIdIn(tenantIds.toArray(new String[tenantIds.size()]));
     }
 
-    if (required != null && required == true) {
+    if (TRUE.equals(required)) {
       query.required();
     }
 
-    if (active != null && active == true) {
+    if (TRUE.equals(active)) {
       query.active();
     }
 
-    if (enabled != null && enabled == true) {
+    if (TRUE.equals(enabled)) {
       query.enabled();
     }
 
-    if (disabled != null && disabled == true) {
+    if (TRUE.equals(disabled)) {
       query.disabled();
     }
 
-    if(Boolean.TRUE.equals(variableNamesIgnoreCase)) {
+    if(TRUE.equals(variableNamesIgnoreCase)) {
       query.matchVariableNamesIgnoreCase();
     }
 
-    if(Boolean.TRUE.equals(variableValuesIgnoreCase)) {
+    if(TRUE.equals(variableValuesIgnoreCase)) {
       query.matchVariableValuesIgnoreCase();
     }
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/CaseInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/CaseInstanceQueryDto.java
@@ -237,21 +237,15 @@ public class CaseInstanceQueryDto extends AbstractQueryDto<CaseInstanceQuery> {
         String op = variableQueryParam.getOperator();
         Object variableValue = variableQueryParam.resolveValue(objectMapper);
 
-        if (op.equals(EQUALS_OPERATOR_NAME)) {
-          query.variableValueEquals(variableName, variableValue);
-        } else if (op.equals(GREATER_THAN_OPERATOR_NAME)) {
-          query.variableValueGreaterThan(variableName, variableValue);
-        } else if (op.equals(GREATER_THAN_OR_EQUALS_OPERATOR_NAME)) {
-          query.variableValueGreaterThanOrEqual(variableName, variableValue);
-        } else if (op.equals(LESS_THAN_OPERATOR_NAME)) {
-          query.variableValueLessThan(variableName, variableValue);
-        } else if (op.equals(LESS_THAN_OR_EQUALS_OPERATOR_NAME)) {
-          query.variableValueLessThanOrEqual(variableName, variableValue);
-        } else if (op.equals(NOT_EQUALS_OPERATOR_NAME)) {
-          query.variableValueNotEquals(variableName, variableValue);
-        } else if (op.equals(LIKE_OPERATOR_NAME)) {
-          query.variableValueLike(variableName, String.valueOf(variableValue));
-        } else {
+        switch (op) {
+        case EQUALS_OPERATOR_NAME -> query.variableValueEquals(variableName, variableValue);
+        case GREATER_THAN_OPERATOR_NAME -> query.variableValueGreaterThan(variableName, variableValue);
+        case GREATER_THAN_OR_EQUALS_OPERATOR_NAME -> query.variableValueGreaterThanOrEqual(variableName, variableValue);
+        case LESS_THAN_OPERATOR_NAME -> query.variableValueLessThan(variableName, variableValue);
+        case LESS_THAN_OR_EQUALS_OPERATOR_NAME -> query.variableValueLessThanOrEqual(variableName, variableValue);
+        case NOT_EQUALS_OPERATOR_NAME -> query.variableValueNotEquals(variableName, variableValue);
+        case LIKE_OPERATOR_NAME -> query.variableValueLike(variableName, String.valueOf(variableValue));
+        default ->
           throw new InvalidRequestException(Status.BAD_REQUEST, "Invalid variable comparator specified: " + op);
         }
       }
@@ -260,14 +254,11 @@ public class CaseInstanceQueryDto extends AbstractQueryDto<CaseInstanceQuery> {
 
   @Override
   protected void applySortBy(CaseInstanceQuery query, String sortBy, Map<String, Object> parameters, ProcessEngine engine) {
-    if (sortBy.equals(SORT_BY_INSTANCE_ID_VALUE)) {
-      query.orderByCaseInstanceId();
-    } else if (sortBy.equals(SORT_BY_DEFINITION_KEY_VALUE)) {
-      query.orderByCaseDefinitionKey();
-    } else if (sortBy.equals(SORT_BY_DEFINITION_ID_VALUE)) {
-      query.orderByCaseDefinitionId();
-    } else if (sortBy.equals(SORT_BY_TENANT_ID)) {
-      query.orderByTenantId();
+    switch (sortBy) {
+    case SORT_BY_INSTANCE_ID_VALUE -> query.orderByCaseInstanceId();
+    case SORT_BY_DEFINITION_KEY_VALUE -> query.orderByCaseDefinitionKey();
+    case SORT_BY_DEFINITION_ID_VALUE -> query.orderByCaseDefinitionId();
+    case SORT_BY_TENANT_ID -> query.orderByTenantId();
     }
   }
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/CaseInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/CaseInstanceQueryDto.java
@@ -214,19 +214,19 @@ public class CaseInstanceQueryDto extends AbstractQueryDto<CaseInstanceQuery> {
     if (TRUE.equals(withoutTenantId)) {
       query.withoutTenantId();
     }
-    if (active != null && active == true) {
+    if (TRUE.equals(active)) {
       query.active();
     }
-    if (completed != null && completed == true) {
+    if (TRUE.equals(completed)) {
       query.completed();
     }
-    if (terminated != null && terminated == true) {
+    if (TRUE.equals(terminated)) {
       query.terminated();
     }
-    if(Boolean.TRUE.equals(variableNamesIgnoreCase)) {
+    if(TRUE.equals(variableNamesIgnoreCase)) {
       query.matchVariableNamesIgnoreCase();
     }
-    if(Boolean.TRUE.equals(variableValuesIgnoreCase)) {
+    if(TRUE.equals(variableValuesIgnoreCase)) {
       query.matchVariableValuesIgnoreCase();
     }
     if (variables != null) {

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/ExecutionQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/ExecutionQueryDto.java
@@ -238,21 +238,15 @@ public class ExecutionQueryDto extends AbstractQueryDto<ExecutionQuery> {
         String op = variableQueryParam.getOperator();
         Object variableValue = variableQueryParam.resolveValue(objectMapper);
 
-        if (op.equals(EQUALS_OPERATOR_NAME)) {
-          query.variableValueEquals(variableName, variableValue);
-        } else if (op.equals(GREATER_THAN_OPERATOR_NAME)) {
-          query.variableValueGreaterThan(variableName, variableValue);
-        } else if (op.equals(GREATER_THAN_OR_EQUALS_OPERATOR_NAME)) {
-          query.variableValueGreaterThanOrEqual(variableName, variableValue);
-        } else if (op.equals(LESS_THAN_OPERATOR_NAME)) {
-          query.variableValueLessThan(variableName, variableValue);
-        } else if (op.equals(LESS_THAN_OR_EQUALS_OPERATOR_NAME)) {
-          query.variableValueLessThanOrEqual(variableName, variableValue);
-        } else if (op.equals(NOT_EQUALS_OPERATOR_NAME)) {
-          query.variableValueNotEquals(variableName, variableValue);
-        } else if (op.equals(LIKE_OPERATOR_NAME)) {
-          query.variableValueLike(variableName, String.valueOf(variableValue));
-        } else {
+        switch (op) {
+        case EQUALS_OPERATOR_NAME -> query.variableValueEquals(variableName, variableValue);
+        case GREATER_THAN_OPERATOR_NAME -> query.variableValueGreaterThan(variableName, variableValue);
+        case GREATER_THAN_OR_EQUALS_OPERATOR_NAME -> query.variableValueGreaterThanOrEqual(variableName, variableValue);
+        case LESS_THAN_OPERATOR_NAME -> query.variableValueLessThan(variableName, variableValue);
+        case LESS_THAN_OR_EQUALS_OPERATOR_NAME -> query.variableValueLessThanOrEqual(variableName, variableValue);
+        case NOT_EQUALS_OPERATOR_NAME -> query.variableValueNotEquals(variableName, variableValue);
+        case LIKE_OPERATOR_NAME -> query.variableValueLike(variableName, String.valueOf(variableValue));
+        default ->
           throw new InvalidRequestException(Status.BAD_REQUEST, "Invalid variable comparator specified: " + op);
         }
       }
@@ -277,14 +271,11 @@ public class ExecutionQueryDto extends AbstractQueryDto<ExecutionQuery> {
 
   @Override
   protected void applySortBy(ExecutionQuery query, String sortBy, Map<String, Object> parameters, ProcessEngine engine) {
-    if (sortBy.equals(SORT_BY_INSTANCE_ID_VALUE)) {
-      query.orderByProcessInstanceId();
-    } else if (sortBy.equals(SORT_BY_DEFINITION_KEY_VALUE)) {
-      query.orderByProcessDefinitionKey();
-    } else if (sortBy.equals(SORT_BY_DEFINITION_ID_VALUE)) {
-      query.orderByProcessDefinitionId();
-    } else if (sortBy.equals(SORT_BY_TENANT_ID)) {
-      query.orderByTenantId();
+    switch (sortBy) {
+    case SORT_BY_INSTANCE_ID_VALUE -> query.orderByProcessInstanceId();
+    case SORT_BY_DEFINITION_KEY_VALUE -> query.orderByProcessDefinitionKey();
+    case SORT_BY_DEFINITION_ID_VALUE -> query.orderByProcessDefinitionId();
+    case SORT_BY_TENANT_ID -> query.orderByTenantId();
     }
   }
 }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/ExecutionQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/ExecutionQueryDto.java
@@ -35,6 +35,8 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import static java.lang.Boolean.TRUE;
+
 public class ExecutionQueryDto extends AbstractQueryDto<ExecutionQuery> {
 
   private static final String SORT_BY_INSTANCE_ID_VALUE = "instanceId";
@@ -203,10 +205,10 @@ public class ExecutionQueryDto extends AbstractQueryDto<ExecutionQuery> {
     if (messageEventSubscriptionName != null) {
       query.messageEventSubscriptionName(messageEventSubscriptionName);
     }
-    if (active != null && active == true) {
+    if (TRUE.equals(active)) {
       query.active();
     }
-    if (suspended != null && suspended == true) {
+    if (TRUE.equals(suspended)) {
       query.suspended();
     }
     if (incidentId != null) {
@@ -224,10 +226,10 @@ public class ExecutionQueryDto extends AbstractQueryDto<ExecutionQuery> {
     if (tenantIdIn != null && !tenantIdIn.isEmpty()) {
       query.tenantIdIn(tenantIdIn.toArray(new String[tenantIdIn.size()]));
     }
-    if(Boolean.TRUE.equals(variableNamesIgnoreCase)) {
+    if(TRUE.equals(variableNamesIgnoreCase)) {
       query.matchVariableNamesIgnoreCase();
     }
-    if(Boolean.TRUE.equals(variableValuesIgnoreCase)) {
+    if(TRUE.equals(variableValuesIgnoreCase)) {
       query.matchVariableValuesIgnoreCase();
     }
     if (variables != null) {

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/JsonPathUtil.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/JsonPathUtil.java
@@ -16,11 +16,8 @@
  */
 package org.operaton.bpm.engine.rest.util;
 
-import org.operaton.bpm.engine.rest.mapper.JacksonConfigurator;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.restassured.path.json.mapper.factory.DefaultJackson2ObjectMapperFactory;
 import io.restassured.path.json.JsonPath;
+import io.restassured.path.json.mapper.factory.DefaultJackson2ObjectMapperFactory;
 
 public final class JsonPathUtil {
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/AuthorizationQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/AuthorizationQueryImpl.java
@@ -106,7 +106,7 @@ public class AuthorizationQueryImpl extends AbstractQuery<AuthorizationQuery, Au
     if (resourcesIntersection.isEmpty()) {
       resourcesIntersection.addAll(Arrays.asList(p.getTypes()));
     } else {
-      resourcesIntersection.retainAll(new HashSet<Resource>(Arrays.asList(p.getTypes())));
+      resourcesIntersection.retainAll(new HashSet<>(Arrays.asList(p.getTypes())));
     }
 
     this.permission |= p.getValue();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/SchemaOperationsProcessEngineBuild.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/SchemaOperationsProcessEngineBuild.java
@@ -20,7 +20,6 @@ import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.SchemaOperationsCommand;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.context.Context;
-import org.operaton.bpm.engine.impl.db.EnginePersistenceLogger;
 import org.operaton.bpm.engine.impl.db.PersistenceSession;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/TaskQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/TaskQueryImpl.java
@@ -1589,7 +1589,7 @@ public class TaskQueryImpl extends AbstractQuery<TaskQuery, Task> implements Tas
   }
 
   public boolean isIncludeAssignedTasks() {
-    return includeAssignedTasks != null ? includeAssignedTasks : false;
+    return Boolean.TRUE.equals(includeAssignedTasks);
   }
 
   public Boolean isIncludeAssignedTasksInternal() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ant/DeployBarTask.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ant/DeployBarTask.java
@@ -41,7 +41,8 @@ public class DeployBarTask extends Task {
   String processEngineName = ProcessEngines.NAME_DEFAULT;
   File file;
   List<FileSet> fileSets;
-  
+
+  @Override
   public void execute() throws BuildException {
     List<File> files = new ArrayList<>();
     if (file!=null) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ant/LaunchTask.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ant/LaunchTask.java
@@ -36,7 +36,8 @@ public class LaunchTask extends Task {
   String script;
   String msg;
   String args;
-  
+
+  @Override
   public void execute() throws BuildException {
     if (dir==null) {
       throw new BuildException("dir attribute is required with the launch task");

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -1685,7 +1685,7 @@ public class BpmnParse extends Parse {
     LegacyBehavior.parseCancelBoundaryEvent(activity);
 
     ActivityImpl transaction = (ActivityImpl) activity.getEventScope();
-    if (transaction.getActivityBehavior() != null && transaction.getActivityBehavior() instanceof MultiInstanceActivityBehavior) {
+    if (transaction.getActivityBehavior() instanceof MultiInstanceActivityBehavior) {
       transaction = transaction.getActivities().get(0);
     }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/CronExpression.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/CronExpression.java
@@ -311,25 +311,25 @@ public class CronExpression implements Serializable, Cloneable {
         try {
 
             if (seconds == null) {
-                seconds = new TreeSet<Integer>();
+                seconds = new TreeSet<>();
             }
             if (minutes == null) {
-                minutes = new TreeSet<Integer>();
+                minutes = new TreeSet<>();
             }
             if (hours == null) {
-                hours = new TreeSet<Integer>();
+                hours = new TreeSet<>();
             }
             if (daysOfMonth == null) {
-                daysOfMonth = new TreeSet<Integer>();
+                daysOfMonth = new TreeSet<>();
             }
             if (months == null) {
-                months = new TreeSet<Integer>();
+                months = new TreeSet<>();
             }
             if (daysOfWeek == null) {
-                daysOfWeek = new TreeSet<Integer>();
+                daysOfWeek = new TreeSet<>();
             }
             if (years == null) {
-                years = new TreeSet<Integer>();
+                years = new TreeSet<>();
             }
 
             int exprOn = SECOND;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -1467,7 +1467,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         if (jdbcMaxWaitTime > 0) {
           pooledDataSource.setPoolTimeToWait(jdbcMaxWaitTime);
         }
-        if (jdbcPingEnabled == true) {
+        if (jdbcPingEnabled) {
           pooledDataSource.setPoolPingEnabled(true);
           if (jdbcPingQuery != null) {
             pooledDataSource.setPoolPingQuery(jdbcPingQuery);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractInstantiationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractInstantiationCmd.java
@@ -280,7 +280,7 @@ public abstract class AbstractInstantiationCmd extends AbstractProcessInstanceMo
    */
   protected boolean supportsConcurrentChildInstantiation(ScopeImpl flowScope) {
     CoreActivityBehavior<?> behavior = flowScope.getActivityBehavior();
-    return behavior == null || !(behavior instanceof SequentialMultiInstanceActivityBehavior);
+    return !(behavior instanceof SequentialMultiInstanceActivityBehavior);
   }
 
   protected ExecutionEntity getSingleExecutionForScope(ActivityExecutionTreeMapping mapping, ScopeImpl scope) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricCaseInstancesBulkCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/DeleteHistoricCaseInstancesBulkCmd.java
@@ -49,7 +49,7 @@ public class DeleteHistoricCaseInstancesBulkCmd implements Command<Void>, Serial
     // Check if case instances are all closed
     commandContext.runWithoutAuthorization((Callable<Void>) () -> {
       ensureEquals(BadUserRequestException.class, "ClosedCaseInstanceIds",
-          new HistoricCaseInstanceQueryImpl().closed().caseInstanceIds(new HashSet<String>(caseInstanceIds)).count(), caseInstanceIds.size());
+          new HistoricCaseInstanceQueryImpl().closed().caseInstanceIds(new HashSet<>(caseInstanceIds)).count(), caseInstanceIds.size());
       return null;
     });
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseExecutionEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseExecutionEntity.java
@@ -763,6 +763,7 @@ public class CaseExecutionEntity extends CmmnExecution implements CaseExecution,
     }
   }
 
+  @Override
   protected String getToStringIdentity() {
     return id;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AbstractAtomicOperationCaseExecutionComplete.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AbstractAtomicOperationCaseExecutionComplete.java
@@ -40,6 +40,7 @@ public abstract class AbstractAtomicOperationCaseExecutionComplete extends Abstr
     return COMPLETE;
   }
 
+  @Override
   protected CmmnExecution eventNotificationsStarted(CmmnExecution execution) {
     CmmnActivityBehavior behavior = getActivityBehavior(execution);
     triggerBehavior(behavior, execution);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AbstractAtomicOperationCaseExecutionResume.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AbstractAtomicOperationCaseExecutionResume.java
@@ -28,6 +28,7 @@ import org.operaton.bpm.engine.impl.cmmn.execution.CmmnExecution;
  */
 public abstract class AbstractAtomicOperationCaseExecutionResume extends AbstractCmmnEventAtomicOperation {
 
+  @Override
   protected CmmnExecution eventNotificationsStarted(CmmnExecution execution) {
     CmmnActivityBehavior behavior = getActivityBehavior(execution);
     triggerBehavior(behavior, execution);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AbstractAtomicOperationCaseExecutionSuspend.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AbstractAtomicOperationCaseExecutionSuspend.java
@@ -29,6 +29,7 @@ import org.operaton.bpm.engine.impl.cmmn.execution.CmmnExecution;
  */
 public abstract class AbstractAtomicOperationCaseExecutionSuspend extends AbstractCmmnEventAtomicOperation {
 
+  @Override
   protected CmmnExecution eventNotificationsStarted(CmmnExecution execution) {
     execution.setCurrentState(SUSPENDED);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AbstractAtomicOperationCaseExecutionTerminate.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AbstractAtomicOperationCaseExecutionTerminate.java
@@ -29,6 +29,7 @@ import org.operaton.bpm.engine.impl.cmmn.execution.CmmnExecution;
  */
 public abstract class AbstractAtomicOperationCaseExecutionTerminate extends AbstractCmmnEventAtomicOperation {
 
+  @Override
   protected CmmnExecution eventNotificationsStarted(CmmnExecution execution) {
     // set current case execution as "TERMINATED"
     execution.setCurrentState(TERMINATED);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseExecutionCreate.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseExecutionCreate.java
@@ -38,6 +38,7 @@ public class AtomicOperationCaseExecutionCreate extends AbstractCmmnEventAtomicO
     return CREATE;
   }
 
+  @Override
   protected CmmnExecution eventNotificationsStarted(CmmnExecution execution) {
     CmmnActivityBehavior behavior = getActivityBehavior(execution);
     behavior.onCreate(execution);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseExecutionDisable.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseExecutionDisable.java
@@ -39,6 +39,7 @@ public class AtomicOperationCaseExecutionDisable extends AbstractCmmnEventAtomic
     return DISABLE;
   }
 
+  @Override
   protected CmmnExecution eventNotificationsStarted(CmmnExecution execution) {
     CmmnActivityBehavior behavior = getActivityBehavior(execution);
     behavior.onDisable(execution);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseExecutionEnable.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseExecutionEnable.java
@@ -38,6 +38,7 @@ public class AtomicOperationCaseExecutionEnable extends AbstractCmmnEventAtomicO
     return ENABLE;
   }
 
+  @Override
   protected CmmnExecution eventNotificationsStarted(CmmnExecution execution) {
     CmmnActivityBehavior behavior = getActivityBehavior(execution);
     behavior.onEnable(execution);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseExecutionManualStart.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseExecutionManualStart.java
@@ -38,6 +38,7 @@ public class AtomicOperationCaseExecutionManualStart extends AbstractCmmnEventAt
     return MANUAL_START;
   }
 
+  @Override
   protected CmmnExecution eventNotificationsStarted(CmmnExecution execution) {
     CmmnActivityBehavior behavior = getActivityBehavior(execution);
     behavior.onManualStart(execution);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseExecutionReactivate.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseExecutionReactivate.java
@@ -38,6 +38,7 @@ public class AtomicOperationCaseExecutionReactivate extends AbstractCmmnEventAto
     return RE_ACTIVATE;
   }
 
+  @Override
   protected CmmnExecution eventNotificationsStarted(CmmnExecution execution) {
     CmmnActivityBehavior behavior = getActivityBehavior(execution);
     behavior.onReactivation(execution);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseExecutionReenable.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseExecutionReenable.java
@@ -38,6 +38,7 @@ public class AtomicOperationCaseExecutionReenable extends AbstractCmmnEventAtomi
     return RE_ENABLE;
   }
 
+  @Override
   protected CmmnExecution eventNotificationsStarted(CmmnExecution execution) {
     CmmnActivityBehavior behavior = getActivityBehavior(execution);
     behavior.onReenable(execution);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseInstanceClose.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseInstanceClose.java
@@ -38,6 +38,7 @@ public class AtomicOperationCaseInstanceClose extends AbstractCmmnEventAtomicOpe
     return CLOSE;
   }
 
+  @Override
   protected CmmnExecution eventNotificationsStarted(CmmnExecution execution) {
     CmmnActivityBehavior behavior = getActivityBehavior(execution);
     behavior.onClose(execution);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseInstanceCreate.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/AtomicOperationCaseInstanceCreate.java
@@ -38,6 +38,7 @@ public class AtomicOperationCaseInstanceCreate extends AbstractCmmnEventAtomicOp
     return CREATE;
   }
 
+  @Override
   protected CmmnExecution eventNotificationsStarted(CmmnExecution execution) {
     // the case instance perform a transition directly
     // to state ACTIVE

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/el/AbstractElResolverDelegate.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/el/AbstractElResolverDelegate.java
@@ -88,6 +88,7 @@ public abstract class AbstractElResolverDelegate extends ELResolver {
     }
   }
 
+  @Override
   public Object invoke(ELContext context, Object base, Object method, Class<?>[] paramTypes, Object[] params) {
     context.setPropertyResolved(false);
     ELResolver delegate = getElResolverDelegate();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/JobExecutorContext.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/JobExecutorContext.java
@@ -39,7 +39,7 @@ public class JobExecutorContext {
   }
 
   public boolean isExecutingExclusiveJob() {
-    return currentJob == null ? false : currentJob.isExclusive();
+    return currentJob != null && currentJob.isExclusive();
   }
 
   public void setCurrentJob(JobEntity currentJob) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/HistoryCleanupJobDeclaration.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/HistoryCleanupJobDeclaration.java
@@ -16,10 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.jobexecutor.historycleanup;
 
-import java.util.Date;
-import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.operaton.bpm.engine.impl.cmd.CommandLogger;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.core.variable.mapping.value.ConstantValueProvider;
 import org.operaton.bpm.engine.impl.core.variable.mapping.value.ParameterValueProvider;
@@ -28,6 +25,8 @@ import org.operaton.bpm.engine.impl.jobexecutor.JobDeclaration;
 import org.operaton.bpm.engine.impl.persistence.entity.EverLivingJobEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
+
+import java.util.Date;
 
 /**
  * Job declaration for history cleanup.

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/json/JsonQueryOrderingPropertyConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/json/JsonQueryOrderingPropertyConverter.java
@@ -40,7 +40,7 @@ public class JsonQueryOrderingPropertyConverter extends JsonObjectConverter<Quer
       new JsonQueryOrderingPropertyConverter();
 
   protected static JsonArrayConverter<List<QueryOrderingProperty>> ARRAY_CONVERTER =
-      new JsonArrayOfObjectsConverter<QueryOrderingProperty>(INSTANCE);
+      new JsonArrayOfObjectsConverter<>(INSTANCE);
 
   public static final String RELATION = "relation";
   public static final String QUERY_PROPERTY = "queryProperty";

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/instance/MigratingScopeInstanceBranch.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/instance/MigratingScopeInstanceBranch.java
@@ -41,7 +41,7 @@ public class MigratingScopeInstanceBranch {
 
   public MigratingScopeInstanceBranch copy() {
     return new MigratingScopeInstanceBranch(
-        new HashMap<ScopeImpl, MigratingScopeInstance>(scopeInstances));
+        new HashMap<>(scopeInstances));
   }
 
   public MigratingScopeInstance getInstance(ScopeImpl scope) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/deploy/cache/CachePurgeReport.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/deploy/cache/CachePurgeReport.java
@@ -44,7 +44,7 @@ public class CachePurgeReport implements PurgeReporting<Set<String>> {
 
   @Override
   public void addPurgeInformation(String key, Set<String> value) {
-    deletedCache.put(key, new HashSet<String>(value));
+    deletedCache.put(key, new HashSet<>(value));
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -1093,7 +1093,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
    * @return true if the next listener can be invoked; false if not
    */
   protected boolean invokeListener(CoreExecution currentExecution, String eventName, TaskListener taskListener) throws Exception {
-    boolean isBpmnTask = currentExecution instanceof ActivityExecution && currentExecution != null;
+    boolean isBpmnTask = currentExecution instanceof ActivityExecution;
     final TaskListenerInvocation listenerInvocation = new TaskListenerInvocation(taskListener, this, currentExecution);
 
     try {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationProcessStart.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationProcessStart.java
@@ -48,6 +48,7 @@ public class PvmAtomicOperationProcessStart extends AbstractPvmEventAtomicOperat
     return ExecutionListener.EVENTNAME_START;
   }
 
+  @Override
   protected PvmExecutionImpl eventNotificationsStarted(PvmExecutionImpl execution) {
 
     // restoring the starting flag in case this operation is executed

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/test/PluggableProcessEngineTestCase.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/test/PluggableProcessEngineTestCase.java
@@ -59,7 +59,7 @@ public class PluggableProcessEngineTestCase extends AbstractProcessEngineTestCas
                 .createProcessEngineConfigurationFromResource("operaton.cfg.xml")
                 .buildProcessEngine();
       } catch (RuntimeException ex) {
-        if (ex.getCause() != null && ex.getCause() instanceof FileNotFoundException) {
+        if (ex.getCause() instanceof FileNotFoundException) {
           cachedProcessEngine = ProcessEngineConfiguration
               .createProcessEngineConfigurationFromResource("activiti.cfg.xml")
               .buildProcessEngine();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/tree/ReferenceWalker.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/tree/ReferenceWalker.java
@@ -62,11 +62,11 @@ public abstract class ReferenceWalker<T> {
   }
 
   public T walkWhile() {
-    return walkWhile(new ReferenceWalker.NullCondition<T>());
+    return walkWhile(new ReferenceWalker.NullCondition<>());
   }
 
   public T walkUntil() {
-    return walkUntil(new ReferenceWalker.NullCondition<T>());
+    return walkUntil(new ReferenceWalker.NullCondition<>());
   }
 
   public T walkWhile(ReferenceWalker.WalkCondition<T> condition) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/JsonUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/JsonUtil.java
@@ -512,7 +512,7 @@ public final class JsonUtil {
         LOG.logJsonException(e);
       }
 
-      if (numberValue != null && numberValue instanceof LazilyParsedNumber) {
+      if (numberValue instanceof LazilyParsedNumber) {
         String numberString = numberValue.toString();
         if (numberString != null) {
           rawObject = parseNumber(numberString);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/variable/serializer/AbstractObjectValueSerializer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/variable/serializer/AbstractObjectValueSerializer.java
@@ -95,6 +95,7 @@ public abstract class AbstractObjectValueSerializer extends AbstractSerializable
     return valueFields.getTextValue2();
   }
 
+  @Override
   public boolean isMutableValue(ObjectValue typedValue) {
     return typedValue.isDeserialized();
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/variable/serializer/JavaObjectSerializer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/variable/serializer/JavaObjectSerializer.java
@@ -98,6 +98,7 @@ public class JavaObjectSerializer extends AbstractObjectValueSerializer {
       super(in);
     }
 
+    @Override
     protected Class<?> resolveClass(ObjectStreamClass desc) {
       return ReflectUtil.loadClass(desc.getName());
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/test/ProcessEngineRule.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/test/ProcessEngineRule.java
@@ -185,7 +185,7 @@ public class ProcessEngineRule extends TestWatcher implements ProcessEngineServi
     try {
       processEngine = TestHelper.getProcessEngine(configurationResource);
     } catch (RuntimeException ex) {
-      if (ex.getCause() != null && ex.getCause() instanceof FileNotFoundException) {
+      if (ex.getCause() instanceof FileNotFoundException) {
         processEngine = TestHelper.getProcessEngine(configurationResourceCompat);
       } else {
         throw ex;

--- a/engine/src/main/java/org/operaton/bpm/engine/test/ProcessEngineTestCase.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/test/ProcessEngineTestCase.java
@@ -124,7 +124,7 @@ public class ProcessEngineTestCase extends TestCase {
     try {
       processEngine = TestHelper.getProcessEngine(getConfigurationResource());
     } catch (RuntimeException ex) {
-      if (ex.getCause() != null && ex.getCause() instanceof FileNotFoundException) {
+      if (ex.getCause() instanceof FileNotFoundException) {
         processEngine = ProcessEngineConfiguration
             .createProcessEngineConfigurationFromResource(configurationResourceCompat)
             .buildProcessEngine();

--- a/engine/src/test/java/org/operaton/bpm/application/impl/el/CalledProcessApplication.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/el/CalledProcessApplication.java
@@ -36,6 +36,7 @@ public class CalledProcessApplication extends EmbeddedProcessApplication {
 
   public static final String STRING_VARIABLE_VALUE = "aVariableValue";
 
+  @Override
   protected ELResolver initProcessApplicationElResolver() {
     Map<Object, Object> resolvableValues = new HashMap<>();
     resolvableValues.put("aStringValue", STRING_VARIABLE_VALUE);

--- a/engine/src/test/java/org/operaton/bpm/application/impl/el/CallingProcessApplication.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/el/CallingProcessApplication.java
@@ -34,6 +34,7 @@ import jakarta.el.ELResolver;
 )
 public class CallingProcessApplication extends EmbeddedProcessApplication {
 
+  @Override
   protected ELResolver initProcessApplicationElResolver() {
     Map<Object, Object> resolvableValues = new HashMap<>();
     resolvableValues.put("shouldTakeFlow", true);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/creation/removaltime/SetRemovalTimeForHistoricDecisionInstancesBatchAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/creation/removaltime/SetRemovalTimeForHistoricDecisionInstancesBatchAuthorizationTest.java
@@ -93,6 +93,7 @@ public class SetRemovalTimeForHistoricDecisionInstancesBatchAuthorizationTest ex
     authRule.assertScenario(scenario);
   }
 
+  @Override
   protected List<String> setupHistory() {
     engineRule.getDecisionService()
       .evaluateDecisionTableByKey("dish-decision", Variables.createVariables()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/util/AuthorizationTestRule.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/util/AuthorizationTestRule.java
@@ -83,6 +83,7 @@ public class AuthorizationTestRule extends AuthorizationTestBaseRule {
     return interceptor.getLastException() != null;
   }
 
+  @Override
   protected void starting(Description description) {
     ProcessEngineConfigurationImpl engineConfiguration =
         (ProcessEngineConfigurationImpl) engineRule.getProcessEngine().getProcessEngineConfiguration();
@@ -94,6 +95,7 @@ public class AuthorizationTestRule extends AuthorizationTestBaseRule {
     super.starting(description);
   }
 
+  @Override
   protected void finished(Description description) {
     super.finished(description);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseHistoryPropertyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseHistoryPropertyTest.java
@@ -103,6 +103,7 @@ public class DatabaseHistoryPropertyTest {
       super(processEngineConfiguration);
     }
 
+    @Override
     protected void executeSchemaOperations() {
       super.executeSchemaOperations();
     }
@@ -113,6 +114,7 @@ public class DatabaseHistoryPropertyTest {
       super(processEngineConfiguration);
     }
 
+    @Override
     protected void executeSchemaOperations() {
       // nop - do not execute create schema operations
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseTableSchemaTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseTableSchemaTest.java
@@ -164,6 +164,7 @@ public class DatabaseTableSchemaTest {
         super(processEngineConfiguration);
       }
 
+      @Override
       protected void executeSchemaOperations() {
         // nop - do not execute create schema operations
       }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DmnDisabledTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DmnDisabledTest.java
@@ -79,6 +79,7 @@ public class DmnDisabledTest {
       super(processEngineConfiguration);
     }
 
+    @Override
     protected void executeSchemaOperations() {
       // noop - do not execute create schema operations
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/FallbackSerializerFactoryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/FallbackSerializerFactoryTest.java
@@ -153,6 +153,7 @@ public class FallbackSerializerFactoryTest {
       return ExampleSerializer.FORMAT;
     }
 
+    @Override
     protected Object deserializeFromByteArray(byte[] bytes, String objectTypeName) {
       // deserialize everything to a constant string
       return DESERIALIZED_VALUE;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceAsyncOperationsTest.java
@@ -578,6 +578,7 @@ public class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperation
         .toList();
   }
 
+  @Override
   protected List<String> startTestProcesses(int numberOfProcesses) {
     ArrayList<String> processIds = new ArrayList<>();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CaseCallActivityTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CaseCallActivityTest.java
@@ -1567,6 +1567,7 @@ public class CaseCallActivityTest extends CmmnTest {
     return runtimeService.startProcessInstanceByKey(processDefinitionKey, businessKey, variables);
   }
 
+  @Override
   protected CaseExecution queryCaseExecutionById(String id) {
     return caseService
         .createCaseExecutionQuery()
@@ -1574,6 +1575,7 @@ public class CaseCallActivityTest extends CmmnTest {
         .singleResult();
   }
 
+  @Override
   protected CaseExecution queryCaseExecutionByActivityId(String activityId) {
     return caseService
         .createCaseExecutionQuery()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/casetask/CaseTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/casetask/CaseTaskTest.java
@@ -1600,10 +1600,12 @@ public class CaseTaskTest extends CmmnTest {
     assertEquals("caseTask", caseTask.getActivityType());
   }
 
+  @Override
   protected CaseInstance createCaseInstanceByKey(String caseDefinitionKey) {
     return createCaseInstanceByKey(caseDefinitionKey, null, null);
   }
 
+  @Override
   protected CaseInstance createCaseInstanceByKey(String caseDefinitionKey, String businessKey) {
     return caseService
         .withCaseDefinitionByKey(caseDefinitionKey)
@@ -1611,6 +1613,7 @@ public class CaseTaskTest extends CmmnTest {
         .create();
   }
 
+  @Override
   protected CaseExecution queryCaseExecutionById(String id) {
     return caseService
         .createCaseExecutionQuery()
@@ -1618,6 +1621,7 @@ public class CaseTaskTest extends CmmnTest {
         .singleResult();
   }
 
+  @Override
   protected CaseExecution queryCaseExecutionByActivityId(String activityId) {
     return caseService
         .createCaseExecutionQuery()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/operation/TaskWaitState.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/operation/TaskWaitState.java
@@ -25,6 +25,7 @@ import org.operaton.bpm.engine.impl.cmmn.execution.CmmnActivityExecution;
  */
 public class TaskWaitState extends TaskActivityBehavior {
 
+  @Override
   protected void performStart(CmmnActivityExecution execution) {
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/AsyncTransactionContext.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/AsyncTransactionContext.java
@@ -32,6 +32,7 @@ public class AsyncTransactionContext extends StandaloneTransactionContext {
   }
 
   // event is fired in new thread
+  @Override
   protected void fireTransactionEvent(final TransactionState transactionState) {
     Thread thread = new Thread() {
       @Override

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/ControllableJobExecutor.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/ControllableJobExecutor.java
@@ -94,6 +94,7 @@ public class ControllableJobExecutor extends JobExecutor {
     return this;
   }
 
+  @Override
   protected void ensureInitialization() {
     // already initialized in constructor
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/db/entitymanager/DbOperationsOrderingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/db/entitymanager/DbOperationsOrderingTest.java
@@ -258,6 +258,7 @@ public class DbOperationsOrderingTest {
     /**
      * Expose this method for test purposes
      */
+    @Override
     public void flushEntityCache() {
       super.flushEntityCache();
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/entity/EntitySerializationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/entity/EntitySerializationTest.java
@@ -16,17 +16,6 @@
  */
 package org.operaton.bpm.engine.test.standalone.entity;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.util.Collections;
-import java.util.Date;
-
 import org.operaton.bpm.engine.delegate.ExecutionListener;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
@@ -35,7 +24,13 @@ import org.operaton.bpm.engine.impl.pvm.process.ProcessDefinitionImpl;
 import org.operaton.bpm.engine.impl.pvm.process.TransitionImpl;
 import org.operaton.bpm.engine.impl.task.TaskDefinition;
 import org.operaton.bpm.engine.task.DelegationState;
+
+import java.io.*;
+import java.util.Date;
+
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class EntitySerializationTest {
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/util/DbSchemaPrefixTestHelper.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/util/DbSchemaPrefixTestHelper.java
@@ -95,6 +95,7 @@ public class DbSchemaPrefixTestHelper implements InitializingBean, DisposableBea
         super(processEngineConfiguration);
       }
 
+      @Override
       protected void executeSchemaOperations() {
         // nop - do not execute create schema operations
       }

--- a/examples/invoice/src/test/java/org/operaton/bpm/example/invoice/InvoiceTestCase.java
+++ b/examples/invoice/src/test/java/org/operaton/bpm/example/invoice/InvoiceTestCase.java
@@ -42,14 +42,14 @@ import static org.operaton.bpm.engine.impl.test.ProcessEngineAssert.assertProces
 import static org.operaton.bpm.engine.variable.Variables.fileValue;
 
 @ExtendWith(ProcessEngineExtension.class)
-public class InvoiceTestCase {
+class InvoiceTestCase {
    ProcessEngine processEngine;
    RuntimeService runtimeService;
    TaskService taskService;
    ManagementService managementService;
    @Deployment(resources = {"invoice.v1.bpmn", "invoiceBusinessDecisions.dmn"})
    @Test
-   public void testHappyPathV1() {
+   void testHappyPathV1() {
     InputStream invoiceInputStream = InvoiceProcessApplication.class.getClassLoader().getResourceAsStream("invoice.pdf");
     VariableMap variables = Variables.createVariables()
       .putValue("creditor", "Great Pizza for Everyone Inc.")
@@ -93,7 +93,7 @@ public class InvoiceTestCase {
 
    @Deployment(resources = {"invoice.v2.bpmn", "invoiceBusinessDecisions.dmn"})
    @Test
-   public void testHappyPathV2() {
+   void testHappyPathV2() {
     InputStream invoiceInputStream = InvoiceProcessApplication.class.getClassLoader().getResourceAsStream("invoice.pdf");
     VariableMap variables = Variables.createVariables()
       .putValue("creditor", "Great Pizza for Everyone Inc.")
@@ -137,7 +137,7 @@ public class InvoiceTestCase {
 
    @Deployment(resources = {"invoice.v2.bpmn", "invoiceBusinessDecisions.dmn"})
    @Test
-   public void testApproveInvoiceAssignment() {
+   void testApproveInvoiceAssignment() {
     InputStream invoiceInputStream = InvoiceProcessApplication.class.getClassLoader().getResourceAsStream("invoice.pdf");
 
     VariableMap variables = Variables.createVariables()
@@ -182,7 +182,7 @@ public class InvoiceTestCase {
 
    @Deployment(resources = {"invoice.v2.bpmn", "reviewInvoice.bpmn", "invoiceBusinessDecisions.dmn"})
    @Test
-   public void testNonSuccessfulPath() {
+   void testNonSuccessfulPath() {
     InputStream invoiceInputStream = InvoiceProcessApplication.class.getClassLoader().getResourceAsStream("invoice.pdf");
     VariableMap variables = Variables.createVariables()
       .putValue("creditor", "Great Pizza for Everyone Inc.")

--- a/javaee/ejb-client/src/main/java/org/operaton/bpm/application/impl/ejb/DefaultEjbProcessApplication.java
+++ b/javaee/ejb-client/src/main/java/org/operaton/bpm/application/impl/ejb/DefaultEjbProcessApplication.java
@@ -53,7 +53,8 @@ public class DefaultEjbProcessApplication extends org.operaton.bpm.application.i
   public void stop() {
     undeploy();
   }
-  
+
+  @Override
   public Map<String, String> getProperties() {
     return properties;
   }

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/RootPropertyResolver.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/RootPropertyResolver.java
@@ -92,7 +92,7 @@ public class RootPropertyResolver extends ELResolver {
 
 	@Override
 	public boolean isReadOnly(ELContext context, Object base, Object property) {
-		return resolve(context, base, property) ? readOnly : false;
+		return resolve(context, base, property) && readOnly;
 	}
 
 	@Override

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/CreateModelTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/CreateModelTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Sebastian Menski
  */
-public class CreateModelTest {
+class CreateModelTest {
 
   public BpmnModelInstance modelInstance;
   public Definitions definitions;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/di/CoordinatesGenerationTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/di/CoordinatesGenerationTest.java
@@ -38,7 +38,7 @@ import org.operaton.bpm.model.bpmn.instance.bpmndi.BpmnShape;
 import org.operaton.bpm.model.bpmn.instance.dc.Bounds;
 import org.operaton.bpm.model.bpmn.instance.di.Waypoint;
 
-public class CoordinatesGenerationTest {
+class CoordinatesGenerationTest {
 
   private BpmnModelInstance instance;
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/BaseElementTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/BaseElementTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Sebastian Menski
  */
-public class BaseElementTest extends BpmnModelElementInstanceTest {
+class BaseElementTest extends BpmnModelElementInstanceTest {
 
   @Override
   public TypeAssumption getTypeAssumption() {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ComplexGatewayTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ComplexGatewayTest.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ComplexGatewayTest extends AbstractGatewayTest<ComplexGateway> {
+class ComplexGatewayTest extends AbstractGatewayTest<ComplexGateway> {
 
   @Override
   public Collection<ChildElementAssumption> getChildElementAssumptions() {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ConditionalEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ConditionalEventDefinitionTest.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
 
-public class ConditionalEventDefinitionTest extends AbstractEventDefinitionTest {
+class ConditionalEventDefinitionTest extends AbstractEventDefinitionTest {
 
   @Override
   public Collection<ChildElementAssumption> getChildElementAssumptions() {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/InclusiveGatewayTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/InclusiveGatewayTest.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class InclusiveGatewayTest extends AbstractGatewayTest<InclusiveGateway> {
+class InclusiveGatewayTest extends AbstractGatewayTest<InclusiveGateway> {
 
   @Override
   public Collection<AttributeAssumption> getAttributesAssumptions() {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/MessageEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/MessageEventDefinitionTest.java
@@ -28,7 +28,7 @@ import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
 /**
  * @author Sebastian Menski
  */
-public class MessageEventDefinitionTest extends AbstractEventDefinitionTest {
+class MessageEventDefinitionTest extends AbstractEventDefinitionTest {
 
   @Override
   public Collection<ChildElementAssumption> getChildElementAssumptions() {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ProcessTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ProcessTest.java
@@ -31,7 +31,7 @@ import org.operaton.bpm.model.bpmn.impl.instance.Supports;
 /**
  * @author Sebastian Menski
  */
-public class ProcessTest extends BpmnModelElementInstanceTest {
+class ProcessTest extends BpmnModelElementInstanceTest {
 
   @Override
   public TypeAssumption getTypeAssumption() {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ServiceTaskTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/ServiceTaskTest.java
@@ -28,7 +28,7 @@ import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
 /**
  * @author Sebastian Menski
  */
-public class ServiceTaskTest extends BpmnModelElementInstanceTest {
+class ServiceTaskTest extends BpmnModelElementInstanceTest {
 
   @Override
   public TypeAssumption getTypeAssumption() {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/SignalEventDefinitionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/SignalEventDefinitionTest.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
 
-public class SignalEventDefinitionTest extends AbstractEventDefinitionTest {
+class SignalEventDefinitionTest extends AbstractEventDefinitionTest {
 
   @Override
   public Collection<AttributeAssumption> getAttributesAssumptions() {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TransactionTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/TransactionTest.java
@@ -43,7 +43,7 @@ import org.xml.sax.SAXException;
 /**
  * @author Thorben Lindhauer
  */
-public class TransactionTest extends BpmnModelElementInstanceTest {
+class TransactionTest extends BpmnModelElementInstanceTest {
 
   @Override
   public TypeAssumption getTypeAssumption() {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonInputParameterTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonInputParameterTest.java
@@ -28,7 +28,7 @@ import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
 /**
  * @author Sebastian Menski
  */
-public class OperatonInputParameterTest extends BpmnModelElementInstanceTest {
+class OperatonInputParameterTest extends BpmnModelElementInstanceTest {
 
   @Override
   public TypeAssumption getTypeAssumption() {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonListTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonListTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.bpmn.instance.BpmnModelElementInstanceTest;
 
-public class OperatonListTest extends BpmnModelElementInstanceTest {
+class OperatonListTest extends BpmnModelElementInstanceTest {
 
   @Override
   public TypeAssumption getTypeAssumption() {

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonOutputParameterTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/operaton/OperatonOutputParameterTest.java
@@ -28,7 +28,7 @@ import static org.operaton.bpm.model.bpmn.impl.BpmnModelConstants.OPERATON_NS;
 /**
  * @author Sebastian Menski
  */
-public class OperatonOutputParameterTest extends BpmnModelElementInstanceTest {
+class OperatonOutputParameterTest extends BpmnModelElementInstanceTest {
 
   @Override
   public TypeAssumption getTypeAssumption() {

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CreateModelTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CreateModelTest.java
@@ -29,7 +29,7 @@ import org.operaton.bpm.model.cmmn.instance.Stage;
 /**
  * @author Sebastian Menski
  */
-public class CreateModelTest {
+class CreateModelTest {
 
   public CmmnModelInstance modelInstance;
   public Definitions definitions;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/attribute/EnumAttributeBuilder.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/attribute/EnumAttributeBuilder.java
@@ -25,7 +25,7 @@ import org.operaton.bpm.model.xml.impl.type.ModelElementTypeImpl;
 public class EnumAttributeBuilder<T extends Enum<T>> extends AttributeBuilderImpl<T> {
 
   public EnumAttributeBuilder(String attributeName, ModelElementTypeImpl modelType, Class<T> type) {
-    super(attributeName, modelType, new EnumAttribute<T>(modelType, type));
+    super(attributeName, modelType, new EnumAttribute<>(modelType, type));
   }
 
   @Override

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/attribute/NamedEnumAttributeBuilder.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/attribute/NamedEnumAttributeBuilder.java
@@ -21,7 +21,7 @@ import org.operaton.bpm.model.xml.impl.type.ModelElementTypeImpl;
 public class NamedEnumAttributeBuilder<T extends Enum<T>> extends AttributeBuilderImpl<T> {
 
   public NamedEnumAttributeBuilder(String attributeName, ModelElementTypeImpl modelType, Class<T> type) {
-    super(attributeName, modelType, new NamedEnumAttribute<T>(modelType, type));
+    super(attributeName, modelType, new NamedEnumAttribute<>(modelType, type));
   }
 
   @Override

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author Ronny Bräunlich
  */
-public class AlternativeNsTest extends TestModelTest {
+class AlternativeNsTest extends TestModelTest {
 
   private static final String MECHANICAL_NS = "http://operaton.org/mechanical";
   private static final String YET_ANOTHER_NS = "http://operaton.org/yans";

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/delegation/DelegatedVariableMappingTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/delegation/DelegatedVariableMappingTest.java
@@ -17,8 +17,6 @@
 package org.operaton.bpm.integrationtest.functional.delegation;
 
 import org.operaton.bpm.integrationtest.functional.delegation.beans.DelegateVarMapping;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.inject.Inject;
 import static junit.framework.TestCase.assertEquals;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/ConfigurableProcessEngineTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/ConfigurableProcessEngineTest.java
@@ -30,7 +30,7 @@ import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ConfigurableProcessEngineTest {
+class ConfigurableProcessEngineTest {
 
   @RegisterExtension
   static final QuarkusUnitTest unitTest = new QuarkusUnitTest()

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/EmbeddedProcessEngineTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/EmbeddedProcessEngineTest.java
@@ -28,7 +28,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class EmbeddedProcessEngineTest {
+class EmbeddedProcessEngineTest {
 
   @RegisterExtension
   protected static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineDefaultConfigTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/config/OperatonEngineDefaultConfigTest.java
@@ -34,7 +34,7 @@ import jakarta.inject.Inject;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.DB_SCHEMA_UPDATE_TRUE;
 
-public class OperatonEngineDefaultConfigTest {
+class OperatonEngineDefaultConfigTest {
 
   @RegisterExtension
   static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/deployment/ProcessEngineMultipleDeploymentTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/deployment/ProcessEngineMultipleDeploymentTest.java
@@ -37,7 +37,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ProcessEngineMultipleDeploymentTest {
+class ProcessEngineMultipleDeploymentTest {
 
   @RegisterExtension
   protected static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/deployment/ProcessEngineSingleDeploymentTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/deployment/ProcessEngineSingleDeploymentTest.java
@@ -35,7 +35,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-public class ProcessEngineSingleDeploymentTest {
+class ProcessEngineSingleDeploymentTest {
 
   @RegisterExtension
   protected static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/id/DefaultIdGeneratorTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/id/DefaultIdGeneratorTest.java
@@ -32,7 +32,7 @@ import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DefaultIdGeneratorTest {
+class DefaultIdGeneratorTest {
 
   @RegisterExtension
   static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()

--- a/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/format/DomXmlDataFormat.java
+++ b/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/format/DomXmlDataFormat.java
@@ -227,11 +227,11 @@ public class DomXmlDataFormat implements DataFormat<SpinXmlElement> {
     documentBuilderFactory.setIgnoringElementContentWhitespace(false);
     LOG.documentBuilderFactoryConfiguration("ignoringElementContentWhitespace", "false");
 
-    if ((boolean) configurationProperties.getOrDefault(XXE_PROPERTY, false) == false) {
+    if (!((boolean) configurationProperties.getOrDefault(XXE_PROPERTY, false))) {
       disableXxeProcessing(documentBuilderFactory);
     }
 
-    if ((boolean) configurationProperties.getOrDefault(SP_PROPERTY, true) == true) {
+    if ((boolean) configurationProperties.getOrDefault(SP_PROPERTY, true)) {
       enableSecureProcessing(documentBuilderFactory);
     }
 

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionParameterizedJunit5Test.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionParameterizedJunit5Test.java
@@ -34,14 +34,14 @@ import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @ExtendWith(ProcessEngineExtension.class)
-public class ProcessEngineExtensionParameterizedJunit5Test {
+class ProcessEngineExtensionParameterizedJunit5Test {
 
   ProcessEngine engine;
 
   @ParameterizedTest
   @ValueSource(ints = {1, 2})
   @Deployment
-  public void extensionUsageExample() {
+  void extensionUsageExample() {
     RuntimeService runtimeService = engine.getRuntimeService();
     runtimeService.startProcessInstanceByKey("extensionUsage");
 
@@ -56,7 +56,7 @@ public class ProcessEngineExtensionParameterizedJunit5Test {
   @ParameterizedTest
   @ValueSource(strings = {"A", "B"})
   @Deployment(resources = "org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionParameterizedJunit5Test.extensionUsageExample.bpmn20.xml")
-  public void extensionUsageExampleWithNamedAnnotation(String value) {
+  void extensionUsageExampleWithNamedAnnotation(String value) {
     Map<String,Object> variables = new HashMap<>();
     variables.put("key", value);
     RuntimeService runtimeService = engine.getRuntimeService();
@@ -79,7 +79,7 @@ public class ProcessEngineExtensionParameterizedJunit5Test {
    */
   @ParameterizedTest
   @EmptySource
-  public void testWithoutDeploymentAnnotation(String argument) {
+  void testWithoutDeploymentAnnotation(String argument) {
     assertThat(argument).isEmpty();
   }
 

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/deployment/ProcessEngineExtensionDeploymentIdAccess.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/engine/test/junit5/deployment/ProcessEngineExtensionDeploymentIdAccess.java
@@ -16,9 +16,7 @@
  */
 package org.operaton.bpm.engine.test.junit5.deployment;
 
-import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 class ProcessEngineExtensionDeploymentIdAccess {
 

--- a/webapps/assembly/src/main/java/org/operaton/bpm/cockpit/impl/plugin/base/dto/query/AbstractProcessInstanceQueryDto.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/cockpit/impl/plugin/base/dto/query/AbstractProcessInstanceQueryDto.java
@@ -194,7 +194,7 @@ public abstract class AbstractProcessInstanceQueryDto<T extends ProcessInstanceD
 
   private List<QueryVariableValue> createQueryVariableValues(VariableSerializers variableTypes, List<VariableQueryParameterDto> variables, String dbType) {
 
-    List<QueryVariableValue> values = new ArrayList<QueryVariableValue>();
+    List<QueryVariableValue> values = new ArrayList<>();
 
     if (variables == null) {
       return values;

--- a/webapps/assembly/src/main/java/org/operaton/bpm/cockpit/impl/plugin/base/dto/query/ProcessDefinitionQueryDto.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/cockpit/impl/plugin/base/dto/query/ProcessDefinitionQueryDto.java
@@ -114,7 +114,7 @@ public class ProcessDefinitionQueryDto extends AbstractRestQueryParametersDto<Pr
 
   private List<QueryVariableValue> createQueryVariableValues(VariableSerializers variableTypes, List<VariableQueryParameterDto> variables, String dbType) {
 
-    List<QueryVariableValue> values = new ArrayList<QueryVariableValue>();
+    List<QueryVariableValue> values = new ArrayList<>();
 
     if (variables == null) {
       return values;

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/engine/EnginesFilterTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/engine/EnginesFilterTest.java
@@ -93,6 +93,7 @@ public class EnginesFilterTest {
 
     Cockpit.setCockpitRuntimeDelegate(new DefaultCockpitRuntimeDelegate() {
 
+      @Override
       protected ProcessEngineProvider loadProcessEngineProvider() {
         return null;
       }
@@ -117,6 +118,7 @@ public class EnginesFilterTest {
 
     Cockpit.setCockpitRuntimeDelegate(new DefaultCockpitRuntimeDelegate() {
 
+      @Override
       protected ProcessEngineProvider loadProcessEngineProvider() {
         return null;
       }


### PR DESCRIPTION
Code cleanups to resolve Sonar warnings:
- Remove unnecessary null checks
- Remove unnecessary comparison of boolean literals
- Use diamond operator where possible
- Remove unused imports
- Add missing `@Override` annotations 
- Remove unnecessary public modifiers from tests

related to #88