### PR TITLE
chore(tests): Join multiple assertions

### DIFF
--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionResultTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionResultTest.java
@@ -173,13 +173,15 @@ class DmnDecisionResultTest extends DmnEngineTest {
     assertThat(entryMapList).hasSize(2);
 
     Map<String, Object> firstResult = entryMapList.get(0);
-    assertThat(firstResult).hasSize(1);
-    assertThat(firstResult).containsEntry("firstOutput", "singleValue");
+    assertThat(firstResult)
+      .hasSize(1)
+      .containsEntry("firstOutput", "singleValue");
 
     Map<String, Object> secondResult = entryMapList.get(1);
-    assertThat(secondResult).hasSize(2);
-    assertThat(secondResult).containsEntry("firstOutput", "multipleValues1");
-    assertThat(secondResult).containsEntry("secondOutput", "multipleValues2");
+    assertThat(secondResult)
+      .hasSize(2)
+      .containsEntry("firstOutput", "multipleValues1")
+      .containsEntry("secondOutput", "multipleValues2");
   }
 
   @Test
@@ -191,9 +193,10 @@ class DmnDecisionResultTest extends DmnEngineTest {
     assertThat(ruleResult).hasSize(2);
 
     Map<String, Object> entryMap = ruleResult.getEntryMap();
-    assertThat(entryMap).hasSize(2);
-    assertThat(entryMap).containsEntry("firstOutput", "multipleValues1");
-    assertThat(entryMap).containsEntry("secondOutput", "multipleValues2");
+    assertThat(entryMap)
+      .hasSize(2)
+      .containsEntry("firstOutput", "multipleValues1")
+      .containsEntry("secondOutput", "multipleValues2");
   }
 
   @Test

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionTableResultTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/api/DmnDecisionTableResultTest.java
@@ -171,13 +171,15 @@ class DmnDecisionTableResultTest extends DmnEngineTest {
     assertThat(entryMapList).hasSize(2);
 
     Map<String, Object> firstResult = entryMapList.get(0);
-    assertThat(firstResult).hasSize(1);
-    assertThat(firstResult).containsEntry("firstOutput", "singleValue");
+    assertThat(firstResult)
+      .hasSize(1)
+      .containsEntry("firstOutput", "singleValue");
 
     Map<String, Object> secondResult = entryMapList.get(1);
-    assertThat(secondResult).hasSize(2);
-    assertThat(secondResult).containsEntry("firstOutput", "multipleValues1");
-    assertThat(secondResult).containsEntry("secondOutput", "multipleValues2");
+    assertThat(secondResult)
+      .hasSize(2)
+      .containsEntry("firstOutput", "multipleValues1")
+      .containsEntry("secondOutput", "multipleValues2");
   }
 
   @Test
@@ -189,9 +191,10 @@ class DmnDecisionTableResultTest extends DmnEngineTest {
     assertThat(ruleResult).hasSize(2);
 
     Map<String, Object> entryMap = ruleResult.getEntryMap();
-    assertThat(entryMap).hasSize(2);
-    assertThat(entryMap).containsEntry("firstOutput", "multipleValues1");
-    assertThat(entryMap).containsEntry("secondOutput", "multipleValues2");
+    assertThat(entryMap)
+      .hasSize(2)
+      .containsEntry("firstOutput", "multipleValues1")
+      .containsEntry("secondOutput", "multipleValues2");
   }
 
   @Test

--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapUserQueryTest.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/impl/ldap/LdapUserQueryTest.java
@@ -137,9 +137,10 @@ public class LdapUserQueryTest {
     List<User> users = identityService.createUserQuery().userIdIn("oscar", "monster", "daniel", "non-existing").list();
 
     // then
-    assertThat(users).isNotNull();
-    assertThat(users).hasSize(3);
-    assertThat(users).extracting("id").containsOnly("oscar", "monster", "daniel");
+    assertThat(users)
+      .isNotNull()
+      .hasSize(3)
+      .extracting("id").containsOnly("oscar", "monster", "daniel");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/application/impl/deployment/EmptyProcessesXmlTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/deployment/EmptyProcessesXmlTest.java
@@ -74,8 +74,9 @@ public class EmptyProcessesXmlTest {
     assertEquals(Boolean.FALSE.toString(), isDeployChangedOnly);
 
     String resumePreviousBy = properties.get(ProcessArchiveXml.PROP_RESUME_PREVIOUS_BY);
-    assertThat(resumePreviousBy).isNotNull();
-    assertThat(resumePreviousBy).isSameAs(ResumePreviousBy.RESUME_BY_PROCESS_DEFINITION_KEY);
+    assertThat(resumePreviousBy)
+      .isNotNull()
+      .isSameAs(ResumePreviousBy.RESUME_BY_PROCESS_DEFINITION_KEY);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/incident/CompositeIncidentHandlerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/incident/CompositeIncidentHandlerTest.java
@@ -166,8 +166,9 @@ public class CompositeIncidentHandlerTest {
 
     Incident result = compositeIncidentHandler.handleIncident(incidentContext, "Incident message");
 
-    assertThat(result).isNotNull();
-    assertThat(result).isEqualTo(incident);
+    assertThat(result)
+      .isNotNull()
+      .isEqualTo(incident);
 
     verify(mainHandler).handleIncident(eq(incidentContext), eq("Incident message"));
     verify(subHandler, new Times(3)).handleIncident(eq(incidentContext), eq("Incident message"));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/InstallationCfgTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/InstallationCfgTest.java
@@ -50,7 +50,8 @@ public class InstallationCfgTest {
 
     // then
     String installationId = configuration.getInstallationId();
-    assertThat(installationId).isNotEmpty();
-    assertThat(installationId).matches("[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}");
+    assertThat(installationId)
+      .isNotEmpty()
+      .matches("[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}");
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceTest.java
@@ -1088,8 +1088,9 @@ public class IdentityServiceTest {
     String toString = user.toString();
 
     // then
-    assertThat(toString).doesNotContain(salt);
-    assertThat(toString).doesNotContain(hashedPassword);
+    assertThat(toString)
+      .doesNotContain(salt)
+      .doesNotContain(hashedPassword);
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/IncidentMultipleProcessingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/IncidentMultipleProcessingTest.java
@@ -72,16 +72,18 @@ public class IncidentMultipleProcessingTest {
   public void jobHandlerShouldBeCompositeHandler() {
     IncidentHandler incidentHandler = engineRule.getProcessEngineConfiguration().getIncidentHandler(Incident.FAILED_JOB_HANDLER_TYPE);
 
-    assertThat(incidentHandler).isNotNull();
-    assertThat(incidentHandler).isInstanceOf(CompositeIncidentHandler.class);
+    assertThat(incidentHandler)
+      .isNotNull()
+      .isInstanceOf(CompositeIncidentHandler.class);
   }
 
   @Test
   public void externalTaskHandlerShouldBeCompositeHandler() {
     IncidentHandler incidentHandler = engineRule.getProcessEngineConfiguration().getIncidentHandler(Incident.EXTERNAL_TASK_HANDLER_TYPE);
 
-    assertThat(incidentHandler).isNotNull();
-    assertThat(incidentHandler).isInstanceOf(CompositeIncidentHandler.class);
+    assertThat(incidentHandler)
+      .isNotNull()
+      .isInstanceOf(CompositeIncidentHandler.class);
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/mgmt/IncidentTest.testShouldCreateOneIncident.bpmn" })

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceGetTelemetryDataTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceGetTelemetryDataTest.java
@@ -342,8 +342,9 @@ public class ManagementServiceGetTelemetryDataTest {
     Date afterToggleTelemetry = managementService.getTelemetryData().getProduct().getInternals()
         .getDataCollectionStartDate();
 
-    assertThat(beforeToggleTelemetry).isNotNull();
-    assertThat(beforeToggleTelemetry).isEqualTo(afterToggleTelemetry);
+    assertThat(beforeToggleTelemetry)
+      .isNotNull()
+      .isEqualTo(afterToggleTelemetry);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/license/LicenseKeyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/license/LicenseKeyTest.java
@@ -79,9 +79,10 @@ public class LicenseKeyTest {
 
     // then
     assertThat(licenseKeyLegacyProperty).isNull();
-    assertThat(licenseByteArrayId).isNotNull();
+    assertThat(licenseByteArrayId)
+      .isNotNull()
     // make sure a newly set license is not stored in properties...
-    assertThat(licenseByteArrayId).isNotEqualTo(licenseKey);
+      .isNotEqualTo(licenseKey);
     // ...but in the byte array table, referenced by the property
     assertThat(processEngineConfiguration.getCommandExecutorTxRequired().execute(new GetByteArrayCommand(licenseByteArrayId)).getBytes())
         .isEqualTo(licenseKey.getBytes());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyStatisticsQueryTest.java
@@ -101,8 +101,7 @@ public class MultiTenancyStatisticsQueryTest extends PluggableProcessEngineTest 
     assertThat(query.count()).isEqualTo(2L);
 
     Set<String> tenantIds = collectDeploymentTenantIds(query.list());
-    assertThat(tenantIds).hasSize(2);
-    assertThat(tenantIds).contains(null, TENANT_ONE);
+    assertThat(tenantIds).containsExactlyInAnyOrder(null, TENANT_ONE);
   }
 
   @Test
@@ -114,8 +113,7 @@ public class MultiTenancyStatisticsQueryTest extends PluggableProcessEngineTest 
     assertThat(query.count()).isEqualTo(3L);
 
     Set<String> tenantIds = collectDeploymentTenantIds(query.list());
-    assertThat(tenantIds).hasSize(3);
-    assertThat(tenantIds).contains(null, TENANT_ONE, TENANT_TWO);
+    assertThat(tenantIds).containsExactlyInAnyOrder(null, TENANT_ONE, TENANT_TWO);
   }
 
   @Test
@@ -128,8 +126,7 @@ public class MultiTenancyStatisticsQueryTest extends PluggableProcessEngineTest 
     assertThat(query.count()).isEqualTo(3L);
 
     Set<String> tenantIds = collectDeploymentTenantIds(query.list());
-    assertThat(tenantIds).hasSize(3);
-    assertThat(tenantIds).contains(null, TENANT_ONE, TENANT_TWO);
+    assertThat(tenantIds).containsExactlyInAnyOrder(null, TENANT_ONE, TENANT_TWO);
   }
 
   @Test
@@ -153,8 +150,7 @@ public class MultiTenancyStatisticsQueryTest extends PluggableProcessEngineTest 
     assertThat(query.count()).isEqualTo(2L);
 
     Set<String> tenantIds = collectDefinitionTenantIds(query.list());
-    assertThat(tenantIds).hasSize(2);
-    assertThat(tenantIds).contains(null, TENANT_ONE);
+    assertThat(tenantIds).containsExactlyInAnyOrder(null, TENANT_ONE);
   }
 
   @Test
@@ -166,8 +162,7 @@ public class MultiTenancyStatisticsQueryTest extends PluggableProcessEngineTest 
     assertThat(query.count()).isEqualTo(3L);
 
     Set<String> tenantIds = collectDefinitionTenantIds(query.list());
-    assertThat(tenantIds).hasSize(3);
-    assertThat(tenantIds).contains(null, TENANT_ONE, TENANT_TWO);
+    assertThat(tenantIds).containsExactlyInAnyOrder(null, TENANT_ONE, TENANT_TWO);
   }
 
   @Test
@@ -180,8 +175,7 @@ public class MultiTenancyStatisticsQueryTest extends PluggableProcessEngineTest 
     assertThat(query.count()).isEqualTo(3L);
 
     Set<String> tenantIds = collectDefinitionTenantIds(query.list());
-    assertThat(tenantIds).hasSize(3);
-    assertThat(tenantIds).contains(null, TENANT_ONE, TENANT_TWO);
+    assertThat(tenantIds).containsExactlyInAnyOrder(null, TENANT_ONE, TENANT_TWO);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
@@ -315,7 +315,6 @@ public class MultiTenancyHistoricExternalTaskLogTest {
     String stacktrace = historyService.getHistoricExternalTaskLogErrorDetails(failedHistoricExternalTaskLogId);
 
     // then
-    assertThat(stacktrace).isNotNull();
     assertThat(stacktrace).isEqualTo(ERROR_DETAILS);
   }
 
@@ -343,9 +342,7 @@ public class MultiTenancyHistoricExternalTaskLogTest {
     String stacktrace2 = historyService.getHistoricExternalTaskLogErrorDetails(logIdTenant2);
 
     // then
-    assertThat(stacktrace1).isNotNull();
     assertThat(stacktrace1).isEqualTo(ERROR_DETAILS);
-    assertThat(stacktrace2).isNotNull();
     assertThat(stacktrace2).isEqualTo(ERROR_DETAILS);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricDecisionInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricDecisionInstancesForOptimizeTest.java
@@ -155,8 +155,9 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
     assertThat(decisionInstances).hasSize(1);
     HistoricDecisionInstance decisionInstance = decisionInstances.get(0);
     List<HistoricDecisionInputInstance> inputs = decisionInstance.getInputs();
-    assertThat(inputs).isNotNull();
-    assertThat(inputs).hasSize(1);
+    assertThat(inputs)
+      .isNotNull()
+      .hasSize(1);
 
     HistoricDecisionInputInstance input = inputs.get(0);
     assertThat(input.getDecisionInstanceId()).isEqualTo(decisionInstance.getId());
@@ -180,8 +181,9 @@ public class GetHistoricDecisionInstancesForOptimizeTest {
     assertThat(decisionInstances).hasSize(1);
     HistoricDecisionInstance decisionInstance = decisionInstances.get(0);
     List<HistoricDecisionOutputInstance> outputs = decisionInstance.getOutputs();
-    assertThat(outputs).isNotNull();
-    assertThat(outputs).hasSize(1);
+    assertThat(outputs)
+      .isNotNull()
+      .hasSize(1);
 
     HistoricDecisionOutputInstance output = outputs.get(0);
     assertThat(output.getDecisionInstanceId()).isEqualTo(decisionInstance.getId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstantiationAtStartEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstantiationAtStartEventTest.java
@@ -86,7 +86,6 @@ public class ProcessInstantiationAtStartEventTest extends PluggableProcessEngine
     ProcessInstance processInstance = runtimeService.createProcessInstanceByKey(PROCESS_DEFINITION_KEY).setVariable("var", "value").execute();
 
     Object variable = runtimeService.getVariable(processInstance.getId(), "var");
-    assertThat(variable).isNotNull();
     assertThat(variable).isEqualTo("value");
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/DelegateTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/DelegateTaskTest.java
@@ -122,7 +122,6 @@ public class DelegateTaskTest {
     String processInstanceId = processInstance.getId();
     Date followUpDate = (Date) runtimeService.getVariable(processInstanceId, "followUp");
 
-    assertThat(followUpDate).isNotNull();
     assertThat(followUpDate).isEqualTo(FOLLOW_UP_DATE);
   }
 
@@ -146,7 +145,6 @@ public class DelegateTaskTest {
     Task task = taskService.createTaskQuery().singleResult();
     Date followUpDate = task.getFollowUpDate();
 
-    assertThat(followUpDate).isNotNull();
     assertThat(followUpDate).isEqualTo(FOLLOW_UP_DATE);
   }
 
@@ -173,8 +171,9 @@ public class DelegateTaskTest {
     // then
 
     Date lastUpdated = (Date) runtimeService.getVariable(processInstanceId, "lastUpdated");
-    assertThat(lastUpdated).isNotNull();
-    assertThat(lastUpdated).isAfter(beforeUpdate);
+    assertThat(lastUpdated)
+      .isNotNull()
+      .isAfter(beforeUpdate);
   }
 
   public static class GetFollowUpDateListener implements TaskListener {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryExpressionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryExpressionTest.java
@@ -531,10 +531,11 @@ public class TaskQueryExpressionTest {
     // execute query so expression will be evaluated
     taskQuery.count();
 
-    assertThat(queryString).isEqualTo(taskQuery.getAssignee());
-    assertThat(queryString).isEqualTo(taskQuery.getAssigneeLike());
-    assertThat(queryString).isEqualTo(taskQuery.getOwner());
-    assertThat(queryString).isEqualTo(taskQuery.getInvolvedUser());
+    assertThat(queryString)
+      .isEqualTo(taskQuery.getAssignee())
+      .isEqualTo(taskQuery.getAssigneeLike())
+      .isEqualTo(taskQuery.getOwner())
+      .isEqualTo(taskQuery.getInvolvedUser());
     assertThat(taskQuery.getUpdatedAfter()).isEqualTo(queryDate);
     assertThat(taskQuery.getCreateTimeBefore().equals(queryDate));
     assertThat(taskQuery.getCreateTime().equals(queryDate));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskServiceTest.java
@@ -729,7 +729,6 @@ public class TaskServiceTest {
 
     List<Comment> updateCommentLst = taskService.getProcessInstanceComments(processInstanceId);
 
-    assertThat(updateCommentLst).isNotEmpty();
     assertThat(updateCommentLst).hasSize(1);
 
     Comment actual = updateCommentLst.get(0);
@@ -749,7 +748,6 @@ public class TaskServiceTest {
 
     List<Comment> updateCommentLst = taskService.getProcessInstanceComments(processInstanceId);
 
-    assertThat(updateCommentLst).isNotEmpty();
     assertThat(updateCommentLst).hasSize(1);
 
     Comment actual = updateCommentLst.get(0);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CallActivityTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CallActivityTest.java
@@ -1328,7 +1328,6 @@ public class CallActivityTest extends PluggableProcessEngineTest {
     assertThat(task.getName()).isEqualTo("Task after error");
 
     Object variable = runtimeService.getVariable(task.getProcessInstanceId(), variableName);
-    assertThat(variable).isNotNull();
     assertThat(variable).isEqualTo(variableValue);
   }
 
@@ -1353,7 +1352,6 @@ public class CallActivityTest extends PluggableProcessEngineTest {
     assertThat(task.getName()).isEqualTo("Task after error");
 
     Object variable = runtimeService.getVariable(task.getProcessInstanceId(), variableName);
-    assertThat(variable).isNotNull();
     assertThat(variable).isEqualTo(variableValue);
   }
 
@@ -1380,7 +1378,6 @@ public class CallActivityTest extends PluggableProcessEngineTest {
 
     Object variable = runtimeService.getVariable(task.getProcessInstanceId(), variableName);
     //both processes have and out mapping for all, so we want the variable to be propagated to the process with the event handler
-    assertThat(variable).isNotNull();
     assertThat(variable).isEqualTo(variableValue);
   }
 
@@ -1416,10 +1413,8 @@ public class CallActivityTest extends PluggableProcessEngineTest {
 
     //the two subprocess don't pass all their variables, so we check that not all were passed
     Object variable = runtimeService.getVariable(task.getProcessInstanceId(), variableName2);
-    assertThat(variable).isNotNull();
     assertThat(variable).isEqualTo(variableValue);
     variable = runtimeService.getVariable(task.getProcessInstanceId(), variableName3);
-    assertThat(variable).isNotNull();
     assertThat(variable).isEqualTo(variableValue2);
     variable = runtimeService.getVariable(task.getProcessInstanceId(), variableName1);
     assertThat(variable).isNull();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.java
@@ -90,8 +90,9 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
     // verify content
     InputStream deploymentInputStream = repositoryService.getResourceAsStream(deploymentId, bpmnResourceName);
     String contentFromDeployment = readInputStreamToString(deploymentInputStream);
-    assertThat(contentFromDeployment).isNotEmpty();
-    assertThat(contentFromDeployment).contains("process id=\"emptyProcess\"");
+    assertThat(contentFromDeployment)
+      .isNotEmpty()
+      .contains("process id=\"emptyProcess\"");
 
     InputStream fileInputStream = ReflectUtil.getResourceAsStream("org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.testGetBpmnXmlFileThroughService.bpmn20.xml");
     String contentFromFile = readInputStreamToString(fileInputStream);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/signal/SignalEventConcurrencyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/signal/SignalEventConcurrencyTest.java
@@ -116,8 +116,9 @@ public class SignalEventConcurrencyTest extends ConcurrencyTestHelper {
 
     // sending the signal will fail because it cannot find the execution anymore
     final Throwable exception = signalThread.getException();
-    assertThat(exception).isInstanceOf(NullValueException.class);
-    assertThat(exception).hasMessage(
+    assertThat(exception)
+      .isInstanceOf(NullValueException.class)
+      .hasMessage(
         String.format("Cannot restore state of process instance %s: list of executions is empty",
             mainTask.getProcessInstanceId()));
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/TaskListenerEventLifecycleTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/TaskListenerEventLifecycleTest.java
@@ -36,6 +36,9 @@ import org.operaton.bpm.engine.test.bpmn.tasklistener.util.CompletingTaskListene
 import org.operaton.bpm.engine.test.bpmn.tasklistener.util.RecorderTaskListener;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
+
+import static org.operaton.bpm.engine.delegate.TaskListener.*;
+
 import org.junit.Test;
 
 public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
@@ -47,10 +50,10 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
    */
 
   protected static final String[] TRACKED_EVENTS = {
-      TaskListener.EVENTNAME_CREATE,
-      TaskListener.EVENTNAME_UPDATE,
-      TaskListener.EVENTNAME_ASSIGNMENT,
-      TaskListener.EVENTNAME_COMPLETE,
+      EVENTNAME_CREATE,
+      EVENTNAME_UPDATE,
+      EVENTNAME_ASSIGNMENT,
+      EVENTNAME_COMPLETE,
       TaskListener.EVENTNAME_DELETE
   };
 
@@ -66,9 +69,9 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
 
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
-    assertThat(orderedEvents).hasSize(2);
-    assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
-                                              TaskListener.EVENTNAME_ASSIGNMENT);
+    assertThat(orderedEvents)
+      .hasSize(2)
+      .containsExactly(EVENTNAME_CREATE, EVENTNAME_ASSIGNMENT);
   }
 
   @Test
@@ -76,7 +79,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // given
     BpmnModelInstance model = createModelWithTaskEventsRecorderOnAssignedUserTask(TRACKED_EVENTS,
                                                                                   null,
-                                                                                  TaskListener.EVENTNAME_CREATE,
+                                                                                  EVENTNAME_CREATE,
                                                                                   CompletingTaskListener.class);
     testRule.deploy(model);
 
@@ -85,9 +88,9 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
 
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
-    assertThat(orderedEvents).hasSize(2);
-    assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
-                                              TaskListener.EVENTNAME_COMPLETE);
+    assertThat(orderedEvents)
+      .hasSize(2)
+      .containsExactly(EVENTNAME_CREATE, EVENTNAME_COMPLETE);
   }
 
   @Test
@@ -95,7 +98,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // given
     BpmnModelInstance model = createModelWithTaskEventsRecorderOnAssignedUserTask(TRACKED_EVENTS,
                                                                                   null,
-                                                                                  TaskListener.EVENTNAME_ASSIGNMENT,
+                                                                                  EVENTNAME_ASSIGNMENT,
                                                                                   CompletingTaskListener.class);
     testRule.deploy(model);
     runtimeService.startProcessInstanceByKey("process");
@@ -106,11 +109,12 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
 
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
-    assertThat(orderedEvents).hasSize(4);
-    assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
-                                              TaskListener.EVENTNAME_UPDATE,
-                                              TaskListener.EVENTNAME_ASSIGNMENT,
-                                              TaskListener.EVENTNAME_COMPLETE);
+    assertThat(orderedEvents)
+      .hasSize(4)
+      .containsExactly(EVENTNAME_CREATE,
+        EVENTNAME_UPDATE,
+        EVENTNAME_ASSIGNMENT,
+        EVENTNAME_COMPLETE);
   }
 
   @Test
@@ -122,7 +126,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     BpmnModelInstance model = Bpmn.createExecutableProcess("process")
         .startEvent()
           .userTask("task")
-            .operatonTaskListenerClass(TaskListener.EVENTNAME_CREATE, RecorderTaskListener.class)
+            .operatonTaskListenerClass(EVENTNAME_CREATE, RecorderTaskListener.class)
             .operatonTaskListenerClassTimeoutWithDate(TaskListener.EVENTNAME_TIMEOUT,
                                                      RecorderTaskListener.class,
                                                      sdf.format(now.getTime()))
@@ -136,13 +140,13 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
 
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
-    assertThat(orderedEvents).hasSize(2);
 
     // the TIMEOUT event will always fire after the CREATE event, since the Timer Job can't be
     // picked up by the JobExecutor before it's committed. And it is committed in the same
     // transaction as the task creation phase.
-    assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
-                                              TaskListener.EVENTNAME_TIMEOUT);
+    assertThat(orderedEvents)
+      .hasSize(2)
+      .containsExactly(EVENTNAME_CREATE, TaskListener.EVENTNAME_TIMEOUT);
   }
 
   @Test
@@ -154,8 +158,8 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     BpmnModelInstance model = Bpmn.createExecutableProcess("process")
                                   .startEvent()
                                   .userTask("task")
-                                  .operatonTaskListenerClass(TaskListener.EVENTNAME_CREATE, RecorderTaskListener.class)
-                                  .operatonTaskListenerClass(TaskListener.EVENTNAME_COMPLETE, RecorderTaskListener.class)
+                                  .operatonTaskListenerClass(EVENTNAME_CREATE, RecorderTaskListener.class)
+                                  .operatonTaskListenerClass(EVENTNAME_COMPLETE, RecorderTaskListener.class)
                                   .operatonTaskListenerClassTimeoutWithDate(TaskListener.EVENTNAME_TIMEOUT,
                                                                            RecorderTaskListener.class,
                                                                            sdf.format(now.getTime()))
@@ -175,7 +179,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     assertThat(runningJobCount).isOne();
     assertThat(completedJobCount).isZero();
     assertThat(orderedEvents).hasSize(2);
-    assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_COMPLETE);
+    assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(EVENTNAME_COMPLETE);
   }
 
   // UPDATE phase
@@ -193,9 +197,9 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
     // create event fired on task creation
-    assertThat(orderedEvents).hasSize(2);
-    assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
-                                              TaskListener.EVENTNAME_UPDATE);
+    assertThat(orderedEvents)
+      .hasSize(2)
+      .containsExactly(EVENTNAME_CREATE, EVENTNAME_UPDATE);
   }
 
   @Test
@@ -211,10 +215,9 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents).hasSize(3);
-    assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
-                                              TaskListener.EVENTNAME_UPDATE,
-                                              TaskListener.EVENTNAME_ASSIGNMENT);
+    assertThat(orderedEvents)
+      .hasSize(3)
+      .containsExactly(EVENTNAME_CREATE, EVENTNAME_UPDATE, EVENTNAME_ASSIGNMENT);
   }
 
   @Test
@@ -222,7 +225,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // given
     BpmnModelInstance model = createModelWithTaskEventsRecorderOnAssignedUserTask(TRACKED_EVENTS,
                                                                                   null,
-                                                                                  TaskListener.EVENTNAME_UPDATE,
+                                                                                  EVENTNAME_UPDATE,
                                                                                   CompletingTaskListener.class);
     testRule.deploy(model);
     runtimeService.startProcessInstanceByKey("process");
@@ -235,10 +238,9 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
     // assignment event should not be processed
-    assertThat(orderedEvents).hasSize(3);
-    assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
-                                              TaskListener.EVENTNAME_UPDATE,
-                                              TaskListener.EVENTNAME_COMPLETE);
+    assertThat(orderedEvents)
+      .hasSize(3)
+      .containsExactly(EVENTNAME_CREATE, EVENTNAME_UPDATE, EVENTNAME_COMPLETE);
   }
 
   @Test
@@ -246,7 +248,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // given
     BpmnModelInstance model = createModelWithTaskEventsRecorderOnAssignedUserTask(TRACKED_EVENTS,
                                                                                   null,
-                                                                                  TaskListener.EVENTNAME_ASSIGNMENT,
+                                                                                  EVENTNAME_ASSIGNMENT,
                                                                                   CompletingTaskListener.class);
     testRule.deploy(model);
     runtimeService.startProcessInstanceByKey("process");
@@ -258,11 +260,9 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents).hasSize(4);
-    assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
-                                              TaskListener.EVENTNAME_UPDATE,
-                                              TaskListener.EVENTNAME_ASSIGNMENT,
-                                              TaskListener.EVENTNAME_COMPLETE);
+    assertThat(orderedEvents)
+      .hasSize(4)
+      .containsExactly(EVENTNAME_CREATE, EVENTNAME_UPDATE, EVENTNAME_ASSIGNMENT, EVENTNAME_COMPLETE);
   }
 
   @Test
@@ -270,7 +270,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // given
     BpmnModelInstance process = createModelWithTaskEventsRecorderOnAssignedUserTask(TRACKED_EVENTS,
                                                                                   null,
-                                                                                  TaskListener.EVENTNAME_CREATE,
+                                                                                  EVENTNAME_CREATE,
                                                                                   ModifyingTaskListener.class);
     testRule.deploy(process);
 
@@ -280,11 +280,11 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents).hasSize(2);
     // ASSIGNMENT Event is fired, since the ModifyingTaskListener sets an assignee, and the
     // ASSIGNMENT Event evaluation happens after the CREATE Event evaluation
-    assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
-                                              TaskListener.EVENTNAME_ASSIGNMENT);
+    assertThat(orderedEvents)
+      .hasSize(2)
+      .containsExactly(EVENTNAME_CREATE, EVENTNAME_ASSIGNMENT);
   }
 
   @Test
@@ -292,7 +292,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // given
     BpmnModelInstance process = createModelWithTaskEventsRecorderOnAssignedUserTask(TRACKED_EVENTS,
                                                                                     null,
-                                                                                    TaskListener.EVENTNAME_UPDATE,
+                                                                                    EVENTNAME_UPDATE,
                                                                                     ModifyingTaskListener.class);
     testRule.deploy(process);
     engineRule.getRuntimeService().startProcessInstanceByKey("process");
@@ -305,12 +305,11 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // only the initial, first update event is expected
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents).hasSize(3);
     // ASSIGNMENT Event is fired, since the ModifyingTaskListener sets an assignee, and the
     // ASSIGNMENT Event evaluation happens after the UPDATE Event evaluation
-    assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
-                                              TaskListener.EVENTNAME_UPDATE,
-                                              TaskListener.EVENTNAME_ASSIGNMENT);
+    assertThat(orderedEvents)
+      .hasSize(3)
+      .containsExactly(EVENTNAME_CREATE, EVENTNAME_UPDATE, EVENTNAME_ASSIGNMENT);
   }
 
   @Test
@@ -318,7 +317,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // given
     BpmnModelInstance process = createModelWithTaskEventsRecorderOnAssignedUserTask(TRACKED_EVENTS,
                                                                                     null,
-                                                                                    TaskListener.EVENTNAME_ASSIGNMENT,
+                                                                                    EVENTNAME_ASSIGNMENT,
                                                                                     ModifyingTaskListener.class);
     testRule.deploy(process);
     engineRule.getRuntimeService().startProcessInstanceByKey("process");
@@ -331,10 +330,9 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // only one update event is expected, from the initial assignment
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents).hasSize(3);
-    assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
-                                              TaskListener.EVENTNAME_UPDATE,
-                                              TaskListener.EVENTNAME_ASSIGNMENT);
+    assertThat(orderedEvents)
+      .hasSize(3)
+      .containsExactly(EVENTNAME_CREATE, EVENTNAME_UPDATE, EVENTNAME_ASSIGNMENT);
   }
 
   @Test
@@ -342,7 +340,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // given
     BpmnModelInstance process = createModelWithTaskEventsRecorderOnAssignedUserTask(TRACKED_EVENTS,
                                                                                     null,
-                                                                                    TaskListener.EVENTNAME_COMPLETE,
+                                                                                    EVENTNAME_COMPLETE,
                                                                                     ModifyingTaskListener.class);
     testRule.deploy(process);
     engineRule.getRuntimeService().startProcessInstanceByKey("process");
@@ -354,9 +352,9 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents).hasSize(2);
-    assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
-                                              TaskListener.EVENTNAME_COMPLETE);
+    assertThat(orderedEvents)
+      .hasSize(2)
+      .containsExactly(EVENTNAME_CREATE, EVENTNAME_COMPLETE);
   }
 
   @Test
@@ -377,7 +375,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
     assertThat(orderedEvents).hasSize(2);
-    assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
+    assertThat(orderedEvents).containsExactly(EVENTNAME_CREATE,
                                               TaskListener.EVENTNAME_DELETE);
   }
 
@@ -397,7 +395,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
     assertThat(orderedEvents).hasSize(2);
-    assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_COMPLETE);
+    assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(EVENTNAME_COMPLETE);
   }
 
   @Test
@@ -405,7 +403,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // given
     BpmnModelInstance model = createModelWithTaskEventsRecorderOnAssignedUserTask(TRACKED_EVENTS,
                                                                                   null,
-                                                                                  TaskListener.EVENTNAME_COMPLETE,
+                                                                                  EVENTNAME_COMPLETE,
                                                                                   CandidateUserAssignment.class);
     testRule.deploy(model);
     runtimeService.startProcessInstanceByKey("process");
@@ -418,7 +416,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
     assertThat(orderedEvents).hasSize(2);
-    assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_COMPLETE);
+    assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(EVENTNAME_COMPLETE);
   }
 
   @Test
@@ -426,7 +424,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // given
     BpmnModelInstance model = createModelWithTaskEventsRecorderOnAssignedUserTask(TRACKED_EVENTS,
                                                                                   null,
-                                                                                  TaskListener.EVENTNAME_COMPLETE,
+                                                                                  EVENTNAME_COMPLETE,
                                                                                   AssigneeAssignment.class);
     testRule.deploy(model);
     runtimeService.startProcessInstanceByKey("process");
@@ -439,7 +437,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
     assertThat(orderedEvents).hasSize(2);
-    assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_COMPLETE);
+    assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(EVENTNAME_COMPLETE);
   }
 
   @Test
@@ -447,7 +445,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // given
     BpmnModelInstance model = createModelWithTaskEventsRecorderOnAssignedUserTask(TRACKED_EVENTS,
                                                                                   null,
-                                                                                  TaskListener.EVENTNAME_COMPLETE,
+                                                                                  EVENTNAME_COMPLETE,
                                                                                   TaskDeleteTaskListener.class);
     testRule.deploy(model);
     runtimeService.startProcessInstanceByKey("process");
@@ -464,7 +462,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
       LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
       assertThat(orderedEvents).hasSize(2);
-      assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_COMPLETE);
+      assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(EVENTNAME_COMPLETE);
     }
   }
 
@@ -473,7 +471,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // given
     BpmnModelInstance model = createModelWithTaskEventsRecorderOnAssignedUserTask(TRACKED_EVENTS,
                                                                                   null,
-                                                                                  TaskListener.EVENTNAME_COMPLETE,
+                                                                                  EVENTNAME_COMPLETE,
                                                                                   ProcessInstanceDeleteTaskListener.class);
     testRule.deploy(model);
     runtimeService.startProcessInstanceByKey("process");
@@ -485,10 +483,10 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents).hasSize(3);
-    assertThat(orderedEvents).containsExactly(TaskListener.EVENTNAME_CREATE,
-                                              TaskListener.EVENTNAME_COMPLETE,
-                                              TaskListener.EVENTNAME_DELETE);
+    assertThat(orderedEvents)
+      .hasSize(3).containsExactly(EVENTNAME_CREATE,
+        EVENTNAME_COMPLETE,
+        TaskListener.EVENTNAME_DELETE);
   }
 
   @Test
@@ -496,7 +494,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // given
     BpmnModelInstance model = createModelWithTaskEventsRecorderOnAssignedUserTask(TRACKED_EVENTS,
                                                                                   null,
-                                                                                  TaskListener.EVENTNAME_COMPLETE,
+                                                                                  EVENTNAME_COMPLETE,
                                                                                   CompletingTaskListener.class);
     testRule.deploy(model);
     runtimeService.startProcessInstanceByKey("process");
@@ -513,8 +511,8 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
       LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
       assertThat(orderedEvents).hasSize(2);
-      assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(TaskListener.EVENTNAME_CREATE);
-      assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_COMPLETE);
+      assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(EVENTNAME_CREATE);
+      assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(EVENTNAME_COMPLETE);
     }
   }
 
@@ -533,7 +531,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
     assertThat(orderedEvents).hasSize(2);
-    assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(TaskListener.EVENTNAME_CREATE);
+    assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(EVENTNAME_CREATE);
     assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
   }
 
@@ -554,7 +552,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
     assertThat(orderedEvents).hasSize(2);
-    assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(TaskListener.EVENTNAME_CREATE);
+    assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(EVENTNAME_CREATE);
     assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
   }
 
@@ -575,7 +573,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
     assertThat(orderedEvents).hasSize(2);
-    assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(TaskListener.EVENTNAME_CREATE);
+    assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(EVENTNAME_CREATE);
     assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
   }
 
@@ -600,7 +598,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
       LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
       assertThat(orderedEvents).hasSize(2);
-      assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(TaskListener.EVENTNAME_CREATE);
+      assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(EVENTNAME_CREATE);
       assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
     }
   }
@@ -626,7 +624,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
       LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
       assertThat(orderedEvents).hasSize(2);
-      assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(TaskListener.EVENTNAME_CREATE);
+      assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(EVENTNAME_CREATE);
       assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
     }
   }
@@ -648,7 +646,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
     assertThat(orderedEvents).hasSize(2);
-    assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(TaskListener.EVENTNAME_CREATE);
+    assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(EVENTNAME_CREATE);
     assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/processtask/ProcessTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/processtask/ProcessTaskTest.java
@@ -1834,7 +1834,6 @@ public class ProcessTaskTest extends CmmnTest {
     taskService.complete(task.getId());
 
     Object variable = caseService.getVariable(caseInstanceId, variableName);
-    assertThat(variable).isNotNull();
     assertThat(variable).isEqualTo(variableValue);
   }
 
@@ -1851,7 +1850,6 @@ public class ProcessTaskTest extends CmmnTest {
     taskService.complete(task.getId());
 
     Object variable = caseService.getVariable(caseInstanceId, variableName);
-    assertThat(variable).isNotNull();
     assertThat(variable).isEqualTo(variableValue);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/AbstractCompetingTransactionsOptimisticLockingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/AbstractCompetingTransactionsOptimisticLockingTest.java
@@ -84,8 +84,9 @@ public abstract class AbstractCompetingTransactionsOptimisticLockingTest {
     thread1.proceedAndWaitTillDone();
 
     // then
-    assertThat(thread1.exception).isNotNull();
-    assertThat(thread1.exception).isInstanceOf(OptimisticLockingException.class);
+    assertThat(thread1.exception)
+      .isNotNull()
+      .isInstanceOf(OptimisticLockingException.class);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/concurrency/AbstractCompetingTransactionsOptimisticLockingTest.shouldDetectConcurrentDeletionOfExecutionForTaskInsert.bpmn20.xml")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentInstallationIdInitializationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ConcurrentInstallationIdInitializationTest.java
@@ -76,8 +76,9 @@ public class ConcurrentInstallationIdInitializationTest extends ConcurrencyTestC
     assertNull(thread2Exception);
 
     String id = processEngineConfiguration.getInstallationId();
-    assertThat(id).isNotEmpty();
-    assertThat(id).matches("[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}");
+    assertThat(id)
+      .isNotEmpty()
+      .matches("[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}");
   }
 
   protected static class ControllableInstallationIdInitializationCommand extends ControllableCommand<Void> {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricJobLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricJobLogTest.java
@@ -1194,8 +1194,9 @@ public class HistoricJobLogTest {
         .getId();
 
     String stacktrace = historyService.getHistoricJobLogExceptionStacktrace(failedHistoricJobLogId);
-    assertThat(stacktrace).isNotNull();
-    assertThat(stacktrace).containsIgnoringCase(FailingDelegate.EXCEPTION_MESSAGE);
+    assertThat(stacktrace)
+      .isNotNull()
+      .containsIgnoringCase(FailingDelegate.EXCEPTION_MESSAGE);
   }
 
   @Test
@@ -1245,9 +1246,10 @@ public class HistoricJobLogTest {
     assertThat(serviceTask1FailedHistoricJobLog.getJobExceptionMessage()).isEqualTo(FirstFailingDelegate.FIRST_EXCEPTION_MESSAGE);
 
     String serviceTask1Stacktrace = historyService.getHistoricJobLogExceptionStacktrace(serviceTask1FailedHistoricJobLogId);
-    assertThat(serviceTask1Stacktrace).isNotNull();
-    assertThat(serviceTask1Stacktrace).containsIgnoringCase(FirstFailingDelegate.FIRST_EXCEPTION_MESSAGE);
-    assertThat(serviceTask1Stacktrace).containsIgnoringCase(FirstFailingDelegate.class.getName());
+    assertThat(serviceTask1Stacktrace)
+      .isNotNull()
+      .containsIgnoringCase(FirstFailingDelegate.FIRST_EXCEPTION_MESSAGE)
+      .containsIgnoringCase(FirstFailingDelegate.class.getName());
 
     // when (2)
     runtimeService.setVariable(processInstanceId, "firstFail", false);
@@ -1272,9 +1274,10 @@ public class HistoricJobLogTest {
     assertThat(serviceTask2FailedHistoricJobLog.getJobExceptionMessage()).isEqualTo(SecondFailingDelegate.SECOND_EXCEPTION_MESSAGE);
 
     String serviceTask2Stacktrace = historyService.getHistoricJobLogExceptionStacktrace(serviceTask2FailedHistoricJobLogId);
-    assertThat(serviceTask2Stacktrace).isNotNull();
-    assertThat(serviceTask2Stacktrace).containsIgnoringCase(SecondFailingDelegate.SECOND_EXCEPTION_MESSAGE);
-    assertThat(serviceTask2Stacktrace).containsIgnoringCase(SecondFailingDelegate.class.getName());
+    assertThat(serviceTask2Stacktrace)
+      .isNotNull()
+      .containsIgnoringCase(SecondFailingDelegate.SECOND_EXCEPTION_MESSAGE)
+      .containsIgnoringCase(SecondFailingDelegate.class.getName());
 
     assertThat(serviceTask1Stacktrace.equals(serviceTask2Stacktrace)).isFalse();
   }
@@ -1306,8 +1309,9 @@ public class HistoricJobLogTest {
     assertThat(failedHistoricJobLog.getJobExceptionMessage()).isNull();
 
     String stacktrace = historyService.getHistoricJobLogExceptionStacktrace(failedHistoricJobLogId);
-    assertThat(stacktrace).isNotNull();
-    assertThat(stacktrace).containsIgnoringCase(ThrowExceptionWithoutMessageDelegate.class.getName());
+    assertThat(stacktrace)
+      .isNotNull()
+      .containsIgnoringCase(ThrowExceptionWithoutMessageDelegate.class.getName());
   }
 
   @Deployment

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceTest.java
@@ -189,8 +189,9 @@ public class HistoricDecisionInstanceTest extends PluggableProcessEngineTest {
 
     HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery().includeInputs().singleResult();
     List<HistoricDecisionInputInstance> inputs = historicDecisionInstance.getInputs();
-    assertThat(inputs).isNotNull();
-    assertThat(inputs).hasSize(1);
+    assertThat(inputs)
+      .isNotNull()
+      .hasSize(1);
 
     HistoricDecisionInputInstance input = inputs.get(0);
     assertThat(input.getDecisionInstanceId()).isEqualTo(historicDecisionInstance.getId());
@@ -263,8 +264,9 @@ public class HistoricDecisionInstanceTest extends PluggableProcessEngineTest {
 
     HistoricDecisionInstance historicDecisionInstance = historyService.createHistoricDecisionInstanceQuery().includeOutputs().singleResult();
     List<HistoricDecisionOutputInstance> outputs = historicDecisionInstance.getOutputs();
-    assertThat(outputs).isNotNull();
-    assertThat(outputs).hasSize(1);
+    assertThat(outputs)
+      .isNotNull()
+      .hasSize(1);
 
     HistoricDecisionOutputInstance output = outputs.get(0);
     assertThat(output.getDecisionInstanceId()).isEqualTo(historicDecisionInstance.getId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/persistence/DatabaseNamingConsistencyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/persistence/DatabaseNamingConsistencyTest.java
@@ -102,7 +102,8 @@ public class DatabaseNamingConsistencyTest {
     }
 
     // then
-    assertThat(errors).containsAll(Arrays.asList(testStringsIncorrect));
-    assertThat(errors).doesNotContainAnyElementsOf(Arrays.asList(testStringsCorrect));
+    assertThat(errors)
+      .containsAll(Arrays.asList(testStringsIncorrect))
+      .doesNotContainAnyElementsOf(Arrays.asList(testStringsCorrect));
   }
 }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
@@ -1083,9 +1083,10 @@ public class OperatonExtensionsTest {
     newValues.add(this.modelInstance.newInstance(OperatonValue.class));
     newValues.add(this.modelInstance.newInstance(OperatonValue.class));
     elements.addAll(newValues);
-    assertThat(elements).hasSize(3);
 
-    assertThat(elements).doesNotContain(this.modelInstance.newInstance(OperatonValue.class));
+    assertThat(elements)
+      .hasSize(3)
+      .doesNotContain(this.modelInstance.newInstance(OperatonValue.class));
     assertThat(elements.containsAll(Arrays.asList(this.modelInstance.newInstance(OperatonValue.class)))).isFalse();
 
     assertThat(elements.remove(this.modelInstance.newInstance(OperatonValue.class))).isFalse();

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ReferenceTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/ReferenceTest.java
@@ -111,8 +111,9 @@ class ReferenceTest extends BpmnModelTest {
   @Test
   void testShouldAddMessageEventDefinitionRef() {
     Collection<EventDefinition> eventDefinitionRefs = startEvent.getEventDefinitionRefs();
-    assertThat(eventDefinitionRefs).isNotEmpty();
-    assertThat(eventDefinitionRefs).contains(messageEventDefinition);
+    assertThat(eventDefinitionRefs)
+      .isNotEmpty()
+      .contains(messageEventDefinition);
   }
 
   @Test
@@ -128,7 +129,6 @@ class ReferenceTest extends BpmnModelTest {
   void testShouldRemoveMessageEventDefinitionRefIfMessageEventDefinitionIsRemoved() {
     startEvent.getEventDefinitions().remove(messageEventDefinition);
     Collection<EventDefinition> eventDefinitionRefs = startEvent.getEventDefinitionRefs();
-    assertThat(eventDefinitionRefs).doesNotContain(messageEventDefinition);
     assertThat(eventDefinitionRefs).isEmpty();
   }
 
@@ -139,8 +139,9 @@ class ReferenceTest extends BpmnModelTest {
     Collection<EventDefinition> eventDefinitionRefs = startEvent.getEventDefinitionRefs();
     assertThat(eventDefinitionRefs).contains(messageEventDefinition);
     messageEventDefinition.replaceWithElement(otherMessageEventDefinition);
-    assertThat(eventDefinitionRefs).doesNotContain(messageEventDefinition);
-    assertThat(eventDefinitionRefs).contains(otherMessageEventDefinition);
+    assertThat(eventDefinitionRefs)
+      .doesNotContain(messageEventDefinition)
+      .contains(otherMessageEventDefinition);
   }
 
   @Test
@@ -148,7 +149,6 @@ class ReferenceTest extends BpmnModelTest {
     Collection<EventDefinition> eventDefinitionRefs = startEvent.getEventDefinitionRefs();
     assertThat(eventDefinitionRefs).contains(messageEventDefinition);
     messageEventDefinition.removeAttribute("id");
-    assertThat(eventDefinitionRefs).doesNotContain(messageEventDefinition);
     assertThat(eventDefinitionRefs).isEmpty();
   }
 
@@ -168,19 +168,21 @@ class ReferenceTest extends BpmnModelTest {
 
     StartEvent startEvent = bpmnModelInstance.getModelElementById("start-event");
     Collection<EventDefinition> eventDefinitionRefs = startEvent.getEventDefinitionRefs();
-    assertThat(eventDefinitionRefs).isNotEmpty();
-    assertThat(eventDefinitionRefs).contains(messageEventDefinition);
+    assertThat(eventDefinitionRefs)
+      .isNotEmpty()
+      .contains(messageEventDefinition);
     messageEventDefinition.setId("changed-message-event");
-    assertThat(eventDefinitionRefs).isNotEmpty();
-    assertThat(eventDefinitionRefs).contains(messageEventDefinition);
+    assertThat(eventDefinitionRefs)
+      .isNotEmpty()
+      .contains(messageEventDefinition);
     messageEventDefinition.setAttributeValue("id", "again-changed-message-event", true);
-    assertThat(eventDefinitionRefs).isNotEmpty();
-    assertThat(eventDefinitionRefs).contains(messageEventDefinition);
+    assertThat(eventDefinitionRefs)
+      .isNotEmpty()
+      .contains(messageEventDefinition);
 
     message.removeAttribute("id");
     assertThat(messageEventDefinition.getMessage()).isNull();
     messageEventDefinition.removeAttribute("id");
-    assertThat(eventDefinitionRefs).doesNotContain(messageEventDefinition);
     assertThat(eventDefinitionRefs).isEmpty();
   }
 }

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/ModelTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/ModelTest.java
@@ -41,13 +41,14 @@ class ModelTest {
   @Test
   void testGetTypes() {
     Collection<ModelElementType> types = model.getTypes();
-    assertThat(types).isNotEmpty();
-    assertThat(types).contains(
-      model.getType(Animals.class),
-      model.getType(Animal.class),
-      model.getType(FlyingAnimal.class),
-      model.getType(Bird.class),
-      model.getType(RelationshipDefinition.class)
+    assertThat(types)
+      .isNotEmpty()
+      .contains(
+        model.getType(Animals.class),
+        model.getType(Animal.class),
+        model.getType(FlyingAnimal.class),
+        model.getType(Bird.class),
+        model.getType(RelationshipDefinition.class)
       );
   }
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/BirdTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/BirdTest.java
@@ -377,12 +377,16 @@ public class BirdTest extends TestModelTest {
   void testGetGuards(TestModelArgs args) {
     init(args);
     Collection<Animal> guards = egg1.getGuardians();
-    assertThat(guards).isNotEmpty().hasSize(2);
-    assertThat(guards).contains(hedwig, timmy);
+    assertThat(guards)
+      .isNotEmpty()
+      .hasSize(2)
+      .contains(hedwig, timmy);
 
     guards = egg2.getGuardians();
-    assertThat(guards).isNotEmpty().hasSize(2);
-    assertThat(guards).contains(hedwig, timmy);
+    assertThat(guards)
+      .isNotEmpty()
+      .hasSize(2)
+      .contains(hedwig, timmy);
   }
 
   @ParameterizedTest

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/ManagedJobExecutorTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/ManagedJobExecutorTest.java
@@ -91,8 +91,9 @@ class ManagedJobExecutorTest {
     // then
     // an quarkus managed executor is created
     JobExecutor jobExecutor = processEngineConfiguration.getJobExecutor();
-    assertThat(jobExecutor).isNotNull();
-    assertThat(jobExecutor).isInstanceOf(ManagedJobExecutor.class);
+    assertThat(jobExecutor)
+      .isNotNull()
+      .isInstanceOf(ManagedJobExecutor.class);
   }
 
   @Test

--- a/spin/core/src/test/java/org/operaton/spin/spi/DataFormatLoadingTest.java
+++ b/spin/core/src/test/java/org/operaton/spin/spi/DataFormatLoadingTest.java
@@ -70,8 +70,9 @@ class DataFormatLoadingTest {
     DataFormat<?> customDataFormat = DataFormats.getDataFormat(CustomDataFormatProvider.NAME);
 
     // then it should be properly returned
-    assertThat(customDataFormat).isNotNull();
-    assertThat(customDataFormat).isSameAs(CustomDataFormatProvider.DATA_FORMAT);
+    assertThat(customDataFormat)
+      .isNotNull()
+      .isSameAs(CustomDataFormatProvider.DATA_FORMAT);
   }
 
 

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeCreateTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeCreateTest.java
@@ -78,10 +78,11 @@ class JsonTreeCreateTest {
   @Test
   void shouldBeIdempotent() {
     SpinJsonNode json = JSON(EXAMPLE_JSON);
-    assertThat(json).isEqualTo(JSON(json));
-    assertThat(json).isEqualTo(S(json, json()));
-    assertThat(json).isEqualTo(S(json, DataFormats.JSON_DATAFORMAT_NAME));
-    assertThat(json).isEqualTo(S(json));
+    assertThat(json)
+      .isEqualTo(JSON(json))
+      .isEqualTo(S(json, json()))
+      .isEqualTo(S(json, DataFormats.JSON_DATAFORMAT_NAME))
+      .isEqualTo(S(json));
   }
 
   @Test

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeEditListPropertyScriptTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeEditListPropertyScriptTest.java
@@ -273,8 +273,9 @@ public abstract class JsonTreeEditListPropertyScriptTest extends ScriptTest {
 
     // casts to int because ruby returns long instead of int
     assertThat(oldSize.intValue() + 1).isEqualTo(newSize.intValue());
-    assertThat(oldValue).isEqualTo("euro");
-    assertThat(oldValue).isEqualTo(oldValueOnNewPosition);
+    assertThat(oldValue)
+      .isEqualTo("euro")
+      .isEqualTo(oldValueOnNewPosition);
     assertThat(newValue).isEqualTo("Test");
   }
 
@@ -291,8 +292,9 @@ public abstract class JsonTreeEditListPropertyScriptTest extends ScriptTest {
 
     // casts to int because ruby returns long instead of int
     assertThat(oldSize.intValue() + 1).isEqualTo(newSize.intValue());
-    assertThat(oldValue).isEqualTo("dollar");
-    assertThat(oldValue).isEqualTo(oldValueOnNewPosition);
+    assertThat(oldValue)
+      .isEqualTo("dollar")
+      .isEqualTo(oldValueOnNewPosition);
     assertThat(newValue).isEqualTo("Test");
   }
 
@@ -352,8 +354,9 @@ public abstract class JsonTreeEditListPropertyScriptTest extends ScriptTest {
 
     // casts to int because ruby returns long instead of int
     assertThat(oldSize.intValue() + 1).isEqualTo(newSize.intValue());
-    assertThat(oldValue).isEqualTo("dollar");
-    assertThat(oldValue).isEqualTo(oldValueOnNewPosition);
+    assertThat(oldValue)
+      .isEqualTo("dollar")
+      .isEqualTo(oldValueOnNewPosition);
     assertThat(newValue).isEqualTo("Test");
   }
 

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeSetPropertyScriptTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeSetPropertyScriptTest.java
@@ -55,8 +55,9 @@ public abstract class JsonTreeSetPropertyScriptTest extends ScriptTest {
     String oldValue = script.getVariable("oldValue");
     String newValue = script.getVariable("newValue");
 
-    assertThat(newValue).isNotEqualTo(oldValue);
-    assertThat(newValue).isEqualTo("new Order");
+    assertThat(newValue)
+      .isNotEqualTo(oldValue)
+      .isEqualTo("new Order");
   }
 
   @Test
@@ -161,8 +162,9 @@ public abstract class JsonTreeSetPropertyScriptTest extends ScriptTest {
     String oldValue = script.getVariable("oldValue");
     Boolean newValue = script.getVariable("newValue");
 
-    assertThat(newValue).isNotEqualTo(oldValue);
-    assertThat(newValue).isFalse();
+    assertThat(newValue)
+      .isNotEqualTo(oldValue)
+      .isFalse();
   }
 
   @Test

--- a/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomCreateTest.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomCreateTest.java
@@ -73,10 +73,11 @@ class XmlDomCreateTest {
   @Test
   void shouldBeIdempotent() {
     SpinXmlElement xml = XML(EXAMPLE_XML);
-    assertThat(xml).isEqualTo(XML(xml));
-    assertThat(xml).isEqualTo(S(xml, xmlDataFormat));
-    assertThat(xml).isEqualTo(S(xml, DataFormats.XML_DATAFORMAT_NAME));
-    assertThat(xml).isEqualTo(S(xml));
+    assertThat(xml)
+      .isEqualTo(XML(xml))
+      .isEqualTo(S(xml, xmlDataFormat))
+      .isEqualTo(S(xml, DataFormats.XML_DATAFORMAT_NAME))
+      .isEqualTo(S(xml));
   }
 
   @Test

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/IncidentRestServiceTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/IncidentRestServiceTest.java
@@ -94,8 +94,9 @@ public class IncidentRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setProcessInstanceIdIn(processInstanceIds);
 
     List<IncidentDto> result = resource.queryIncidents(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(1);
 
     IncidentDto incident = result.get(0);
 
@@ -140,8 +141,9 @@ public class IncidentRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setProcessInstanceIdIn(processInstanceIds);
 
     List<IncidentDto> result = resource.queryIncidents(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(2);
   }
 
   @Test
@@ -159,8 +161,9 @@ public class IncidentRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setActivityIdIn(activityIds);
 
     List<IncidentDto> result = resource.queryIncidents(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(1);
 
     IncidentDto incident = result.get(0);
 
@@ -203,8 +206,9 @@ public class IncidentRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setActivityIdIn(activityIds);
 
     List<IncidentDto> result = resource.queryIncidents(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(2);
   }
 
   @Test
@@ -224,8 +228,9 @@ public class IncidentRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setActivityIdIn(activityIds);
 
     List<IncidentDto> result = resource.queryIncidents(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(1);
   }
 
   @Test
@@ -271,8 +276,9 @@ public class IncidentRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setProcessInstanceIdIn(processInstanceIds);
 
     List<IncidentDto> result = resource.queryIncidents(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(1);
 
     IncidentDto incident = result.get(0);
 
@@ -314,20 +320,23 @@ public class IncidentRestServiceTest extends AbstractCockpitPluginTest {
     IncidentQueryDto queryParameter = new IncidentQueryDto();
 
     List<IncidentDto> result = resource.queryIncidents(queryParameter, 0, 2);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(2);
 
     result = resource.queryIncidents(queryParameter, 2, 1);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(1);
 
     result = resource.queryIncidents(queryParameter, 4, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(6);
+    assertThat(result)
+      .isNotEmpty().hasSize(6);
 
     result = resource.queryIncidents(queryParameter, null, 4);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(4);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(4);
   }
 
   @Test
@@ -347,8 +356,9 @@ public class IncidentRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setProcessDefinitionIdIn(processDefinitionIds);
 
     List<IncidentDto> result = resource.queryIncidents(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(1);
 
     IncidentDto incident = result.get(0);
 
@@ -383,8 +393,9 @@ public class IncidentRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setProcessDefinitionIdIn(processDefinitionIds);
 
     List<IncidentDto> result = resource.queryIncidents(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(2);
   }
 
   @Test

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/ProcessDefinitionResourceTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/ProcessDefinitionResourceTest.java
@@ -22,10 +22,7 @@ import static org.operaton.bpm.engine.rest.dto.ConditionQueryParameterDto.LIKE_O
 import static org.operaton.bpm.engine.rest.dto.ConditionQueryParameterDto.NOT_EQUALS_OPERATOR_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.operaton.bpm.cockpit.impl.plugin.base.dto.ProcessDefinitionDto;
 import org.operaton.bpm.cockpit.impl.plugin.base.dto.query.ProcessDefinitionQueryDto;
@@ -97,8 +94,9 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
     ProcessDefinitionQueryDto queryParameter = new ProcessDefinitionQueryDto();
 
     List<ProcessDefinitionDto> result = resource.queryCalledProcessDefinitions(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(1);
 
     ProcessDefinitionDto dto = result.get(0);
 
@@ -131,8 +129,9 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
     ProcessDefinitionQueryDto queryParameter = new ProcessDefinitionQueryDto();
 
     List<ProcessDefinitionDto> result = resource.queryCalledProcessDefinitions(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(1);
 
     ProcessDefinitionDto dto = result.get(0);
 
@@ -173,8 +172,9 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
     ProcessDefinitionQueryDto queryParameter1 = new ProcessDefinitionQueryDto();
 
     List<ProcessDefinitionDto> result1 = resource1.queryCalledProcessDefinitions(queryParameter1);
-    assertThat(result1).isNotEmpty();
-    assertThat(result1).hasSize(1);
+    assertThat(result1)
+      .isNotEmpty()
+      .hasSize(1);
 
     ProcessDefinitionDto dto1 = result1.get(0);
 
@@ -197,8 +197,9 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
     ProcessDefinitionQueryDto queryParameter2 = new ProcessDefinitionQueryDto();
 
     List<ProcessDefinitionDto> result2 = resource2.queryCalledProcessDefinitions(queryParameter2);
-    assertThat(result2).isNotEmpty();
-    assertThat(result2).hasSize(1);
+    assertThat(result2)
+      .isNotEmpty()
+      .hasSize(1);
 
     ProcessDefinitionDto dto2 = result2.get(0);
 
@@ -235,8 +236,9 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
     ProcessDefinitionQueryDto queryParameter = new ProcessDefinitionQueryDto();
 
     List<ProcessDefinitionDto> result = resource.queryCalledProcessDefinitions(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(2);
 
     ProcessDefinition compareWith = null;
     for (ProcessDefinitionDto dto : result) {
@@ -301,8 +303,9 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
     ProcessDefinitionQueryDto queryParameter = new ProcessDefinitionQueryDto();
 
     List<ProcessDefinitionDto> result = resource.queryCalledProcessDefinitions(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(2);
 
     ProcessDefinition compareWith = null;
     for (ProcessDefinitionDto dto : result) {
@@ -351,8 +354,9 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
     queryParameter.setSuperProcessDefinitionId(processInstance.getProcessDefinitionId());
 
     List<ProcessDefinitionDto> result = resource.queryCalledProcessDefinitions(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(1);
 
     ProcessDefinitionDto dto = result.get(0);
 
@@ -390,8 +394,9 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
     queryParameter1.setActivityIdIn(activityIds1);
 
     List<ProcessDefinitionDto> result1 = resource.queryCalledProcessDefinitions(queryParameter1);
-    assertThat(result1).isNotEmpty();
-    assertThat(result1).hasSize(1);
+    assertThat(result1)
+      .isNotEmpty()
+      .hasSize(1);
 
     ProcessDefinitionDto dto1 = result1.get(0);
 
@@ -410,8 +415,9 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
     queryParameter2.setActivityIdIn(activityIds2);
 
     List<ProcessDefinitionDto> result2 = resource.queryCalledProcessDefinitions(queryParameter2);
-    assertThat(result2).isNotEmpty();
-    assertThat(result2).hasSize(1);
+    assertThat(result2)
+      .isNotEmpty()
+      .hasSize(1);
 
     ProcessDefinitionDto dto2 = result2.get(0);
 
@@ -430,8 +436,9 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
     queryParameter3.setActivityIdIn(activityIds3);
 
     List<ProcessDefinitionDto> result3 = resource.queryCalledProcessDefinitions(queryParameter3);
-    assertThat(result3).isNotEmpty();
-    assertThat(result3).hasSize(2);
+    assertThat(result3)
+      .isNotEmpty()
+      .hasSize(2);
 
   }
 
@@ -455,15 +462,17 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
     queryParameter1.setBusinessKey("aBusinessKey");
 
     List<ProcessDefinitionDto> result1 = resource.queryCalledProcessDefinitions(queryParameter1);
-    assertThat(result1).isNotEmpty();
-    assertThat(result1).hasSize(2);
+    assertThat(result1)
+      .isNotEmpty()
+      .hasSize(2);
 
     ProcessDefinitionQueryDto queryParameter2 = new ProcessDefinitionQueryDto();
     queryParameter2.setBusinessKey("anotherBusinessKey");
 
     List<ProcessDefinitionDto> result2 = resource.queryCalledProcessDefinitions(queryParameter2);
-    assertThat(result2).isNotEmpty();
-    assertThat(result2).hasSize(2);
+    assertThat(result2)
+      .isNotEmpty()
+      .hasSize(2);
   }
 
   @Test
@@ -486,8 +495,6 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
 
     List<ProcessDefinitionDto> result1 = resource.queryCalledProcessDefinitions(queryParameter1);
     assertThat(result1).isEmpty();
-    assertThat(result1).isEmpty();
-
   }
 
   @Test
@@ -545,8 +552,9 @@ public class ProcessDefinitionResourceTest extends AbstractCockpitPluginTest {
 
     // then
     List<ProcessDefinitionDto> results = resource.queryCalledProcessDefinitions(queryParameter);
-    assertThat(results).isNotEmpty();
-    assertThat(results).hasSize(1);
+    assertThat(results)
+      .isNotEmpty()
+      .hasSize(1);
 
     ProcessDefinitionDto dto = results.get(0);
 

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/ProcessInstanceResourceTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/ProcessInstanceResourceTest.java
@@ -102,8 +102,9 @@ public class ProcessInstanceResourceTest extends AbstractCockpitPluginTest {
     CalledProcessInstanceQueryDto queryParameter = new CalledProcessInstanceQueryDto();
 
     List<CalledProcessInstanceDto> result = resource.queryCalledProcessInstances(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result)
+      .isNotEmpty()
+      .hasSize(2);
 
     ProcessDefinition compareWith = null;
     for (ProcessInstanceDto instance : result) {
@@ -160,24 +161,27 @@ public class ProcessInstanceResourceTest extends AbstractCockpitPluginTest {
     queryParameter1.setActivityInstanceIdIn(activityInstanceIds1);
 
     List<CalledProcessInstanceDto> result1 = resource.queryCalledProcessInstances(queryParameter1);
-    assertThat(result1).isNotEmpty();
-    assertThat(result1).hasSize(1);
+    assertThat(result1)
+      .isNotEmpty()
+      .hasSize(1);
 
     CalledProcessInstanceQueryDto queryParameter2 = new CalledProcessInstanceQueryDto();
     String[] activityInstanceIds2 = {secondActivityInstanceId};
     queryParameter2.setActivityInstanceIdIn(activityInstanceIds2);
 
     List<CalledProcessInstanceDto> result2 = resource.queryCalledProcessInstances(queryParameter2);
-    assertThat(result2).isNotEmpty();
-    assertThat(result2).hasSize(1);
+    assertThat(result2)
+      .isNotEmpty()
+      .hasSize(1);
 
     CalledProcessInstanceQueryDto queryParameter3 = new CalledProcessInstanceQueryDto();
     String[] activityInstanceIds3 = {firstActivityInstanceId, secondActivityInstanceId};
     queryParameter3.setActivityInstanceIdIn(activityInstanceIds3);
 
     List<CalledProcessInstanceDto> result3 = resource.queryCalledProcessInstances(queryParameter3);
-    assertThat(result3).isNotEmpty();
-    assertThat(result3).hasSize(2);
+    assertThat(result3)
+      .isNotEmpty()
+      .hasSize(2);
   }
 
   @Test
@@ -210,12 +214,14 @@ public class ProcessInstanceResourceTest extends AbstractCockpitPluginTest {
     queryParameter1.setProcessDefinitionId(processDefinition1);
 
     List<CalledProcessInstanceDto> callActivityInstances = resource.queryCalledProcessInstances(queryParameter1);
-    assertThat(callActivityInstances).isNotEmpty();
-    assertThat(callActivityInstances).hasSize(1);
+    assertThat(callActivityInstances)
+      .isNotEmpty()
+      .hasSize(1);
 
     List<IncidentStatisticsDto> incidents1 = callActivityInstances.get(0).getIncidents();
-    assertThat(incidents1).isNotEmpty();
-    assertThat(incidents1).hasSize(1);
+    assertThat(incidents1)
+      .isNotEmpty()
+      .hasSize(1);
 
     assertThat(incidents1.get(0).getIncidentCount()).isEqualTo(1);
     assertThat(incidents1.get(0).getIncidentType()).isEqualTo("failedJob");
@@ -224,12 +230,14 @@ public class ProcessInstanceResourceTest extends AbstractCockpitPluginTest {
     queryParameter2.setProcessDefinitionId(processDefinition2);
 
     List<CalledProcessInstanceDto> failingProcessInstance = resource.queryCalledProcessInstances(queryParameter2);
-    assertThat(failingProcessInstance).isNotEmpty();
-    assertThat(failingProcessInstance).hasSize(1);
+    assertThat(failingProcessInstance)
+      .isNotEmpty()
+      .hasSize(1);
 
     List<IncidentStatisticsDto> incidents2 = failingProcessInstance.get(0).getIncidents();
-    assertThat(incidents2).isNotEmpty();
-    assertThat(incidents2).hasSize(1);
+    assertThat(incidents2)
+      .isNotEmpty()
+      .hasSize(1);
 
     assertThat(incidents2.get(0).getIncidentCount()).isEqualTo(1);
     assertThat(incidents2.get(0).getIncidentType()).isEqualTo("failedJob");

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/ProcessInstanceRestServiceTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/ProcessInstanceRestServiceTest.java
@@ -132,8 +132,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setProcessDefinitionId(processDefinitionId);
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(3);
+    assertThat(result).isNotEmpty().hasSize(3);
   }
 
   @Test
@@ -167,8 +166,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setSortBy("startTime");
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(3);
+    assertThat(result).isNotEmpty().hasSize(3);
 
     for (int i=1; i < result.size(); i++) {
       Date previousStartTime = result.get(i - 1).getStartTime();
@@ -192,8 +190,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setSortOrder("asc");
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(3);
+    assertThat(result).isNotEmpty().hasSize(3);
 
     for (int i=1; i < result.size(); i++) {
       Date previousStartTime = result.get(i - 1).getStartTime();
@@ -217,8 +214,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setSortOrder("desc");
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(3);
+    assertThat(result).isNotEmpty().hasSize(3);
 
     for (int i=1; i < result.size(); i++) {
       Date previousStartTime = result.get(i - 1).getStartTime();
@@ -240,16 +236,13 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setProcessDefinitionId(processDefinitionId);
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, 0, 3);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(3);
+    assertThat(result).isNotEmpty().hasSize(3);
 
     result = resource.queryProcessInstances(queryParameter, 2, 3);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(3);
+    assertThat(result).isNotEmpty().hasSize(3);
 
     result = resource.queryProcessInstances(queryParameter, 3, 1);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
   }
 
   @Test
@@ -269,18 +262,15 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     List<ProcessInstanceDto> allResults = new ArrayList<>();
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, 0, 3);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(3);
+    assertThat(result).isNotEmpty().hasSize(3);
     allResults.addAll(result);
 
     result = resource.queryProcessInstances(queryParameter, 3, 3);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(3);
+    assertThat(result).isNotEmpty().hasSize(3);
     allResults.addAll(result);
 
     result = resource.queryProcessInstances(queryParameter, 6, 3);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
     allResults.addAll(result);
 
     for (int i=1; i < allResults.size(); i++) {
@@ -308,18 +298,15 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     List<ProcessInstanceDto> allResults = new ArrayList<>();
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, 0, 3);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(3);
+    assertThat(result).isNotEmpty().hasSize(3);
     allResults.addAll(result);
 
     result = resource.queryProcessInstances(queryParameter, 3, 3);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(3);
+    assertThat(result).isNotEmpty().hasSize(3);
     allResults.addAll(result);
 
     result = resource.queryProcessInstances(queryParameter, 6, 3);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
     allResults.addAll(result);
 
     for (int i=1; i < allResults.size(); i++) {
@@ -344,8 +331,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
 
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     List<IncidentStatisticsDto> incidents = result.get(0).getIncidents();
 
@@ -366,13 +352,11 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
 
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     List<IncidentStatisticsDto> incidents = result.get(0).getIncidents();
 
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(1);
+    assertThat(incidents).isNotEmpty().hasSize(1);
 
     IncidentStatisticsDto incident = incidents.get(0);
 
@@ -394,13 +378,11 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
 
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     List<IncidentStatisticsDto> incidents = result.get(0).getIncidents();
 
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(3);
+    assertThat(incidents).isNotEmpty().hasSize(3);
 
     for (IncidentStatisticsDto incident : incidents) {
       String incidentType = incident.getIncidentType();
@@ -560,12 +542,10 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter1.setProcessDefinitionId(nestedCallActivityId);
 
     List<ProcessInstanceDto> nestedCallActivityInstances = resource.queryProcessInstances(queryParameter1, null, null);
-    assertThat(nestedCallActivityInstances).isNotEmpty();
-    assertThat(nestedCallActivityInstances).hasSize(1);
+    assertThat(nestedCallActivityInstances).isNotEmpty().hasSize(1);
 
     List<IncidentStatisticsDto> nestedCallActivityIncidents = nestedCallActivityInstances.get(0).getIncidents();
-    assertThat(nestedCallActivityIncidents).isNotEmpty();
-    assertThat(nestedCallActivityIncidents).hasSize(1);
+    assertThat(nestedCallActivityIncidents).isNotEmpty().hasSize(1);
 
     IncidentStatisticsDto nestedCallActivityIncident = nestedCallActivityIncidents.get(0);
     assertThat(nestedCallActivityIncident.getIncidentType()).isEqualTo("failedJob");
@@ -575,12 +555,10 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter2.setProcessDefinitionId(callActivityId);
 
     List<ProcessInstanceDto> callActivityInstances = resource.queryProcessInstances(queryParameter2, null, null);
-    assertThat(callActivityInstances).isNotEmpty();
-    assertThat(callActivityInstances).hasSize(1);
+    assertThat(callActivityInstances).isNotEmpty().hasSize(1);
 
     List<IncidentStatisticsDto> callActivityIncidents = callActivityInstances.get(0).getIncidents();
-    assertThat(callActivityIncidents).isNotEmpty();
-    assertThat(callActivityIncidents).hasSize(1);
+    assertThat(callActivityIncidents).isNotEmpty().hasSize(1);
 
     IncidentStatisticsDto callActivityIncident = callActivityIncidents.get(0);
     assertThat(callActivityIncident.getIncidentType()).isEqualTo("failedJob");
@@ -590,12 +568,10 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter3.setProcessDefinitionId(failingProcess);
 
     List<ProcessInstanceDto> failingProcessInstances = resource.queryProcessInstances(queryParameter3, null, null);
-    assertThat(failingProcessInstances).isNotEmpty();
-    assertThat(failingProcessInstances).hasSize(1);
+    assertThat(failingProcessInstances).isNotEmpty().hasSize(1);
 
     List<IncidentStatisticsDto> failingProcessIncidents = failingProcessInstances.get(0).getIncidents();
-    assertThat(failingProcessIncidents).isNotEmpty();
-    assertThat(failingProcessIncidents).hasSize(1);
+    assertThat(failingProcessIncidents).isNotEmpty().hasSize(1);
 
     IncidentStatisticsDto failingProcessIncident = failingProcessIncidents.get(0);
     assertThat(failingProcessIncident.getIncidentType()).isEqualTo("failedJob");
@@ -613,8 +589,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setBusinessKey("businessKey_2");
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
   }
 
   @Test
@@ -645,8 +620,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setBusinessKey("businessKey_2");
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
   }
 
   @Test
@@ -680,8 +654,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setProcessDefinitionId(userTaskProcess.getId());
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
   }
 
   @Test
@@ -717,8 +690,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setActivityIdIn(activityIds);
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
   }
 
   @Test
@@ -755,8 +727,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setActivityIdIn(activityIds);
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
   }
 
   @Test
@@ -798,8 +769,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setActivityIdIn(activityIds);
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
   }
 
   @Test
@@ -844,8 +814,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setParentProcessDefinitionId(twoCallActivitiesProcess.getId());
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(4);
+    assertThat(result).isNotEmpty().hasSize(4);
   }
 
   @Test
@@ -895,8 +864,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setProcessDefinitionId(userTaskProcess.getId());
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
   }
 
   @Test
@@ -953,8 +921,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setActivityIdIn(activityIds);
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
   }
 
   @Test
@@ -1003,8 +970,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1027,8 +993,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1051,8 +1016,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1075,8 +1039,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1099,8 +1062,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1123,8 +1085,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1147,8 +1108,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1171,8 +1131,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1195,8 +1154,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1219,8 +1177,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1243,8 +1200,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1267,8 +1223,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1291,8 +1246,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1315,8 +1269,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1339,8 +1292,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1363,8 +1315,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1387,8 +1338,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1411,8 +1361,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1435,8 +1384,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1459,8 +1407,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1484,8 +1431,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1509,8 +1455,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1534,8 +1479,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1559,8 +1503,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1583,8 +1526,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1607,8 +1549,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1631,8 +1572,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1655,8 +1595,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1679,8 +1618,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1703,8 +1641,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1727,8 +1664,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1751,8 +1687,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1775,8 +1710,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1799,8 +1733,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1823,8 +1756,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1847,8 +1779,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1871,8 +1802,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1895,8 +1825,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1919,8 +1848,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1943,8 +1871,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1967,8 +1894,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -1991,8 +1917,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2015,8 +1940,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2039,8 +1963,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2064,8 +1987,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2089,8 +2011,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2114,8 +2035,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2139,8 +2059,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2163,8 +2082,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2187,8 +2105,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2211,8 +2128,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2235,8 +2151,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2259,8 +2174,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2283,8 +2197,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2307,8 +2220,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2331,8 +2243,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2355,8 +2266,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2379,8 +2289,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2403,8 +2312,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2427,8 +2335,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2451,8 +2358,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2475,8 +2381,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2499,8 +2404,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2523,8 +2427,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2547,8 +2450,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2571,8 +2473,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2595,8 +2496,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2619,8 +2519,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2644,8 +2543,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2669,8 +2567,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2694,8 +2591,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2719,8 +2615,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2743,8 +2638,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2767,8 +2661,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2791,8 +2684,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2815,8 +2707,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2839,8 +2730,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2863,8 +2753,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2887,8 +2776,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2911,8 +2799,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2935,8 +2822,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2959,8 +2845,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -2983,8 +2868,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -3007,8 +2891,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -3031,8 +2914,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -3055,8 +2937,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -3079,8 +2960,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -3103,8 +2983,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -3127,8 +3006,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -3151,8 +3029,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -3175,8 +3052,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -3199,8 +3075,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -3223,8 +3098,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -3247,8 +3121,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -3271,8 +3144,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -3295,8 +3167,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setVariables(Arrays.asList(variable));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     ProcessInstanceDto dto = result.get(0);
 
@@ -3319,8 +3190,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setStartedAfter(currentDate);
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(5);
+    assertThat(result).isNotEmpty().hasSize(5);
   }
 
   @Test
@@ -3342,8 +3212,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setStartedBefore(hourFromNow.getTime());
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(5);
+    assertThat(result).isNotEmpty().hasSize(5);
   }
 
   @Test
@@ -3366,8 +3235,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
     queryParameter.setStartedBefore(hourFromNow.getTime());
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(5);
+    assertThat(result).isNotEmpty().hasSize(5);
   }
 
   @Test
@@ -3469,8 +3337,7 @@ public class ProcessInstanceRestServiceTest extends AbstractCockpitPluginTest {
 
     List<IncidentStatisticsDto> incidents = result.get(0).getIncidents();
 
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(1);
+    assertThat(incidents).isNotEmpty().hasSize(1);
 
     IncidentStatisticsDto incident = incidents.get(0);
 

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/authorization/IncidentRestServiceAuthorizationTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/authorization/IncidentRestServiceAuthorizationTest.java
@@ -92,8 +92,7 @@ public class IncidentRestServiceAuthorizationTest extends AuthorizationTest {
     List<IncidentDto> incidents = resource.queryIncidents(queryParameter, null, null);
 
     // then
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(1);
+    assertThat(incidents).isNotEmpty().hasSize(1);
     assertThat(incidents.get(0).getProcessInstanceId()).isEqualTo(processInstanceId);
   }
 
@@ -108,8 +107,7 @@ public class IncidentRestServiceAuthorizationTest extends AuthorizationTest {
     List<IncidentDto> incidents = resource.queryIncidents(queryParameter, null, null);
 
     // then
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(3);
+    assertThat(incidents).isNotEmpty().hasSize(3);
   }
 
   @Test
@@ -125,8 +123,7 @@ public class IncidentRestServiceAuthorizationTest extends AuthorizationTest {
     List<IncidentDto> incidents = resource.queryIncidents(queryParameter, null, null);
 
     // then
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(3);
+    assertThat(incidents).isNotEmpty().hasSize(3);
   }
 
   @Test
@@ -140,8 +137,7 @@ public class IncidentRestServiceAuthorizationTest extends AuthorizationTest {
     List<IncidentDto> incidents = resource.queryIncidents(queryParameter, null, null);
 
     // then
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(3);
+    assertThat(incidents).isNotEmpty().hasSize(3);
   }
 
 }

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/authorization/ProcessInstanceResourceAuthorizationTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/authorization/ProcessInstanceResourceAuthorizationTest.java
@@ -99,8 +99,7 @@ public class ProcessInstanceResourceAuthorizationTest extends AuthorizationTest 
     List<CalledProcessInstanceDto> calledInstances = resource.queryCalledProcessInstances(queryParameter);
 
     // then
-    assertThat(calledInstances).isNotEmpty();
-    assertThat(calledInstances).hasSize(1);
+    assertThat(calledInstances).isNotEmpty().hasSize(1);
     assertThat(calledInstances.get(0).getId()).isNotEqualTo(processInstanceId);
   }
 
@@ -118,8 +117,7 @@ public class ProcessInstanceResourceAuthorizationTest extends AuthorizationTest 
     List<CalledProcessInstanceDto> calledInstances = resource.queryCalledProcessInstances(queryParameter);
 
     // then
-    assertThat(calledInstances).isNotEmpty();
-    assertThat(calledInstances).hasSize(1);
+    assertThat(calledInstances).isNotEmpty().hasSize(1);
     assertThat(calledInstances.get(0).getId()).isNotEqualTo(processInstanceId);
   }
 
@@ -137,8 +135,7 @@ public class ProcessInstanceResourceAuthorizationTest extends AuthorizationTest 
     List<CalledProcessInstanceDto> calledInstances = resource.queryCalledProcessInstances(queryParameter);
 
     // then
-    assertThat(calledInstances).isNotEmpty();
-    assertThat(calledInstances).hasSize(1);
+    assertThat(calledInstances).isNotEmpty().hasSize(1);
     assertThat(calledInstances.get(0).getId()).isNotEqualTo(processInstanceId);
   }
 
@@ -157,8 +154,7 @@ public class ProcessInstanceResourceAuthorizationTest extends AuthorizationTest 
     List<CalledProcessInstanceDto> calledInstances = resource.queryCalledProcessInstances(queryParameter);
 
     // then
-    assertThat(calledInstances).isNotEmpty();
-    assertThat(calledInstances).hasSize(1);
+    assertThat(calledInstances).isNotEmpty().hasSize(1);
     assertThat(calledInstances.get(0).getId()).isNotEqualTo(processInstanceId);
   }
 
@@ -189,8 +185,7 @@ public class ProcessInstanceResourceAuthorizationTest extends AuthorizationTest 
     List<CalledProcessInstanceDto> calledInstances = executeCalledInstancesQueryWithAuthorization(queryParameter);
 
     // then
-    assertThat(calledInstances).isNotEmpty();
-    assertThat(calledInstances).hasSize(1);
+    assertThat(calledInstances).isNotEmpty().hasSize(1);
     assertThat(calledInstances.get(0).getId()).isNotEqualTo(processInstanceId);
   }
 
@@ -205,8 +200,7 @@ public class ProcessInstanceResourceAuthorizationTest extends AuthorizationTest 
     List<CalledProcessInstanceDto> calledInstances = executeCalledInstancesQueryWithAuthorization(queryParameter);
 
     // then
-    assertThat(calledInstances).isNotEmpty();
-    assertThat(calledInstances).hasSize(3);
+    assertThat(calledInstances).isNotEmpty().hasSize(3);
   }
 
   @Test
@@ -220,8 +214,7 @@ public class ProcessInstanceResourceAuthorizationTest extends AuthorizationTest 
     List<CalledProcessInstanceDto> calledInstances = executeCalledInstancesQueryWithAuthorization(queryParameter);
 
     // then
-    assertThat(calledInstances).isNotEmpty();
-    assertThat(calledInstances).hasSize(3);
+    assertThat(calledInstances).isNotEmpty().hasSize(3);
   }
 
   @Test
@@ -236,8 +229,7 @@ public class ProcessInstanceResourceAuthorizationTest extends AuthorizationTest 
     List<CalledProcessInstanceDto> calledInstances = executeCalledInstancesQueryWithAuthorization(queryParameter);
 
     // then
-    assertThat(calledInstances).isNotEmpty();
-    assertThat(calledInstances).hasSize(3);
+    assertThat(calledInstances).isNotEmpty().hasSize(3);
   }
 
   // helper ////////////////////////////////////////////////////////////////////////////

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/authorization/ProcessInstanceRestServiceAuthorizationTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/authorization/ProcessInstanceRestServiceAuthorizationTest.java
@@ -88,8 +88,7 @@ public class ProcessInstanceRestServiceAuthorizationTest extends AuthorizationTe
     List<ProcessInstanceDto> instances = resource.queryProcessInstances(queryParameter, null, null);
 
     // then
-    assertThat(instances).isNotEmpty();
-    assertThat(instances).hasSize(1);
+    assertThat(instances).isNotEmpty().hasSize(1);
     assertThat(instances.get(0).getId()).isEqualTo(processInstanceId);
   }
 
@@ -104,8 +103,7 @@ public class ProcessInstanceRestServiceAuthorizationTest extends AuthorizationTe
     List<ProcessInstanceDto> instances = resource.queryProcessInstances(queryParameter, null, null);
 
     // then
-    assertThat(instances).isNotEmpty();
-    assertThat(instances).hasSize(3);
+    assertThat(instances).isNotEmpty().hasSize(3);
   }
 
   @Test
@@ -119,8 +117,7 @@ public class ProcessInstanceRestServiceAuthorizationTest extends AuthorizationTe
     List<ProcessInstanceDto> instances = resource.queryProcessInstances(queryParameter, null, null);
 
     // then
-    assertThat(instances).isNotEmpty();
-    assertThat(instances).hasSize(3);
+    assertThat(instances).isNotEmpty().hasSize(3);
   }
 
   @Test
@@ -135,16 +132,13 @@ public class ProcessInstanceRestServiceAuthorizationTest extends AuthorizationTe
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, 0, 3);
 
     // then
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(3);
+    assertThat(result).isNotEmpty().hasSize(3);
 
     result = resource.queryProcessInstances(queryParameter, 0, 2);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
 
     result = resource.queryProcessInstances(queryParameter, 2, 2);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
   }
 
 }

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/tenantcheck/IncidentRestServiceTenantCheckTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/tenantcheck/IncidentRestServiceTenantCheckTest.java
@@ -105,8 +105,7 @@ public class IncidentRestServiceTenantCheckTest extends AbstractCockpitPluginTes
     identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
 
     List<IncidentDto> result = resource.queryIncidents(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     IncidentDto incident = result.get(0);
     assertThat(incident.getProcessInstanceId()).isEqualTo(processInstanceTenantOne);
@@ -126,8 +125,7 @@ public class IncidentRestServiceTenantCheckTest extends AbstractCockpitPluginTes
       processInstnaceIds.add(incidentDto.getProcessInstanceId());
     }
 
-    assertThat(processInstnaceIds).contains(processInstanceTenantOne);
-    assertThat(processInstnaceIds).contains(processInstanceTenantTwo);
+    assertThat(processInstnaceIds).contains(processInstanceTenantOne, processInstanceTenantTwo);
   }
 
   @Test
@@ -144,8 +142,7 @@ public class IncidentRestServiceTenantCheckTest extends AbstractCockpitPluginTes
       processInstnaceIds.add(incidentDto.getProcessInstanceId());
     }
 
-    assertThat(processInstnaceIds).contains(processInstanceTenantOne);
-    assertThat(processInstnaceIds).contains(processInstanceTenantTwo);
+    assertThat(processInstnaceIds).contains(processInstanceTenantOne, processInstanceTenantTwo);
   }
 
   @Test
@@ -162,8 +159,7 @@ public class IncidentRestServiceTenantCheckTest extends AbstractCockpitPluginTes
       processInstnaceIds.add(incidentDto.getProcessInstanceId());
     }
 
-    assertThat(processInstnaceIds).contains(processInstanceTenantOne);
-    assertThat(processInstnaceIds).contains(processInstanceTenantTwo);
+    assertThat(processInstnaceIds).contains(processInstanceTenantOne, processInstanceTenantTwo);
   }
 
   @Test
@@ -180,8 +176,7 @@ public class IncidentRestServiceTenantCheckTest extends AbstractCockpitPluginTes
       processInstnaceIds.add(incidentDto.getProcessInstanceId());
     }
 
-    assertThat(processInstnaceIds).contains(processInstanceTenantOne);
-    assertThat(processInstnaceIds).contains(processInstanceTenantTwo);
+    assertThat(processInstnaceIds).contains(processInstanceTenantOne, processInstanceTenantTwo);
   }
 
 }

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/tenantcheck/ProcessDefinitionResourceTenantCheckTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/tenantcheck/ProcessDefinitionResourceTenantCheckTest.java
@@ -97,8 +97,7 @@ public class ProcessDefinitionResourceTenantCheckTest extends AbstractCockpitPlu
     identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
 
     List<ProcessDefinitionDto> result = resource.queryCalledProcessDefinitions(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     assertThat(getCalledFromActivityIds(result)).containsOnly("CallActivity_Tenant1");
   }
@@ -110,8 +109,7 @@ public class ProcessDefinitionResourceTenantCheckTest extends AbstractCockpitPlu
     identityService.setAuthentication("user", null, null);
 
     List<ProcessDefinitionDto> result = resource.queryCalledProcessDefinitions(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
 
     assertThat(getCalledFromActivityIds(result)).contains("CallActivity_Tenant1", "CallActivity_Tenant2");
   }
@@ -122,8 +120,7 @@ public class ProcessDefinitionResourceTenantCheckTest extends AbstractCockpitPlu
     identityService.setAuthentication("user", Collections.singletonList(Groups.OPERATON_ADMIN), null);
 
     List<ProcessDefinitionDto> result = resource.queryCalledProcessDefinitions(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
 
     assertThat(getCalledFromActivityIds(result)).contains("CallActivity_Tenant1", "CallActivity_Tenant2");
   }
@@ -134,8 +131,7 @@ public class ProcessDefinitionResourceTenantCheckTest extends AbstractCockpitPlu
     identityService.setAuthentication("user", Collections.singletonList(ADMIN_GROUP), null);
 
     List<ProcessDefinitionDto> result = resource.queryCalledProcessDefinitions(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
 
     assertThat(getCalledFromActivityIds(result)).contains("CallActivity_Tenant1", "CallActivity_Tenant2");
   }
@@ -146,8 +142,7 @@ public class ProcessDefinitionResourceTenantCheckTest extends AbstractCockpitPlu
     identityService.setAuthentication("adminUser", null, null);
 
     List<ProcessDefinitionDto> result = resource.queryCalledProcessDefinitions(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
 
     assertThat(getCalledFromActivityIds(result)).contains("CallActivity_Tenant1", "CallActivity_Tenant2");
   }

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/tenantcheck/ProcessInstanceResourceTenantCheckTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/tenantcheck/ProcessInstanceResourceTenantCheckTest.java
@@ -94,8 +94,7 @@ public class ProcessInstanceResourceTenantCheckTest extends AbstractCockpitPlugi
     identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
 
     List<CalledProcessInstanceDto> result = resource.queryCalledProcessInstances(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     CalledProcessInstanceDto dto = result.get(0);
     assertThat(dto.getCallActivityId()).isEqualTo("CallActivity_Tenant1");
@@ -108,8 +107,7 @@ public class ProcessInstanceResourceTenantCheckTest extends AbstractCockpitPlugi
     identityService.setAuthentication("user", null, null);
 
     List<CalledProcessInstanceDto> result = resource.queryCalledProcessInstances(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
 
     assertThat(getCalledActivityIds(result)).contains("CallActivity_Tenant1", "CallActivity_Tenant2");
   }
@@ -120,8 +118,7 @@ public class ProcessInstanceResourceTenantCheckTest extends AbstractCockpitPlugi
     identityService.setAuthentication("user", Collections.singletonList(Groups.OPERATON_ADMIN), null);
 
     List<CalledProcessInstanceDto> result = resource.queryCalledProcessInstances(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
 
     assertThat(getCalledActivityIds(result)).contains("CallActivity_Tenant1", "CallActivity_Tenant2");
   }
@@ -132,8 +129,7 @@ public class ProcessInstanceResourceTenantCheckTest extends AbstractCockpitPlugi
     identityService.setAuthentication("user", Collections.singletonList(ADMIN_GROUP), null);
 
     List<CalledProcessInstanceDto> result = resource.queryCalledProcessInstances(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
 
     assertThat(getCalledActivityIds(result)).contains("CallActivity_Tenant1", "CallActivity_Tenant2");
   }
@@ -144,8 +140,7 @@ public class ProcessInstanceResourceTenantCheckTest extends AbstractCockpitPlugi
     identityService.setAuthentication("adminUser", null, null);
 
     List<CalledProcessInstanceDto> result = resource.queryCalledProcessInstances(queryParameter);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
 
     assertThat(getCalledActivityIds(result)).contains("CallActivity_Tenant1", "CallActivity_Tenant2");
   }

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/tenantcheck/ProcessInstanceRestServiceTenantCheckTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/tenantcheck/ProcessInstanceRestServiceTenantCheckTest.java
@@ -138,12 +138,10 @@ public class ProcessInstanceRestServiceTenantCheckTest extends AbstractCockpitPl
     identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(1);
+    assertThat(result).isNotEmpty().hasSize(1);
 
     List<IncidentStatisticsDto> incidents = result.get(0).getIncidents();
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(1);
+    assertThat(incidents).isNotEmpty().hasSize(1);
   }
 
   @Test
@@ -153,16 +151,13 @@ public class ProcessInstanceRestServiceTenantCheckTest extends AbstractCockpitPl
     identityService.setAuthentication("user", null, null);
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
 
     List<IncidentStatisticsDto> incidents = result.get(0).getIncidents();
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(1);
+    assertThat(incidents).isNotEmpty().hasSize(1);
 
     incidents = result.get(1).getIncidents();
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(1);
+    assertThat(incidents).isNotEmpty().hasSize(1);
   }
 
   @Test
@@ -171,16 +166,13 @@ public class ProcessInstanceRestServiceTenantCheckTest extends AbstractCockpitPl
     identityService.setAuthentication("user", Collections.singletonList(Groups.OPERATON_ADMIN), null);
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
 
     List<IncidentStatisticsDto> incidents = result.get(0).getIncidents();
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(1);
+    assertThat(incidents).isNotEmpty().hasSize(1);
 
     incidents = result.get(1).getIncidents();
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(1);
+    assertThat(incidents).isNotEmpty().hasSize(1);
   }
 
   @Test
@@ -189,16 +181,13 @@ public class ProcessInstanceRestServiceTenantCheckTest extends AbstractCockpitPl
     identityService.setAuthentication("user", Collections.singletonList(ADMIN_GROUP), null);
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
 
     List<IncidentStatisticsDto> incidents = result.get(0).getIncidents();
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(1);
+    assertThat(incidents).isNotEmpty().hasSize(1);
 
     incidents = result.get(1).getIncidents();
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(1);
+    assertThat(incidents).isNotEmpty().hasSize(1);
   }
 
   @Test
@@ -207,16 +196,13 @@ public class ProcessInstanceRestServiceTenantCheckTest extends AbstractCockpitPl
     identityService.setAuthentication("adminUser", null, null);
 
     List<ProcessInstanceDto> result = resource.queryProcessInstances(queryParameter, null, null);
-    assertThat(result).isNotEmpty();
-    assertThat(result).hasSize(2);
+    assertThat(result).isNotEmpty().hasSize(2);
 
     List<IncidentStatisticsDto> incidents = result.get(0).getIncidents();
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(1);
+    assertThat(incidents).isNotEmpty().hasSize(1);
 
     incidents = result.get(1).getIncidents();
-    assertThat(incidents).isNotEmpty();
-    assertThat(incidents).hasSize(1);
+    assertThat(incidents).isNotEmpty().hasSize(1);
   }
 
   private void startProcessInstancesWithTenantId(String processDefinitionKey, String tenantId) {

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/filter/csrf/CsrfPreventionFilterAppPathTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/filter/csrf/CsrfPreventionFilterAppPathTest.java
@@ -80,9 +80,9 @@ public class CsrfPreventionFilterAppPathTest extends CsrfPreventionFilterTest {
     assertThat(headerToken).isNotNull().isNotEmpty();
 
     String regex = CSRF_COOKIE_NAME + "=[A-Z0-9]{32}" + CSRF_PATH_FIELD_NAME + "/;SameSite=Lax";
-    assertThat(cookieToken).matches(regex.replace(";", ";\\s*"));
-
-    assertThat(cookieToken).contains(headerToken);
+    assertThat(cookieToken)
+      .matches(regex.replace(";", ";\\s*"))
+      .contains(headerToken);
   }
 
   @Override


### PR DESCRIPTION
- Join assertions to one assertion chain
- Remove assertions when they are redundant
  - isNotNull() followed by isEquals() can be removed

Resolves Sonar warnings of type java:S5838

related to #27