### PR TITLE
refactor(tests): Testing exceptions with only one possible invocation throwing

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseHistoryPropertyAutoTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseHistoryPropertyAutoTest.java
@@ -59,7 +59,8 @@ public class DatabaseHistoryPropertyAutoTest {
   public void failWhenSecondEngineDoesNotHaveTheSameHistoryLevel() {
     buildEngine(config("true", ProcessEngineConfiguration.HISTORY_FULL));
 
-    assertThatThrownBy(() -> buildEngine(config(ProcessEngineConfiguration.HISTORY_AUDIT)))
+    ProcessEngineConfigurationImpl config = config(ProcessEngineConfiguration.HISTORY_AUDIT);
+    assertThatThrownBy(() -> buildEngine(config))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("historyLevel mismatch: configuration says HistoryLevelAudit(name=audit, id=2) and database says HistoryLevelFull(name=full, id=3)");
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseTableSchemaTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseTableSchemaTest.java
@@ -34,8 +34,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * @author Ronny Bräunlich
@@ -121,30 +121,23 @@ public class DatabaseTableSchemaTest {
 
   @Test
   public void testCreateConfigurationWithMismatchtingSchemaAndPrefix() {
-    try {
-      StandaloneInMemProcessEngineConfiguration configuration = new StandaloneInMemProcessEngineConfiguration();
-      configuration.setDatabaseSchema("foo");
-      configuration.setDatabaseTablePrefix("bar");
-      configuration.buildProcessEngine();
-      fail("Should throw exception");
-    } catch (ProcessEngineException e) {
-      // as expected
-      assertTrue(e.getMessage().contains("When setting a schema the prefix has to be schema + '.'"));
-    }
+    StandaloneInMemProcessEngineConfiguration configuration = new StandaloneInMemProcessEngineConfiguration();
+    configuration.setDatabaseSchema("foo");
+    configuration.setDatabaseTablePrefix("bar");
+
+    assertThatThrownBy(configuration::buildProcessEngine)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("When setting a schema the prefix has to be schema + '.'");
   }
 
   @Test
   public void testCreateConfigurationWithMissingDotInSchemaAndPrefix() {
-    try {
-      StandaloneInMemProcessEngineConfiguration configuration = new StandaloneInMemProcessEngineConfiguration();
-      configuration.setDatabaseSchema("foo");
-      configuration.setDatabaseTablePrefix("foo");
-      configuration.buildProcessEngine();
-      fail("Should throw exception");
-    } catch (ProcessEngineException e) {
-      // as expected
-      assertTrue(e.getMessage().contains("When setting a schema the prefix has to be schema + '.'"));
-    }
+    StandaloneInMemProcessEngineConfiguration configuration = new StandaloneInMemProcessEngineConfiguration();
+    configuration.setDatabaseSchema("foo");
+    configuration.setDatabaseTablePrefix("foo");
+
+    assertThatThrownBy(configuration::buildProcessEngine).isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("When setting a schema the prefix has to be schema + '.'");
   }
 
   // ----------------------- TEST HELPERS -----------------------

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/PersistenceExceptionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/PersistenceExceptionTest.java
@@ -16,9 +16,6 @@
  */
 package org.operaton.bpm.engine.test.api.cfg;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
-
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.RuntimeService;
@@ -34,6 +31,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Svetlana Dorokhova.
@@ -63,13 +62,11 @@ public class PersistenceExceptionTest {
     }
     final BpmnModelInstance modelInstance = Bpmn.createExecutableProcess("process1").operatonHistoryTimeToLive(180).startEvent().userTask(longString.toString()).endEvent().done();
     testRule.deploy(modelInstance);
-    try {
-      runtimeService.startProcessInstanceByKey("process1").getId();
-      fail("persistence exception is expected");
-    } catch (ProcessEngineException ex) {
-      Throwable cause = ex.getCause();
-      assertThat(cause.getMessage()).contains("insertHistoricTaskInstanceEvent");
-    }
-  }
 
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("process1"))
+      .isInstanceOf(ProcessEngineException.class)
+      .extracting(e -> e.getCause().getMessage())
+      .asString()
+      .contains("insertHistoricTaskInstanceEvent");
+  }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceCaseInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceCaseInstanceTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.cmmn;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -31,10 +32,7 @@ import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.exception.NotAllowedException;
 import org.operaton.bpm.engine.exception.NotFoundException;
 import org.operaton.bpm.engine.exception.NotValidException;
-import org.operaton.bpm.engine.runtime.CaseExecution;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.VariableInstance;
-import org.operaton.bpm.engine.runtime.VariableInstanceQuery;
+import org.operaton.bpm.engine.runtime.*;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.junit.Test;
@@ -85,20 +83,14 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
 
   @Test
   public void testCreateByInvalidKey() {
-    try {
-      caseService
-          .withCaseDefinitionByKey("invalid")
-          .create();
-      fail();
-    } catch (NotFoundException e) { }
+    CaseInstanceBuilder caseDefinitionWithInvalidKey = caseService.withCaseDefinitionByKey("invalid");
+    assertThatThrownBy(caseDefinitionWithInvalidKey::create)
+        .isInstanceOf(NotFoundException.class);
 
-    try {
-      caseService
-          .withCaseDefinitionByKey(null)
-          .create();
-      fail();
-    } catch (NotValidException e) { }
-
+    CaseInstanceBuilder caseDefinitionWithNullKey = caseService
+        .withCaseDefinitionByKey(null);
+    assertThatThrownBy(caseDefinitionWithNullKey::create)
+        .isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -142,20 +134,13 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
 
   @Test
   public void testCreateByInvalidId() {
-    try {
-      caseService
-          .withCaseDefinition("invalid")
-          .create();
-      fail();
-    } catch (NotFoundException e) { }
+    CaseInstanceBuilder builderForInvalidCaseDefinition = caseService.withCaseDefinition("invalid");
+    assertThatThrownBy(builderForInvalidCaseDefinition::create)
+        .isInstanceOf(NotFoundException.class);
 
-    try {
-      caseService
-          .withCaseDefinition(null)
-          .create();
-      fail();
-    } catch (NotValidException e) { }
-
+    CaseInstanceBuilder builderForNullCaseDefinition = caseService.withCaseDefinition(null);
+    assertThatThrownBy(builderForNullCaseDefinition::create)
+        .isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -438,14 +423,10 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
         .getId();
 
     // when
-    try {
-      caseService
-        .withCaseExecution(caseInstanceId)
-        .manualStart();
-      fail("It should not be possible to start a case instance manually.");
-    } catch (NotAllowedException e) {
-    }
-
+    CaseExecutionCommandBuilder builder = caseService.withCaseExecution(caseInstanceId);
+    assertThatThrownBy(builder::manualStart)
+        .withFailMessage("It should not be possible to start a case instance manually.")
+        .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -464,14 +445,12 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
         .create()
         .getId();
 
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseInstanceId);
+
     // when
-    try {
-      caseService
-        .withCaseExecution(caseInstanceId)
-        .disable();
-      fail("It should not be possible to disable a case instance.");
-    } catch (NotAllowedException e) {
-    }
+    assertThatThrownBy(commandBuilder::disable)
+        .withFailMessage("It should not be possible to disable a case instance.")
+        .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -490,14 +469,12 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
         .create()
         .getId();
 
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseInstanceId);
+
     // when
-    try {
-      caseService
-        .withCaseExecution(caseInstanceId)
-        .reenable();
-      fail("It should not be possible to re-enable a case instance.");
-    } catch (NotAllowedException e) {
-    }
+    assertThatThrownBy(commandBuilder::reenable)
+        .withFailMessage("It should not be possible to re-enable a case instance.")
+        .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCaseWithManualActivation.cmmn"})
@@ -612,14 +589,12 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
        .create()
        .getId();
 
-    // when
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseInstanceId);
 
-    try {
-      caseService
-        .withCaseExecution(caseInstanceId)
-        .complete();
-      fail("It should not be possible to complete a case instance containing an active task.");
-    } catch (ProcessEngineException e) {}
+    // when
+    assertThatThrownBy(commandBuilder::complete)
+        .withFailMessage("It should not be possible to complete a case instance containing an active task.")
+        .isInstanceOf(ProcessEngineException.class);
 
     // then
 
@@ -662,14 +637,12 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    // when
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseInstanceId);
 
-    try {
-      caseService
-        .withCaseExecution(caseInstanceId)
-        .complete();
-      fail("It should not be possible to complete a case instance containing an active stage.");
-    } catch (ProcessEngineException e) {}
+    // when
+    assertThatThrownBy(commandBuilder::complete)
+        .withFailMessage("It should not be possible to complete a case instance containing an active stage.")
+        .isInstanceOf(ProcessEngineException.class);
 
     // then
 
@@ -731,14 +704,11 @@ public class CaseServiceCaseInstanceTest extends PluggableProcessEngineTest {
        .create()
        .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseInstanceId)
-        .close();
-      fail("It should not be possible to close an active case instance.");
-    } catch (ProcessEngineException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseInstanceId);
+
+    assertThatThrownBy(commandBuilder::close)
+        .withFailMessage("It should not be possible to close an active case instance.")
+        .isInstanceOf(ProcessEngineException.class);
 
     // then
     CaseInstance caseInstance = caseService

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceHumanTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceHumanTaskTest.java
@@ -28,16 +28,15 @@ import java.util.List;
 import java.util.Map;
 
 import org.operaton.bpm.engine.exception.NotAllowedException;
-import org.operaton.bpm.engine.runtime.CaseExecution;
-import org.operaton.bpm.engine.runtime.CaseExecutionQuery;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.VariableInstance;
+import org.operaton.bpm.engine.runtime.*;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Roman Smirnov
@@ -623,14 +622,12 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .reenable();
-      fail("It should not be possible to re-enable an enabled human task.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+
+    // when
+    assertThatThrownBy(commandBuilder::reenable)
+        .withFailMessage("It should not be possible to re-enable an enabled human task.")
+        .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/twoTaskCase.cmmn"})
@@ -696,13 +693,11 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
         .getId();
 
     // when
-    try {
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .reenable();
-      fail("It should not be possible to re-enable an active human task.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+
+    assertThatThrownBy(commandBuilder::reenable)
+        .withFailMessage("It should not be possible to re-enable an active human task.")
+        .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/twoTaskCase.cmmn"})
@@ -764,18 +759,14 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
         .getId();
 
     // the human task is disabled
-    caseService
-      .withCaseExecution(caseExecutionId)
-      .disable();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+    commandBuilder.disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .disable();
-      fail("It should not be possible to disable a already disabled human task.");
-    } catch (NotAllowedException e) {
-    }
+    // when
+    assertThatThrownBy(commandBuilder::disable)
+        // then
+        .withFailMessage("It should not be possible to disable a already disabled human task.")
+        .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -799,14 +790,13 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+
     // when
-    try {
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .disable();
-      fail("It should not be possible to disable an active human task.");
-    } catch (NotAllowedException e) {
-    }
+    assertThatThrownBy(commandBuilder::disable)
+        // then
+        .withFailMessage("It should not be possible to disable an active human task.")
+        .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/twoTaskCase.cmmn"})
@@ -834,14 +824,13 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
       .withCaseExecution(caseExecutionId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .manualStart();
-      fail("It should not be possible to start a disabled human task manually.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+
+    // when
+    assertThatThrownBy(commandBuilder::manualStart)
+        // then
+        .withFailMessage("It should not be possible to start a disabled human task manually.")
+        .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -865,14 +854,13 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .manualStart();
-      fail("It should not be possible to start an already active human task manually.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+
+    // when
+    assertThatThrownBy(commandBuilder::manualStart)
+        // then
+        .withFailMessage("It should not be possible to start an already active human task manually.")
+        .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/twoTaskCase.cmmn"})
@@ -1137,13 +1125,13 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .complete();
-      fail("Should not be able to complete task.");
-    } catch (NotAllowedException e) {}
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+
+    // when
+    assertThatThrownBy(commandBuilder::complete)
+        // then
+        .withFailMessage("Should not be able to complete task.")
+        .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/twoTaskCase.cmmn"})
@@ -1171,13 +1159,13 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
       .withCaseExecution(caseExecutionId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .complete();
-      fail("Should not be able to complete task.");
-    } catch (NotAllowedException e) {}
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+
+    // when
+    assertThatThrownBy(commandBuilder::complete)
+        // then
+        .withFailMessage("Should not be able to complete task.")
+        .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/twoTaskCase.cmmn"})
@@ -1519,16 +1507,13 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .close();
-      fail("It should not be possible to close a task.");
-    } catch (NotAllowedException e) {
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
 
-    }
-
+    // when
+    assertThatThrownBy(commandBuilder::close)
+        // then
+        .withFailMessage("It should not be possible to close a task.")
+        .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -1599,14 +1584,14 @@ public class CaseServiceHumanTaskTest extends PluggableProcessEngineTest {
 
     CaseExecution taskExecution = queryCaseExecutionByActivityId("PI_HumanTask_1");
 
-    try {
-      // when
-      caseService.terminateCaseExecution(taskExecution.getId());
-      fail("It should not be possible to terminate a task.");
-    } catch (NotAllowedException e) {
-      boolean result = e.getMessage().contains("The case execution must be in state 'active' to terminate");
-      assertTrue(result);
-    }
+    String taskExecutionId = taskExecution.getId();
+
+    // when
+    assertThatThrownBy(() -> caseService.terminateCaseExecution(taskExecutionId))
+        // then
+        .withFailMessage("It should not be possible to terminate a task.")
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("The case execution must be in state 'active' to terminate");
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceMilestoneTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceMilestoneTest.java
@@ -18,15 +18,18 @@ package org.operaton.bpm.engine.test.api.cmmn;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 import org.operaton.bpm.engine.exception.NotAllowedException;
 import org.operaton.bpm.engine.runtime.CaseExecution;
+import org.operaton.bpm.engine.runtime.CaseExecutionCommandBuilder;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
+
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Roman Smirnov
@@ -37,85 +40,63 @@ public class CaseServiceMilestoneTest extends PluggableProcessEngineTest {
   protected final String DEFINITION_KEY = "oneMilestoneCase";
   protected final String MILESTONE_KEY = "PI_Milestone_1";
 
-  @Deployment(resources={
-      "org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"
-      })
+  @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"})
   @Test
   public void testManualStart() {
     // given
     createCaseInstance(DEFINITION_KEY).getId();
     String caseTaskId = queryCaseExecutionByActivityId(MILESTONE_KEY).getId();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .manualStart();
-      fail();
-    } catch (NotAllowedException e) {
-    }
+    // when
+    assertThatThrownBy(commandBuilder::manualStart)
+      // then
+      .isInstanceOf(NotAllowedException.class);
   }
 
-  @Deployment(resources={
-      "org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"
-      })
+  @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"})
   @Test
   public void testDisable() {
     // given
     createCaseInstance(DEFINITION_KEY).getId();
     String caseTaskId = queryCaseExecutionByActivityId(MILESTONE_KEY).getId();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .disable();
-      fail();
-    } catch (NotAllowedException e) {
-    }
+    // when
+    assertThatThrownBy(commandBuilder::disable)
+      // then
+      .isInstanceOf(NotAllowedException.class);
   }
 
-  @Deployment(resources={
-      "org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"
-      })
+  @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"})
   @Test
   public void testReenable() {
     // given
     createCaseInstance(DEFINITION_KEY).getId();
     String caseTaskId = queryCaseExecutionByActivityId(MILESTONE_KEY).getId();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .reenable();
-      fail();
-    } catch (NotAllowedException e) {
-    }
+    // when
+    assertThatThrownBy(commandBuilder::reenable)
+      // then
+      .isInstanceOf(NotAllowedException.class);
   }
 
-  @Deployment(resources={
-      "org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"
-      })
+  @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"})
   @Test
   public void testComplete() {
     // given
     createCaseInstance(DEFINITION_KEY).getId();
     String caseTaskId = queryCaseExecutionByActivityId(MILESTONE_KEY).getId();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .complete();
-      fail();
-    } catch (NotAllowedException e) {
-    }
+    // when
+    assertThatThrownBy(commandBuilder::complete)
+      // then
+      .isInstanceOf(NotAllowedException.class);
   }
 
-  @Deployment(resources={
-      "org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"
-      })
+  @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"})
   @Test
   public void testTerminate() {
     // given
@@ -131,9 +112,7 @@ public class CaseServiceMilestoneTest extends PluggableProcessEngineTest {
     assertNull(caseMilestone);
   }
 
-  @Deployment(resources={
-      "org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"
-      })
+  @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"})
   @Test
   public void testTerminateNonFluent() {
     // given

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceProcessTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceProcessTaskTest.java
@@ -16,6 +16,18 @@
  */
 package org.operaton.bpm.engine.test.api.cmmn;
 
+import org.operaton.bpm.engine.exception.NotAllowedException;
+import org.operaton.bpm.engine.runtime.*;
+import org.operaton.bpm.engine.task.Task;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -23,19 +35,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
-import org.operaton.bpm.engine.exception.NotAllowedException;
-import org.operaton.bpm.engine.runtime.CaseExecution;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.runtime.VariableInstance;
-import org.operaton.bpm.engine.task.Task;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Roman Smirnov
@@ -228,15 +229,13 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
 
     ProcessInstance processInstance = queryProcessInstance();
     assertNull(processInstance);
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .reenable();
-      fail("It should not be possible to re-enable an enabled process task.");
-    } catch (NotAllowedException e) {
-    }
+    // when
+    assertThatThrownBy(commandBuilder::reenable)
+      // then
+      .withFailMessage("It should not be possible to re-enable an enabled process task.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={
@@ -275,15 +274,13 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
     // given
     createCaseInstance(DEFINITION_KEY);
     String processTaskId = queryCaseExecutionByActivityId(PROCESS_TASK_KEY).getId();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .reenable();
-      fail("It should not be possible to re-enable an active process task.");
-    } catch (NotAllowedException e) {
-    }
+    // when
+    assertThatThrownBy(commandBuilder::reenable)
+      // then
+      .withFailMessage("It should not be possible to re-enable an active process task.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneProcessTaskWithManualActivationAndOneHumanTaskCase.cmmn"})
@@ -317,14 +314,13 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
       .withCaseExecution(processTaskId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .disable();
-      fail("It should not be possible to disable a already disabled process task.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
+
+    // when
+    assertThatThrownBy(commandBuilder::disable)
+      // then
+      .withFailMessage("It should not be possible to disable a already disabled process task.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={
@@ -336,15 +332,13 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
     // given
     createCaseInstance(DEFINITION_KEY);
     String processTaskId = queryCaseExecutionByActivityId(PROCESS_TASK_KEY).getId();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
 
     // when
-    try {
-      caseService
-        .withCaseExecution(processTaskId)
-        .disable();
-      fail("It should not be possible to disable an active process task.");
-    } catch (NotAllowedException e) {
-    }
+    assertThatThrownBy(commandBuilder::disable)
+      // then
+      .withFailMessage("It should not be possible to disable an active process task.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneProcessTaskWithManualActivationAndOneHumanTaskCase.cmmn"})
@@ -358,14 +352,13 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
       .withCaseExecution(processTaskId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .manualStart();
-      fail("It should not be possible to start a disabled process task manually.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
+
+    // when
+    assertThatThrownBy(commandBuilder::manualStart)
+      // then
+      .withFailMessage("It should not be possible to start a disabled process task manually.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={
@@ -378,14 +371,13 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
     createCaseInstance(DEFINITION_KEY);
     String processTaskId = queryCaseExecutionByActivityId(PROCESS_TASK_KEY).getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .manualStart();
-      fail("It should not be possible to start an already active process task manually.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
+
+    // when
+    assertThatThrownBy(commandBuilder::manualStart)
+      // then
+      .withFailMessage("It should not be possible to start an already active process task manually.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={
@@ -398,14 +390,13 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
     createCaseInstance(DEFINITION_KEY);
     String processTaskId = queryCaseExecutionByActivityId(PROCESS_TASK_KEY).getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .complete();
-      fail("It should not be possible to complete a process task, while the process instance is still running.");
-    } catch (NotAllowedException e) {}
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
 
+    // when
+    assertThatThrownBy(commandBuilder::complete)
+      // then
+      .withFailMessage("It should not be possible to complete a process task, while the process instance is still running.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={
@@ -470,13 +461,13 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
     createCaseInstance(DEFINITION_KEY);
     String processTaskId = queryCaseExecutionByActivityId(PROCESS_TASK_KEY).getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .complete();
-      fail("Should not be able to complete an enabled process task.");
-    } catch (NotAllowedException e) {}
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
+
+    // when
+    assertThatThrownBy(commandBuilder::complete)
+      // then
+      .withFailMessage("It should not be possible to complete an enabled process task.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneProcessTaskWithManualActivationAndOneHumanTaskCase.cmmn"})
@@ -490,13 +481,13 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
       .withCaseExecution(processTaskId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .complete();
-      fail("Should not be able to complete a disabled process task.");
-    } catch (NotAllowedException e) {}
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
+
+    // when
+    assertThatThrownBy(commandBuilder::complete)
+      // then
+      .withFailMessage("It should not be possible to complete a disabled process task.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneProcessTaskCaseWithManualActivation.cmmn"})
@@ -506,16 +497,13 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
     createCaseInstance(DEFINITION_KEY);
     String processTaskId = queryCaseExecutionByActivityId(PROCESS_TASK_KEY).getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .close();
-      fail("It should not be possible to close a process task.");
-    } catch (NotAllowedException e) {
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(processTaskId);
 
-    }
-
+    // when
+    assertThatThrownBy(commandBuilder::close)
+      // then
+      .withFailMessage("It should not be possible to close a process task.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={
@@ -568,15 +556,15 @@ public class CaseServiceProcessTaskTest extends PluggableProcessEngineTest {
     createCaseInstance(DEFINITION_KEY);
     CaseExecution processTask = queryCaseExecutionByActivityId(PROCESS_TASK_KEY);
     assertTrue(processTask.isEnabled());
-    
-    try {
-      // when
-      caseService.terminateCaseExecution(processTask.getId());
-      fail("It should not be possible to terminate a task.");
-    } catch (NotAllowedException e) {
-      boolean result = e.getMessage().contains("The case execution must be in state 'active' to terminate");
-      assertTrue(result);
-    }
+
+    String taskId = processTask.getId();
+
+    // when
+    assertThatThrownBy(() -> caseService.terminateCaseExecution(taskId))
+      // then
+      .withFailMessage("It should not be possible to terminate a task.")
+      .isInstanceOf(NotAllowedException.class)
+      .hasMessageContaining("The case execution must be in state 'active' to terminate");
   }
 
   protected CaseInstance createCaseInstance(String caseDefinitionKey) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceStageTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceStageTest.java
@@ -28,13 +28,12 @@ import java.util.List;
 import java.util.Map;
 
 import org.operaton.bpm.engine.exception.NotAllowedException;
-import org.operaton.bpm.engine.runtime.CaseExecution;
-import org.operaton.bpm.engine.runtime.CaseExecutionQuery;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.VariableInstance;
+import org.operaton.bpm.engine.runtime.*;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Roman Smirnov
@@ -414,14 +413,13 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .reenable();
-      fail("It should not be possible to re-enable an enabled stage.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+
+    // when
+    assertThatThrownBy(commandBuilder::reenable)
+      // then
+      .withFailMessage("It should not be possible to re-enable an enabled stage.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskAndOneStageWithManualActivationCase.cmmn"})
@@ -486,14 +484,13 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+
     // when
-    try {
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .reenable();
-      fail("It should not be possible to re-enable an active human task.");
-    } catch (NotAllowedException e) {
-    }
+    assertThatThrownBy(commandBuilder::reenable)
+      // then
+      .withFailMessage("It should not be possible to re-enable an active human task.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskAndOneStageWithManualActivationCase.cmmn"})
@@ -559,14 +556,13 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
       .withCaseExecution(caseExecutionId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .disable();
-      fail("It should not be possible to disable a already disabled human task.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+
+    // when
+    assertThatThrownBy(commandBuilder::disable)
+      // then
+        .withFailMessage("It should not be possible to disable a already disabled human task.")
+        .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneStageCase.cmmn"})
@@ -590,14 +586,13 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+
     // when
-    try {
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .disable();
-      fail("It should not be possible to disable an active human task.");
-    } catch (NotAllowedException e) {
-    }
+    assertThatThrownBy(commandBuilder::disable)
+      // then
+      .withFailMessage("It should not be possible to disable an active human task.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskAndOneStageWithManualActivationCase.cmmn"})
@@ -625,14 +620,13 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
       .withCaseExecution(caseExecutionId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .manualStart();
-      fail("It should not be possible to start a disabled human task manually.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+
+    // when
+    assertThatThrownBy(commandBuilder::manualStart)
+      // then
+      .withFailMessage("It should not be possible to start a disabled human task manually.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneStageCase.cmmn"})
@@ -656,14 +650,13 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .manualStart();
-      fail("It should not be possible to start an already active human task manually.");
-    } catch (NotAllowedException e) {
-    }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+
+    // when
+    assertThatThrownBy(commandBuilder::manualStart)
+      // then
+      .withFailMessage("It should not be possible to start an already active human task manually.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneStageCaseWithManualActivation.cmmn"})
@@ -840,13 +833,13 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .complete();
-      fail("Should not be able to complete stage.");
-    } catch (NotAllowedException e) {}
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+
+    // when
+    assertThatThrownBy(commandBuilder::complete)
+      // then
+      .withFailMessage("Should not be able to complete stage.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskAndOneStageWithManualActivationCase.cmmn"})
@@ -874,13 +867,13 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
       .withCaseExecution(caseExecutionId)
       .disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .complete();
-      fail("Should not be able to complete stage.");
-    } catch (NotAllowedException e) {}
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
+
+    // when
+    assertThatThrownBy(commandBuilder::complete)
+      // then
+      .withFailMessage("Should not be able to complete stage.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/emptyStageCase.cmmn"})
@@ -935,16 +928,13 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
         .singleResult()
         .getId();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseExecutionId)
-        .close();
-      fail("It should not be possible to close a stage.");
-    } catch (NotAllowedException e) {
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseExecutionId);
 
-    }
-
+    // when
+    assertThatThrownBy(commandBuilder::close)
+      // then
+      .withFailMessage("It should not be possible to close a stage.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneStageCase.cmmn"})
@@ -1027,17 +1017,14 @@ public class CaseServiceStageTest extends PluggableProcessEngineTest {
       .getId();
 
     CaseExecution stageExecution = queryCaseExecutionByActivityId("PI_Stage_1");
+    String executionId = stageExecution.getId();
 
     // when
-    try {
-      // when
-      caseService.terminateCaseExecution(stageExecution.getId());
-      fail("It should not be possible to terminate a task.");
-    } catch (NotAllowedException e) {
-      boolean result = e.getMessage().contains("The case execution must be in state 'active' to terminate");
-      assertTrue(result);
-    }
-    
+    assertThatThrownBy(() -> caseService.terminateCaseExecution(executionId))
+      // then
+      .withFailMessage("It should not be possible to terminate a task.")
+      .isInstanceOf(NotAllowedException.class)
+      .hasMessageContaining("The case execution must be in state 'active' to terminate");
   }
 
   protected CaseExecution queryCaseExecutionByActivityId(String activityId) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceTest.java
@@ -35,12 +35,7 @@ import java.util.Map;
 import org.operaton.bpm.engine.exception.NotFoundException;
 import org.operaton.bpm.engine.exception.NotValidException;
 import org.operaton.bpm.engine.repository.CaseDefinition;
-import org.operaton.bpm.engine.runtime.CaseExecution;
-import org.operaton.bpm.engine.runtime.CaseExecutionCommandBuilder;
-import org.operaton.bpm.engine.runtime.CaseExecutionQuery;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.CaseInstanceQuery;
-import org.operaton.bpm.engine.runtime.VariableInstance;
+import org.operaton.bpm.engine.runtime.*;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.operaton.bpm.engine.variable.VariableMap;
@@ -48,6 +43,8 @@ import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
 import org.operaton.bpm.engine.variable.value.StringValue;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Roman Smirnov
@@ -78,83 +75,52 @@ public class CaseServiceTest extends PluggableProcessEngineTest {
 
   @Test
   public void testManualStartInvalidCaseExecution() {
-    try {
-      caseService
-          .withCaseExecution("invalid")
-          .manualStart();
-      fail();
-    } catch (NotFoundException e) { }
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution("invalid");
+    assertThatThrownBy(commandBuilder::manualStart)
+      .isInstanceOf(NotFoundException.class);
 
-    try {
-      caseService
-        .withCaseExecution(null)
-        .manualStart();
-      fail();
-    } catch (NotValidException e) { }
-
+    CaseExecutionCommandBuilder commandBuilder2 = caseService.withCaseExecution(null);
+    assertThatThrownBy(commandBuilder2::manualStart)
+      .isInstanceOf(NotValidException.class);
   }
 
   @Test
   public void testCompleteInvalidCaseExeuction() {
-    try {
-      caseService
-        .withCaseExecution("invalid")
-        .complete();
-      fail("The case execution should not be found.");
-    } catch (NotFoundException e) {
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution("invalid");
+    assertThatThrownBy(commandBuilder::complete)
+      .withFailMessage("The case execution should not be found.")
+      .isInstanceOf(NotFoundException.class);
 
-    }
-
-    try {
-      caseService
-        .withCaseExecution(null)
-        .complete();
-      fail("The case execution should not be found.");
-    } catch (NotValidException e) {
-
-    }
+    CaseExecutionCommandBuilder commandBuilder2 = caseService.withCaseExecution(null);
+    assertThatThrownBy(commandBuilder2::complete)
+      .withFailMessage("The case execution should not be found.")
+      .isInstanceOf(NotValidException.class);
   }
 
   @Test
   public void testCloseInvalidCaseExeuction() {
-    try {
-      caseService
-        .withCaseExecution("invalid")
-        .close();
-      fail("The case execution should not be found.");
-    } catch (NotFoundException e) {
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution("invalid");
+    assertThatThrownBy(commandBuilder::close)
+      .withFailMessage("The case execution should not be found.")
+      .isInstanceOf(NotFoundException.class);
 
-    }
-
-    try {
-      caseService
-        .withCaseExecution(null)
-        .close();
-      fail("The case execution should not be found.");
-    } catch (NotValidException e) {
-
-    }
+    CaseExecutionCommandBuilder commandBuilder2 = caseService.withCaseExecution(null);
+    assertThatThrownBy(commandBuilder2::close)
+      .withFailMessage("The case execution should not be found.")
+      .isInstanceOf(NotValidException.class);
   }
 
   @Test
   public void testTerminateInvalidCaseExeuction() {
-    try {
-      caseService
-        .withCaseExecution("invalid")
-        .terminate();
-      fail("The case execution should not be found.");
-    } catch (NotFoundException e) {
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution("invalid");
+    assertThatThrownBy(commandBuilder::terminate)
+      .withFailMessage("The case execution should not be found.")
+      .isInstanceOf(NotFoundException.class);
 
-    }
-
-    try {
-      caseService
-        .withCaseExecution(null)
-        .terminate();
-      fail("The case execution should not be found.");
-    } catch (NotValidException e) {
-
-    }
+    CaseExecutionCommandBuilder commandBuilder2 = caseService.withCaseExecution(null);
+    assertThatThrownBy(commandBuilder2::terminate)
+      .withFailMessage("The case execution should not be found.")
+      .isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/dmn/DecisionServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/dmn/DecisionServiceTest.java
@@ -16,14 +16,12 @@
  */
 package org.operaton.bpm.engine.test.api.dmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import org.operaton.bpm.dmn.engine.DmnDecisionResult;
 import org.operaton.bpm.dmn.engine.DmnDecisionTableResult;
 import org.operaton.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
 import org.operaton.bpm.engine.DecisionService;
 import org.operaton.bpm.engine.RepositoryService;
+import org.operaton.bpm.engine.dmn.DecisionsEvaluationBuilder;
 import org.operaton.bpm.engine.exception.NotFoundException;
 import org.operaton.bpm.engine.exception.NotValidException;
 import org.operaton.bpm.engine.repository.DecisionDefinition;
@@ -34,11 +32,15 @@ import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.engine.test.util.ResetDmnConfigUtil;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Philipp Ossler
@@ -177,7 +179,8 @@ public class DecisionServiceTest {
 	public void evaluateDecisionTableByKeyWithNonExistingVersion() {
     DecisionDefinition decisionDefinition = repositoryService.createDecisionDefinitionQuery().singleResult();
 
-    assertThatThrownBy(() -> decisionService.evaluateDecisionTableByKeyAndVersion(decisionDefinition.getKey(), 42, null))
+    String key = decisionDefinition.getKey();
+    assertThatThrownBy(() -> decisionService.evaluateDecisionTableByKeyAndVersion(key, 42, null))
       .isInstanceOf(NotFoundException.class)
       .hasMessageContaining("no decision definition deployed with key = 'decision' and version = '42'");
   }
@@ -249,28 +252,32 @@ public class DecisionServiceTest {
 
   @Test
   public void evaluateDecisionByNullId() {
-    assertThatThrownBy(() -> decisionService.evaluateDecisionById(null).evaluate())
+    var decisionsEvaluationBuilder = decisionService.evaluateDecisionById(null);
+    assertThatThrownBy(decisionsEvaluationBuilder::evaluate)
       .isInstanceOf(NotValidException.class)
       .hasMessageContaining("either decision definition id or key must be set");
   }
 
   @Test
   public void evaluateDecisionByNonExistingId() {
-    assertThatThrownBy(() -> decisionService.evaluateDecisionById("unknown").evaluate())
+    var decisionsEvaluationBuilder = decisionService.evaluateDecisionById("unknown");
+    assertThatThrownBy(decisionsEvaluationBuilder::evaluate)
       .isInstanceOf(NotFoundException.class)
       .hasMessageContaining("no deployed decision definition found with id 'unknown'");
   }
 
   @Test
   public void evaluateDecisionByNullKey() {
-    assertThatThrownBy(() -> decisionService.evaluateDecisionByKey(null).evaluate())
+    var decisionsEvaluationBuilder = decisionService.evaluateDecisionByKey(null);
+    assertThatThrownBy(decisionsEvaluationBuilder::evaluate)
       .isInstanceOf(NotValidException.class)
       .hasMessageContaining("either decision definition id or key must be set");
   }
 
   @Test
   public void evaluateDecisionByNonExistingKey() {
-    assertThatThrownBy(() -> decisionService.evaluateDecisionByKey("unknown").evaluate())
+    var decisionsEvaluationBuilder = decisionService.evaluateDecisionByKey("unknown");
+    assertThatThrownBy(decisionsEvaluationBuilder::evaluate)
       .isInstanceOf(NotFoundException.class)
       .hasMessageContaining("no decision definition deployed with key 'unknown'");
   }
@@ -279,11 +286,11 @@ public class DecisionServiceTest {
   @Test
   public void evaluateDecisionByKeyWithNonExistingVersion() {
     DecisionDefinition decisionDefinition = repositoryService.createDecisionDefinitionQuery().singleResult();
-
-    assertThatThrownBy(() -> decisionService
+    var decisionsEvaluationBuilder = decisionService
         .evaluateDecisionByKey(decisionDefinition.getKey())
-        .version(42)
-        .evaluate())
+        .version(42);
+
+    assertThatThrownBy(decisionsEvaluationBuilder::evaluate)
       .isInstanceOf(NotFoundException.class)
       .hasMessageContaining("no decision definition deployed with key = 'decision' and version = '42'");
   }


### PR DESCRIPTION
Refactor tests that check for exceptions to have only a single call in the calling code that could throw a RuntimeException.

Refactor to use `assertThatThrownBy()`` for checking code for exceptions thrown.

related to #88, #27