### PR TITLE
refactor(tests): Replace try/catch by assertThatThrownBy

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceCaseTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceCaseTaskTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.cmmn;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -29,6 +30,7 @@ import java.util.Map;
 
 import org.operaton.bpm.engine.exception.NotAllowedException;
 import org.operaton.bpm.engine.runtime.CaseExecution;
+import org.operaton.bpm.engine.runtime.CaseExecutionCommandBuilder;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.runtime.VariableInstance;
 import org.operaton.bpm.engine.task.Task;
@@ -43,9 +45,9 @@ import org.junit.Test;
  */
 public class CaseServiceCaseTaskTest extends PluggableProcessEngineTest {
 
-  protected final String DEFINITION_KEY = "oneCaseTaskCase";
-  protected final String DEFINITION_KEY_2 = "oneTaskCase";
-  protected final String CASE_TASK_KEY = "PI_CaseTask_1";
+  protected static final String DEFINITION_KEY = "oneCaseTaskCase";
+  protected static final String DEFINITION_KEY_2 = "oneTaskCase";
+  protected static final String CASE_TASK_KEY = "PI_CaseTask_1";
 
 
   @Deployment(resources={
@@ -404,15 +406,13 @@ public class CaseServiceCaseTaskTest extends PluggableProcessEngineTest {
 
     CaseInstance subCaseInstance = queryCaseInstanceByKey(DEFINITION_KEY_2);
     assertNull(subCaseInstance);
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .reenable();
-      fail("It should not be possible to re-enable an enabled case task.");
-    } catch (NotAllowedException e) {
-    }
+    // when
+    assertThatThrownBy(commandBuilder::reenable)
+      // then
+      .withFailMessage("It should not be possible to re-enable an enabled case task.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={
@@ -451,15 +451,13 @@ public class CaseServiceCaseTaskTest extends PluggableProcessEngineTest {
     // given
     createCaseInstance(DEFINITION_KEY);
     String caseTaskId = queryCaseExecutionByActivityId(CASE_TASK_KEY).getId();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .reenable();
-      fail("It should not be possible to re-enable an active case task.");
-    } catch (NotAllowedException e) {
-    }
+    // when
+    assertThatThrownBy(commandBuilder::reenable)
+      // then
+      .withFailMessage("It should not be possible to re-enable an active case task.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneCaseTaskAndOneHumanTaskCaseWithManualActivation.cmmn"})
@@ -489,18 +487,14 @@ public class CaseServiceCaseTaskTest extends PluggableProcessEngineTest {
     createCaseInstance(DEFINITION_KEY);
     String caseTaskId = queryCaseExecutionByActivityId(CASE_TASK_KEY).getId();
 
-    caseService
-      .withCaseExecution(caseTaskId)
-      .disable();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
+    commandBuilder.disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .disable();
-      fail("It should not be possible to disable a already disabled case task.");
-    } catch (NotAllowedException e) {
-    }
+    // when
+    assertThatThrownBy(commandBuilder::disable)
+      // then
+      .withFailMessage("It should not be possible to disable a already disabled case task.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={
@@ -512,15 +506,13 @@ public class CaseServiceCaseTaskTest extends PluggableProcessEngineTest {
     // given
     createCaseInstance(DEFINITION_KEY);
     String caseTaskId = queryCaseExecutionByActivityId(CASE_TASK_KEY).getId();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
 
     // when
-    try {
-      caseService
-        .withCaseExecution(caseTaskId)
-        .disable();
-      fail("It should not be possible to disable an active case task.");
-    } catch (NotAllowedException e) {
-    }
+    assertThatThrownBy(commandBuilder::disable)
+      // then
+      .withFailMessage("It should not be possible to disable an active case task.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneCaseTaskAndOneHumanTaskCaseWithManualActivation.cmmn"})
@@ -530,18 +522,14 @@ public class CaseServiceCaseTaskTest extends PluggableProcessEngineTest {
     createCaseInstance(DEFINITION_KEY);
     String caseTaskId = queryCaseExecutionByActivityId(CASE_TASK_KEY).getId();
 
-    caseService
-      .withCaseExecution(caseTaskId)
-      .disable();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
+    commandBuilder.disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .manualStart();
-      fail("It should not be possible to start a disabled case task manually.");
-    } catch (NotAllowedException e) {
-    }
+    // when
+    assertThatThrownBy(commandBuilder::manualStart)
+      // then
+      .withFailMessage("It should not be possible to start a disabled case task manually.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={
@@ -553,15 +541,13 @@ public class CaseServiceCaseTaskTest extends PluggableProcessEngineTest {
     // given
     createCaseInstance(DEFINITION_KEY);
     String caseTaskId = queryCaseExecutionByActivityId(CASE_TASK_KEY).getId();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .manualStart();
-      fail("It should not be possible to start an already active case task manually.");
-    } catch (NotAllowedException e) {
-    }
+    // when
+    assertThatThrownBy(commandBuilder::manualStart)
+      // then
+      .withFailMessage("It should not be possible to start an already active case task manually.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={
@@ -573,15 +559,13 @@ public class CaseServiceCaseTaskTest extends PluggableProcessEngineTest {
     // given
     createCaseInstance(DEFINITION_KEY);
     String caseTaskId = queryCaseExecutionByActivityId(CASE_TASK_KEY).getId();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .complete();
-      fail("It should not be possible to complete a case task, while the process instance is still running.");
-    } catch (NotAllowedException e) {}
-
+    // when
+    assertThatThrownBy(commandBuilder::complete)
+      // then
+      .withFailMessage("It should not be possible to complete a case task, while the process instance is still running.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={
@@ -646,14 +630,13 @@ public class CaseServiceCaseTaskTest extends PluggableProcessEngineTest {
     // given
     createCaseInstance(DEFINITION_KEY);
     String caseTaskId = queryCaseExecutionByActivityId(CASE_TASK_KEY).getId();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .complete();
-      fail("Should not be able to complete an enabled case task.");
-    } catch (NotAllowedException e) {}
+    // when
+    assertThatThrownBy(commandBuilder::complete)
+      // then
+      .withFailMessage("Should not be able to complete an enabled case task.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneCaseTaskAndOneHumanTaskCaseWithManualActivation.cmmn"})
@@ -663,17 +646,14 @@ public class CaseServiceCaseTaskTest extends PluggableProcessEngineTest {
     createCaseInstance(DEFINITION_KEY);
     String caseTaskId = queryCaseExecutionByActivityId(CASE_TASK_KEY).getId();
 
-    caseService
-      .withCaseExecution(caseTaskId)
-      .disable();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
+    commandBuilder.disable();
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .complete();
-      fail("Should not be able to complete a disabled case task.");
-    } catch (NotAllowedException e) {}
+    // when
+    assertThatThrownBy(commandBuilder::complete)
+      // then
+      .withFailMessage("Should not be able to complete a disabled case task.")
+      .isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneCaseTaskCaseWithManualActivation.cmmn"})
@@ -682,16 +662,13 @@ public class CaseServiceCaseTaskTest extends PluggableProcessEngineTest {
     // given
     createCaseInstance(DEFINITION_KEY);
     String caseTaskId = queryCaseExecutionByActivityId(CASE_TASK_KEY).getId();
+    CaseExecutionCommandBuilder commandBuilder = caseService.withCaseExecution(caseTaskId);
 
-    try {
-      // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .close();
-      fail("It should not be possible to close a case task.");
-    } catch (NotAllowedException e) {
-
-    }
+    // when
+    assertThatThrownBy(commandBuilder::close)
+      // then
+      .withFailMessage("It should not be possible to close a case task.")
+      .isInstanceOf(NotAllowedException.class);
 
   }
 
@@ -740,16 +717,14 @@ public class CaseServiceCaseTaskTest extends PluggableProcessEngineTest {
     // given
     createCaseInstance(DEFINITION_KEY);
     CaseExecution caseTaskExecution = queryCaseExecutionByActivityId(CASE_TASK_KEY);
-    
-    try {
-      // when
-      caseService 
-        .terminateCaseExecution(caseTaskExecution.getId());
-      fail("It should not be possible to terminate a case task.");
-    } catch (NotAllowedException e) {
-      boolean result = e.getMessage().contains("The case execution must be in state 'active' to terminate");
-      assertTrue(result);   
-    }
+    String caseTaskExecutionId = caseTaskExecution.getId();
+
+    // when
+    assertThatThrownBy(() -> caseService.terminateCaseExecution(caseTaskExecutionId))
+      // then
+      .withFailMessage("It should not be possible to terminate a case task.")
+      .isInstanceOf(NotAllowedException.class)
+      .hasMessageContaining("The case execution must be in state 'active' to terminate");
   }
   
   protected CaseInstance createCaseInstance(String caseDefinitionKey) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskQueryTest.java
@@ -24,12 +24,13 @@ import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.external
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.externalTaskByProcessInstanceId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -218,12 +219,14 @@ public class ExternalTaskQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testFailQueryByActivityIdInNull() {
-    try {
-      externalTaskService.createExternalTaskQuery()
-          .activityIdIn((String) null);
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    // given
+    var externalTaskQuery = externalTaskService.createExternalTaskQuery();
+
+    // when
+    assertThatThrownBy(() -> externalTaskQuery.activityIdIn((String) null))
+    // then
+        .isInstanceOf(NullValueException.class)
+        .hasMessageContaining("activityIdIn contains null value");
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/parallelExternalTaskProcess.bpmn20.xml")
@@ -318,13 +321,13 @@ public class ExternalTaskQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryByProcessInstanceIdNull() {
-    try {
-      externalTaskService.createExternalTaskQuery()
-        .processInstanceIdIn((String) null);
-
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    // given
+    var externalTaskQuery = externalTaskService.createExternalTaskQuery();
+    // when
+    assertThatThrownBy(() -> externalTaskQuery.processInstanceIdIn((String) null))
+      // then
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("processInstanceIdIn contains null value");
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
@@ -408,68 +411,42 @@ public class ExternalTaskQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryWithNullValues() {
-    try {
-      externalTaskService.createExternalTaskQuery().externalTaskId(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("externalTaskId is null", e.getMessage());
-    }
+    var externalTaskQuery = externalTaskService.createExternalTaskQuery();
+    assertThatThrownBy(() -> externalTaskQuery.externalTaskId(null))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("externalTaskId is null");
 
-    try {
-      externalTaskService.createExternalTaskQuery().activityId(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("activityId is null", e.getMessage());
-    }
+    assertThatThrownBy(() -> externalTaskQuery.activityId(null))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("activityId is null");
+    
+    assertThatThrownBy(() -> externalTaskQuery.executionId(null))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("executionId is null");
 
-    try {
-      externalTaskService.createExternalTaskQuery().executionId(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("executionId is null", e.getMessage());
-    }
+    assertThatThrownBy(() -> externalTaskQuery.lockExpirationAfter(null))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("lockExpirationAfter is null");
 
-    try {
-      externalTaskService.createExternalTaskQuery().lockExpirationAfter(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("lockExpirationAfter is null", e.getMessage());
-    }
+    assertThatThrownBy(() -> externalTaskQuery.lockExpirationBefore(null))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("lockExpirationBefore is null");
 
-    try {
-      externalTaskService.createExternalTaskQuery().lockExpirationBefore(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("lockExpirationBefore is null", e.getMessage());
-    }
+    assertThatThrownBy(() -> externalTaskQuery.processDefinitionId(null))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("processDefinitionId is null");
 
-    try {
-      externalTaskService.createExternalTaskQuery().processDefinitionId(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("processDefinitionId is null", e.getMessage());
-    }
+    assertThatThrownBy(() -> externalTaskQuery.processInstanceId(null))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("processInstanceId is null");
 
-    try {
-      externalTaskService.createExternalTaskQuery().processInstanceId(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("processInstanceId is null", e.getMessage());
-    }
+    assertThatThrownBy(() -> externalTaskQuery.topicName(null))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("topicName is null");
 
-    try {
-      externalTaskService.createExternalTaskQuery().topicName(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("topicName is null", e.getMessage());
-    }
-
-    try {
-      externalTaskService.createExternalTaskQuery().workerId(null).list();
-      fail("expected exception");
-    } catch (NullValueException e) {
-      testRule.assertTextPresent("workerId is null", e.getMessage());
-    }
+    assertThatThrownBy(() -> externalTaskQuery.workerId(null))
+      .isInstanceOf(NullValueException.class)
+      .hasMessageContaining("workerId is null");
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml",
@@ -615,13 +592,12 @@ public class ExternalTaskQueryTest extends PluggableProcessEngineTest {
   public void testQueryByIdsWithNull() {
     // given
     Set<String> ids = null;
-    try {
-      // when
-      externalTaskService.createExternalTaskQuery().externalTaskIdIn(ids).list();
-    } catch (ProcessEngineException e) {
-      // then
-      assertThat(e).hasMessage("Set of external task ids is null");
-    }
+    var externalTaskQuery = externalTaskService.createExternalTaskQuery();
+    // when
+    assertThatThrownBy(() -> externalTaskQuery.externalTaskIdIn(ids))
+    // then
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("Set of external task ids is null");
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
@@ -629,13 +605,12 @@ public class ExternalTaskQueryTest extends PluggableProcessEngineTest {
   public void testQueryByIdsWithEmptyList() {
     // given
     Set<String> ids = new HashSet<>();
-    try {
-      // when
-      externalTaskService.createExternalTaskQuery().externalTaskIdIn(ids).list();
-    } catch (ProcessEngineException e) {
-      // then
-      assertThat(e).hasMessage("Set of external task ids is empty");
-    }
+    var externalTaskQuery = externalTaskService.createExternalTaskQuery();
+    // when
+    assertThatThrownBy(() -> externalTaskQuery.externalTaskIdIn(ids))
+    // then
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("Set of external task ids is empty");
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")


### PR DESCRIPTION
Refactor tests that check for exceptions to have only a single call in the calling code that could throw a RuntimeException.

Refactor to use `assertThatThrownBy()` for checking code for exceptions thrown.

related to #88, #27