### PR TITLE
refactor: Resolve Sonar warnings

### DIFF
--- a/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/VariableMapImpl.java
+++ b/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/VariableMapImpl.java
@@ -24,10 +24,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-
-import org.operaton.bpm.engine.variable.context.VariableContext;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
+import org.operaton.bpm.engine.variable.context.VariableContext;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 
 /**
@@ -162,7 +161,7 @@ public class VariableMapImpl implements VariableMap, Serializable, VariableConte
         variables.putAll(variableMapImpl.variables);
       }
       else {
-        for (java.util.Map.Entry<? extends String, ? extends Object> entry : m.entrySet()) {
+        for (var entry : m.entrySet()) {
           put(entry.getKey(), entry.getValue());
         }
       }

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/AbstractVariableMap.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/AbstractVariableMap.java
@@ -19,9 +19,7 @@ package org.operaton.bpm.engine.cdi.impl;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-
 import javax.inject.Inject;
-
 import org.operaton.bpm.engine.cdi.BusinessProcess;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.context.VariableContext;
@@ -78,7 +76,7 @@ abstract class AbstractVariableMap implements VariableMap {
 
   @Override
   public void putAll(Map< ? extends String, ? extends Object> m) {
-    for (java.util.Map.Entry< ? extends String, ? extends Object> newEntry : m.entrySet()) {
+    for (var newEntry : m.entrySet()) {
       setVariable(newEntry.getKey(), newEntry.getValue());
     }
   }

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/el/VariableContextScriptBindings.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/el/VariableContextScriptBindings.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.script.Bindings;
-
 import org.operaton.bpm.engine.variable.context.VariableContext;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 
@@ -113,7 +112,7 @@ public class VariableContextScriptBindings implements Bindings {
   }
 
   public void putAll(Map< ? extends String, ?> toMerge) {
-    for (Entry<? extends String, ?> entry : toMerge.entrySet()) {
+    for (var entry : toMerge.entrySet()) {
       put(entry.getKey(), entry.getValue());
     }
   }

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/delegate/DmnDecisionEvaluationListenerTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/delegate/DmnDecisionEvaluationListenerTest.java
@@ -16,20 +16,18 @@
  */
 package org.operaton.bpm.dmn.engine.delegate;
 
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.dmn.engine.DmnDecisionTableResult;
 import org.operaton.bpm.dmn.engine.DmnEngineConfiguration;
 import org.operaton.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
 import org.operaton.bpm.dmn.engine.test.DecisionResource;
 import org.operaton.bpm.dmn.engine.test.DmnEngineTest;
 import org.operaton.commons.utils.IoUtil;
-
-import java.io.InputStream;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -101,8 +99,7 @@ class DmnDecisionEvaluationListenerTest extends DmnEngineTest {
 
     assertThat(decisionResult.getMatchingRules()).hasSize(1);
     Map<String, DmnEvaluatedOutput> outputEntries = decisionResult.getMatchingRules().get(0).getOutputEntries();
-    assertThat(outputEntries).hasSize(1);
-    assertThat(outputEntries).containsKey("desiredDish");
+    assertThat(outputEntries).hasSize(1).containsKey("desiredDish");
     assertThat(outputEntries.get("desiredDish").getValue().getValue()).isEqualTo("Light salad");
     assertThat(decisionResult.getExecutedDecisionElements()).isEqualTo(12L);
 

--- a/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/function/builder/CustomFunctionBuilderImpl.java
+++ b/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/function/builder/CustomFunctionBuilderImpl.java
@@ -16,12 +16,11 @@
  */
 package org.operaton.bpm.dmn.feel.impl.scala.function.builder;
 
-import org.operaton.bpm.dmn.feel.impl.scala.ScalaFeelLogger;
-import org.operaton.bpm.dmn.feel.impl.scala.function.CustomFunction;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
+import org.operaton.bpm.dmn.feel.impl.scala.ScalaFeelLogger;
+import org.operaton.bpm.dmn.feel.impl.scala.function.CustomFunction;
 
 public class CustomFunctionBuilderImpl implements CustomFunctionBuilder {
 
@@ -51,7 +50,7 @@ public class CustomFunctionBuilderImpl implements CustomFunctionBuilder {
   @Override
   public CustomFunctionBuilder setReturnValue(Object returnValue) {
     functionCount++;
-    customFunction.setFunction((args) -> returnValue);
+    customFunction.setFunction(args -> returnValue);
     return this;
   }
 

--- a/engine-plugins/identity-ldap/src/main/java/org/operaton/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
+++ b/engine-plugins/identity-ldap/src/main/java/org/operaton/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
@@ -16,29 +16,18 @@
  */
 package org.operaton.bpm.identity.impl.ldap;
 
-import static org.operaton.bpm.engine.authorization.Permissions.READ;
-import static org.operaton.bpm.engine.authorization.Resources.GROUP;
-import static org.operaton.bpm.engine.authorization.Resources.USER;
-import static org.operaton.bpm.engine.impl.context.Context.getCommandContext;
-import static org.operaton.bpm.engine.impl.context.Context.getProcessEngineConfiguration;
-import static org.operaton.bpm.identity.impl.ldap.LdapConfiguration.DB_QUERY_WILDCARD;
-import static org.operaton.bpm.identity.impl.ldap.LdapConfiguration.LDAP_QUERY_WILDCARD;
-
 import java.io.StringWriter;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
-
 import javax.naming.NamingEnumeration;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.SearchResult;
 import javax.naming.ldap.Control;
 import javax.naming.ldap.LdapContext;
-import javax.naming.ldap.SortKey;
 import javax.naming.ldap.PagedResultsResponseControl;
-
+import javax.naming.ldap.SortKey;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.authorization.Resource;
 import org.operaton.bpm.engine.identity.Group;
@@ -49,18 +38,26 @@ import org.operaton.bpm.engine.identity.TenantQuery;
 import org.operaton.bpm.engine.identity.User;
 import org.operaton.bpm.engine.identity.UserQuery;
 import org.operaton.bpm.engine.impl.AbstractQuery;
+import org.operaton.bpm.engine.impl.Direction;
+import org.operaton.bpm.engine.impl.GroupQueryProperty;
 import org.operaton.bpm.engine.impl.QueryOrderingProperty;
 import org.operaton.bpm.engine.impl.UserQueryImpl;
 import org.operaton.bpm.engine.impl.UserQueryProperty;
-import org.operaton.bpm.engine.impl.GroupQueryProperty;
 import org.operaton.bpm.engine.impl.db.DbEntity;
 import org.operaton.bpm.engine.impl.identity.IdentityProviderException;
 import org.operaton.bpm.engine.impl.identity.ReadOnlyIdentityProvider;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.entity.GroupEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.UserEntity;
-import org.operaton.bpm.engine.impl.Direction;
 import org.operaton.bpm.identity.impl.ldap.util.LdapPluginLogger;
+
+import static org.operaton.bpm.engine.authorization.Permissions.READ;
+import static org.operaton.bpm.engine.authorization.Resources.GROUP;
+import static org.operaton.bpm.engine.authorization.Resources.USER;
+import static org.operaton.bpm.engine.impl.context.Context.getCommandContext;
+import static org.operaton.bpm.engine.impl.context.Context.getProcessEngineConfiguration;
+import static org.operaton.bpm.identity.impl.ldap.LdapConfiguration.DB_QUERY_WILDCARD;
+import static org.operaton.bpm.identity.impl.ldap.LdapConfiguration.LDAP_QUERY_WILDCARD;
 
 /**
  * <p>LDAP {@link ReadOnlyIdentityProvider}.</p>
@@ -547,7 +544,7 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
     StringWriter resultDn = new StringWriter();
     for (String s : parts) {
       String part = s;
-      if (part == null || part.length() == 0) {
+      if (part == null || part.isEmpty()) {
         continue;
       }
       if (part.endsWith(",")) {
@@ -557,7 +554,7 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
         part = part.substring(1);
       }
       String currentDn = resultDn.toString();
-      if (!currentDn.endsWith(",") && currentDn.length() > 0) {
+      if (!currentDn.endsWith(",") && !currentDn.isEmpty()) {
         resultDn.write(",");
       }
       resultDn.write(part);

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/history/HistoricProcessInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/history/HistoricProcessInstanceQueryDto.java
@@ -16,17 +16,14 @@
  */
 package org.operaton.bpm.engine.rest.dto.history;
 
-import static java.lang.Boolean.TRUE;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response.Status;
-
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.history.HistoricProcessInstanceQuery;
 import org.operaton.bpm.engine.impl.HistoricProcessInstanceQueryImpl;
@@ -40,7 +37,8 @@ import org.operaton.bpm.engine.rest.dto.converter.StringSetConverter;
 import org.operaton.bpm.engine.rest.dto.converter.VariableListConverter;
 import org.operaton.bpm.engine.rest.exception.InvalidRequestException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static java.lang.Boolean.TRUE;
+import static org.operaton.bpm.engine.rest.dto.ConditionQueryParameterDto.*;
 
 public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricProcessInstanceQuery> {
 
@@ -518,19 +516,19 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
         String op = variableQueryParam.getOperator();
         Object variableValue = variableQueryParam.resolveValue(objectMapper);
 
-        if (op.equals(VariableQueryParameterDto.EQUALS_OPERATOR_NAME)) {
+        if (op.equals(EQUALS_OPERATOR_NAME)) {
           query.variableValueEquals(variableName, variableValue);
-        } else if (op.equals(VariableQueryParameterDto.GREATER_THAN_OPERATOR_NAME)) {
+        } else if (op.equals(GREATER_THAN_OPERATOR_NAME)) {
           query.variableValueGreaterThan(variableName, variableValue);
-        } else if (op.equals(VariableQueryParameterDto.GREATER_THAN_OR_EQUALS_OPERATOR_NAME)) {
+        } else if (op.equals(GREATER_THAN_OR_EQUALS_OPERATOR_NAME)) {
           query.variableValueGreaterThanOrEqual(variableName, variableValue);
-        } else if (op.equals(VariableQueryParameterDto.LESS_THAN_OPERATOR_NAME)) {
+        } else if (op.equals(LESS_THAN_OPERATOR_NAME)) {
           query.variableValueLessThan(variableName, variableValue);
-        } else if (op.equals(VariableQueryParameterDto.LESS_THAN_OR_EQUALS_OPERATOR_NAME)) {
+        } else if (op.equals(LESS_THAN_OR_EQUALS_OPERATOR_NAME)) {
           query.variableValueLessThanOrEqual(variableName, variableValue);
-        } else if (op.equals(VariableQueryParameterDto.NOT_EQUALS_OPERATOR_NAME)) {
+        } else if (op.equals(NOT_EQUALS_OPERATOR_NAME)) {
           query.variableValueNotEquals(variableName, variableValue);
-        } else if (op.equals(VariableQueryParameterDto.LIKE_OPERATOR_NAME)) {
+        } else if (op.equals(LIKE_OPERATOR_NAME)) {
           query.variableValueLike(variableName, String.valueOf(variableValue));
         } else {
           throw new InvalidRequestException(Status.BAD_REQUEST, "Invalid variable comparator specified: " + op);

--- a/engine/src/main/java/org/operaton/bpm/application/AbstractProcessApplication.java
+++ b/engine/src/main/java/org/operaton/bpm/application/AbstractProcessApplication.java
@@ -16,6 +16,14 @@
  */
 package org.operaton.bpm.application;
 
+import jakarta.el.BeanELResolver;
+import jakarta.el.ELResolver;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.concurrent.Callable;
+import javax.script.ScriptEngine;
 import org.operaton.bpm.application.impl.DefaultElResolverLookup;
 import org.operaton.bpm.application.impl.ProcessApplicationLogger;
 import org.operaton.bpm.application.impl.ProcessApplicationScriptEnvironment;
@@ -25,19 +33,10 @@ import org.operaton.bpm.engine.delegate.ExecutionListener;
 import org.operaton.bpm.engine.delegate.TaskListener;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.context.Context;
-import jakarta.el.BeanELResolver;
-import jakarta.el.ELResolver;
 import org.operaton.bpm.engine.impl.scripting.ExecutableScript;
 import org.operaton.bpm.engine.impl.util.ClassLoaderUtil;
 import org.operaton.bpm.engine.impl.variable.serializer.VariableSerializers;
 import org.operaton.bpm.engine.repository.DeploymentBuilder;
-
-import javax.script.ScriptEngine;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
-import java.util.concurrent.Callable;
 
 
 /**
@@ -106,13 +105,13 @@ public abstract class AbstractProcessApplication implements ProcessApplicationIn
     if (annotation != null) {
       name = annotation.value();
 
-      if (name == null || name.length() == 0) {
+      if (name == null || name.isEmpty()) {
         name = annotation.name();
       }
     }
 
 
-    if (name == null || name.length() == 0) {
+    if (name == null || name.isEmpty()) {
       name = autodetectProcessApplicationName();
     }
 

--- a/engine/src/main/java/org/operaton/bpm/container/impl/deployment/scanning/ClassPathProcessApplicationScanner.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/deployment/scanning/ClassPathProcessApplicationScanner.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-
 import org.operaton.bpm.container.impl.ContainerIntegrationLogger;
 import org.operaton.bpm.container.impl.deployment.scanning.spi.ProcessApplicationScanner;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
@@ -172,7 +171,7 @@ public class ClassPathProcessApplicationScanner implements ProcessApplicationSca
         String modelFileName = zipEntry.getName();
         if (ProcessApplicationScanningUtil.isDeployable(modelFileName, additionalResourceSuffixes) && isBelowPath(modelFileName, paResourceRootPath)) {
           String resourceName = modelFileName;
-          if (paResourceRootPath != null && paResourceRootPath.length() > 0) {
+          if (paResourceRootPath != null && !paResourceRootPath.isEmpty()) {
             // "directory/sub_directory/process.bpmn" -> "sub_directory/process.bpmn"
             resourceName = modelFileName.replaceFirst(paResourceRootPath, "");
           }
@@ -183,7 +182,7 @@ public class ClassPathProcessApplicationScanner implements ProcessApplicationSca
             ZipEntry zipEntry2 = entries2.nextElement();
             String diagramFileName = zipEntry2.getName();
             if (ProcessApplicationScanningUtil.isDiagram(diagramFileName, modelFileName)) {
-              if (paResourceRootPath != null && paResourceRootPath.length() > 0) {
+              if (paResourceRootPath != null && !paResourceRootPath.isEmpty()) {
                 // "directory/sub_directory/process.png" -> "sub_directory/process.png"
                 diagramFileName = diagramFileName.replaceFirst(paResourceRootPath, "");
               }
@@ -203,7 +202,7 @@ public class ClassPathProcessApplicationScanner implements ProcessApplicationSca
     File[] paths = directory.listFiles();
 
     String currentPathSegment = localPath;
-    if (localPath != null && localPath.length() > 0) {
+    if (localPath != null && !localPath.isEmpty()) {
       if (localPath.indexOf('/') > 0) {
         currentPathSegment = localPath.substring(0, localPath.indexOf('/'));
         localPath = localPath.substring(localPath.indexOf('/') + 1, localPath.length());
@@ -217,7 +216,7 @@ public class ClassPathProcessApplicationScanner implements ProcessApplicationSca
 
       if(isPaLocal   // if it is not PA-local, we have already used the classloader to specify the root path explicitly.
               && currentPathSegment != null
-              && currentPathSegment.length()>0) {
+              && !currentPathSegment.isEmpty()) {
 
         if(path.isDirectory()) {
           // only descend into directory, if below resource root:
@@ -293,7 +292,7 @@ public class ClassPathProcessApplicationScanner implements ProcessApplicationSca
   }
 
   protected boolean isBelowPath(String processFileName, String paResourceRootPath) {
-    if(paResourceRootPath == null || paResourceRootPath.length() ==0 ) {
+    if(paResourceRootPath == null || paResourceRootPath.isEmpty() ) {
       return true;
     }
     else {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ShellActivityBehavior.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/ShellActivityBehavior.java
@@ -27,7 +27,6 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.Expression;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
@@ -114,7 +113,7 @@ public class ShellActivityBehavior extends AbstractBpmnActivityBehavior {
         Map<String, String> env = processBuilder.environment();
         env.clear();
       }
-      if (directoryStr != null && directoryStr.length() > 0)
+      if (directoryStr != null && !directoryStr.isEmpty())
         processBuilder.directory(new File(directoryStr));
 
       Process process = processBuilder.start();
@@ -129,7 +128,6 @@ public class ShellActivityBehavior extends AbstractBpmnActivityBehavior {
 
         if (errorCodeVariableStr != null) {
           execution.setVariable(errorCodeVariableStr, Integer.toString(errorCode));
-
         }
 
       }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/CronExpression.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/CronExpression.java
@@ -236,7 +236,7 @@ public class CronExpression implements Serializable, Cloneable {
         dayMap.put("SAT", 7);
     }
 
-    private String cronExpression = null;
+    private String cronExpressionValue = null;
     private TimeZone timeZone = null;
     protected transient TreeSet<Integer> seconds;
     protected transient TreeSet<Integer> minutes;
@@ -259,20 +259,20 @@ public class CronExpression implements Serializable, Cloneable {
      * Constructs a new <CODE>CronExpression</CODE> based on the specified
      * parameter.
      *
-     * @param cronExpression String representation of the cron expression the
+     * @param cronExpressionValue String representation of the cron expression the
      *                       new object should represent
      * @throws java.text.ParseException
      *         if the string expression cannot be parsed into a valid
      *         <CODE>CronExpression</CODE>
      */
-    public CronExpression(String cronExpression) throws ParseException {
-        if (cronExpression == null) {
+    public CronExpression(String cronExpressionValue) throws ParseException {
+        if (cronExpressionValue == null) {
             throw new IllegalArgumentException("cronExpression cannot be null");
         }
 
-        this.cronExpression = cronExpression.toUpperCase(Locale.US);
+        this.cronExpressionValue = cronExpressionValue.toUpperCase(Locale.US);
 
-        buildExpression(this.cronExpression);
+        buildExpression(this.cronExpressionValue);
     }
 
 
@@ -295,7 +295,7 @@ public class CronExpression implements Serializable, Cloneable {
      * @return a string representation of the <CODE>CronExpression</CODE>
      */
     public String toString() {
-        return cronExpression;
+        return cronExpressionValue;
     }
 
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/CronExpression.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/CronExpression.java
@@ -955,7 +955,7 @@ public class CronExpression implements Serializable, Cloneable {
 
             // get second.................................................
             st = seconds.tailSet(sec);
-            if (st != null && st.size() != 0) {
+            if (st != null && !st.isEmpty()) {
                 sec = ((Integer) st.first()).intValue();
             } else {
                 sec = seconds.first().intValue();
@@ -970,7 +970,7 @@ public class CronExpression implements Serializable, Cloneable {
 
             // get minute.................................................
             st = minutes.tailSet(min);
-            if (st != null && st.size() != 0) {
+            if (st != null && !st.isEmpty()) {
                 t = min;
                 min = ((Integer) st.first()).intValue();
             } else {
@@ -991,7 +991,7 @@ public class CronExpression implements Serializable, Cloneable {
 
             // get hour...................................................
             st = hours.tailSet(hr);
-            if (st != null && st.size() != 0) {
+            if (st != null && !st.isEmpty()) {
                 t = hr;
                 hr = ((Integer) st.first()).intValue();
             } else {
@@ -1097,7 +1097,7 @@ public class CronExpression implements Serializable, Cloneable {
                         day = daysOfMonth.first().intValue();
                         mon++;
                     }
-                } else if (st != null && st.size() != 0) {
+                } else if (st != null && !st.isEmpty()) {
                     t = day;
                     day = ((Integer) st.first()).intValue();
                     // make sure we don't over-run a short month, such as february
@@ -1214,7 +1214,7 @@ public class CronExpression implements Serializable, Cloneable {
                     int dow = daysOfWeek.first().intValue(); // desired
                     // d-o-w
                     st = daysOfWeek.tailSet(cDow);
-                    if (st != null && st.size() > 0) {
+                    if (st != null && !st.isEmpty()) {
                         dow = ((Integer) st.first()).intValue();
                     }
 
@@ -1269,7 +1269,7 @@ public class CronExpression implements Serializable, Cloneable {
 
             // get month...................................................
             st = months.tailSet(mon);
-            if (st != null && st.size() != 0) {
+            if (st != null && !st.isEmpty()) {
                 t = mon;
                 mon = ((Integer) st.first()).intValue();
             } else {
@@ -1296,7 +1296,7 @@ public class CronExpression implements Serializable, Cloneable {
 
             // get year...................................................
             st = years.tailSet(year);
-            if (st != null && st.size() != 0) {
+            if (st != null && !st.isEmpty()) {
                 t = year;
                 year = ((Integer) st.first()).intValue();
             } else {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/SynchronousOperationLogProducer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/SynchronousOperationLogProducer.java
@@ -88,7 +88,7 @@ public interface SynchronousOperationLogProducer<T> {
       Map<T, List<PropertyChange>> propChangesForOperation = getPropChangesForOperation(results);
       if(propChangesForOperation == null ) {
         // create a map with empty result lists for each result item
-        propChangesForOperation = results.stream().collect(Collectors.toMap(Function.identity(), (result) -> Collections.singletonList(PropertyChange.EMPTY_CHANGE)));
+        propChangesForOperation = results.stream().collect(Collectors.toMap(Function.identity(), result -> Collections.singletonList(PropertyChange.EMPTY_CHANGE)));
       }
       if (logEntriesPerSyncOperationLimit != UNLIMITED_LOG && logEntriesPerSyncOperationLimit < propChangesForOperation.size()) {
         throw new ProcessEngineException(

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/AcquiredJobs.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/AcquiredJobs.java
@@ -32,7 +32,7 @@ public class AcquiredJobs {
   protected int numberOfJobsAttemptedToAcquire;
 
   protected List<List<String>> acquiredJobBatches = new ArrayList<>();
-  protected Set<String> acquiredJobs = new HashSet<>();
+  protected Set<String> acquiredJobIds = new HashSet<>();
 
   protected int numberOfJobsFailedToLock = 0;
 
@@ -47,7 +47,7 @@ public class AcquiredJobs {
   public void addJobIdBatch(List<String> jobIds) {
     if (!jobIds.isEmpty()) {
       acquiredJobBatches.add(jobIds);
-      acquiredJobs.addAll(jobIds);
+      acquiredJobIds.addAll(jobIds);
     }
   }
 
@@ -59,17 +59,17 @@ public class AcquiredJobs {
   }
 
   public boolean contains(String jobId) {
-    return acquiredJobs.contains(jobId);
+    return acquiredJobIds.contains(jobId);
   }
 
   public int size() {
-    return acquiredJobs.size();
+    return acquiredJobIds.size();
   }
 
   public void removeJobId(String id) {
     numberOfJobsFailedToLock++;
 
-    acquiredJobs.remove(id);
+    acquiredJobIds.remove(id);
 
     Iterator<List<String>> batchIterator = acquiredJobBatches.iterator();
     while (batchIterator.hasNext()) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -16,6 +16,17 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.ProcessEngineServices;
@@ -68,12 +79,10 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.bpmn.instance.UserTask;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 import org.operaton.bpm.model.xml.type.ModelElementType;
+
 import static org.operaton.bpm.engine.delegate.TaskListener.EVENTNAME_DELETE;
 import static org.operaton.bpm.engine.impl.form.handler.DefaultFormHandler.FORM_REF_BINDING_VERSION;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
-
-import java.io.Serializable;
-import java.util.*;
 
 /**
  * @author Tom Baeyens
@@ -189,7 +198,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
    */
   public TaskEntity() {
     this.lifecycleState = TaskState.STATE_CREATED;
-    this.taskState = TaskState.STATE_CREATED.taskState;
+    this.taskState = TaskState.STATE_CREATED.name;
   }
 
   /**
@@ -198,14 +207,14 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
   public TaskEntity(String id) {
     this(TaskState.STATE_INIT);
     this.id = id;
-    this.taskState = TaskState.STATE_INIT.taskState;
+    this.taskState = TaskState.STATE_INIT.name;
   }
 
   protected TaskEntity(TaskState initialState) {
     this.isIdentityLinksInitialized = true;
     this.setCreateTime(ClockUtil.getCurrentTime());
     this.lifecycleState = initialState;
-    this.taskState = this.lifecycleState.taskState;
+    this.taskState = this.lifecycleState.name;
   }
 
   /**
@@ -1168,7 +1177,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
 
   public boolean transitionTo(TaskState state) {
     this.lifecycleState = state;
-    this.taskState = this.lifecycleState.taskState;
+    this.taskState = this.lifecycleState.name;
 
     switch (state) {
     case STATE_CREATED:
@@ -1194,7 +1203,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
     if (lifecycleState == TaskState.STATE_CREATED) {
       registerCommandContextCloseListener();
       setLastUpdated(ClockUtil.getCurrentTime());
-      setTaskState(TaskState.STATE_UPDATED.taskState);
+      setTaskState(TaskState.STATE_UPDATED.name);
       return fireEvent(TaskListener.EVENTNAME_UPDATE) && fireAssignmentEvent();
     }
     else {
@@ -1802,10 +1811,10 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
     STATE_DELETED ("Deleted"),
     STATE_UPDATED ("Updated");
 
-    private String taskState;
+    private String name;
 
-    private TaskState(String taskState) {
-      this.taskState = taskState;
+    private TaskState(String name) {
+      this.name = name;
     }
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskManager.java
@@ -16,12 +16,9 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.operaton.bpm.engine.authorization.Resources;
 import org.operaton.bpm.engine.impl.Page;
 import org.operaton.bpm.engine.impl.TaskQueryImpl;
@@ -31,6 +28,8 @@ import org.operaton.bpm.engine.impl.db.ListQueryParameterObject;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.AbstractManager;
 import org.operaton.bpm.engine.task.Task;
+
+import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 
 /**
@@ -50,7 +49,7 @@ public class TaskManager extends AbstractManager {
       .processInstanceId(processInstanceId)
       .list();
 
-    String reason = (deleteReason == null || deleteReason.length() == 0) ? TaskEntity.DELETE_REASON_DELETED : deleteReason;
+    String reason = (deleteReason == null || deleteReason.isEmpty()) ? TaskEntity.DELETE_REASON_DELETED : deleteReason;
 
     for (TaskEntity task: tasks) {
       task.delete(reason, cascade, skipCustomListeners);
@@ -64,7 +63,7 @@ public class TaskManager extends AbstractManager {
         .caseInstanceId(caseInstanceId)
         .list();
 
-      String reason = (deleteReason == null || deleteReason.length() == 0) ? TaskEntity.DELETE_REASON_DELETED : deleteReason;
+      String reason = (deleteReason == null || deleteReason.isEmpty()) ? TaskEntity.DELETE_REASON_DELETED : deleteReason;
 
       for (TaskEntity task: tasks) {
         task.delete(reason, cascade, false);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/plugin/AdministratorAuthorizationPlugin.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/plugin/AdministratorAuthorizationPlugin.java
@@ -16,10 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.plugin;
 
-import static org.operaton.bpm.engine.authorization.Authorization.ANY;
-import static org.operaton.bpm.engine.authorization.Authorization.AUTH_TYPE_GRANT;
-import static org.operaton.bpm.engine.authorization.Permissions.ALL;
-
 import org.operaton.bpm.engine.AuthorizationService;
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.authorization.Resource;
@@ -28,6 +24,10 @@ import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.cfg.AbstractProcessEnginePlugin;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.persistence.entity.AuthorizationEntity;
+
+import static org.operaton.bpm.engine.authorization.Authorization.ANY;
+import static org.operaton.bpm.engine.authorization.Authorization.AUTH_TYPE_GRANT;
+import static org.operaton.bpm.engine.authorization.Permissions.ALL;
 
 /**
  * @author Daniel Meyer
@@ -56,10 +56,10 @@ public class AdministratorAuthorizationPlugin extends AbstractProcessEnginePlugi
   @Override
   public void postInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
     authorizationEnabled = processEngineConfiguration.isAuthorizationEnabled();
-    if (administratorGroupName != null && administratorGroupName.length() > 0) {
+    if (administratorGroupName != null && !administratorGroupName.isEmpty()) {
       processEngineConfiguration.getAdminGroups().add(administratorGroupName);
     }
-    if (administratorUserName != null && administratorUserName.length() > 0) {
+    if (administratorUserName != null && !administratorUserName.isEmpty()) {
       processEngineConfiguration.getAdminUsers().add(administratorUserName);
     }
   }
@@ -72,7 +72,7 @@ public class AdministratorAuthorizationPlugin extends AbstractProcessEnginePlugi
 
     final AuthorizationService authorizationService = processEngine.getAuthorizationService();
 
-    if(administratorGroupName != null && administratorGroupName.length()>0) {
+    if(administratorGroupName != null && !administratorGroupName.isEmpty()) {
       // create ADMIN authorizations on all built-in resources for configured group
       for (Resource resource : Resources.values()) {
         if(authorizationService.createAuthorizationQuery().groupIdIn(administratorGroupName).resourceType(resource).resourceId(ANY).count() == 0) {
@@ -88,7 +88,7 @@ public class AdministratorAuthorizationPlugin extends AbstractProcessEnginePlugi
       }
     }
 
-    if(administratorUserName != null && administratorUserName.length()>0) {
+    if(administratorUserName != null && !administratorUserName.isEmpty()) {
       // create ADMIN authorizations on all built-in resources for configured user
       for (Resource resource : Resources.values()) {
         if(authorizationService.createAuthorizationQuery().userIdIn(administratorUserName).resourceType(resource).resourceId(ANY).count() == 0) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/ScriptBindings.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/ScriptBindings.java
@@ -23,10 +23,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.script.Bindings;
 import javax.script.ScriptEngine;
-
 import org.operaton.bpm.engine.delegate.VariableScope;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.context.Context;
@@ -161,7 +159,7 @@ public class ScriptBindings implements Bindings {
 
   @Override
   public void putAll(Map< ? extends String, ? extends Object> toMerge) {
-    for (java.util.Map.Entry<? extends String, ? extends Object> entry : toMerge.entrySet()) {
+    for (var entry : toMerge.entrySet()) {
       put(entry.getKey(), entry.getValue());
     }
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/xml/ProblemImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/xml/ProblemImpl.java
@@ -50,7 +50,7 @@ public class ProblemImpl implements Problem {
     this(errorMessage, element);
     this.mainElementId = elementIds[0];
     for (String elementId : elementIds) {
-      if(elementId != null && elementId.length() > 0) {
+      if(elementId != null && !elementId.isEmpty()) {
         this.elementIds.add(elementId);
       }
     }
@@ -64,7 +64,7 @@ public class ProblemImpl implements Problem {
   public ProblemImpl(BpmnParseException exception, String elementId) {
     this(exception);
     this.mainElementId = elementId;
-    if(elementId != null && elementId.length() > 0) {
+    if(elementId != null && !elementId.isEmpty()) {
       this.elementIds.add(elementId);
     }
   }
@@ -85,7 +85,7 @@ public class ProblemImpl implements Problem {
       this.line = element.getLine();
       this.column = element.getColumn();
       String id = element.attribute("id");
-      if (id != null && id.length() > 0) {
+      if (id != null && !id.isEmpty()) {
         this.mainElementId = id;
         this.elementIds.add(id);
       }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -16,12 +16,36 @@
  */
 package org.operaton.bpm.engine.test.api.runtime;
 
-import org.operaton.bpm.engine.*;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.operaton.bpm.engine.CaseService;
+import org.operaton.bpm.engine.ManagementService;
+import org.operaton.bpm.engine.ProcessEngineException;
+import org.operaton.bpm.engine.RepositoryService;
+import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.exception.NullValueException;
 import org.operaton.bpm.engine.impl.ProcessInstanceQueryImpl;
 import org.operaton.bpm.engine.impl.util.ImmutablePair;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
-import org.operaton.bpm.engine.runtime.*;
+import org.operaton.bpm.engine.runtime.Execution;
+import org.operaton.bpm.engine.runtime.Incident;
+import org.operaton.bpm.engine.runtime.Job;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.runtime.ProcessInstanceQuery;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
@@ -31,19 +55,6 @@ import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.processInstanceByBusinessKey;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.processInstanceByProcessDefinitionId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.processInstanceByProcessInstanceId;
-import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
-
-import java.text.SimpleDateFormat;
-import java.util.*;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -51,6 +62,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.processInstanceByBusinessKey;
+import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.processInstanceByProcessDefinitionId;
+import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.processInstanceByProcessInstanceId;
+import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
 
 /**
  * @author Joram Barrez
@@ -140,7 +155,7 @@ public class ProcessInstanceQueryTest {
         .toList()
         .toArray(new ImmutablePair[0]);
     // when
-    List<ImmutablePair<String, String>> mappings = engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired().execute((c) -> {
+    List<ImmutablePair<String, String>> mappings = engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired().execute(c -> {
       ProcessInstanceQuery query = c.getProcessEngineConfiguration().getRuntimeService().createProcessInstanceQuery();
       return ((ProcessInstanceQueryImpl) query).listDeploymentIdMappings();
     });
@@ -166,7 +181,7 @@ public class ProcessInstanceQueryTest {
         runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY).getId());
     expectedMappings.add(newMapping);
     // when
-    List<ImmutablePair<String, String>> mappings = engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired().execute((c) -> {
+    List<ImmutablePair<String, String>> mappings = engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired().execute(c -> {
       ProcessInstanceQuery query = c.getProcessEngineConfiguration().getRuntimeService().createProcessInstanceQuery();
       return ((ProcessInstanceQueryImpl) query).listDeploymentIdMappings();
     });
@@ -221,7 +236,7 @@ public class ProcessInstanceQueryTest {
   public void testQueryByProcessDefinitionKeyDeploymentIdMappings() {
     // given
     String deploymentId = repositoryService.createDeploymentQuery().singleResult().getId();
-    List<String> relevantIds = engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired().execute((c) -> {
+    List<String> relevantIds = engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired().execute(c -> {
       ProcessInstanceQuery query = c.getProcessEngineConfiguration().getRuntimeService().createProcessInstanceQuery()
           .processDefinitionKey(PROCESS_DEFINITION_KEY);
       return ((ProcessInstanceQueryImpl) query).listIds();
@@ -230,7 +245,7 @@ public class ProcessInstanceQueryTest {
         .map(id -> new ImmutablePair<>(deploymentId, id))
         .toList();
     // when
-    List<ImmutablePair<String, String>> mappings = engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired().execute((c) -> {
+    List<ImmutablePair<String, String>> mappings = engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired().execute(c -> {
       ProcessInstanceQuery query = c.getProcessEngineConfiguration().getRuntimeService().createProcessInstanceQuery()
           .processDefinitionKey(PROCESS_DEFINITION_KEY);
       return ((ProcessInstanceQueryImpl)query).listDeploymentIdMappings();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/scripttask/ScriptTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/scripttask/ScriptTaskTest.java
@@ -16,18 +16,10 @@
  */
 package org.operaton.bpm.engine.test.bpmn.scripttask;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
+import org.junit.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.ScriptCompilationException;
 import org.operaton.bpm.engine.ScriptEvaluationException;
@@ -37,7 +29,14 @@ import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.model.bpmn.Bpmn;
-import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 /**
  *
@@ -188,33 +187,33 @@ public class ScriptTaskTest extends AbstractScriptTaskTest {
   @Test
   public void testGroovyProcessVarVisibility() {
 
-    deployProcess(GROOVY,
-
+    deployProcess(GROOVY, """
         // GIVEN
         // an execution variable 'foo'
-        "execution.setVariable('foo', 'a')\n"
+        execution.setVariable('foo', 'a')
 
         // THEN
         // there should be a script variable defined
-      + "if ( !foo ) {\n"
-      + "  throw new Exception('Variable foo should be defined as script variable.')\n"
-      + "}\n"
+        if ( !foo ) {
+          throw new Exception('Variable foo should be defined as script variable.')
+        }
 
         // GIVEN
         // a script variable with the same name
-      + "foo = 'b'\n"
+        foo = 'b'
 
         // THEN
         // it should not change the value of the execution variable
-      + "if (execution.getVariable('foo') != 'a') {\n"
-      + "  throw new Exception('Execution should contain variable foo')\n"
-      + "}\n"
+        if (execution.getVariable('foo') != 'a') {
+          throw new Exception('Execution should contain variable foo')
+        }
 
         // AND
         // it should override the visibility of the execution variable
-      + "if (foo != 'b') {\n"
-      + "  throw new Exception('Script variable must override the visibiltity of the execution variable.')\n"
-      + "}"
+        if (foo != 'b') {
+          throw new Exception('Script variable must override the visibiltity of the execution variable.')
+        }
+      """
 
     );
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/TaskListenerEventLifecycleTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/TaskListenerEventLifecycleTest.java
@@ -111,10 +111,7 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
     assertThat(orderedEvents)
       .hasSize(4)
-      .containsExactly(EVENTNAME_CREATE,
-        EVENTNAME_UPDATE,
-        EVENTNAME_ASSIGNMENT,
-        EVENTNAME_COMPLETE);
+      .containsExactly(EVENTNAME_CREATE, EVENTNAME_UPDATE, EVENTNAME_ASSIGNMENT, EVENTNAME_COMPLETE);
   }
 
   @Test
@@ -449,21 +446,17 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
                                                                                   TaskDeleteTaskListener.class);
     testRule.deploy(model);
     runtimeService.startProcessInstanceByKey("process");
-    Task task = taskService.createTaskQuery().singleResult();
+    String taskId = taskService.createTaskQuery().singleResult().getId();
 
     // when
-    try {
-      // when/then
-      assertThatThrownBy(() -> taskService.complete(task.getId()))
-        .isInstanceOf(ProcessEngineException.class)
-        .hasMessageContaining("The task cannot be deleted because is part of a running process");
-    } finally {
-      // then
-      LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
+    assertThatThrownBy(() -> taskService.complete(taskId))
+    // then
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("The task cannot be deleted because is part of a running process");
 
-      assertThat(orderedEvents).hasSize(2);
-      assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(EVENTNAME_COMPLETE);
-    }
+    LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
+    assertThat(orderedEvents).hasSize(2);
+    assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(EVENTNAME_COMPLETE);
   }
 
   @Test
@@ -499,21 +492,18 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     testRule.deploy(model);
     runtimeService.startProcessInstanceByKey("process");
     Task task = taskService.createTaskQuery().singleResult();
+    String taskId = task.getId();
 
     // when
-    try {
-      // when/then
-      assertThatThrownBy(() -> taskService.complete(task.getId()))
-        .isInstanceOf(ProcessEngineException.class)
-        .hasMessageContaining("invalid task state");
-    } finally {
-      // then
-      LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
+    assertThatThrownBy(() -> taskService.complete(taskId))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("invalid task state");
+    // then
+    LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-      assertThat(orderedEvents).hasSize(2);
-      assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(EVENTNAME_CREATE);
-      assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(EVENTNAME_COMPLETE);
-    }
+    assertThat(orderedEvents).hasSize(2);
+    assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(EVENTNAME_CREATE);
+    assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(EVENTNAME_COMPLETE);
   }
 
   // DELETE phase
@@ -586,21 +576,18 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
                                                                                   CompletingTaskListener.class);
     testRule.deploy(model);
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
+    String processInstanceId = processInstance.getId();
 
     // when
-    try {
-      // when/then
-      assertThatThrownBy(() -> runtimeService.deleteProcessInstance(processInstance.getId(), "Canceled!"))
-        .isInstanceOf(ProcessEngineException.class)
-        .hasMessageContaining("invalid task state");
-    } finally {
-      // then
-      LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
+    assertThatThrownBy(() -> runtimeService.deleteProcessInstance(processInstanceId, "Canceled!"))
+    // then
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("invalid task state");
 
-      assertThat(orderedEvents).hasSize(2);
-      assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(EVENTNAME_CREATE);
-      assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
-    }
+    LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
+    assertThat(orderedEvents).hasSize(2);
+    assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(EVENTNAME_CREATE);
+    assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
   }
 
   @Test
@@ -611,22 +598,18 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
                                                                                   TaskListener.EVENTNAME_DELETE,
                                                                                   TaskDeleteTaskListener.class);
     testRule.deploy(model);
-    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
+    String processInstanceId = runtimeService.startProcessInstanceByKey("process").getId();
 
     // when
-    try {
-      // when/then
-      assertThatThrownBy(() -> runtimeService.deleteProcessInstance(processInstance.getId(), "Canceled!"))
-        .isInstanceOf(ProcessEngineException.class)
-        .hasMessageContaining("The task cannot be deleted because is part of a running process");
-    } finally {
+    assertThatThrownBy(() -> runtimeService.deleteProcessInstance(processInstanceId, "Canceled!"))
       // then
-      LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("The task cannot be deleted because is part of a running process");
 
-      assertThat(orderedEvents).hasSize(2);
-      assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(EVENTNAME_CREATE);
-      assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
-    }
+    LinkedList<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
+    assertThat(orderedEvents).hasSize(2);
+    assertThat(orderedEvents.getFirst()).isEqualToIgnoringCase(EVENTNAME_CREATE);
+    assertThat(orderedEvents.getLast()).isEqualToIgnoringCase(TaskListener.EVENTNAME_DELETE);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/TaskListenerEventLifecycleTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/TaskListenerEventLifecycleTest.java
@@ -16,15 +16,12 @@
  */
 package org.operaton.bpm.engine.test.bpmn.tasklistener;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
-
+import org.junit.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.delegate.DelegateTask;
 import org.operaton.bpm.engine.delegate.TaskListener;
@@ -37,9 +34,12 @@ import org.operaton.bpm.engine.test.bpmn.tasklistener.util.RecorderTaskListener;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
-import static org.operaton.bpm.engine.delegate.TaskListener.*;
-
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.operaton.bpm.engine.delegate.TaskListener.EVENTNAME_ASSIGNMENT;
+import static org.operaton.bpm.engine.delegate.TaskListener.EVENTNAME_COMPLETE;
+import static org.operaton.bpm.engine.delegate.TaskListener.EVENTNAME_CREATE;
+import static org.operaton.bpm.engine.delegate.TaskListener.EVENTNAME_UPDATE;
 
 public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
   /*
@@ -374,9 +374,9 @@ public class TaskListenerEventLifecycleTest extends AbstractTaskListenerTest{
     // then
     List<String> orderedEvents = RecorderTaskListener.getOrderedEvents();
 
-    assertThat(orderedEvents).hasSize(2);
-    assertThat(orderedEvents).containsExactly(EVENTNAME_CREATE,
-                                              TaskListener.EVENTNAME_DELETE);
+    assertThat(orderedEvents)
+        .hasSize(2)
+        .containsExactly(EVENTNAME_CREATE, TaskListener.EVENTNAME_DELETE);
   }
 
   // COMPLETE phase

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/handler/CaseHandlerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/handler/CaseHandlerTest.java
@@ -16,11 +16,9 @@
  */
 package org.operaton.bpm.engine.test.cmmn.handler;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.operaton.bpm.engine.exception.NotValidException;
 import org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
 import org.operaton.bpm.engine.impl.cmmn.behavior.CmmnActivityBehavior;
@@ -30,9 +28,11 @@ import org.operaton.bpm.engine.impl.cmmn.handler.CmmnHandlerContext;
 import org.operaton.bpm.engine.impl.cmmn.model.CmmnActivity;
 import org.operaton.bpm.engine.impl.context.Context;
 import org.operaton.bpm.engine.impl.persistence.entity.DeploymentEntity;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Roman Smirnov
@@ -142,7 +142,7 @@ public class CaseHandlerTest extends CmmnElementHandlerTest {
     CaseDefinitionEntity activity = (CaseDefinitionEntity) handler.handleElement(caseDefinition, context);
 
     // then
-    assertEquals(Integer.valueOf(historyTimeToLive), activity.getHistoryTimeToLive());
+    assertEquals(historyTimeToLive, activity.getHistoryTimeToLive());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorBatchTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorBatchTest.java
@@ -16,10 +16,12 @@
  */
 package org.operaton.bpm.engine.test.jobexecutor;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.List;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.impl.ProcessEngineImpl;
 import org.operaton.bpm.engine.impl.batch.BatchConfiguration;
@@ -33,11 +35,8 @@ import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.api.runtime.migration.MigrationTestRule;
 import org.operaton.bpm.engine.test.api.runtime.migration.batch.BatchMigrationHelper;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+
+import static org.junit.Assert.assertEquals;
 
 public class JobExecutorBatchTest {
 
@@ -129,7 +128,7 @@ public class JobExecutorBatchTest {
     Batch batch = helper.migrateProcessInstancesAsync(4);
     // ... and there are more mappings than ids (simulating an intermediate execution of a SeedJob
     // by an older version that only processes ids but does not update the mappings)
-    engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired().execute((context) -> {
+    engineRule.getProcessEngineConfiguration().getCommandExecutorTxRequired().execute(context -> {
       BatchEntity batchEntity = context.getBatchManager().findBatchById(batch.getId());
       BatchJobHandler batchJobHandler = context.getProcessEngineConfiguration().getBatchHandlers()
           .get(batchEntity.getType());

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/jobexecution/ClassloadingDuringJobExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/jobexecution/ClassloadingDuringJobExecutionTest.java
@@ -16,46 +16,47 @@
  */
 package org.operaton.bpm.integrationtest.functional.classloading.jobexecution;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import java.util.List;
-
-import org.operaton.bpm.engine.runtime.Job;
-import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
-import org.operaton.bpm.integrationtest.util.TestContainer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.operaton.bpm.engine.runtime.Job;
+import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+import org.operaton.bpm.integrationtest.util.TestContainer;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * See CAM-10258
  */
 @RunWith(Arquillian.class)
 public class ClassloadingDuringJobExecutionTest extends AbstractFoxPlatformIntegrationTest {
-  protected static String process =
-      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
-      "<definitions xmlns=\"http://www.omg.org/spec/BPMN/20100524/MODEL\" xmlns:operaton=\"http://operaton.org/schema/1.0/bpmn\" targetNamespace=\"Examples\">\r\n" +
-      "  <process id=\"Process_1\" name=\"ServiceTask_Throw_BMPN_Error\" isExecutable=\"true\" operaton:historyTimeToLive=\"P180D\">\r\n" +
-      "    <startEvent id=\"StartEvent_1\">\r\n" +
-      "    </startEvent>\r\n" +
-      "    <sequenceFlow id=\"SequenceFlow_03wj6bv\" sourceRef=\"StartEvent_1\" targetRef=\"Task_1bkcm2v\" />\r\n" +
-      "    <endEvent id=\"EndEvent_0joyvpc\">\r\n" +
-      "    </endEvent>\r\n" +
-      "    <sequenceFlow id=\"SequenceFlow_0mt1p11\" sourceRef=\"Task_1bkcm2v\" targetRef=\"EndEvent_0joyvpc\" />\r\n" +
-      "    <serviceTask id=\"Task_1bkcm2v\" name=\"Throw BPMN Error\" operaton:asyncBefore=\"true\" operaton:expression=\"${true}\">\r\n" +
-      "      <extensionElements>\r\n" +
-      "        <operaton:inputOutput>\r\n" +
-      "          <operaton:outputParameter name=\"output\">\r\n" +
-      "            <operaton:script scriptFormat=\"Javascript\">throw new org.operaton.bpm.engine.delegate.BpmnError(\"Test error thrown\");</operaton:script>\r\n" +
-      "          </operaton:outputParameter>\r\n" +
-      "        </operaton:inputOutput>\r\n" +
-      "      </extensionElements>\r\n" +
-      "    </serviceTask>\r\n" +
-      "  </process>\r\n" +
-      "</definitions>\r\n";
+  protected static String process = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:operaton="http://operaton.org/schema/1.0/bpmn" targetNamespace="Examples">
+      <process id="Process_1" name="ServiceTask_Throw_BMPN_Error" isExecutable="true" operaton:historyTimeToLive="P180D">
+        <startEvent id="StartEvent_1">
+        </startEvent>
+        <sequenceFlow id="SequenceFlow_03wj6bv" sourceRef="StartEvent_1" targetRef="Task_1bkcm2v" />
+        <endEvent id="EndEvent_0joyvpc">
+        </endEvent>
+        <sequenceFlow id="SequenceFlow_0mt1p11" sourceRef="Task_1bkcm2v" targetRef="EndEvent_0joyvpc" />
+        <serviceTask id="Task_1bkcm2v" name="Throw BPMN Error" operaton:asyncBefore="true" operaton:expression="${true}">
+          <extensionElements>
+            <operaton:inputOutput>
+              <operaton:outputParameter name="output">
+                <operaton:script scriptFormat="Javascript">throw new org.operaton.bpm.engine.delegate.BpmnError("Test error thrown");</operaton:script>
+              </operaton:outputParameter>
+            </operaton:inputOutput>
+          </extensionElements>
+        </serviceTask>
+      </process>
+    </definitions>
+  """;
 
   @Deployment(name="clientDeployment")
   public static WebArchive clientDeployment() {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/GroovyAsyncScriptExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/GroovyAsyncScriptExecutionTest.java
@@ -16,12 +16,6 @@
  */
 package org.operaton.bpm.integrationtest.functional.scriptengine;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
-import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
-import org.operaton.bpm.integrationtest.util.DeploymentHelper;
-import org.operaton.bpm.integrationtest.util.TestContainer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -29,28 +23,35 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+import org.operaton.bpm.integrationtest.util.DeploymentHelper;
+import org.operaton.bpm.integrationtest.util.TestContainer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(Arquillian.class)
 public class GroovyAsyncScriptExecutionTest extends AbstractFoxPlatformIntegrationTest {
 
-  protected static String process =
-      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
-      "<definitions id=\"definitions\" \r\n" +
-      "  xmlns=\"http://www.omg.org/spec/BPMN/20100524/MODEL\"\r\n" +
-      "  xmlns:operaton=\"http://operaton.org/schema/1.0/bpmn\"\r\n" +
-      "  targetNamespace=\"Examples\">\r\n" +
-      "  <process id=\"process\" isExecutable=\"true\" operaton:historyTimeToLive=\"P180D\">\r\n" +
-      "    <startEvent id=\"theStart\" />\r\n" +
-      "    <sequenceFlow id=\"flow1\" sourceRef=\"theStart\" targetRef=\"theScriptTask\" />\r\n" +
-      "    <scriptTask id=\"theScriptTask\" name=\"Execute script\" scriptFormat=\"groovy\" operaton:asyncBefore=\"true\">\r\n" +
-      "      <script>execution.setVariable(\"foo\", S(\"&lt;bar /&gt;\").name())</script>\r\n" +
-      "    </scriptTask>\r\n" +
-      "    <sequenceFlow id=\"flow2\" sourceRef=\"theScriptTask\" targetRef=\"theTask\" />\r\n" +
-      "    <userTask id=\"theTask\" name=\"my task\" />\r\n" +
-      "    <sequenceFlow id=\"flow3\" sourceRef=\"theTask\" targetRef=\"theEnd\" />\r\n" +
-      "    <endEvent id=\"theEnd\" />\r\n" +
-      "  </process>\r\n" +
-      "</definitions>";
+  protected static String process = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <definitions id="definitions" 
+      xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+      xmlns:operaton="http://operaton.org/schema/1.0/bpmn"
+      targetNamespace="Examples">
+      <process id="process" isExecutable="true" operaton:historyTimeToLive="P180D">
+        <startEvent id="theStart" />
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theScriptTask" />
+        <scriptTask id="theScriptTask" name="Execute script" scriptFormat="groovy" operaton:asyncBefore="true">
+          <script>execution.setVariable("foo", S("&lt;bar /&gt;").name())</script>
+        </scriptTask>
+        <sequenceFlow id="flow2" sourceRef="theScriptTask" targetRef="theTask" />
+        <userTask id="theTask" name="my task" />
+        <sequenceFlow id="flow3" sourceRef="theTask" targetRef="theEnd" />
+        <endEvent id="theEnd" />
+      </process>
+    </definitions>
+  """;
 
   @Deployment(name="clientDeployment")
   public static WebArchive clientDeployment() {

--- a/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/util/EngineDataGenerator.java
+++ b/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/util/EngineDataGenerator.java
@@ -17,7 +17,19 @@
 package org.operaton.bpm.qa.largedata.util;
 
 import com.google.common.collect.Lists;
-import org.operaton.bpm.engine.*;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import org.operaton.bpm.engine.DecisionService;
+import org.operaton.bpm.engine.IdentityService;
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.RepositoryService;
+import org.operaton.bpm.engine.RuntimeService;
+import org.operaton.bpm.engine.TaskService;
 import org.operaton.bpm.engine.identity.Group;
 import org.operaton.bpm.engine.identity.User;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -29,10 +41,6 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.dmn.DmnModelInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.*;
-import java.util.function.Consumer;
-import java.util.stream.IntStream;
 
 import static org.operaton.bpm.qa.largedata.util.DmnHelper.createSimpleDmnModel;
 
@@ -89,7 +97,7 @@ public class EngineDataGenerator {
     final List<Integer> sequenceNumberList = createSequenceNumberList();
     generateInBatches(
       sequenceNumberList,
-      (ignored) -> evaluateDecision()
+      ignored -> evaluateDecision()
     );
     logger.info("Successfully generated decision instance data.");
   }
@@ -106,7 +114,7 @@ public class EngineDataGenerator {
     final List<Integer> sequenceNumberList = createSequenceNumberList();
     generateInBatches(
       sequenceNumberList,
-      (ignored) -> startAutoCompleteProcess()
+      ignored -> startAutoCompleteProcess()
     );
     logger.info("Successfully generated completed process instance data...");
   }
@@ -120,7 +128,7 @@ public class EngineDataGenerator {
     final List<Integer> sequenceNumberList = createSequenceNumberList();
     generateInBatches(
         sequenceNumberList,
-        (ignored) -> startAsyncTaskProcess()
+        ignored -> startAsyncTaskProcess()
     );
     logger.info("Successfully generated async task process instance data...");
   }
@@ -135,7 +143,7 @@ public class EngineDataGenerator {
     final List<Integer> sequenceNumberList = createSequenceNumberList();
     generateInBatches(
       sequenceNumberList,
-      (ignored) -> startUserTaskProcess()
+      ignored -> startUserTaskProcess()
     );
     createUser();
     createGroup();
@@ -183,7 +191,7 @@ public class EngineDataGenerator {
     identityService.setAuthenticatedUserId(getUserId());
     generateInBatches(
       list,
-      (task) -> {
+      task -> {
         taskService.addCandidateUser(task.getId(), getUserId());
         taskService.addCandidateGroup(task.getId(), getGroupId());
       }
@@ -194,7 +202,7 @@ public class EngineDataGenerator {
     List<Task> list = taskService.createTaskQuery().list();
     generateInBatches(
       list,
-      (task) -> {
+      task -> {
         taskService.claim(task.getId(), getUserId());
         taskService.complete(task.getId());
       }

--- a/spin/dataformat-json-jackson/src/main/java/org/operaton/spin/impl/json/jackson/format/TypeHelper.java
+++ b/spin/dataformat-json-jackson/src/main/java/org/operaton/spin/impl/json/jackson/format/TypeHelper.java
@@ -16,14 +16,12 @@
  */
 package org.operaton.spin.impl.json.jackson.format;
 
-import java.lang.reflect.TypeVariable;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.type.TypeFactory;
 
 /**
  * Collection of helper methods to construct types.
@@ -44,7 +42,7 @@ public class TypeHelper {
     if (erasedType == null) {
       return false;
     }
-    TypeVariable<? extends Class<?>>[] typeParameters = erasedType.getTypeParameters();
+    var typeParameters = erasedType.getTypeParameters();
     if (typeParameters.length == 0) {
       return false;
     }

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/actuator/JobExecutorHealthIndicator.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/actuator/JobExecutorHealthIndicator.java
@@ -16,15 +16,14 @@
  */
 package org.operaton.bpm.spring.boot.starter.actuator;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.HashSet;
 import java.util.Set;
-
 import org.operaton.bpm.engine.impl.ProcessEngineImpl;
 import org.operaton.bpm.engine.impl.jobexecutor.JobExecutor;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health.Builder;
+
+import static java.util.Objects.requireNonNull;
 
 public class JobExecutorHealthIndicator extends AbstractHealthIndicator {
 
@@ -127,7 +126,7 @@ public class JobExecutorHealthIndicator extends AbstractHealthIndicator {
         return this;
       }
 
-      public DetailsBuilder processEngineNames(Set<? extends String> processEngineNames) {
+      public DetailsBuilder processEngineNames(Set<String> processEngineNames) {
         if (this.processEngineNames == null) {
           this.processEngineNames = new HashSet<>();
         }
@@ -135,7 +134,7 @@ public class JobExecutorHealthIndicator extends AbstractHealthIndicator {
         return this;
       }
 
-      public DetailsBuilder clearProcessEngineNames(Set<? extends String> processEngineNames) {
+      public DetailsBuilder clearProcessEngineNames(Set<String> processEngineNames) {
         if (this.processEngineNames != null) {
           this.processEngineNames.clear();
         }


### PR DESCRIPTION
- Join AssertJ assertions to chain 
- remove unnecessary try/finally
- Avoid wildcards extending final types 
- Use isEmpty() to check whether a collection is empty 
- Use text blocks 
- Rename fields not to match enclosing class name
- Static import of ConditionQueryParameterDto constants
- Remove unnecessary boxing
- Remove unnecessary parantheses for lambda parameters
- Use isEmpty() to check whether a string is empty or not

related to #88 #85 