### PR TITLE
build: Fix docker trigger

### DIFF
--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -156,11 +156,12 @@ jobs:
     steps:
       - name: Notify Docker Repository
         run: |
+          RELEASE_VERSION=echo$(${{needs.build.outputs.version}} | sed 's/-SNAPSHOT//')
           response=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
             -H "Authorization: Bearer ${{ secrets.DOCKER_ACTION_DISPATCH_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            -d '{"ref":"main","inputs":{"version": "${{ needs.build.outputs.version | sed 's/-SNAPSHOT//'}}","snapshot": "true"}}' \
+            -d "{'ref':'main','inputs':{'version': '$RELEASE_VERSION','snapshot': 'true'}}" \
             https://api.github.com/repos/operaton/operaton-docker/actions/workflows/build-test-and-publish.yml/dispatches)
           if [ "$response" -ne 204 ]; then
             echo "Failed to notify Docker repository. HTTP response code: $response"

--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -152,6 +152,7 @@ jobs:
     needs:
       - build
       - release
+    if: ${{ github.event.inputs.dry_run == 'false' }}
     steps:
       - name: Notify Docker Repository
         run: |

--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -159,7 +159,7 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.DOCKER_ACTION_DISPATCH_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            -d '{"ref":"main","inputs":{"version": "${{ needs.build.outputs.version}}","snapshot": "true"}}' \
+            -d '{"ref":"main","inputs":{"version": "${{ needs.build.outputs.version | sed 's/-SNAPSHOT//'}}","snapshot": "true"}}' \
             https://api.github.com/repos/operaton/operaton-docker/actions/workflows/build-test-and-publish.yml/dispatches)
           if [ "$response" -ne 204 ]; then
             echo "Failed to notify Docker repository. HTTP response code: $response"

--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       version: ${{steps.maven-build.outputs.version}}
+      project_version: ${{steps.maven-build.outputs.project_version}}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -55,8 +56,10 @@ jobs:
         shell: bash
         run: |
           .github/scripts/jacoco-create-flag-files.sh
-          RELEASE_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1)
+          PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1)
+          RELEASE_VERSION=$(echo $PROJECT_VERSION | sed 's/-SNAPSHOT//')
           SKIP_TESTS=${{ github.event.inputs.skip_tests || (github.event_name == 'schedule' && false) }}
+          echo "project_version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
           echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
           echo "skip_tests=$SKIP_TESTS"
           ./mvnw \
@@ -113,7 +116,7 @@ jobs:
       - name: Release with JReleaser
         uses: jreleaser/release-action@v2
         env:
-          JRELEASER_PROJECT_VERSION: ${{needs.build.outputs.version}}
+          JRELEASER_PROJECT_VERSION: ${{needs.build.outputs.project_version}}
           JRELEASER_GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           JRELEASER_GPG_PUBLIC_KEY: ${{secrets.GPG_PUBLIC_KEY}}
           JRELEASER_GPG_SECRET_KEY: ${{secrets.GPG_PRIVATE_KEY}}
@@ -156,12 +159,11 @@ jobs:
     steps:
       - name: Notify Docker Repository
         run: |
-          RELEASE_VERSION=echo$(${{needs.build.outputs.version}} | sed 's/-SNAPSHOT//')
           response=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
             -H "Authorization: Bearer ${{ secrets.DOCKER_ACTION_DISPATCH_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            -d "{'ref':'main','inputs':{'version': '$RELEASE_VERSION','snapshot': 'true'}}" \
+            -d '{"ref":"main","inputs":{"version": "${{ needs.build.outputs.version}}","snapshot": "true"}}' \
             https://api.github.com/repos/operaton/operaton-docker/actions/workflows/build-test-and-publish.yml/dispatches)
           if [ "$response" -ne 204 ]; then
             echo "Failed to notify Docker repository. HTTP response code: $response"


### PR DESCRIPTION
- make sure that the right version without "-SNAPSHOT" is passed as payload to the docker build workflow
- skip trigger docker build when performing dry run

related to operaton/operaton-docker#2