### PR TITLE
Fix NPE when running integration tests locally.

### DIFF
--- a/distro/run/core/src/main/java/org/operaton/bpm/run/OperatonBpmRunDeploymentConfiguration.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/OperatonBpmRunDeploymentConfiguration.java
@@ -56,7 +56,7 @@ public class OperatonBpmRunDeploymentConfiguration extends DefaultDeploymentConf
   protected String getNormalizedDeploymentDir() {
     String result = deploymentDir;
 
-    if(File.separator.equals("\\")) {
+    if(result != null && File.separator.equals("\\")) {
       result = result.replace("\\", "/");
     }
     return result;


### PR DESCRIPTION
This fixes https://github.com/operaton/operaton/issues/427 .

Analyse: The issue arises if _operaton.deploymentDir_ is _null_ because in _OperatonBpmRunDeploymentConfiguration.getNormalizedDeploymentDir_ the value is accessed without a check. In a regular installation the property is set in the _run.bat_/_run.sh_ scripts. But these are not used for the integration tests. Instead the deafult is taken from _OperatonBpmRunConfiguration.operatonDeploymentConfiguration_. Here the value is configured to be _null_.

```
  @Bean
  public OperatonBpmRunDeploymentConfiguration operatonDeploymentConfiguration(@Value("${operaton.deploymentDir:#{null}}") String deploymentDir) {
    return new OperatonBpmRunDeploymentConfiguration(deploymentDir);
  }

```

Hence _null_ is a valid value in test scenarious and code should check for null.