### PR TITLE
fix(wildfly): Add missing modules for Spring dependencies

### DIFF
--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -106,6 +106,16 @@
       <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-datetime</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>${version.spring.framework6}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jcl</artifactId>
+      <version>${version.spring.framework6}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.graalvm.js</groupId>
@@ -258,6 +268,28 @@
                   </mapper>
                 </copy>
 
+                <!-- copy spring dependencies to single dir -->
+                <delete dir="target/modules/org/springframework/core" />
+                <copy todir="target/modules" flatten="false">
+                  <fileset refid="maven.project.dependencies" />
+                  <mapper>
+                    <chainedmapper>
+                      <regexpmapper from="^(.*)/([^/]+)/([^/]+)/([^/]*)$$" to="\1/core/main/\4" handledirsep="yes" />
+                      <regexpmapper from="^(org.springframework.spring-core.*/.*.jar)$$" to="\1" handledirsep="yes" />
+                    </chainedmapper>
+                  </mapper>
+                </copy>
+                <copy todir="target/modules" flatten="false">
+                  <fileset refid="maven.project.dependencies" />
+                  <mapper>
+                    <chainedmapper>
+                      <regexpmapper from="^(.*)/([^/]+)/([^/]+)/([^/]*)$$" to="\1/jcl/main/\4" handledirsep="yes" />
+                      <regexpmapper from="^(org.springframework.spring-jcl.*/.*.jar)$$" to="\1" handledirsep="yes" />
+                    </chainedmapper>
+                  </mapper>
+                </copy>
+
+
                 <copy todir="target/modules" flatten="false">
                   <fileset dir="src/main/modules" />
                 </copy>
@@ -327,6 +359,10 @@
                 </replace>
 
                 <replace dir="target/modules" token="@version.icu.icu4j@" value="${version.icu.icu4j}">
+                  <include name="**/module.xml" />
+                </replace>
+
+                <replace dir="target/modules" token="@version.spring@" value="${version.spring.framework6}">
                   <include name="**/module.xml" />
                 </replace>
 

--- a/distro/wildfly/modules/src/main/modules/org/operaton/bpm/operaton-engine/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/operaton/bpm/operaton-engine/main/module.xml
@@ -23,6 +23,7 @@
     <module name="org.mybatis.mybatis" />
     <module name="com.fasterxml.uuid.java-uuid-generator"/>
     <module name="org.joda.time" slot="2.1" />
+    <module name="org.springframework.spring-core" />
 
     <module name="org.apache.groovy.groovy-all" services="import"/>
     <module name="org.graalvm.js.js-scriptengine" services="import"/>

--- a/distro/wildfly/modules/src/main/modules/org/springframework/spring-core/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/springframework/spring-core/main/module.xml
@@ -1,0 +1,10 @@
+<module xmlns="urn:jboss:module:1.0" name="org.springframework.spring-core">
+  <resources>
+    <resource-root path="spring-core-@version.spring@.jar" />
+  </resources>
+
+  <dependencies>
+    <module name="java.base" />
+    <module name="org.springframework.spring-jcl" />
+  </dependencies>
+</module>

--- a/distro/wildfly/modules/src/main/modules/org/springframework/spring-jcl/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/springframework/spring-jcl/main/module.xml
@@ -1,0 +1,9 @@
+<module xmlns="urn:jboss:module:1.0" name="org.springframework.spring-jcl">
+  <resources>
+    <resource-root path="spring-jcl-@version.spring@.jar" />
+  </resources>
+
+  <dependencies>
+    <module name="java.base" />
+  </dependencies>
+</module>


### PR DESCRIPTION
The Wildfly distribution was missing dependencies on Spring Core. Spring Core itself has a dependency on Spring JCL.

This changes adds the Wildfly modules for spring-core and spring-jcl.

closes #419 