### PR TITLE
chore: Convert tests to JUnit 5.

### DIFF
--- a/commons/testing/src/main/java/org/operaton/commons/testing/ProcessEngineLoggingRule.java
+++ b/commons/testing/src/main/java/org/operaton/commons/testing/ProcessEngineLoggingRule.java
@@ -32,6 +32,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 
+// XXX For JUnit5 there is already a replacement for this rule. Have a look at ProcessEngineLoggingExtensions .
 public class ProcessEngineLoggingRule extends TestWatcher {
 
   public static final String LOGGER_NOT_FOUND_ERROR = "no logger found with name ";

--- a/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/AbstractSpringSecurityIT.java
+++ b/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/AbstractSpringSecurityIT.java
@@ -23,11 +23,12 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import org.operaton.bpm.spring.boot.starter.security.SampleApplication;
-import org.junit.Before;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.operaton.bpm.spring.boot.starter.security.SampleApplication;
 import org.springframework.beans.BeansException;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -42,10 +43,10 @@ import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.context.WebApplicationContext;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = SampleApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public abstract class AbstractSpringSecurityIT {
@@ -59,7 +60,7 @@ public abstract class AbstractSpringSecurityIT {
   @LocalServerPort
   protected int port;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     baseUrl = format("http://localhost:%d", port);
   }

--- a/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSampleApplicationIT.java
+++ b/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSampleApplicationIT.java
@@ -16,14 +16,14 @@
  */
 package org.operaton.bpm.spring.boot.starter.security.oauth2;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.context.WebApplicationContext;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class OperatonBpmSampleApplicationIT extends AbstractSpringSecurityIT {
 

--- a/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSecurityAutoConfigOauth2ApplicationIT.java
+++ b/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSecurityAutoConfigOauth2ApplicationIT.java
@@ -16,16 +16,24 @@
  */
 package org.operaton.bpm.spring.boot.starter.security.oauth2;
 
-import jakarta.servlet.Filter;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+
 import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.operaton.bpm.engine.rest.security.auth.AuthenticationResult;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineLoggingExtension;
 import org.operaton.bpm.spring.boot.starter.security.oauth2.impl.AuthorizeTokenFilter;
 import org.operaton.bpm.spring.boot.starter.security.oauth2.impl.OAuth2AuthenticationProvider;
 import org.operaton.bpm.webapp.impl.security.auth.ContainerBasedAuthenticationFilter;
-import org.operaton.commons.testing.ProcessEngineLoggingRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -41,13 +49,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import jakarta.servlet.Filter;
 
 @AutoConfigureMockMvc
 @TestPropertySource("/oauth2-mock.properties")
@@ -68,12 +70,13 @@ public class OperatonBpmSecurityAutoConfigOauth2ApplicationIT extends AbstractSp
   @MockBean
   private OAuth2AuthorizedClientService authorizedClientService;
 
-  @Rule
-  public ProcessEngineLoggingRule loggingRule = new ProcessEngineLoggingRule().watch(AuthorizeTokenFilter.class.getCanonicalName());
+  @RegisterExtension
+  ProcessEngineLoggingExtension logger = new ProcessEngineLoggingExtension()
+      .watch(AuthorizeTokenFilter.class.getCanonicalName());
 
   private OAuth2AuthenticationProvider spiedAuthenticationProvider;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     spyAuthenticationProvider();
@@ -133,7 +136,7 @@ public class OperatonBpmSecurityAutoConfigOauth2ApplicationIT extends AbstractSp
         .andExpect(MockMvcResultMatchers.header().string("Location", baseUrl + "/oauth2/authorization/" + PROVIDER));
 
     String expectedWarn = "Authorize failed for '" + UNAUTHORIZED_USER + "'";
-    assertThat(loggingRule.getFilteredLog(expectedWarn)).hasSize(1);
+    assertThat(logger.getFilteredLog(expectedWarn)).hasSize(1);
     verifyNoInteractions(spiedAuthenticationProvider);
   }
 

--- a/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/OAuth2GrantedAuthoritiesMapperIT.java
+++ b/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/OAuth2GrantedAuthoritiesMapperIT.java
@@ -22,10 +22,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineLoggingExtension;
 import org.operaton.bpm.spring.boot.starter.security.oauth2.AbstractSpringSecurityIT;
-import org.operaton.commons.testing.ProcessEngineLoggingRule;
-import org.junit.Rule;
-import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -40,8 +41,9 @@ public class OAuth2GrantedAuthoritiesMapperIT extends AbstractSpringSecurityIT {
   @Autowired
   private OAuth2GrantedAuthoritiesMapper authoritiesMapper;
 
-  @Rule
-  public ProcessEngineLoggingRule loggingRule = new ProcessEngineLoggingRule().watch(OAuth2GrantedAuthoritiesMapper.class.getCanonicalName());
+  @RegisterExtension
+  ProcessEngineLoggingExtension logger = new ProcessEngineLoggingExtension()
+      .watch(OAuth2GrantedAuthoritiesMapper.class.getCanonicalName());
 
   @Test
   public void testMappingNotOauth2Authorities() {
@@ -62,7 +64,7 @@ public class OAuth2GrantedAuthoritiesMapperIT extends AbstractSpringSecurityIT {
     // then
     assertThat(mappedAuthorities).isEmpty();
     String expectedWarn = "Attribute " + GROUP_NAME_ATTRIBUTE + " is not available";
-    assertThat(loggingRule.getFilteredLog(expectedWarn)).hasSize(1);
+    assertThat(logger.getFilteredLog(expectedWarn)).hasSize(1);
   }
 
   @Test
@@ -99,7 +101,7 @@ public class OAuth2GrantedAuthoritiesMapperIT extends AbstractSpringSecurityIT {
     // then
     assertThat(mappedAuthorities).isEmpty();
     String expectedError = "Could not map granted authorities, unsupported group attribute type: " + object.getClass();
-    assertThat(loggingRule.getFilteredLog(expectedError)).hasSize(1);
+    assertThat(logger.getFilteredLog(expectedError)).hasSize(1);
   }
 
 

--- a/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/OperatonIdentityProviderIT.java
+++ b/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/OperatonIdentityProviderIT.java
@@ -25,6 +25,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.IdentityService;
 import org.operaton.bpm.engine.identity.Group;
 import org.operaton.bpm.engine.identity.GroupQuery;
@@ -34,8 +36,6 @@ import org.operaton.bpm.engine.impl.identity.WritableIdentityProvider;
 import org.operaton.bpm.engine.impl.identity.db.DbGroupQueryImpl;
 import org.operaton.bpm.engine.impl.identity.db.DbUserQueryImpl;
 import org.operaton.bpm.spring.boot.starter.security.oauth2.AbstractSpringSecurityIT;
-import org.junit.Before;
-import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -79,7 +79,7 @@ public class OperatonIdentityProviderIT extends AbstractSpringSecurityIT {
     mockIdentityProviderFactory();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
   }


### PR DESCRIPTION
- Convert tests in "operaton-bpm-spring-boot-starter-security" to JUnit5
- Create ProcessEngineLoggingExtensions as JUnit5 replacement for ProcessEngineLoggingRule

realtes to: #27