### PR TITLE
refactor: Extract method calls in try-blocks within tests to variables

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AuthorizationQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AuthorizationQueryTest.java
@@ -226,29 +226,30 @@ public class AuthorizationQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testInvalidOrderByQueries() {
+    var authorizationQuery = authorizationService.createAuthorizationQuery().orderByResourceType().orderByResourceId();
     try {
-      authorizationService.createAuthorizationQuery().orderByResourceType().list();
+      authorizationQuery.list();
       fail("Exception expected");
     } catch(ProcessEngineException e) {
       testRule.assertTextPresent("Invalid query: call asc() or desc() after using orderByXX()", e.getMessage());
     }
 
     try {
-      authorizationService.createAuthorizationQuery().orderByResourceId().list();
+      authorizationQuery.list();
       fail("Exception expected");
     } catch(ProcessEngineException e) {
       testRule.assertTextPresent("Invalid query: call asc() or desc() after using orderByXX()", e.getMessage());
     }
 
     try {
-      authorizationService.createAuthorizationQuery().orderByResourceId().orderByResourceType().list();
+      authorizationQuery.list();
       fail("Exception expected");
     } catch(ProcessEngineException e) {
       testRule.assertTextPresent("Invalid query: call asc() or desc() after using orderByXX()", e.getMessage());
     }
 
     try {
-      authorizationService.createAuthorizationQuery().orderByResourceType().orderByResourceId().list();
+      authorizationQuery.list();
       fail("Exception expected");
     } catch(ProcessEngineException e) {
       testRule.assertTextPresent("Invalid query: call asc() or desc() after using orderByXX()", e.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AuthorizationServiceAuthorizationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AuthorizationServiceAuthorizationsTest.java
@@ -123,10 +123,11 @@ public class AuthorizationServiceAuthorizationsTest extends PluggableProcessEngi
     // turn on authorization
     processEngineConfiguration.setAuthorizationEnabled(true);
     identityService.setAuthenticatedUserId(jonny2);
+    var basePermsId = basePerms.getId();
 
     try {
       // try to delete authorization
-      authorizationService.deleteAuthorization(basePerms.getId());
+      authorizationService.deleteAuthorization(basePermsId);
       fail("exception expected");
 
     } catch (AuthorizationException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ActivityStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ActivityStatisticsQueryTest.java
@@ -385,8 +385,9 @@ public class ActivityStatisticsQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testNullProcessDefinitionParameter() {
+    var activityStatisticsQuery = managementService.createActivityStatisticsQuery(null);
     try {
-      managementService.createActivityStatisticsQuery(null).list();
+      activityStatisticsQuery.list();
       Assert.fail();
     } catch (ProcessEngineException e) {
       // expected

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/BatchQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/BatchQueryTest.java
@@ -139,8 +139,9 @@ public class BatchQueryTest {
 
   @Test
   public void testBatchQueryByIdNull() {
+    var batchQuery = managementService.createBatchQuery();
     try {
-      managementService.createBatchQuery().batchId(null).singleResult();
+      batchQuery.batchId(null);
       Assert.fail("exception expected");
     }
     catch (NullValueException e) {
@@ -175,8 +176,9 @@ public class BatchQueryTest {
 
   @Test
   public void testBatchQueryByTypeNull() {
+    var batchQuery = managementService.createBatchQuery();
     try {
-      managementService.createBatchQuery().type(null).singleResult();
+      batchQuery.type(null);
       Assert.fail("exception expected");
     }
     catch (NullValueException e) {
@@ -225,8 +227,9 @@ public class BatchQueryTest {
 
   @Test
   public void testBatchQueryOrderingPropertyWithoutOrder() {
+    var batchQuery = managementService.createBatchQuery().orderById();
     try {
-      managementService.createBatchQuery().orderById().singleResult();
+      batchQuery.singleResult();
       Assert.fail("exception expected");
     }
     catch (NotValidException e) {
@@ -237,8 +240,9 @@ public class BatchQueryTest {
 
   @Test
   public void testBatchQueryOrderWithoutOrderingProperty() {
+    var batchQuery = managementService.createBatchQuery();
     try {
-      managementService.createBatchQuery().asc().singleResult();
+      batchQuery.asc();
       Assert.fail("exception expected");
     }
     catch (NotValidException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/queries/BoundedNumberOfMaxResultsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/queries/BoundedNumberOfMaxResultsTest.java
@@ -53,10 +53,11 @@ public class BoundedNumberOfMaxResultsTest {
   @Rule
   public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testHelper);
 
-  protected HistoryService historyService;
-  protected RuntimeService runtimeService;
-  protected TaskService taskService;
-  protected IdentityService identityService;
+  HistoryService historyService;
+  RuntimeService runtimeService;
+  TaskService taskService;
+  IdentityService identityService;
+  FilterService filterService;
 
   protected BpmnModelInstance simpleProcess = Bpmn.createExecutableProcess("process")
       .startEvent()
@@ -77,6 +78,7 @@ public class BoundedNumberOfMaxResultsTest {
     runtimeService = engineRule.getRuntimeService();
     taskService = engineRule.getTaskService();
     identityService = engineRule.getIdentityService();
+    filterService = engineRule.getFilterService();
   }
 
   @Before
@@ -241,18 +243,18 @@ public class BoundedNumberOfMaxResultsTest {
   @Test
   public void shouldThrowExceptionWhenFilterQueryList_MaxResultsLimitExceeded() {
     // given
-    Filter foo = engineRule.getFilterService().newTaskFilter("foo");
+    Filter foo = filterService.newTaskFilter("foo");
     foo.setQuery(taskService.createTaskQuery());
-    engineRule.getFilterService().saveFilter(foo);
+    filterService.saveFilter(foo);
 
-    String filterId = engineRule.getFilterService()
+    String filterId = filterService
         .createFilterQuery()
         .singleResult()
         .getId();
 
     try {
       // when
-      engineRule.getFilterService().list(filterId);
+      filterService.list(filterId);
       fail("Exception expected!");
     } catch (BadUserRequestException e) {
       // then
@@ -260,24 +262,24 @@ public class BoundedNumberOfMaxResultsTest {
     }
 
     // clear
-    engineRule.getFilterService().deleteFilter(filterId);
+    filterService.deleteFilter(filterId);
   }
 
   @Test
   public void shouldThrowExceptionWhenFilterQueryListPage_MaxResultsLimitExceeded() {
     // given
-    Filter foo = engineRule.getFilterService().newTaskFilter("foo");
+    Filter foo = filterService.newTaskFilter("foo");
     foo.setQuery(taskService.createTaskQuery());
-    engineRule.getFilterService().saveFilter(foo);
+    filterService.saveFilter(foo);
 
-    String filterId = engineRule.getFilterService()
+    String filterId = filterService
         .createFilterQuery()
         .singleResult()
         .getId();
 
     try {
       // when
-      engineRule.getFilterService().listPage(filterId, 0, 11);
+      filterService.listPage(filterId, 0, 11);
       fail("Exception expected!");
     } catch (BadUserRequestException e) {
       // then
@@ -285,18 +287,18 @@ public class BoundedNumberOfMaxResultsTest {
     }
 
     // clear
-    engineRule.getFilterService().deleteFilter(filterId);
+    filterService.deleteFilter(filterId);
   }
 
   @Test
   public void shouldThrowExceptionWhenExtendedFilterQueryList_MaxResultsLimitExceeded() {
     // given
-    Filter foo = engineRule.getFilterService().newTaskFilter("foo");
+    Filter foo = filterService.newTaskFilter("foo");
     foo.setQuery(taskService.createTaskQuery());
 
-    engineRule.getFilterService().saveFilter(foo);
+    filterService.saveFilter(foo);
 
-    String filterId = engineRule.getFilterService()
+    String filterId = filterService
         .createFilterQuery()
         .singleResult()
         .getId();
@@ -306,7 +308,7 @@ public class BoundedNumberOfMaxResultsTest {
 
     try {
       // when
-      engineRule.getFilterService().list(filterId, extendingQuery);
+      filterService.list(filterId, extendingQuery);
       fail("Exception expected!");
     } catch (BadUserRequestException e) {
 
@@ -315,7 +317,7 @@ public class BoundedNumberOfMaxResultsTest {
     }
 
     // clear
-    engineRule.getFilterService().deleteFilter(filterId);
+    filterService.deleteFilter(filterId);
   }
 
   @Test
@@ -328,12 +330,12 @@ public class BoundedNumberOfMaxResultsTest {
     runtimeService.startProcessInstanceByKey("process");
     runtimeService.startProcessInstanceByKey("process");
     runtimeService.startProcessInstanceByKey("process");
+    var externalTaskService = engineRule.getExternalTaskService().updateRetries()
+          .externalTaskQuery(engineRule.getExternalTaskService().createExternalTaskQuery());
 
     try {
       // when
-      engineRule.getExternalTaskService().updateRetries()
-          .externalTaskQuery(engineRule.getExternalTaskService().createExternalTaskQuery())
-          .set(5);
+      externalTaskService.set(5);
       fail("Exception expected!");
     } catch (BadUserRequestException e) {
 
@@ -374,12 +376,12 @@ public class BoundedNumberOfMaxResultsTest {
 
     HistoricProcessInstanceQuery historicProcessInstanceQuery = engineRule.getHistoryService()
         .createHistoricProcessInstanceQuery();
+    var externalTaskService = engineRule.getExternalTaskService().updateRetries()
+          .historicProcessInstanceQuery(historicProcessInstanceQuery);
 
     try {
       // when
-      engineRule.getExternalTaskService().updateRetries()
-          .historicProcessInstanceQuery(historicProcessInstanceQuery)
-          .set(5);
+      externalTaskService.set(5);
       fail("Exception expected!");
     } catch (BadUserRequestException e) {
 
@@ -439,12 +441,12 @@ public class BoundedNumberOfMaxResultsTest {
     runtimeService.startProcessInstanceByKey("process");
     runtimeService.startProcessInstanceByKey("process");
     runtimeService.startProcessInstanceByKey("process");
+    var externalTaskService = engineRule.getExternalTaskService().updateRetries()
+          .processInstanceQuery(engineRule.getRuntimeService().createProcessInstanceQuery());
 
     try {
       // when
-      engineRule.getExternalTaskService().updateRetries()
-          .processInstanceQuery(engineRule.getRuntimeService().createProcessInstanceQuery())
-          .set(5);
+      externalTaskService.set(5);
       fail("Exception expected!");
     } catch (BadUserRequestException e) {
 
@@ -499,12 +501,12 @@ public class BoundedNumberOfMaxResultsTest {
     runtimeService.startProcessInstanceById(source);
     runtimeService.startProcessInstanceById(source);
     runtimeService.startProcessInstanceById(source);
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(plan)
+          .processInstanceQuery(runtimeService.createProcessInstanceQuery());
 
     try {
       // when
-      runtimeService.newMigration(plan)
-          .processInstanceQuery(runtimeService.createProcessInstanceQuery())
-          .execute();
+      migrationPlanExecutionBuilder.execute();
       fail("Exception expected!");
     } catch (BadUserRequestException e) {
 
@@ -566,13 +568,13 @@ public class BoundedNumberOfMaxResultsTest {
     runtimeService.startProcessInstanceByKey("process");
     runtimeService.startProcessInstanceByKey("process");
     runtimeService.startProcessInstanceByKey("process");
+    var modificationBuilder = runtimeService.createModification(processDefinitionId)
+          .startAfterActivity("userTask")
+          .processInstanceQuery(runtimeService.createProcessInstanceQuery());
 
     try {
       // when
-      runtimeService.createModification(processDefinitionId)
-          .startAfterActivity("userTask")
-          .processInstanceQuery(runtimeService.createProcessInstanceQuery())
-          .execute();
+      modificationBuilder.execute();
       fail("Exception expected!");
     } catch (BadUserRequestException e) {
 
@@ -631,13 +633,13 @@ public class BoundedNumberOfMaxResultsTest {
     runtimeService.startProcessInstanceByKey("process");
     runtimeService.startProcessInstanceByKey("process");
     runtimeService.startProcessInstanceByKey("process");
+    var restartProcessInstanceBuilder = runtimeService.restartProcessInstances(processDefinitionId)
+          .historicProcessInstanceQuery(historyService.createHistoricProcessInstanceQuery())
+          .startAfterActivity("startEvent");
 
     try {
       // when
-      runtimeService.restartProcessInstances(processDefinitionId)
-          .historicProcessInstanceQuery(historyService.createHistoricProcessInstanceQuery())
-          .startAfterActivity("startEvent")
-          .execute();
+      restartProcessInstanceBuilder.execute();
       fail("Exception expected!");
     } catch (BadUserRequestException e) {
 
@@ -687,12 +689,12 @@ public class BoundedNumberOfMaxResultsTest {
     runtimeService.startProcessInstanceByKey("process");
     runtimeService.startProcessInstanceByKey("process");
     runtimeService.startProcessInstanceByKey("process");
+    var updateProcessInstanceSuspensionStateSelectBuilder = runtimeService.updateProcessInstanceSuspensionState()
+          .byProcessInstanceQuery(runtimeService.createProcessInstanceQuery());
 
     try {
       // when
-      runtimeService.updateProcessInstanceSuspensionState()
-          .byProcessInstanceQuery(runtimeService.createProcessInstanceQuery())
-          .suspend();
+      updateProcessInstanceSuspensionStateSelectBuilder.suspend();
       fail("Exception expected!");
     } catch (BadUserRequestException e) {
 
@@ -712,12 +714,12 @@ public class BoundedNumberOfMaxResultsTest {
     instanceIds.add(runtimeService.startProcessInstanceByKey("process").getId());
     instanceIds.add(runtimeService.startProcessInstanceByKey("process").getId());
     instanceIds.add(runtimeService.startProcessInstanceByKey("process").getId());
+    var updateProcessInstanceSuspensionStateSelectBuilder = runtimeService.updateProcessInstanceSuspensionState()
+          .byProcessInstanceIds(instanceIds);
 
     try {
       // when
-      runtimeService.updateProcessInstanceSuspensionState()
-          .byProcessInstanceIds(instanceIds)
-          .suspend();
+      updateProcessInstanceSuspensionStateSelectBuilder.suspend();
       fail("Exception expected!");
     } catch (BadUserRequestException e) {
 
@@ -756,12 +758,12 @@ public class BoundedNumberOfMaxResultsTest {
     runtimeService.startProcessInstanceByKey("process");
     runtimeService.startProcessInstanceByKey("process");
     runtimeService.startProcessInstanceByKey("process");
+    var updateProcessInstanceSuspensionStateSelectBuilder = runtimeService.updateProcessInstanceSuspensionState()
+          .byHistoricProcessInstanceQuery(historyService.createHistoricProcessInstanceQuery());
 
     try {
       // when
-      runtimeService.updateProcessInstanceSuspensionState()
-          .byHistoricProcessInstanceQuery(historyService.createHistoricProcessInstanceQuery())
-          .suspend();
+      updateProcessInstanceSuspensionStateSelectBuilder.suspend();
       fail("Exception expected!");
     } catch (BadUserRequestException e) {
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CaseExecutionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CaseExecutionQueryTest.java
@@ -527,9 +527,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.variableValueEquals("aByteArrayValue", bytes);
 
     try {
-      query.variableValueEquals("aByteArrayValue", bytes).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -547,9 +548,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.variableValueEquals("aSerializableValue", serializable);
 
     try {
-      query.variableValueEquals("aSerializableValue", serializable).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -666,9 +668,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.variableValueNotEquals("aByteArrayValue", bytes);
 
     try {
-      query.variableValueNotEquals("aByteArrayValue", bytes).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -686,9 +689,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.variableValueNotEquals("aSerializableValue", serializable);
 
     try {
-      query.variableValueNotEquals("aSerializableValue", serializable).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -699,14 +703,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aNullValue", null)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.variableValueGreaterThan("aNullValue", null).list();
+      query.variableValueGreaterThan("aNullValue", null);
       fail();
-    } catch (NotValidException e) {}
-
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'greater than' condition", e.getMessage());
+    }
   }
 
   @Test
@@ -730,14 +734,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aBooleanValue", true)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.variableValueGreaterThan("aBooleanValue", false).list();
+      query.variableValueGreaterThan("aBooleanValue", false);
       fail();
-    } catch (NotValidException e) {}
-
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'greater than' condition", e.getMessage());
+    }
   }
 
   @Test
@@ -829,9 +833,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.variableValueGreaterThan("aByteArrayValue", bytes);
 
     try {
-      query.variableValueGreaterThan("aByteArrayValue", bytes).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -849,9 +854,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.variableValueGreaterThan("aSerializableValue", serializable);
 
     try {
-      query.variableValueGreaterThan("aSerializableValue", serializable).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -862,13 +868,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aNullValue", null)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.variableValueGreaterThanOrEqual("aNullValue", null).list();
+      query.variableValueGreaterThanOrEqual("aNullValue", null);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'greater than or equal' condition", e.getMessage());
+    }
 
   }
 
@@ -899,13 +906,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aBooleanValue", true)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.variableValueGreaterThanOrEqual("aBooleanValue", false).list();
+      query.variableValueGreaterThanOrEqual("aBooleanValue", false);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'greater than or equal' condition", e.getMessage());
+    }
 
   }
 
@@ -1028,9 +1036,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.variableValueGreaterThanOrEqual("aByteArrayValue", bytes);
 
     try {
-      query.variableValueGreaterThanOrEqual("aByteArrayValue", bytes).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1048,9 +1057,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.variableValueGreaterThanOrEqual("aSerializableValue", serializable);
 
     try {
-      query.variableValueGreaterThanOrEqual("aSerializableValue", serializable).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1061,13 +1071,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aNullValue", null)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.variableValueLessThan("aNullValue", null).list();
+      query.variableValueLessThan("aNullValue", null);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'less than' condition", e.getMessage());
+    }
 
   }
 
@@ -1092,13 +1103,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aBooleanValue", true)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.variableValueLessThan("aBooleanValue", false).list();
+      query.variableValueLessThan("aBooleanValue", false);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'less than' condition", e.getMessage());
+    }
 
   }
 
@@ -1108,7 +1120,6 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aShortValue", (short) 123)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     query.variableValueLessThan("aShortValue", (short) 124);
@@ -1191,9 +1202,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.variableValueLessThan("aByteArrayValue", bytes);
 
     try {
-      query.variableValueLessThan("aByteArrayValue", bytes).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1211,9 +1223,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.variableValueLessThan("aSerializableValue", serializable);
 
     try {
-      query.variableValueLessThan("aSerializableValue", serializable).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1224,13 +1237,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aNullValue", null)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.variableValueLessThanOrEqual("aNullValue", null).list();
+      query.variableValueLessThanOrEqual("aNullValue", null);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'less than or equal' condition", e.getMessage());
+    }
 
   }
 
@@ -1261,13 +1275,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aBooleanValue", true)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.variableValueLessThanOrEqual("aBooleanValue", false).list();
+      query.variableValueLessThanOrEqual("aBooleanValue", false);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'less than or equal' condition", e.getMessage());
+    }
 
   }
 
@@ -1390,9 +1405,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.variableValueLessThanOrEqual("aByteArrayValue", bytes);
 
     try {
-      query.variableValueLessThanOrEqual("aByteArrayValue", bytes).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1410,9 +1426,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.variableValueLessThanOrEqual("aSerializableValue", serializable);
 
     try {
-      query.variableValueLessThanOrEqual("aSerializableValue", serializable).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1427,9 +1444,11 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.variableValueLike("aNullValue", null).list();
+      query.variableValueLike("aNullValue", null);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'like' condition", e.getMessage());
+    }
 
   }
 
@@ -1582,9 +1601,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.caseInstanceVariableValueEquals("aByteArrayValue", bytes);
 
     try {
-      query.caseInstanceVariableValueEquals("aByteArrayValue", bytes).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1602,9 +1622,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.caseInstanceVariableValueEquals("aSerializableValue", serializable);
 
     try {
-      query.caseInstanceVariableValueEquals("aSerializableValue", serializable).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1721,9 +1742,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.caseInstanceVariableValueNotEquals("aByteArrayValue", bytes);
 
     try {
-      query.caseInstanceVariableValueNotEquals("aByteArrayValue", bytes).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1741,9 +1763,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.caseInstanceVariableValueNotEquals("aSerializableValue", serializable);
 
     try {
-      query.caseInstanceVariableValueNotEquals("aSerializableValue", serializable).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1754,13 +1777,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aNullValue", null)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.caseInstanceVariableValueGreaterThan("aNullValue", null).list();
+      query.caseInstanceVariableValueGreaterThan("aNullValue", null);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'greater than' condition", e.getMessage());
+    }
 
   }
 
@@ -1785,13 +1809,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aBooleanValue", true)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.caseInstanceVariableValueGreaterThan("aBooleanValue", false).list();
+      query.caseInstanceVariableValueGreaterThan("aBooleanValue", false);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'greater than' condition", e.getMessage());
+    }
 
   }
 
@@ -1884,9 +1909,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.caseInstanceVariableValueGreaterThan("aByteArrayValue", bytes);
 
     try {
-      query.caseInstanceVariableValueGreaterThan("aByteArrayValue", bytes).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1904,9 +1930,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.caseInstanceVariableValueGreaterThan("aSerializableValue", serializable);
 
     try {
-      query.caseInstanceVariableValueGreaterThan("aSerializableValue", serializable).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1917,13 +1944,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aNullValue", null)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.caseInstanceVariableValueGreaterThanOrEqual("aNullValue", null).list();
+      query.caseInstanceVariableValueGreaterThanOrEqual("aNullValue", null);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'greater than or equal' condition", e.getMessage());
+    }
 
   }
 
@@ -1958,9 +1986,11 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.caseInstanceVariableValueGreaterThanOrEqual("aBooleanValue", false).list();
+      query.caseInstanceVariableValueGreaterThanOrEqual("aBooleanValue", false);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'greater than or equal' condition", e.getMessage());
+    }
 
   }
 
@@ -2083,9 +2113,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.caseInstanceVariableValueGreaterThanOrEqual("aByteArrayValue", bytes);
 
     try {
-      query.caseInstanceVariableValueGreaterThanOrEqual("aByteArrayValue", bytes).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -2103,9 +2134,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.caseInstanceVariableValueGreaterThanOrEqual("aSerializableValue", serializable);
 
     try {
-      query.caseInstanceVariableValueGreaterThanOrEqual("aSerializableValue", serializable).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -2116,13 +2148,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aNullValue", null)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.caseInstanceVariableValueLessThan("aNullValue", null).list();
+      query.caseInstanceVariableValueLessThan("aNullValue", null);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'less than' condition", e.getMessage());
+    }
 
   }
 
@@ -2147,13 +2180,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aBooleanValue", true)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.caseInstanceVariableValueLessThan("aBooleanValue", false).list();
+      query.caseInstanceVariableValueLessThan("aBooleanValue", false);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'less than' condition", e.getMessage());
+    }
 
   }
 
@@ -2246,9 +2280,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.caseInstanceVariableValueLessThan("aByteArrayValue", bytes);
 
     try {
-      query.caseInstanceVariableValueLessThan("aByteArrayValue", bytes).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -2266,9 +2301,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.caseInstanceVariableValueLessThan("aSerializableValue", serializable);
 
     try {
-      query.caseInstanceVariableValueLessThan("aSerializableValue", serializable).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -2279,13 +2315,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aNullValue", null)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.caseInstanceVariableValueLessThanOrEqual("aNullValue", null).list();
+      query.caseInstanceVariableValueLessThanOrEqual("aNullValue", null);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'less than or equal' condition", e.getMessage());
+    }
 
   }
 
@@ -2316,13 +2353,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aBooleanValue", true)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.caseInstanceVariableValueLessThanOrEqual("aBooleanValue", false).list();
+      query.caseInstanceVariableValueLessThanOrEqual("aBooleanValue", false);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'less than or equal' condition", e.getMessage());
+    }
 
   }
 
@@ -2445,9 +2483,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.caseInstanceVariableValueLessThanOrEqual("aByteArrayValue", bytes);
 
     try {
-      query.caseInstanceVariableValueLessThanOrEqual("aByteArrayValue", bytes).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -2465,9 +2504,10 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
+    var caseExecutionQuery = query.caseInstanceVariableValueLessThanOrEqual("aSerializableValue", serializable);
 
     try {
-      query.caseInstanceVariableValueLessThanOrEqual("aSerializableValue", serializable).list();
+      caseExecutionQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -2478,13 +2518,14 @@ public class CaseExecutionQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aNullValue", null)
       .create();
-
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
 
     try {
-      query.caseInstanceVariableValueLike("aNullValue", null).list();
+      query.caseInstanceVariableValueLike("aNullValue", null);
       fail();
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      assertEquals("Booleans and null cannot be used in 'like' condition", e.getMessage());
+    }
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CaseInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CaseInstanceQueryTest.java
@@ -479,9 +479,10 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
+    var caseInstanceQuery = query.variableValueEquals("aByteArrayValue", bytes);
 
     try {
-      query.variableValueEquals("aByteArrayValue", bytes).list();
+      caseInstanceQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -499,9 +500,10 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
+    var caseInstanceQuery = query.variableValueEquals("aSerializableValue", serializable);
 
     try {
-      query.variableValueEquals("aSerializableValue", serializable).list();
+      caseInstanceQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -618,9 +620,10 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
+    var caseInstanceQuery = query.variableValueNotEquals("aByteArrayValue", bytes);
 
     try {
-      query.variableValueNotEquals("aByteArrayValue", bytes).list();
+      caseInstanceQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -638,9 +641,10 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
+    var caseInstanceQuery = query.variableValueNotEquals("aSerializableValue", serializable);
 
     try {
-      query.variableValueNotEquals("aSerializableValue", serializable).list();
+      caseInstanceQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -651,13 +655,14 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aNullValue", null)
       .create();
-
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
 
     try {
-      query.variableValueGreaterThan("aNullValue", null).list();
+      query.variableValueGreaterThan("aNullValue", null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Booleans and null cannot be used in 'greater than' condition", e.getMessage());
+    }
 
   }
 
@@ -682,13 +687,14 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aBooleanValue", true)
       .create();
-
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
 
     try {
-      query.variableValueGreaterThan("aBooleanValue", false).list();
+      query.variableValueGreaterThan("aBooleanValue", false);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Booleans and null cannot be used in 'greater than' condition", e.getMessage());
+    }
 
   }
 
@@ -781,9 +787,10 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
+    var caseInstanceQuery = query.variableValueGreaterThan("aByteArrayValue", bytes);
 
     try {
-      query.variableValueGreaterThan("aByteArrayValue", bytes).list();
+      caseInstanceQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -801,9 +808,10 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
+    var caseInstanceQuery = query.variableValueGreaterThan("aSerializableValue", serializable);
 
     try {
-      query.variableValueGreaterThan("aSerializableValue", serializable).list();
+      caseInstanceQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -814,13 +822,14 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aNullValue", null)
       .create();
-
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
 
     try {
-      query.variableValueGreaterThanOrEqual("aNullValue", null).list();
+      query.variableValueGreaterThanOrEqual("aNullValue", null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Booleans and null cannot be used in 'greater than or equal' condition", e.getMessage());
+    }
 
   }
 
@@ -851,13 +860,14 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aBooleanValue", true)
       .create();
-
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
 
     try {
-      query.variableValueGreaterThanOrEqual("aBooleanValue", false).list();
+      query.variableValueGreaterThanOrEqual("aBooleanValue", false);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Booleans and null cannot be used in 'greater than or equal' condition", e.getMessage());
+    }
 
   }
 
@@ -980,9 +990,10 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
+    var caseInstanceQuery = query.variableValueGreaterThanOrEqual("aByteArrayValue", bytes);
 
     try {
-      query.variableValueGreaterThanOrEqual("aByteArrayValue", bytes).list();
+      caseInstanceQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1000,9 +1011,10 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
+    var caseInstanceQuery = query.variableValueGreaterThanOrEqual("aSerializableValue", serializable);
 
     try {
-      query.variableValueGreaterThanOrEqual("aSerializableValue", serializable).list();
+      caseInstanceQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1013,13 +1025,14 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aNullValue", null)
       .create();
-
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
 
     try {
-      query.variableValueLessThan("aNullValue", null).list();
+      query.variableValueLessThan("aNullValue", null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Booleans and null cannot be used in 'less than' condition", e.getMessage());
+    }
 
   }
 
@@ -1044,13 +1057,14 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aBooleanValue", true)
       .create();
-
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
 
     try {
-      query.variableValueLessThan("aBooleanValue", false).list();
+      query.variableValueLessThan("aBooleanValue", false);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Booleans and null cannot be used in 'less than' condition", e.getMessage());
+    }
 
   }
 
@@ -1143,9 +1157,10 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
+    var caseInstanceQuery = query.variableValueLessThan("aByteArrayValue", bytes);
 
     try {
-      query.variableValueLessThan("aByteArrayValue", bytes).list();
+      caseInstanceQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1163,9 +1178,10 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
+    var caseInstanceQuery = query.variableValueLessThan("aSerializableValue", serializable);
 
     try {
-      query.variableValueLessThan("aSerializableValue", serializable).list();
+      caseInstanceQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1176,13 +1192,14 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aNullValue", null)
       .create();
-
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
 
     try {
-      query.variableValueLessThanOrEqual("aNullValue", null).list();
+      query.variableValueLessThanOrEqual("aNullValue", null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Booleans and null cannot be used in 'less than or equal' condition", e.getMessage());
+    }
 
   }
 
@@ -1213,13 +1230,14 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aBooleanValue", true)
       .create();
-
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
 
     try {
-      query.variableValueLessThanOrEqual("aBooleanValue", false).list();
+      query.variableValueLessThanOrEqual("aBooleanValue", false);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Booleans and null cannot be used in 'less than or equal' condition", e.getMessage());
+    }
 
   }
 
@@ -1342,9 +1360,10 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
+    var caseInstanceQuery = query.variableValueLessThanOrEqual("aByteArrayValue", bytes);
 
     try {
-      query.variableValueLessThanOrEqual("aByteArrayValue", bytes).list();
+      caseInstanceQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1362,9 +1381,10 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .create();
 
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
+    var caseInstanceQuery = query.variableValueLessThanOrEqual("aSerializableValue", serializable);
 
     try {
-      query.variableValueLessThanOrEqual("aSerializableValue", serializable).list();
+      caseInstanceQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -1375,13 +1395,14 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
       .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
       .setVariable("aNullValue", null)
       .create();
-
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
 
     try {
-      query.variableValueLike("aNullValue", null).list();
+      query.variableValueLike("aNullValue", null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Booleans and null cannot be used in 'like' condition", e.getMessage());
+    }
 
   }
 
@@ -1417,13 +1438,14 @@ public class CaseInstanceQueryTest extends PluggableProcessEngineTest {
             .withCaseDefinitionByKey(CASE_DEFINITION_KEY)
             .setVariable("aNullValue", null)
             .create();
-
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
 
     try {
-      query.variableValueNotLike("aNullValue", null).list();
+      query.variableValueNotLike("aNullValue", null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Booleans and null cannot be used in 'not like' condition", e.getMessage());
+    }
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CreateAndResolveIncidentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CreateAndResolveIncidentTest.java
@@ -208,8 +208,9 @@ public class CreateAndResolveIncidentTest {
 
     // then
     Incident incident = runtimeService.createIncidentQuery().processInstanceId(processInstance.getId()).singleResult();
+    var incidentId = incident.getId();
     try {
-      runtimeService.resolveIncident(incident.getId());
+      runtimeService.resolveIncident(incidentId);
       fail("Exception expected");
     } catch (BadUserRequestException e) {
       assertThat(e.getMessage()).contains("Cannot resolve an incident of type failedJob");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/batch/BatchMigrationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/batch/BatchMigrationTest.java
@@ -49,6 +49,7 @@ import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -127,8 +128,9 @@ public class BatchMigrationTest {
 
   @Test
   public void testNullMigrationPlan() {
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(null).processInstanceIds(List.of("process"));
     try {
-      runtimeService.newMigration(null).processInstanceIds(Collections.singletonList("process")).executeAsync();
+      migrationPlanExecutionBuilder.executeAsync();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("migration plan is null");
@@ -141,9 +143,10 @@ public class BatchMigrationTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(testProcessDefinition.getId(), testProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds((List<String>) null);
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceIds((List<String>) null).executeAsync();
+      migrationPlanExecutionBuilder.executeAsync();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("process instance ids is empty");
@@ -156,9 +159,10 @@ public class BatchMigrationTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(testProcessDefinition.getId(), testProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds(Arrays.asList("foo", null, "bar"));
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceIds(Arrays.asList("foo", null, "bar")).executeAsync();
+      migrationPlanExecutionBuilder.executeAsync();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("process instance ids contains null value");
@@ -171,9 +175,10 @@ public class BatchMigrationTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(testProcessDefinition.getId(), testProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds(emptyList());
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceIds(Collections.<String>emptyList()).executeAsync();
+      migrationPlanExecutionBuilder.executeAsync();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("process instance ids is empty");
@@ -186,9 +191,10 @@ public class BatchMigrationTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(testProcessDefinition.getId(), testProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds((String[]) null);
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceIds((String[]) null).executeAsync();
+      migrationPlanExecutionBuilder.executeAsync();
       fail("Should not be able to migrate");
     }
     catch (ProcessEngineException e) {
@@ -202,9 +208,10 @@ public class BatchMigrationTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(testProcessDefinition.getId(), testProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds("foo", null, "bar");
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceIds("foo", null, "bar").executeAsync();
+      migrationPlanExecutionBuilder.executeAsync();
       fail("Should not be able to migrate");
     }
     catch (ProcessEngineException e) {
@@ -218,9 +225,10 @@ public class BatchMigrationTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(testProcessDefinition.getId(), testProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceQuery(null);
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceQuery(null).executeAsync();
+      migrationPlanExecutionBuilder.executeAsync();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("process instance ids is empty");
@@ -236,9 +244,10 @@ public class BatchMigrationTest {
 
     ProcessInstanceQuery emptyProcessInstanceQuery = runtimeService.createProcessInstanceQuery();
     assertEquals(0, emptyProcessInstanceQuery.count());
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceQuery(emptyProcessInstanceQuery);
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceQuery(emptyProcessInstanceQuery).executeAsync();
+      migrationPlanExecutionBuilder.executeAsync();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("process instance ids is empty");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/async/AsyncAfterTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/async/AsyncAfterTest.java
@@ -54,12 +54,12 @@ public class AsyncAfterTest extends PluggableProcessEngineTest {
 
   @Test
   public void testTransitionIdRequired() {
+    var deploymentBuilder = repositoryService.createDeployment()
+        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/async/AsyncAfterTest.testTransitionIdRequired.bpmn20.xml");
 
     // if an outgoing sequence flow has no id, we cannot use it in asyncAfter
     try {
-      repositoryService.createDeployment()
-        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/async/AsyncAfterTest.testTransitionIdRequired.bpmn20.xml")
-        .deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected");
     } catch (ParseException e) {
       testRule.assertTextPresent("Sequence flow with sourceRef='service' must have an id, activity with id 'service' uses 'asyncAfter'.", e.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CallActivityTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CallActivityTest.java
@@ -1031,11 +1031,11 @@ public class CallActivityTest extends PluggableProcessEngineTest {
 
     // and executing a call activity in parameter where the source variable is not mapped by an activity
     // input parameter fails
-    Task beforeSecondCallActivityTask = taskService.createTaskQuery().singleResult();
     runtimeService.setVariable(processInstance.getId(), "globalVariable", "42");
+    var beforeSecondCallActivityTaskId = taskService.createTaskQuery().singleResult().getId();
 
     try {
-      taskService.complete(beforeSecondCallActivityTask.getId());
+      taskService.complete(beforeSecondCallActivityTaskId);
       fail("expected exception");
     } catch (ProcessEngineException e) {
        testRule.assertTextPresent("Cannot resolve identifier 'globalVariable'", e.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CaseCallActivityTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CaseCallActivityTest.java
@@ -1469,11 +1469,11 @@ public class CaseCallActivityTest extends CmmnTest {
     // and executing a call activity in parameter where the source variable is not mapped by an activity
     // input parameter fails
 
-    Task beforeSecondCallActivityTask = taskService.createTaskQuery().singleResult();
     runtimeService.setVariable(processInstance.getId(), "globalVariable", "42");
+    var beforeSecondCallActivityTaskId = taskService.createTaskQuery().singleResult().getId();
 
     try {
-      taskService.complete(beforeSecondCallActivityTask.getId());
+      taskService.complete(beforeSecondCallActivityTaskId);
       fail("expected exception");
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent("Cannot resolve identifier 'globalVariable'", e.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/compensate/CompensationEventParseInvalidProcessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/compensate/CompensationEventParseInvalidProcessTest.java
@@ -84,10 +84,10 @@ public class CompensationEventParseInvalidProcessTest {
 
   @Test
   public void testParseInvalidProcessDefinition() {
+    var deploymentBuilder = repositoryService.createDeployment()
+        .addClasspathResource(PROCESS_DEFINITION_DIRECTORY + processDefinitionResource);
     try {
-      repositoryService.createDeployment()
-        .addClasspathResource(PROCESS_DEFINITION_DIRECTORY + processDefinitionResource)
-        .deploy();
+      deploymentBuilder.deploy();
 
       fail("exception expected: " + expectedErrorMessage);
     } catch (ParseException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/conditional/BoundaryConditionalEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/conditional/BoundaryConditionalEventTest.java
@@ -1606,10 +1606,11 @@ public class BoundaryConditionalEventTest extends AbstractConditionalEventTestCa
 
     // given suspended process
     ProcessInstance procInst = runtimeService.startProcessInstanceByKey(CONDITIONAL_EVENT_PROCESS_KEY);
-    runtimeService.suspendProcessInstanceById(procInst.getId());
+    var processInstanceId = procInst.getId();
+    runtimeService.suspendProcessInstanceById(processInstanceId);
 
     //when wrong variable is set
-    runtimeService.setVariable(procInst.getId(), VARIABLE_NAME+1, 1);
+    runtimeService.setVariable(processInstanceId, VARIABLE_NAME+1, 1);
 
     //then nothing happens
     assertTrue(runtimeService.createProcessInstanceQuery().singleResult().isSuspended());
@@ -1617,12 +1618,12 @@ public class BoundaryConditionalEventTest extends AbstractConditionalEventTestCa
     //when variable which triggers condition is set
     //then exception is expected
     try {
-      runtimeService.setVariable(procInst.getId(), VARIABLE_NAME, 1);
+      runtimeService.setVariable(processInstanceId, VARIABLE_NAME, 1);
       fail("Should fail!");
     } catch (SuspendedEntityInteractionException seie) {
       //expected
     }
-    runtimeService.activateProcessInstanceById(procInst.getId());
+    runtimeService.activateProcessInstanceById(processInstanceId);
     tasksAfterVariableIsSet = taskService.createTaskQuery().list();
   }
 
@@ -1638,10 +1639,11 @@ public class BoundaryConditionalEventTest extends AbstractConditionalEventTestCa
 
     // given suspended process
     ProcessInstance procInst = runtimeService.startProcessInstanceByKey(CONDITIONAL_EVENT_PROCESS_KEY);
-    runtimeService.suspendProcessInstanceById(procInst.getId());
+    var processInstanceId = procInst.getId();
+    runtimeService.suspendProcessInstanceById(processInstanceId);
 
     //when wrong variable is set
-    runtimeService.setVariable(procInst.getId(), VARIABLE_NAME+1, 1);
+    runtimeService.setVariable(processInstanceId, VARIABLE_NAME+1, 1);
 
     //then nothing happens
     assertTrue(runtimeService.createProcessInstanceQuery().singleResult().isSuspended());
@@ -1649,12 +1651,12 @@ public class BoundaryConditionalEventTest extends AbstractConditionalEventTestCa
     //when variable which triggers condition is set
     //then exception is expected
     try {
-      runtimeService.setVariable(procInst.getId(), VARIABLE_NAME, 1);
+      runtimeService.setVariable(processInstanceId, VARIABLE_NAME, 1);
       fail("Should fail!");
     } catch (SuspendedEntityInteractionException seie) {
       //expected
     }
-    runtimeService.activateProcessInstanceById(procInst.getId());
+    runtimeService.activateProcessInstanceById(processInstanceId);
     tasksAfterVariableIsSet = taskService.createTaskQuery().list();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/error/BoundaryErrorEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/error/BoundaryErrorEventTest.java
@@ -86,10 +86,10 @@ public class BoundaryErrorEventTest extends PluggableProcessEngineTest {
 
   @Test
   public void testThrowErrorWithoutErrorCode() {
+    var deploymentBuilder = repositoryService.createDeployment()
+        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/error/BoundaryErrorEventTest.testThrowErrorWithoutErrorCode.bpmn20.xml");
     try {
-      repositoryService.createDeployment()
-        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/error/BoundaryErrorEventTest.testThrowErrorWithoutErrorCode.bpmn20.xml")
-        .deploy();
+      deploymentBuilder.deploy();
       fail("ProcessEngineException expected");
     } catch (ParseException e) {
       testRule.assertTextPresent("'errorCode' is mandatory on errors referenced by throwing error event definitions", e.getMessage());
@@ -99,10 +99,10 @@ public class BoundaryErrorEventTest extends PluggableProcessEngineTest {
 
   @Test
   public void testThrowErrorWithEmptyErrorCode() {
+    var deploymentBuilder = repositoryService.createDeployment()
+        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/error/BoundaryErrorEventTest.testThrowErrorWithEmptyErrorCode.bpmn20.xml");
     try {
-      repositoryService.createDeployment()
-        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/error/BoundaryErrorEventTest.testThrowErrorWithEmptyErrorCode.bpmn20.xml")
-        .deploy();
+      deploymentBuilder.deploy();
       fail("ProcessEngineException expected");
     } catch (ParseException e) {
       testRule.assertTextPresent("'errorCode' is mandatory on errors referenced by throwing error event definitions", e.getMessage());
@@ -544,9 +544,9 @@ public class BoundaryErrorEventTest extends PluggableProcessEngineTest {
   @Deployment
   @Test
   public void testCatchExceptionExpressionThrownByFollowUpTask() {
+    Map<String, Object> vars = throwException();
     try {
-      Map<String, Object> vars = throwException();
-      runtimeService.startProcessInstanceByKey("testProcess", vars).getId();
+      runtimeService.startProcessInstanceByKey("testProcess", vars);
       fail("should fail and not catch the error on the first task");
     } catch (ProcessEngineException e) {
       // happy path
@@ -558,9 +558,9 @@ public class BoundaryErrorEventTest extends PluggableProcessEngineTest {
   @Deployment
   @Test
   public void testCatchExceptionClassDelegateThrownByFollowUpTask() {
+    Map<String, Object> vars = throwException();
     try {
-      Map<String, Object> vars = throwException();
-      runtimeService.startProcessInstanceByKey("testProcess", vars).getId();
+      runtimeService.startProcessInstanceByKey("testProcess", vars);
       fail("should fail");
     } catch (ProcessEngineException e) {
       // happy path
@@ -572,9 +572,9 @@ public class BoundaryErrorEventTest extends PluggableProcessEngineTest {
   @Deployment
   @Test
   public void testCatchExceptionExpressionThrownByFollowUpScopeTask() {
+    Map<String, Object> vars = throwException();
     try {
-      Map<String, Object> vars = throwException();
-      runtimeService.startProcessInstanceByKey("testProcess", vars).getId();
+      runtimeService.startProcessInstanceByKey("testProcess", vars);
       fail("should fail and not catch the error on the first task");
     } catch (ProcessEngineException e) {
       // happy path

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/parse/BpmnParseTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/parse/BpmnParseTest.java
@@ -98,9 +98,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidSubProcessWithTimerStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithTimerStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithTimerStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could be parsed, although the sub process contains a timer start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("timerEventDefinition is not allowed on start event within a subprocess", e.getMessage());
@@ -112,9 +113,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidSubProcessWithMessageStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithMessageStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithMessageStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Process definition could be parsed, although the sub process contains not a blanco start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("messageEventDefinition only allowed on start event if subprocess is an event subprocess", e.getMessage());
@@ -126,9 +128,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidSubProcessWithoutStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithoutStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithoutStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Process definition could be parsed, although the sub process did not contain a start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("subProcess must define a startEvent element", e.getMessage());
@@ -138,9 +141,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidSubProcessWithConditionalStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithConditionalStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithConditionalStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could be parsed, although the sub process contains a conditional start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("The content of element 'bpmn2:conditionalEventDefinition' is not complete.", e.getMessage());
@@ -154,9 +158,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidSubProcessWithSignalStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithSignalStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithSignalStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could be parsed, although the sub process contains a signal start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("signalEventDefintion only allowed on start event if subprocess is an event subprocess", e.getMessage());
@@ -168,9 +173,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidSubProcessWithErrorStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithErrorStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithErrorStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could be parsed, although the sub process contains a error start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("errorEventDefinition only allowed on start event if subprocess is an event subprocess", e.getMessage());
@@ -182,9 +188,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidSubProcessWithEscalationStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithEscalationStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithEscalationStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could be parsed, although the sub process contains a escalation start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("escalationEventDefinition is not allowed on start event within a subprocess", e.getMessage());
@@ -196,9 +203,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidSubProcessWithCompensationStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithCompensationStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSubProcessWithCompensationStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could be parsed, although the sub process contains a compensation start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("compensateEventDefinition is not allowed on start event within a subprocess", e.getMessage());
@@ -210,9 +218,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidTransactionWithMessageStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidTransactionWithMessageStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidTransactionWithMessageStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Process definition could be parsed, although the sub process contains not a blanco start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("messageEventDefinition only allowed on start event if subprocess is an event subprocess", e.getMessage());
@@ -224,9 +233,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidTransactionWithTimerStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidTransactionWithTimerStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidTransactionWithTimerStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could be parsed, although the sub process contains a timer start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("timerEventDefinition is not allowed on start event within a subprocess", e.getMessage());
@@ -238,9 +248,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidTransactionWithConditionalStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidTransactionWithConditionalStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidTransactionWithConditionalStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could be parsed, although the sub process contains a conditional start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("The content of element 'bpmn2:conditionalEventDefinition' is not complete.", e.getMessage());
@@ -254,9 +265,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidTransactionWithSignalStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidTransactionWithSignalStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidTransactionWithSignalStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could be parsed, although the sub process contains a signal start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("signalEventDefintion only allowed on start event if subprocess is an event subprocess", e.getMessage());
@@ -268,9 +280,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidTransactionWithErrorStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidTransactionWithErrorStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidTransactionWithErrorStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could be parsed, although the sub process contains a error start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("errorEventDefinition only allowed on start event if subprocess is an event subprocess", e.getMessage());
@@ -282,9 +295,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidTransactionWithEscalationStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidTransactionWithEscalationStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidTransactionWithEscalationStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could be parsed, although the sub process contains a escalation start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("escalationEventDefinition is not allowed on start event within a subprocess", e.getMessage());
@@ -296,9 +310,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidTransactionWithCompensationStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidTransactionWithCompensationStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidTransactionWithCompensationStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could be parsed, although the sub process contains a compensation start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("compensateEventDefinition is not allowed on start event within a subprocess", e.getMessage());
@@ -310,9 +325,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidProcessDefinition() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidProcessDefinition");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidProcessDefinition");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail();
     } catch (ParseException e) {
       testRule.assertTextPresent("cvc-complex-type.3.2.2:", e.getMessage());
@@ -324,9 +340,10 @@ public class BpmnParseTest {
 
   @Test
   public void testExpressionParsingErrors() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testExpressionParsingErrors");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testExpressionParsingErrors");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could not be parsed, the expression contains an escalation start event.");
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent("Error parsing '${currentUser()': syntax error at position 15, encountered 'null', expected '}'", e.getMessage());
@@ -335,9 +352,10 @@ public class BpmnParseTest {
 
   @Test
   public void testXmlParsingErrors() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testXMLParsingErrors");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testXMLParsingErrors");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could not be parsed, the XML contains an escalation start event.");
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent("The end-tag for element type \"bpmndi:BPMNLabel\" must end with a '>' delimiter", e.getMessage());
@@ -346,9 +364,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidSequenceFlowInAndOutEventSubProcess() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSequenceFlowInAndOutEventSubProcess");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidSequenceFlowInAndOutEventSubProcess");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could be parsed, although the sub process has incoming and outgoing sequence flows");
     } catch (ParseException e) {
       testRule.assertTextPresent("start event of event subprocess must be of type 'error', 'message', 'timer', 'signal', 'compensation' or 'escalation'", e.getMessage());
@@ -364,9 +383,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidProcessWithoutStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidProcessWithoutStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidProcessWithoutStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Process definition could be parsed, although the process did not contain a start event.");
     } catch (ParseException e) {
       testRule.assertTextPresent("process must define a startEvent element", e.getMessage());
@@ -382,9 +402,10 @@ public class BpmnParseTest {
    **/
   @Test
   public void testParseMultipleStartEvent() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseMultipleStartEvent");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseMultipleStartEvent");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail();
     } catch (ParseException e) {
       // fail in "regular" subprocess
@@ -421,9 +442,10 @@ public class BpmnParseTest {
 
   @Test
   public void testInvalidAsyncAfterEventBasedGateway() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidAsyncAfterEventBasedGateway");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testInvalidAsyncAfterEventBasedGateway");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail();
     } catch (ParseException e) {
       // fail on asyncAfter
@@ -772,9 +794,10 @@ public class BpmnParseTest {
 
   @Test
   public void testNoOperatonInSourceThrowsError() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testNoOperatonInSourceThrowsError");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testNoOperatonInSourceThrowsError");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Process operaton:in extension element should contain source!");
     } catch (ParseException e) {
       testRule.assertTextPresent("Missing parameter 'source' or 'sourceExpression' when passing variables", e.getMessage());
@@ -800,9 +823,10 @@ public class BpmnParseTest {
 
   @Test
   public void testEmptyOperatonInSourceThrowsError() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testEmptyOperatonInSourceThrowsError");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testEmptyOperatonInSourceThrowsError");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Process operaton:in extension element should contain source!");
     } catch (ParseException e) {
       testRule.assertTextPresent("Empty attribute 'source' when passing variables", e.getMessage());
@@ -828,9 +852,10 @@ public class BpmnParseTest {
 
   @Test
   public void testNoOperatonInTargetThrowsError() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testNoOperatonInTargetThrowsError");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testNoOperatonInTargetThrowsError");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Process operaton:in extension element should contain target!");
     } catch (ParseException e) {
       testRule.assertTextPresent("Missing attribute 'target' when attribute 'source' or 'sourceExpression' is set", e.getMessage());
@@ -840,11 +865,11 @@ public class BpmnParseTest {
 
   @Test
   public void testNoOperatonInTargetWithoutValidation() {
+    processEngineConfiguration.setDisableStrictCallActivityValidation(true);
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testNoOperatonInTargetThrowsError");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      processEngineConfiguration.setDisableStrictCallActivityValidation(true);
-
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testNoOperatonInTargetThrowsError");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Process operaton:in extension element should contain target!");
     } catch (ParseException e) {
       testRule.assertTextPresent("Missing attribute 'target' when attribute 'source' or 'sourceExpression' is set", e.getMessage());
@@ -856,9 +881,10 @@ public class BpmnParseTest {
 
   @Test
   public void testEmptyOperatonInTargetThrowsError() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testEmptyOperatonInTargetThrowsError");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testEmptyOperatonInTargetThrowsError");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Process operaton:in extension element should contain target!");
     } catch (ParseException e) {
       testRule.assertTextPresent("Empty attribute 'target' when attribute 'source' or 'sourceExpression' is set", e.getMessage());
@@ -880,9 +906,10 @@ public class BpmnParseTest {
 
   @Test
   public void testNoOperatonOutSourceThrowsError() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testNoOperatonOutSourceThrowsError");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testNoOperatonOutSourceThrowsError");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Process operaton:out extension element should contain source!");
     } catch (ParseException e) {
       testRule.assertTextPresent("Missing parameter 'source' or 'sourceExpression' when passing variables", e.getMessage());
@@ -908,9 +935,10 @@ public class BpmnParseTest {
 
   @Test
   public void testEmptyOperatonOutSourceThrowsError() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testEmptyOperatonOutSourceThrowsError");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testEmptyOperatonOutSourceThrowsError");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Process operaton:out extension element should contain source!");
     } catch (ParseException e) {
       testRule.assertTextPresent("Empty attribute 'source' when passing variables", e.getMessage());
@@ -936,9 +964,10 @@ public class BpmnParseTest {
 
   @Test
   public void testNoOperatonOutTargetThrowsError() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testNoOperatonOutTargetThrowsError");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testNoOperatonOutTargetThrowsError");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Process operaton:out extension element should contain target!");
     } catch (ParseException e) {
       testRule.assertTextPresent("Missing attribute 'target' when attribute 'source' or 'sourceExpression' is set", e.getMessage());
@@ -948,11 +977,11 @@ public class BpmnParseTest {
 
   @Test
   public void testNoOperatonOutTargetWithoutValidation() {
+    processEngineConfiguration.setDisableStrictCallActivityValidation(true);
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testNoOperatonOutTargetThrowsError");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      processEngineConfiguration.setDisableStrictCallActivityValidation(true);
-
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testNoOperatonOutTargetThrowsError");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Process operaton:out extension element should contain target!");
     } catch (ParseException e) {
       testRule.assertTextPresent("Missing attribute 'target' when attribute 'source' or 'sourceExpression' is set", e.getMessage());
@@ -964,9 +993,10 @@ public class BpmnParseTest {
 
   @Test
   public void testEmptyOperatonOutTargetThrowsError() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testEmptyOperatonOutTargetThrowsError");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testEmptyOperatonOutTargetThrowsError");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Process operaton:out extension element should contain target!");
     } catch (ParseException e) {
       testRule.assertTextPresent("Empty attribute 'target' when attribute 'source' or 'sourceExpression' is set", e.getMessage());
@@ -1014,9 +1044,10 @@ public class BpmnParseTest {
 
   @Test
   public void testParseProcessDefinitionMalformedStringTtl() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionMalformedStringTtl");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionMalformedStringTtl");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition historyTimeToLive value can not be parsed.");
     } catch (ParseException e) {
       testRule.assertTextPresent("Cannot parse historyTimeToLive", e.getMessage());
@@ -1067,9 +1098,10 @@ public class BpmnParseTest {
   @Test
   public void testParseProcessDefinitionWithoutTtlWithMalformedConfigDefault() {
     processEngineConfiguration.setHistoryTimeToLive("PP555DDD");
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionWithoutTtl");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionWithoutTtl");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition historyTimeToLive value can not be parsed.");
     } catch (ParseException e) {
       testRule.assertTextPresent("Cannot parse historyTimeToLive", e.getMessage());
@@ -1081,9 +1113,10 @@ public class BpmnParseTest {
   @Test
   public void testParseProcessDefinitionWithoutTtlWithInvalidConfigDefault() {
     processEngineConfiguration.setHistoryTimeToLive("invalidValue");
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionWithoutTtl");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionWithoutTtl");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition historyTimeToLive value can not be parsed.");
     } catch (ParseException e) {
       testRule.assertTextPresent("Cannot parse historyTimeToLive", e.getMessage());
@@ -1095,9 +1128,10 @@ public class BpmnParseTest {
   @Test
   public void testParseProcessDefinitionWithoutTtlWithNegativeConfigDefault() {
     processEngineConfiguration.setHistoryTimeToLive("-6");
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionWithoutTtl");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionWithoutTtl");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition historyTimeToLive value can not be parsed.");
     } catch (ParseException e) {
       testRule.assertTextPresent("Cannot parse historyTimeToLive", e.getMessage());
@@ -1108,9 +1142,10 @@ public class BpmnParseTest {
 
   @Test
   public void testParseProcessDefinitionInvalidTtl() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionInvalidTtl");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionInvalidTtl");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition historyTimeToLive value can not be parsed.");
     } catch (ParseException e) {
       testRule.assertTextPresent("Cannot parse historyTimeToLive", e.getMessage());
@@ -1119,9 +1154,10 @@ public class BpmnParseTest {
 
   @Test
   public void testParseProcessDefinitionNegativTtl() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionNegativeTtl");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionNegativeTtl");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition historyTimeToLive value can not be parsed.");
     } catch (ParseException e) {
       testRule.assertTextPresent("Cannot parse historyTimeToLive", e.getMessage());
@@ -1208,9 +1244,10 @@ public class BpmnParseTest {
   public void testFeatureSecureProcessingRejectsDefinitionDueToAttributeLimit() {
     // IBM JDKs do not check on attribute number limits, skip the test there
     Assume.assumeThat(System.getProperty("java.vm.vendor"), not(containsString("IBM")));
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionFSP");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testParseProcessDefinitionFSP");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Attribute Number Limit should have been exceeded while parsing the model!");
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent("JAXP00010002", e.getMessage());
@@ -1278,8 +1315,7 @@ public class BpmnParseTest {
 
   @Test
   public void testTimerWithoutFullDefinition() {
-    try {
-      String timerWithoutDetails = "<?xml version='1.0' encoding='UTF-8'?>" +
+    String timerWithoutDetails = "<?xml version='1.0' encoding='UTF-8'?>" +
           "<definitions xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'" +
           "  xmlns='http://www.omg.org/spec/BPMN/20100524/MODEL'" +
           "  xmlns:operaton='http://operaton.org/schema/1.0/bpmn'" +
@@ -1290,7 +1326,9 @@ public class BpmnParseTest {
           "    </startEvent>" +
           "  </process>" +
           "</definitions>";
-      repositoryService.createDeployment().addString("process.bpmn20.xml", timerWithoutDetails).deploy();
+    var deploymentBuilder = repositoryService.createDeployment().addString("process.bpmn20.xml", timerWithoutDetails);
+    try {
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could be parsed, it contains uncomplete timer event definition.");
     } catch (ParseException e) {
       testRule.assertTextPresent("Timer needs configuration (either timeDate, timeCycle or timeDuration is needed).", e.getMessage());
@@ -1302,8 +1340,7 @@ public class BpmnParseTest {
 
   @Test
   public void testSequenceFlowNoIdAndUnexistantDestination() {
-    try {
-      String incorrectSequenceFlow = "<?xml version='1.0' encoding='UTF-8'?>" +
+    String incorrectSequenceFlow = "<?xml version='1.0' encoding='UTF-8'?>" +
           "<definitions xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'" +
           "  xmlns='http://www.omg.org/spec/BPMN/20100524/MODEL'" +
           "  xmlns:operaton='http://operaton.org/schema/1.0/bpmn'" +
@@ -1313,7 +1350,9 @@ public class BpmnParseTest {
           "    <sequenceFlow sourceRef='start' targetRef='eventBasedGateway' />" +
           "  </process>" +
           "</definitions>";
-      repositoryService.createDeployment().addString("process.bpmn20.xml", incorrectSequenceFlow).deploy();
+    var deploymentBuilder = repositoryService.createDeployment().addString("process.bpmn20.xml", incorrectSequenceFlow);
+    try {
+      deploymentBuilder.deploy();
       fail("Exception expected: Unexisting target.");
     } catch (ParseException e) {
       testRule.assertTextPresent("Invalid destination 'eventBasedGateway' of sequence flow 'null'", e.getMessage());
@@ -1326,9 +1365,10 @@ public class BpmnParseTest {
 
   @Test
   public void testMultipleTimerStartEvents() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testMultipleTimerStartEvents");
+    var deploymentBuilder = repositoryService.createDeployment().name(resource).addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testMultipleTimerStartEvents");
-      repositoryService.createDeployment().name(resource).addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected: Process definition could be parsed, it contains multiple multiple none start events or timer start events.");
     } catch (ParseException e) {
       testRule.assertTextPresent("multiple none start events or timer start events not supported on process definition", e.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/casetask/CaseTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/casetask/CaseTaskTest.java
@@ -841,12 +841,12 @@ public class CaseTaskTest extends CmmnTest {
     // given
     String superCaseInstanceId = createCaseInstanceByKey(ONE_CASE_TASK_CASE).getId();
     String caseTaskId = queryCaseExecutionByActivityId(CASE_TASK).getId();
+    var caseExecutionCommandBuilder = caseService
+        .withCaseExecution(caseTaskId);
 
     try {
       // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .manualStart();
+      caseExecutionCommandBuilder.manualStart();
       fail("It should not be possible to start a not existing case instance.");
     } catch (NotFoundException e) {}
 
@@ -1340,12 +1340,12 @@ public class CaseTaskTest extends CmmnTest {
     // given
     String superCaseInstanceId = createCaseInstanceByKey(ONE_CASE_TASK_CASE).getId();
     String caseTaskId = queryCaseExecutionByActivityId(CASE_TASK).getId();
+    var caseExecutionCommandBuilder = caseService
+        .withCaseExecution(caseTaskId);
 
     try {
       // when
-      caseService
-        .withCaseExecution(caseTaskId)
-        .complete();
+      caseExecutionCommandBuilder.complete();
       fail("It should not be possible to complete a case task, while the case instance is active.");
     } catch (NotAllowedException e) {}
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/cmmn10/Cmmn10CompatibilityTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/cmmn10/Cmmn10CompatibilityTest.java
@@ -43,6 +43,7 @@ public class Cmmn10CompatibilityTest extends CmmnTest {
   public void testRequiredRule() {
     CaseInstance caseInstance =
         createCaseInstanceByKey("case", Variables.createVariables().putValue("required", true));
+    var caseInstanceId = caseInstance.getId();
 
     CaseExecution taskExecution = queryCaseExecutionByActivityId("PI_HumanTask_1");
 
@@ -50,7 +51,7 @@ public class Cmmn10CompatibilityTest extends CmmnTest {
     assertTrue(taskExecution.isRequired());
 
     try {
-      caseService.completeCaseExecution(caseInstance.getId());
+      caseService.completeCaseExecution(caseInstanceId);
       fail("completing the containing stage should not be allowed");
     } catch (NotAllowedException e) {
       // happy path

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/deployment/CmmnDeployerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/deployment/CmmnDeployerTest.java
@@ -73,14 +73,14 @@ public class CmmnDeployerTest extends PluggableProcessEngineTest {
 
   @Test
   public void testDeployTwoCasesWithDuplicateIdAtTheSameTime() {
-    try {
-      String cmmnResourceName1 = "org/operaton/bpm/engine/test/cmmn/deployment/CmmnDeploymentTest.testSimpleDeployment.cmmn";
-      String cmmnResourceName2 = "org/operaton/bpm/engine/test/cmmn/deployment/CmmnDeploymentTest.testSimpleDeployment2.cmmn";
-      repositoryService.createDeployment()
+    String cmmnResourceName1 = "org/operaton/bpm/engine/test/cmmn/deployment/CmmnDeploymentTest.testSimpleDeployment.cmmn";
+    String cmmnResourceName2 = "org/operaton/bpm/engine/test/cmmn/deployment/CmmnDeploymentTest.testSimpleDeployment2.cmmn";
+    var deploymentBuilder = repositoryService.createDeployment()
               .addClasspathResource(cmmnResourceName1)
               .addClasspathResource(cmmnResourceName2)
-              .name("duplicateAtTheSameTime")
-              .deploy();
+              .name("duplicateAtTheSameTime");
+    try {
+      deploymentBuilder.deploy();
       fail();
     } catch (Exception e) {
       // Verify that nothing is deployed

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/AcquirableJobCacheTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/AcquirableJobCacheTest.java
@@ -95,10 +95,11 @@ public class AcquirableJobCacheTest {
     testRule.deploy(process);
     runtimeService.startProcessInstanceByKey("startTimer");
     Execution execution = runtimeService.createExecutionQuery().activityId("userTask").singleResult();
+    var executionId = execution.getId();
 
     try {
       // when
-      fetchTimerJobAfterCachedAcquirableJob(execution.getId());
+      fetchTimerJobAfterCachedAcquirableJob(executionId);
       fail("expected exception");
     } catch (Exception e) {
       // then

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/interceptor/CommandContextInterceptorTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/interceptor/CommandContextInterceptorTest.java
@@ -40,8 +40,9 @@ public class CommandContextInterceptorTest extends PluggableProcessEngineTest {
 
   @Test
   public void testCommandContextGetCurrentAfterException() {
+    var commandExecutor = processEngineConfiguration.getCommandExecutorTxRequired();
     try {
-      processEngineConfiguration.getCommandExecutorTxRequired().execute(commandContext -> {
+      commandExecutor.execute(commandContext -> {
         throw new IllegalStateException("here i come!");
       });
 
@@ -110,8 +111,9 @@ public class CommandContextInterceptorTest extends PluggableProcessEngineTest {
    testRule.deploy(modelInstance);
 
     boolean errorThrown = false;
+    var commandExecutor = processEngineConfiguration.getCommandExecutorTxRequired();
     try {
-      processEngineConfiguration.getCommandExecutorTxRequired().execute(commandContext -> {
+      commandExecutor.execute(commandContext -> {
 
         runtimeService.startProcessInstanceByKey("processThrowingThrowable");
         return null;


### PR DESCRIPTION
Resolves Sonar issues of type java:S5778 Only one method invocation is expected when testing runtime exceptions

related to #88