### PR TITLE
refactor: Extract method calls in try-blocks within tests to variables

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/GroupQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/GroupQueryTest.java
@@ -102,11 +102,14 @@ public class GroupQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidId() {
     GroupQuery query = identityService.createGroupQuery().groupId("invalid");
     verifyQueryResults(query, 0);
+    var groupQuery = identityService.createGroupQuery();
 
     try {
-      identityService.createGroupQuery().groupId(null).list();
+      groupQuery.groupId(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Provided id is null", e.getMessage());
+    }
   }
 
   @Test
@@ -149,11 +152,14 @@ public class GroupQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidName() {
     GroupQuery query = identityService.createGroupQuery().groupName("invalid");
     verifyQueryResults(query, 0);
+    var groupQuery = identityService.createGroupQuery();
 
     try {
-      identityService.createGroupQuery().groupName(null).list();
+      groupQuery.groupName(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Provided name is null", e.getMessage());
+    }
   }
 
   @Test
@@ -175,11 +181,14 @@ public class GroupQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidNameLike() {
     GroupQuery query = identityService.createGroupQuery().groupNameLike("%invalid%");
     verifyQueryResults(query, 0);
+    var groupQuery = identityService.createGroupQuery();
 
     try {
-      identityService.createGroupQuery().groupNameLike(null).list();
+      groupQuery.groupNameLike(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Provided nameLike is null", e.getMessage());
+    }
   }
 
   @Test
@@ -195,11 +204,14 @@ public class GroupQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidType() {
     GroupQuery query = identityService.createGroupQuery().groupType("invalid");
     verifyQueryResults(query, 0);
+    var groupQuery = identityService.createGroupQuery();
 
     try {
-      identityService.createGroupQuery().groupType(null).list();
+      groupQuery.groupType(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Provided type is null", e.getMessage());
+    }
   }
 
   @Test
@@ -228,11 +240,14 @@ public class GroupQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidMember() {
     GroupQuery query = identityService.createGroupQuery().groupMember("invalid");
     verifyQueryResults(query, 0);
+    var groupQuery = identityService.createGroupQuery();
 
     try {
-      identityService.createGroupQuery().groupMember(null).list();
+      groupQuery.groupMember(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Provided userId is null", e.getMessage());
+    }
   }
 
   @Test
@@ -277,13 +292,14 @@ public class GroupQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryInvalidSortingUsage() {
+    var groupQuery = identityService.createGroupQuery().orderByGroupId().orderByGroupName();
     try {
-      identityService.createGroupQuery().orderByGroupId().list();
+      groupQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
 
     try {
-      identityService.createGroupQuery().orderByGroupId().orderByGroupName().list();
+      groupQuery.list();
       fail();
     } catch (ProcessEngineException e) {}
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/EventSubscriptionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/EventSubscriptionQueryTest.java
@@ -61,11 +61,13 @@ public class EventSubscriptionQueryTest extends PluggableProcessEngineTest {
     assertEquals(1, query.count());
     assertEquals(1, query.list().size());
     assertNotNull(query.singleResult());
+    var eventSubscriptionQuery = runtimeService.createEventSubscriptionQuery();
 
     try {
-      runtimeService.createEventSubscriptionQuery().eventSubscriptionId(null).list();
+      eventSubscriptionQuery.eventSubscriptionId(null);
       fail("Expected ProcessEngineException");
     } catch (ProcessEngineException e) {
+      assertEquals("event subscription id is null", e.getMessage());
     }
 
     cleanDb();
@@ -85,11 +87,13 @@ public class EventSubscriptionQueryTest extends PluggableProcessEngineTest {
       .eventName("messageName2")
       .list();
     assertEquals(1, list.size());
+    var eventSubscriptionQuery = runtimeService.createEventSubscriptionQuery();
 
     try {
-      runtimeService.createEventSubscriptionQuery().eventName(null).list();
+      eventSubscriptionQuery.eventName(null);
       fail("Expected ProcessEngineException");
     } catch (ProcessEngineException e) {
+      assertEquals("event name is null", e.getMessage());
     }
 
     cleanDb();
@@ -110,11 +114,13 @@ public class EventSubscriptionQueryTest extends PluggableProcessEngineTest {
       .eventType("message")
       .list();
     assertEquals(2, list.size());
+    var eventSubscriptionQuery = runtimeService.createEventSubscriptionQuery();
 
     try {
-      runtimeService.createEventSubscriptionQuery().eventType(null).list();
+      eventSubscriptionQuery.eventType(null);
       fail("Expected ProcessEngineException");
     } catch (ProcessEngineException e) {
+      assertEquals("event type is null", e.getMessage());
     }
 
     cleanDb();
@@ -136,11 +142,13 @@ public class EventSubscriptionQueryTest extends PluggableProcessEngineTest {
       .eventType("message")
       .list();
     assertEquals(2, list.size());
+    var eventSubscriptionQuery = runtimeService.createEventSubscriptionQuery();
 
     try {
-      runtimeService.createEventSubscriptionQuery().activityId(null).list();
+      eventSubscriptionQuery.activityId(null);
       fail("Expected ProcessEngineException");
     } catch (ProcessEngineException e) {
+      assertEquals("activity id is null", e.getMessage());
     }
 
     cleanDb();
@@ -173,11 +181,13 @@ public class EventSubscriptionQueryTest extends PluggableProcessEngineTest {
     assertNotNull(signalSubscription);
 
     assertEquals(signalSubscription, subscription);
+    var eventSubscriptionQuery = runtimeService.createEventSubscriptionQuery();
 
     try {
-      runtimeService.createEventSubscriptionQuery().executionId(null).list();
+      eventSubscriptionQuery.executionId(null);
       fail("Expected ProcessEngineException");
     } catch (ProcessEngineException e) {
+      assertEquals("execution id is null", e.getMessage());
     }
 
     cleanDb();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/async/FoxJobRetryCmdTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/async/FoxJobRetryCmdTest.java
@@ -238,9 +238,10 @@ public class FoxJobRetryCmdTest extends PluggableProcessEngineTest {
     Job job = managementService.createJobQuery().singleResult();
 
     assertEquals(3, job.getRetries());
+    var jobId = job.getId();
 
     try {
-      managementService.executeJob(job.getId());
+      managementService.executeJob(jobId);
       fail();
     } catch (Exception e) {
       // expected

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/conditional/EventSubProcessStartConditionalEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/conditional/EventSubProcessStartConditionalEventTest.java
@@ -1056,10 +1056,11 @@ public class EventSubProcessStartConditionalEventTest extends AbstractConditiona
 
     // given suspended process
     ProcessInstance procInst = runtimeService.startProcessInstanceByKey(CONDITIONAL_EVENT_PROCESS_KEY);
+    var processInstanceId = procInst.getId();
     runtimeService.suspendProcessInstanceById(procInst.getId());
 
     //when wrong variable is set
-    runtimeService.setVariable(procInst.getId(), VARIABLE_NAME+1, 1);
+    runtimeService.setVariable(processInstanceId, VARIABLE_NAME+1, 1);
 
     //then nothing happens
     assertTrue(runtimeService.createProcessInstanceQuery().singleResult().isSuspended());
@@ -1067,12 +1068,12 @@ public class EventSubProcessStartConditionalEventTest extends AbstractConditiona
     //when variable which triggers condition is set
     //then exception is expected
     try {
-      runtimeService.setVariable(procInst.getId(), VARIABLE_NAME, 1);
+      runtimeService.setVariable(processInstanceId, VARIABLE_NAME, 1);
       fail("Should fail!");
     } catch (SuspendedEntityInteractionException seie) {
       //expected
     }
-    runtimeService.activateProcessInstanceById(procInst.getId());
+    runtimeService.activateProcessInstanceById(processInstanceId);
     tasksAfterVariableIsSet = taskService.createTaskQuery().list();
   }
 
@@ -1089,10 +1090,11 @@ public class EventSubProcessStartConditionalEventTest extends AbstractConditiona
 
     // given suspended process
     ProcessInstance procInst = runtimeService.startProcessInstanceByKey(CONDITIONAL_EVENT_PROCESS_KEY);
+    var processInstanceId = procInst.getId();
     runtimeService.suspendProcessInstanceById(procInst.getId());
 
     //when wrong variable is set
-    runtimeService.setVariable(procInst.getId(), VARIABLE_NAME+1, 1);
+    runtimeService.setVariable(processInstanceId, VARIABLE_NAME+1, 1);
 
     //then nothing happens
     assertTrue(runtimeService.createProcessInstanceQuery().singleResult().isSuspended());
@@ -1100,12 +1102,12 @@ public class EventSubProcessStartConditionalEventTest extends AbstractConditiona
     //when variable which triggers condition is set
     //then exception is expected
     try {
-      runtimeService.setVariable(procInst.getId(), VARIABLE_NAME, 1);
+      runtimeService.setVariable(processInstanceId, VARIABLE_NAME, 1);
       fail("Should fail!");
     } catch (SuspendedEntityInteractionException seie) {
       //expected
     }
-    runtimeService.activateProcessInstanceById(procInst.getId());
+    runtimeService.activateProcessInstanceById(processInstanceId);
     tasksAfterVariableIsSet = taskService.createTaskQuery().list();
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/escalation/EscalationEventParseInvalidProcessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/escalation/EscalationEventParseInvalidProcessTest.java
@@ -27,6 +27,7 @@ import junit.framework.AssertionFailedError;
 import org.operaton.bpm.engine.ParseException;
 import org.operaton.bpm.engine.Problem;
 import org.operaton.bpm.engine.RepositoryService;
+import org.operaton.bpm.engine.repository.DeploymentBuilder;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.junit.Before;
@@ -91,14 +92,11 @@ public class EscalationEventParseInvalidProcessTest {
 
   @Test
   public void testParseInvalidProcessDefinition() {
+    var deploymentBuilder = repositoryService.createDeployment()
+      .addClasspathResource(PROCESS_DEFINITION_DIRECTORY + processDefinitionResource);
+
     try {
-      String deploymentId = repositoryService.createDeployment()
-        .addClasspathResource(PROCESS_DEFINITION_DIRECTORY + processDefinitionResource)
-        .deploy().getId();
-
-      // in case that the deployment do not fail
-      repositoryService.deleteDeployment(deploymentId, true);
-
+      deploymentBuilder.deploy();
       fail("exception expected: " + expectedErrorMessage);
     } catch (ParseException e) {
       assertExceptionMessageContainsText(e, expectedErrorMessage);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/EventBasedGatewayTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/EventBasedGatewayTest.java
@@ -146,11 +146,11 @@ public class EventBasedGatewayTest extends PluggableProcessEngineTest {
 
   @Test
   public void testConnectedToActitity() {
+    var deploymentBuilder = repositoryService.createDeployment()
+        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/gateway/EventBasedGatewayTest.testConnectedToActivity.bpmn20.xml");
 
     try {
-      repositoryService.createDeployment()
-        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/gateway/EventBasedGatewayTest.testConnectedToActivity.bpmn20.xml")
-        .deploy();
+      deploymentBuilder.deploy();
       fail("exception expected");
     } catch (ParseException e) {
       assertTrue(e.getMessage().contains("Event based gateway can only be connected to elements of type intermediateCatchEvent"));
@@ -161,11 +161,11 @@ public class EventBasedGatewayTest extends PluggableProcessEngineTest {
 
   @Test
   public void testInvalidSequenceFlow() {
+    var deploymentBuilder = repositoryService.createDeployment()
+        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/gateway/EventBasedGatewayTest.testEventInvalidSequenceFlow.bpmn20.xml");
 
     try {
-      repositoryService.createDeployment()
-        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/gateway/EventBasedGatewayTest.testEventInvalidSequenceFlow.bpmn20.xml")
-        .deploy();
+      deploymentBuilder.deploy();
       fail("exception expected");
     } catch (ParseException e) {
       assertTrue(e.getMessage().contains("Invalid incoming sequenceflow for intermediateCatchEvent"));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/ExclusiveGatewayTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/ExclusiveGatewayTest.java
@@ -74,8 +74,9 @@ public class ExclusiveGatewayTest extends PluggableProcessEngineTest {
   @Deployment
   @Test
   public void testNoSequenceFlowSelected() {
+    var variables = CollectionUtil.singletonMap("input", 4);
     try {
-      runtimeService.startProcessInstanceByKey("exclusiveGwNoSeqFlowSelected", CollectionUtil.singletonMap("input", 4));
+      runtimeService.startProcessInstanceByKey("exclusiveGwNoSeqFlowSelected", variables);
       fail();
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent("ENGINE-02004 No outgoing sequence flow for the element with id 'exclusiveGw' could be selected for continuing the process.", e.getMessage());
@@ -97,10 +98,10 @@ public class ExclusiveGatewayTest extends PluggableProcessEngineTest {
   @Deployment(resources = {"org/operaton/bpm/engine/test/bpmn/gateway/ExclusiveGatewayTest.testDivergingExclusiveGateway.bpmn20.xml"})
   @Test
   public void testUnknownVariableInExpression() {
+    var variables = CollectionUtil.singletonMap("iinput", 1);
     // Instead of 'input' we're starting a process instance with the name 'iinput' (ie. a typo)
     try {
-      runtimeService.startProcessInstanceByKey(
-            "exclusiveGwDiverging", CollectionUtil.singletonMap("iinput", 1));
+      runtimeService.startProcessInstanceByKey("exclusiveGwDiverging", variables);
       fail();
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent("Unknown property used in expression", e.getMessage());
@@ -159,9 +160,9 @@ public class ExclusiveGatewayTest extends PluggableProcessEngineTest {
   @Deployment
   @Test
   public void testInvalidMethodExpression() {
+    var variables = CollectionUtil.singletonMap("order", new ExclusiveGatewayTestOrder(50));
     try {
-      runtimeService.startProcessInstanceByKey("invalidMethodExpression",
-            CollectionUtil.singletonMap("order", new ExclusiveGatewayTestOrder(50)));
+      runtimeService.startProcessInstanceByKey("invalidMethodExpression", variables);
       fail();
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent("Unknown method used in expression", e.getMessage());
@@ -212,8 +213,9 @@ public class ExclusiveGatewayTest extends PluggableProcessEngineTest {
             "    <userTask id='theTask2' name='Default input' /> " +
             "  </process>" +
             "</definitions>";
+    var deploymentBuilder = repositoryService.createDeployment().addString("myprocess.bpmn20.xml", flowWithoutConditionNoDefaultFlow);
     try {
-      repositoryService.createDeployment().addString("myprocess.bpmn20.xml", flowWithoutConditionNoDefaultFlow).deploy();
+      deploymentBuilder.deploy();
       fail("Could deploy a process definition with a sequence flow out of a XOR Gateway without condition with is not the default flow.");
     }
     catch (ParseException e) {
@@ -244,8 +246,9 @@ public class ExclusiveGatewayTest extends PluggableProcessEngineTest {
             "    <userTask id='theTask2' name='Default input' /> " +
             "  </process>" +
             "</definitions>";
+    var deploymentBuilder = repositoryService.createDeployment().addString("myprocess.bpmn20.xml", defaultFlowWithCondition);
     try {
-      repositoryService.createDeployment().addString("myprocess.bpmn20.xml", defaultFlowWithCondition).deploy();
+      deploymentBuilder.deploy();
       fail("Could deploy a process definition with a sequence flow out of a XOR Gateway without condition with is not the default flow.");
     }
     catch (ParseException e) {
@@ -266,8 +269,9 @@ public class ExclusiveGatewayTest extends PluggableProcessEngineTest {
             "    <exclusiveGateway id='exclusiveGw' name='Exclusive Gateway' /> " +
             "  </process>" +
             "</definitions>";
+    var deploymentBuilder = repositoryService.createDeployment().addString("myprocess.bpmn20.xml", noOutgoingFlow);
     try {
-      repositoryService.createDeployment().addString("myprocess.bpmn20.xml", noOutgoingFlow).deploy();
+      deploymentBuilder.deploy();
       fail("Could deploy a process definition with a sequence flow out of a XOR Gateway without condition with is not the default flow.");
     }
     catch (ParseException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/el/ExpressionBeanAccessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/el/ExpressionBeanAccessTest.java
@@ -58,11 +58,12 @@ public class ExpressionBeanAccessTest {
     // Exposed bean returns 'I'm exposed' when to-string is called in first service-task
     ProcessInstance pi = runtimeService.startProcessInstanceByKey("expressionBeanAccess");
     assertEquals("I'm exposed", runtimeService.getVariable(pi.getId(), "exposedBeanResult"));
+    var processInstanceId = pi.getId();
 
     // After signaling, an expression tries to use a bean that is present in the configuration but
     // is not added to the beans-list
     try {
-      runtimeService.signal(pi.getId());
+      runtimeService.signal(processInstanceId);
       fail("Exception expected");
     } catch(ProcessEngineException ae) {
       assertNotNull(ae.getCause());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/FullHistoryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/FullHistoryTest.java
@@ -728,50 +728,56 @@ public class FullHistoryTest {
 
   @Test
   public void testHistoricDetailQueryInvalidSorting() {
+    var historicDetailQuery = historyService.createHistoricDetailQuery();
     try {
-      historyService.createHistoricDetailQuery().asc().list();
+      historicDetailQuery.asc();
       fail();
     } catch (ProcessEngineException e) {
 
     }
 
     try {
-      historyService.createHistoricDetailQuery().desc().list();
+      historicDetailQuery.desc();
       fail();
     } catch (ProcessEngineException e) {
 
     }
 
+    HistoricDetailQuery queryOrderByProcessInstanceId = historicDetailQuery.orderByProcessInstanceId();
     try {
-      historyService.createHistoricDetailQuery().orderByProcessInstanceId().list();
+      queryOrderByProcessInstanceId.list();
       fail();
     } catch (ProcessEngineException e) {
 
     }
 
+    HistoricDetailQuery queryOrderByTime = historicDetailQuery.orderByTime();
     try {
-      historyService.createHistoricDetailQuery().orderByTime().list();
+      queryOrderByTime.list();
       fail();
     } catch (ProcessEngineException e) {
 
     }
 
+    HistoricDetailQuery queryOrderByVariableName = historicDetailQuery.orderByVariableName();
     try {
-      historyService.createHistoricDetailQuery().orderByVariableName().list();
+      queryOrderByVariableName.list();
       fail();
     } catch (ProcessEngineException e) {
 
     }
 
+    HistoricDetailQuery queryOrderByVariableRevision = historicDetailQuery.orderByVariableRevision();
     try {
-      historyService.createHistoricDetailQuery().orderByVariableRevision().list();
+      queryOrderByVariableRevision.list();
       fail();
     } catch (ProcessEngineException e) {
 
     }
 
+    HistoricDetailQuery queryByVariableType = historicDetailQuery.orderByVariableType();
     try {
-      historyService.createHistoricDetailQuery().orderByVariableType().list();
+      queryByVariableType.list();
       fail();
     } catch (ProcessEngineException e) {
 
@@ -873,10 +879,11 @@ public class FullHistoryTest {
   public void testDeleteRunningHistoricProcessInstance() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("HistoricTaskInstanceTest");
     assertNotNull(processInstance);
+    var processInstanceId = processInstance.getId();
 
     try {
       // Delete the historic process-instance, which is still running
-      historyService.deleteHistoricProcessInstance(processInstance.getId());
+      historyService.deleteHistoricProcessInstance(processInstanceId);
       fail("Exception expected when deleting process-instance that is still running");
     } catch(ProcessEngineException ae) {
       // Expected exception


### PR DESCRIPTION
Resolves Sonar issues of type java:S5778 Only one method invocation is expected when testing runtime exceptions

related to #88