### PR TITLE
refactor: Extract method calls in try-blocks within tests to variables

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricProcessInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricProcessInstanceAuthorizationTest.java
@@ -515,13 +515,13 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
     enableAuthorization();
 
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
+    var historicProcessInstanceReport = historyService
+        .createHistoricProcessInstanceReport()
+        .processDefinitionIdIn(processInstance1.getProcessDefinitionId(), processInstance2.getProcessDefinitionId());
 
     // when
     try {
-      historyService
-        .createHistoricProcessInstanceReport()
-        .processDefinitionIdIn(processInstance1.getProcessDefinitionId(), processInstance2.getProcessDefinitionId())
-        .duration(PeriodUnit.MONTH);
+      historicProcessInstanceReport.duration(PeriodUnit.MONTH);
 
       // then
       fail("Exception expected: It should not be possible to create a historic process instance report");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricBatchQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricBatchQueryTest.java
@@ -151,8 +151,9 @@ public class HistoricBatchQueryTest {
 
   @Test
   public void testBatchQueryByIdNull() {
+    var historicBatchQuery = historyService.createHistoricBatchQuery();
     try {
-      historyService.createHistoricBatchQuery().batchId(null).singleResult();
+      historicBatchQuery.batchId(null);
       Assert.fail("exception expected");
     }
     catch (NullValueException e) {
@@ -212,8 +213,9 @@ public class HistoricBatchQueryTest {
 
   @Test
   public void testBatchQueryByTypeNull() {
+    var historicBatchQuery = historyService.createHistoricBatchQuery();
     try {
-      historyService.createHistoricBatchQuery().type(null).singleResult();
+      historicBatchQuery.type(null);
       Assert.fail("exception expected");
     }
     catch (NullValueException e) {
@@ -328,25 +330,25 @@ public class HistoricBatchQueryTest {
 
   @Test
   public void testBatchQueryOrderingPropertyWithoutOrder() {
+    var historicBatchQuery = historyService.createHistoricBatchQuery().orderById();
     try {
-      historyService.createHistoricBatchQuery().orderById().singleResult();
+      historicBatchQuery.singleResult();
       Assert.fail("exception expected");
     }
     catch (NotValidException e) {
-      assertThat(e.getMessage()).contains("Invalid query: "
-          + "call asc() or desc() after using orderByXX()");
+      assertThat(e.getMessage()).contains("Invalid query: call asc() or desc() after using orderByXX()");
     }
   }
 
   @Test
   public void testBatchQueryOrderWithoutOrderingProperty() {
+    var historicBatchQuery = historyService.createHistoricBatchQuery();
     try {
-      historyService.createHistoricBatchQuery().asc().singleResult();
+      historicBatchQuery.asc();
       Assert.fail("exception expected");
     }
     catch (NotValidException e) {
-      assertThat(e.getMessage()).contains("You should call any of the orderBy methods "
-          + "first before specifying a direction");
+      assertThat(e.getMessage()).contains("You should call any of the orderBy methods first before specifying a direction");
     }
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricActivityInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricActivityInstanceTest.java
@@ -445,12 +445,11 @@ public class HistoricActivityInstanceTest extends PluggableProcessEngineTest {
 
   @Test
   public void testHistoricActivityInstanceQueryByCompleteScopeAndCanceled() {
-    try {
-      historyService
+    var historicActivityInstanceQuery = historyService
           .createHistoricActivityInstanceQuery()
-          .completeScope()
-          .canceled()
-          .list();
+          .completeScope();
+    try {
+      historicActivityInstanceQuery.canceled();
       fail("It should not be possible to query by completeScope and canceled.");
     } catch (ProcessEngineException e) {
       // exception expected

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
@@ -582,8 +582,9 @@ public class HistoricCaseActivityInstanceTest extends CmmnTest {
 
   @Test
   public void testInvalidSorting() {
+    var historicCaseActivityInstanceQuery = historicQuery();
     try {
-      historicQuery().asc();
+      historicCaseActivityInstanceQuery.asc();
       fail("Exception expected");
     }
     catch (ProcessEngineException e) {
@@ -591,15 +592,16 @@ public class HistoricCaseActivityInstanceTest extends CmmnTest {
     }
 
     try {
-      historicQuery().desc();
+      historicCaseActivityInstanceQuery.desc();
       fail("Exception expected");
     }
     catch (ProcessEngineException e) {
       // expected
     }
 
+    var historicCaseActivityInstanceQuery1 = historicQuery().orderByHistoricCaseActivityInstanceId();
     try {
-      historicQuery().orderByHistoricCaseActivityInstanceId().count();
+      historicCaseActivityInstanceQuery1.count();
       fail("Exception expected");
     }
     catch (ProcessEngineException e) {
@@ -902,14 +904,15 @@ public class HistoricCaseActivityInstanceTest extends CmmnTest {
 
     // then
     assertCount(0, query);
+    var historicCaseActivityInstanceQuery = historicQuery();
 
     try {
-      historicQuery().caseActivityInstanceIdIn((String[])null);
+      historicCaseActivityInstanceQuery.caseActivityInstanceIdIn((String[])null);
       fail("A NotValidException was expected.");
     } catch (NotValidException e) {}
 
     try {
-      historicQuery().caseActivityInstanceIdIn((String)null);
+      historicCaseActivityInstanceQuery.caseActivityInstanceIdIn((String)null);
       fail("A NotValidException was expected.");
     } catch (NotValidException e) {}
   }
@@ -940,14 +943,15 @@ public class HistoricCaseActivityInstanceTest extends CmmnTest {
 
     // then
     assertCount(0, query);
+    var historicCaseActivityInstanceQuery = historicQuery();
 
     try {
-      historicQuery().caseActivityIdIn((String[])null);
+      historicCaseActivityInstanceQuery.caseActivityIdIn((String[])null);
       fail("A NotValidException was expected.");
     } catch (NotValidException e) {}
 
     try {
-      historicQuery().caseActivityIdIn((String)null);
+      historicCaseActivityInstanceQuery.caseActivityIdIn((String)null);
       fail("A NotValidException was expected.");
     } catch (NotValidException e) {}
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityStatisticsQueryTest.java
@@ -62,13 +62,13 @@ public class HistoricCaseActivityStatisticsQueryTest {
 
   @Test
   public void testCaseDefinitionNull() {
+    var historicCaseActivityStatisticsQuery = historyService
+        .createHistoricCaseActivityStatisticsQuery(null);
     // given
 
     // when
     try {
-      historyService
-        .createHistoricCaseActivityStatisticsQuery(null)
-        .list();
+      historicCaseActivityStatisticsQuery.list();
       fail("It should not be possible to query for statistics by null.");
     } catch (NullValueException exception) {
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIncidentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIncidentQueryTest.java
@@ -558,9 +558,10 @@ public class HistoricIncidentQueryTest {
   @Test
   public void testQueryByInvalidOpen() {
     HistoricIncidentQuery query = historyService.createHistoricIncidentQuery();
+    var historicIncidentQuery = query.open();
 
     try {
-      query.open().open();
+      historicIncidentQuery.open();
       fail("It was possible to set a the open flag twice.");
     } catch (ProcessEngineException e) { }
   }
@@ -583,9 +584,10 @@ public class HistoricIncidentQueryTest {
   @Test
   public void testQueryByInvalidResolved() {
     HistoricIncidentQuery query = historyService.createHistoricIncidentQuery();
+    var historicIncidentQuery = query.resolved();
 
     try {
-      query.resolved().resolved();
+      historicIncidentQuery.resolved();
       fail("It was possible to set a the resolved flag twice.");
     } catch (ProcessEngineException e) { }
   }
@@ -608,9 +610,10 @@ public class HistoricIncidentQueryTest {
   @Test
   public void testQueryByInvalidDeleted() {
     HistoricIncidentQuery query = historyService.createHistoricIncidentQuery();
+    var historicIncidentQuery = query.deleted();
 
     try {
-      query.deleted().deleted();
+      historicIncidentQuery.deleted();
       fail("It was possible to set a the deleted flag twice.");
     } catch (ProcessEngineException e) { }
   }
@@ -666,9 +669,9 @@ public class HistoricIncidentQueryTest {
 
   @Test
   public void testQueryByNullJobDefinitionId() {
+    var historicIncidentQuery = historyService.createHistoricIncidentQuery();
     try {
-      historyService.createHistoricIncidentQuery()
-        .jobDefinitionIdIn((String) null);
+      historicIncidentQuery.jobDefinitionIdIn((String) null);
       fail("Should fail");
     }
     catch (NullValueException e) {
@@ -678,9 +681,9 @@ public class HistoricIncidentQueryTest {
 
   @Test
   public void testQueryByNullJobDefinitionIds() {
+    var historicIncidentQuery = historyService.createHistoricIncidentQuery();
     try {
-      historyService.createHistoricIncidentQuery()
-        .jobDefinitionIdIn((String[]) null);
+      historicIncidentQuery.jobDefinitionIdIn((String[]) null);
       fail("Should fail");
     }
     catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricJobLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricJobLogTest.java
@@ -159,9 +159,10 @@ public class HistoricJobLogTest {
     JobEntity job = (JobEntity) managementService
         .createJobQuery()
         .singleResult();
+    var jobId = job.getId();
 
     try {
-      managementService.executeJob(job.getId());
+      managementService.executeJob(jobId);
       fail("exception expected");
     } catch (Exception e) {
       // expected
@@ -1325,10 +1326,11 @@ public class HistoricJobLogTest {
 
     runtimeService.startProcessInstanceByKey("process", Variables.createVariables().putValue("delegate", delegate));
     Job job = managementService.createJobQuery().singleResult();
+    var jobId = job.getId();
 
     // when
     try {
-      managementService.executeJob(job.getId());
+      managementService.executeJob(jobId);
       fail("exception expected");
     } catch (Exception e) {
       // expected

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceStateTest.java
@@ -201,16 +201,16 @@ public class HistoricProcessInstanceStateTest {
         .endEvent()
         .done();
     ProcessDefinition processDefinition = processEngineTestRule.deployAndGetDefinition(instance);
+    processEngineRule.getRuntimeService().startProcessInstanceById(processDefinition.getId());
 
+    var jobId = processEngineRule.getManagementService().createJobQuery().executable().singleResult().getId();
+    var managementService = processEngineRule.getManagementService();
 
     try {
-      ProcessInstance pi = processEngineRule.getRuntimeService()
-          .startProcessInstanceById(processDefinition.getId());
-      processEngineRule.getManagementService().executeJob(
-          processEngineRule.getManagementService().createJobQuery().executable().singleResult().getId());
+      managementService.executeJob(jobId);
       fail("exception expected");
     } catch (Exception e) {
-      //expected
+      assertThat(e.getMessage()).contains("Unable to evaluate script while executing activity");
     }
 
     assertThat(processEngineRule.getRuntimeService().createProcessInstanceQuery().active().list()).hasSize(1);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
@@ -474,21 +474,23 @@ public class HistoricProcessInstanceTest {
 
   @Test
   public void testHistoricProcessInstanceQueryWithIncidentMessageNull() {
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
     try {
-      historyService.createHistoricProcessInstanceQuery().incidentMessage(null).count();
+      historicProcessInstanceQuery.incidentMessage(null);
       fail("incidentMessage with null value is not allowed");
     } catch( NullValueException nex ) {
-      // expected
+      assertEquals("incidentMessage is null", nex.getMessage());
     }
   }
 
   @Test
   public void testHistoricProcessInstanceQueryWithIncidentMessageLikeNull() {
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
     try {
-      historyService.createHistoricProcessInstanceQuery().incidentMessageLike(null).count();
+      historicProcessInstanceQuery.incidentMessageLike(null);
       fail("incidentMessageLike with null value is not allowed");
     } catch( NullValueException nex ) {
-      // expected
+      assertEquals("incidentMessageLike is null", nex.getMessage());
     }
   }
 
@@ -542,14 +544,16 @@ public class HistoricProcessInstanceTest {
     exludeIds.add("oneTaskProcess");
     assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTaskProcess").processDefinitionKeyNotIn(exludeIds).count());
     assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionKeyNotIn(exludeIds).count());
+    var emptyProcessDefinitionKeys = List.of("");
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
 
     try {
       // oracle handles empty string like null which seems to lead to undefined behavior of the LIKE comparison
-      historyService.createHistoricProcessInstanceQuery().processDefinitionKeyNotIn(Arrays.asList(""));
+      historicProcessInstanceQuery.processDefinitionKeyNotIn(emptyProcessDefinitionKeys);
       fail("Exception expected");
     }
     catch (NotValidException e) {
-      // expected
+      assertEquals("processDefinitionKeys contains empty string", e.getMessage());
     }
 
     // After finishing process
@@ -663,25 +667,27 @@ public class HistoricProcessInstanceTest {
 
   @Test
   public void testInvalidSorting() {
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
     try {
-      historyService.createHistoricProcessInstanceQuery().asc();
+      historicProcessInstanceQuery.asc();
       fail();
     } catch (ProcessEngineException e) {
-
+      assertEquals("You should call any of the orderBy methods first before specifying a direction: currentOrderingProperty is null", e.getMessage());
     }
 
     try {
-      historyService.createHistoricProcessInstanceQuery().desc();
+      historicProcessInstanceQuery.desc();
       fail();
     } catch (ProcessEngineException e) {
-
+      assertEquals("You should call any of the orderBy methods first before specifying a direction: currentOrderingProperty is null", e.getMessage());
     }
 
+    var historicProcessInstanceQuery1 = historicProcessInstanceQuery.orderByProcessInstanceId();
     try {
-      historyService.createHistoricProcessInstanceQuery().orderByProcessInstanceId().list();
+      historicProcessInstanceQuery1.list();
       fail();
     } catch (ProcessEngineException e) {
-
+      assertEquals("Invalid query: call asc() or desc() after using orderByXX(): direction is null", e.getMessage());
     }
   }
 
@@ -1508,9 +1514,9 @@ public class HistoricProcessInstanceTest {
 
   @Test
   public void testHistoricProcInstQueryWithExecutedActivityIdsNull() {
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
     try {
-      historyService.createHistoricProcessInstanceQuery()
-      .executedActivityIdIn((String[]) null).list();
+      historicProcessInstanceQuery.executedActivityIdIn((String[]) null);
       fail("exception expected");
     } catch (BadUserRequestException e) {
       assertThat(e.getMessage()).contains("activity ids is null");
@@ -1519,9 +1525,9 @@ public class HistoricProcessInstanceTest {
 
   @Test
   public void testHistoricProcInstQueryWithExecutedActivityIdsContainNull() {
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
     try {
-      historyService.createHistoricProcessInstanceQuery()
-      .executedActivityIdIn(null, "1").list();
+      historicProcessInstanceQuery.executedActivityIdIn(null, "1");
       fail("exception expected");
     } catch (BadUserRequestException e) {
       assertThat(e.getMessage()).contains("activity ids contains null");
@@ -1556,9 +1562,9 @@ public class HistoricProcessInstanceTest {
 
   @Test
   public void shouldFailWhenQueryByNullActivityId() {
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
     try {
-      historyService.createHistoricProcessInstanceQuery()
-          .activityIdIn((String) null);
+      historicProcessInstanceQuery.activityIdIn((String) null);
       fail("exception expected");
     }
     catch (BadUserRequestException e) {
@@ -1568,9 +1574,9 @@ public class HistoricProcessInstanceTest {
 
   @Test
   public void shouldFailWhenQueryByNullActivityIds() {
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
     try {
-      historyService.createHistoricProcessInstanceQuery()
-          .activityIdIn((String[]) null);
+      historicProcessInstanceQuery.activityIdIn((String[]) null);
       fail("exception expected");
     }
     catch (BadUserRequestException e) {
@@ -2021,8 +2027,9 @@ public class HistoricProcessInstanceTest {
 
     // when: incident is raised
     for(int i = 0; i<3; i++) {
+      var jobId = job.getId();
       try {
-        managementService.executeJob(job.getId());
+        managementService.executeJob(jobId);
         fail("Exception expected");
       } catch (Exception e) {
         // exception expected
@@ -2042,9 +2049,9 @@ public class HistoricProcessInstanceTest {
 
   @Test
   public void testHistoricProcInstQueryWithActiveActivityIdsNull() {
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
     try {
-      historyService.createHistoricProcessInstanceQuery()
-      .activeActivityIdIn((String[]) null).list();
+      historicProcessInstanceQuery.activeActivityIdIn((String[]) null);
       fail("exception expected");
     } catch (BadUserRequestException e) {
       assertThat(e.getMessage()).contains("activity ids is null");
@@ -2053,9 +2060,9 @@ public class HistoricProcessInstanceTest {
 
   @Test
   public void testHistoricProcInstQueryWithActiveActivityIdsContainNull() {
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
     try {
-      historyService.createHistoricProcessInstanceQuery()
-      .activeActivityIdIn(null, "1").list();
+      historicProcessInstanceQuery.activeActivityIdIn(null, "1");
       fail("exception expected");
     } catch (BadUserRequestException e) {
       assertThat(e.getMessage()).contains("activity ids contains null");
@@ -2165,10 +2172,10 @@ public class HistoricProcessInstanceTest {
 
   @Test
   public void testQueryByOneInvalidProcessDefinitionKeyIn() {
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
     try {
       // when
-      historyService.createHistoricProcessInstanceQuery()
-        .processDefinitionKeyIn((String) null);
+      historicProcessInstanceQuery.processDefinitionKeyIn((String) null);
       fail();
     } catch(ProcessEngineException expected) {
       // then Exception is expected
@@ -2177,10 +2184,10 @@ public class HistoricProcessInstanceTest {
 
   @Test
   public void testQueryByMultipleInvalidProcessDefinitionKeyIn() {
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
     try {
       // when
-      historyService.createHistoricProcessInstanceQuery()
-        .processDefinitionKeyIn(ProcessModels.PROCESS_KEY, null);
+      historicProcessInstanceQuery.processDefinitionKeyIn(ProcessModels.PROCESS_KEY, null);
       fail();
     } catch(ProcessEngineException expected) {
       // then Exception is expected
@@ -2250,11 +2257,12 @@ public class HistoricProcessInstanceTest {
 
   @Test
   public void shouldFailWhenQueryWithNullIncidentIdIn() {
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
     try {
-      historyService.createHistoricProcessInstanceQuery().incidentIdIn(null).list();
+      historicProcessInstanceQuery.incidentIdIn(null);
       fail("incidentMessage with null value is not allowed");
     } catch( NullValueException nex ) {
-      // expected
+      assertEquals("incidentIds is null", nex.getMessage());
     }
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
@@ -42,6 +42,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
@@ -106,9 +107,10 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
     startProcessInstanceAndEvaluateDecision();
 
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
+    var historicDecisionInstance = query.singleResult();
 
     try {
-      query.singleResult().getOutputs();
+      historicDecisionInstance.getOutputs();
       fail("expected exception: output not fetched");
     } catch (ProcessEngineException e) {
       // should throw exception if output is not fetched
@@ -250,10 +252,10 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
   public void testQueryByInvalidDecisionDefinitionIdIn() {
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
     try {
-      query.decisionDefinitionIdIn("aFake", null).count();
+      query.decisionDefinitionIdIn("aFake", null);
       fail("exception expected");
     } catch (ProcessEngineException e) {
-      //expected
+      assertEquals("decisionDefinitionIdIn contains null value", e.getMessage());
     }
   }
 
@@ -279,10 +281,10 @@ public class HistoricDecisionInstanceQueryTest extends PluggableProcessEngineTes
   public void testQueryByInvalidDecisionDefinitionKeyIn() {
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
     try {
-      query.decisionDefinitionKeyIn("aFake", null).count();
+      query.decisionDefinitionKeyIn("aFake", null);
       fail("exception expected");
     } catch (ProcessEngineException e) {
-      //expected
+      assertEquals("decisionDefinitionKeyIn contains null value", e.getMessage());
     }
   }
 


### PR DESCRIPTION
Resolves Sonar issues of type java:S5778 Only one method invocation is expected when testing runtime exceptions

related to #88