### PR TITLE
refactor: Extract method calls in try-blocks within tests to variables

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceAuthorizationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceAuthorizationsTest.java
@@ -295,10 +295,11 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
 
     processEngineConfiguration.setAuthorizationEnabled(true);
     identityService.setAuthentication("admin", null, null);
+    var lockedUserId = lockedUser.getId();
 
     // when
     try {
-      identityService.unlockUser(lockedUser.getId());
+      identityService.unlockUser(lockedUserId);
       fail("expected exception");
     } catch (AuthorizationException e) {
       assertTrue(e.getMessage().contains("ENGINE-03029 Required admin authenticated group or user."));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceTenantTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceTenantTest.java
@@ -154,9 +154,9 @@ public class IdentityServiceTenantTest {
   @Test
   public void testInvalidTenantIdOnUpdate() {
     String invalidId = "john's tenant";
+    Tenant updatedTenant = identityService.newTenant("john");
+    updatedTenant.setId(invalidId);
     try {
-      Tenant updatedTenant = identityService.newTenant("john");
-      updatedTenant.setId(invalidId);
       identityService.saveTenant(updatedTenant);
 
       fail("Invalid tenant id exception expected!");
@@ -175,8 +175,9 @@ public class IdentityServiceTenantTest {
     String invalidId = "john's tenant";
 
     Tenant tenant = processEngine.getIdentityService().newTenant(invalidId);
+    var identityService = processEngine.getIdentityService();
     try {
-      processEngine.getIdentityService().saveTenant(tenant);
+      identityService.saveTenant(tenant);
       fail("Invalid tenant id exception expected!");
     } catch (ProcessEngineException ex) {
       assertEquals(String.format(INVALID_ID_MESSAGE, "Tenant", invalidId), ex.getMessage());
@@ -192,11 +193,12 @@ public class IdentityServiceTenantTest {
 
     String validId = "johnsTenant";
     String invalidId = "john!@#$%";
+    Tenant tenant = processEngine.getIdentityService().newTenant(validId);
+    tenant.setId(invalidId);
+    var identityService = processEngine.getIdentityService();
 
     try {
-      Tenant tenant = processEngine.getIdentityService().newTenant(validId);
-      tenant.setId(invalidId);
-      processEngine.getIdentityService().saveTenant(tenant);
+      identityService.saveTenant(tenant);
 
       fail("Invalid tenant id exception expected!");
     } catch (ProcessEngineException ex) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceTest.java
@@ -919,9 +919,9 @@ public class IdentityServiceTest {
   @Test
   public void testInvalidUserIdOnSave() {
     String invalidId = "john doe";
+    User updatedUser = identityService.newUser("john");
+    updatedUser.setId(invalidId);
     try {
-      User updatedUser = identityService.newUser("john");
-      updatedUser.setId(invalidId);
       identityService.saveUser(updatedUser);
 
       fail("Invalid user id exception expected!");
@@ -945,9 +945,9 @@ public class IdentityServiceTest {
   @Test
   public void testInvalidGroupIdOnSave() {
     String invalidId = "john's group";
+    Group updatedGroup = identityService.newGroup("group");
+    updatedGroup.setId(invalidId);
     try {
-      Group updatedGroup = identityService.newGroup("group");
-      updatedGroup.setId(invalidId);
       identityService.saveGroup(updatedGroup);
 
       fail("Invalid group id exception expected!");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/IncidentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/IncidentTest.java
@@ -130,10 +130,11 @@ public class IncidentTest extends PluggableProcessEngineTest {
     Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
 
     assertNotNull(job);
+    var jobId = job.getId();
 
     // set job retries to 1 -> should fail again and a second incident should be created
     try {
-      managementService.executeJob(job.getId());
+      managementService.executeJob(jobId);
       fail("Exception was expected.");
     } catch (ProcessEngineException e) {
       // exception expected
@@ -531,10 +532,12 @@ public class IncidentTest extends PluggableProcessEngineTest {
     });
 
     assertEquals(0, job.getRetries());
+    var jobId = job.getJobDefinitionId();
+    var jobDefinitionId = job.getJobDefinitionId();
 
     // retries should still be 0 after execution this job again
     try {
-      managementService.executeJob(job.getId());
+      managementService.executeJob(jobId);
       fail("Exception expected");
     }
     catch (ProcessEngineException e) {
@@ -549,7 +552,7 @@ public class IncidentTest extends PluggableProcessEngineTest {
 
     // it should not be possible to set the retries to a negative number with the management service
     try {
-      managementService.setJobRetries(job.getId(), -200);
+      managementService.setJobRetries(jobId, -200);
       fail("Exception expected");
     }
     catch (ProcessEngineException e) {
@@ -557,7 +560,7 @@ public class IncidentTest extends PluggableProcessEngineTest {
     }
 
     try {
-      managementService.setJobRetriesByJobDefinitionId(job.getJobDefinitionId(), -300);
+      managementService.setJobRetriesByJobDefinitionId(jobDefinitionId, -300);
       fail("Exception expected");
     }
     catch (ProcessEngineException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobDefinitionQueryTest.java
@@ -62,9 +62,10 @@ public class JobDefinitionQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidJobDefinitionId() {
     JobDefinitionQuery query = managementService.createJobDefinitionQuery().jobDefinitionId("invalid");
     verifyQueryResults(query, 0);
+    var jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
     try {
-      managementService.createJobDefinitionQuery().jobDefinitionId(null);
+      jobDefinitionQuery.jobDefinitionId(null);
       fail("A ProcessEngineExcpetion was expected.");
     } catch (ProcessEngineException e) {}
   }
@@ -90,16 +91,21 @@ public class JobDefinitionQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidActivityId() {
     JobDefinitionQuery query = managementService.createJobDefinitionQuery().activityIdIn("invalid");
     verifyQueryResults(query, 0);
+    var jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
     try {
-      managementService.createJobDefinitionQuery().activityIdIn(null);
+      jobDefinitionQuery.activityIdIn(null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Activity ids is null", e.getMessage());
+    }
 
     try {
-      managementService.createJobDefinitionQuery().activityIdIn((String)null);
+      jobDefinitionQuery.activityIdIn((String)null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Activity ids contains null value", e.getMessage());
+    }
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/JobDefinitionQueryTest.testBase.bpmn"})
@@ -116,9 +122,10 @@ public class JobDefinitionQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidDefinitionId() {
     JobDefinitionQuery query = managementService.createJobDefinitionQuery().processDefinitionId("invalid");
     verifyQueryResults(query, 0);
+    var jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
     try {
-      managementService.createJobDefinitionQuery().processDefinitionId(null);
+      jobDefinitionQuery.processDefinitionId(null);
       fail("A ProcessEngineExcpetion was expected.");
     } catch (ProcessEngineException e) {}
   }
@@ -137,9 +144,10 @@ public class JobDefinitionQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidDefinitionKey() {
     JobDefinitionQuery query = managementService.createJobDefinitionQuery().processDefinitionKey("invalid");
     verifyQueryResults(query, 0);
+    var jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
     try {
-      managementService.createJobDefinitionQuery().processDefinitionKey(null);
+      jobDefinitionQuery.processDefinitionKey(null);
       fail("A ProcessEngineExcpetion was expected.");
     } catch (ProcessEngineException e) {}
   }
@@ -165,9 +173,10 @@ public class JobDefinitionQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidJobType() {
     JobDefinitionQuery query = managementService.createJobDefinitionQuery().jobType("invalid");
     verifyQueryResults(query, 0);
+    var jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
     try {
-      managementService.createJobDefinitionQuery().jobType(null);
+      jobDefinitionQuery.jobType(null);
       fail("A ProcessEngineExcpetion was expected.");
     } catch (ProcessEngineException e) {}
   }
@@ -177,9 +186,10 @@ public class JobDefinitionQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidJobConfiguration() {
     JobDefinitionQuery query = managementService.createJobDefinitionQuery().jobConfiguration("invalid");
     verifyQueryResults(query, 0);
+    var jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
     try {
-      managementService.createJobDefinitionQuery().jobConfiguration(null);
+      jobDefinitionQuery.jobConfiguration(null);
       fail("A ProcessEngineExcpetion was expected.");
     } catch (ProcessEngineException e) {}
   }
@@ -290,15 +300,17 @@ public class JobDefinitionQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryInvalidSortingUsage() {
+    var jobDefinitionQuery = managementService.createJobDefinitionQuery().orderByJobDefinitionId();
     try {
-      managementService.createJobDefinitionQuery().orderByJobDefinitionId().list();
+      jobDefinitionQuery.list();
       fail();
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent("call asc() or desc() after using orderByXX()", e.getMessage());
     }
 
+    var jobQuery = managementService.createJobQuery();
     try {
-      managementService.createJobQuery().asc();
+      jobQuery.asc();
       fail();
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent("You should call any of the orderBy methods first before specifying a direction", e.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobEntityTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobEntityTest.java
@@ -173,10 +173,11 @@ public class JobEntityTest {
 
     runtimeService.startProcessInstanceByKey("process", Variables.createVariables().putValue("fail", true));
     JobEntity job = (JobEntity) managementService.createJobQuery().singleResult();
+    var jobId = job.getId();
 
     // when
     try {
-      managementService.executeJob(job.getId());
+      managementService.executeJob(jobId);
       fail("Exception expected");
     } catch (Exception e) {
       // exception expected
@@ -203,10 +204,11 @@ public class JobEntityTest {
 
     runtimeService.startProcessInstanceByKey("process", Variables.createVariables().putValue("fail", true));
     JobEntity job = (JobEntity) managementService.createJobQuery().singleResult();
+    var jobId = job.getId();
 
     // when
     try {
-      managementService.executeJob(job.getId());
+      managementService.executeJob(jobId);
       fail("Exception expected");
     } catch (Exception e) {
       // exception expected
@@ -235,10 +237,11 @@ public class JobEntityTest {
 
     runtimeService.startProcessInstanceByKey("process", Variables.createVariables().putValue("fail", true));
     JobEntity job = (JobEntity) managementService.createJobQuery().singleResult();
+    var jobId = job.getId();
 
     // when
     try {
-      managementService.executeJob(job.getId());
+      managementService.executeJob(jobId);
       fail("Exception expected");
     } catch (Exception e) {
       // exception expected

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/IncidentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/IncidentQueryTest.java
@@ -546,9 +546,9 @@ public class IncidentQueryTest {
 
   @Test
   public void testQueryByNullJobDefinitionId() {
+    var incidentQuery = runtimeService.createIncidentQuery();
     try {
-      runtimeService.createIncidentQuery()
-        .jobDefinitionIdIn((String) null);
+      incidentQuery.jobDefinitionIdIn((String) null);
       fail("Should fail");
     }
     catch (NullValueException e) {
@@ -558,9 +558,9 @@ public class IncidentQueryTest {
 
   @Test
   public void testQueryByNullJobDefinitionIds() {
+    var incidentQuery = runtimeService.createIncidentQuery();
     try {
-      runtimeService.createIncidentQuery()
-        .jobDefinitionIdIn((String[]) null);
+      incidentQuery.jobDefinitionIdIn((String[]) null);
       fail("Should fail");
     }
     catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/conditional/IntermediateConditionalEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/conditional/IntermediateConditionalEventTest.java
@@ -492,11 +492,12 @@ public class IntermediateConditionalEventTest extends AbstractConditionalEventTe
 
     //then nothing happens
     assertTrue(runtimeService.createProcessInstanceQuery().singleResult().isSuspended());
+    var processInstanceId = procInst.getId();
 
     //when variable which triggers condition is set
     //then exception is expected
     try {
-      runtimeService.setVariable(procInst.getId(), VARIABLE_NAME, 1);
+      runtimeService.setVariable(processInstanceId, VARIABLE_NAME, 1);
       fail("Should fail!");
     } catch (SuspendedEntityInteractionException seie) {
       //expected

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/InclusiveGatewayTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/InclusiveGatewayTest.java
@@ -130,8 +130,9 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
   @Deployment
   @Test
   public void testNoSequenceFlowSelected() {
+    var variables = CollectionUtil.singletonMap("input", 4);
     try {
-      runtimeService.startProcessInstanceByKey("inclusiveGwNoSeqFlowSelected", CollectionUtil.singletonMap("input", 4));
+      runtimeService.startProcessInstanceByKey("inclusiveGwNoSeqFlowSelected", variables);
       fail();
     } catch (ProcessEngineException e) {
        testRule.assertTextPresent("ENGINE-02004 No outgoing sequence flow for the element with id 'inclusiveGw' could be selected for continuing the process.", e.getMessage());
@@ -199,10 +200,11 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
   @Deployment(resources = { "org/operaton/bpm/engine/test/bpmn/gateway/InclusiveGatewayTest.testDivergingInclusiveGateway.bpmn20.xml" })
   @Test
   public void testUnknownVariableInExpression() {
+    var variables = CollectionUtil.singletonMap("iinput", 1);
     // Instead of 'input' we're starting a process instance with the name
     // 'iinput' (ie. a typo)
     try {
-      runtimeService.startProcessInstanceByKey("inclusiveGwDiverging", CollectionUtil.singletonMap("iinput", 1));
+      runtimeService.startProcessInstanceByKey("inclusiveGwDiverging", variables);
       fail();
     } catch (ProcessEngineException e) {
        testRule.assertTextPresent("Unknown property used in expression", e.getMessage());
@@ -296,9 +298,10 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
       expectedNames.remove(t.getName());
     }
     assertEquals(0, expectedNames.size());
+    var variables = CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(300));
 
     try {
-      runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnBeanMethod", CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(300)));
+      runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnBeanMethod", variables);
       fail();
     } catch (ProcessEngineException e) {
       // Should get an exception indicating that no path could be taken
@@ -309,11 +312,12 @@ public class InclusiveGatewayTest extends PluggableProcessEngineTest {
   @Deployment
   @Test
   public void testInvalidMethodExpression() {
+    var variables = CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(50));
     try {
-      runtimeService.startProcessInstanceByKey("inclusiveInvalidMethodExpression", CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(50)));
+      runtimeService.startProcessInstanceByKey("inclusiveInvalidMethodExpression", variables);
       fail();
     } catch (ProcessEngineException e) {
-       testRule.assertTextPresent("Unknown method used in expression", e.getMessage());
+      testRule.assertTextPresent("Unknown method used in expression", e.getMessage());
     }
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputEventTest.java
@@ -123,12 +123,12 @@ public class InputOutputEventTest extends PluggableProcessEngineTest {
 
   @Test
   public void testMessageStartEvent() {
+    var deploymentBuilder = repositoryService
+        .createDeployment()
+        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputEventTest.testMessageStartEvent.bpmn20.xml");
 
     try {
-      repositoryService
-        .createDeployment()
-        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputEventTest.testMessageStartEvent.bpmn20.xml")
-        .deploy();
+      deploymentBuilder.deploy();
       fail("expected exception");
     } catch (ParseException e) {
       testRule.assertTextPresent("operaton:inputOutput mapping unsupported for element type 'startEvent'", e.getMessage());
@@ -138,11 +138,11 @@ public class InputOutputEventTest extends PluggableProcessEngineTest {
 
   @Test
   public void testNoneEndEvent() {
-    try {
-      repositoryService
+    var deploymentBuilder = repositoryService
         .createDeployment()
-        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputEventTest.testNoneEndEvent.bpmn20.xml")
-        .deploy();
+        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputEventTest.testNoneEndEvent.bpmn20.xml");
+    try {
+      deploymentBuilder.deploy();
       fail("expected exception");
     } catch (ParseException e) {
       testRule.assertTextPresent("operaton:outputParameter not allowed for element type 'endEvent'", e.getMessage());
@@ -254,11 +254,11 @@ public class InputOutputEventTest extends PluggableProcessEngineTest {
 
   @Test
   public void testMessageBoundaryEvent() {
-    try {
-      repositoryService
+    var deploymentBuilder = repositoryService
         .createDeployment()
-        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputEventTest.testMessageBoundaryEvent.bpmn20.xml")
-        .deploy();
+        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputEventTest.testMessageBoundaryEvent.bpmn20.xml");
+    try {
+      deploymentBuilder.deploy();
       fail("expected exception");
     } catch (ParseException e) {
       testRule.assertTextPresent("operaton:inputOutput mapping unsupported for element type 'boundaryEvent'", e.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputTest.java
@@ -831,11 +831,11 @@ public class InputOutputTest extends PluggableProcessEngineTest {
 
   @Test
   public void testInterruptingEventSubprocessIoSupport() {
-    try {
-      repositoryService
+    var deploymentBuilder = repositoryService
         .createDeployment()
-        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputTest.testInterruptingEventSubprocessIoSupport.bpmn")
-        .deploy();
+        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputTest.testInterruptingEventSubprocessIoSupport.bpmn");
+    try {
+      deploymentBuilder.deploy();
       fail("exception expected");
     } catch (ParseException e) {
       // happy path
@@ -1016,10 +1016,10 @@ public class InputOutputTest extends PluggableProcessEngineTest {
 
   @Test
   public void testMIOutputMappingDisallowed() {
+    var deploymentBuilder = repositoryService.createDeployment()
+      .addClasspathResource("org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputTest.testMIOutputMappingDisallowed.bpmn20.xml");
     try {
-      repositoryService.createDeployment()
-      .addClasspathResource("org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputTest.testMIOutputMappingDisallowed.bpmn20.xml")
-      .deploy();
+      deploymentBuilder.deploy();
       fail("Exception expected");
     } catch (ParseException e) {
       testRule.assertTextPresent("operaton:outputParameter not allowed for multi-instance constructs", e.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/job/JobPrioritizationBpmnConstantValueTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/job/JobPrioritizationBpmnConstantValueTest.java
@@ -200,11 +200,11 @@ public class JobPrioritizationBpmnConstantValueTest extends PluggableProcessEngi
 
   @Test
   public void testFailOnMalformedInput() {
-    try {
-      repositoryService
+    var deploymentBuilder = repositoryService
         .createDeployment()
-        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/job/invalidPrioProcess.bpmn20.xml")
-        .deploy();
+        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/job/invalidPrioProcess.bpmn20.xml");
+    try {
+      deploymentBuilder.deploy();
       fail("deploying a process with malformed priority should not succeed");
     } catch (ParseException e) {
       testRule.assertTextPresentIgnoreCase("value 'thisIsNotANumber' for attribute 'jobPriority' "

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/job/JobPrioritizationBpmnExpressionValueTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/job/JobPrioritizationBpmnExpressionValueTest.java
@@ -114,12 +114,12 @@ public class JobPrioritizationBpmnExpressionValueTest extends PluggableProcessEn
   @Ignore("CAM-4207")
   @Test
   public void testVariableValueExpressionPrioritizationFailsWhenVariableMisses() {
+    var processInstantiationBuilder = runtimeService
+        .createProcessInstanceByKey("jobPrioExpressionProcess")
+        .startBeforeActivity("task1");
     // when
     try {
-      runtimeService
-        .createProcessInstanceByKey("jobPrioExpressionProcess")
-        .startBeforeActivity("task1")
-        .execute();
+      processInstantiationBuilder.execute();
       fail("this should not succeed since the priority variable is not defined");
     } catch (ProcessEngineException e) {
 
@@ -148,13 +148,13 @@ public class JobPrioritizationBpmnExpressionValueTest extends PluggableProcessEn
   @Deployment(resources = "org/operaton/bpm/engine/test/bpmn/job/jobPrioExpressionProcess.bpmn20.xml")
   @Test
   public void testExpressionEvaluatesToNull() {
-    // when
-    try {
-      runtimeService
+    var processInstantiationBuilder = runtimeService
         .createProcessInstanceByKey("jobPrioExpressionProcess")
         .startBeforeActivity("task3")
-        .setVariable("priority", null)
-        .execute();
+        .setVariable("priority", null);
+    // when
+    try {
+      processInstantiationBuilder.execute();
       fail("this should not succeed since the priority variable is not defined");
     } catch (ProcessEngineException e) {
       testRule.assertTextPresentIgnoreCase("Priority value is not an Integer", e.getMessage());
@@ -164,13 +164,13 @@ public class JobPrioritizationBpmnExpressionValueTest extends PluggableProcessEn
   @Deployment(resources = "org/operaton/bpm/engine/test/bpmn/job/jobPrioExpressionProcess.bpmn20.xml")
   @Test
   public void testExpressionEvaluatesToNonNumericalValue() {
-    // when
-    try {
-      runtimeService
+    var processInstantiationBuilder = runtimeService
         .createProcessInstanceByKey("jobPrioExpressionProcess")
         .startBeforeActivity("task3")
-        .setVariable("priority", "aNonNumericalVariableValue")
-        .execute();
+        .setVariable("priority", "aNonNumericalVariableValue");
+    // when
+    try {
+      processInstantiationBuilder.execute();
       fail("this should not succeed since the priority must be integer");
     } catch (ProcessEngineException e) {
       testRule.assertTextPresentIgnoreCase("Priority value is not an Integer", e.getMessage());
@@ -180,13 +180,13 @@ public class JobPrioritizationBpmnExpressionValueTest extends PluggableProcessEn
   @Deployment(resources = "org/operaton/bpm/engine/test/bpmn/job/jobPrioExpressionProcess.bpmn20.xml")
   @Test
   public void testExpressionEvaluatesToNonIntegerValue() {
-    // when
-    try {
-      runtimeService
+    var processInstantiationBuilder = runtimeService
         .createProcessInstanceByKey("jobPrioExpressionProcess")
         .startBeforeActivity("task3")
-        .setVariable("priority", 4.2d)
-        .execute();
+        .setVariable("priority", 4.2d);
+    // when
+    try {
+      processInstantiationBuilder.execute();
       fail("this should not succeed since the priority must be integer");
     } catch (ProcessEngineException e) {
       testRule.assertTextPresentIgnoreCase("Priority value must be either Short, Integer, or Long",
@@ -237,12 +237,12 @@ public class JobPrioritizationBpmnExpressionValueTest extends PluggableProcessEn
   public void testDisableGracefulDegradation() {
     try {
       processEngineConfiguration.setEnableGracefulDegradationOnContextSwitchFailure(false);
+      var processInstantiationBuilder = runtimeService
+          .createProcessInstanceByKey("jobPrioExpressionProcess")
+          .startBeforeActivity("task1");
 
       try {
-        runtimeService
-          .createProcessInstanceByKey("jobPrioExpressionProcess")
-          .startBeforeActivity("task1")
-          .execute();
+        processInstantiationBuilder.execute();
         fail("should not succeed due to missing variable");
       } catch (ProcessEngineException e) {
         testRule.assertTextPresentIgnoreCase("unknown property used in expression", e.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/servicetask/JavaServiceTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/servicetask/JavaServiceTaskTest.java
@@ -100,8 +100,9 @@ public class JavaServiceTaskTest extends PluggableProcessEngineTest {
 
   @Test
   public void testIllegalUseOfResultVariableName() {
+    var deploymentBuilder = repositoryService.createDeployment().addClasspathResource("org/operaton/bpm/engine/test/bpmn/servicetask/JavaServiceTaskTest.testIllegalUseOfResultVariableName.bpmn20.xml");
     try {
-      repositoryService.createDeployment().addClasspathResource("org/operaton/bpm/engine/test/bpmn/servicetask/JavaServiceTaskTest.testIllegalUseOfResultVariableName.bpmn20.xml").deploy();
+      deploymentBuilder.deploy();
       fail();
     } catch (ProcessEngineException e) {
       assertTrue(e.getMessage().contains("resultVariable"));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/subprocess/InterruptingEventSubProcessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/subprocess/InterruptingEventSubProcessTest.java
@@ -61,9 +61,10 @@ public class InterruptingEventSubProcessTest extends PluggableProcessEngineTest 
     assertEquals("taskAfterMessageStartEvent", task.getTaskDefinitionKey());
 
     assertEquals(0, eventSubscriptionQuery.count());
+    var processInstanceId = pi.getId();
 
     try {
-      runtimeService.signalEventReceived("newSignal", pi.getId());
+      runtimeService.signalEventReceived("newSignal", processInstanceId);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
       // expected exception;
@@ -96,9 +97,10 @@ public class InterruptingEventSubProcessTest extends PluggableProcessEngineTest 
     assertEquals("tastAfterSignalStartEvent", task.getTaskDefinitionKey());
 
     assertEquals(0, eventSubscriptionQuery.count());
+    var processInstanceId = pi.getId();
 
     try {
-      runtimeService.messageEventReceived("newMessage", pi.getId());
+      runtimeService.messageEventReceived("newMessage", processInstanceId);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
       // expected exception;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorCmdExceptionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorCmdExceptionTest.java
@@ -121,11 +121,12 @@ public class JobExecutorCmdExceptionTest extends PluggableProcessEngineTest {
 
     // execute the existing job
     Job job = managementService.createJobQuery().singleResult();
+    var jobId = job.getId();
 
     assertEquals(3, job.getRetries());
 
     try {
-      managementService.executeJob(job.getId());
+      managementService.executeJob(jobId);
       fail("Exception expected");
     } catch (Exception e) {
       // expected


### PR DESCRIPTION
Resolves Sonar issues of type java:S5778 Only one method invocation is expected when testing runtime exceptions

related to #88