### PR TITLE
refactor: Extract method calls in try-blocks within tests to variables

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/container/impl/jmx/kernel/MBeanServiceContainerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/jmx/kernel/MBeanServiceContainerTest.java
@@ -34,6 +34,7 @@ import org.operaton.bpm.container.impl.jmx.kernel.util.StartServiceDeploymentOpe
 import org.operaton.bpm.container.impl.jmx.kernel.util.StopServiceDeploymentOperationStep;
 import org.operaton.bpm.container.impl.jmx.kernel.util.TestService;
 import org.operaton.bpm.container.impl.jmx.kernel.util.TestServiceType;
+import org.operaton.bpm.container.impl.spi.DeploymentOperation;
 import org.operaton.bpm.container.impl.spi.PlatformService;
 import org.junit.After;
 import org.junit.Before;
@@ -234,13 +235,13 @@ public class MBeanServiceContainerTest {
 
   @Test
   public void testFailingDeploymentOperation() {
+    var deploymentOperationBuilder = serviceContainer.createDeploymentOperation("test failing op")
+        .addStep(new StartServiceDeploymentOperationStep(service1Name, service1))
+        .addStep(new StartServiceDeploymentOperationStep(service2Name, service2))
+        .addStep(new FailingDeploymentOperationStep());
 
     try {
-      serviceContainer.createDeploymentOperation("test failing op")
-        .addStep(new StartServiceDeploymentOperationStep(service1Name, service1))
-        .addStep(new FailingDeploymentOperationStep())                               // <- this step fails
-        .addStep(new StartServiceDeploymentOperationStep(service2Name, service2))
-        .execute();
+      deploymentOperationBuilder.execute();
 
       fail("Exception expected");
 
@@ -255,12 +256,12 @@ public class MBeanServiceContainerTest {
 
     // different step ordering //////////////////////////////////
 
+    var deploymentOperationBuilder1 = serviceContainer.createDeploymentOperation("test failing op")
+      .addStep(new StartServiceDeploymentOperationStep(service1Name, service1))
+      .addStep(new StartServiceDeploymentOperationStep(service2Name, service2))
+      .addStep(new FailingDeploymentOperationStep());
     try {
-      serviceContainer.createDeploymentOperation("test failing op")
-        .addStep(new StartServiceDeploymentOperationStep(service1Name, service1))
-        .addStep(new StartServiceDeploymentOperationStep(service2Name, service2))
-        .addStep(new FailingDeploymentOperationStep())                               // <- this step fails
-        .execute();
+      deploymentOperationBuilder1.execute();
 
       fail("Exception expected");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskCommentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskCommentAuthorizationTest.java
@@ -41,10 +41,11 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
     // given
     createTask(TASK_ID);
     Comment createdComment = createComment(TASK_ID, null, "aComment");
+    var createdCommentId = createdComment.getId();
 
     try {
       // when
-      taskService.deleteTaskComment(TASK_ID, createdComment.getId());
+      taskService.deleteTaskComment(TASK_ID, createdCommentId);
       fail("Exception expected: It should not be possible to delete a comment.");
     } catch (AuthorizationException e) {
       // then
@@ -121,10 +122,11 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
     // given
     createTask(TASK_ID);
     Comment createdComment = createComment(TASK_ID, null, "originalComment");
+    var createdCommentId = createdComment.getId();
 
     try {
       // when
-      taskService.updateTaskComment(TASK_ID, createdComment.getId(), "updateMessage");
+      taskService.updateTaskComment(TASK_ID, createdCommentId, "updateMessage");
       fail("Exception expected: It should not be possible to delete a comment.");
     } catch (AuthorizationException e) {
       // then
@@ -163,12 +165,12 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
   public void testDeleteProcessTaskCommentWithoutAuthorization() {
     // given
     ProcessInstance processInstance = startProcessInstanceByKey(PROCESS_KEY);
-    Task task = selectSingleTask();
-    Comment createdComment = createComment(task.getId(), processInstance.getId(), "aComment");
+    var taskId = selectSingleTask().getId();
+    var createdCommentId = createComment(taskId, processInstance.getId(), "aComment").getId();
 
     try {
       // when
-      taskService.deleteTaskComment(task.getId(), createdComment.getId());
+      taskService.deleteTaskComment(taskId, createdCommentId);
       fail("Exception expected: It should not be possible to delete a comment.");
     } catch (AuthorizationException e) {
       // then
@@ -202,11 +204,12 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
     // given
     ProcessInstance processInstance = startProcessInstanceByKey(PROCESS_KEY);
     Task task = selectSingleTask();
-    createComment(task.getId(), processInstance.getId(), "aComment");
+    var taskId = task.getId();
+    createComment(taskId, processInstance.getId(), "aComment");
 
     try {
       // when
-      taskService.deleteTaskComments(task.getId());
+      taskService.deleteTaskComments(taskId);
       fail("Exception expected: It should not be possible to delete a comment.");
     } catch (AuthorizationException e) {
       // then
@@ -240,13 +243,12 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
   public void testUpdateProcessTaskCommentWithoutAuthorization() {
     // given
     ProcessInstance processInstance = startProcessInstanceByKey(PROCESS_KEY);
-    Task task = selectSingleTask();
-
-    Comment createdComment = createComment(task.getId(), processInstance.getId(), "originalComment");
+    var taskId = selectSingleTask().getId();
+    var createdCommentId = createComment(taskId, processInstance.getId(), "originalComment").getId();
 
     try {
       // when
-      taskService.updateTaskComment(task.getId(), createdComment.getId(), "updateMessage");
+      taskService.updateTaskComment(taskId, createdCommentId, "updateMessage");
       fail("Exception expected: It should not be possible to delete a comment.");
     } catch (AuthorizationException e) {
       // then

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/SetExternalTasksRetriesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/SetExternalTasksRetriesTest.java
@@ -191,11 +191,9 @@ public class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
     }
 
     externalTaskIds.add(null);
-    Batch batch = null;
 
     try {
-      batch = externalTaskService.setRetriesAsync(externalTaskIds, null, 10);
-      executeSeedAndBatchJobs(batch);
+      externalTaskService.setRetriesAsync(externalTaskIds, null, 10);
       fail("exception expected");
     } catch (BadUserRequestException e) {
       assertThat(e.getMessage()).contains("External task id cannot be null");
@@ -230,8 +228,9 @@ public class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
 
     List<String> externalTaskIds = Arrays.asList("externalTaskId");
 
+    Batch batch = externalTaskService.setRetriesAsync(externalTaskIds, null, -10);
+
     try {
-      Batch batch = externalTaskService.setRetriesAsync(externalTaskIds, null, -10);
       executeSeedAndBatchJobs(batch);
       fail("exception expected");
     } catch (BadUserRequestException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/UserQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/UserQueryTest.java
@@ -99,9 +99,10 @@ public class UserQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidId() {
     UserQuery query = identityService.createUserQuery().userId("invalid");
     verifyQueryResults(query, 0);
+    var userQuery = identityService.createUserQuery();
 
     try {
-      identityService.createUserQuery().userId(null).singleResult();
+      userQuery.userId(null);
       fail();
     } catch (ProcessEngineException e) { }
   }
@@ -119,9 +120,10 @@ public class UserQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidFirstName() {
     UserQuery query = identityService.createUserQuery().userFirstName("invalid");
     verifyQueryResults(query, 0);
+    var userQuery = identityService.createUserQuery().userFirstName(null);
 
     try {
-      identityService.createUserQuery().userFirstName(null).singleResult();
+      userQuery.singleResult();
       fail();
     } catch (ProcessEngineException e) { }
   }
@@ -142,9 +144,10 @@ public class UserQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidFirstNameLike() {
     UserQuery query = identityService.createUserQuery().userFirstNameLike("%mispiggy%");
     verifyQueryResults(query, 0);
+    var userQuery = identityService.createUserQuery();
 
     try {
-      identityService.createUserQuery().userFirstNameLike(null).singleResult();
+      userQuery.userFirstNameLike(null);
       fail();
     } catch (ProcessEngineException e) { }
   }
@@ -162,9 +165,10 @@ public class UserQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidLastName() {
     UserQuery query = identityService.createUserQuery().userLastName("invalid");
     verifyQueryResults(query, 0);
+    var userQuery = identityService.createUserQuery().userLastName(null);
 
     try {
-      identityService.createUserQuery().userLastName(null).singleResult();
+      userQuery.singleResult();
       fail();
     } catch (ProcessEngineException e) { }
   }
@@ -182,9 +186,10 @@ public class UserQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidLastNameLike() {
     UserQuery query = identityService.createUserQuery().userLastNameLike("%invalid%");
     verifyQueryResults(query, 0);
+    var userQuery = identityService.createUserQuery();
 
     try {
-      identityService.createUserQuery().userLastNameLike(null).singleResult();
+      userQuery.userLastNameLike(null);
       fail();
     } catch (ProcessEngineException e) { }
   }
@@ -199,9 +204,10 @@ public class UserQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidEmail() {
     UserQuery query = identityService.createUserQuery().userEmail("invalid");
     verifyQueryResults(query, 0);
+    var userQuery = identityService.createUserQuery().userEmail(null);
 
     try {
-      identityService.createUserQuery().userEmail(null).singleResult();
+      userQuery.singleResult();
       fail();
     } catch (ProcessEngineException e) { }
   }
@@ -219,9 +225,10 @@ public class UserQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidEmailLike() {
     UserQuery query = identityService.createUserQuery().userEmailLike("%invalid%");
     verifyQueryResults(query, 0);
+    var userQuery = identityService.createUserQuery();
 
     try {
-      identityService.createUserQuery().userEmailLike(null).singleResult();
+      userQuery.userEmailLike(null);
       fail();
     } catch (ProcessEngineException e) { }
   }
@@ -250,13 +257,15 @@ public class UserQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryInvalidSortingUsage() {
+    var userQuery1 = identityService.createUserQuery().orderByUserId();
     try {
-      identityService.createUserQuery().orderByUserId().list();
+      userQuery1.list();
       fail();
     } catch (ProcessEngineException e) {}
 
+    var userQuery2 = identityService.createUserQuery().orderByUserId().orderByUserEmail();
     try {
-      identityService.createUserQuery().orderByUserId().orderByUserEmail().list();
+      userQuery2.list();
       fail();
     } catch (ProcessEngineException e) {}
   }
@@ -277,9 +286,10 @@ public class UserQueryTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidMemberOfGoup() {
     UserQuery query = identityService.createUserQuery().memberOfGroup("invalid");
     verifyQueryResults(query, 0);
+    var userQuery = identityService.createUserQuery();
 
     try {
-      identityService.createUserQuery().memberOfGroup(null).list();
+      userQuery.memberOfGroup(null);
       fail();
     } catch (ProcessEngineException e) { }
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.java
@@ -56,7 +56,11 @@ import org.junit.runners.Parameterized;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 /**
  * @author Joram Barrez
@@ -194,11 +198,14 @@ public class JobQueryTest {
   public void testQueryByInvalidActivityId(){
     JobQuery query = managementService.createJobQuery().activityId("invalid");
     verifyQueryResults(query, 0);
+    var jobQuery = managementService.createJobQuery();
 
     try {
-      managementService.createJobQuery().activityId(null).list();
+      jobQuery.activityId(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Provided activity id is null", e.getMessage());
+    }
   }
 
   @Test
@@ -213,11 +220,14 @@ public class JobQueryTest {
   public void testByInvalidJobDefinitionId() {
     JobQuery query = managementService.createJobQuery().jobDefinitionId("invalid");
     verifyQueryResults(query, 0);
+    var jobQuery = managementService.createJobQuery();
 
     try {
-      managementService.createJobQuery().jobDefinitionId(null).list();
+      jobQuery.jobDefinitionId(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Provided job definition id is null", e.getMessage());
+    }
   }
 
   @Test
@@ -230,11 +240,14 @@ public class JobQueryTest {
   public void testQueryByInvalidProcessInstanceId() {
     JobQuery query = managementService.createJobQuery().processInstanceId("invalid");
     verifyQueryResults(query, 0);
+    var jobQuery = managementService.createJobQuery();
 
     try {
-      managementService.createJobQuery().processInstanceId(null);
+      jobQuery.processInstanceId(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Provided process instance id is null", e.getMessage());
+    }
   }
 
   @Test
@@ -249,11 +262,14 @@ public class JobQueryTest {
   public void testQueryByInvalidExecutionId() {
     JobQuery query = managementService.createJobQuery().executionId("invalid");
     verifyQueryResults(query, 0);
+    var jobQuery = managementService.createJobQuery();
 
     try {
-      managementService.createJobQuery().executionId(null).list();
+      jobQuery.executionId(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Provided execution id is null", e.getMessage());
+    }
   }
 
   @Test
@@ -268,11 +284,14 @@ public class JobQueryTest {
   public void testQueryByInvalidProcessDefinitionId() {
     JobQuery query = managementService.createJobQuery().processDefinitionId("invalid");
     verifyQueryResults(query, 0);
+    var jobQuery = managementService.createJobQuery();
 
     try {
-      managementService.createJobQuery().processDefinitionId(null).list();
+      jobQuery.processDefinitionId(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Provided process definition id is null", e.getMessage());
+    }
   }
 
   @Test
@@ -307,11 +326,14 @@ public class JobQueryTest {
   public void testQueryByInvalidProcessDefinitionKey() {
     JobQuery query = managementService.createJobQuery().processDefinitionKey("invalid");
     verifyQueryResults(query, 0);
+    var jobQuery = managementService.createJobQuery();
 
     try {
-      managementService.createJobQuery().processDefinitionKey(null).list();
+      jobQuery.processDefinitionKey(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Provided process instance key is null", e.getMessage());
+    }
   }
 
   @Test
@@ -372,8 +394,9 @@ public class JobQueryTest {
 
   @Test
   public void testInvalidOnlyTimersUsage() {
+    var jobQuery = managementService.createJobQuery().timers();
     try {
-      managementService.createJobQuery().timers().messages().list();
+      jobQuery.messages();
       fail();
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Cannot combine onlyTimers() with onlyMessages() in the same query");
@@ -579,8 +602,9 @@ public class JobQueryTest {
 
   @Test
   public void testQueryByExceptionMessageNull() {
+    var jobQuery = managementService.createJobQuery();
     try {
-      managementService.createJobQuery().exceptionMessage(null);
+      jobQuery.exceptionMessage(null);
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException e) {
       assertEquals("Provided exception message is null", e.getMessage());
@@ -603,11 +627,14 @@ public class JobQueryTest {
   public void testQueryByInvalidFailedActivityId(){
     JobQuery query = managementService.createJobQuery().failedActivityId("invalid");
     verifyQueryResults(query, 0);
+    var jobQuery = managementService.createJobQuery();
 
     try {
-      managementService.createJobQuery().failedActivityId(null).list();
+      jobQuery.failedActivityId(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Provided activity id is null", e.getMessage());
+    }
   }
 
 
@@ -840,15 +867,17 @@ public class JobQueryTest {
 
   @Test
   public void testQueryInvalidSortingUsage() {
+    var jobQuery = managementService.createJobQuery().orderByJobId();
     try {
-      managementService.createJobQuery().orderByJobId().list();
+      jobQuery.list();
       fail();
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("call asc() or desc() after using orderByXX()");
     }
 
+    var jobQuery2 = managementService.createJobQuery();
     try {
-      managementService.createJobQuery().asc();
+      jobQuery2.asc();
       fail();
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("You should call any of the orderBy methods first before specifying a direction");
@@ -914,7 +943,8 @@ public class JobQueryTest {
     try {
       query.singleResult();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+    }
   }
 
   private void createJobWithoutExceptionMsg() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.java
@@ -130,9 +130,10 @@ public class ManagementServiceTest extends PluggableProcessEngineTest {
         .singleResult();
 
     assertNotNull("No job found for process instance", timerJob);
+    var timerJobId = timerJob.getId();
 
     try {
-      managementService.executeJob(timerJob.getId());
+      managementService.executeJob(timerJobId);
       fail("RuntimeException from within the script task expected");
     } catch (RuntimeException re) {
       testRule.assertTextPresent("This is an exception thrown from scriptTask", re.getMessage());
@@ -663,6 +664,7 @@ public class ManagementServiceTest extends PluggableProcessEngineTest {
 
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("timerOnTask");
     Job timerJob = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
+    var timerJobId = timerJob.getId();
 
     // We need to move time at least one hour to make the timer executable
     ClockUtil.setCurrentTime(new Date(ClockUtil.getCurrentTime().getTime() + 7200000L));
@@ -676,7 +678,7 @@ public class ManagementServiceTest extends PluggableProcessEngineTest {
 
     // Try to delete the job. This should fail.
     try {
-      managementService.deleteJob(timerJob.getId());
+      managementService.deleteJob(timerJobId);
       fail();
     } catch (ProcessEngineException e) {
       // Exception is expected

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyBatchTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyBatchTest.java
@@ -189,11 +189,12 @@ public class MultiTenancyBatchTest {
   public void testDeleteBatchFailsWithWrongTenant() {
     // given
     Batch batch = batchHelper.migrateProcessInstanceAsync(tenant2Definition, tenant2Definition);
+    var batchId = batch.getId();
 
     // when
     identityService.setAuthentication("user", null, singletonList(TENANT_ONE));
     try {
-      managementService.deleteBatch(batch.getId(), true);
+      managementService.deleteBatch(batchId, true);
       Assert.fail("exception expected");
     }
     catch (ProcessEngineException e) {
@@ -225,11 +226,12 @@ public class MultiTenancyBatchTest {
   public void testSuspendBatchFailsWithWrongTenant() {
     // given
     Batch batch = batchHelper.migrateProcessInstanceAsync(tenant2Definition, tenant2Definition);
+    var batchId = batch.getId();
 
     // when
     identityService.setAuthentication("user", null, singletonList(TENANT_ONE));
     try {
-      managementService.suspendBatchById(batch.getId());
+      managementService.suspendBatchById(batchId);
       Assert.fail("exception expected");
     }
     catch (ProcessEngineException e) {
@@ -263,11 +265,12 @@ public class MultiTenancyBatchTest {
     // given
     Batch batch = batchHelper.migrateProcessInstanceAsync(tenant2Definition, tenant2Definition);
     managementService.suspendBatchById(batch.getId());
+    var batchId = batch.getId();
 
     // when
     identityService.setAuthentication("user", null, singletonList(TENANT_ONE));
     try {
-      managementService.activateBatchById(batch.getId());
+      managementService.activateBatchById(batchId);
       Assert.fail("exception expected");
     }
     catch (ProcessEngineException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyBusinessRuleTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyBusinessRuleTaskTest.java
@@ -235,11 +235,11 @@ public class MultiTenancyBusinessRuleTaskTest extends PluggableProcessEngineTest
 
     testRule.deployForTenant(TENANT_ONE, process);
     testRule.deployForTenant(TENANT_TWO, DMN_FILE);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("process")
+        .processDefinitionTenantId(TENANT_ONE);
 
     try {
-      runtimeService.createProcessInstanceByKey("process")
-        .processDefinitionTenantId(TENANT_ONE)
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -261,11 +261,11 @@ public class MultiTenancyBusinessRuleTaskTest extends PluggableProcessEngineTest
 
     testRule.deployForTenant(TENANT_ONE, process);
     testRule.deployForTenant(TENANT_TWO, DMN_FILE);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("process")
+        .processDefinitionTenantId(TENANT_ONE);
 
     try {
-      runtimeService.createProcessInstanceByKey("process")
-        .processDefinitionTenantId(TENANT_ONE)
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -290,11 +290,11 @@ public class MultiTenancyBusinessRuleTaskTest extends PluggableProcessEngineTest
 
     testRule.deployForTenant(TENANT_TWO, DMN_FILE);
     testRule.deployForTenant(TENANT_TWO, DMN_FILE);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("process")
+        .processDefinitionTenantId(TENANT_ONE);
 
     try {
-      runtimeService.createProcessInstanceByKey("process")
-        .processDefinitionTenantId(TENANT_ONE)
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -320,12 +320,12 @@ public class MultiTenancyBusinessRuleTaskTest extends PluggableProcessEngineTest
     testRule.deployForTenant(TENANT_ONE, process);
 
     testRule.deployForTenant(TENANT_TWO, DMN_FILE_VERSION_TAG);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("process")
+        .processDefinitionTenantId(TENANT_ONE);
 
     try {
       // when
-      runtimeService.createProcessInstanceByKey("process")
-        .processDefinitionTenantId(TENANT_ONE)
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyCallActivityTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyCallActivityTest.java
@@ -169,11 +169,11 @@ public class MultiTenancyCallActivityTest extends PluggableProcessEngineTest {
 
     testRule.deployForTenant(TENANT_ONE, callingProcess);
     testRule.deployForTenant(TENANT_TWO, SUB_PROCESS);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("callingProcess")
+        .processDefinitionTenantId(TENANT_ONE);
 
     try {
-      runtimeService.createProcessInstanceByKey("callingProcess")
-        .processDefinitionTenantId(TENANT_ONE)
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -194,11 +194,11 @@ public class MultiTenancyCallActivityTest extends PluggableProcessEngineTest {
 
     testRule.deployForTenant(TENANT_ONE, callingProcess);
     testRule.deployForTenant(TENANT_TWO, SUB_PROCESS);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("callingProcess")
+        .processDefinitionTenantId(TENANT_ONE);
 
     try {
-      runtimeService.createProcessInstanceByKey("callingProcess")
-        .processDefinitionTenantId(TENANT_ONE)
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -222,11 +222,11 @@ public class MultiTenancyCallActivityTest extends PluggableProcessEngineTest {
 
     testRule.deployForTenant(TENANT_TWO, SUB_PROCESS);
     testRule.deployForTenant(TENANT_TWO, SUB_PROCESS);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("callingProcess")
+        .processDefinitionTenantId(TENANT_ONE);
 
     try {
-      runtimeService.createProcessInstanceByKey("callingProcess")
-        .processDefinitionTenantId(TENANT_ONE)
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -240,12 +240,12 @@ public class MultiTenancyCallActivityTest extends PluggableProcessEngineTest {
     BpmnModelInstance callingProcess = createCallingProcess("callingProcess", "ver_tag_2");
     testRule.deployForTenant(TENANT_ONE, callingProcess);
     testRule.deployForTenant(TENANT_TWO, "org/operaton/bpm/engine/test/bpmn/callactivity/subProcessWithVersionTag2.bpmn20.xml");
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("callingProcess")
+        .processDefinitionTenantId(TENANT_ONE);
 
     try {
       // when
-      runtimeService.createProcessInstanceByKey("callingProcess")
-        .processDefinitionTenantId(TENANT_ONE)
-        .execute();
+      processInstantiationBuilder.execute();
       fail("expected exception");
     } catch (ProcessEngineException e) {
       // then
@@ -360,11 +360,11 @@ public class MultiTenancyCallActivityTest extends PluggableProcessEngineTest {
 
     testRule.deployForTenant(TENANT_ONE, callingProcess);
     testRule.deployForTenant(TENANT_TWO, CMMN);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("callingProcess")
+        .processDefinitionTenantId(TENANT_ONE);
 
     try {
-      runtimeService.createProcessInstanceByKey("callingProcess")
-        .processDefinitionTenantId(TENANT_ONE)
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -385,11 +385,11 @@ public class MultiTenancyCallActivityTest extends PluggableProcessEngineTest {
 
     testRule.deployForTenant(TENANT_ONE, callingProcess);
     testRule.deployForTenant(TENANT_TWO, CMMN);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("callingProcess")
+        .processDefinitionTenantId(TENANT_ONE);
 
     try {
-      runtimeService.createProcessInstanceByKey("callingProcess")
-        .processDefinitionTenantId(TENANT_ONE)
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -413,11 +413,11 @@ public class MultiTenancyCallActivityTest extends PluggableProcessEngineTest {
 
     testRule.deployForTenant(TENANT_TWO, CMMN);
     testRule.deployForTenant(TENANT_TWO, CMMN);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("callingProcess")
+        .processDefinitionTenantId(TENANT_ONE);
 
     try {
-      runtimeService.createProcessInstanceByKey("callingProcess")
-        .processDefinitionTenantId(TENANT_ONE)
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyDecisionEvaluationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyDecisionEvaluationTest.java
@@ -48,12 +48,12 @@ public class MultiTenancyDecisionEvaluationTest extends PluggableProcessEngineTe
    testRule.deploy(DMN_FILE);
 
     DecisionDefinition decisionDefinition = repositoryService.createDecisionDefinitionQuery().singleResult();
+    var decisionsEvaluationBuilder = decisionService.evaluateDecisionById(decisionDefinition.getId())
+          .variables(createVariables())
+          .decisionDefinitionWithoutTenantId();
 
     try {
-      decisionService.evaluateDecisionById(decisionDefinition.getId())
-          .variables(createVariables())
-          .decisionDefinitionWithoutTenantId()
-          .evaluate();
+      decisionsEvaluationBuilder.evaluate();
       fail("BadUserRequestException exception");
     } catch(BadUserRequestException e) {
       assertThat(e.getMessage()).contains("Cannot specify a tenant-id");
@@ -65,12 +65,12 @@ public class MultiTenancyDecisionEvaluationTest extends PluggableProcessEngineTe
     testRule.deployForTenant(TENANT_ONE, DMN_FILE);
 
     DecisionDefinition decisionDefinition = repositoryService.createDecisionDefinitionQuery().singleResult();
+    var decisionsEvaluationBuilder = decisionService.evaluateDecisionById(decisionDefinition.getId())
+          .variables(createVariables())
+          .decisionDefinitionTenantId(TENANT_ONE);
 
     try {
-      decisionService.evaluateDecisionById(decisionDefinition.getId())
-          .variables(createVariables())
-          .decisionDefinitionTenantId(TENANT_ONE)
-          .evaluate();
+      decisionsEvaluationBuilder.evaluate();
       fail("BadUserRequestException exception");
     } catch(BadUserRequestException e) {
       assertThat(e.getMessage()).contains("Cannot specify a tenant-id");
@@ -81,12 +81,12 @@ public class MultiTenancyDecisionEvaluationTest extends PluggableProcessEngineTe
   public void testFailToEvaluateDecisionByKeyForNonExistingTenantID() {
     testRule.deployForTenant(TENANT_ONE, DMN_FILE);
     testRule.deployForTenant(TENANT_TWO, DMN_FILE);
+    var decisionsEvaluationBuilder = decisionService.evaluateDecisionByKey(DECISION_DEFINITION_KEY)
+          .variables(createVariables())
+          .decisionDefinitionTenantId("nonExistingTenantId");
 
     try {
-      decisionService.evaluateDecisionByKey(DECISION_DEFINITION_KEY)
-          .variables(createVariables())
-          .decisionDefinitionTenantId("nonExistingTenantId")
-          .evaluate();
+      decisionsEvaluationBuilder.evaluate();
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("no decision definition deployed with key 'decision' and tenant-id 'nonExistingTenantId'");
@@ -97,11 +97,11 @@ public class MultiTenancyDecisionEvaluationTest extends PluggableProcessEngineTe
   public void testFailToEvaluateDecisionByKeyForMultipleTenants() {
     testRule.deployForTenant(TENANT_ONE, DMN_FILE);
     testRule.deployForTenant(TENANT_TWO, DMN_FILE);
+    var decisionsEvaluationBuilder = decisionService.evaluateDecisionByKey(DECISION_DEFINITION_KEY)
+          .variables(createVariables());
 
     try {
-      decisionService.evaluateDecisionByKey(DECISION_DEFINITION_KEY)
-          .variables(createVariables())
-          .evaluate();
+      decisionsEvaluationBuilder.evaluate();
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("multiple tenants.");
@@ -193,11 +193,11 @@ public class MultiTenancyDecisionEvaluationTest extends PluggableProcessEngineTe
     identityService.setAuthentication("user", null, null);
 
     testRule.deployForTenant(TENANT_ONE, DMN_FILE);
+    var decisionsEvaluationBuilder = decisionService.evaluateDecisionByKey(DECISION_DEFINITION_KEY)
+        .variables(createVariables());
 
     try {
-      decisionService.evaluateDecisionByKey(DECISION_DEFINITION_KEY)
-        .variables(createVariables())
-        .evaluate();
+      decisionsEvaluationBuilder.evaluate();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -210,12 +210,12 @@ public class MultiTenancyDecisionEvaluationTest extends PluggableProcessEngineTe
     identityService.setAuthentication("user", null, null);
 
     testRule.deployForTenant(TENANT_ONE, DMN_FILE);
+    var decisionsEvaluationBuilder = decisionService.evaluateDecisionByKey(DECISION_DEFINITION_KEY)
+        .decisionDefinitionTenantId(TENANT_ONE)
+        .variables(createVariables());
 
     try {
-      decisionService.evaluateDecisionByKey(DECISION_DEFINITION_KEY)
-        .decisionDefinitionTenantId(TENANT_ONE)
-        .variables(createVariables())
-        .evaluate();
+      decisionsEvaluationBuilder.evaluate();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -232,11 +232,11 @@ public class MultiTenancyDecisionEvaluationTest extends PluggableProcessEngineTe
       .singleResult();
 
     identityService.setAuthentication("user", null, null);
+    var decisionsEvaluationBuilder = decisionService.evaluateDecisionById(decisionDefinition.getId())
+        .variables(createVariables());
 
     try {
-      decisionService.evaluateDecisionById(decisionDefinition.getId())
-        .variables(createVariables())
-        .evaluate();
+      decisionsEvaluationBuilder.evaluate();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyDecisionTableEvaluationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyDecisionTableEvaluationTest.java
@@ -48,12 +48,12 @@ public class MultiTenancyDecisionTableEvaluationTest extends PluggableProcessEng
    testRule.deploy(DMN_FILE);
 
     DecisionDefinition decisionDefinition = repositoryService.createDecisionDefinitionQuery().singleResult();
+    var decisionEvaluationBuilder = decisionService.evaluateDecisionTableById(decisionDefinition.getId())
+          .variables(createVariables())
+          .decisionDefinitionWithoutTenantId();
 
     try {
-      decisionService.evaluateDecisionTableById(decisionDefinition.getId())
-          .variables(createVariables())
-          .decisionDefinitionWithoutTenantId()
-          .evaluate();
+      decisionEvaluationBuilder.evaluate();
       fail("BadUserRequestException exception");
     } catch(BadUserRequestException e) {
       assertThat(e.getMessage()).contains("Cannot specify a tenant-id");
@@ -65,12 +65,12 @@ public class MultiTenancyDecisionTableEvaluationTest extends PluggableProcessEng
     testRule.deployForTenant(TENANT_ONE, DMN_FILE);
 
     DecisionDefinition decisionDefinition = repositoryService.createDecisionDefinitionQuery().singleResult();
+    var decisionEvaluationBuilder = decisionService.evaluateDecisionTableById(decisionDefinition.getId())
+          .variables(createVariables())
+          .decisionDefinitionTenantId(TENANT_ONE);
 
     try {
-      decisionService.evaluateDecisionTableById(decisionDefinition.getId())
-          .variables(createVariables())
-          .decisionDefinitionTenantId(TENANT_ONE)
-          .evaluate();
+      decisionEvaluationBuilder.evaluate();
       fail("BadUserRequestException exception");
     } catch(BadUserRequestException e) {
       assertThat(e.getMessage()).contains("Cannot specify a tenant-id");
@@ -81,12 +81,12 @@ public class MultiTenancyDecisionTableEvaluationTest extends PluggableProcessEng
   public void testFailToEvaluateDecisionByKeyForNonExistingTenantID() {
     testRule.deployForTenant(TENANT_ONE, DMN_FILE);
     testRule.deployForTenant(TENANT_TWO, DMN_FILE);
+    var decisionEvaluationBuilder = decisionService.evaluateDecisionTableByKey(DECISION_DEFINITION_KEY)
+          .variables(createVariables())
+          .decisionDefinitionTenantId("nonExistingTenantId");
 
     try {
-      decisionService.evaluateDecisionTableByKey(DECISION_DEFINITION_KEY)
-          .variables(createVariables())
-          .decisionDefinitionTenantId("nonExistingTenantId")
-          .evaluate();
+      decisionEvaluationBuilder.evaluate();
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("no decision definition deployed with key 'decision' and tenant-id 'nonExistingTenantId'");
@@ -97,11 +97,11 @@ public class MultiTenancyDecisionTableEvaluationTest extends PluggableProcessEng
   public void testFailToEvaluateDecisionByKeyForMultipleTenants() {
     testRule.deployForTenant(TENANT_ONE, DMN_FILE);
     testRule.deployForTenant(TENANT_TWO, DMN_FILE);
+    var decisionEvaluationBuilder = decisionService.evaluateDecisionTableByKey(DECISION_DEFINITION_KEY)
+          .variables(createVariables());
 
     try {
-      decisionService.evaluateDecisionTableByKey(DECISION_DEFINITION_KEY)
-          .variables(createVariables())
-          .evaluate();
+      decisionEvaluationBuilder.evaluate();
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("multiple tenants.");
@@ -193,11 +193,11 @@ public class MultiTenancyDecisionTableEvaluationTest extends PluggableProcessEng
     identityService.setAuthentication("user", null, null);
 
     testRule.deployForTenant(TENANT_ONE, DMN_FILE);
+    var decisionEvaluationBuilder = decisionService.evaluateDecisionTableByKey(DECISION_DEFINITION_KEY)
+        .variables(createVariables());
 
     try {
-      decisionService.evaluateDecisionTableByKey(DECISION_DEFINITION_KEY)
-        .variables(createVariables())
-        .evaluate();
+      decisionEvaluationBuilder.evaluate();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -210,12 +210,12 @@ public class MultiTenancyDecisionTableEvaluationTest extends PluggableProcessEng
     identityService.setAuthentication("user", null, null);
 
     testRule.deployForTenant(TENANT_ONE, DMN_FILE);
+    var decisionEvaluationBuilder = decisionService.evaluateDecisionTableByKey(DECISION_DEFINITION_KEY)
+        .decisionDefinitionTenantId(TENANT_ONE)
+        .variables(createVariables());
 
     try {
-      decisionService.evaluateDecisionTableByKey(DECISION_DEFINITION_KEY)
-        .decisionDefinitionTenantId(TENANT_ONE)
-        .variables(createVariables())
-        .evaluate();
+      decisionEvaluationBuilder.evaluate();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -232,11 +232,11 @@ public class MultiTenancyDecisionTableEvaluationTest extends PluggableProcessEng
       .singleResult();
 
     identityService.setAuthentication("user", null, null);
+    var decisionEvaluationBuilder = decisionService.evaluateDecisionTableById(decisionDefinition.getId())
+        .variables(createVariables());
 
     try {
-      decisionService.evaluateDecisionTableById(decisionDefinition.getId())
-        .variables(createVariables())
-        .evaluate();
+      decisionEvaluationBuilder.evaluate();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyMigrationTenantProviderTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyMigrationTenantProviderTest.java
@@ -70,13 +70,13 @@ public class MultiTenancyMigrationTenantProviderTest {
     MigrationPlan migrationPlan = engineRule.getRuntimeService().createMigrationPlan(sharedDefinition.getId(), tenantDefinition.getId())
         .mapEqualActivities()
         .build();
+    var runtimeService = engineRule.getRuntimeService()
+        .newMigration(migrationPlan)
+        .processInstanceIds(Arrays.asList(processInstance.getId()));
 
     // when
     try {
-      engineRule.getRuntimeService()
-        .newMigration(migrationPlan)
-        .processInstanceIds(Arrays.asList(processInstance.getId()))
-        .execute();
+      runtimeService.execute();
       Assert.fail("exception expected");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Cannot migrate process instance '" + processInstance.getId() + "' "

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyMigrationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyMigrationTest.java
@@ -52,12 +52,12 @@ public class MultiTenancyMigrationTest {
     // given
     ProcessDefinition tenant1Definition = testHelper.deployForTenantAndGetDefinition(TENANT_ONE, ProcessModels.ONE_TASK_PROCESS);
     ProcessDefinition tenant2Definition = testHelper.deployForTenantAndGetDefinition(TENANT_TWO, ProcessModels.ONE_TASK_PROCESS);
+    var runtimeService = engineRule.getRuntimeService().createMigrationPlan(tenant1Definition.getId(), tenant2Definition.getId())
+      .mapEqualActivities();
 
     // when
     try {
-      engineRule.getRuntimeService().createMigrationPlan(tenant1Definition.getId(), tenant2Definition.getId())
-      .mapEqualActivities()
-      .build();
+      runtimeService.build();
       Assert.fail("exception expected");
     } catch (ProcessEngineException e) {
       // then
@@ -144,13 +144,13 @@ public class MultiTenancyMigrationTest {
     MigrationPlan migrationPlan = engineRule.getRuntimeService().createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
         .mapEqualActivities()
         .build();
+    var runtimeService = engineRule.getRuntimeService()
+        .newMigration(migrationPlan)
+        .processInstanceIds(Arrays.asList(processInstance.getId()));
 
     // when
     try {
-      engineRule.getRuntimeService()
-        .newMigration(migrationPlan)
-        .processInstanceIds(Arrays.asList(processInstance.getId()))
-        .execute();
+      runtimeService.execute();
       Assert.fail("exception expected");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains(

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyProcessInstantiationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyProcessInstantiationTest.java
@@ -101,11 +101,11 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
   @Test
   public void testFailToStartProcessInstanceByKeyForOtherTenant() {
     testRule.deployForTenant(TENANT_ONE, PROCESS);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("testProcess")
+        .processDefinitionTenantId(TENANT_TWO);
 
     try {
-      runtimeService.createProcessInstanceByKey("testProcess")
-        .processDefinitionTenantId(TENANT_TWO)
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -117,10 +117,10 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
   public void testFailToStartProcessInstanceByKeyForMultipleTenants() {
     testRule.deployForTenant(TENANT_ONE, PROCESS);
     testRule.deployForTenant(TENANT_TWO, PROCESS);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("testProcess");
 
     try {
-      runtimeService.createProcessInstanceByKey("testProcess")
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -133,11 +133,11 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
     testRule.deployForTenant(TENANT_ONE, PROCESS);
 
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
+    var processInstantiationBuilder = runtimeService.createProcessInstanceById(processDefinition.getId())
+        .processDefinitionTenantId(TENANT_ONE);
 
     try {
-      runtimeService.createProcessInstanceById(processDefinition.getId())
-        .processDefinitionTenantId(TENANT_ONE)
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (BadUserRequestException e) {
@@ -150,11 +150,11 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
     testRule.deployForTenant(TENANT_ONE, PROCESS);
 
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
+    var processInstantiationBuilder = runtimeService.createProcessInstanceById(processDefinition.getId())
+        .processDefinitionWithoutTenantId();
 
     try {
-      runtimeService.createProcessInstanceById(processDefinition.getId())
-        .processDefinitionWithoutTenantId()
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (BadUserRequestException e) {
@@ -204,12 +204,12 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
   @Test
   public void testFailToStartProcessInstanceAtActivityByKeyForOtherTenant() {
     testRule.deployForTenant(TENANT_ONE, PROCESS);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("testProcess")
+        .processDefinitionTenantId(TENANT_TWO)
+        .startBeforeActivity("userTask");
 
     try {
-      runtimeService.createProcessInstanceByKey("testProcess")
-        .processDefinitionTenantId(TENANT_TWO)
-        .startBeforeActivity("userTask")
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -221,11 +221,11 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
   public void testFailToStartProcessInstanceAtActivityByKeyForMultipleTenants() {
     testRule.deployForTenant(TENANT_ONE, PROCESS);
     testRule.deployForTenant(TENANT_TWO, PROCESS);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("testProcess")
+        .startBeforeActivity("userTask");
 
     try {
-      runtimeService.createProcessInstanceByKey("testProcess")
-        .startBeforeActivity("userTask")
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -238,12 +238,12 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
     testRule.deployForTenant(TENANT_ONE, PROCESS);
 
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
+    var processInstantiationBuilder = runtimeService.createProcessInstanceById(processDefinition.getId())
+        .processDefinitionTenantId(TENANT_ONE)
+        .startBeforeActivity("userTask");
 
     try {
-      runtimeService.createProcessInstanceById(processDefinition.getId())
-        .processDefinitionTenantId(TENANT_ONE)
-        .startBeforeActivity("userTask")
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (BadUserRequestException e) {
@@ -256,12 +256,12 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
    testRule.deploy(PROCESS);
 
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
+    var processInstantiationBuilder = runtimeService.createProcessInstanceById(processDefinition.getId())
+        .processDefinitionWithoutTenantId()
+        .startBeforeActivity("userTask");
 
     try {
-      runtimeService.createProcessInstanceById(processDefinition.getId())
-        .processDefinitionWithoutTenantId()
-        .startBeforeActivity("userTask")
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (BadUserRequestException e) {
@@ -288,10 +288,10 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
     identityService.setAuthentication("user", null, null);
 
     testRule.deployForTenant(TENANT_ONE, PROCESS);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("testProcess");
 
     try {
-      runtimeService.createProcessInstanceByKey("testProcess")
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -304,11 +304,11 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
     identityService.setAuthentication("user", null, null);
 
     testRule.deployForTenant(TENANT_ONE, PROCESS);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey("testProcess")
+        .processDefinitionTenantId(TENANT_ONE);
 
     try {
-      runtimeService.createProcessInstanceByKey("testProcess")
-        .processDefinitionTenantId(TENANT_ONE)
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -325,10 +325,10 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
       .singleResult();
 
     identityService.setAuthentication("user", null, null);
+    var processInstantiationBuilder = runtimeService.createProcessInstanceById(processDefinition.getId());
 
     try {
-      runtimeService.createProcessInstanceById(processDefinition.getId())
-        .execute();
+      processInstantiationBuilder.execute();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -453,13 +453,13 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
     ProcessInstance processInstance = startAndDeleteProcessInstance(TENANT_ONE, PROCESS);
 
     identityService.setAuthentication("user", null, Collections.singletonList(TENANT_TWO));
+    var restartProcessInstanceBuilder = runtimeService.restartProcessInstances(processInstance.getProcessDefinitionId())
+        .startBeforeActivity("userTask")
+        .processInstanceIds(processInstance.getId());
 
     try {
       // when
-      runtimeService.restartProcessInstances(processInstance.getProcessDefinitionId())
-        .startBeforeActivity("userTask")
-        .processInstanceIds(processInstance.getId())
-        .execute();
+      restartProcessInstanceBuilder.execute();
 
       fail("expected exception");
     } catch (BadUserRequestException e) {
@@ -545,13 +545,13 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId());
 
     identityService.setAuthentication("user", null, Collections.singletonList(TENANT_TWO));
+    var restartProcessInstanceBuilder = runtimeService.restartProcessInstances(processInstance.getProcessDefinitionId())
+        .startBeforeActivity("userTask")
+        .historicProcessInstanceQuery(query);
 
     try {
       // when
-      runtimeService.restartProcessInstances(processInstance.getProcessDefinitionId())
-        .startBeforeActivity("userTask")
-        .historicProcessInstanceQuery(query)
-        .execute();
+      restartProcessInstanceBuilder.execute();
 
       fail("expected exception");
     } catch (BadUserRequestException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/MultiTenancyCreateCaseInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/MultiTenancyCreateCaseInstanceTest.java
@@ -42,11 +42,11 @@ public class MultiTenancyCreateCaseInstanceTest extends PluggableProcessEngineTe
    testRule.deploy(CMMN_FILE);
 
     CaseDefinition caseDefinition = repositoryService.createCaseDefinitionQuery().singleResult();
+    var caseInstanceBuilder = caseService.withCaseDefinition(caseDefinition.getId())
+          .caseDefinitionWithoutTenantId();
 
     try {
-      caseService.withCaseDefinition(caseDefinition.getId())
-          .caseDefinitionWithoutTenantId()
-          .create();
+      caseInstanceBuilder.create();
       fail("BadUserRequestException exception");
     } catch(BadUserRequestException e) {
       assertThat(e.getMessage()).contains("Cannot specify a tenant-id");
@@ -58,11 +58,11 @@ public class MultiTenancyCreateCaseInstanceTest extends PluggableProcessEngineTe
     testRule.deployForTenant(TENANT_ONE, CMMN_FILE);
 
     CaseDefinition caseDefinition = repositoryService.createCaseDefinitionQuery().singleResult();
+    var caseInstanceBuilder = caseService.withCaseDefinition(caseDefinition.getId())
+          .caseDefinitionTenantId(TENANT_ONE);
 
     try {
-      caseService.withCaseDefinition(caseDefinition.getId())
-          .caseDefinitionTenantId(TENANT_ONE)
-          .create();
+      caseInstanceBuilder.create();
       fail("BadUserRequestException exception");
     } catch(BadUserRequestException e) {
       assertThat(e.getMessage()).contains("Cannot specify a tenant-id");
@@ -73,11 +73,11 @@ public class MultiTenancyCreateCaseInstanceTest extends PluggableProcessEngineTe
   public void testFailToCreateCaseInstanceByKeyForNonExistingTenantID() {
     testRule.deployForTenant(TENANT_ONE, CMMN_FILE);
     testRule.deployForTenant(TENANT_TWO, CMMN_FILE);
+    var caseInstanceBuilder = caseService.withCaseDefinitionByKey(CASE_DEFINITION_KEY)
+          .caseDefinitionTenantId("nonExistingTenantId");
 
     try {
-      caseService.withCaseDefinitionByKey(CASE_DEFINITION_KEY)
-          .caseDefinitionTenantId("nonExistingTenantId")
-          .create();
+      caseInstanceBuilder.create();
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("no case definition deployed with key 'oneTaskCase' and tenant-id 'nonExistingTenantId'");
@@ -88,10 +88,10 @@ public class MultiTenancyCreateCaseInstanceTest extends PluggableProcessEngineTe
   public void testFailToCreateCaseInstanceByKeyForMultipleTenants() {
     testRule.deployForTenant(TENANT_ONE, CMMN_FILE);
     testRule.deployForTenant(TENANT_TWO, CMMN_FILE);
+    var caseInstanceBuilder = caseService.withCaseDefinitionByKey(CASE_DEFINITION_KEY);
 
     try {
-      caseService.withCaseDefinitionByKey(CASE_DEFINITION_KEY)
-          .create();
+      caseInstanceBuilder.create();
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("multiple tenants.");
@@ -153,9 +153,10 @@ public class MultiTenancyCreateCaseInstanceTest extends PluggableProcessEngineTe
     identityService.setAuthentication("user", null, null);
 
     testRule.deployForTenant(TENANT_ONE, CMMN_FILE);
+    var caseInstanceBuilder = caseService.withCaseDefinitionByKey(CASE_DEFINITION_KEY);
 
     try {
-      caseService.withCaseDefinitionByKey(CASE_DEFINITION_KEY).create();
+      caseInstanceBuilder.create();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -168,11 +169,11 @@ public class MultiTenancyCreateCaseInstanceTest extends PluggableProcessEngineTe
     identityService.setAuthentication("user", null, null);
 
     testRule.deployForTenant(TENANT_ONE, CMMN_FILE);
+    var caseInstanceBuilder = caseService.withCaseDefinitionByKey(CASE_DEFINITION_KEY)
+        .caseDefinitionTenantId(TENANT_ONE);
 
     try {
-      caseService.withCaseDefinitionByKey(CASE_DEFINITION_KEY)
-        .caseDefinitionTenantId(TENANT_ONE)
-        .create();
+      caseInstanceBuilder.create();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {
@@ -189,9 +190,10 @@ public class MultiTenancyCreateCaseInstanceTest extends PluggableProcessEngineTe
       .singleResult();
 
     identityService.setAuthentication("user", null, null);
+    var caseInstanceBuilder = caseService.withCaseDefinition(caseDefinition.getId());
 
     try {
-      caseService.withCaseDefinition(caseDefinition.getId()).create();
+      caseInstanceBuilder.create();
 
       fail("expected exception");
     } catch (ProcessEngineException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseDefinitionQueryTest.java
@@ -251,9 +251,9 @@ public class MultiTenancyCaseDefinitionQueryTest extends PluggableProcessEngineT
 
   @Test
   public void testFailQueryByTenantIdNull() {
+    var caseDefinitionQuery = repositoryService.createCaseDefinitionQuery();
     try {
-      repositoryService.createCaseDefinitionQuery()
-        .tenantIdIn((String) null);
+      caseDefinitionQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseExecutionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseExecutionQueryTest.java
@@ -100,9 +100,9 @@ public class MultiTenancyCaseExecutionQueryTest extends PluggableProcessEngineTe
 
   @Test
   public void testFailQueryByTenantIdNull() {
+    var caseExecutionQuery = caseService.createCaseExecutionQuery();
     try {
-      caseService.createCaseExecutionQuery()
-        .tenantIdIn((String) null);
+      caseExecutionQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseInstanceQueryTest.java
@@ -100,9 +100,9 @@ public class MultiTenancyCaseInstanceQueryTest extends PluggableProcessEngineTes
 
   @Test
   public void testFailQueryByTenantIdNull() {
+    var caseInstanceQuery = caseService.createCaseInstanceQuery();
     try {
-      caseService.createCaseInstanceQuery()
-        .tenantIdIn((String) null);
+      caseInstanceQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseActivityInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseActivityInstanceQueryTest.java
@@ -139,10 +139,10 @@ public class MultiTenancyHistoricCaseActivityInstanceQueryTest {
 
   @Test
   public void shouldFailQueryByTenantIdNull() {
+    var historicCaseActivityInstanceQuery = historyService.createHistoricCaseActivityInstanceQuery();
     try {
       // when
-      historyService.createHistoricCaseActivityInstanceQuery()
-        .tenantIdIn((String) null);
+      historicCaseActivityInstanceQuery.tenantIdIn((String) null);
 
       fail("expected exception");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseInstanceQueryTest.java
@@ -128,9 +128,9 @@ public class MultiTenancyHistoricCaseInstanceQueryTest {
 
   @Test
   public void shouldFailQueryByTenantIdNull() {
+    var historicCaseInstanceQuery = historyService.createHistoricCaseInstanceQuery();
     try {
-      historyService.createHistoricCaseInstanceQuery()
-        .tenantIdIn((String) null);
+      historicCaseInstanceQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyBatchQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyBatchQueryTest.java
@@ -223,8 +223,9 @@ public class MultiTenancyBatchQueryTest {
   public void testBatchQueryFailOnNullTenantIdCase1() {
 
     String[] tenantIds = null;
+    var batchQuery = managementService.createBatchQuery();
     try {
-      managementService.createBatchQuery().tenantIdIn(tenantIds);
+      batchQuery.tenantIdIn(tenantIds);
       Assert.fail("exception expected");
     }
     catch (NullValueException e) {
@@ -236,8 +237,9 @@ public class MultiTenancyBatchQueryTest {
   public void testBatchQueryFailOnNullTenantIdCase2() {
 
     String[] tenantIds = new String[]{ null };
+    var batchQuery = managementService.createBatchQuery();
     try {
-      managementService.createBatchQuery().tenantIdIn(tenantIds);
+      batchQuery.tenantIdIn(tenantIds);
       Assert.fail("exception expected");
     }
     catch (NullValueException e) {
@@ -304,8 +306,9 @@ public class MultiTenancyBatchQueryTest {
   public void testBatchStatisticsQueryFailOnNullTenantIdCase1() {
 
     String[] tenantIds = null;
+    var batchStatisticsQuery = managementService.createBatchStatisticsQuery();
     try {
-      managementService.createBatchStatisticsQuery().tenantIdIn(tenantIds);
+      batchStatisticsQuery.tenantIdIn(tenantIds);
       Assert.fail("exception expected");
     }
     catch (NullValueException e) {
@@ -317,8 +320,9 @@ public class MultiTenancyBatchQueryTest {
   public void testBatchStatisticsQueryFailOnNullTenantIdCase2() {
 
     String[] tenantIds = new String[]{ null };
+    var batchStatisticsQuery = managementService.createBatchStatisticsQuery();
     try {
-      managementService.createBatchStatisticsQuery().tenantIdIn(tenantIds);
+      batchStatisticsQuery.tenantIdIn(tenantIds);
       Assert.fail("exception expected");
     }
     catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDecisionDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDecisionDefinitionQueryTest.java
@@ -254,9 +254,9 @@ public class MultiTenancyDecisionDefinitionQueryTest extends PluggableProcessEng
 
   @Test
   public void testFailQueryByTenantIdNull() {
+    var decisionDefinitionQuery = repositoryService.createDecisionDefinitionQuery();
     try {
-      repositoryService.createDecisionDefinitionQuery()
-        .tenantIdIn((String) null);
+      decisionDefinitionQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDeploymentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDeploymentQueryTest.java
@@ -121,9 +121,9 @@ public class MultiTenancyDeploymentQueryTest extends PluggableProcessEngineTest 
 
   @Test
   public void testFailQueryByTenantIdNull() {
+    var deploymentQuery = repositoryService.createDeploymentQuery();
     try {
-      repositoryService.createDeploymentQuery()
-        .tenantIdIn((String) null);
+      deploymentQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyEventSubscriptionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyEventSubscriptionQueryTest.java
@@ -129,9 +129,9 @@ public class MultiTenancyEventSubscriptionQueryTest extends PluggableProcessEngi
 
   @Test
   public void testFailQueryByTenantIdNull() {
+    var eventSubscriptionQuery = runtimeService.createEventSubscriptionQuery();
     try {
-      runtimeService.createEventSubscriptionQuery()
-        .tenantIdIn((String) null);
+      eventSubscriptionQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyExecutionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyExecutionQueryTest.java
@@ -105,9 +105,9 @@ public class MultiTenancyExecutionQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testFailQueryByTenantIdNull() {
+    var executionQuery = runtimeService.createExecutionQuery();
     try {
-      runtimeService.createExecutionQuery()
-        .tenantIdIn((String) null);
+      executionQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyExternalTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyExternalTaskQueryTest.java
@@ -96,9 +96,9 @@ public class MultiTenancyExternalTaskQueryTest extends PluggableProcessEngineTes
 
   @Test
   public void testFailQueryByTenantIdNull() {
+    var externalTaskQuery = externalTaskService.createExternalTaskQuery();
     try {
-      externalTaskService.createExternalTaskQuery()
-        .tenantIdIn((String) null);
+      externalTaskQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyIncidentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyIncidentQueryTest.java
@@ -96,9 +96,9 @@ public class MultiTenancyIncidentQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testFailQueryByTenantIdNull() {
+    var incidentQuery = runtimeService.createIncidentQuery();
     try {
-      runtimeService.createIncidentQuery()
-        .tenantIdIn((String) null);
+      incidentQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyJobDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyJobDefinitionQueryTest.java
@@ -129,9 +129,9 @@ public class MultiTenancyJobDefinitionQueryTest extends PluggableProcessEngineTe
 
   @Test
   public void testFailQueryByTenantIdNull() {
+    var jobDefinitionQuery = managementService.createJobDefinitionQuery();
     try {
-      managementService.createJobDefinitionQuery()
-        .tenantIdIn((String) null);
+      jobDefinitionQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyJobQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyJobQueryTest.java
@@ -130,9 +130,9 @@ public class MultiTenancyJobQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testFailQueryByTenantIdNull() {
+    var jobQuery = managementService.createJobQuery();
     try {
-      managementService.createJobQuery()
-        .tenantIdIn((String) null);
+      jobQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyProcessDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyProcessDefinitionQueryTest.java
@@ -254,9 +254,9 @@ public class MultiTenancyProcessDefinitionQueryTest extends PluggableProcessEngi
 
   @Test
   public void testFailQueryByTenantIdNull() {
+    var processDefinitionQuery = repositoryService.createProcessDefinitionQuery();
     try {
-      repositoryService.createProcessDefinitionQuery()
-        .tenantIdIn((String) null);
+      processDefinitionQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyProcessInstanceQueryTest.java
@@ -106,9 +106,9 @@ public class MultiTenancyProcessInstanceQueryTest extends PluggableProcessEngine
 
   @Test
   public void testFailQueryByTenantIdNull() {
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery();
     try {
-      runtimeService.createProcessInstanceQuery()
-        .tenantIdIn((String) null);
+      processInstanceQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyTaskQueryTest.java
@@ -116,9 +116,9 @@ public class MultiTenancyTaskQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryByTenantIdNullFails() {
+    var taskQuery = taskService.createTaskQuery();
     try {
-      assertEquals(0, taskService.createTaskQuery()
-          .tenantIdIn((String)null));
+      taskQuery.tenantIdIn((String)null);
 
       fail("Exception expected");
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyVariableInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyVariableInstanceQueryTest.java
@@ -96,9 +96,9 @@ public class MultiTenancyVariableInstanceQueryTest extends PluggableProcessEngin
 
   @Test
   public void testFailQueryByTenantIdNull() {
+    var variableInstanceQuery = runtimeService.createVariableInstanceQuery();
     try {
-      runtimeService.createVariableInstanceQuery()
-        .tenantIdIn((String) null);
+      variableInstanceQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricActivityInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricActivityInstanceQueryTest.java
@@ -143,10 +143,10 @@ public class MultiTenancyHistoricActivityInstanceQueryTest {
 
   @Test
   public void shouldFailQueryByTenantIdNull() {
+    var historicActivityInstanceQuery = historyService.createHistoricActivityInstanceQuery();
     try {
       // when
-      historyService.createHistoricActivityInstanceQuery()
-        .tenantIdIn((String) null);
+      historicActivityInstanceQuery.tenantIdIn((String) null);
 
       fail("expected exception");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricBatchQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricBatchQueryTest.java
@@ -161,10 +161,11 @@ public class MultiTenancyHistoricBatchQueryTest {
   public void testDeleteHistoricBatchFailsWithWrongTenant() {
     // given
     identityService.setAuthentication("user", null, singletonList(TENANT_ONE));
+    var tenant2BatchId = tenant2Batch.getId();
 
     // when
     try {
-      historyService.deleteHistoricBatch(tenant2Batch.getId());
+      historyService.deleteHistoricBatch(tenant2BatchId);
       Assert.fail("exception expected");
     }
     catch (ProcessEngineException e) {
@@ -216,8 +217,9 @@ public class MultiTenancyHistoricBatchQueryTest {
   public void testBatchQueryFailOnNullTenantIdCase1() {
 
     String[] tenantIds = null;
+    var historicBatchQuery = historyService.createHistoricBatchQuery();
     try {
-      historyService.createHistoricBatchQuery().tenantIdIn(tenantIds);
+      historicBatchQuery.tenantIdIn(tenantIds);
       Assert.fail("exception expected");
     }
     catch (NullValueException e) {
@@ -229,8 +231,9 @@ public class MultiTenancyHistoricBatchQueryTest {
   public void testBatchQueryFailOnNullTenantIdCase2() {
 
     String[] tenantIds = new String[]{ null };
+    var historicBatchQuery = historyService.createHistoricBatchQuery();
     try {
-      historyService.createHistoricBatchQuery().tenantIdIn(tenantIds);
+      historicBatchQuery.tenantIdIn(tenantIds);
       Assert.fail("exception expected");
     }
     catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDecisionInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDecisionInstanceQueryTest.java
@@ -128,9 +128,9 @@ public class MultiTenancyHistoricDecisionInstanceQueryTest {
 
   @Test
   public void shouldFailQueryByTenantIdNull() {
+    var historicDecisionInstanceQuery = historyService.createHistoricDecisionInstanceQuery();
     try {
-      historyService.createHistoricDecisionInstanceQuery()
-        .tenantIdIn((String) null);
+      historicDecisionInstanceQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailFormPropertyQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailFormPropertyQueryTest.java
@@ -168,11 +168,11 @@ public class MultiTenancyHistoricDetailFormPropertyQueryTest {
 
   @Test
   public void shouldFailQueryByTenantIdNull() {
+    var historicDetailQuery = historyService.createHistoricDetailQuery()
+        .formFields();
     try {
       // when
-      historyService.createHistoricDetailQuery()
-        .formFields()
-        .tenantIdIn((String) null);
+      historicDetailQuery.tenantIdIn((String) null);
 
       fail("expected exception");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailVariableUpdateQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailVariableUpdateQueryTest.java
@@ -167,11 +167,11 @@ public class MultiTenancyHistoricDetailVariableUpdateQueryTest {
 
   @Test
   public void shouldFailQueryByTenantIdNull() {
+    var historicDetailQuery = historyService.createHistoricDetailQuery()
+        .variableUpdates();
     try {
       // when
-      historyService.createHistoricDetailQuery()
-        .variableUpdates()
-        .tenantIdIn((String) null);
+      historicDetailQuery.tenantIdIn((String) null);
 
       fail("expected exception");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
@@ -163,10 +163,10 @@ public class MultiTenancyHistoricExternalTaskLogTest {
 
   @Test
   public void shouldFailQueryByTenantIdNull() {
+    var historicExternalTaskLogQuery = historyService.createHistoricExternalTaskLogQuery();
     try {
       // when
-      historyService.createHistoricExternalTaskLogQuery()
-        .tenantIdIn((String) null);
+      historicExternalTaskLogQuery.tenantIdIn((String) null);
 
       fail("expected exception");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricIncidentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricIncidentQueryTest.java
@@ -146,10 +146,10 @@ public class MultiTenancyHistoricIncidentQueryTest {
 
   @Test
   public void shouldFailQueryByTenantIdNull() {
+    var historicIncidentQuery = historyService.createHistoricIncidentQuery();
     try {
       // when
-      historyService.createHistoricIncidentQuery()
-        .tenantIdIn((String) null);
+      historicIncidentQuery.tenantIdIn((String) null);
 
       fail("expected exception");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricJobLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricJobLogQueryTest.java
@@ -147,10 +147,10 @@ public class MultiTenancyHistoricJobLogQueryTest {
 
   @Test
   public void shouldFailQueryByTenantIdNull() {
+    var historicJobLogQuery = historyService.createHistoricJobLogQuery();
     try {
       // when
-      historyService.createHistoricJobLogQuery()
-        .tenantIdIn((String) null);
+      historicJobLogQuery.tenantIdIn((String) null);
 
       fail("expected exception");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricProcessInstanceQueryTest.java
@@ -131,9 +131,9 @@ public class MultiTenancyHistoricProcessInstanceQueryTest {
 
   @Test
   public void shouldFailQueryByTenantIdNull() {
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
     try {
-      historyService.createHistoricProcessInstanceQuery()
-        .tenantIdIn((String) null);
+      historicProcessInstanceQuery.tenantIdIn((String) null);
 
       fail("expected exception");
     } catch (NullValueException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricTaskInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricTaskInstanceQueryTest.java
@@ -153,10 +153,10 @@ public class MultiTenancyHistoricTaskInstanceQueryTest {
 
   @Test
   public void shouldFailQueryByTenantIdNull() {
+    var historicTaskInstanceQuery = historyService.createHistoricTaskInstanceQuery();
     try {
       // when
-      historyService.createHistoricTaskInstanceQuery()
-        .tenantIdIn((String) null);
+      historicTaskInstanceQuery.tenantIdIn((String) null);
 
       fail("expected exception");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricVariableInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricVariableInstanceQueryTest.java
@@ -153,10 +153,10 @@ public class MultiTenancyHistoricVariableInstanceQueryTest {
 
   @Test
   public void shouldFailQueryByTenantIdNull() {
+    var historicVariableInstanceQuery = historyService.createHistoricVariableInstanceQuery();
     try {
       // when
-      historyService.createHistoricVariableInstanceQuery()
-        .tenantIdIn((String) null);
+      historicVariableInstanceQuery.tenantIdIn((String) null);
 
       fail("expected exception");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessApplicationDeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessApplicationDeploymentTest.java
@@ -109,19 +109,17 @@ public class ProcessApplicationDeploymentTest {
 
   @Test
   public void testEmptyDeployment() {
+    var deploymentBuilder = repositoryService.createDeployment(processApplication.getReference());
+    var deploymentBuilder2 = repositoryService.createDeployment();
     try {
-      repositoryService
-        .createDeployment(processApplication.getReference())
-        .deploy();
+      deploymentBuilder.deploy();
       fail("it should not be possible to deploy without deployment resources");
     } catch (NotValidException e) {
       // expected
     }
 
     try {
-      repositoryService
-        .createDeployment()
-        .deploy();
+      deploymentBuilder2.deploy();
       fail("it should not be possible to deploy without deployment resources");
     } catch (NotValidException e) {
       // expected

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
@@ -204,12 +204,13 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
     List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
     assertEquals(1, processDefinitions.size());
     ProcessDefinition processDefinition = processDefinitions.get(0);
+    var deploymentId = processDefinition.getDeploymentId();
 
     runtimeService.startProcessInstanceById(processDefinition.getId());
 
     // Try to delete the deployment
     try {
-      repositoryService.deleteDeployment(processDefinition.getDeploymentId());
+      repositoryService.deleteDeployment(deploymentId);
       fail("Exception expected");
     } catch (ProcessEngineException pex) {
       // Exception expected when deleting deployment with running process
@@ -491,9 +492,10 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
   public void testGetResourceAsStreamUnexistingResourceInExistingDeployment() {
     // Get hold of the deployment id
     org.operaton.bpm.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
+    var deploymentId = deployment.getId();
 
     try {
-      repositoryService.getResourceAsStream(deployment.getId(), "org/operaton/bpm/engine/test/api/unexistingProcess.bpmn.xml");
+      repositoryService.getResourceAsStream(deploymentId, "org/operaton/bpm/engine/test/api/unexistingProcess.bpmn.xml");
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
       testRule.assertTextPresent("no resource found with name", ae.getMessage());
@@ -932,10 +934,11 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
   public void testDecisionDefinitionUpdateTimeToLiveNegative() {
     //given
     DecisionDefinition decisionDefinition = findOnlyDecisionDefinition();
+    var decisionDefinitionId = decisionDefinition.getId();
 
     //when
     try {
-      repositoryService.updateDecisionDefinitionHistoryTimeToLive(decisionDefinition.getId(), -1);
+      repositoryService.updateDecisionDefinitionHistoryTimeToLive(decisionDefinitionId, -1);
       fail("Exception is expected, that negative value is not allowed.");
     } catch (BadUserRequestException ex) {
       assertTrue(ex.getMessage().contains("greater than"));
@@ -978,10 +981,11 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
   public void testProcessDefinitionUpdateTimeToLiveNegative() {
     //given
     ProcessDefinition processDefinition = findOnlyProcessDefinition();
+    var processDefinitionId = processDefinition.getId();
 
     //when
     try {
-      repositoryService.updateProcessDefinitionHistoryTimeToLive(processDefinition.getId(), -1);
+      repositoryService.updateProcessDefinitionHistoryTimeToLive(processDefinitionId, -1);
       fail("Exception is expected, that negative value is not allowed.");
     } catch (BadUserRequestException ex) {
       assertTrue(ex.getMessage().contains("greater than"));
@@ -1144,10 +1148,11 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
     // there exists a deployment containing a case definition with key "oneTaskCase"
 
     CaseDefinition caseDefinition = findOnlyCaseDefinition();
+    var caseDefinitionId = caseDefinition.getId();
 
     // when
     try {
-      repositoryService.updateCaseDefinitionHistoryTimeToLive(caseDefinition.getId(), -1);
+      repositoryService.updateCaseDefinitionHistoryTimeToLive(caseDefinitionId, -1);
       fail("Exception is expected, that negative value is not allowed.");
     } catch (BadUserRequestException ex) {
       assertTrue(ex.getMessage().contains("greater than"));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/diagram/ProcessDiagramParseTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/diagram/ProcessDiagramParseTest.java
@@ -60,22 +60,17 @@ public class ProcessDiagramParseTest {
   @Test
   public void testXxeParsingIsDisabled() {
     processEngineConfiguration.setEnableXxeProcessing(false);
+    final InputStream bpmnXmlStream = getResourceInputStream(resourcePath + ".bpmn20.xml");
+    final InputStream imageStream = getResourceInputStream(resourcePath + ".png");
+    assertNotNull(bpmnXmlStream);
+    var processEngineConfigurationImpl = engineRule.getProcessEngineConfiguration()
+        .getCommandExecutorTxRequired();
 
     try {
-      final InputStream bpmnXmlStream = new FileInputStream(
-        resourcePath + ".bpmn20.xml");
-      final InputStream imageStream = new FileInputStream(
-        resourcePath + ".png");
-
-      assertNotNull(bpmnXmlStream);
 
       // when we run this in the ProcessEngine context
-      engineRule.getProcessEngineConfiguration()
-        .getCommandExecutorTxRequired()
-        .execute(commandContext -> new ProcessDiagramLayoutFactory().getProcessDiagramLayout(bpmnXmlStream, imageStream));
+      processEngineConfigurationImpl.execute(commandContext -> new ProcessDiagramLayoutFactory().getProcessDiagramLayout(bpmnXmlStream, imageStream));
       fail("The test model contains a DOCTYPE declaration! The test should fail.");
-    } catch (FileNotFoundException ex) {
-      fail("The test BPMN model file is missing. " + ex.getMessage());
     } catch (Exception e) {
       // then
       assertThat(e.getMessage()).contains("Error while parsing BPMN model");
@@ -86,26 +81,29 @@ public class ProcessDiagramParseTest {
   @Test
   public void testXxeParsingIsEnabled() {
     processEngineConfiguration.setEnableXxeProcessing(true);
+    final InputStream bpmnXmlStream = getResourceInputStream(resourcePath + ".bpmn20.xml");
+    final InputStream imageStream = getResourceInputStream(resourcePath + ".png");
+    assertNotNull(bpmnXmlStream);
+    var processEngineConfigurationImpl = engineRule.getProcessEngineConfiguration()
+        .getCommandExecutorTxRequired();
 
     try {
-      final InputStream bpmnXmlStream = new FileInputStream(
-        resourcePath + ".bpmn20.xml");
-      final InputStream imageStream = new FileInputStream(
-        resourcePath + ".png");
-
-      assertNotNull(bpmnXmlStream);
 
       // when we run this in the ProcessEngine context
-      engineRule.getProcessEngineConfiguration()
-        .getCommandExecutorTxRequired()
-        .execute(commandContext -> new ProcessDiagramLayoutFactory().getProcessDiagramLayout(bpmnXmlStream, imageStream));
+      processEngineConfigurationImpl.execute(commandContext -> new ProcessDiagramLayoutFactory().getProcessDiagramLayout(bpmnXmlStream, imageStream));
       fail("The test model contains a DOCTYPE declaration! The test should fail.");
-    } catch (FileNotFoundException ex) {
-      fail("The test BPMN model file is missing. " + ex.getMessage());
     } catch (Exception e) {
       // then
       assertThat(e.getMessage()).contains("Error while parsing BPMN model");
       assertThat(e.getCause().getMessage()).contains("file.txt");
+    }
+  }
+
+  private InputStream getResourceInputStream(String path) {
+    try {
+      return new FileInputStream(path);
+    } catch (FileNotFoundException ex) {
+      throw new AssertionError("The test BPMN model file is missing. " + ex.getMessage());
     }
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionAsyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionAsyncTest.java
@@ -158,9 +158,10 @@ public class ModificationExecutionAsyncTest {
 
   @Test
   public void createModificationWithNullProcessInstanceIdsListAsync() {
+    var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds((List<String>) null);
 
     try {
-      runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds((List<String>) null).executeAsync();
+      modificationBuilder.executeAsync();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids is empty");
@@ -170,8 +171,8 @@ public class ModificationExecutionAsyncTest {
   @Test
   public void createModificationWithNullProcessDefinitionId() {
     try {
-      runtimeService.createModification(null).cancelAllForActivity("activityId").processInstanceIds(Arrays.asList("20", "1--0")).executeAsync();
-      fail("Should not succed");
+      runtimeService.createModification(null);
+      fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("processDefinitionId is null");
     }
@@ -180,9 +181,10 @@ public class ModificationExecutionAsyncTest {
 
   @Test
   public void createModificationUsingProcessInstanceIdsListWithNullValueAsync() {
+    var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds(Arrays.asList("foo", null, "bar"));
 
     try {
-      runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds(Arrays.asList("foo", null, "bar")).executeAsync();
+      modificationBuilder.executeAsync();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids contains null value");
@@ -191,8 +193,9 @@ public class ModificationExecutionAsyncTest {
 
   @Test
   public void createModificationWithEmptyProcessInstanceIdsListAsync() {
+    var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds(Collections.<String> emptyList());
     try {
-      runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds(Collections.<String> emptyList()).executeAsync();
+      modificationBuilder.executeAsync();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids is empty");
@@ -201,9 +204,10 @@ public class ModificationExecutionAsyncTest {
 
   @Test
   public void createModificationWithNullProcessInstanceIdsArrayAsync() {
+    var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds((String[]) null);
 
     try {
-      runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds((String[]) null).executeAsync();
+      modificationBuilder.executeAsync();
       fail("Should not be able to modify");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids is empty");
@@ -212,9 +216,10 @@ public class ModificationExecutionAsyncTest {
 
   @Test
   public void createModificationUsingProcessInstanceIdsArrayWithNullValueAsync() {
+    var modificationBuilder = runtimeService.createModification("processDefinitionId").cancelAllForActivity("user1").processInstanceIds("foo", null, "bar");
 
     try {
-      runtimeService.createModification("processDefinitionId").cancelAllForActivity("user1").processInstanceIds("foo", null, "bar").executeAsync();
+      modificationBuilder.executeAsync();
       fail("Should not be able to modify");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids contains null value");
@@ -223,9 +228,10 @@ public class ModificationExecutionAsyncTest {
 
   @Test
   public void testNullProcessInstanceQueryAsync() {
+    var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceQuery(null);
 
     try {
-      runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceQuery(null).executeAsync();
+      modificationBuilder.executeAsync();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids is empty");
@@ -234,9 +240,10 @@ public class ModificationExecutionAsyncTest {
 
   @Test
   public void testNullHistoricProcessInstanceQueryAsync() {
+    var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").historicProcessInstanceQuery(null);
 
     try {
-      runtimeService.createModification("processDefinitionId").startAfterActivity("user1").historicProcessInstanceQuery(null).executeAsync();
+      modificationBuilder.executeAsync();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids is empty");
@@ -249,8 +256,9 @@ public class ModificationExecutionAsyncTest {
     deployment.getDeployedProcessDefinitions().get(0);
 
     List<String> processInstanceIds = helper.startInstances("process1", 2);
+    var modificationBuilder = runtimeService.createModification("foo").cancelAllForActivity("activityId").processInstanceIds(processInstanceIds);
     try {
-      runtimeService.createModification("foo").cancelAllForActivity("activityId").processInstanceIds(processInstanceIds).executeAsync();
+      modificationBuilder.executeAsync();
       fail("Should not succed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("processDefinition is null");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionSyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionSyncTest.java
@@ -175,9 +175,10 @@ public class ModificationExecutionSyncTest {
 
   @Test
   public void createModificationWithNullProcessInstanceIdsList() {
+    var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1") .processInstanceIds((List<String>) null);
 
     try {
-     runtimeService.createModification("processDefinitionId").startAfterActivity("user1") .processInstanceIds((List<String>) null).execute();
+     modificationBuilder.execute();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids is empty");
@@ -186,9 +187,10 @@ public class ModificationExecutionSyncTest {
 
   @Test
   public void createModificationUsingProcessInstanceIdsListWithNullValue() {
+    var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds(Arrays.asList("foo", null, "bar"));
 
     try {
-      runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds(Arrays.asList("foo", null, "bar")).execute();
+      modificationBuilder.execute();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids contains null value");
@@ -197,9 +199,10 @@ public class ModificationExecutionSyncTest {
 
   @Test
   public void createModificationWithEmptyProcessInstanceIdsList() {
+    var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds(Collections.<String> emptyList());
 
     try {
-      runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds(Collections.<String> emptyList()).execute();
+      modificationBuilder.execute();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids is empty");
@@ -209,8 +212,8 @@ public class ModificationExecutionSyncTest {
   @Test
   public void createModificationWithNullProcessDefinitionId() {
     try {
-      runtimeService.createModification(null).cancelAllForActivity("activityId").processInstanceIds(Arrays.asList("20", "1--0")).execute();
-      fail("Should not succed");
+      runtimeService.createModification(null);
+      fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("processDefinitionId is null");
     }
@@ -218,11 +221,12 @@ public class ModificationExecutionSyncTest {
 
   @Test
   public void createModificationWithNullProcessInstanceIdsArray() {
+    var modificationBuilder = runtimeService.createModification("processDefinitionId")
+      .startAfterActivity("user1")
+      .processInstanceIds((String[]) null);
 
     try {
-      runtimeService.createModification("processDefinitionId")
-      .startAfterActivity("user1")
-      .processInstanceIds((String[]) null).execute();
+      modificationBuilder.execute();
       fail("Should not be able to modify");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids is empty");
@@ -231,9 +235,10 @@ public class ModificationExecutionSyncTest {
 
   @Test
   public void createModificationUsingProcessInstanceIdsArrayWithNullValue() {
+    var modificationBuilder = runtimeService.createModification("processDefinitionId").cancelAllForActivity("user1").processInstanceIds("foo", null, "bar");
 
     try {
-      runtimeService.createModification("processDefinitionId").cancelAllForActivity("user1").processInstanceIds("foo", null, "bar").execute();
+      modificationBuilder.execute();
       fail("Should not be able to modify");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids contains null value");
@@ -242,8 +247,9 @@ public class ModificationExecutionSyncTest {
 
   @Test
   public void testNullProcessInstanceQuery() {
+    var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceQuery(null);
     try {
-      runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceQuery(null).execute();
+      modificationBuilder.execute();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids is empty");
@@ -252,8 +258,9 @@ public class ModificationExecutionSyncTest {
 
   @Test
   public void testNullHistoricProcessInstanceQuery() {
+    var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").historicProcessInstanceQuery(null);
     try {
-      runtimeService.createModification("processDefinitionId").startAfterActivity("user1").historicProcessInstanceQuery(null).execute();
+      modificationBuilder.execute();
       fail("Should not succeed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Process instance ids is empty");
@@ -266,8 +273,9 @@ public class ModificationExecutionSyncTest {
     deployment.getDeployedProcessDefinitions().get(0);
 
     List<String> processInstanceIds = helper.startInstances("process1", 2);
+    var modificationBuilder = runtimeService.createModification("foo").cancelAllForActivity("activityId").processInstanceIds(processInstanceIds);
     try {
-      runtimeService.createModification("foo").cancelAllForActivity("activityId").processInstanceIds(processInstanceIds).execute();
+      modificationBuilder.execute();
       fail("Should not succed");
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("processDefinition is null");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationMultiInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationMultiInstanceTest.java
@@ -640,11 +640,11 @@ public class ProcessInstanceModificationMultiInstanceTest extends PluggableProce
 
     // then creating a second inner instance is not possible
     ActivityInstance tree = runtimeService.getActivityInstance(processInstance.getId());
-    try {
-      runtimeService
+    var processInstanceModificationBuilder = runtimeService
       .createProcessInstanceModification(processInstance.getId())
-      .startBeforeActivity("miTasks", tree.getActivityInstances("miTasks#multiInstanceBody")[0].getId())
-      .execute();
+      .startBeforeActivity("miTasks", tree.getActivityInstances("miTasks#multiInstanceBody")[0].getId());
+    try {
+      processInstanceModificationBuilder.execute();
       fail("expect exception");
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent(e.getMessage(), "Concurrent instantiation not possible for activities "
@@ -662,11 +662,11 @@ public class ProcessInstanceModificationMultiInstanceTest extends PluggableProce
 
     // when
     ActivityInstance tree = runtimeService.getActivityInstance(processInstance.getId());
-    try {
-      runtimeService
+    var processInstanceModificationBuilder = runtimeService
         .createProcessInstanceModification(processInstance.getId())
-        .startBeforeActivity("miSubProcess", tree.getActivityInstances("miSubProcess#multiInstanceBody")[0].getId())
-        .execute();
+        .startBeforeActivity("miSubProcess", tree.getActivityInstances("miSubProcess#multiInstanceBody")[0].getId());
+    try {
+      processInstanceModificationBuilder.execute();
       fail("expect exception");
     } catch (ProcessEngineException e) {
        testRule.assertTextPresent(e.getMessage(), "Concurrent instantiation not possible for activities "

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -289,10 +289,10 @@ public class ProcessInstanceQueryTest {
 
   @Test
   public void testQueryByOneInvalidProcessDefinitionKeyIn() {
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery();
     try {
       // when
-      runtimeService.createProcessInstanceQuery()
-        .processDefinitionKeyIn((String) null);
+      processInstanceQuery.processDefinitionKeyIn((String) null);
       fail();
     } catch(ProcessEngineException expected) {
       // then Exception is expected
@@ -301,10 +301,10 @@ public class ProcessInstanceQueryTest {
 
   @Test
   public void testQueryByMultipleInvalidProcessDefinitionKeyIn() {
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery();
     try {
       // when
-      runtimeService.createProcessInstanceQuery()
-        .processDefinitionKeyIn(PROCESS_DEFINITION_KEY, null);
+      processInstanceQuery.processDefinitionKeyIn(PROCESS_DEFINITION_KEY, null);
       fail();
     } catch(ProcessEngineException expected) {
       // Exception is expected
@@ -345,10 +345,10 @@ public class ProcessInstanceQueryTest {
 
   @Test
   public void testQueryByOneInvalidProcessDefinitionKeyNotIn() {
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery();
     try {
       // when
-      runtimeService.createProcessInstanceQuery()
-        .processDefinitionKeyNotIn((String) null);
+      processInstanceQuery.processDefinitionKeyNotIn((String) null);
       fail();
     } catch(ProcessEngineException expected) {
       // then Exception is expected
@@ -357,10 +357,10 @@ public class ProcessInstanceQueryTest {
 
   @Test
   public void testQueryByMultipleInvalidProcessDefinitionKeyNotIn() {
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery();
     try {
       // when
-      runtimeService.createProcessInstanceQuery()
-        .processDefinitionKeyNotIn(PROCESS_DEFINITION_KEY, null);
+      processInstanceQuery.processDefinitionKeyNotIn(PROCESS_DEFINITION_KEY, null);
       fail();
     } catch(ProcessEngineException expected) {
       // then Exception is expected
@@ -401,12 +401,13 @@ public class ProcessInstanceQueryTest {
   @Test
   public void testQueryByInvalidBusinessKey() {
     assertEquals(0, runtimeService.createProcessInstanceQuery().processInstanceBusinessKey("invalid").count());
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery();
 
     try {
-      runtimeService.createProcessInstanceQuery().processInstanceBusinessKey(null).count();
+      processInstanceQuery.processInstanceBusinessKey(null);
       fail();
     } catch(ProcessEngineException ignored) {
-
+      assertEquals("Business key is null", ignored.getMessage());
     }
   }
 
@@ -516,8 +517,9 @@ public class ProcessInstanceQueryTest {
 
   @Test
   public void testQueryInvalidSorting() {
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery().orderByProcessDefinitionId();
     try {
-      runtimeService.createProcessInstanceQuery().orderByProcessDefinitionId().list(); // asc - desc not called -> exception
+      processInstanceQuery.list(); // asc - desc not called -> exception
       fail();
     }catch (ProcessEngineException ignored) {}
   }
@@ -1060,31 +1062,32 @@ public class ProcessInstanceQueryTest {
     assertNotNull(instances);
     assertEquals(1, instances.size());
     assertEquals(processInstance1.getId(), instances.get(0).getId());
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery();
 
     // Test unsupported operations
     try {
-      runtimeService.createProcessInstanceQuery().variableValueGreaterThan("booleanVar", true);
+      processInstanceQuery.variableValueGreaterThan("booleanVar", true);
       fail("Excetion expected");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("Booleans and null cannot be used in 'greater than' condition");
     }
 
     try {
-      runtimeService.createProcessInstanceQuery().variableValueGreaterThanOrEqual("booleanVar", true);
+      processInstanceQuery.variableValueGreaterThanOrEqual("booleanVar", true);
       fail("Excetion expected");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("Booleans and null cannot be used in 'greater than or equal' condition");
     }
 
     try {
-      runtimeService.createProcessInstanceQuery().variableValueLessThan("booleanVar", true);
+      processInstanceQuery.variableValueLessThan("booleanVar", true);
       fail("Excetion expected");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("Booleans and null cannot be used in 'less than' condition");
     }
 
     try {
-      runtimeService.createProcessInstanceQuery().variableValueLessThanOrEqual("booleanVar", true);
+      processInstanceQuery.variableValueLessThanOrEqual("booleanVar", true);
       fail("Excetion expected");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("Booleans and null cannot be used in 'less than or equal' condition");
@@ -1178,38 +1181,39 @@ public class ProcessInstanceQueryTest {
     Assert.assertEquals(1, runtimeService.createProcessInstanceQuery().variableValueNotEquals("nullVarDouble", null).count());
     // When a byte-array refrence is present, the variable is not considered null
     Assert.assertEquals(1, runtimeService.createProcessInstanceQuery().variableValueNotEquals("nullVarByte", null).count());
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery();
 
     // All other variable queries with null should throw exception
     try {
-      runtimeService.createProcessInstanceQuery().variableValueGreaterThan("nullVar", null);
+      processInstanceQuery.variableValueGreaterThan("nullVar", null);
       fail("Excetion expected");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("Booleans and null cannot be used in 'greater than' condition");
     }
 
     try {
-      runtimeService.createProcessInstanceQuery().variableValueGreaterThanOrEqual("nullVar", null);
+      processInstanceQuery.variableValueGreaterThanOrEqual("nullVar", null);
       fail("Excetion expected");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("Booleans and null cannot be used in 'greater than or equal' condition");
     }
 
     try {
-      runtimeService.createProcessInstanceQuery().variableValueLessThan("nullVar", null);
+      processInstanceQuery.variableValueLessThan("nullVar", null);
       fail("Excetion expected");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("Booleans and null cannot be used in 'less than' condition");
     }
 
     try {
-      runtimeService.createProcessInstanceQuery().variableValueLessThanOrEqual("nullVar", null);
+      processInstanceQuery.variableValueLessThanOrEqual("nullVar", null);
       fail("Excetion expected");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("Booleans and null cannot be used in 'less than or equal' condition");
     }
 
     try {
-      runtimeService.createProcessInstanceQuery().variableValueLike("nullVar", null);
+      processInstanceQuery.variableValueLike("nullVar", null);
       fail("Excetion expected");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("Booleans and null cannot be used in 'like' condition");
@@ -1226,24 +1230,24 @@ public class ProcessInstanceQueryTest {
   @Deployment(resources={"org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
   public void testQueryInvalidTypes() {
     Map<String, Object> vars = new HashMap<>();
-    vars.put("bytesVar", "test".getBytes());
-    vars.put("serializableVar",new DummySerializable());
+    byte[] testBytes = "test".getBytes();
+    vars.put("bytesVar", testBytes);
+    DummySerializable dummySerializable = new DummySerializable();
+    vars.put("serializableVar", dummySerializable);
 
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery().variableValueEquals("bytesVar", testBytes);
 
     try {
-      runtimeService.createProcessInstanceQuery()
-        .variableValueEquals("bytesVar", "test".getBytes())
-        .list();
+      processInstanceQuery.list();
       fail("Expected exception");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("Variables of type ByteArray cannot be used to query");
     }
 
+    var processInstanceQuery2 = runtimeService.createProcessInstanceQuery().variableValueEquals("serializableVar", dummySerializable);
     try {
-      runtimeService.createProcessInstanceQuery()
-        .variableValueEquals("serializableVar", new DummySerializable())
-        .list();
+      processInstanceQuery2.list();
       fail("Expected exception");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("Object values cannot be used to query");
@@ -1254,44 +1258,45 @@ public class ProcessInstanceQueryTest {
 
   @Test
   public void testQueryVariablesNullNameArgument() {
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery();
     try {
-      runtimeService.createProcessInstanceQuery().variableValueEquals(null, "value");
+      processInstanceQuery.variableValueEquals(null, "value");
       fail("Expected exception");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("name is null");
     }
     try {
-      runtimeService.createProcessInstanceQuery().variableValueNotEquals(null, "value");
+      processInstanceQuery.variableValueNotEquals(null, "value");
       fail("Expected exception");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("name is null");
     }
     try {
-      runtimeService.createProcessInstanceQuery().variableValueGreaterThan(null, "value");
+      processInstanceQuery.variableValueGreaterThan(null, "value");
       fail("Expected exception");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("name is null");
     }
     try {
-      runtimeService.createProcessInstanceQuery().variableValueGreaterThanOrEqual(null, "value");
+      processInstanceQuery.variableValueGreaterThanOrEqual(null, "value");
       fail("Expected exception");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("name is null");
     }
     try {
-      runtimeService.createProcessInstanceQuery().variableValueLessThan(null, "value");
+      processInstanceQuery.variableValueLessThan(null, "value");
       fail("Expected exception");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("name is null");
     }
     try {
-      runtimeService.createProcessInstanceQuery().variableValueLessThanOrEqual(null, "value");
+      processInstanceQuery.variableValueLessThanOrEqual(null, "value");
       fail("Expected exception");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("name is null");
     }
     try {
-      runtimeService.createProcessInstanceQuery().variableValueLike(null, "value");
+      processInstanceQuery.variableValueLike(null, "value");
       fail("Expected exception");
     } catch(ProcessEngineException ae) {
       assertThat(ae.getMessage()).contains("name is null");
@@ -1375,8 +1380,9 @@ public class ProcessInstanceQueryTest {
 
   @Test
   public void testQueryByProcessInstanceIdsEmpty() {
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery();
     try {
-      runtimeService.createProcessInstanceQuery().processInstanceIds(new HashSet<>());
+      processInstanceQuery.processInstanceIds(new HashSet<>());
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException re) {
       assertThat(re.getMessage()).contains("Set of process instance ids is empty");
@@ -1385,8 +1391,9 @@ public class ProcessInstanceQueryTest {
 
   @Test
   public void testQueryByProcessInstanceIdsNull() {
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery();
     try {
-      runtimeService.createProcessInstanceQuery().processInstanceIds(null);
+      processInstanceQuery.processInstanceIds(null);
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException re) {
       assertThat(re.getMessage()).contains("Set of process instance ids is null");
@@ -1983,20 +1990,21 @@ public class ProcessInstanceQueryTest {
   @Test
   public void testQueryByInvalidDeploymentId() {
     assertEquals(0, runtimeService.createProcessInstanceQuery().deploymentId("invalid").count());
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery();
 
     try {
-      runtimeService.createProcessInstanceQuery().deploymentId(null).count();
+      processInstanceQuery.deploymentId(null);
       fail();
     } catch(ProcessEngineException e) {
-      // expected
+      assertEquals("Deployment id is null", e.getMessage());
     }
   }
 
   @Test
   public void testQueryByNullActivityId() {
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery();
     try {
-      runtimeService.createProcessInstanceQuery()
-        .activityIdIn((String) null);
+      processInstanceQuery.activityIdIn((String) null);
       fail("exception expected");
     }
     catch (NullValueException e) {
@@ -2006,9 +2014,9 @@ public class ProcessInstanceQueryTest {
 
   @Test
   public void testQueryByNullActivityIds() {
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery();
     try {
-      runtimeService.createProcessInstanceQuery()
-        .activityIdIn((String[]) null);
+      processInstanceQuery.activityIdIn((String[]) null);
       fail("exception expected");
     }
     catch (NullValueException e) {
@@ -2226,9 +2234,10 @@ public class ProcessInstanceQueryTest {
   @Test
   public void testQueryByRootProcessInstancesAndSuperProcess() {
     // when
+    ProcessInstanceQuery processInstanceQuery1 = runtimeService.createProcessInstanceQuery()
+      .rootProcessInstances();
     try {
-      runtimeService.createProcessInstanceQuery()
-        .rootProcessInstances()
+      processInstanceQuery1
         .superProcessInstanceId("processInstanceId");
 
       fail("expected exception");
@@ -2238,9 +2247,10 @@ public class ProcessInstanceQueryTest {
     }
 
     // when
+    ProcessInstanceQuery processInstanceId2 = runtimeService.createProcessInstanceQuery()
+      .superProcessInstanceId("processInstanceId");
     try {
-      runtimeService.createProcessInstanceQuery()
-        .superProcessInstanceId("processInstanceId")
+      processInstanceId2
         .rootProcessInstances();
 
       fail("expected exception");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceSuspensionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceSuspensionTest.java
@@ -732,9 +732,10 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
     runtimeService.suspendProcessInstanceById(processInstance.getId());
+    var taskQuery = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId();
 
     try {
-      formService.submitTaskFormData(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId(), new HashMap<>());
+      formService.submitTaskFormData(taskQuery, new HashMap<>());
       fail();
     } catch(SuspendedEntityInteractionException e) {
       // This is expected
@@ -747,9 +748,10 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
     runtimeService.suspendProcessInstanceByProcessDefinitionId(processDefinition.getId());
+    var taskQuery = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId();
 
     try {
-      formService.submitTaskFormData(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId(), new HashMap<>());
+      formService.submitTaskFormData(taskQuery, new HashMap<>());
       fail();
     } catch(SuspendedEntityInteractionException e) {
       // This is expected
@@ -762,9 +764,10 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
     runtimeService.suspendProcessInstanceByProcessDefinitionKey(processDefinition.getKey());
+    var taskQuery = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId();
 
     try {
-      formService.submitTaskFormData(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId(), new HashMap<>());
+      formService.submitTaskFormData(taskQuery, new HashMap<>());
       fail();
     } catch(SuspendedEntityInteractionException e) {
       // This is expected
@@ -778,10 +781,11 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     // Suspend process instance
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
-    runtimeService.suspendProcessInstanceById(processInstance.getId());
+    var processInstanceId = processInstance.getId();
+    runtimeService.suspendProcessInstanceById(processInstanceId);
 
     try {
-      runtimeService.signal(processInstance.getId());
+      runtimeService.signal(processInstanceId);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -790,7 +794,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.signal(processInstance.getId(), new HashMap<>());
+      runtimeService.signal(processInstanceId, new HashMap<>());
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -807,9 +811,10 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
     runtimeService.suspendProcessInstanceByProcessDefinitionId(processDefinition.getId());
+    String processInstanceId = processInstance.getId();
 
     try {
-      runtimeService.signal(processInstance.getId());
+      runtimeService.signal(processInstanceId);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -818,7 +823,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.signal(processInstance.getId(), new HashMap<>());
+      runtimeService.signal(processInstanceId, new HashMap<>());
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -834,10 +839,11 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     // Suspend process instance
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
+    var processInstanceId = processInstance.getId();
     runtimeService.suspendProcessInstanceByProcessDefinitionKey(processDefinition.getKey());
 
     try {
-      runtimeService.signal(processInstance.getId());
+      runtimeService.signal(processInstanceId);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -846,7 +852,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.signal(processInstance.getId(), new HashMap<>());
+      runtimeService.signal(processInstanceId, new HashMap<>());
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -862,9 +868,10 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
     runtimeService.suspendProcessInstanceById(processInstance.getId());
     EventSubscription subscription = runtimeService.createEventSubscriptionQuery().singleResult();
+    var executionId = subscription.getExecutionId();
 
     try {
-      runtimeService.messageEventReceived("someMessage", subscription.getExecutionId());
+      runtimeService.messageEventReceived("someMessage", executionId);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -872,7 +879,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.messageEventReceived("someMessage", subscription.getExecutionId(), new HashMap<>());
+      runtimeService.messageEventReceived("someMessage", executionId, new HashMap<>());
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -887,9 +894,10 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     runtimeService.startProcessInstanceById(processDefinition.getId());
     runtimeService.suspendProcessInstanceByProcessDefinitionId(processDefinition.getId());
     EventSubscription subscription = runtimeService.createEventSubscriptionQuery().singleResult();
+    var executionId = subscription.getExecutionId();
 
     try {
-      runtimeService.messageEventReceived("someMessage", subscription.getExecutionId());
+      runtimeService.messageEventReceived("someMessage", executionId);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -897,7 +905,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.messageEventReceived("someMessage", subscription.getExecutionId(), new HashMap<>());
+      runtimeService.messageEventReceived("someMessage", executionId, new HashMap<>());
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -912,9 +920,10 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     runtimeService.startProcessInstanceById(processDefinition.getId());
     runtimeService.suspendProcessInstanceByProcessDefinitionKey(processDefinition.getKey());
     EventSubscription subscription = runtimeService.createEventSubscriptionQuery().singleResult();
+    var executionId = subscription.getExecutionId();
 
     try {
-      runtimeService.messageEventReceived("someMessage", subscription.getExecutionId());
+      runtimeService.messageEventReceived("someMessage", executionId);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -922,7 +931,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.messageEventReceived("someMessage", subscription.getExecutionId(), new HashMap<>());
+      runtimeService.messageEventReceived("someMessage", executionId, new HashMap<>());
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -951,8 +960,9 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     assertEquals(1, runtimeService.createProcessInstanceQuery().count());
 
     EventSubscription subscription = runtimeService.createEventSubscriptionQuery().singleResult();
+    var executionId = subscription.getExecutionId();
     try {
-      runtimeService.signalEventReceived(signal, subscription.getExecutionId());
+      runtimeService.signalEventReceived(signal, executionId);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -960,7 +970,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.signalEventReceived(signal, subscription.getExecutionId(), new HashMap<>());
+      runtimeService.signalEventReceived(signal, executionId, new HashMap<>());
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -994,8 +1004,9 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     assertEquals(1, runtimeService.createProcessInstanceQuery().count());
 
     EventSubscription subscription = runtimeService.createEventSubscriptionQuery().singleResult();
+    var executionId = subscription.getExecutionId();
     try {
-      runtimeService.signalEventReceived(signal, subscription.getExecutionId());
+      runtimeService.signalEventReceived(signal, executionId);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -1003,7 +1014,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.signalEventReceived(signal, subscription.getExecutionId(), new HashMap<>());
+      runtimeService.signalEventReceived(signal, executionId, new HashMap<>());
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -1042,8 +1053,9 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     assertEquals(1, runtimeService.createProcessInstanceQuery().count());
 
     EventSubscription subscription = runtimeService.createEventSubscriptionQuery().singleResult();
+    var executionId = subscription.getExecutionId();
     try {
-      runtimeService.signalEventReceived(signal, subscription.getExecutionId());
+      runtimeService.signalEventReceived(signal, executionId);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -1051,7 +1063,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.signalEventReceived(signal, subscription.getExecutionId(), new HashMap<>());
+      runtimeService.signalEventReceived(signal, executionId, new HashMap<>());
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -1073,13 +1085,14 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
     final Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
     assertNotNull(task);
+    var taskId = task.getId();
 
     // Suspend the process instance
     runtimeService.suspendProcessInstanceById(processInstance.getId());
 
     // Completing the task should fail
     try {
-      taskService.complete(task.getId());
+      taskService.complete(taskId);
       fail("It is not allowed to complete a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1087,7 +1100,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Claiming the task should fail
     try {
-      taskService.claim(task.getId(), "jos");
+      taskService.claim(taskId, "jos");
       fail("It is not allowed to claim a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1097,7 +1110,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Adding candidate groups on the task should fail
     try {
-      taskService.addCandidateGroup(task.getId(), "blahGroup");
+      taskService.addCandidateGroup(taskId, "blahGroup");
       fail("It is not allowed to add a candidate group on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1105,7 +1118,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Adding candidate users on the task should fail
     try {
-      taskService.addCandidateUser(task.getId(), "blahUser");
+      taskService.addCandidateUser(taskId, "blahUser");
       fail("It is not allowed to add a candidate user on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1113,7 +1126,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Adding group identity links on the task should fail
     try {
-      taskService.addGroupIdentityLink(task.getId(), "blahGroup", IdentityLinkType.CANDIDATE);
+      taskService.addGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE);
       fail("It is not allowed to add a candidate user on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1121,7 +1134,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Adding an identity link on the task should fail
     try {
-      taskService.addUserIdentityLink(task.getId(), "blahUser", IdentityLinkType.OWNER);
+      taskService.addUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER);
       fail("It is not allowed to add an identityLink on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1130,7 +1143,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Set an assignee on the task should fail
     try {
-      taskService.setAssignee(task.getId(), "mispiggy");
+      taskService.setAssignee(taskId, "mispiggy");
       fail("It is not allowed to set an assignee on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1138,7 +1151,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Set an owner on the task should fail
     try {
-      taskService.setOwner(task.getId(), "kermit");
+      taskService.setOwner(taskId, "kermit");
       fail("It is not allowed to set an owner on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1146,7 +1159,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Removing candidate groups on the task should fail
     try {
-      taskService.deleteCandidateGroup(task.getId(), "blahGroup");
+      taskService.deleteCandidateGroup(taskId, "blahGroup");
       fail("It is not allowed to remove a candidate group on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1154,7 +1167,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Removing candidate users on the task should fail
     try {
-      taskService.deleteCandidateUser(task.getId(), "blahUser");
+      taskService.deleteCandidateUser(taskId, "blahUser");
       fail("It is not allowed to remove a candidate user on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1162,7 +1175,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Removing group identity links on the task should fail
     try {
-      taskService.deleteGroupIdentityLink(task.getId(), "blahGroup", IdentityLinkType.CANDIDATE);
+      taskService.deleteGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE);
       fail("It is not allowed to remove a candidate user on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1170,7 +1183,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Removing an identity link on the task should fail
     try {
-      taskService.deleteUserIdentityLink(task.getId(), "blahUser", IdentityLinkType.OWNER);
+      taskService.deleteUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER);
       fail("It is not allowed to remove an identityLink on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1187,13 +1200,14 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
     final Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
     assertNotNull(task);
+    var taskId = task.getId();
 
     // Suspend the process instance
     runtimeService.suspendProcessInstanceByProcessDefinitionId(processDefinition.getId());
 
     // Completing the task should fail
     try {
-      taskService.complete(task.getId());
+      taskService.complete(taskId);
       fail("It is not allowed to complete a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1201,7 +1215,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Claiming the task should fail
     try {
-      taskService.claim(task.getId(), "jos");
+      taskService.claim(taskId, "jos");
       fail("It is not allowed to claim a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1211,7 +1225,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Adding candidate groups on the task should fail
     try {
-      taskService.addCandidateGroup(task.getId(), "blahGroup");
+      taskService.addCandidateGroup(taskId, "blahGroup");
       fail("It is not allowed to add a candidate group on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1219,7 +1233,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Adding candidate users on the task should fail
     try {
-      taskService.addCandidateUser(task.getId(), "blahUser");
+      taskService.addCandidateUser(taskId, "blahUser");
       fail("It is not allowed to add a candidate user on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1227,7 +1241,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Adding group identity links on the task should fail
     try {
-      taskService.addGroupIdentityLink(task.getId(), "blahGroup", IdentityLinkType.CANDIDATE);
+      taskService.addGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE);
       fail("It is not allowed to add a candidate user on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1235,7 +1249,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Adding an identity link on the task should fail
     try {
-      taskService.addUserIdentityLink(task.getId(), "blahUser", IdentityLinkType.OWNER);
+      taskService.addUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER);
       fail("It is not allowed to add an identityLink on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1244,7 +1258,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Set an assignee on the task should fail
     try {
-      taskService.setAssignee(task.getId(), "mispiggy");
+      taskService.setAssignee(taskId, "mispiggy");
       fail("It is not allowed to set an assignee on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1252,7 +1266,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Set an owner on the task should fail
     try {
-      taskService.setOwner(task.getId(), "kermit");
+      taskService.setOwner(taskId, "kermit");
       fail("It is not allowed to set an owner on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1260,7 +1274,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Removing candidate groups on the task should fail
     try {
-      taskService.deleteCandidateGroup(task.getId(), "blahGroup");
+      taskService.deleteCandidateGroup(taskId, "blahGroup");
       fail("It is not allowed to remove a candidate group on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1268,7 +1282,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Removing candidate users on the task should fail
     try {
-      taskService.deleteCandidateUser(task.getId(), "blahUser");
+      taskService.deleteCandidateUser(taskId, "blahUser");
       fail("It is not allowed to remove a candidate user on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1276,7 +1290,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Removing group identity links on the task should fail
     try {
-      taskService.deleteGroupIdentityLink(task.getId(), "blahGroup", IdentityLinkType.CANDIDATE);
+      taskService.deleteGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE);
       fail("It is not allowed to remove a candidate user on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1284,7 +1298,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Removing an identity link on the task should fail
     try {
-      taskService.deleteUserIdentityLink(task.getId(), "blahUser", IdentityLinkType.OWNER);
+      taskService.deleteUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER);
       fail("It is not allowed to remove an identityLink on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1301,13 +1315,14 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
     final Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
     assertNotNull(task);
+    var taskId = task.getId();
 
     // Suspend the process instance
     runtimeService.suspendProcessInstanceByProcessDefinitionKey(processDefinition.getKey());
 
     // Completing the task should fail
     try {
-      taskService.complete(task.getId());
+      taskService.complete(taskId);
       fail("It is not allowed to complete a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1315,7 +1330,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Claiming the task should fail
     try {
-      taskService.claim(task.getId(), "jos");
+      taskService.claim(taskId, "jos");
       fail("It is not allowed to claim a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1325,7 +1340,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Adding candidate groups on the task should fail
     try {
-      taskService.addCandidateGroup(task.getId(), "blahGroup");
+      taskService.addCandidateGroup(taskId, "blahGroup");
       fail("It is not allowed to add a candidate group on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1333,7 +1348,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Adding candidate users on the task should fail
     try {
-      taskService.addCandidateUser(task.getId(), "blahUser");
+      taskService.addCandidateUser(taskId, "blahUser");
       fail("It is not allowed to add a candidate user on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1341,7 +1356,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Adding group identity links on the task should fail
     try {
-      taskService.addGroupIdentityLink(task.getId(), "blahGroup", IdentityLinkType.CANDIDATE);
+      taskService.addGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE);
       fail("It is not allowed to add a candidate user on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1349,7 +1364,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Adding an identity link on the task should fail
     try {
-      taskService.addUserIdentityLink(task.getId(), "blahUser", IdentityLinkType.OWNER);
+      taskService.addUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER);
       fail("It is not allowed to add an identityLink on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1358,7 +1373,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Set an assignee on the task should fail
     try {
-      taskService.setAssignee(task.getId(), "mispiggy");
+      taskService.setAssignee(taskId, "mispiggy");
       fail("It is not allowed to set an assignee on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1366,7 +1381,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Set an owner on the task should fail
     try {
-      taskService.setOwner(task.getId(), "kermit");
+      taskService.setOwner(taskId, "kermit");
       fail("It is not allowed to set an owner on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1374,7 +1389,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Removing candidate groups on the task should fail
     try {
-      taskService.deleteCandidateGroup(task.getId(), "blahGroup");
+      taskService.deleteCandidateGroup(taskId, "blahGroup");
       fail("It is not allowed to remove a candidate group on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1382,7 +1397,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Removing candidate users on the task should fail
     try {
-      taskService.deleteCandidateUser(task.getId(), "blahUser");
+      taskService.deleteCandidateUser(taskId, "blahUser");
       fail("It is not allowed to remove a candidate user on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1390,7 +1405,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Removing group identity links on the task should fail
     try {
-      taskService.deleteGroupIdentityLink(task.getId(), "blahGroup", IdentityLinkType.CANDIDATE);
+      taskService.deleteGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE);
       fail("It is not allowed to remove a candidate user on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1398,7 +1413,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Removing an identity link on the task should fail
     try {
-      taskService.deleteUserIdentityLink(task.getId(), "blahUser", IdentityLinkType.OWNER);
+      taskService.deleteUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER);
       fail("It is not allowed to remove an identityLink on a task of a suspended process instance");
     } catch (SuspendedEntityInteractionException e) {
       // This is good
@@ -1812,9 +1827,10 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     runtimeService.suspendProcessInstanceById(instance.getId());
 
     Task task = taskService.createTaskQuery().singleResult();
+    var taskId = task.getId();
 
     try {
-      taskService.complete(task.getId());
+      taskService.complete(taskId);
       fail("this should not be successful, as the execution of a suspended instance is resumed");
     } catch (SuspendedEntityInteractionException e) {
       // this is expected to fail
@@ -1835,9 +1851,10 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     runtimeService.suspendProcessInstanceByProcessDefinitionId(instance.getProcessDefinitionId());
 
     Task task = taskService.createTaskQuery().singleResult();
+    var taskId = task.getId();
 
     try {
-      taskService.complete(task.getId());
+      taskService.complete(taskId);
       fail("this should not be successful, as the execution of a suspended instance is resumed");
     } catch (SuspendedEntityInteractionException e) {
       // this is expected to fail
@@ -1863,9 +1880,10 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     runtimeService.suspendProcessInstanceByProcessDefinitionKey(processDefinition.getKey());
 
     Task task = taskService.createTaskQuery().singleResult();
+    var taskId = task.getId();
 
     try {
-      taskService.complete(task.getId());
+      taskService.complete(taskId);
       fail("this should not be successful, as the execution of a suspended instance is resumed");
     } catch (SuspendedEntityInteractionException e) {
       // this is expected to fail
@@ -1888,16 +1906,18 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     List<Task> tasks = taskService.createTaskQuery().list();
     Task task1 = tasks.get(0);
     Task task2 = tasks.get(1);
+    String task1Id = task1.getId();
+    String task2Id = task2.getId();
 
     try {
-      taskService.complete(task1.getId());
+      taskService.complete(task1Id);
       fail("this should not be successful, as the execution of a suspended instance is resumed");
     } catch (SuspendedEntityInteractionException e) {
       // this is expected to fail
     }
 
     try {
-      taskService.complete(task2.getId());
+      taskService.complete(task2Id);
       fail("this should not be successful, as the execution of a suspended instance is resumed");
     } catch (SuspendedEntityInteractionException e) {
       // this is expected to fail
@@ -1905,8 +1925,8 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // should be successful after reactivation
     runtimeService.activateProcessInstanceById(instance.getId());
-    taskService.complete(task1.getId());
-    taskService.complete(task2.getId());
+    taskService.complete(task1Id);
+    taskService.complete(task2Id);
 
     assertEquals(0, runtimeService.createProcessInstanceQuery().count());
   }
@@ -1921,16 +1941,18 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     List<Task> tasks = taskService.createTaskQuery().list();
     Task task1 = tasks.get(0);
     Task task2 = tasks.get(1);
+    String task1Id = task1.getId();
+    String task2Id = task2.getId();
 
     try {
-      taskService.complete(task1.getId());
+      taskService.complete(task1Id);
       fail("this should not be successful, as the execution of a suspended instance is resumed");
     } catch (SuspendedEntityInteractionException e) {
       // this is expected to fail
     }
 
     try {
-      taskService.complete(task2.getId());
+      taskService.complete(task2Id);
       fail("this should not be successful, as the execution of a suspended instance is resumed");
     } catch (SuspendedEntityInteractionException e) {
       // this is expected to fail
@@ -1938,8 +1960,8 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // should be successful after reactivation
     runtimeService.activateProcessInstanceByProcessDefinitionId(instance.getProcessDefinitionId());
-    taskService.complete(task1.getId());
-    taskService.complete(task2.getId());
+    taskService.complete(task1Id);
+    taskService.complete(task2Id);
 
     assertEquals(0, runtimeService.createProcessInstanceQuery().count());
   }
@@ -1958,16 +1980,18 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     List<Task> tasks = taskService.createTaskQuery().list();
     Task task1 = tasks.get(0);
     Task task2 = tasks.get(1);
+    String task1Id = task1.getId();
+    String task2Id = task2.getId();
 
     try {
-      taskService.complete(task1.getId());
+      taskService.complete(task1Id);
       fail("this should not be successful, as the execution of a suspended instance is resumed");
     } catch (SuspendedEntityInteractionException e) {
       // this is expected to fail
     }
 
     try {
-      taskService.complete(task2.getId());
+      taskService.complete(task2Id);
       fail("this should not be successful, as the execution of a suspended instance is resumed");
     } catch (SuspendedEntityInteractionException e) {
       // this is expected to fail
@@ -1975,8 +1999,8 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // should be successful after reactivation
     runtimeService.activateProcessInstanceByProcessDefinitionKey(processDefinition.getKey());
-    taskService.complete(task1.getId());
-    taskService.complete(task2.getId());
+    taskService.complete(task1Id);
+    taskService.complete(task2Id);
 
     assertEquals(0, runtimeService.createProcessInstanceQuery().count());
   }
@@ -1992,10 +2016,11 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Suspend process instance
     runtimeService.suspendProcessInstanceById(processInstance.getId());
+    var processInstanceModificationBuilder = runtimeService.createProcessInstanceModification(processInstance.getId()).startBeforeActivity("theTask");
 
     // try to start before activity for suspended processDefinition
     try {
-      runtimeService.createProcessInstanceModification(processInstance.getId()).startBeforeActivity("theTask").execute();
+      processInstanceModificationBuilder.execute();
       fail("Exception is expected but not thrown");
     } catch(SuspendedEntityInteractionException e) {
       testRule.assertTextPresentIgnoreCase("is suspended", e.getMessage());
@@ -2013,10 +2038,11 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
 
     // Suspend process instance
     runtimeService.suspendProcessInstanceById(processInstance.getId());
+    var processInstanceModificationBuilder = runtimeService.createProcessInstanceModification(processInstance.getId()).startAfterActivity("theTask");
 
     // try to start after activity for suspended processDefinition
     try {
-      runtimeService.createProcessInstanceModification(processInstance.getId()).startAfterActivity("theTask").execute();
+      processInstanceModificationBuilder.execute();
       fail("Exception is expected but not thrown");
     } catch(SuspendedEntityInteractionException e) {
       testRule.assertTextPresentIgnoreCase("is suspended", e.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstantiationAtActivitiesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstantiationAtActivitiesTest.java
@@ -30,11 +30,7 @@ import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.delegate.ExecutionListener;
 import org.operaton.bpm.engine.exception.NotValidException;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
-import org.operaton.bpm.engine.runtime.ActivityInstance;
-import org.operaton.bpm.engine.runtime.Execution;
-import org.operaton.bpm.engine.runtime.Job;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.runtime.VariableInstance;
+import org.operaton.bpm.engine.runtime.*;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.bpmn.executionlistener.RecorderExecutionListener;
@@ -184,12 +180,12 @@ public class ProcessInstantiationAtActivitiesTest extends PluggableProcessEngine
   @Deployment(resources = EXCLUSIVE_GATEWAY_PROCESS)
   @Test
   public void testStartWithInvalidInitialActivity() {
+    var processInstantiationBuilder = runtimeService
+          .createProcessInstanceByKey("exclusiveGateway")
+          .startBeforeActivity("someNonExistingActivity");
     try {
       // when
-      runtimeService
-          .createProcessInstanceByKey("exclusiveGateway")
-          .startBeforeActivity("someNonExistingActivity")
-          .execute();
+      processInstantiationBuilder.execute();
       fail("should not succeed");
     } catch (NotValidException e) {
       // then
@@ -290,15 +286,17 @@ public class ProcessInstantiationAtActivitiesTest extends PluggableProcessEngine
 
   @Test
   public void testStartNonExistingProcessDefinition() {
+    var processInstantiationBuilder1 = runtimeService.createProcessInstanceById("I don't exist").startBeforeActivity("start");
     try {
-      runtimeService.createProcessInstanceById("I don't exist").startBeforeActivity("start").execute();
+      processInstantiationBuilder1.execute();
       fail("exception expected");
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent("no deployed process definition found with id", e.getMessage());
     }
 
+    var processInstantiationBuilder2 = runtimeService.createProcessInstanceByKey("I don't exist either").startBeforeActivity("start");
     try {
-      runtimeService.createProcessInstanceByKey("I don't exist either").startBeforeActivity("start").execute();
+      processInstantiationBuilder2.execute();
       fail("exception expected");
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent("no processes deployed with key", e.getMessage());
@@ -307,15 +305,17 @@ public class ProcessInstantiationAtActivitiesTest extends PluggableProcessEngine
 
   @Test
   public void testStartNullProcessDefinition() {
+    var processInstantiationBuilder1 = runtimeService.createProcessInstanceById(null).startBeforeActivity("start");
     try {
-      runtimeService.createProcessInstanceById(null).startBeforeActivity("start").execute();
+      processInstantiationBuilder1.execute();
       fail("exception expected");
     } catch (ProcessEngineException e) {
       // happy path
     }
 
+    var processInstantiationBuilder2 = runtimeService.createProcessInstanceByKey(null).startBeforeActivity("start");
     try {
-      runtimeService.createProcessInstanceByKey(null).startBeforeActivity("start").execute();
+      processInstantiationBuilder2.execute();
       fail("exception expected");
     } catch (ProcessEngineException e) {
       // happy path

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstantiationAtStartEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstantiationAtStartEventTest.java
@@ -108,8 +108,9 @@ public class ProcessInstantiationAtStartEventTest extends PluggableProcessEngine
 
   @Test
   public void testFailToStartProcessInstanceSkipListeners() {
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey(PROCESS_DEFINITION_KEY);
     try {
-      runtimeService.createProcessInstanceByKey(PROCESS_DEFINITION_KEY).execute(true, false);
+      processInstantiationBuilder.execute(true, false);
 
       fail("expected exception");
     } catch (BadUserRequestException e) {
@@ -119,8 +120,9 @@ public class ProcessInstantiationAtStartEventTest extends PluggableProcessEngine
 
   @Test
   public void testFailToStartProcessInstanceSkipInputOutputMapping() {
+    var processInstantiationBuilder = runtimeService.createProcessInstanceByKey(PROCESS_DEFINITION_KEY);
     try {
-      runtimeService.createProcessInstanceByKey(PROCESS_DEFINITION_KEY).execute(false, true);
+      processInstantiationBuilder.execute(false, true);
 
       fail("expected exception");
     } catch (BadUserRequestException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RestartProcessInstanceAsyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RestartProcessInstanceAsyncTest.java
@@ -51,11 +51,7 @@ import org.operaton.bpm.engine.impl.cfg.multitenancy.TenantIdProviderProcessInst
 import org.operaton.bpm.engine.impl.persistence.entity.HistoricProcessInstanceEntity;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
-import org.operaton.bpm.engine.runtime.ActivityInstance;
-import org.operaton.bpm.engine.runtime.Execution;
-import org.operaton.bpm.engine.runtime.Job;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.runtime.VariableInstance;
+import org.operaton.bpm.engine.runtime.*;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
@@ -149,8 +145,7 @@ public class RestartProcessInstanceAsyncTest {
   @Test
   public void restartProcessInstanceWithNullProcessDefinitionId() {
     try {
-      runtimeService.restartProcessInstances(null)
-      .executeAsync();
+      runtimeService.restartProcessInstances(null);
       fail("exception expected");
     } catch (BadUserRequestException e) {
       assertThat(e.getMessage()).contains("processDefinitionId is null");
@@ -161,10 +156,10 @@ public class RestartProcessInstanceAsyncTest {
   public void restartProcessInstanceWithoutInstructions() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(ProcessModels.TWO_TASKS_PROCESS);
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("Process");
+    var restartProcessInstanceBuilder = runtimeService.restartProcessInstances(processDefinition.getId()).processInstanceIds(processInstance.getId());
 
     try {
-      Batch batch = runtimeService.restartProcessInstances(processDefinition.getId()).processInstanceIds(processInstance.getId()).executeAsync();
-      helper.completeBatch(batch);
+      restartProcessInstanceBuilder.executeAsync();
       fail("exception expected");
     } catch (BadUserRequestException e) {
       assertThat(e.getMessage()).contains("instructions is empty");
@@ -173,8 +168,9 @@ public class RestartProcessInstanceAsyncTest {
 
   @Test
   public void restartProcessInstanceWithoutProcessInstanceIds() {
+    var restartProcessInstanceBuilder = runtimeService.restartProcessInstances("foo").startAfterActivity("bar");
     try {
-      runtimeService.restartProcessInstances("foo").startAfterActivity("bar").executeAsync();
+      restartProcessInstanceBuilder.executeAsync();
       fail("exception expected");
     } catch (BadUserRequestException e) {
       assertThat(e.getMessage()).contains("processInstanceIds is empty");
@@ -183,11 +179,11 @@ public class RestartProcessInstanceAsyncTest {
 
   @Test
   public void restartProcessInstanceWithNullProcessInstanceId() {
-    try {
-      runtimeService.restartProcessInstances("foo")
+    var restartProcessInstanceBuilder = runtimeService.restartProcessInstances("foo")
       .startAfterActivity("bar")
-      .processInstanceIds((String) null)
-      .executeAsync();
+      .processInstanceIds((String) null);
+    try {
+      restartProcessInstanceBuilder.executeAsync();
       fail("exception expected");
     } catch (BadUserRequestException e) {
       assertThat(e.getMessage()).contains("processInstanceIds contains null value");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.java
@@ -496,9 +496,10 @@ public class RuntimeServiceTest {
   @Test
   public void testDeleteProcessInstancesWithFake() {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    var processInstanceIds = Arrays.asList(instance.getId(), "aFake");
 
     try {
-      runtimeService.deleteProcessInstances(Arrays.asList(instance.getId(), "aFake"), "test", false, false, false, false);
+      runtimeService.deleteProcessInstances(processInstanceIds, "test", false, false, false, false);
       fail("ProcessEngineException expected");
     }catch (ProcessEngineException e) {
       //expected
@@ -795,10 +796,11 @@ public class RuntimeServiceTest {
   @Test
   public void testSignalInactiveExecution() {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("testSignalInactiveExecution");
+    var instanceId = instance.getId();
 
     // there exist two executions: the inactive parent (the process instance) and the child that actually waits in the receive task
     try {
-      runtimeService.signal(instance.getId());
+      runtimeService.signal(instanceId);
       fail();
     } catch(ProcessEngineException e) {
       // happy path
@@ -882,9 +884,10 @@ public class RuntimeServiceTest {
     "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
   @Test
   public void testSetVariableNullVariableName() {
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    var processInstanceId = processInstance.getId();
     try {
-      ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
-      runtimeService.setVariable(processInstance.getId(), null, "variableValue");
+      runtimeService.setVariable(processInstanceId, null, "variableValue");
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
       testRule.assertTextPresent("variableName is null", ae.getMessage());
@@ -1447,8 +1450,9 @@ public class RuntimeServiceTest {
    Execution execution = runtimeService.createExecutionQuery()
      .signalEventSubscriptionName("alert")
      .singleResult();
+   var executionId = execution.getId();
    try {
-     runtimeService.signalEventReceived("bogusSignal", execution.getId());
+     runtimeService.signalEventReceived("bogusSignal", executionId);
      fail("exeception expected");
    }catch (ProcessEngineException e) {
      // this is good
@@ -2448,9 +2452,10 @@ public class RuntimeServiceTest {
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
   @Test
   public void testSetAbstractNumberValueFails() {
+    var variables = Variables.createVariables().putValueTyped("var", Variables.numberValue(42));
+    var variableMap = Variables.numberValue(42);
     try {
-      runtimeService.startProcessInstanceByKey("oneTaskProcess",
-          Variables.createVariables().putValueTyped("var", Variables.numberValue(42)));
+      runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
       fail("exception expected");
     } catch (ProcessEngineException e) {
       // happy path
@@ -2458,9 +2463,10 @@ public class RuntimeServiceTest {
     }
 
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    var processInstanceId = processInstance.getId();
 
     try {
-      runtimeService.setVariable(processInstance.getId(), "var", Variables.numberValue(42));
+      runtimeService.setVariable(processInstanceId, "var", variableMap);
       fail("exception expected");
     } catch (ProcessEngineException e) {
       // happy path
@@ -2503,11 +2509,12 @@ public class RuntimeServiceTest {
   @Test
   public void testStartProcessInstanceByMessageWithNonExistingMessageStartEvent() {
 	  String deploymentId = null;
-	  try {
-		 deploymentId = repositoryService.createDeployment().addClasspathResource("org/operaton/bpm/engine/test/api/runtime/messageStartEvent_version2.bpmn20.xml").deploy().getId();
-		 ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionVersion(1).singleResult();
+	  deploymentId = repositoryService.createDeployment().addClasspathResource("org/operaton/bpm/engine/test/api/runtime/messageStartEvent_version2.bpmn20.xml").deploy().getId();
+	  ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionVersion(1).singleResult();
+	  var processDefinitionId = processDefinition.getId();
 
-		 runtimeService.startProcessInstanceByMessageAndProcessDefinitionId("newStartMessage", processDefinition.getId());
+    try {
+		 runtimeService.startProcessInstanceByMessageAndProcessDefinitionId("newStartMessage", processDefinitionId);
 
 		 fail("exeception expected");
 	 } catch(ProcessEngineException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/SingleProcessInstanceModificationAsyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/SingleProcessInstanceModificationAsyncTest.java
@@ -243,11 +243,10 @@ public class SingleProcessInstanceModificationAsyncTest extends PluggableProcess
   public void testStartBeforeNonExistingActivity() {
     // given
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("exclusiveGateway");
+    Batch modificationBatch = runtimeService.createProcessInstanceModification(instance.getId()).startBeforeActivity("someNonExistingActivity").executeAsync();
+    assertNotNull(modificationBatch);
 
     try {
-      // when
-      Batch modificationBatch = runtimeService.createProcessInstanceModification(instance.getId()).startBeforeActivity("someNonExistingActivity").executeAsync();
-      assertNotNull(modificationBatch);
       executeSeedAndBatchJobs(modificationBatch);
       fail("should not succeed");
     } catch (NotValidException e) {
@@ -359,10 +358,10 @@ public class SingleProcessInstanceModificationAsyncTest extends PluggableProcess
   public void testStartTransitionInvalidTransitionId() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("exclusiveGateway");
     String processInstanceId = processInstance.getId();
+    Batch modificationBatch = runtimeService.createProcessInstanceModification(processInstanceId).startTransition("invalidFlowId").executeAsync();
+    assertNotNull(modificationBatch);
 
     try {
-      Batch modificationBatch = runtimeService.createProcessInstanceModification(processInstanceId).startTransition("invalidFlowId").executeAsync();
-      assertNotNull(modificationBatch);
       executeSeedAndBatchJobs(modificationBatch);
 
       fail("should not suceed");
@@ -444,13 +443,13 @@ public class SingleProcessInstanceModificationAsyncTest extends PluggableProcess
   public void testStartAfterActivityAmbiguousTransitions() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("exclusiveGateway");
     String processInstanceId = processInstance.getId();
-
-    try {
-      Batch modificationBatch = runtimeService
+    Batch modificationBatch = runtimeService
           .createProcessInstanceModification(processInstanceId)
           .startAfterActivity("fork")
           .executeAsync();
-      assertNotNull(modificationBatch);
+    assertNotNull(modificationBatch);
+
+    try {
       executeSeedAndBatchJobs(modificationBatch);
       fail("should not suceed since 'fork' has more than one outgoing sequence flow");
     } catch (ProcessEngineException e) {
@@ -464,13 +463,13 @@ public class SingleProcessInstanceModificationAsyncTest extends PluggableProcess
   public void testStartAfterActivityNoOutgoingTransitions() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("exclusiveGateway");
     String processInstanceId = processInstance.getId();
-
-    try {
-      Batch modificationBatch = runtimeService
+    Batch modificationBatch = runtimeService
           .createProcessInstanceModification(processInstanceId)
           .startAfterActivity("theEnd")
           .executeAsync();
-      assertNotNull(modificationBatch);
+    assertNotNull(modificationBatch);
+
+    try {
       executeSeedAndBatchJobs(modificationBatch);
       fail("should not suceed since 'theEnd' has no outgoing sequence flow");
 
@@ -485,14 +484,13 @@ public class SingleProcessInstanceModificationAsyncTest extends PluggableProcess
   public void testStartAfterNonExistingActivity() {
     // given
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("exclusiveGateway");
-
-    try {
-      // when
-      Batch modificationBatch = runtimeService
+    Batch modificationBatch = runtimeService
           .createProcessInstanceModification(instance.getId())
           .startAfterActivity("someNonExistingActivity")
           .executeAsync();
-      assertNotNull(modificationBatch);
+    assertNotNull(modificationBatch);
+
+    try {
       executeSeedAndBatchJobs(modificationBatch);
       fail("should not succeed");
     } catch (NotValidException e) {
@@ -751,14 +749,14 @@ public class SingleProcessInstanceModificationAsyncTest extends PluggableProcess
   public void testCancelNonExistingActivityInstance() {
     // given
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("exclusiveGateway");
-
-    // when - then throw exception
-    try {
-      Batch modificationBatch = runtimeService
+    Batch modificationBatch = runtimeService
           .createProcessInstanceModification(instance.getId())
           .cancelActivityInstance("nonExistingActivityInstance")
           .executeAsync();
-      assertNotNull(modificationBatch);
+    assertNotNull(modificationBatch);
+
+    // when - then throw exception
+    try {
       executeSeedAndBatchJobs(modificationBatch);
       fail("should not succeed");
     } catch (NotValidException e) {
@@ -773,14 +771,14 @@ public class SingleProcessInstanceModificationAsyncTest extends PluggableProcess
   public void testCancelNonExistingTranisitionInstance() {
     // given
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("exclusiveGateway");
-
-    // when - then throw exception
-    try {
-      Batch modificationBatch = runtimeService
+    Batch modificationBatch = runtimeService
           .createProcessInstanceModification(instance.getId())
           .cancelTransitionInstance("nonExistingActivityInstance")
           .executeAsync();
-      assertNotNull(modificationBatch);
+    assertNotNull(modificationBatch);
+
+    // when - then throw exception
+    try {
       executeSeedAndBatchJobs(modificationBatch);
       fail("should not succeed");
     } catch (NotValidException e) {
@@ -814,12 +812,7 @@ public class SingleProcessInstanceModificationAsyncTest extends PluggableProcess
   @Test
   public void testModifyNullProcessInstance() {
     try {
-      Batch modificationBatch = runtimeService
-          .createProcessInstanceModification(null)
-          .startBeforeActivity("someActivity")
-          .executeAsync();
-      assertNotNull(modificationBatch);
-      executeSeedAndBatchJobs(modificationBatch);
+      runtimeService.createProcessInstanceModification(null);
       fail("should not succeed");
     } catch (NotValidException e) {
       testRule.assertTextPresent("processInstanceId is null", e.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationAddMultiInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationAddMultiInstanceTest.java
@@ -46,12 +46,12 @@ public class MigrationAddMultiInstanceTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(MultiInstanceProcessModels.PAR_MI_ONE_TASK_PROCESS);
+    var runtimeService = rule.getRuntimeService()
+      .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+      .mapActivities("userTask", "userTask");
 
     try {
-      rule.getRuntimeService()
-      .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-      .mapActivities("userTask", "userTask")
-      .build();
+      runtimeService.build();
       fail("Should not succeed");
     }
     catch (MigrationPlanValidationException e) {
@@ -68,12 +68,12 @@ public class MigrationAddMultiInstanceTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(MultiInstanceProcessModels.PAR_MI_ONE_TASK_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(MultiInstanceProcessModels.PAR_MI_ONE_TASK_PROCESS);
+    var runtimeService = rule.getRuntimeService()
+      .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+      .mapActivities("userTask", "userTask");
 
     try {
-      rule.getRuntimeService()
-      .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-      .mapActivities("userTask", "userTask")
-      .build();
+      runtimeService.build();
       fail("Should not succeed");
     }
     catch (MigrationPlanValidationException e) {
@@ -90,12 +90,12 @@ public class MigrationAddMultiInstanceTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(MultiInstanceProcessModels.PAR_MI_SUBPROCESS_PROCESS);
+    var runtimeService = rule.getRuntimeService()
+      .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+      .mapActivities("userTask", "userTask");
 
     try {
-      rule.getRuntimeService()
-      .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-      .mapActivities("userTask", "userTask")
-      .build();
+      runtimeService.build();
       fail("Should not succeed");
     }
     catch (MigrationPlanValidationException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationCompensationAddSubProcessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationCompensationAddSubProcessTest.java
@@ -322,16 +322,16 @@ public class MigrationCompensationAddSubProcessTest {
           .compensateEventDefinitionDone()
         .endEvent()
         .done());
+    var runtimeService = rule.getRuntimeService().createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapActivities("subProcess", "outerSubProcess")
+        .mapActivities("eventSubProcessStart", "eventSubProcessStart")
+        .mapActivities("compensationBoundary", "compensationBoundary")
+        .mapActivities("userTask2", "userTask2");
 
 
     try {
       // when
-      rule.getRuntimeService().createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities("subProcess", "outerSubProcess")
-        .mapActivities("eventSubProcessStart", "eventSubProcessStart")
-        .mapActivities("compensationBoundary", "compensationBoundary")
-        .mapActivities("userTask2", "userTask2")
-        .build();
+      runtimeService.build();
       Assert.fail("exception expected");
     } catch (MigrationPlanValidationException e) {
       // then

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationCompensationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationCompensationTest.java
@@ -900,14 +900,14 @@ public class MigrationCompensationTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(CompensationModels.DOUBLE_SUBPROCESS_MODEL);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(CompensationModels.DOUBLE_SUBPROCESS_MODEL);
+    var runtimeService = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapActivities("outerSubProcess", "innerSubProcess")
+        .mapActivities("innerSubProcess", "outerSubProcess");
 
     try {
       // when
-      rule.getRuntimeService()
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities("outerSubProcess", "innerSubProcess")
-        .mapActivities("innerSubProcess", "outerSubProcess")
-        .build();
+      runtimeService.build();
       Assert.fail("exception expected");
     } catch (MigrationPlanValidationException e) {
       // then
@@ -931,14 +931,14 @@ public class MigrationCompensationTest {
           .startEvent()
           .endEvent()
         .done());
+    var runtimeService = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapActivities("subProcess", "addedSubProcess")
+        .mapActivities("compensationBoundary", "compensationBoundary");
 
     try {
       // when
-      rule.getRuntimeService()
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities("subProcess", "addedSubProcess")
-        .mapActivities("compensationBoundary", "compensationBoundary")
-        .build();
+      runtimeService.build();
       Assert.fail("exception expected");
     } catch (MigrationPlanValidationException e) {
       // then
@@ -955,13 +955,13 @@ public class MigrationCompensationTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(CompensationModels.COMPENSATION_EVENT_SUBPROCESS_MODEL);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(CompensationModels.COMPENSATION_EVENT_SUBPROCESS_MODEL);
+    var runtimeService = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapActivities("eventSubProcessStart", "eventSubProcessStart");
 
     try {
       // when
-      rule.getRuntimeService()
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities("eventSubProcessStart", "eventSubProcessStart")
-        .build();
+      runtimeService.build();
       Assert.fail("exception expected");
     } catch (MigrationPlanValidationException e) {
       // then
@@ -980,13 +980,13 @@ public class MigrationCompensationTest {
 
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(model);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(model);
+    var runtimeService = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapActivities("eventSubProcessStart", "eventSubProcessStart");
 
     try {
       // when
-      rule.getRuntimeService()
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities("eventSubProcessStart", "eventSubProcessStart")
-        .build();
+      runtimeService.build();
       Assert.fail("exception expected");
     } catch (MigrationPlanValidationException e) {
       // then

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationEventSubProcessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationEventSubProcessTest.java
@@ -405,14 +405,14 @@ public class MigrationEventSubProcessTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(EventSubProcessModels.SIGNAL_EVENT_SUBPROCESS_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(EventSubProcessModels.TIMER_EVENT_SUBPROCESS_PROCESS);
+    var runtimeService = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapActivities(USER_TASK_ID, USER_TASK_ID)
+        .mapActivities(EVENT_SUB_PROCESS_START_ID, EVENT_SUB_PROCESS_START_ID);
 
     try {
       // when
-      rule.getRuntimeService()
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities(USER_TASK_ID, USER_TASK_ID)
-        .mapActivities(EVENT_SUB_PROCESS_START_ID, EVENT_SUB_PROCESS_START_ID)
-        .build();
+      runtimeService.build();
       Assert.fail("exception expected");
     } catch (MigrationPlanValidationException e) {
       // then

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationExternalTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationExternalTaskTest.java
@@ -270,12 +270,12 @@ public class MigrationExternalTaskTest {
   public void cannotMigrateFromExternalToClassDelegateServiceTask() {
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(ExternalTaskModels.ONE_EXTERNAL_TASK_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(ServiceTaskModels.oneClassDelegateServiceTask("foo.Bar"));
+    var runtimeService = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapActivities("externalTask", "serviceTask");
 
     try {
-      rule.getRuntimeService()
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities("externalTask", "serviceTask")
-        .build();
+      runtimeService.build();
       Assert.fail("exception expected");
     } catch (MigrationPlanValidationException e) {
       // then

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationFlipScopesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationFlipScopesTest.java
@@ -44,15 +44,15 @@ public class MigrationFlipScopesTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(ProcessModels.DOUBLE_SUBPROCESS_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(ProcessModels.DOUBLE_SUBPROCESS_PROCESS);
-
-    // when
-    try {
-      rule.getRuntimeService()
+    var runtimeService = rule.getRuntimeService()
         .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
         .mapActivities("outerSubProcess", "innerSubProcess")
         .mapActivities("innerSubProcess", "outerSubProcess")
-        .mapActivities("userTask", "userTask")
-        .build();
+        .mapActivities("userTask", "userTask");
+
+    // when
+    try {
+      runtimeService.build();
 
       Assert.fail("should not validate");
     } catch (MigrationPlanValidationException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationGatewayTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationGatewayTest.java
@@ -244,12 +244,12 @@ public class MigrationGatewayTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(GatewayModels.PARALLEL_GW);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(GatewayModels.INCLUSIVE_GW);
+    var runtimeService = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapActivities("join", "join");
 
     try {
-      rule.getRuntimeService()
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities("join", "join")
-        .build();
+      runtimeService.build();
       Assert.fail("exception expected");
     } catch (MigrationPlanValidationException e) {
       // then
@@ -266,12 +266,12 @@ public class MigrationGatewayTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(GatewayModels.INCLUSIVE_GW);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(GatewayModels.PARALLEL_GW);
+    var runtimeService = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapActivities("join", "join");
 
     try {
-      rule.getRuntimeService()
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities("join", "join")
-        .build();
+      runtimeService.build();
       Assert.fail("exception expected");
     } catch (MigrationPlanValidationException e) {
       // then
@@ -293,12 +293,12 @@ public class MigrationGatewayTest {
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(GatewayModels.PARALLEL_GW);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(modify(GatewayModels.PARALLEL_GW)
         .removeFlowNode("parallel2"));
+    var runtimeService = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapActivities("join", "join");
 
     try {
-      rule.getRuntimeService()
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities("join", "join")
-        .build();
+      runtimeService.build();
       Assert.fail("exception expected");
     } catch (MigrationPlanValidationException e) {
       // then
@@ -361,12 +361,12 @@ public class MigrationGatewayTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(GatewayModels.PARALLEL_GW_IN_SUBPROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(GatewayModels.PARALLEL_GW);
+    var runtimeService = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapActivities("join", "join");
 
     try {
-      rule.getRuntimeService()
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities("join", "join")
-        .build();
+      runtimeService.build();
       Assert.fail("exception expected");
     } catch (MigrationPlanValidationException e) {
       // then
@@ -386,13 +386,13 @@ public class MigrationGatewayTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(GatewayModels.PARALLEL_GW);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(GatewayModels.PARALLEL_GW);
-
-    try {
-      rule.getRuntimeService()
+    var runtimeService = rule.getRuntimeService()
         .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
         .mapActivities("join", "join")
-        .mapActivities("fork", "join")
-        .build();
+        .mapActivities("fork", "join");
+
+    try {
+      runtimeService.build();
       Assert.fail("exception expected");
     } catch (MigrationPlanValidationException e) {
       // then

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationHorizontalScopeChangeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationHorizontalScopeChangeTest.java
@@ -45,16 +45,16 @@ public class MigrationHorizontalScopeChangeTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(ProcessModels.PARALLEL_SUBPROCESS_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(ProcessModels.PARALLEL_SUBPROCESS_PROCESS);
-
-    // when
-    try {
-      rule.getRuntimeService()
+    var runtimeService = rule.getRuntimeService()
         .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
         .mapActivities("subProcess1", "subProcess1")
         .mapActivities("subProcess2", "subProcess2")
         .mapActivities("userTask1", "userTask2")
-        .mapActivities("userTask2", "userTask1")
-        .build();
+        .mapActivities("userTask2", "userTask1");
+
+    // when
+    try {
+      runtimeService.build();
 
       Assert.fail("should fail");
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationMultiInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationMultiInstanceTest.java
@@ -205,13 +205,13 @@ public class MigrationMultiInstanceTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(MultiInstanceProcessModels.PAR_MI_SUBPROCESS_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(MultiInstanceProcessModels.PAR_MI_ONE_TASK_PROCESS);
-
-    try {
-      rule.getRuntimeService()
+    var runtimeService = rule.getRuntimeService()
       .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
       .mapActivities(miBodyOf("subProcess"), miBodyOf("userTask"))
-      .mapActivities("userTask", "userTask")
-      .build();
+      .mapActivities("userTask", "userTask");
+
+    try {
+      runtimeService.build();
       fail("Should not succeed");
     }
     catch (MigrationPlanValidationException e) {
@@ -228,13 +228,13 @@ public class MigrationMultiInstanceTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(MultiInstanceProcessModels.PAR_MI_ONE_TASK_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(MultiInstanceProcessModels.PAR_MI_SUBPROCESS_PROCESS);
-
-    try {
-      rule.getRuntimeService()
+    var runtimeService = rule.getRuntimeService()
       .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
       .mapActivities(miBodyOf("userTask"), miBodyOf("subProcess"))
-      .mapActivities("userTask", "userTask")
-      .build();
+      .mapActivities("userTask", "userTask");
+
+    try {
+      runtimeService.build();
       fail("Should not succeed");
     }
     catch (MigrationPlanValidationException e) {
@@ -353,13 +353,13 @@ public class MigrationMultiInstanceTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(MultiInstanceProcessModels.SEQ_MI_SUBPROCESS_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(MultiInstanceProcessModels.SEQ_MI_ONE_TASK_PROCESS);
-
-    try {
-      rule.getRuntimeService()
+    var runtimeService = rule.getRuntimeService()
       .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
       .mapActivities(miBodyOf("subProcess"), miBodyOf("userTask"))
-      .mapActivities("userTask", "userTask")
-      .build();
+      .mapActivities("userTask", "userTask");
+
+    try {
+      runtimeService.build();
       fail("Should not succeed");
     }
     catch (MigrationPlanValidationException e) {
@@ -376,13 +376,13 @@ public class MigrationMultiInstanceTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(MultiInstanceProcessModels.SEQ_MI_ONE_TASK_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(MultiInstanceProcessModels.SEQ_MI_SUBPROCESS_PROCESS);
-
-    try {
-      rule.getRuntimeService()
+    var runtimeService = rule.getRuntimeService()
       .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
       .mapActivities(miBodyOf("userTask"), miBodyOf("subProcess"))
-      .mapActivities("userTask", "userTask")
-      .build();
+      .mapActivities("userTask", "userTask");
+
+    try {
+      runtimeService.build();
       fail("Should not succeed");
     }
     catch (MigrationPlanValidationException e) {
@@ -398,13 +398,13 @@ public class MigrationMultiInstanceTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(MultiInstanceProcessModels.PAR_MI_ONE_TASK_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(MultiInstanceProcessModels.SEQ_MI_ONE_TASK_PROCESS);
-
-    try {
-      rule.getRuntimeService()
+    var runtimeService = rule.getRuntimeService()
       .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
       .mapActivities(miBodyOf("userTask"), miBodyOf("userTask"))
-      .mapActivities("userTask", "userTask")
-      .build();
+      .mapActivities("userTask", "userTask");
+
+    try {
+      runtimeService.build();
       fail("Should not succeed");
     }
     catch (MigrationPlanValidationException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationPlanCreationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationPlanCreationTest.java
@@ -93,12 +93,12 @@ public class MigrationPlanCreationTest {
   @Test
   public void testMigrateNonExistingSourceDefinition() {
     ProcessDefinition processDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    var migrationPlanBuilder = runtimeService
+        .createMigrationPlan("aNonExistingProcDefId", processDefinition.getId())
+        .mapActivities("userTask", "userTask");
 
     try {
-      runtimeService
-        .createMigrationPlan("aNonExistingProcDefId", processDefinition.getId())
-        .mapActivities("userTask", "userTask")
-        .build();
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     } catch (BadUserRequestException e) {
       assertExceptionMessage(e, "Source process definition with id 'aNonExistingProcDefId' does not exist");
@@ -108,12 +108,12 @@ public class MigrationPlanCreationTest {
   @Test
   public void testMigrateNullSourceDefinition() {
     ProcessDefinition processDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    var migrationPlanBuilder = runtimeService
+        .createMigrationPlan(null, processDefinition.getId())
+        .mapActivities("userTask", "userTask");
 
     try {
-      runtimeService
-        .createMigrationPlan(null, processDefinition.getId())
-        .mapActivities("userTask", "userTask")
-        .build();
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     } catch (BadUserRequestException e) {
       assertExceptionMessage(e, "Source process definition id is null");
@@ -123,11 +123,11 @@ public class MigrationPlanCreationTest {
   @Test
   public void testMigrateNonExistingTargetDefinition() {
     ProcessDefinition processDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
-    try {
-      runtimeService
+    var migrationPlanBuilder = runtimeService
         .createMigrationPlan(processDefinition.getId(), "aNonExistingProcDefId")
-        .mapActivities("userTask", "userTask")
-        .build();
+        .mapActivities("userTask", "userTask");
+    try {
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     } catch (BadUserRequestException e) {
       assertExceptionMessage(e, "Target process definition with id 'aNonExistingProcDefId' does not exist");
@@ -137,12 +137,12 @@ public class MigrationPlanCreationTest {
   @Test
   public void testMigrateNullTargetDefinition() {
     ProcessDefinition processDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    var migrationPlanBuilder = runtimeService
+        .createMigrationPlan(processDefinition.getId(), null)
+        .mapActivities("userTask", "userTask");
 
     try {
-      runtimeService
-        .createMigrationPlan(processDefinition.getId(), null)
-        .mapActivities("userTask", "userTask")
-        .build();
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     } catch (BadUserRequestException e) {
       assertExceptionMessage(e, "Target process definition id is null");
@@ -153,12 +153,12 @@ public class MigrationPlanCreationTest {
   public void testMigrateNonExistingSourceActivityId() {
     ProcessDefinition sourceDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessDefinition targetDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    var migrationPlanBuilder = runtimeService
+        .createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
+        .mapActivities("thisActivityDoesNotExist", "userTask");
 
     try {
-      runtimeService
-        .createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
-        .mapActivities("thisActivityDoesNotExist", "userTask")
-        .build();
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     } catch (MigrationPlanValidationException e) {
       assertThat(e.getValidationReport())
@@ -170,12 +170,12 @@ public class MigrationPlanCreationTest {
   public void testMigrateNullSourceActivityId() {
     ProcessDefinition sourceDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessDefinition targetDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    var migrationPlanBuilder = runtimeService
+        .createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
+        .mapActivities(null, "userTask");
 
     try {
-      runtimeService
-        .createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
-        .mapActivities(null, "userTask")
-        .build();
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     } catch (MigrationPlanValidationException e) {
       assertThat(e.getValidationReport())
@@ -187,12 +187,12 @@ public class MigrationPlanCreationTest {
   public void testMigrateNonExistingTargetActivityId() {
     ProcessDefinition sourceDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessDefinition targetDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    var migrationPlanBuilder = runtimeService
+        .createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
+        .mapActivities("userTask", "thisActivityDoesNotExist");
 
     try {
-      runtimeService
-        .createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
-        .mapActivities("userTask", "thisActivityDoesNotExist")
-        .build();
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     } catch (MigrationPlanValidationException e) {
       assertThat(e.getValidationReport())
@@ -204,12 +204,12 @@ public class MigrationPlanCreationTest {
   public void testMigrateNullTargetActivityId() {
     ProcessDefinition sourceDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessDefinition targetDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    var migrationPlanBuilder = runtimeService
+        .createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
+        .mapActivities("userTask", null);
 
     try {
-      runtimeService
-        .createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
-        .mapActivities("userTask", null)
-        .build();
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     } catch (MigrationPlanValidationException e) {
       assertThat(e.getValidationReport())
@@ -240,12 +240,12 @@ public class MigrationPlanCreationTest {
 
     ProcessDefinition sourceDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessDefinition targetDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_RECEIVE_TASK_PROCESS);
+    var migrationPlanBuilder = runtimeService
+        .createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
+        .mapActivities("userTask", "receiveTask");
 
     try {
-      runtimeService
-        .createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
-        .mapActivities("userTask", "receiveTask")
-        .build();
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     } catch (MigrationPlanValidationException e) {
       assertThat(e.getValidationReport())
@@ -261,12 +261,12 @@ public class MigrationPlanCreationTest {
     ProcessDefinition targetDefinition = testHelper.deployAndGetDefinition(modify(ProcessModels.SUBPROCESS_PROCESS)
       .swapElementIds("userTask", "subProcess")
     );
+    var migrationPlanBuilder = runtimeService
+        .createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
+        .mapActivities("userTask", "userTask");
 
     try {
-      runtimeService
-        .createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
-        .mapActivities("userTask", "userTask")
-        .build();
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     } catch (MigrationPlanValidationException e) {
       assertThat(e.getValidationReport())
@@ -287,13 +287,13 @@ public class MigrationPlanCreationTest {
       .boundaryEvent("boundary").signal(SIGNAL_NAME)
       .done()
     );
-
-    try {
-      runtimeService
+    var migrationPlanBuilder = runtimeService
         .createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
         .mapActivities("userTask", "userTask")
-        .mapActivities("boundary", "boundary")
-        .build();
+        .mapActivities("boundary", "boundary");
+
+    try {
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     } catch (MigrationPlanValidationException e) {
       assertThat(e.getValidationReport())
@@ -305,12 +305,12 @@ public class MigrationPlanCreationTest {
   public void testMigrateSubProcessToProcessDefinition() {
     ProcessDefinition sourceDefinition = testHelper.deployAndGetDefinition(ProcessModels.SUBPROCESS_PROCESS);
     ProcessDefinition targetDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    var migrationPlanBuilder = runtimeService
+        .createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
+        .mapActivities("subProcess", targetDefinition.getId());
 
     try {
-      runtimeService
-        .createMigrationPlan(sourceDefinition.getId(), targetDefinition.getId())
-        .mapActivities("subProcess", targetDefinition.getId())
-        .build();
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     } catch (MigrationPlanValidationException e) {
       assertThat(e.getValidationReport())
@@ -326,13 +326,13 @@ public class MigrationPlanCreationTest {
       .multiInstance().parallel().cardinality("3").multiInstanceDone().done();
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(testProcess);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(testProcess);
+    var migrationPlanBuilder = runtimeService
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapActivities("userTask", "userTask");
 
     // when
     try {
-      runtimeService
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities("userTask", "userTask")
-        .build();
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     }
     catch (MigrationPlanValidationException e) {
@@ -436,14 +436,14 @@ public class MigrationPlanCreationTest {
 
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(sourceProcess);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(targetProcess);
-
-    try {
-      runtimeService
+    var migrationPlanBuilder = runtimeService
         .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
         .mapActivities("userTask1", "userTask1")
         .mapActivities("userTask2", "userTask2")
-        .mapActivities("boundary", "boundary")
-        .build();
+        .mapActivities("boundary", "boundary");
+
+    try {
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     }
     catch (MigrationPlanValidationException e) {
@@ -525,14 +525,14 @@ public class MigrationPlanCreationTest {
 
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(sourceProcess);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(targetProcess);
-
-    try {
-      runtimeService
+    var migrationPlanBuilder = runtimeService
         .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
         .mapActivities("subProcess", "subProcess")
         .mapActivities("userTask", "userTask")
-        .mapActivities("boundary", "boundary")
-        .build();
+        .mapActivities("boundary", "boundary");
+
+    try {
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     }
     catch (MigrationPlanValidationException e) {
@@ -556,14 +556,14 @@ public class MigrationPlanCreationTest {
 
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(sourceProcess);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(targetProcess);
-
-    try {
-      runtimeService
+    var migrationPlanBuilder = runtimeService
         .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
         .mapActivities("subProcess", "subProcess")
         .mapActivities("userTask", "userTask")
-        .mapActivities("boundary", "boundary")
-        .build();
+        .mapActivities("boundary", "boundary");
+
+    try {
+      migrationPlanBuilder.build();
 
       fail("Should not succeed");
     }
@@ -716,13 +716,13 @@ public class MigrationPlanCreationTest {
   public void testNotMapActivitiesMoreThanOnce() {
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(ProcessModels.PARALLEL_GATEWAY_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(ProcessModels.PARALLEL_GATEWAY_PROCESS);
-
-    try {
-      runtimeService
+    var migrationPlanBuilder = runtimeService
         .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
         .mapActivities("userTask1", "userTask1")
-        .mapActivities("userTask1", "userTask2")
-        .build();
+        .mapActivities("userTask1", "userTask2");
+
+    try {
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     }
     catch (MigrationPlanValidationException e) {
@@ -739,12 +739,12 @@ public class MigrationPlanCreationTest {
 
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
+    var migrationPlanBuilder = runtimeService
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapActivities("userTask", "userTask").updateEventTrigger();
 
     try {
-      runtimeService
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities("userTask", "userTask").updateEventTrigger()
-        .build();
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     }
     catch (MigrationPlanValidationException e) {
@@ -759,12 +759,12 @@ public class MigrationPlanCreationTest {
   public void testCannotUpdateEventTriggerForEventSubProcess() {
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(EventSubProcessModels.TIMER_EVENT_SUBPROCESS_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(EventSubProcessModels.TIMER_EVENT_SUBPROCESS_PROCESS);
+    var migrationPlanBuilder = runtimeService
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapActivities("eventSubProcess", "eventSubProcess").updateEventTrigger();
 
     try {
-      runtimeService
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities("eventSubProcess", "eventSubProcess").updateEventTrigger()
-        .build();
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     }
     catch (MigrationPlanValidationException e) {
@@ -999,9 +999,7 @@ public class MigrationPlanCreationTest {
         testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessDefinition targetProcessDefinition =
         testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
-
-    try {
-      runtimeService
+    var migrationPlanBuilder = runtimeService
           .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
           .setVariables(
               Variables.putValueTyped("foo",
@@ -1011,8 +1009,10 @@ public class MigrationPlanCreationTest {
                       .serializationDataFormat(Variables.SerializationDataFormats.JAVA.getName())
                       .create())
           )
-          .mapEqualActivities()
-          .build();
+          .mapEqualActivities();
+
+    try {
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     } catch (MigrationPlanValidationException e) {
       assertThat(e.getValidationReport())
@@ -1033,16 +1033,16 @@ public class MigrationPlanCreationTest {
         .objectTypeName(ArrayList.class.getName())
         .serializationDataFormat(Variables.SerializationDataFormats.JAVA.getName())
         .create();
-
-    try {
-      runtimeService
+    var migrationPlanBuilder = runtimeService
           .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
           .setVariables(
               Variables.putValueTyped("foo", objectValue)
               .putValueTyped("bar", objectValue)
           )
-          .mapEqualActivities()
-          .build();
+          .mapEqualActivities();
+
+    try {
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     } catch (MigrationPlanValidationException e) {
       assertThat(e.getValidationReport())
@@ -1065,14 +1065,14 @@ public class MigrationPlanCreationTest {
         .objectTypeName(ArrayList.class.getName())
         .serializationDataFormat(Variables.SerializationDataFormats.JAVA.getName())
         .create();
-
-    try {
-      runtimeService
+    var migrationPlanBuilder = runtimeService
           .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
           .setVariables(Variables.putValueTyped("foo", objectValue))
           .mapActivities("foo", "bar")
-          .mapActivities("bar", "foo")
-          .build();
+          .mapActivities("bar", "foo");
+
+    try {
+      migrationPlanBuilder.build();
       fail("Should not succeed");
     } catch (MigrationPlanValidationException e) {
       assertThat(e.getValidationReport())

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationProcessInstanceTest.java
@@ -79,8 +79,9 @@ public class MigrationProcessInstanceTest {
 
   @Test
   public void testNullMigrationPlan() {
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(null).processInstanceIds(Collections.<String>emptyList());
     try {
-      runtimeService.newMigration(null).processInstanceIds(Collections.<String>emptyList()).execute();
+      migrationPlanExecutionBuilder.execute();
       fail("Should not be able to migrate");
     }
     catch (ProcessEngineException e) {
@@ -94,9 +95,10 @@ public class MigrationProcessInstanceTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(testProcessDefinition.getId(), testProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds((List<String>) null);
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceIds((List<String>) null).execute();
+      migrationPlanExecutionBuilder.execute();
       fail("Should not be able to migrate");
     }
     catch (ProcessEngineException e) {
@@ -110,9 +112,10 @@ public class MigrationProcessInstanceTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(testProcessDefinition.getId(), testProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds(Arrays.asList("foo", null, "bar"));
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceIds(Arrays.asList("foo", null, "bar")).execute();
+      migrationPlanExecutionBuilder.execute();
       fail("Should not be able to migrate");
     }
     catch (ProcessEngineException e) {
@@ -126,9 +129,10 @@ public class MigrationProcessInstanceTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(testProcessDefinition.getId(), testProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds((String[]) null);
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceIds((String[]) null).execute();
+      migrationPlanExecutionBuilder.execute();
       fail("Should not be able to migrate");
     }
     catch (ProcessEngineException e) {
@@ -142,9 +146,10 @@ public class MigrationProcessInstanceTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(testProcessDefinition.getId(), testProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds("foo", null, "bar");
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceIds("foo", null, "bar").execute();
+      migrationPlanExecutionBuilder.execute();
       fail("Should not be able to migrate");
     }
     catch (ProcessEngineException e) {
@@ -158,9 +163,10 @@ public class MigrationProcessInstanceTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(testProcessDefinition.getId(), testProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds(Collections.<String>emptyList());
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceIds(Collections.<String>emptyList()).execute();
+      migrationPlanExecutionBuilder.execute();
       fail("Should not be able to migrate");
     }
     catch (ProcessEngineException e) {
@@ -174,9 +180,10 @@ public class MigrationProcessInstanceTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(testProcessDefinition.getId(), testProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds(new String[]{});
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceIds(new String[]{}).execute();
+      migrationPlanExecutionBuilder.execute();
       fail("Should not be able to migrate");
     }
     catch (ProcessEngineException e) {
@@ -195,9 +202,10 @@ public class MigrationProcessInstanceTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds(Collections.singletonList(processInstance.getId()));
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceIds(Collections.singletonList(processInstance.getId())).execute();
+      migrationPlanExecutionBuilder.execute();
       fail("Should not be able to migrate");
     }
     catch (ProcessEngineException e) {
@@ -213,9 +221,10 @@ public class MigrationProcessInstanceTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds(Collections.singletonList("unknown"));
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceIds(Collections.singletonList("unknown")).execute();
+      migrationPlanExecutionBuilder.execute();
       fail("Should not be able to migrate");
     }
     catch (ProcessEngineException e) {
@@ -231,9 +240,10 @@ public class MigrationProcessInstanceTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceIds(Collections.<String>singletonList(null));
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceIds(Collections.<String>singletonList(null)).execute();
+      migrationPlanExecutionBuilder.execute();
       fail("Should not be able to migrate");
     }
     catch (ProcessEngineException e) {
@@ -277,9 +287,10 @@ public class MigrationProcessInstanceTest {
     MigrationPlan migrationPlan = runtimeService.createMigrationPlan(testProcessDefinition.getId(), testProcessDefinition.getId())
       .mapEqualActivities()
       .build();
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceQuery(null);
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceQuery(null).execute();
+      migrationPlanExecutionBuilder.execute();
       fail("Should not be able to migrate");
     }
     catch (ProcessEngineException e) {
@@ -296,9 +307,10 @@ public class MigrationProcessInstanceTest {
 
     ProcessInstanceQuery emptyProcessInstanceQuery = runtimeService.createProcessInstanceQuery();
     assertEquals(0, emptyProcessInstanceQuery.count());
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceQuery(emptyProcessInstanceQuery);
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceQuery(emptyProcessInstanceQuery).execute();
+      migrationPlanExecutionBuilder.execute();
       fail("Should not be able to migrate");
     }
     catch (ProcessEngineException e) {
@@ -319,9 +331,10 @@ public class MigrationProcessInstanceTest {
 
     ProcessInstanceQuery wrongProcessInstanceQuery = runtimeService.createProcessInstanceQuery().processDefinitionId(wrongProcessDefinition.getId());
     assertEquals(1, wrongProcessInstanceQuery.count());
+    var migrationPlanExecutionBuilder = runtimeService.newMigration(migrationPlan).processInstanceQuery(wrongProcessInstanceQuery);
 
     try {
-      runtimeService.newMigration(migrationPlan).processInstanceQuery(wrongProcessInstanceQuery).execute();
+      migrationPlanExecutionBuilder.execute();
       fail("Should not be able to migrate");
     }
     catch (ProcessEngineException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationRemoveSubprocessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationRemoveSubprocessTest.java
@@ -367,15 +367,15 @@ public class MigrationRemoveSubprocessTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(ProcessModels.PARALLEL_GATEWAY_SUBPROCESS_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(ProcessModels.PARALLEL_TASK_AND_SUBPROCESS_PROCESS);
-
-    // when
-    try {
-      rule.getRuntimeService()
+    var runtimeService = rule.getRuntimeService()
         .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
         .mapActivities("subProcess", "subProcess")
         .mapActivities("userTask1", "userTask1")
-        .mapActivities("userTask2", "userTask2")
-        .build();
+        .mapActivities("userTask2", "userTask2");
+
+    // when
+    try {
+      runtimeService.build();
 
       Assert.fail("should not validate");
     } catch (MigrationPlanValidationException e) {
@@ -551,17 +551,17 @@ public class MigrationRemoveSubprocessTest {
     // given
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(ProcessModels.TRIPLE_SUBPROCESS_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(ProcessModels.TRIPLE_SUBPROCESS_PROCESS);
+    var runtimeService = rule.getRuntimeService()
+        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+        .mapActivities("subProcess1", "subProcess1")
+        .mapActivities("subProcess3", "subProcess1")
+        .mapActivities("userTask", "userTask");
 
     // when
     try {
       // subProcess2 is not migrated
       // subProcess 3 is moved out of the subProcess1 scope (by becoming a subProcess1 itself)
-      rule.getRuntimeService()
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities("subProcess1", "subProcess1")
-        .mapActivities("subProcess3", "subProcess1")
-        .mapActivities("userTask", "userTask")
-        .build();
+      runtimeService.build();
 
       Assert.fail("should not validate");
     } catch (MigrationPlanValidationException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationSignallableServiceTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationSignallableServiceTaskTest.java
@@ -98,12 +98,12 @@ public class MigrationSignallableServiceTaskTest {
 
     String processInstanceId = rule.getRuntimeService().startProcessInstanceById(sourceProcessDefinition.getId()).getId();
     testHelper.executeAvailableJobs();
+    var runtimeService = rule.getRuntimeService().newMigration(migrationPlan)
+        .processInstanceIds(processInstanceId);
 
     // when
     try {
-      rule.getRuntimeService().newMigration(migrationPlan)
-        .processInstanceIds(processInstanceId)
-        .execute();
+      runtimeService.execute();
 
       Assert.fail("should fail");
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationTransitionInstancesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationTransitionInstancesTest.java
@@ -1091,12 +1091,12 @@ public class MigrationTransitionInstancesTest {
 
     String processInstanceId = rule.getRuntimeService().startProcessInstanceById(sourceProcessDefinition.getId()).getId();
     testHelper.executeAvailableJobs();
+    var runtimeService = rule.getRuntimeService().newMigration(migrationPlan)
+        .processInstanceIds(processInstanceId);
 
     // when
     try {
-      rule.getRuntimeService().newMigration(migrationPlan)
-        .processInstanceIds(processInstanceId)
-        .execute();
+      runtimeService.execute();
 
       Assert.fail("should fail");
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryExpressionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryExpressionTest.java
@@ -192,8 +192,9 @@ public class TaskQueryExpressionTest {
     assertCount(taskQuery().taskCandidateGroupInExpression("${currentUserGroups()}"), 0);
 
     setCurrentUser(userWithoutGroups);
+    var taskQuery = taskQuery().taskCandidateGroupInExpression("${currentUserGroups()}");
     try {
-      taskQuery().taskCandidateGroupInExpression("${currentUserGroups()}").count();
+      taskQuery.count();
       fail("Exception expected");
     }
     catch (ProcessEngineException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskServiceTest.java
@@ -447,9 +447,10 @@ public class TaskServiceTest {
     taskService.saveTask(task);
     String taskId = task.getId();
     Comment comment = taskService.createComment(taskId, null, "originalMessage");
+    var commentId = comment.getId();
 
     try {
-      taskService.updateTaskComment(null, comment.getId(), "updatedMessage");
+      taskService.updateTaskComment(null, commentId, "updatedMessage");
       fail("BadUserRequestException expected");
     } catch (BadUserRequestException ae) {
       testRule.assertTextPresent("Both process instance and task ids are null", ae.getMessage());
@@ -464,9 +465,10 @@ public class TaskServiceTest {
     taskService.saveTask(task);
     String taskId = task.getId();
     Comment comment = taskService.createComment(taskId, null, "originalMessage");
+    var commentId = comment.getId();
 
     try {
-      taskService.updateTaskComment(taskId, comment.getId(), null);
+      taskService.updateTaskComment(taskId, commentId, null);
       fail("NullValueException expected");
     } catch (NullValueException ae) {
       testRule.assertTextPresent("message is null", ae.getMessage());
@@ -660,8 +662,9 @@ public class TaskServiceTest {
   @Test
   public void testUpdateProcessInstanceCommentNullCommentId() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    var processInstanceId = processInstance.getId();
     try {
-      taskService.updateProcessInstanceComment(processInstance.getId(), null, "aMessage");
+      taskService.updateProcessInstanceComment(processInstanceId, null, "aMessage");
       fail("NullValueException expected");
     } catch (NullValueException ae) {
       testRule.assertTextPresent("commentId is null", ae.getMessage());
@@ -674,9 +677,10 @@ public class TaskServiceTest {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
     Comment comment = taskService.createComment(null, processInstance.getId(), "originalMessage");
+    var commentId = comment.getId();
 
     try {
-      taskService.updateProcessInstanceComment(null, comment.getId(), "updatedMessage");
+      taskService.updateProcessInstanceComment(null, commentId, "updatedMessage");
       fail("BadUserRequestException expected");
     } catch (BadUserRequestException ae) {
       testRule.assertTextPresent("Both process instance and task ids are null", ae.getMessage());
@@ -690,9 +694,10 @@ public class TaskServiceTest {
     String processInstanceId = processInstance.getId();
 
     Comment comment = taskService.createComment(null, processInstanceId, "originalMessage");
+    var commentId = comment.getId();
 
     try {
-      taskService.updateProcessInstanceComment(processInstanceId, comment.getId(), null);
+      taskService.updateProcessInstanceComment(processInstanceId, commentId, null);
       fail("NullValueException expected");
     } catch (NullValueException ae) {
       testRule.assertTextPresent("message is null", ae.getMessage());
@@ -803,8 +808,9 @@ public class TaskServiceTest {
     if (historyLevel> ProcessEngineConfigurationImpl.HISTORYLEVEL_NONE) {
       Task task = taskService.newTask("testId");
       taskService.saveTask(task);
+      var taskId = task.getId();
       try {
-        taskService.createComment(task.getId(), null, null);
+        taskService.createComment(taskId, null, null);
         fail("Expected process engine exception");
       }
       catch (ProcessEngineException e) {}
@@ -1091,9 +1097,10 @@ public class TaskServiceTest {
   public void testClaimUnexistingTaskId() {
     User user = identityService.newUser("user");
     identityService.saveUser(user);
+    var userId = user.getId();
 
     try {
-      taskService.claim("unexistingtaskid", user.getId());
+      taskService.claim("unexistingtaskid", userId);
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
       testRule.assertTextPresent("Cannot find task with id unexistingtaskid", ae.getMessage());
@@ -1113,9 +1120,11 @@ public class TaskServiceTest {
 
     // Claim task the first time
     taskService.claim(task.getId(), user.getId());
+    var secondUserId = secondUser.getId();
+    var taskId = task.getId();
 
     try {
-      taskService.claim(task.getId(), secondUser.getId());
+      taskService.claim(taskId, secondUserId);
       fail("ProcessEngineException expected");
     } catch (TaskAlreadyClaimedException ae) {
       testRule.assertTextPresent("Task '" + task.getId() + "' is already claimed by someone else.", ae.getMessage());
@@ -1643,9 +1652,10 @@ public class TaskServiceTest {
   public void testSetAssigneeUnexistingTask() {
     User user = identityService.newUser("user");
     identityService.saveUser(user);
+    var userId = user.getId();
 
     try {
-      taskService.setAssignee("unexistingTaskId", user.getId());
+      taskService.setAssignee("unexistingTaskId", userId);
       fail("ProcessEngineException expected");
     } catch (NotFoundException ae) {
       testRule.assertTextPresent("Cannot find task with id unexistingTaskId", ae.getMessage());
@@ -1668,9 +1678,10 @@ public class TaskServiceTest {
   public void testSetOwnerUnexistingTask() {
     User user = identityService.newUser("user");
     identityService.saveUser(user);
+    var userId = user.getId();
 
     try {
-      taskService.setOwner("unexistingTaskId", user.getId());
+      taskService.setOwner("unexistingTaskId", userId);
       fail("ProcessEngineException expected");
     } catch (NotFoundException ae) {
       testRule.assertTextPresent("Cannot find task with id unexistingTaskId", ae.getMessage());
@@ -1683,9 +1694,10 @@ public class TaskServiceTest {
   public void testSetOwnerNullUser() {
     Task task = taskService.newTask();
     taskService.saveTask(task);
+    var taskId = task.getId();
 
     try {
-      taskService.setOwner(task.getId(), null);
+      taskService.setOwner(taskId, null);
       fail("ProcessEngineException expected");
     } catch (NullValueException ae) {
       testRule.assertTextPresent("userId and groupId cannot both be null", ae.getMessage());
@@ -1736,9 +1748,10 @@ public class TaskServiceTest {
   public void testAddCandidateUserUnexistingTask() {
     User user = identityService.newUser("user");
     identityService.saveUser(user);
+    var userId = user.getId();
 
     try {
-      taskService.addCandidateUser("unexistingTaskId", user.getId());
+      taskService.addCandidateUser("unexistingTaskId", userId);
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
       testRule.assertTextPresent("Cannot find task with id unexistingTaskId", ae.getMessage());
@@ -1771,8 +1784,9 @@ public class TaskServiceTest {
   public void testAddCandidateGroupUnexistingTask() {
     Group group = identityService.newGroup("group");
     identityService.saveGroup(group);
+    var groupId = group.getId();
     try {
-      taskService.addCandidateGroup("unexistingTaskId", group.getId());
+      taskService.addCandidateGroup("unexistingTaskId", groupId);
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
       testRule.assertTextPresent("Cannot find task with id unexistingTaskId", ae.getMessage());
@@ -1804,9 +1818,10 @@ public class TaskServiceTest {
   public void testAddGroupIdentityLinkUnexistingTask() {
     User user = identityService.newUser("user");
     identityService.saveUser(user);
+    var userId = user.getId();
 
     try {
-      taskService.addGroupIdentityLink("unexistingTaskId", user.getId(), IdentityLinkType.CANDIDATE);
+      taskService.addGroupIdentityLink("unexistingTaskId", userId, IdentityLinkType.CANDIDATE);
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
       testRule.assertTextPresent("Cannot find task with id unexistingTaskId", ae.getMessage());
@@ -1839,9 +1854,10 @@ public class TaskServiceTest {
   public void testAddUserIdentityLinkUnexistingTask() {
     User user = identityService.newUser("user");
     identityService.saveUser(user);
+    var userId = user.getId();
 
     try {
-      taskService.addUserIdentityLink("unexistingTaskId", user.getId(), IdentityLinkType.CANDIDATE);
+      taskService.addUserIdentityLink("unexistingTaskId", userId, IdentityLinkType.CANDIDATE);
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
       testRule.assertTextPresent("Cannot find task with id unexistingTaskId", ae.getMessage());
@@ -2041,9 +2057,10 @@ public class TaskServiceTest {
   public void testSetNameNullTaskName() {
     Task task = taskService.newTask();
     taskService.saveTask(task);
+    var taskId = task.getId();
 
     try {
-      taskService.setName(task.getId(), null);
+      taskService.setName(taskId, null);
       fail("ProcessEngineException expected");
     } catch (NullValueException ae) {
       testRule.assertTextPresent("value is null", ae.getMessage());
@@ -2375,9 +2392,9 @@ public class TaskServiceTest {
 
     task1.setDescription("test description one");
     taskService.saveTask(task1);
+    task2.setDescription("test description two");
 
     try {
-      task2.setDescription("test description two");
       taskService.saveTask(task2);
 
       fail("Expecting exception");
@@ -2477,44 +2494,46 @@ public class TaskServiceTest {
 
     Task task = taskService.createTaskQuery().singleResult();
     assertNotNull(task);
+    String taskId = task.getId();
+    var taskIds = Arrays.asList(task.getId());
 
     try {
-      taskService.deleteTask(task.getId());
+      taskService.deleteTask(taskId);
       fail("Should not be possible to delete task");
     } catch(ProcessEngineException ae) {
       assertEquals("The task cannot be deleted because is part of a running case instance", ae.getMessage());
     }
 
     try {
-      taskService.deleteTask(task.getId(), true);
+      taskService.deleteTask(taskId, true);
       fail("Should not be possible to delete task");
     } catch(ProcessEngineException ae) {
       assertEquals("The task cannot be deleted because is part of a running case instance", ae.getMessage());
     }
 
     try {
-      taskService.deleteTask(task.getId(), "test");
+      taskService.deleteTask(taskId, "test");
       fail("Should not be possible to delete task");
     } catch(ProcessEngineException ae) {
       assertEquals("The task cannot be deleted because is part of a running case instance", ae.getMessage());
     }
 
     try {
-      taskService.deleteTasks(Arrays.asList(task.getId()));
+      taskService.deleteTasks(taskIds);
       fail("Should not be possible to delete task");
     } catch(ProcessEngineException ae) {
       assertEquals("The task cannot be deleted because is part of a running case instance", ae.getMessage());
     }
 
     try {
-      taskService.deleteTasks(Arrays.asList(task.getId()), true);
+      taskService.deleteTasks(taskIds, true);
       fail("Should not be possible to delete task");
     } catch(ProcessEngineException ae) {
       assertEquals("The task cannot be deleted because is part of a running case instance", ae.getMessage());
     }
 
     try {
-      taskService.deleteTasks(Arrays.asList(task.getId()), "test");
+      taskService.deleteTasks(taskIds, "test");
       fail("Should not be possible to delete task");
     } catch(ProcessEngineException ae) {
       assertEquals("The task cannot be deleted because is part of a running case instance", ae.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/async/JobRetryCmdWithDefaultPropertyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/async/JobRetryCmdWithDefaultPropertyTest.java
@@ -75,10 +75,11 @@ public class JobRetryCmdWithDefaultPropertyTest {
 
     Job job = managementService.createJobQuery().processInstanceId(pi.getProcessInstanceId()).singleResult();
     assertNotNull(job);
+    var jobId = job.getId();
     assertEquals(pi.getProcessInstanceId(), job.getProcessInstanceId());
 
     try {
-      managementService.executeJob(job.getId());
+      managementService.executeJob(jobId);
       fail("Exception expected!");
     } catch(Exception e) {
       // expected

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/link/LinkEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/link/LinkEventTest.java
@@ -94,8 +94,9 @@ public class LinkEventTest extends PluggableProcessEngineTest {
 
   @Test
   public void testInvalidEventLinkMultipleTargets() {
+    var deploymentBuilder = repositoryService.createDeployment().addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/link/LinkEventTest.testInvalidEventLinkMultipleTargets.bpmn20.xml");
     try {
-      repositoryService.createDeployment().addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/link/LinkEventTest.testInvalidEventLinkMultipleTargets.bpmn20.xml").deploy();
+      deploymentBuilder.deploy();
       fail("process should not deploy because it contains multiple event link targets which is invalid in the BPMN 2.0 spec");
     }
     catch (ParseException e) {
@@ -106,8 +107,9 @@ public class LinkEventTest extends PluggableProcessEngineTest {
 
   @Test
   public void testCatchLinkEventAfterEventBasedGatewayNotAllowed() {
+    var deploymentBuilder = repositoryService.createDeployment().addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/link/LinkEventTest.testCatchLinkEventAfterEventBasedGatewayNotAllowed.bpmn20.xml");
     try {
-      repositoryService.createDeployment().addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/link/LinkEventTest.testCatchLinkEventAfterEventBasedGatewayNotAllowed.bpmn20.xml").deploy();
+      deploymentBuilder.deploy();
       fail("process should not deploy because it contains multiple event link targets which is invalid in the BPMN 2.0 spec");
     }
     catch (ParseException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageBoundaryEventTest.java
@@ -95,12 +95,12 @@ public class MessageBoundaryEventTest extends PluggableProcessEngineTest {
 
   @Test
   public void testDoubleBoundaryMessageEventSameMessageId() {
+    var deploymentBuilder = repositoryService
+          .createDeployment()
+          .addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/message/MessageBoundaryEventTest.testDoubleBoundaryMessageEventSameMessageId.bpmn20.xml");
     // deployment fails when two boundary message events have the same messageId
     try {
-      repositoryService
-          .createDeployment()
-          .addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/message/MessageBoundaryEventTest.testDoubleBoundaryMessageEventSameMessageId.bpmn20.xml")
-          .deploy();
+      deploymentBuilder.deploy();
       fail("Deployment should fail because Activiti cannot handle two boundary message events with same messageId.");
     } catch (ParseException e) {
       testRule.assertTextPresent("Cannot have more than one message event subscription with name 'messageName' for scope 'task'", e.getMessage());
@@ -131,6 +131,7 @@ public class MessageBoundaryEventTest extends PluggableProcessEngineTest {
         .messageEventSubscriptionName("messageName_2")
         .singleResult();
     assertNotNull(execution2);
+    var execution2Id = execution2.getId();
 
     assertEquals(execution1.getId(), execution2.getId());
 
@@ -140,7 +141,7 @@ public class MessageBoundaryEventTest extends PluggableProcessEngineTest {
 
     // this should then throw an exception because execution2 no longer exists
     try {
-      runtimeService.messageEventReceived("messageName_2", execution2.getId());
+      runtimeService.messageEventReceived("messageName_2", execution2Id);
       fail();
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent("does not have a subscription to a message event with name 'messageName_2'", e.getMessage());
@@ -193,6 +194,7 @@ public class MessageBoundaryEventTest extends PluggableProcessEngineTest {
     Execution execution2 = runtimeService.createExecutionQuery().messageEventSubscriptionName("messageName_2").singleResult();
     // both executions are the same
     assertEquals(execution1.getId(), execution2.getId());
+    var execution2Id = execution2.getId();
 
     ///////////////////////////////////////////////////////////////////////////////////
     // 1. first message received cancels all tasks and the executions and both subscriptions
@@ -200,7 +202,7 @@ public class MessageBoundaryEventTest extends PluggableProcessEngineTest {
 
     // this should then throw an exception because execution2 no longer exists
     try {
-      runtimeService.messageEventReceived("messageName_2", execution2.getId());
+      runtimeService.messageEventReceived("messageName_2", execution2Id);
       fail();
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent("does not have a subscription to a message event with name 'messageName_2'", e.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
@@ -184,11 +184,11 @@ public class MessageIntermediateEventTest {
 
   @Test
   public void testEmptyMessageNameFails() {
-    try {
-      repositoryService
+    var deploymentBuilder = repositoryService
           .createDeployment()
-          .addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/message/MessageIntermediateEventTest.testEmptyMessageNameFails.bpmn20.xml")
-          .deploy();
+          .addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/message/MessageIntermediateEventTest.testEmptyMessageNameFails.bpmn20.xml");
+    try {
+      deploymentBuilder.deploy();
       fail("exception expected");
     } catch (ParseException e) {
       assertTrue(e.getMessage().contains("Cannot have a message event subscription with an empty or missing name"));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageStartEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageStartEventTest.java
@@ -64,11 +64,11 @@ public class MessageStartEventTest extends PluggableProcessEngineTest {
         .addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/message/MessageStartEventTest.testSingleMessageStartEvent.bpmn20.xml")
         .deploy()
         .getId();
-    try {
-      repositoryService
+    var deploymentBuilder = repositoryService
           .createDeployment()
-          .addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/message/otherProcessWithNewInvoiceMessage.bpmn20.xml")
-          .deploy();
+          .addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/message/otherProcessWithNewInvoiceMessage.bpmn20.xml");
+    try {
+      deploymentBuilder.deploy();
       fail("exception expected");
     } catch (ProcessEngineException e) {
       assertTrue(e.getMessage().contains("there already is a message event subscription for the message with name"));
@@ -87,11 +87,11 @@ public class MessageStartEventTest extends PluggableProcessEngineTest {
   // SEE: https://app.camunda.com/jira/browse/CAM-1448
   @Test
   public void testEmptyMessageNameFails() {
-    try {
-      repositoryService
+    var deploymentBuilder = repositoryService
           .createDeployment()
-          .addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/message/MessageStartEventTest.testEmptyMessageNameFails.bpmn20.xml")
-          .deploy();
+          .addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/message/MessageStartEventTest.testEmptyMessageNameFails.bpmn20.xml");
+    try {
+      deploymentBuilder.deploy();
       fail("exception expected");
     } catch (ParseException e) {
       assertTrue(e.getMessage().contains("Cannot have a message event subscription with an empty or missing name"));
@@ -101,11 +101,11 @@ public class MessageStartEventTest extends PluggableProcessEngineTest {
 
   @Test
   public void testSameMessageNameInSameProcessFails() {
-    try {
-      repositoryService
+    var deploymentBuilder = repositoryService
           .createDeployment()
-          .addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/message/testSameMessageNameInSameProcessFails.bpmn20.xml")
-          .deploy();
+          .addClasspathResource("org/operaton/bpm/engine/test/bpmn/event/message/testSameMessageNameInSameProcessFails.bpmn20.xml");
+    try {
+      deploymentBuilder.deploy();
       fail("exception expected");
     } catch (ProcessEngineException e) {
       assertTrue(e.getMessage().contains("Cannot have more than one message event subscription with name 'newInvoiceMessage' for scope"));
@@ -355,12 +355,12 @@ public class MessageStartEventTest extends PluggableProcessEngineTest {
     String processDefinition =
         "org/operaton/bpm/engine/test/bpmn/event/message/" +
             "MessageStartEventTest.testUsingExpressionWithDollarTagInMessageStartEventNameThrowsException.bpmn20.xml";
+    var deploymentBuilder = repositoryService
+          .createDeployment()
+          .addClasspathResource(processDefinition);
     try {
       // when deploying the process
-      repositoryService
-          .createDeployment()
-          .addClasspathResource(processDefinition)
-          .deploy();
+      deploymentBuilder.deploy();
       fail("exception expected");
     } catch (ProcessEngineException e) {
       // then a process engine exception should be thrown with a certain message
@@ -376,12 +376,12 @@ public class MessageStartEventTest extends PluggableProcessEngineTest {
     String processDefinition =
         "org/operaton/bpm/engine/test/bpmn/event/message/" +
             "MessageStartEventTest.testUsingExpressionWithHashTagInMessageStartEventNameThrowsException.bpmn20.xml";
+    var deploymentBuilder = repositoryService
+          .createDeployment()
+          .addClasspathResource(processDefinition);
     try {
       // when deploying the process
-      repositoryService
-          .createDeployment()
-          .addClasspathResource(processDefinition)
-          .deploy();
+      deploymentBuilder.deploy();
       fail("exception expected");
     } catch (ProcessEngineException e) {
       // then a process engine exception should be thrown with a certain message

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/signal/SignalEventParseInvalidProcessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/signal/SignalEventParseInvalidProcessTest.java
@@ -78,10 +78,10 @@ public class SignalEventParseInvalidProcessTest {
 
   @Test
   public void testParseInvalidProcessDefinition() {
+    var deploymentBuilder = repositoryService.createDeployment()
+        .addClasspathResource(PROCESS_DEFINITION_DIRECTORY + processDefinitionResource);
     try {
-      repositoryService.createDeployment()
-        .addClasspathResource(PROCESS_DEFINITION_DIRECTORY + processDefinitionResource)
-        .deploy();
+      deploymentBuilder.deploy();
 
       fail("exception expected: " + expectedErrorMessage);
     } catch (ParseException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/receivetask/ReceiveTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/receivetask/ReceiveTaskTest.java
@@ -342,10 +342,11 @@ public class ReceiveTaskTest extends PluggableProcessEngineTest {
     // expect: there are two message event subscriptions
     List<EventSubscription> subscriptions = getEventSubscriptionList();
     assertEquals(2, subscriptions.size());
+    var eventSubscription = subscriptions.get(0).getEventName();
 
     // then: we can not correlate an event
     try {
-      runtimeService.correlateMessage(subscriptions.get(0).getEventName());
+      runtimeService.correlateMessage(eventSubscription);
       fail("should throw a mismatch");
     } catch (MismatchingMessageCorrelationException e) {
       // expected

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/scripttask/ScriptTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/scripttask/ScriptTaskTest.java
@@ -565,14 +565,15 @@ public class ScriptTaskTest extends AbstractScriptTaskTest {
 
   @Test
   public void testShouldNotDeployProcessWithMissingScriptElementAndResource() {
-    try {
-      deployProcess(Bpmn.createExecutableProcess("testProcess")
+    var processBuilder = Bpmn.createExecutableProcess("testProcess")
         .startEvent()
         .scriptTask()
           .scriptFormat(RUBY)
         .userTask()
         .endEvent()
-      .done());
+      .done();
+    try {
+      deployProcess(processBuilder);
 
       fail("this process should not be deployable");
     } catch (ProcessEngineException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/servicetask/ServiceTaskClassDelegateActivityBehaviorTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/servicetask/ServiceTaskClassDelegateActivityBehaviorTest.java
@@ -40,8 +40,9 @@ public class ServiceTaskClassDelegateActivityBehaviorTest extends PluggableProce
     Map<Object, Object> beans = processEngineConfiguration.getBeans();
     beans.put("dummyServiceTask", new DummyServiceTask());
     processEngineConfiguration.setBeans(beans);
+    var variables = Collections.<String, Object> singletonMap("count", 0);
     try {
-      runtimeService.startProcessInstanceByKey("process", Collections.<String, Object> singletonMap("count", 0));
+      runtimeService.startProcessInstanceByKey("process", variables);
       fail();
     } // since the NVE extends the ProcessEngineException we have to handle it
       // separately

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/servicetask/ServiceTaskDelegateExpressionActivityBehaviorTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/servicetask/ServiceTaskDelegateExpressionActivityBehaviorTest.java
@@ -40,9 +40,10 @@ public class ServiceTaskDelegateExpressionActivityBehaviorTest extends Pluggable
     Map<Object, Object> beans = processEngineConfiguration.getBeans();
     beans.put("dummyServiceTask", new DummyServiceTask());
     processEngineConfiguration.setBeans(beans);
+    var variables = Collections.<String, Object> singletonMap("count", 0);
 
     try {
-      runtimeService.startProcessInstanceByKey("process", Collections.<String, Object> singletonMap("count", 0));
+      runtimeService.startProcessInstanceByKey("process", variables);
       fail();
     } // since the NVE extends the ProcessEngineException we have to handle it
       // separately

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/servicetask/ServiceTaskExpressionActivityBehaviorTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/servicetask/ServiceTaskExpressionActivityBehaviorTest.java
@@ -40,9 +40,10 @@ public class ServiceTaskExpressionActivityBehaviorTest extends PluggableProcessE
     Map<Object, Object> beans = processEngineConfiguration.getBeans();
     beans.put("dummyServiceTask", new DummyServiceTask());
     processEngineConfiguration.setBeans(beans);
+    var variables = Collections.<String, Object>singletonMap("count", 0);
 
     try{
-      runtimeService.startProcessInstanceByKey("process", Collections.<String, Object>singletonMap("count", 0));
+      runtimeService.startProcessInstanceByKey("process", variables);
       fail();
       // the EL resolver will wrap the actual exception inside a process engine exception
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.java
@@ -631,10 +631,10 @@ public class TransactionSubProcessTest extends PluggableProcessEngineTest {
 
   @Test
   public void testMultipleCancelBoundaryFails() {
+    var deploymentBuilder = repositoryService.createDeployment()
+        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.testMultipleCancelBoundaryFails.bpmn20.xml");
     try {
-      repositoryService.createDeployment()
-        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.testMultipleCancelBoundaryFails.bpmn20.xml")
-        .deploy();
+      deploymentBuilder.deploy();
       fail("exception expected");
     } catch (ParseException e) {
       assertThat(e.getMessage()).contains("multiple boundary events with cancelEventDefinition not supported on same transaction");
@@ -644,10 +644,10 @@ public class TransactionSubProcessTest extends PluggableProcessEngineTest {
 
   @Test
   public void testCancelBoundaryNoTransactionFails() {
+    var deploymentBuilder = repositoryService.createDeployment()
+        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.testCancelBoundaryNoTransactionFails.bpmn20.xml");
     try {
-      repositoryService.createDeployment()
-        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.testCancelBoundaryNoTransactionFails.bpmn20.xml")
-        .deploy();
+      deploymentBuilder.deploy();
       fail("exception expected");
     } catch (ParseException e) {
       assertThat(e.getMessage()).contains("boundary event with cancelEventDefinition only supported on transaction subprocesses");
@@ -657,10 +657,10 @@ public class TransactionSubProcessTest extends PluggableProcessEngineTest {
 
   @Test
   public void testCancelEndNoTransactionFails() {
+    var deploymentBuilder = repositoryService.createDeployment()
+        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.testCancelEndNoTransactionFails.bpmn20.xml");
     try {
-      repositoryService.createDeployment()
-        .addClasspathResource("org/operaton/bpm/engine/test/bpmn/subprocess/transaction/TransactionSubProcessTest.testCancelEndNoTransactionFails.bpmn20.xml")
-        .deploy();
+      deploymentBuilder.deploy();
       fail("exception expected");
     } catch (ParseException e) {
       assertThat(e.getMessage()).contains("end event with cancelEventDefinition only supported inside transaction subprocess");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/usertask/TaskAssignmentExtensionsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/usertask/TaskAssignmentExtensionsTest.java
@@ -75,9 +75,10 @@ public class TaskAssignmentExtensionsTest extends PluggableProcessEngineTest {
 
   @Test
   public void testDuplicateAssigneeDeclaration() {
+    String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testDuplicateAssigneeDeclaration");
+    var deploymentBuilder = repositoryService.createDeployment().addClasspathResource(resource);
     try {
-      String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testDuplicateAssigneeDeclaration");
-      repositoryService.createDeployment().addClasspathResource(resource).deploy();
+      deploymentBuilder.deploy();
       fail("Invalid BPMN 2.0 process should not parse, but it gets parsed sucessfully");
     } catch (ProcessEngineException e) {
       // Exception is to be expected

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/listener/VariableListenerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/listener/VariableListenerTest.java
@@ -459,12 +459,12 @@ public class VariableListenerTest extends PluggableProcessEngineTest {
     CaseExecution taskExecution =
         caseService.createCaseExecutionQuery().activityId("PI_HumanTask_1").singleResult();
     assertNotNull(taskExecution);
+    var caseExecutionCommandBuilder = caseService
+        .withCaseExecution(taskExecution.getId())
+        .setVariableLocal("aTaskVariable", "aTaskValue");
 
     try {
-      caseService
-        .withCaseExecution(taskExecution.getId())
-        .setVariableLocal("aTaskVariable", "aTaskValue")
-        .execute();
+      caseExecutionCommandBuilder.execute();
 
       fail("expected exception during variable listener invocation");
     } catch (ProcessEngineException e) {
@@ -482,12 +482,12 @@ public class VariableListenerTest extends PluggableProcessEngineTest {
     CaseExecution taskExecution =
         caseService.createCaseExecutionQuery().activityId("PI_HumanTask_1").singleResult();
     assertNotNull(taskExecution);
+    var caseExecutionCommandBuilder = caseService
+        .withCaseExecution(taskExecution.getId())
+        .setVariableLocal("aTaskVariable", "aTaskValue");
 
     try {
-      caseService
-        .withCaseExecution(taskExecution.getId())
-        .setVariableLocal("aTaskVariable", "aTaskValue")
-        .execute();
+      caseExecutionCommandBuilder.execute();
 
       fail("expected exception during variable listener invocation");
     } catch (ProcessEngineException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/processtask/ProcessTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/processtask/ProcessTaskTest.java
@@ -906,12 +906,12 @@ public class ProcessTaskTest extends CmmnTest {
     // given
     String caseInstanceId = createCaseInstanceByKey(ONE_PROCESS_TASK_CASE).getId();
     String processTaskId = queryCaseExecutionByActivityId(PROCESS_TASK).getId();
+    var caseExecutionCommandBuilder = caseService
+        .withCaseExecution(processTaskId);
 
     try {
       // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .manualStart();
+      caseExecutionCommandBuilder.manualStart();
       fail("It should not be possible to start a process instance.");
     } catch (ProcessEngineException e) {}
 
@@ -1459,12 +1459,12 @@ public class ProcessTaskTest extends CmmnTest {
     // given
     String caseInstanceId = createCaseInstanceByKey(ONE_PROCESS_TASK_CASE).getId();
     String processTaskId = queryCaseExecutionByActivityId(PROCESS_TASK).getId();
+    var caseExecutionCommandBuilder = caseService
+        .withCaseExecution(processTaskId);
 
     try {
       // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .complete();
+      caseExecutionCommandBuilder.complete();
       fail("It should not be possible to complete a process task, while the process instance is running.");
     } catch (NotAllowedException e) {}
 
@@ -1498,12 +1498,12 @@ public class ProcessTaskTest extends CmmnTest {
 
     ProcessInstance processInstance = queryProcessInstance();
     assertNull(processInstance);
+    var caseExecutionCommandBuilder = caseService
+        .withCaseExecution(processTaskId);
 
     try {
       // when
-      caseService
-        .withCaseExecution(processTaskId)
-        .complete();
+      caseExecutionCommandBuilder.complete();
       fail("It should not be possible to complete a process task");
     } catch (Exception e) {}
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/required/RequiredRuleTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/required/RequiredRuleTest.java
@@ -42,6 +42,7 @@ public class RequiredRuleTest extends PluggableProcessEngineTest {
   public void testRequiredRuleEvaluatesToTrue() {
     CaseInstance caseInstance =
         caseService.createCaseInstanceByKey("case", Collections.<String, Object>singletonMap("required", true));
+    var caseInstanceId = caseInstance.getId();
 
     CaseExecution taskExecution = caseService
         .createCaseExecutionQuery()
@@ -51,7 +52,7 @@ public class RequiredRuleTest extends PluggableProcessEngineTest {
     assertTrue(taskExecution.isRequired());
 
     try {
-      caseService.completeCaseExecution(caseInstance.getId());
+      caseService.completeCaseExecution(caseInstanceId);
       fail("completing the containing stage should not be allowed");
     } catch (NotAllowedException e) {
       // happy path
@@ -81,6 +82,7 @@ public class RequiredRuleTest extends PluggableProcessEngineTest {
   public void testDefaultRequiredRuleEvaluatesToTrue() {
     CaseInstance caseInstance =
         caseService.createCaseInstanceByKey("case", Collections.<String, Object>singletonMap("required", true));
+    var caseInstanceId = caseInstance.getId();
 
     CaseExecution taskExecution = caseService
         .createCaseExecutionQuery()
@@ -91,7 +93,7 @@ public class RequiredRuleTest extends PluggableProcessEngineTest {
     assertTrue(taskExecution.isRequired());
 
     try {
-      caseService.completeCaseExecution(caseInstance.getId());
+      caseService.completeCaseExecution(caseInstanceId);
       fail("completing the containing stage should not be allowed");
     } catch (NotAllowedException e) {
       // happy path

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/tasklistener/TaskListenerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/tasklistener/TaskListenerTest.java
@@ -1299,11 +1299,9 @@ public class TaskListenerTest extends PluggableProcessEngineTest {
   @Deployment(resources = {"org/operaton/bpm/engine/test/cmmn/tasklistener/TaskListenerTest.testDoesNotImplementTaskListenerInterfaceByClass.cmmn"})
   @Test
   public void testDoesNotImplementTaskListenerInterfaceByClass() {
+    var caseInstanceBuilder = caseService.withCaseDefinitionByKey("case");
     try {
-      caseService
-          .withCaseDefinitionByKey("case")
-          .create()
-          .getId();
+      caseInstanceBuilder.create();
       fail("exception expected");
     } catch (Exception e) {
       // then
@@ -1317,12 +1315,11 @@ public class TaskListenerTest extends PluggableProcessEngineTest {
   @Deployment(resources = {"org/operaton/bpm/engine/test/cmmn/tasklistener/TaskListenerTest.testDoesNotImplementTaskListenerInterfaceByDelegateExpression.cmmn"})
   @Test
   public void testDoesNotImplementTaskListenerInterfaceByDelegateExpression() {
-    try {
-      caseService
+    var caseInstanceBuilder = caseService
           .withCaseDefinitionByKey("case")
-          .setVariable("myTaskListener", new NotTaskListener())
-          .create()
-          .getId();
+          .setVariable("myTaskListener", new NotTaskListener());
+    try {
+      caseInstanceBuilder.create();
       fail("exception expected");
     } catch (Exception e) {
       // then
@@ -1336,12 +1333,10 @@ public class TaskListenerTest extends PluggableProcessEngineTest {
   @Deployment(resources = {"org/operaton/bpm/engine/test/cmmn/tasklistener/TaskListenerTest.testTaskListenerDoesNotExist.cmmn"})
   @Test
   public void testTaskListenerDoesNotExist() {
+    var caseInstanceBuilder = caseService.withCaseDefinitionByKey("case");
 
     try {
-      caseService
-          .withCaseDefinitionByKey("case")
-          .create()
-          .getId();
+      caseInstanceBuilder.create();
       fail("exception expected");
     } catch (Exception e) {
       // then

--- a/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
@@ -410,9 +410,10 @@ public class ProcessDataLoggingContextTest {
     // given
     manageDeployment(modelDelegateFailure());
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
     try {
-      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      taskService.complete(taskQuery);
       fail("Exception expected");
     } catch (Exception e) {
       // expected exception in the task listener that is not caught
@@ -435,9 +436,10 @@ public class ProcessDataLoggingContextTest {
         .endEvent("end")
         .done());
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
     try {
-      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      taskService.complete(taskQuery);
       fail("Exception expected");
     } catch (Exception e) {
       // expected exception in the task listener that is not caught
@@ -458,9 +460,10 @@ public class ProcessDataLoggingContextTest {
         .endEvent("end")
         .done());
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
     try {
-      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      taskService.complete(taskQuery);
       fail("Exception expected");
     } catch (Exception e) {
       // expected exception in the task listener that is not caught
@@ -479,9 +482,10 @@ public class ProcessDataLoggingContextTest {
         .endEvent("end")
         .done());
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
     try {
-      taskService.setAssignee(taskService.createTaskQuery().singleResult().getId(), "testUser");
+      taskService.setAssignee(taskQuery, "testUser");
       fail("Exception expected");
     } catch (Exception e) {
       // expected exception in the task listener that is not caught
@@ -500,9 +504,10 @@ public class ProcessDataLoggingContextTest {
         .endEvent("end")
         .done());
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
     try {
-      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      taskService.complete(taskQuery);
       fail("Exception expected");
     } catch (Exception e) {
       // expected exception in the task listener that is not caught
@@ -521,9 +526,10 @@ public class ProcessDataLoggingContextTest {
         .endEvent("end")
         .done());
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    var instanceId = instance.getId();
     // when
     try {
-      runtimeService.deleteProcessInstance(instance.getId(), "cancel it");
+      runtimeService.deleteProcessInstance(instanceId, "cancel it");
       fail("Exception expected");
     } catch (Exception e) {
       // expected exception in the task listener that is not caught
@@ -537,9 +543,10 @@ public class ProcessDataLoggingContextTest {
     // given
     manageDeployment(modelExecutionListenerFailure());
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
     try {
-      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      taskService.complete(taskQuery);
       fail("Exception expected");
     } catch (Exception e) {
       // expected exception in the execution listener that is not caught
@@ -584,9 +591,10 @@ public class ProcessDataLoggingContextTest {
           .endEvent("failingEnd")
         .done());
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
     try {
-      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      taskService.complete(taskQuery);
       fail("Exception expected");
     } catch (Exception e) {
       // expected exception in the service task that is not caught
@@ -613,9 +621,10 @@ public class ProcessDataLoggingContextTest {
         .endEvent("end")
         .done());
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
     try {
-      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      taskService.complete(taskQuery);
       fail("Exception expected");
     } catch (Exception e) {
       // expected exception in the nested delegate that is not caught
@@ -644,9 +653,10 @@ public class ProcessDataLoggingContextTest {
         .endEvent("end")
         .done());
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
     try {
-      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      taskService.complete(taskQuery);
       fail("Exception expected");
     } catch (Exception e) {
       // expected exception in the nested delegate that is not caught
@@ -708,9 +718,10 @@ public class ProcessDataLoggingContextTest {
         .endEvent("end")
         .done());
     ProcessInstance pi = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
     try {
-      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      taskService.complete(taskQuery);
       fail("Exception expected");
     } catch (Exception e) {
       // expected exception in the delegate resolution that is not caught
@@ -732,9 +743,10 @@ public class ProcessDataLoggingContextTest {
         .endEvent("end")
         .done());
     ProcessInstance pi = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
     try {
-      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      taskService.complete(taskQuery);
       fail("Exception expected");
     } catch (Exception e) {
       // expected exception in the delegate resolution that is not caught
@@ -756,9 +768,10 @@ public class ProcessDataLoggingContextTest {
     };
     application.deploy();
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
     try {
-      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      taskService.complete(taskQuery);
       fail("Exception expected");
     } catch (Exception e) {
       // expected exception in the task listener that is not caught
@@ -780,9 +793,10 @@ public class ProcessDataLoggingContextTest {
     };
     application.deploy();
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
     try {
-      taskService.complete(taskService.createTaskQuery().singleResult().getId());
+      taskService.complete(taskQuery);
       fail("Exception expected");
     } catch (Exception e) {
       // expected exception in the execution listener that is not caught

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/initialization/NoDbConnectionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/initialization/NoDbConnectionTest.java
@@ -31,10 +31,10 @@ public class NoDbConnectionTest {
 
   @Test
   public void testNoDbConnection() {
+    var processEngineConfiguration = ProcessEngineConfiguration
+        .createProcessEngineConfigurationFromResource("org/operaton/bpm/engine/test/standalone/initialization/nodbconnection.operaton.cfg.xml");
     try {
-      ProcessEngineConfiguration
-        .createProcessEngineConfigurationFromResource("org/operaton/bpm/engine/test/standalone/initialization/nodbconnection.operaton.cfg.xml")
-        .buildProcessEngine();
+      processEngineConfiguration.buildProcessEngine();
       fail("expected exception");
     } catch (RuntimeException e) {
       assertTrue(containsSqlException(e));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/initialization/ProcessEngineInitializationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/initialization/ProcessEngineInitializationTest.java
@@ -33,10 +33,10 @@ public class ProcessEngineInitializationTest {
 
   @Test
   public void testNoTables() {
+    var processEngineConfiguration = ProcessEngineConfiguration
+      .createProcessEngineConfigurationFromResource("org/operaton/bpm/engine/test/standalone/initialization/notables.operaton.cfg.xml");
     try {
-      ProcessEngineConfiguration
-      .createProcessEngineConfigurationFromResource("org/operaton/bpm/engine/test/standalone/initialization/notables.operaton.cfg.xml")
-        .buildProcessEngine();
+      processEngineConfiguration.buildProcessEngine();
       fail("expected exception");
     } catch (Exception e) {
       // OK


### PR DESCRIPTION
Resolves Sonar issues of type java:S5778 Only one method invocation is expected when testing runtime exceptions

related to #88