### PR TITLE
refactor: Resolve Sonar warnings

### DIFF
--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
@@ -146,8 +146,8 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     String content = response.asString();
     List<LinkedHashMap<String, String>> instances = from(content).getList("");
-    assertThat(instances).hasSize(1).as("There should be one task returned.");
-    assertThat(instances.get(0)).isNotNull().as("The returned task should not be null.");
+    assertThat(instances).withFailMessage("There should be one task returned.").hasSize(1);
+    assertThat(instances.get(0)).withFailMessage("The returned task should not be null.").isNotNull();
 
     String returnedTaskName = from(content).getString("[0].name");
     String returnedId = from(content).getString("[0].id");
@@ -172,28 +172,28 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     String returnedFormKey = from(content).getString("[0].formKey");
     String returnedTenantId = from(content).getString("[0].tenantId");
 
-    assertThat(MockProvider.EXAMPLE_TASK_NAME).isEqualTo(returnedTaskName);
-    assertThat(MockProvider.EXAMPLE_TASK_ID).isEqualTo(returnedId);
-    assertThat(MockProvider.EXAMPLE_TASK_ASSIGNEE_NAME).isEqualTo(returendAssignee);
-    assertThat(MockProvider.EXAMPLE_TASK_CREATE_TIME).isEqualTo(returnedCreateTime);
-    assertThat(MockProvider.EXAMPLE_TASK_LAST_UPDATED).isEqualTo(returnedLastUpdated);
-    assertThat(MockProvider.EXAMPLE_TASK_DUE_DATE).isEqualTo(returnedDueDate);
-    assertThat(MockProvider.EXAMPLE_FOLLOW_UP_DATE).isEqualTo(returnedFollowUpDate);
-    assertThat(MockProvider.EXAMPLE_TASK_DELEGATION_STATE).hasToString(returnedDelegationState);
-    assertThat(MockProvider.EXAMPLE_TASK_DESCRIPTION).isEqualTo(returnedDescription);
-    assertThat(MockProvider.EXAMPLE_TASK_EXECUTION_ID).isEqualTo(returnedExecutionId);
-    assertThat(MockProvider.EXAMPLE_TASK_OWNER).isEqualTo(returnedOwner);
-    assertThat(MockProvider.EXAMPLE_TASK_PARENT_TASK_ID).isEqualTo(returnedParentTaskId);
-    assertThat(MockProvider.EXAMPLE_TASK_PRIORITY).isEqualTo(returnedPriority);
-    assertThat(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID).isEqualTo(returnedProcessDefinitionId);
-    assertThat(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID).isEqualTo(returnedProcessInstanceId);
-    assertThat(MockProvider.EXAMPLE_TASK_DEFINITION_KEY).isEqualTo(returnedTaskDefinitionKey);
-    assertThat(MockProvider.EXAMPLE_CASE_DEFINITION_ID).isEqualTo(returnedCaseDefinitionId);
-    assertThat(MockProvider.EXAMPLE_CASE_INSTANCE_ID).isEqualTo(returnedCaseInstanceId);
-    assertThat(MockProvider.EXAMPLE_CASE_EXECUTION_ID).isEqualTo(returnedCaseExecutionId);
-    assertThat(MockProvider.EXAMPLE_TASK_SUSPENSION_STATE).isEqualTo(returnedSuspensionState);
-    assertThat(MockProvider.EXAMPLE_FORM_KEY).isEqualTo(returnedFormKey);
-    assertThat(MockProvider.EXAMPLE_TENANT_ID).isEqualTo(returnedTenantId);
+    assertThat(returnedTaskName).isEqualTo(MockProvider.EXAMPLE_TASK_NAME);
+    assertThat(returnedId).isEqualTo(MockProvider.EXAMPLE_TASK_ID);
+    assertThat(returendAssignee).isEqualTo(MockProvider.EXAMPLE_TASK_ASSIGNEE_NAME);
+    assertThat(returnedCreateTime).isEqualTo(MockProvider.EXAMPLE_TASK_CREATE_TIME);
+    assertThat(returnedLastUpdated).isEqualTo(MockProvider.EXAMPLE_TASK_LAST_UPDATED);
+    assertThat(returnedDueDate).isEqualTo(MockProvider.EXAMPLE_TASK_DUE_DATE);
+    assertThat(returnedFollowUpDate).isEqualTo(MockProvider.EXAMPLE_FOLLOW_UP_DATE);
+    assertThat(returnedDelegationState).isEqualTo(MockProvider.EXAMPLE_TASK_DELEGATION_STATE.name());
+    assertThat(returnedDescription).isEqualTo(MockProvider.EXAMPLE_TASK_DESCRIPTION);
+    assertThat(returnedExecutionId).isEqualTo(MockProvider.EXAMPLE_TASK_EXECUTION_ID);
+    assertThat(returnedOwner).isEqualTo(MockProvider.EXAMPLE_TASK_OWNER);
+    assertThat(returnedParentTaskId).isEqualTo(MockProvider.EXAMPLE_TASK_PARENT_TASK_ID);
+    assertThat(returnedPriority).isEqualTo(MockProvider.EXAMPLE_TASK_PRIORITY);
+    assertThat(returnedProcessDefinitionId).isEqualTo(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
+    assertThat(returnedProcessInstanceId).isEqualTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID);
+    assertThat(returnedTaskDefinitionKey).isEqualTo(MockProvider.EXAMPLE_TASK_DEFINITION_KEY);
+    assertThat(returnedCaseDefinitionId).isEqualTo(MockProvider.EXAMPLE_CASE_DEFINITION_ID);
+    assertThat(returnedCaseInstanceId).isEqualTo(MockProvider.EXAMPLE_CASE_INSTANCE_ID);
+    assertThat(returnedCaseExecutionId).isEqualTo(MockProvider.EXAMPLE_CASE_EXECUTION_ID);
+    assertThat(returnedSuspensionState).isEqualTo(MockProvider.EXAMPLE_TASK_SUSPENSION_STATE);
+    assertThat(returnedFormKey).isEqualTo(MockProvider.EXAMPLE_FORM_KEY);
+    assertThat(returnedTenantId).isEqualTo(MockProvider.EXAMPLE_TENANT_ID);
 
   }
   @Test
@@ -212,14 +212,14 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     String content = response.asString();
     List<LinkedHashMap<String, String>> instances = from(content).getList("");
-    assertThat(instances).hasSize(1).as("There should be one task returned.");
-    assertThat(instances.get(0)).isNotNull().as("The returned task should not be null.");
+    assertThat(instances).withFailMessage("There should be one task returned.").hasSize(1);
+    assertThat(instances.get(0)).withFailMessage("The returned task should not be null.").isNotNull();
 
     boolean returnedAttachmentsInfo = from(content).getBoolean("[0].attachment");
     boolean returnedCommentsInfo = from(content).getBoolean("[0].comment");
 
-    assertThat(MockProvider.EXAMPLE_TASK_ATTACHMENT_STATE).isEqualTo(returnedAttachmentsInfo);
-    assertThat(MockProvider.EXAMPLE_TASK_COMMENT_STATE).isEqualTo(returnedCommentsInfo);
+    assertThat(returnedAttachmentsInfo).isEqualTo(MockProvider.EXAMPLE_TASK_ATTACHMENT_STATE);
+    assertThat(returnedCommentsInfo).isEqualTo(MockProvider.EXAMPLE_TASK_COMMENT_STATE);
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormDataTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormDataTest.java
@@ -229,7 +229,7 @@ public class FormDataTest extends PluggableProcessEngineTest {
         assertEquals("validator", e.getName());
         assertEquals("customFieldWithValidationDetails", e.getId());
         FormFieldValidationException exception = (FormFieldValidationException) e.getCause();
-        assertEquals(exception.getDetail(), "EXPIRED");
+        assertEquals("EXPIRED", exception.getDetail());
       });
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupTest.java
@@ -898,7 +898,7 @@ public class HistoryCleanupTest {
 
       //job rescheduled till next batch window start time
       Date nextRun = getNextRunWithinBatchWindow(ClockUtil.getCurrentTime());
-      assertTrue(jobEntity.getDuedate().equals(nextRun));
+      assertEquals(jobEntity.getDuedate(), nextRun);
 
       //countEmptyRuns canceled
       assertEquals(0, configuration.getCountEmptyRuns());
@@ -933,7 +933,7 @@ public class HistoryCleanupTest {
 
       //job rescheduled till next batch window start
       Date nextRun = getNextRunWithinBatchWindow(ClockUtil.getCurrentTime());
-      assertTrue(jobEntity.getDuedate().equals(nextRun));
+      assertEquals(jobEntity.getDuedate(), nextRun);
 
       //countEmptyRuns canceled
       assertEquals(0, configuration.getCountEmptyRuns());
@@ -965,7 +965,7 @@ public class HistoryCleanupTest {
 
     //job rescheduled till next batch window start
     Date nextRun = getNextRunWithinBatchWindow(ClockUtil.getCurrentTime());
-    assertTrue(jobEntity.getDuedate().equals(nextRun));
+    assertEquals(jobEntity.getDuedate(), nextRun);
     assertTrue(nextRun.after(ClockUtil.getCurrentTime()));
 
     //countEmptyRuns canceled
@@ -997,7 +997,7 @@ public class HistoryCleanupTest {
 
     //job rescheduled till next batch window start
     Date nextRun = getNextRunWithinBatchWindow(ClockUtil.getCurrentTime());
-    assertTrue(jobEntity.getDuedate().equals(nextRun));
+    assertEquals(jobEntity.getDuedate(), nextRun);
     assertTrue(nextRun.after(ClockUtil.getCurrentTime()));
 
     //countEmptyRuns cancelled
@@ -1111,7 +1111,7 @@ public class HistoryCleanupTest {
     //job rescheduled till next batch window start
     Date nextRun = getNextRunWithinBatchWindow(ClockUtil.getCurrentTime());
 
-    assertTrue(jobEntity.getDuedate().equals(nextRun));
+    assertEquals(jobEntity.getDuedate(), nextRun);
     assertTrue(nextRun.after(ClockUtil.getCurrentTime()));
 
     //countEmptyRuns canceled
@@ -1196,7 +1196,7 @@ public class HistoryCleanupTest {
 
     processEngineConfiguration.setHistoryCleanupBatchSize(500);
     processEngineConfiguration.initHistoryCleanup();
-    assertEquals(processEngineConfiguration.getHistoryCleanupBatchSize(), 500);
+    assertEquals(500, processEngineConfiguration.getHistoryCleanupBatchSize());
 
     processEngineConfiguration.setHistoryTimeToLive("5");
     processEngineConfiguration.initHistoryCleanup();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.java
@@ -621,7 +621,7 @@ public class JobQueryTest {
     assertNotNull(job);
 
     List<Job> list = managementService.createJobQuery().withException().list();
-    assertEquals(list.size(), 1);
+    assertEquals(1, list.size());
 
     deleteJobInDatabase();
 
@@ -632,7 +632,7 @@ public class JobQueryTest {
     assertNotNull(job);
 
     list = managementService.createJobQuery().withException().list();
-    assertEquals(list.size(), 1);
+    assertEquals(1, list.size());
 
     deleteJobInDatabase();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyProcessInstantiationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyProcessInstantiationTest.java
@@ -419,7 +419,7 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
         .processDefinitionId(processInstance.getProcessDefinitionId()).singleResult();
 
     assertNotNull(restartedInstance);
-    assertEquals(restartedInstance.getTenantId(), TENANT_ONE);
+    assertEquals(TENANT_ONE, restartedInstance.getTenantId());
   }
 
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
@@ -443,7 +443,7 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
       .processDefinitionId(processInstance.getProcessDefinitionId()).singleResult();
 
     assertNotNull(restartedInstance);
-    assertEquals(restartedInstance.getTenantId(), TENANT_ONE);
+    assertEquals(TENANT_ONE, restartedInstance.getTenantId());
   }
 
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
@@ -509,7 +509,7 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
       .processDefinitionId(processInstance.getProcessDefinitionId()).singleResult();
 
     assertNotNull(restartedInstance);
-    assertEquals(restartedInstance.getTenantId(), TENANT_ONE);
+    assertEquals(TENANT_ONE, restartedInstance.getTenantId());
   }
 
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
@@ -534,7 +534,7 @@ public class MultiTenancyProcessInstantiationTest extends PluggableProcessEngine
       .processDefinitionId(processInstance.getProcessDefinitionId()).singleResult();
 
     assertNotNull(restartedInstance);
-    assertEquals(restartedInstance.getTenantId(), TENANT_ONE);
+    assertEquals(TENANT_ONE, restartedInstance.getTenantId());
   }
 
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyTaskServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyTaskServiceTest.java
@@ -228,8 +228,8 @@ public class MultiTenancyTaskServiceTest extends PluggableProcessEngineTest {
         .singleResult();
 
     List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(tenantTask.getId());
-    assertEquals(identityLinks.size(),1);
-    assertEquals(identityLinks.get(0).getTenantId(), "tenant");
+    assertEquals(1, identityLinks.size());
+    assertEquals("tenant", identityLinks.get(0).getTenantId());
   }
 
   @Test
@@ -254,8 +254,8 @@ public class MultiTenancyTaskServiceTest extends PluggableProcessEngineTest {
         .singleResult();
 
     List<IdentityLink> identityLinks = taskService.getIdentityLinksForTask(tenantTask.getId());
-    assertEquals(identityLinks.size(),1);
-    assertEquals(identityLinks.get(0).getTenantId(), "tenant");
+    assertEquals(1, identityLinks.size());
+    assertEquals("tenant", identityLinks.get(0).getTenantId());
   }
 
   protected void deleteTasks(Task... tasks) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyExternalTaskCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyExternalTaskCmdsTenantCheckTest.java
@@ -348,7 +348,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
     externalTaskService.handleBpmnError(taskId, WORKER_ID, "ERROR-OCCURED");
 
     // then
-    assertEquals(taskService.createTaskQuery().singleResult().getTaskDefinitionKey(), "afterBpmnError");
+    assertEquals("afterBpmnError", taskService.createTaskQuery().singleResult().getTaskDefinitionKey());
   }
 
   @Test
@@ -386,7 +386,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
     externalTaskService.handleBpmnError(taskId, WORKER_ID, "ERROR-OCCURED");
 
     // then
-    assertEquals(taskService.createTaskQuery().singleResult().getTaskDefinitionKey(), "afterBpmnError");
+    assertEquals("afterBpmnError", taskService.createTaskQuery().singleResult().getTaskDefinitionKey());
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyFormServiceCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyFormServiceCmdsTenantCheckTest.java
@@ -366,7 +366,7 @@ public class MultiTenancyFormServiceCmdsTenantCheckTest {
 
     runtimeService.startProcessInstanceById(processDefinitionId);
 
-    assertEquals(taskService.createTaskQuery().processDefinitionId(processDefinitionId).count(), 1);
+    assertEquals(1, taskService.createTaskQuery().processDefinitionId(processDefinitionId).count());
 
     String taskId = taskService.createTaskQuery().processDefinitionId(processDefinitionId).singleResult().getId();
 
@@ -375,7 +375,7 @@ public class MultiTenancyFormServiceCmdsTenantCheckTest {
     formService.submitTaskForm(taskId, null);
 
     // task gets completed on execution of submitTaskForm
-    assertEquals(taskService.createTaskQuery().processDefinitionId(processDefinitionId).count(), 0);
+    assertEquals(0, taskService.createTaskQuery().processDefinitionId(processDefinitionId).count());
   }
 
   @Test
@@ -419,7 +419,7 @@ public class MultiTenancyFormServiceCmdsTenantCheckTest {
     formService.submitTaskForm(taskId, null);
 
     // task gets completed on execution of submitTaskForm
-    assertEquals(taskService.createTaskQuery().processDefinitionId(processDefinitionId).count(), 0);
+    assertEquals(0, taskService.createTaskQuery().processDefinitionId(processDefinitionId).count());
   }
 
   // getRenderedTaskForm

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ExecutionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ExecutionQueryTest.java
@@ -1169,7 +1169,7 @@ public class ExecutionQueryTest extends PluggableProcessEngineTest {
   @Test
   public void testExecutionQueryForSuspendedExecutions() {
     List<Execution> suspendedExecutions = runtimeService.createExecutionQuery().suspended().list();
-    assertEquals(suspendedExecutions.size(), 0);
+    assertEquals(0, suspendedExecutions.size());
 
     for (String instanceId : concurrentProcessInstanceIds) {
       runtimeService.suspendProcessInstanceById(instanceId);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionSyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionSyncTest.java
@@ -97,7 +97,7 @@ public class ModificationExecutionSyncTest {
 
       List<String> activeActivityIds = runtimeService.getActiveActivityIds(instanceId);
       assertEquals(1, activeActivityIds.size());
-      assertEquals(activeActivityIds.iterator().next(), "user2");
+      assertEquals("user2", activeActivityIds.iterator().next());
     }
   }
 
@@ -114,7 +114,7 @@ public class ModificationExecutionSyncTest {
     for (String instanceId : instances) {
       List<String> activeActivityIds = runtimeService.getActiveActivityIds(instanceId);
       assertEquals(1, activeActivityIds.size());
-      assertEquals(activeActivityIds.iterator().next(), "user2");
+      assertEquals("user2", activeActivityIds.iterator().next());
     }
   }
 
@@ -133,7 +133,7 @@ public class ModificationExecutionSyncTest {
     for (String instanceId : instances) {
       List<String> activeActivityIds = runtimeService.getActiveActivityIds(instanceId);
       assertEquals(1, activeActivityIds.size());
-      assertEquals(activeActivityIds.iterator().next(), "user2");
+      assertEquals("user2", activeActivityIds.iterator().next());
     }
   }
 
@@ -152,7 +152,7 @@ public class ModificationExecutionSyncTest {
     for (String instanceId : instances) {
       List<String> activeActivityIds = runtimeService.getActiveActivityIds(instanceId);
       assertEquals(1, activeActivityIds.size());
-      assertEquals(activeActivityIds.iterator().next(), "user2");
+      assertEquals("user2", activeActivityIds.iterator().next());
     }
   }
 
@@ -170,7 +170,7 @@ public class ModificationExecutionSyncTest {
 
     List<String> activeActivityIds = runtimeService.getActiveActivityIds(instances.get(1));
     assertEquals(1, activeActivityIds.size());
-    assertEquals(activeActivityIds.iterator().next(), "user2");
+    assertEquals("user2", activeActivityIds.iterator().next());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RestartProcessInstanceAsyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RestartProcessInstanceAsyncTest.java
@@ -23,7 +23,6 @@ import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.describeA
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Arrays;
@@ -449,9 +448,9 @@ public class RestartProcessInstanceAsyncTest {
     restartedProcessInstance = restartedProcessInstances.get(1);
     VariableInstance variableInstance2 = runtimeService.createVariableInstanceQuery().processInstanceIdIn(restartedProcessInstance.getId()).singleResult();
     assertEquals(variableInstance2.getExecutionId(), restartedProcessInstance.getId());
-    assertTrue(variableInstance1.getName().equals(variableInstance2.getName()));
+    assertEquals(variableInstance1.getName(), variableInstance2.getName());
     assertEquals("var", variableInstance1.getName());
-    assertTrue(variableInstance1.getValue().equals(variableInstance2.getValue()));
+    assertEquals(variableInstance1.getValue(), variableInstance2.getValue());
     assertEquals("foo", variableInstance2.getValue());
   }
 
@@ -1050,7 +1049,7 @@ public class RestartProcessInstanceAsyncTest {
 
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
-    assertEquals(processInstance.getTenantId(), TestTenantIdProvider.TENANT_ID);
+    assertEquals(TestTenantIdProvider.TENANT_ID, processInstance.getTenantId());
     runtimeService.deleteProcessInstance(processInstance.getId(), "test");
 
     // when
@@ -1066,7 +1065,7 @@ public class RestartProcessInstanceAsyncTest {
       .processDefinitionId(processDefinition.getId()).singleResult();
 
     assertNotNull(restartedInstance);
-    assertEquals(restartedInstance.getTenantId(), TestTenantIdProvider.TENANT_ID);
+    assertEquals(TestTenantIdProvider.TENANT_ID, restartedInstance.getTenantId());
   }
 
   @Test
@@ -1077,7 +1076,7 @@ public class RestartProcessInstanceAsyncTest {
 
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
-    assertEquals(processInstance.getTenantId(), TestTenantIdProvider.TENANT_ID);
+    assertEquals(TestTenantIdProvider.TENANT_ID, processInstance.getTenantId());
     runtimeService.deleteProcessInstance(processInstance.getId(), "test");
 
     // set tenant id provider to fail to verify it is not called during instantiation
@@ -1097,7 +1096,7 @@ public class RestartProcessInstanceAsyncTest {
       .processDefinitionId(processDefinition.getId()).singleResult();
 
     assertNotNull(restartedInstance);
-    assertEquals(restartedInstance.getTenantId(), TestTenantIdProvider.TENANT_ID);
+    assertEquals(TestTenantIdProvider.TENANT_ID, restartedInstance.getTenantId());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RestartProcessInstanceSyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RestartProcessInstanceSyncTest.java
@@ -784,7 +784,7 @@ public class RestartProcessInstanceSyncTest {
 
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
-    assertEquals(processInstance.getTenantId(), TestTenantIdProvider.TENANT_ID);
+    assertEquals(TestTenantIdProvider.TENANT_ID, processInstance.getTenantId());
     runtimeService.deleteProcessInstance(processInstance.getId(), "test");
 
     // when
@@ -798,7 +798,7 @@ public class RestartProcessInstanceSyncTest {
         .processDefinitionId(processDefinition.getId()).singleResult();
 
     assertNotNull(restartedInstance);
-    assertEquals(restartedInstance.getTenantId(), TestTenantIdProvider.TENANT_ID);
+    assertEquals(TestTenantIdProvider.TENANT_ID, restartedInstance.getTenantId());
   }
 
   @Test
@@ -809,7 +809,7 @@ public class RestartProcessInstanceSyncTest {
 
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
-    assertEquals(processInstance.getTenantId(), TestTenantIdProvider.TENANT_ID);
+    assertEquals(TestTenantIdProvider.TENANT_ID, processInstance.getTenantId());
     runtimeService.deleteProcessInstance(processInstance.getId(), "test");
 
     // set tenant id provider to fail to verify it is not called during instantiation
@@ -827,7 +827,7 @@ public class RestartProcessInstanceSyncTest {
       .processDefinitionId(processDefinition.getId()).singleResult();
 
     assertNotNull(restartedInstance);
-    assertEquals(restartedInstance.getTenantId(), TestTenantIdProvider.TENANT_ID);
+    assertEquals(TestTenantIdProvider.TENANT_ID, restartedInstance.getTenantId());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/TransientVariableTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/TransientVariableTest.java
@@ -352,7 +352,7 @@ public class TransientVariableTest {
     // then
     List<VariableInstance> variables = runtimeService.createVariableInstanceQuery().list();
     assertEquals(1, variables.size());
-    assertEquals(variables.get(0).getValue(), 9L);
+    assertEquals(9L, variables.get(0).getValue());
   }
 
   @Test
@@ -370,7 +370,7 @@ public class TransientVariableTest {
     // then
     List<VariableInstance> variables = runtimeService.createVariableInstanceQuery().list();
     assertEquals(1, variables.size());
-    assertEquals(variables.get(0).getValue(), 9L);
+    assertEquals(9L, variables.get(0).getValue());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/external/ExternalTaskParseTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/external/ExternalTaskParseTest.java
@@ -59,7 +59,7 @@ public class ExternalTaskParseTest extends PluggableProcessEngineTest {
 
     runtimeService.startProcessInstanceByKey("oneExternalTaskWithExpressionTopicProcess", variables);
     ExternalTask task = externalTaskService.createExternalTaskQuery().singleResult();
-    assertThat("testTopicExpression").isEqualTo(task.getTopicName());
+    assertThat(task.getTopicName()).isEqualTo("testTopicExpression");
   }
 
   @Deployment
@@ -69,6 +69,6 @@ public class ExternalTaskParseTest extends PluggableProcessEngineTest {
 
     runtimeService.startProcessInstanceByKey("oneExternalTaskWithStringTopicProcess", variables);
     ExternalTask task = externalTaskService.createExternalTaskQuery().singleResult();
-    assertThat("testTopicString").isEqualTo(task.getTopicName());
+    assertThat(task.getTopicName()).isEqualTo("testTopicString");
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.java
@@ -148,7 +148,7 @@ public class TaskListenerTest extends AbstractTaskListenerTest {
     runtimeService.startProcessInstanceByKey("mainProc");
     Task task = taskService.createTaskQuery().singleResult();
 
-    Assert.assertEquals(task.getTaskDefinitionKey(), "calledTask");
+    Assert.assertEquals("calledTask", task.getTaskDefinitionKey());
   }
 
   // COMPLETE Task Listener tests
@@ -158,8 +158,8 @@ public class TaskListenerTest extends AbstractTaskListenerTest {
   public void testTaskCompleteListener() {
     TaskDeleteListener.clear();
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerProcess");
-    assertEquals(null, runtimeService.getVariable(processInstance.getId(), "greeting"));
-    assertEquals(null, runtimeService.getVariable(processInstance.getId(), "expressionValue"));
+    assertNull(runtimeService.getVariable(processInstance.getId(), "greeting"));
+    assertNull(runtimeService.getVariable(processInstance.getId(), "expressionValue"));
 
     // Completing first task will change the description
     Task task = taskService.createTaskQuery().singleResult();
@@ -289,7 +289,7 @@ public class TaskListenerTest extends AbstractTaskListenerTest {
   @Deployment(resources = {"org/operaton/bpm/engine/test/bpmn/tasklistener/TaskListenerTest.bpmn20.xml"})
   public void testTaskListenerWithExpression() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskListenerProcess");
-    assertEquals(null, runtimeService.getVariable(processInstance.getId(), "greeting2"));
+    assertNull(runtimeService.getVariable(processInstance.getId(), "greeting2"));
 
     // Completing first task will change the description
     Task task = taskService.createTaskQuery().singleResult();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
@@ -86,8 +86,8 @@ public class TaskDueDateExtensionsTest extends PluggableProcessEngineTest {
     assertNotNull(dueDate);
     
     Period period = new Period(task.getCreateTime().getTime(), dueDate.getTime());
-    assertEquals(period.getDays(), 2);
-    assertEquals(period.getHours(), 2);
-    assertEquals(period.getMinutes(), 30);
+    assertEquals(2, period.getDays());
+    assertEquals(2, period.getHours());
+    assertEquals(30, period.getMinutes());
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/usertask/TaskFollowUpDateExtensionsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/usertask/TaskFollowUpDateExtensionsTest.java
@@ -85,9 +85,9 @@ public class TaskFollowUpDateExtensionsTest extends PluggableProcessEngineTest {
     assertNotNull(followUpDate);
 
     Period period = new Period(task.getCreateTime().getTime(), followUpDate.getTime());
-    assertEquals(period.getDays(), 2);
-    assertEquals(period.getHours(), 2);
-    assertEquals(period.getMinutes(), 30);
+    assertEquals(2, period.getDays());
+    assertEquals(2, period.getHours());
+    assertEquals(30, period.getMinutes());
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/deployment/CmmnDeployerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/deployment/CmmnDeployerTest.java
@@ -235,7 +235,7 @@ public class CmmnDeployerTest extends PluggableProcessEngineTest {
     CaseDefinition caseDefinition = repositoryService.createCaseDefinitionQuery().singleResult();
     Integer historyTimeToLive = caseDefinition.getHistoryTimeToLive();
     assertNotNull(historyTimeToLive);
-    assertEquals((int) historyTimeToLive, 5);
+    assertEquals(5, (int) historyTimeToLive);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/cmmn/deployment/CmmnDeploymentTest.testDeployCaseDefinitionWithStringHistoryTimeToLive.cmmn")
@@ -244,7 +244,7 @@ public class CmmnDeployerTest extends PluggableProcessEngineTest {
     CaseDefinition caseDefinition = repositoryService.createCaseDefinitionQuery().singleResult();
     Integer historyTimeToLive = caseDefinition.getHistoryTimeToLive();
     assertNotNull(historyTimeToLive);
-    assertEquals((int) historyTimeToLive, 5);
+    assertEquals(5, (int) historyTimeToLive);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/humantask/HumanTaskFollowUpDateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/humantask/HumanTaskFollowUpDateTest.java
@@ -82,9 +82,9 @@ public class HumanTaskFollowUpDateTest extends PluggableProcessEngineTest {
     assertNotNull(followUpDate);
 
     Period period = new Period(task.getCreateTime().getTime(), followUpDate.getTime());
-    assertEquals(period.getDays(), 2);
-    assertEquals(period.getHours(), 2);
-    assertEquals(period.getMinutes(), 30);
+    assertEquals(2, period.getDays());
+    assertEquals(2, period.getHours());
+    assertEquals(30, period.getMinutes());
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingMessageCorrelationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingMessageCorrelationTest.java
@@ -103,7 +103,7 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
 
     // thread 2 can't continue because the event subscription it tried to lock was deleted
     thread2.waitForSync();
-    assertTrue(thread2.getException() != null);
+    assertNotNull(thread2.getException());
     assertTrue(thread2.getException() instanceof ProcessEngineException);
     assertThat(thread2.getException().getMessage())
         .contains("does not have a subscription to a message event with name 'Message'");
@@ -114,7 +114,7 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
 
     // the follow-up task was reached
     Task afterMessageTask = taskService.createTaskQuery().singleResult();
-    assertEquals(afterMessageTask.getTaskDefinitionKey(), "afterMessageUserTask");
+    assertEquals("afterMessageUserTask", afterMessageTask.getTaskDefinitionKey());
 
     // the service task was not executed a second time
     assertEquals(1, InvocationLogListener.getInvocations());
@@ -153,11 +153,11 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
     assertNull(thread1.getException());
 
     Task afterMessageTask = taskService.createTaskQuery().singleResult();
-    assertEquals(afterMessageTask.getTaskDefinitionKey(), "afterMessageUserTask");
+    assertEquals("afterMessageUserTask", afterMessageTask.getTaskDefinitionKey());
 
     // the second thread ends its transaction and fails with optimistic locking exception
     thread2.waitUntilDone();
-    assertTrue(thread2.getException() != null);
+    assertNotNull(thread2.getException());
     assertTrue(thread2.getException() instanceof OptimisticLockingException);
   }
 
@@ -292,13 +292,13 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
     assertNull(thread1.getException());
 
     Task afterMessageTask = taskService.createTaskQuery().singleResult();
-    assertEquals(afterMessageTask.getTaskDefinitionKey(), "afterMessageUserTask");
+    assertEquals("afterMessageUserTask", afterMessageTask.getTaskDefinitionKey());
 
     // thread two attempts to end its transaction and fails with optimistic locking
     thread2.makeContinue();
     thread2.waitForSync();
 
-    assertTrue(thread2.getException() != null);
+    assertNotNull(thread2.getException());
     assertTrue(thread2.getException() instanceof OptimisticLockingException);
   }
 
@@ -353,11 +353,11 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
 
     Task afterMessageTask = taskService.createTaskQuery().singleResult();
     assertNotNull(afterMessageTask);
-    assertEquals(afterMessageTask.getTaskDefinitionKey(), "afterMessageUserTask");
+    assertEquals("afterMessageUserTask", afterMessageTask.getTaskDefinitionKey());
 
     // thread 1 flush fails with optimistic locking
     thread1.join();
-    assertTrue(thread1.getException() != null);
+    assertNotNull(thread1.getException());
     assertTrue(thread1.getException() instanceof OptimisticLockingException);
   }
 
@@ -392,7 +392,7 @@ public class CompetingMessageCorrelationTest extends ConcurrencyTestCase {
 
     // the second thread ends its transaction and fails with optimistic locking exception
     thread2.waitUntilDone();
-    assertTrue(thread2.getException() != null);
+    assertNotNull(thread2.getException());
     assertTrue(thread2.getException() instanceof OptimisticLockingException);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/dmn/deployment/DecisionDefinitionDeployerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/dmn/deployment/DecisionDefinitionDeployerTest.java
@@ -519,10 +519,10 @@ public class DecisionDefinitionDeployerTest {
 
     // then
     List<DecisionDefinition> deployedDecisionDefinitions = deployment.getDeployedDecisionDefinitions();
-    assertEquals(deployedDecisionDefinitions.size(), 1);
+    assertEquals(1, deployedDecisionDefinitions.size());
     Integer historyTimeToLive = deployedDecisionDefinitions.get(0).getHistoryTimeToLive();
     assertNotNull(historyTimeToLive);
-    assertEquals((int) historyTimeToLive, 5);
+    assertEquals(5, (int) historyTimeToLive);
   }
 
   @Test
@@ -532,10 +532,10 @@ public class DecisionDefinitionDeployerTest {
 
     // then
     List<DecisionDefinition> deployedDecisionDefinitions = deployment.getDeployedDecisionDefinitions();
-    assertEquals(deployedDecisionDefinitions.size(), 1);
+    assertEquals(1, deployedDecisionDefinitions.size());
     Integer historyTimeToLive = deployedDecisionDefinitions.get(0).getHistoryTimeToLive();
     assertNotNull(historyTimeToLive);
-    assertEquals((int) historyTimeToLive, 5);
+    assertEquals(5, (int) historyTimeToLive);
   }
 
   @Test
@@ -554,7 +554,7 @@ public class DecisionDefinitionDeployerTest {
 
       // then
       List<DecisionDefinition> deployedDecisionDefinitions = deployment.getDeployedDecisionDefinitions();
-      assertEquals(deployedDecisionDefinitions.size(), 1);
+      assertEquals(1, deployedDecisionDefinitions.size());
       Integer historyTimeToLive = deployedDecisionDefinitions.get(0).getHistoryTimeToLive();
       assertNull(historyTimeToLive);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityStatisticsQueryTest.java
@@ -71,7 +71,7 @@ public class HistoricCaseActivityStatisticsQueryTest {
       historicCaseActivityStatisticsQuery.list();
       fail("It should not be possible to query for statistics by null.");
     } catch (NullValueException exception) {
-
+      // expected
     }
   }
 
@@ -127,7 +127,7 @@ public class HistoricCaseActivityStatisticsQueryTest {
     // then
     List<HistoricCaseActivityStatistics> statistics = query.list();
     assertThat(statistics).hasSize(6);
-    assertEquals(query.count(), 6);
+    assertEquals(6, query.count());
 
     assertStatisitcs(statistics.get(0), "ACTIVE", 5, 0, 0, 0, 0, 0);
     assertStatisitcs(statistics.get(1), "AVAILABLE", 0, 5, 0, 0, 0, 0);
@@ -176,7 +176,7 @@ public class HistoricCaseActivityStatisticsQueryTest {
     // then
     List<HistoricCaseActivityStatistics> statistics = query.list();
     assertThat(statistics).hasSize(6);
-    assertEquals(query.count(), 6);
+    assertEquals(6, query.count());
 
     assertStatisitcs(statistics.get(0), "ACTIVE", 2, 0, 8, 0, 0, 5);
     assertStatisitcs(statistics.get(1), "AVAILABLE", 0, 7, 3, 0, 0, 5);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricDetailQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricDetailQueryTest.java
@@ -247,8 +247,8 @@ public class HistoricDetailQueryTest {
     assertEquals(1, query.count());
     HistoricDetail historicDetail = query.list().get(0);
     if (historicDetail instanceof HistoricVariableUpdate variableUpdate) {
-      assertEquals(variableUpdate.getVariableName(), "stringVar");
-      assertEquals(variableUpdate.getTypeName(), "string");
+      assertEquals("stringVar", variableUpdate.getVariableName());
+      assertEquals("string", variableUpdate.getTypeName());
     } else {
       fail("Historic detail should be a variable update!");
     }
@@ -273,8 +273,8 @@ public class HistoricDetailQueryTest {
     assertEquals(1, query.count());
     HistoricDetail historicDetail = query.list().get(0);
     if (historicDetail instanceof HistoricVariableUpdate variableUpdate) {
-      assertEquals(variableUpdate.getVariableName(), "boolVar");
-      assertEquals(variableUpdate.getTypeName(), "boolean");
+      assertEquals("boolVar", variableUpdate.getVariableName());
+      assertEquals("boolean", variableUpdate.getTypeName());
     } else {
       fail("Historic detail should be a variable update!");
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIdentityLinkLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIdentityLinkLogQueryTest.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.test.history;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -69,7 +70,7 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
   public void testQueryAddTaskCandidateforAddIdentityLink() {
 
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     ProcessInstance processInstance = startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -81,12 +82,12 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
 
     // Query test
     HistoricIdentityLinkLog historicIdentityLink = historyService.createHistoricIdentityLinkLogQuery().singleResult();
-    assertEquals(historicIdentityLink.getUserId(), A_USER_ID);
+    assertEquals(A_USER_ID, historicIdentityLink.getUserId());
     assertEquals(historicIdentityLink.getTaskId(), taskId);
-    assertEquals(historicIdentityLink.getType(), IdentityLinkType.CANDIDATE);
-    assertEquals(historicIdentityLink.getAssignerId(), A_ASSIGNER_ID);
-    assertEquals(historicIdentityLink.getGroupId(), null);
-    assertEquals(historicIdentityLink.getOperationType(), IDENTITY_LINK_ADD);
+    assertEquals(IdentityLinkType.CANDIDATE, historicIdentityLink.getType());
+    assertEquals(A_ASSIGNER_ID, historicIdentityLink.getAssignerId());
+    assertNull(historicIdentityLink.getGroupId());
+    assertEquals(IDENTITY_LINK_ADD, historicIdentityLink.getOperationType());
     assertEquals(historicIdentityLink.getProcessDefinitionId(), processInstance.getProcessDefinitionId());
     assertEquals(historicIdentityLink.getProcessDefinitionKey(), PROCESS_DEFINITION_KEY);
   }
@@ -96,7 +97,7 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
   public void testGroupQueryTaskCandidateForAddAndDeleteIdentityLink() {
 
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     ProcessInstance processInstance = startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -108,12 +109,12 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
 
     // Query test
     HistoricIdentityLinkLog historicIdentityLink = historyService.createHistoricIdentityLinkLogQuery().singleResult();
-    assertEquals(historicIdentityLink.getUserId(), null);
+    assertNull(historicIdentityLink.getUserId());
     assertEquals(historicIdentityLink.getTaskId(), taskId);
-    assertEquals(historicIdentityLink.getType(), IdentityLinkType.CANDIDATE);
-    assertEquals(historicIdentityLink.getAssignerId(), A_ASSIGNER_ID);
-    assertEquals(historicIdentityLink.getGroupId(), A_GROUP_ID);
-    assertEquals(historicIdentityLink.getOperationType(), IDENTITY_LINK_ADD);
+    assertEquals(IdentityLinkType.CANDIDATE, historicIdentityLink.getType());
+    assertEquals(A_ASSIGNER_ID, historicIdentityLink.getAssignerId());
+    assertEquals(A_GROUP_ID, historicIdentityLink.getGroupId());
+    assertEquals(IDENTITY_LINK_ADD, historicIdentityLink.getOperationType());
     assertEquals(historicIdentityLink.getProcessDefinitionId(), processInstance.getProcessDefinitionId());
     assertEquals(historicIdentityLink.getProcessDefinitionKey(), PROCESS_DEFINITION_KEY);
   }
@@ -123,7 +124,7 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
   public void testValidIndividualQueryTaskCandidateForAddAndDeleteIdentityLink() {
 
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     ProcessInstance processInstance = startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -136,28 +137,28 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
 
     // Valid Individual Query test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.taskId(taskId).count(), 2);
+    assertEquals(2, query.taskId(taskId).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.type(IdentityLinkType.CANDIDATE).count(), 2);
+    assertEquals(2, query.type(IdentityLinkType.CANDIDATE).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.userId(A_USER_ID).count(), 2);
+    assertEquals(2, query.userId(A_USER_ID).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.assignerId(A_ASSIGNER_ID).count(), 2);
+    assertEquals(2, query.assignerId(A_ASSIGNER_ID).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.operationType(IDENTITY_LINK_DELETE).count(), 1);
+    assertEquals(1, query.operationType(IDENTITY_LINK_DELETE).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.operationType(IDENTITY_LINK_ADD).count(), 1);
+    assertEquals(1, query.operationType(IDENTITY_LINK_ADD).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.processDefinitionId(processInstance.getProcessDefinitionId()).count(), 2);
+    assertEquals(2, query.processDefinitionId(processInstance.getProcessDefinitionId()).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.processDefinitionKey(PROCESS_DEFINITION_KEY).count(), 2);
+    assertEquals(2, query.processDefinitionKey(PROCESS_DEFINITION_KEY).count());
 
   }
 
@@ -166,7 +167,7 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
   public void testValidGroupQueryTaskCandidateForAddAndDeleteIdentityLink() {
 
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     ProcessInstance processInstance = startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -179,14 +180,14 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
 
     // Valid group query test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.taskId(taskId).count(), 2);
-    assertEquals(query.type(IdentityLinkType.CANDIDATE).count(), 2);
-    assertEquals(query.userId(A_USER_ID).count(), 2);
-    assertEquals(query.assignerId(A_ASSIGNER_ID).count(), 2);
-    assertEquals(query.processDefinitionId(processInstance.getProcessDefinitionId()).count(), 2);
-    assertEquals(query.processDefinitionKey(PROCESS_DEFINITION_KEY).count(), 2);
-    assertEquals(query.operationType(IDENTITY_LINK_DELETE).count(), 1);
-    assertEquals(query.operationType(IDENTITY_LINK_ADD).count(), 1);
+    assertEquals(2, query.taskId(taskId).count());
+    assertEquals(2, query.type(IdentityLinkType.CANDIDATE).count());
+    assertEquals(2, query.userId(A_USER_ID).count());
+    assertEquals(2, query.assignerId(A_ASSIGNER_ID).count());
+    assertEquals(2, query.processDefinitionId(processInstance.getProcessDefinitionId()).count());
+    assertEquals(2, query.processDefinitionKey(PROCESS_DEFINITION_KEY).count());
+    assertEquals(1, query.operationType(IDENTITY_LINK_DELETE).count());
+    assertEquals(1, query.operationType(IDENTITY_LINK_ADD).count());
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
@@ -194,7 +195,7 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
   public void testInvalidIndividualQueryTaskCandidateForAddAndDeleteIdentityLink() {
 
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -207,22 +208,22 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
 
     // Invalid Individual Query test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.taskId(INVALID_TASK_ID).count(), 0);
+    assertEquals(0, query.taskId(INVALID_TASK_ID).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.type(INVALID_IDENTITY_LINK_TYPE).count(), 0);
+    assertEquals(0, query.type(INVALID_IDENTITY_LINK_TYPE).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.userId(INVALID_USER_ID).count(), 0);
+    assertEquals(0, query.userId(INVALID_USER_ID).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.groupId(INVALID_GROUP_ID).count(), 0);
+    assertEquals(0, query.groupId(INVALID_GROUP_ID).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.assignerId(INVALID_ASSIGNER_ID).count(), 0);
+    assertEquals(0, query.assignerId(INVALID_ASSIGNER_ID).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.operationType(INVALID_HISTORY_EVENT_TYPE).count(), 0);
+    assertEquals(0, query.operationType(INVALID_HISTORY_EVENT_TYPE).count());
 
   }
 
@@ -231,7 +232,7 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
   public void testInvalidGroupQueryTaskCandidateForAddAndDeleteIdentityLink() {
 
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -244,14 +245,14 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
 
     // Invalid Individual Query test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.taskId(INVALID_TASK_ID).count(), 0);
-    assertEquals(query.type(INVALID_IDENTITY_LINK_TYPE).count(), 0);
-    assertEquals(query.userId(INVALID_USER_ID).count(), 0);
-    assertEquals(query.groupId(INVALID_GROUP_ID).count(), 0);
-    assertEquals(query.assignerId(INVALID_ASSIGNER_ID).count(), 0);
-    assertEquals(query.operationType(INVALID_HISTORY_EVENT_TYPE).count(), 0);
-    assertEquals(query.processDefinitionId(INVALID_PROCESS_DEFINITION_ID).count(), 0);
-    assertEquals(query.processDefinitionKey(INVALID_PROCESS_DEFINITION_KEY).count(), 0);
+    assertEquals(0, query.taskId(INVALID_TASK_ID).count());
+    assertEquals(0, query.type(INVALID_IDENTITY_LINK_TYPE).count());
+    assertEquals(0, query.userId(INVALID_USER_ID).count());
+    assertEquals(0, query.groupId(INVALID_GROUP_ID).count());
+    assertEquals(0, query.assignerId(INVALID_ASSIGNER_ID).count());
+    assertEquals(0, query.operationType(INVALID_HISTORY_EVENT_TYPE).count());
+    assertEquals(0, query.processDefinitionId(INVALID_PROCESS_DEFINITION_ID).count());
+    assertEquals(0, query.processDefinitionKey(INVALID_PROCESS_DEFINITION_KEY).count());
   }
 
   /**
@@ -270,7 +271,7 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
   public void testShouldAddTaskOwnerForAddandDeleteIdentityLinkByTimeStamp() {
 
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -294,22 +295,22 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
 
     // Query records with time before 12:20
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.dateBefore(newYearNoon(20)).count(), 6);
-    assertEquals(query.operationType(IDENTITY_LINK_ADD).count(), 3);
-    assertEquals(query.operationType(IDENTITY_LINK_DELETE).count(), 3);
+    assertEquals(6, query.dateBefore(newYearNoon(20)).count());
+    assertEquals(3, query.operationType(IDENTITY_LINK_ADD).count());
+    assertEquals(3, query.operationType(IDENTITY_LINK_DELETE).count());
 
     // Query records with time between 00:01 and 12:00
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.dateBefore(newYearNoon(0)).count(), 6);
-    assertEquals(query.dateAfter(newYearMorning(1)).count(), 1);
-    assertEquals(query.operationType(IDENTITY_LINK_ADD).count(), 0);
-    assertEquals(query.operationType(IDENTITY_LINK_DELETE).count(), 1);
+    assertEquals(6, query.dateBefore(newYearNoon(0)).count());
+    assertEquals(1, query.dateAfter(newYearMorning(1)).count());
+    assertEquals(0, query.operationType(IDENTITY_LINK_ADD).count());
+    assertEquals(1, query.operationType(IDENTITY_LINK_DELETE).count());
 
     // Query records with time after 12:45
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.dateAfter(newYearNoon(45)).count(), 1);
-    assertEquals(query.operationType(IDENTITY_LINK_ADD).count(), 0);
-    assertEquals(query.operationType(IDENTITY_LINK_DELETE).count(), 1);
+    assertEquals(1, query.dateAfter(newYearNoon(45)).count());
+    assertEquals(0, query.operationType(IDENTITY_LINK_ADD).count());
+    assertEquals(1, query.operationType(IDENTITY_LINK_DELETE).count());
 
     ClockUtil.setCurrentTime(new Date());
   }
@@ -327,40 +328,40 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
     // Add candiate group with process definition
     repositoryService.addCandidateStarterGroup(latestProcessDef.getId(), GROUP_1);
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 1);
+    assertEquals(1, historicIdentityLinks.size());
     // Query test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.processDefinitionId(latestProcessDef.getId()).count(), 1);
-    assertEquals(query.operationType(IDENTITY_LINK_ADD).count(), 1);
-    assertEquals(query.groupId(GROUP_1).count(), 1);
+    assertEquals(1, query.processDefinitionId(latestProcessDef.getId()).count());
+    assertEquals(1, query.operationType(IDENTITY_LINK_ADD).count());
+    assertEquals(1, query.groupId(GROUP_1).count());
 
     // Add candidate user for process definition
     repositoryService.addCandidateStarterUser(latestProcessDef.getId(), USER_1);
     // Query test
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.processDefinitionId(latestProcessDef.getId()).count(), 2);
-    assertEquals(query.processDefinitionKey(latestProcessDef.getKey()).count(), 2);
-    assertEquals(query.operationType(IDENTITY_LINK_ADD).count(), 2);
-    assertEquals(query.userId(USER_1).count(), 1);
+    assertEquals(2, query.processDefinitionId(latestProcessDef.getId()).count());
+    assertEquals(2, query.processDefinitionKey(latestProcessDef.getKey()).count());
+    assertEquals(2, query.operationType(IDENTITY_LINK_ADD).count());
+    assertEquals(1, query.userId(USER_1).count());
 
     // Delete candiate group with process definition
     repositoryService.deleteCandidateStarterGroup(latestProcessDef.getId(), GROUP_1);
     // Query test
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.processDefinitionId(latestProcessDef.getId()).count(), 3);
-    assertEquals(query.processDefinitionKey(latestProcessDef.getKey()).count(), 3);
-    assertEquals(query.groupId(GROUP_1).count(), 2);
-    assertEquals(query.operationType(IDENTITY_LINK_DELETE).count(), 1);
+    assertEquals(3, query.processDefinitionId(latestProcessDef.getId()).count());
+    assertEquals(3, query.processDefinitionKey(latestProcessDef.getKey()).count());
+    assertEquals(2, query.groupId(GROUP_1).count());
+    assertEquals(1, query.operationType(IDENTITY_LINK_DELETE).count());
 
     // Delete candidate user for process definition
     repositoryService.deleteCandidateStarterUser(latestProcessDef.getId(), USER_1);
     // Query test
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.processDefinitionId(latestProcessDef.getId()).count(), 4);
-    assertEquals(query.processDefinitionKey(latestProcessDef.getKey()).count(), 4);
-    assertEquals(query.userId(USER_1).count(), 2);
+    assertEquals(4, query.processDefinitionId(latestProcessDef.getId()).count());
+    assertEquals(4, query.processDefinitionKey(latestProcessDef.getKey()).count());
+    assertEquals(2, query.userId(USER_1).count());
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.operationType(IDENTITY_LINK_DELETE).count(), 2);
+    assertEquals(2, query.operationType(IDENTITY_LINK_DELETE).count());
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/OneTaskProcessWithMultipleCandidateUser.bpmn20.xml" })
@@ -382,7 +383,7 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
 
     // Pre test - Historical identity link is added as part of deployment
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
     startProcessInstance(PROCESS_DEFINITION_KEY_MULTIPLE_CANDIDATE_USER);
 
     assertEquals(4, historyService.createHistoricIdentityLinkLogQuery().orderByAssignerId().asc().list().size());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIdentityLinkLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIdentityLinkLogTest.java
@@ -62,7 +62,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
 
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -73,7 +73,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
     taskService.addCandidateUser(taskId, A_USER_ID);
 
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 1);
+    assertEquals(1, historicIdentityLinks.size());
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
@@ -82,7 +82,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
 
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -94,24 +94,24 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
     taskService.deleteUserIdentityLink(taskId, B_USER_ID, IdentityLinkType.ASSIGNEE);
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
     // Addition of A_USER, Deletion of A_USER, Addition of A_USER as owner, Addition of B_USER and deletion of B_USER
-    assertEquals(historicIdentityLinks.size(), 5);
+    assertEquals(5, historicIdentityLinks.size());
 
     //Query test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.userId(A_USER_ID).count(), 3);
+    assertEquals(3, query.userId(A_USER_ID).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.userId(B_USER_ID).count(), 2);
+    assertEquals(2, query.userId(B_USER_ID).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.operationType(IDENTITY_LINK_ADD).count(), 3);
+    assertEquals(3, query.operationType(IDENTITY_LINK_ADD).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.operationType(IDENTITY_LINK_DELETE).count(), 2);
+    assertEquals(2, query.operationType(IDENTITY_LINK_DELETE).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.type(IdentityLinkType.ASSIGNEE).count(), 4);
-    assertEquals(query.type(IdentityLinkType.OWNER).count(), 1);
+    assertEquals(4, query.type(IdentityLinkType.ASSIGNEE).count());
+    assertEquals(1, query.type(IdentityLinkType.OWNER).count());
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
@@ -120,7 +120,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
 
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -129,20 +129,20 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
     taskService.claim(taskId, A_USER_ID);
 
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 1);
+    assertEquals(1, historicIdentityLinks.size());
 
     //Query test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.userId(A_USER_ID).count(), 1);
+    assertEquals(1, query.userId(A_USER_ID).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.operationType(IDENTITY_LINK_ADD).count(), 1);
+    assertEquals(1, query.operationType(IDENTITY_LINK_ADD).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.operationType(IDENTITY_LINK_DELETE).count(), 0);
+    assertEquals(0, query.operationType(IDENTITY_LINK_DELETE).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.type(IdentityLinkType.ASSIGNEE).count(), 1);
+    assertEquals(1, query.type(IdentityLinkType.ASSIGNEE).count());
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
@@ -151,7 +151,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
 
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -165,30 +165,30 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
     // Addition of A_USER, Deletion of A_USER, Addition of A_USER as owner,
     // Addition of B_USER, Deletion of B_USER, Addition of C_USER, Deletion of C_USER
-    assertEquals(historicIdentityLinks.size(), 7);
+    assertEquals(7, historicIdentityLinks.size());
 
     //Query test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.userId(A_USER_ID).count(), 3);
+    assertEquals(3, query.userId(A_USER_ID).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.userId(B_USER_ID).count(), 2);
+    assertEquals(2, query.userId(B_USER_ID).count());
 
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.userId(C_USER_ID).count(), 2);
+    assertEquals(2, query.userId(C_USER_ID).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.operationType(IDENTITY_LINK_ADD).count(), 4);
+    assertEquals(4, query.operationType(IDENTITY_LINK_ADD).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.operationType(IDENTITY_LINK_DELETE).count(), 3);
+    assertEquals(3, query.operationType(IDENTITY_LINK_DELETE).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.type(IdentityLinkType.ASSIGNEE).count(), 6);
+    assertEquals(6, query.type(IdentityLinkType.ASSIGNEE).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.type(IdentityLinkType.OWNER).count(), 1);
+    assertEquals(1, query.type(IdentityLinkType.OWNER).count());
   }
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
   @Test
@@ -196,7 +196,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
 
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -209,7 +209,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
 
     // then
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 2);
+    assertEquals(2, historicIdentityLinks.size());
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
@@ -217,7 +217,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
   public void testShouldAddGroupCandidateForAddAndDeleteIdentityLink() {
 
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -230,11 +230,11 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
 
     // then
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 2);
+    assertEquals(2, historicIdentityLinks.size());
 
     // Basic Query test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.groupId(A_GROUP_ID).count(), 2);
+    assertEquals(2, query.groupId(A_GROUP_ID).count());
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
@@ -243,7 +243,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
 
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -255,7 +255,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
 
     // then
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
@@ -264,7 +264,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
 
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -274,11 +274,11 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
     addAndDeleteUserWithAssigner(taskId, IdentityLinkType.ASSIGNEE);
     // then
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 2);
+    assertEquals(2, historicIdentityLinks.size());
 
     // Basic Query test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.type(IdentityLinkType.ASSIGNEE).count(), 2);
+    assertEquals(2, query.type(IdentityLinkType.ASSIGNEE).count());
   }
 
   @SuppressWarnings("deprecation")
@@ -288,7 +288,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
 
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // Given
     ProcessDefinition latestProcessDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).singleResult();
@@ -299,22 +299,22 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
     // Add candiate group with process definition
     repositoryService.addCandidateStarterGroup(latestProcessDef.getId(), GROUP_1);
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 1);
+    assertEquals(1, historicIdentityLinks.size());
 
     // Add candidate user for process definition
     repositoryService.addCandidateStarterUser(latestProcessDef.getId(), USER_1);
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 2);
+    assertEquals(2, historicIdentityLinks.size());
 
     // Delete candiate group with process definition
     repositoryService.deleteCandidateStarterGroup(latestProcessDef.getId(), GROUP_1);
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 3);
+    assertEquals(3, historicIdentityLinks.size());
 
     // Delete candidate user for process definition
     repositoryService.deleteCandidateStarterUser(latestProcessDef.getId(), USER_1);
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 4);
+    assertEquals(4, historicIdentityLinks.size());
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
@@ -323,7 +323,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
 
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     startProcessInstance(PROCESS_DEFINITION_KEY);
@@ -334,11 +334,11 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
 
     // then
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 2);
+    assertEquals(2, historicIdentityLinks.size());
 
     // Basic Query test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.type(IdentityLinkType.OWNER).count(), 2);
+    assertEquals(2, query.type(IdentityLinkType.OWNER).count());
   }
 
   @Test
@@ -348,7 +348,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
     String taskOwnerId = "Owner";
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     Task taskAssignee = taskService.newTask(taskAssigneeId);
     taskAssignee.setAssignee(USER_1);
@@ -363,16 +363,16 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
 
     // then
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 2);
+    assertEquals(2, historicIdentityLinks.size());
 
     // Basic Query test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.type(IdentityLinkType.ASSIGNEE).count(), 1);
-    assertEquals(query.userId(USER_1).count(), 1);
+    assertEquals(1, query.type(IdentityLinkType.ASSIGNEE).count());
+    assertEquals(1, query.userId(USER_1).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.type(IdentityLinkType.OWNER).count(), 1);
-    assertEquals(query.userId(OWNER_1).count(), 1);
+    assertEquals(1, query.type(IdentityLinkType.OWNER).count());
+    assertEquals(1, query.userId(OWNER_1).count());
 
     taskService.deleteTask(taskAssigneeId,true);
     taskService.deleteTask(taskOwnerId,true);
@@ -386,7 +386,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
     String taskAssigneeId = "Assigneee";
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     ProcessInstance processInstance = startProcessInstance(PROCESS_DEFINITION_KEY);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -401,15 +401,15 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
 
     // then
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 3);
+    assertEquals(3, historicIdentityLinks.size());
 
     // Basic Query test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.type(IdentityLinkType.ASSIGNEE).count(), 3);
+    assertEquals(3, query.type(IdentityLinkType.ASSIGNEE).count());
 
     query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.processDefinitionId(processInstance.getProcessDefinitionId()).count(), 2);
-    assertEquals(query.processDefinitionKey(PROCESS_DEFINITION_KEY).count(), 2);
+    assertEquals(2, query.processDefinitionId(processInstance.getProcessDefinitionId()).count());
+    assertEquals(2, query.processDefinitionKey(PROCESS_DEFINITION_KEY).count());
 
     taskService.deleteTask(taskAssigneeId, true);
   }
@@ -420,7 +420,7 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
   public void testShouldNotDeleteIdentityLinkForTaskCompletion() {
     //given
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
     startProcessInstance(PROCESS_DEFINITION_KEY);
 
     Task task = taskService.createTaskQuery().singleResult();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIdentityLinkLogTestByXml.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIdentityLinkLogTestByXml.java
@@ -58,16 +58,16 @@ public class HistoricIdentityLinkLogTestByXml extends PluggableProcessEngineTest
 
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     startProcessInstance(PROCESS_DEFINITION_KEY_CANDIDATE_USER);
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 1);
+    assertEquals(1, historicIdentityLinks.size());
 
     // query Test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.userId(XML_USER).count(), 1);
+    assertEquals(1, query.userId(XML_USER).count());
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/OneTaskProcessWithTaskAssignee.bpmn20.xml" })
@@ -76,16 +76,16 @@ public class HistoricIdentityLinkLogTestByXml extends PluggableProcessEngineTest
 
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     startProcessInstance(PROCESS_DEFINITION_KEY_ASSIGNEE);
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 1);
+    assertEquals(1, historicIdentityLinks.size());
 
     // query Test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.userId(XML_ASSIGNEE).count(), 1);
+    assertEquals(1, query.userId(XML_ASSIGNEE).count());
 
 
   }
@@ -96,16 +96,16 @@ public class HistoricIdentityLinkLogTestByXml extends PluggableProcessEngineTest
 
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     startProcessInstance(PROCESS_DEFINITION_KEY_CANDIDATE_GROUP);
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 1);
+    assertEquals(1, historicIdentityLinks.size());
 
     // query Test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.groupId(XML_GROUP).count(), 1);
+    assertEquals(1, query.groupId(XML_GROUP).count());
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/OneTaskProcessWithCandidateStarterUsers.bpmn20.xml" })
@@ -114,7 +114,7 @@ public class HistoricIdentityLinkLogTestByXml extends PluggableProcessEngineTest
 
     // Pre test - Historical identity link is added as part of deployment
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 1);
+    assertEquals(1, historicIdentityLinks.size());
 
     // given
     ProcessDefinition latestProcessDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY_CANDIDATE_STARTER_USER)
@@ -125,18 +125,18 @@ public class HistoricIdentityLinkLogTestByXml extends PluggableProcessEngineTest
     assertEquals(1, links.size());
 
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 1);
+    assertEquals(1, historicIdentityLinks.size());
 
     // query Test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.userId(XML_USER).count(), 1);
+    assertEquals(1, query.userId(XML_USER).count());
   }
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/OneTaskProcessWithCandidateStarterGroups.bpmn20.xml" })
   public void testShouldAddProcessCandidateStarterGroupforAddIdentityLinkUsingXml() {
 
     // Pre test - Historical identity link is added as part of deployment
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 1);
+    assertEquals(1, historicIdentityLinks.size());
 
     // given
     ProcessDefinition latestProcessDef = repositoryService.createProcessDefinitionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY_CANDIDATE_STARTER_GROUP)
@@ -147,11 +147,11 @@ public class HistoricIdentityLinkLogTestByXml extends PluggableProcessEngineTest
     assertEquals(1, links.size());
 
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 1);
+    assertEquals(1, historicIdentityLinks.size());
 
     // query Test
     HistoricIdentityLinkLogQuery query = historyService.createHistoricIdentityLinkLogQuery();
-    assertEquals(query.groupId(XML_GROUP).count(), 1);
+    assertEquals(1, query.groupId(XML_GROUP).count());
   }
 
   @Test
@@ -164,7 +164,7 @@ public class HistoricIdentityLinkLogTestByXml extends PluggableProcessEngineTest
 
     // then
     List<HistoricIdentityLinkLog> historicLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicLinks.size(), 1);
+    assertEquals(1, historicLinks.size());
 
     HistoricIdentityLinkLog historicLink = historicLinks.get(0);
     assertNotNull(historicLink.getTenantId());
@@ -203,7 +203,7 @@ public class HistoricIdentityLinkLogTestByXml extends PluggableProcessEngineTest
 
       // then
       List<HistoricIdentityLinkLog> historicLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-      assertEquals(historicLinks.size(), 1);
+      assertEquals(1, historicLinks.size());
 
       HistoricIdentityLinkLog historicLink = historicLinks.get(0);
       assertNotNull(historicLink.getTenantId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricVariableInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricVariableInstanceTest.java
@@ -19,12 +19,7 @@ package org.operaton.bpm.engine.test.history;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.io.Serializable;
 import java.text.ParseException;
@@ -361,7 +356,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
      * execution id: On which execution it was set
      * activity id: in which activity was the process instance when setting the variable
      */
-      assertFalse(historicActivityInstance2.getExecutionId().equals(update2.getExecutionId()));
+      assertNotEquals(historicActivityInstance2.getExecutionId(), update2.getExecutionId());
     }
   }
 
@@ -581,7 +576,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     // then
     assertEquals(1, query.list().size());
     assertEquals(1, query.count());
-    assertEquals(query.list().get(0).getName(), "stringVar");
+    assertEquals("stringVar", query.list().get(0).getName());
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
@@ -600,7 +595,7 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     // then
     assertEquals(1, query.list().size());
     assertEquals(1, query.count());
-    assertEquals(query.list().get(0).getName(), "boolVar");
+    assertEquals("boolVar", query.list().get(0).getName());
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
@@ -2136,16 +2131,16 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
 
       // then the history contains one entry for each variable
       HistoricVariableInstanceQuery query = historyService.createHistoricVariableInstanceQuery();
-      assertEquals(query.count(), 2);
+      assertEquals(2, query.count());
 
       HistoricVariableInstance firstVariable = query.variableName("var1").singleResult();
       assertNotNull(firstVariable);
-      assertEquals(firstVariable.getValue(), "foo");
+      assertEquals("foo", firstVariable.getValue());
       assertNotNull(firstVariable.getActivityInstanceId());
 
       HistoricVariableInstance secondVariable = query.variableName("var2").singleResult();
       assertNotNull(secondVariable);
-      assertEquals(secondVariable.getValue(), "bar");
+      assertEquals("bar", secondVariable.getValue());
       assertNotNull(secondVariable.getActivityInstanceId());
     }
   }
@@ -2176,10 +2171,10 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
       // then the history contains only one entry for the latest update (value = "bar")
       // - the entry for the initial value (value = "foo") is lost because of current limitations
       HistoricVariableInstanceQuery query = historyService.createHistoricVariableInstanceQuery();
-      assertEquals(query.count(), 1);
+      assertEquals(1, query.count());
 
       HistoricVariableInstance variable = query.singleResult();
-      assertEquals(variable.getValue(), "bar");
+      assertEquals("bar", variable.getValue());
       assertNotNull(variable.getActivityInstanceId());
     }
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobDefinitionCreationAndDeletionWithParseListenerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobDefinitionCreationAndDeletionWithParseListenerTest.java
@@ -86,9 +86,9 @@ public class JobDefinitionCreationAndDeletionWithParseListenerTest {
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     JobDefinition jobDef = query.singleResult();
     assertNotNull(jobDef);
-    assertEquals(jobDef.getProcessDefinitionKey(), "oneTaskProcess");
-    assertEquals(jobDef.getActivityId(), "servicetask1");
-    assertEquals(jobDef.getJobConfiguration(), MessageJobDeclaration.ASYNC_AFTER);
+    assertEquals("oneTaskProcess", jobDef.getProcessDefinitionKey());
+    assertEquals("servicetask1", jobDef.getActivityId());
+    assertEquals(MessageJobDeclaration.ASYNC_AFTER, jobDef.getJobConfiguration());
   }
 
   @Test
@@ -106,9 +106,9 @@ public class JobDefinitionCreationAndDeletionWithParseListenerTest {
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     JobDefinition jobDef = query.singleResult();
     assertNotNull(jobDef);
-    assertEquals(jobDef.getProcessDefinitionKey(), "oneTaskProcess");
-    assertEquals(jobDef.getActivityId(), "servicetask1");
-    assertEquals(jobDef.getJobConfiguration(), MessageJobDeclaration.ASYNC_AFTER);
+    assertEquals("oneTaskProcess", jobDef.getProcessDefinitionKey());
+    assertEquals("servicetask1", jobDef.getActivityId());
+    assertEquals(MessageJobDeclaration.ASYNC_AFTER, jobDef.getJobConfiguration());
   }
 
   @Test
@@ -126,8 +126,8 @@ public class JobDefinitionCreationAndDeletionWithParseListenerTest {
     JobDefinitionQuery query = engineRule.getManagementService().createJobDefinitionQuery();
     JobDefinition jobDef = query.singleResult();
     assertNotNull(jobDef);
-    assertEquals(jobDef.getProcessDefinitionKey(), "oneTaskProcess");
-    assertEquals(jobDef.getActivityId(), "servicetask1");
-    assertEquals(jobDef.getJobConfiguration(), MessageJobDeclaration.ASYNC_AFTER);
+    assertEquals("oneTaskProcess", jobDef.getProcessDefinitionKey());
+    assertEquals("servicetask1", jobDef.getActivityId());
+    assertEquals(MessageJobDeclaration.ASYNC_AFTER, jobDef.getJobConfiguration());
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
@@ -960,7 +960,7 @@ public class ProcessDataLoggingContextTest {
       } else {
         // second BPMN stack trace log corresponds to outer service task
         assertThat(mdcPropertyMap).containsKey("businessKey");
-        assertThat("startProcess").isEqualTo(mdcPropertyMap.get("activityId"));
+        assertThat(mdcPropertyMap).containsEntry("activityId", "startProcess");
         assertThat(instance.getBusinessKey()).isEqualTo(mdcPropertyMap.get("businessKey"));
         assertThat(instance.getProcessDefinitionId()).isEqualTo(mdcPropertyMap.get("processDefinitionId"));
         assertThat(instance.getId()).isEqualTo(mdcPropertyMap.get("processInstanceId"));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/CustomHistoryLevelIdentityLinkTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/CustomHistoryLevelIdentityLinkTest.java
@@ -18,7 +18,7 @@ package org.operaton.bpm.engine.test.standalone.history;
 
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -107,7 +107,7 @@ public class CustomHistoryLevelIdentityLinkTest {
   public void testDeletingIdentityLinkByProcDefId() {
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     runtimeService.startProcessInstanceByKey("oneTaskProcess");
@@ -119,7 +119,7 @@ public class CustomHistoryLevelIdentityLinkTest {
 
     // assume
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertTrue(!historicIdentityLinks.isEmpty());
+    assertFalse(historicIdentityLinks.isEmpty());
 
     // when
     repositoryService.deleteProcessDefinitions()
@@ -136,7 +136,7 @@ public class CustomHistoryLevelIdentityLinkTest {
   public void testDeletingIdentityLinkByTaskId() {
     // Pre test
     List<HistoricIdentityLinkLog> historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertEquals(historicIdentityLinks.size(), 0);
+    assertEquals(0, historicIdentityLinks.size());
 
     // given
     Task task = taskService.newTask();
@@ -149,7 +149,7 @@ public class CustomHistoryLevelIdentityLinkTest {
 
     // assume
     historicIdentityLinks = historyService.createHistoricIdentityLinkLogQuery().list();
-    assertTrue(!historicIdentityLinks.isEmpty());
+    assertFalse(historicIdentityLinks.isEmpty());
 
     // when
     taskService.deleteTask(taskId, true);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryTest.java
@@ -554,7 +554,7 @@ public class HistoricTaskInstanceQueryTest extends PluggableProcessEngineTest {
     taskService.addCandidateGroup(taskId, "aGroupId");
 
     // then
-    assertEquals(historyService.createHistoricTaskInstanceQuery().withCandidateGroups().count(), 1);
+    assertEquals(1, historyService.createHistoricTaskInstanceQuery().withCandidateGroups().count());
 
     // cleanup
     taskService.deleteTask("newTask", true);
@@ -574,8 +574,8 @@ public class HistoricTaskInstanceQueryTest extends PluggableProcessEngineTest {
     runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
     // then
-    assertEquals(historyService.createHistoricTaskInstanceQuery().count(), 2);
-    assertEquals(historyService.createHistoricTaskInstanceQuery().withoutCandidateGroups().count(), 1);
+    assertEquals(2, historyService.createHistoricTaskInstanceQuery().count());
+    assertEquals(1, historyService.createHistoricTaskInstanceQuery().withoutCandidateGroups().count());
 
     // cleanup
     taskService.deleteTask("newTask", true);
@@ -646,7 +646,7 @@ public class HistoricTaskInstanceQueryTest extends PluggableProcessEngineTest {
     List<HistoricTaskInstance> list = historyService.createHistoricTaskInstanceQuery().taskAssigned().list();
 
     // then
-    assertEquals(list.size(), 2);
+    assertEquals(2, list.size());
 
     // cleanup
     taskService.deleteTask("taskOne",true);
@@ -675,7 +675,7 @@ public class HistoricTaskInstanceQueryTest extends PluggableProcessEngineTest {
     List<HistoricTaskInstance> list = historyService.createHistoricTaskInstanceQuery().taskUnassigned().list();
 
     // then
-    assertEquals(list.size(), 1);
+    assertEquals(1, list.size());
 
     // cleanup
     taskService.deleteTask("taskOne",true);


### PR DESCRIPTION
- flip order of arguments of assertEquals to actual/expected
- flip order of arguments of assertThat().isEqualTo()
- change assertTrue(XXX.equals()) -> assertEquals()
- change assertTrue(XXX != null) -> assertNotNull()

related to #88