### PR TITLE
refactor: Simplify assertions

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/impl/util/ImmutablePairTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/util/ImmutablePairTest.java
@@ -16,17 +16,17 @@
  */
 package org.operaton.bpm.engine.impl.util;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.HashMap;
 import java.util.Map.Entry;
 
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ImmutablePairTest {
 
@@ -54,9 +54,9 @@ public class ImmutablePairTest {
   public void shouldCompareWithLeftFirst() {
     final ImmutablePair<String, String> pair1 = new ImmutablePair<>("A", "D");
     final ImmutablePair<String, String> pair2 = new ImmutablePair<>("B", "C");
-    assertTrue(pair1.compareTo(pair1) == 0);
+    assertEquals(0, pair1.compareTo(pair1));
     assertTrue(pair1.compareTo(pair2) < 0);
-    assertTrue(pair2.compareTo(pair2) == 0);
+    assertEquals(0, pair2.compareTo(pair2));
     assertTrue(pair2.compareTo(pair1) > 0);
   }
 
@@ -64,9 +64,9 @@ public class ImmutablePairTest {
   public void shouldCompareWithRightSecond() {
     final ImmutablePair<String, String> pair1 = new ImmutablePair<>("A", "C");
     final ImmutablePair<String, String> pair2 = new ImmutablePair<>("A", "D");
-    assertTrue(pair1.compareTo(pair1) == 0);
+    assertEquals(0, pair1.compareTo(pair1));
     assertTrue(pair1.compareTo(pair2) < 0);
-    assertTrue(pair2.compareTo(pair2) == 0);
+    assertEquals(0, pair2.compareTo(pair2));
     assertTrue(pair2.compareTo(pair1) > 0);
   }
 
@@ -85,12 +85,12 @@ public class ImmutablePairTest {
   @Test
   public void shouldFulfillEqualityRules() {
     assertEquals(new ImmutablePair<>(null, "foo"), new ImmutablePair<>(null, "foo"));
-    assertFalse(new ImmutablePair<>("foo", 0).equals(new ImmutablePair<>("foo", null)));
-    assertFalse(new ImmutablePair<>("foo", "bar").equals(new ImmutablePair<>("xyz", "bar")));
+    assertNotEquals(new ImmutablePair<>("foo", 0), new ImmutablePair<>("foo", null));
+    assertNotEquals(new ImmutablePair<>("foo", "bar"), new ImmutablePair<>("xyz", "bar"));
 
     final ImmutablePair<String, String> p = new ImmutablePair<>("foo", "bar");
-    assertTrue(p.equals(p));
-    assertFalse(p.equals(new Object()));
+    assertEquals(p, p);
+    assertNotEquals(p, new Object());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/ForceCloseMybatisConnectionPoolTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/ForceCloseMybatisConnectionPoolTest.java
@@ -16,13 +16,15 @@
  */
 package org.operaton.bpm.engine.test.api.cfg;
 
-import org.apache.ibatis.datasource.pooled.PoolState;
-import org.apache.ibatis.datasource.pooled.PooledDataSource;
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
-import org.junit.Assert;
+
+import org.apache.ibatis.datasource.pooled.PoolState;
+import org.apache.ibatis.datasource.pooled.PooledDataSource;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Daniel Meyer
@@ -53,7 +55,7 @@ public class ForceCloseMybatisConnectionPoolTest {
     processEngine.close();
 
     // the idle connections are closed
-    Assert.assertTrue(state.getIdleConnectionCount() == 0);
+    assertEquals(0, state.getIdleConnectionCount());
 
   }
 
@@ -80,11 +82,11 @@ public class ForceCloseMybatisConnectionPoolTest {
     processEngine.close();
 
     // the idle connections are not closed
-    Assert.assertEquals(state.getIdleConnectionCount(), idleConnections);
+    assertEquals(state.getIdleConnectionCount(), idleConnections);
 
     pooledDataSource.forceCloseAll();
 
-    Assert.assertTrue(state.getIdleConnectionCount() == 0);
+    assertEquals(0, state.getIdleConnectionCount());
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/delegate/DelegateExecutionHierarchyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/delegate/DelegateExecutionHierarchyTest.java
@@ -77,7 +77,7 @@ public class DelegateExecutionHierarchyTest extends PluggableProcessEngineTest {
 
     AssertingJavaDelegate.addAsserts(
         execution -> {
-          assertFalse(execution.equals(execution.getProcessInstance()));
+          assertNotEquals(execution, execution.getProcessInstance());
           assertNull(execution.getSuperExecution());
         }
     );
@@ -102,7 +102,7 @@ public class DelegateExecutionHierarchyTest extends PluggableProcessEngineTest {
 
     AssertingJavaDelegate.addAsserts(
         execution -> {
-          assertFalse(execution.equals(execution.getProcessInstance()));
+          assertNotEquals(execution, execution.getProcessInstance());
           assertNull(execution.getSuperExecution());
         }
     );
@@ -129,7 +129,7 @@ public class DelegateExecutionHierarchyTest extends PluggableProcessEngineTest {
 
     AssertingJavaDelegate.addAsserts(
         execution -> {
-          assertTrue(execution.equals(execution.getProcessInstance()));
+          assertEquals(execution, execution.getProcessInstance());
           assertNotNull(execution.getSuperExecution());
         }
     );

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskQueryTest.java
@@ -551,7 +551,7 @@ public class ExternalTaskQueryTest extends PluggableProcessEngineTest {
 
     assertEquals(2, tasksWithoutRetries.size());
     for (ExternalTask task : tasksWithoutRetries) {
-      assertTrue(task.getRetries() == 0);
+      assertEquals(0, (int) task.getRetries());
     }
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
@@ -16,45 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.form;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.entry;
-import static org.operaton.bpm.engine.test.util.OperatonFormUtils.findAllOperatonFormDefinitionEntities;
-import static org.operaton.bpm.engine.variable.Variables.booleanValue;
-import static org.operaton.bpm.engine.variable.Variables.createVariables;
-import static org.operaton.bpm.engine.variable.Variables.objectValue;
-import static org.operaton.bpm.engine.variable.Variables.serializedObjectValue;
-import static org.operaton.bpm.engine.variable.Variables.stringValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import org.operaton.bpm.engine.BadUserRequestException;
-import org.operaton.bpm.engine.CaseService;
-import org.operaton.bpm.engine.FormService;
-import org.operaton.bpm.engine.HistoryService;
-import org.operaton.bpm.engine.IdentityService;
-import org.operaton.bpm.engine.ManagementService;
-import org.operaton.bpm.engine.ProcessEngineConfiguration;
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
+import org.operaton.bpm.engine.*;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.ExecutionListener;
 import org.operaton.bpm.engine.exception.NotFoundException;
@@ -87,12 +49,30 @@ import org.operaton.bpm.engine.variable.value.ObjectValue;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.commons.utils.IoUtil;
+import static org.operaton.bpm.engine.test.util.OperatonFormUtils.findAllOperatonFormDefinitionEntities;
+import static org.operaton.bpm.engine.variable.Variables.booleanValue;
+import static org.operaton.bpm.engine.variable.Variables.createVariables;
+import static org.operaton.bpm.engine.variable.Variables.objectValue;
+import static org.operaton.bpm.engine.variable.Variables.serializedObjectValue;
+import static org.operaton.bpm.engine.variable.Variables.stringValue;
+
+import java.io.InputStream;
+import java.util.*;
+import java.util.Map.Entry;
 
 import org.apache.groovy.util.Maps;
 import org.junit.*;
 import org.junit.rules.RuleChain;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Joram Barrez
@@ -1388,7 +1368,7 @@ public class FormServiceTest {
 
     List<VariableInstance> result = runtimeService.createVariableInstanceQuery().list();
     assertEquals(1, result.size());
-    assertTrue(result.get(0).getName().equals("secondParam"));
+    assertEquals("secondParam", result.get(0).getName());
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/form/DeployedFormsProcess.bpmn20.xml",

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.test.api.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -75,22 +76,22 @@ public class HistoryServiceTest extends PluggableProcessEngineTest {
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
   public void testHistoricProcessInstanceQuery() {
     // With a clean ProcessEngine, no instances should be available
-    assertTrue(historyService.createHistoricProcessInstanceQuery().count() == 0);
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().count());
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(ONE_TASK_PROCESS);
-    assertTrue(historyService.createHistoricProcessInstanceQuery().count() == 1);
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().count());
 
     // Complete the task and check if the size is count 1
     List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
     assertEquals(1, tasks.size());
     taskService.complete(tasks.get(0).getId());
-    assertTrue(historyService.createHistoricProcessInstanceQuery().count() == 1);
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().count());
   }
 
   @Test
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
   public void testHistoricProcessInstanceQueryOrderBy() {
     // With a clean ProcessEngine, no instances should be available
-    assertTrue(historyService.createHistoricProcessInstanceQuery().count() == 0);
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().count());
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(ONE_TASK_PROCESS);
 
     List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
@@ -771,8 +772,7 @@ public class HistoryServiceTest extends PluggableProcessEngineTest {
 
   @Test
   public void testDeleteProcessInstanceIfExistsWithFake() {
-      historyService.deleteHistoricProcessInstanceIfExists("aFake");
-      //don't expect exception
+      assertThatCode(() -> historyService.deleteHistoricProcessInstanceIfExists("aFake")).doesNotThrowAnyException();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceTest.java
@@ -427,7 +427,7 @@ public class IdentityServiceTest {
     identityService.createMembership(johndoe.getId(), sales.getId());
 
     List<Group> groups = identityService.createGroupQuery().groupMember(johndoe.getId()).list();
-    assertTrue(groups.size() == 1);
+    assertEquals(1, groups.size());
     assertEquals("sales", groups.get(0).getId());
 
     // Delete the membership and check members of sales group

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/DeploymentStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/DeploymentStatisticsQueryTest.java
@@ -68,7 +68,7 @@ public class DeploymentStatisticsQueryTest extends PluggableProcessEngineTest {
     cal2.setTime(result.getDeploymentTime());
     cal2.set(Calendar.MILLISECOND, 0);
 
-    Assert.assertTrue(cal1.equals(cal2));
+    assertEquals(cal1, cal2);
 
     repositoryService.deleteDeployment(deployment.getId(), true);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/IncidentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/IncidentTest.java
@@ -97,7 +97,7 @@ public class IncidentTest extends PluggableProcessEngineTest {
     List<Incident> incidents = runtimeService.createIncidentQuery().processInstanceId(processInstance.getId()).list();
 
     assertFalse(incidents.isEmpty());
-    assertTrue(incidents.size() == 1);
+    assertEquals(1, incidents.size());
 
     Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
 
@@ -112,7 +112,7 @@ public class IncidentTest extends PluggableProcessEngineTest {
 
     // There is still one incident
     assertFalse(incidents.isEmpty());
-    assertTrue(incidents.size() == 1);
+    assertEquals(1, incidents.size());
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/IncidentTest.testShouldCreateOneIncident.bpmn"})
@@ -125,7 +125,7 @@ public class IncidentTest extends PluggableProcessEngineTest {
     List<Incident> incidents = runtimeService.createIncidentQuery().processInstanceId(processInstance.getId()).list();
 
     assertFalse(incidents.isEmpty());
-    assertTrue(incidents.size() == 1);
+    assertEquals(1, incidents.size());
 
     Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
 
@@ -144,7 +144,7 @@ public class IncidentTest extends PluggableProcessEngineTest {
 
     // There is still one incident
     assertFalse(incidents.isEmpty());
-    assertTrue(incidents.size() == 1);
+    assertEquals(1, incidents.size());
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/IncidentTest.testShouldCreateOneIncidentForNestedExecution.bpmn"})
@@ -162,7 +162,7 @@ public class IncidentTest extends PluggableProcessEngineTest {
 
     String executionIdOfNestedFailingExecution = job.getExecutionId();
 
-    assertFalse(processInstance.getId() == executionIdOfNestedFailingExecution);
+    assertNotSame(processInstance.getId(), executionIdOfNestedFailingExecution);
 
     assertNotNull(incident.getId());
     assertNotNull(incident.getIncidentTimestamp());
@@ -231,7 +231,7 @@ public class IncidentTest extends PluggableProcessEngineTest {
 
     List<Incident> incidents = runtimeService.createIncidentQuery().list();
     assertFalse(incidents.isEmpty());
-    assertTrue(incidents.size() == 2);
+    assertEquals(2, incidents.size());
 
     ProcessInstance failingProcess = runtimeService.createProcessInstanceQuery().processDefinitionKey("failingProcess").singleResult();
     assertNotNull(failingProcess);
@@ -291,7 +291,7 @@ public class IncidentTest extends PluggableProcessEngineTest {
 
     List<Incident> incidents = runtimeService.createIncidentQuery().list();
     assertFalse(incidents.isEmpty());
-    assertTrue(incidents.size() == 3);
+    assertEquals(3, incidents.size());
 
     // Root Cause Incident
     ProcessInstance failingProcess = runtimeService.createProcessInstanceQuery().processDefinitionKey("failingProcess").singleResult();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.java
@@ -58,6 +58,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -313,7 +314,7 @@ public class JobQueryTest {
     verifyQueryResults(query, 1);
 
     String anotherJobId = query.singleResult().getId();
-    assertFalse(jobId.equals(anotherJobId));
+    assertNotEquals(jobId, anotherJobId);
   }
 
   @Test
@@ -349,7 +350,7 @@ public class JobQueryTest {
     verifyQueryResults(query, 1);
 
     String anotherJobId = query.singleResult().getId();
-    assertFalse(jobId.equals(anotherJobId));
+    assertNotEquals(jobId, anotherJobId);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/metrics/MetricsIntervalTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/metrics/MetricsIntervalTest.java
@@ -438,14 +438,14 @@ public class MetricsIntervalTest extends AbstractMetricsIntervalTest {
     //on query with name
      metrics = managementService.createMetricsQuery().name(ACTIVTY_INSTANCE_START).limit(1).interval();
     long newValue = metrics.get(0).getValue();
-    Assert.assertTrue(value + 3 == newValue);
+    Assert.assertEquals(value + 3, newValue);
 
     //on query without name also
      metrics = managementService.createMetricsQuery().interval();
      for (MetricIntervalValue intervalValue : metrics) {
        if (intervalValue.getName().equalsIgnoreCase(ACTIVTY_INSTANCE_START)) {
         newValue = intervalValue.getValue();
-        Assert.assertTrue(value + 3 == newValue);
+         Assert.assertEquals(value + 3, newValue);
         break;
        }
      }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RedeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RedeploymentTest.java
@@ -16,13 +16,6 @@
  */
 package org.operaton.bpm.engine.test.api.repository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,6 +43,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
+
+import static org.junit.Assert.*;
 
 
 /**
@@ -372,7 +367,7 @@ public class RedeploymentTest {
     // then
     assertNotNull(deployment2);
     assertNotNull(deployment2.getId());
-    assertFalse(deployment1.getId().equals(deployment2.getId()));
+    assertNotEquals(deployment1.getId(), deployment2.getId());
 
     verifyQueryResults(query, 2);
   }
@@ -443,7 +438,7 @@ public class RedeploymentTest {
 
     // then
     assertNotNull(deployment2);
-    assertFalse(deployment1.getName().equals(deployment2.getName()));
+    assertNotEquals(deployment1.getName(), deployment2.getName());
   }
 
   @Test
@@ -529,7 +524,7 @@ public class RedeploymentTest {
 
     // id
     assertNotNull(resource3.getId());
-    assertFalse(resource1.getId().equals(resource3.getId()));
+    assertNotEquals(resource1.getId(), resource3.getId());
 
     // deployment id
     assertEquals(deployment3.getId(), resource3.getDeploymentId());
@@ -541,7 +536,7 @@ public class RedeploymentTest {
     byte[] bytes1 = resource1.getBytes();
     byte[] bytes2 = resource2.getBytes();
     byte[] bytes3 = resource3.getBytes();
-    assertTrue(Arrays.equals(bytes1, bytes3));
+    assertArrayEquals(bytes1, bytes3);
     assertFalse(Arrays.equals(bytes2, bytes3));
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationAsyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationAsyncTest.java
@@ -20,13 +20,6 @@ import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.assertTha
 import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.describeActivityInstanceTree;
 import static org.operaton.bpm.engine.test.util.ExecutionAssert.assertThat;
 import static org.operaton.bpm.engine.test.util.ExecutionAssert.describeExecutionTree;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.List;
 
@@ -47,6 +40,8 @@ import org.operaton.bpm.engine.test.util.ExecutionTree;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.operaton.bpm.engine.variable.Variables;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * @author Thorben Lindhauer
@@ -373,7 +368,7 @@ public class ProcessInstanceModificationAsyncTest extends PluggableProcessEngine
 
     // and the async job should be a new one
     Job newAsyncJob = managementService.createJobQuery().singleResult();
-    assertFalse(asyncJob.getId().equals(newAsyncJob.getId()));
+    assertNotEquals(asyncJob.getId(), newAsyncJob.getId());
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstance.getId(), processEngine);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationCancellationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationCancellationTest.java
@@ -16,18 +16,6 @@
  */
 package org.operaton.bpm.engine.test.api.runtime;
 
-import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.assertThat;
-import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.describeActivityInstanceTree;
-import static org.operaton.bpm.engine.test.util.ExecutionAssert.assertThat;
-import static org.operaton.bpm.engine.test.util.ExecutionAssert.describeExecutionTree;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Collections;
-import java.util.List;
-
 import org.operaton.bpm.engine.delegate.ExecutionListener;
 import org.operaton.bpm.engine.runtime.ActivityInstance;
 import org.operaton.bpm.engine.runtime.EventSubscription;
@@ -40,7 +28,20 @@ import org.operaton.bpm.engine.test.bpmn.executionlistener.RecorderExecutionList
 import org.operaton.bpm.engine.test.util.ExecutionTree;
 import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
 import org.operaton.bpm.engine.variable.Variables;
+import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.assertThat;
+import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.describeActivityInstanceTree;
+import static org.operaton.bpm.engine.test.util.ExecutionAssert.assertThat;
+import static org.operaton.bpm.engine.test.util.ExecutionAssert.describeExecutionTree;
+
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests cancellation of four basic patterns of active activities in a scope:
@@ -138,7 +139,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
     assertEquals(tree.getId(), updatedTree.getId());
-    assertTrue(!getInstanceIdForActivity(tree, "theTask").equals(getInstanceIdForActivity(updatedTree, "theTask")));
+    assertNotEquals(getInstanceIdForActivity(tree, "theTask"), getInstanceIdForActivity(updatedTree, "theTask"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -179,7 +180,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "theTask").equals(getInstanceIdForActivity(updatedTree, "theTask")));
+    assertNotEquals(getInstanceIdForActivity(tree, "theTask"), getInstanceIdForActivity(updatedTree, "theTask"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -258,7 +259,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "theTask").equals(getInstanceIdForActivity(updatedTree, "theTask")));
+    assertNotEquals(getInstanceIdForActivity(tree, "theTask"), getInstanceIdForActivity(updatedTree, "theTask"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -300,7 +301,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "theTask").equals(getInstanceIdForActivity(updatedTree, "theTask")));
+    assertNotEquals(getInstanceIdForActivity(tree, "theTask"), getInstanceIdForActivity(updatedTree, "theTask"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -425,7 +426,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "task1").equals(getInstanceIdForActivity(updatedTree, "task1")));
+    assertNotEquals(getInstanceIdForActivity(tree, "task1"), getInstanceIdForActivity(updatedTree, "task1"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -472,7 +473,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "task1").equals(getInstanceIdForActivity(updatedTree, "task1")));
+    assertNotEquals(getInstanceIdForActivity(tree, "task1"), getInstanceIdForActivity(updatedTree, "task1"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -518,7 +519,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "task1").equals(getInstanceIdForActivity(updatedTree, "task1")));
+    assertNotEquals(getInstanceIdForActivity(tree, "task1"), getInstanceIdForActivity(updatedTree, "task1"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -607,7 +608,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "task1").equals(getInstanceIdForActivity(updatedTree, "task1")));
+    assertNotEquals(getInstanceIdForActivity(tree, "task1"), getInstanceIdForActivity(updatedTree, "task1"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -656,7 +657,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "task1").equals(getInstanceIdForActivity(updatedTree, "task1")));
+    assertNotEquals(getInstanceIdForActivity(tree, "task1"), getInstanceIdForActivity(updatedTree, "task1"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -785,7 +786,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "innerTask").equals(getInstanceIdForActivity(updatedTree, "innerTask")));
+    assertNotEquals(getInstanceIdForActivity(tree, "innerTask"), getInstanceIdForActivity(updatedTree, "innerTask"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -835,7 +836,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "innerTask").equals(getInstanceIdForActivity(updatedTree, "innerTask")));
+    assertNotEquals(getInstanceIdForActivity(tree, "innerTask"), getInstanceIdForActivity(updatedTree, "innerTask"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -963,7 +964,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "innerTask").equals(getInstanceIdForActivity(updatedTree, "innerTask")));
+    assertNotEquals(getInstanceIdForActivity(tree, "innerTask"), getInstanceIdForActivity(updatedTree, "innerTask"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -1014,7 +1015,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "innerTask").equals(getInstanceIdForActivity(updatedTree, "innerTask")));
+    assertNotEquals(getInstanceIdForActivity(tree, "innerTask"), getInstanceIdForActivity(updatedTree, "innerTask"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -1152,7 +1153,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "innerTask1").equals(getInstanceIdForActivity(updatedTree, "innerTask1")));
+    assertNotEquals(getInstanceIdForActivity(tree, "innerTask1"), getInstanceIdForActivity(updatedTree, "innerTask1"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -1204,7 +1205,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "innerTask1").equals(getInstanceIdForActivity(updatedTree, "innerTask1")));
+    assertNotEquals(getInstanceIdForActivity(tree, "innerTask1"), getInstanceIdForActivity(updatedTree, "innerTask1"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -1344,7 +1345,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "innerTask1").equals(getInstanceIdForActivity(updatedTree, "innerTask1")));
+    assertNotEquals(getInstanceIdForActivity(tree, "innerTask1"), getInstanceIdForActivity(updatedTree, "innerTask1"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
@@ -1399,7 +1400,7 @@ public class ProcessInstanceModificationCancellationTest extends PluggableProces
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
     assertNotNull(updatedTree);
     assertEquals(processInstanceId, updatedTree.getProcessInstanceId());
-    assertTrue(!getInstanceIdForActivity(tree, "innerTask1").equals(getInstanceIdForActivity(updatedTree, "innerTask1")));
+    assertNotEquals(getInstanceIdForActivity(tree, "innerTask1"), getInstanceIdForActivity(updatedTree, "innerTask1"));
 
     assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationEventTest.java
@@ -22,6 +22,7 @@ import static org.operaton.bpm.engine.test.util.ExecutionAssert.assertThat;
 import static org.operaton.bpm.engine.test.util.ExecutionAssert.describeExecutionTree;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -316,7 +317,7 @@ public class ProcessInstanceModificationEventTest extends PluggableProcessEngine
 
     Task afterCancellationTask = taskService.createTaskQuery().singleResult();
     assertNotNull(afterCancellationTask);
-    assertFalse(txTask.getId().equals(afterCancellationTask.getId()));
+    assertNotEquals(txTask.getId(), afterCancellationTask.getId());
     assertEquals("afterCancellation", afterCancellationTask.getTaskDefinitionKey());
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -58,6 +58,7 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -1979,7 +1980,7 @@ public class ProcessInstanceQueryTest {
     assertEquals(5, instances.size());
 
     for (ProcessInstance returnedInstance : instances) {
-      assertTrue(!returnedInstance.getId().equals(secondProcessInstance.getId()));
+      assertFalse(returnedInstance.getId().equals(secondProcessInstance.getId()));
     }
 
     // cleanup

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstantiationAtActivitiesHistoryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstantiationAtActivitiesHistoryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.runtime;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -73,7 +73,7 @@ public class ProcessInstantiationAtActivitiesHistoryTest extends PluggableProces
     assertNotNull(historicActivityInstance);
     assertEquals("task1", historicActivityInstance.getActivityId());
     assertNotNull(historicActivityInstance.getId());
-    assertFalse(instance.getId().equals(historicActivityInstance.getId()));
+    assertNotEquals(instance.getId(), historicActivityInstance.getId());
     assertNotNull(historicActivityInstance.getStartTime());
     assertNull(historicActivityInstance.getEndTime());
   }
@@ -106,7 +106,7 @@ public class ProcessInstantiationAtActivitiesHistoryTest extends PluggableProces
     assertNotNull(subProcessInstance);
     assertEquals("subProcess", subProcessInstance.getActivityId());
     assertNotNull(subProcessInstance.getId());
-    assertFalse(instance.getId().equals(subProcessInstance.getId()));
+    assertNotEquals(instance.getId(), subProcessInstance.getId());
     assertNotNull(subProcessInstance.getStartTime());
     assertNull(subProcessInstance.getEndTime());
 
@@ -115,7 +115,7 @@ public class ProcessInstantiationAtActivitiesHistoryTest extends PluggableProces
     assertNotNull(startEventInstance);
     assertEquals("theSubProcessStart", startEventInstance.getActivityId());
     assertNotNull(startEventInstance.getId());
-    assertFalse(instance.getId().equals(startEventInstance.getId()));
+    assertNotEquals(instance.getId(), startEventInstance.getId());
     assertNotNull(startEventInstance.getStartTime());
     assertNotNull(startEventInstance.getEndTime());
 
@@ -128,7 +128,7 @@ public class ProcessInstantiationAtActivitiesHistoryTest extends PluggableProces
       assertNotNull(innerTaskInstance);
       assertEquals("innerTask", innerTaskInstance.getActivityId());
       assertNotNull(innerTaskInstance.getId());
-      assertFalse(instance.getId().equals(innerTaskInstance.getId()));
+      assertNotEquals(instance.getId(), innerTaskInstance.getId());
       assertNotNull(innerTaskInstance.getStartTime());
       assertNull(innerTaskInstance.getEndTime());
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstantiationWithVariablesInReturnTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstantiationWithVariablesInReturnTest.java
@@ -124,7 +124,7 @@ public class ProcessInstantiationWithVariablesInReturnTest {
       serializedVar.getValue();
       Assert.fail("Deserialization should fail!");
     } catch (IllegalStateException ise) {
-      assertTrue(ise.getMessage().equals("Object is not deserialized."));
+      assertEquals("Object is not deserialized.", ise.getMessage());
     }
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.java
@@ -71,12 +71,7 @@ import org.junit.rules.RuleChain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Frederik Heremans
@@ -298,7 +293,7 @@ public class RuntimeServiceTest {
     // if we do not skip the custom listeners,
     runtimeService.deleteProcessInstance(processInstance.getId(), null, false);
     // the custom listener is invoked
-    assertTrue(TestExecutionListener.collectedEvents.size() == 1);
+    assertEquals(1, TestExecutionListener.collectedEvents.size());
     TestExecutionListener.reset();
 
     processInstance = runtimeService.startProcessInstanceByKey("testProcess");
@@ -319,7 +314,7 @@ public class RuntimeServiceTest {
     // if we do not skip the custom listeners,
     runtimeService.deleteProcessInstance(processInstance.getId(), null, false);
     // the custom listener is invoked
-    assertTrue(TestExecutionListener.collectedEvents.size() == 1);
+    assertEquals(1, TestExecutionListener.collectedEvents.size());
     TestExecutionListener.reset();
 
     processInstance = runtimeService.startProcessInstanceByKey("testProcess");
@@ -1502,7 +1497,7 @@ public class RuntimeServiceTest {
     assertEquals(processInstance.getId(), rootActInstance.getProcessInstanceId());
     assertEquals(processInstance.getProcessDefinitionId(), rootActInstance.getProcessDefinitionId());
     assertEquals(processInstance.getId(), rootActInstance.getProcessInstanceId());
-    assertTrue(rootActInstance.getExecutionIds()[0].equals(processInstance.getId()));
+    assertEquals(rootActInstance.getExecutionIds()[0], processInstance.getId());
     assertEquals(rootActInstance.getProcessDefinitionId(), rootActInstance.getActivityId());
     assertNull(rootActInstance.getParentActivityInstanceId());
     assertEquals("processDefinition", rootActInstance.getActivityType());
@@ -1513,7 +1508,7 @@ public class RuntimeServiceTest {
     assertEquals(processInstance.getId(), childActivityInstance.getProcessInstanceId());
     assertEquals(processInstance.getProcessDefinitionId(), childActivityInstance.getProcessDefinitionId());
     assertEquals(processInstance.getId(), childActivityInstance.getProcessInstanceId());
-    assertTrue(childActivityInstance.getExecutionIds()[0].equals(task.getExecutionId()));
+    assertEquals(childActivityInstance.getExecutionIds()[0], task.getExecutionId());
     assertEquals("theTask", childActivityInstance.getActivityId());
     assertEquals(rootActInstance.getId(), childActivityInstance.getParentActivityInstanceId());
     assertEquals("userTask", childActivityInstance.getActivityType());
@@ -1793,7 +1788,7 @@ public class RuntimeServiceTest {
 
     assertEquals("innerTask", asyncBeforeInstances[0].getActivityId());
     assertEquals("innerTask", asyncBeforeInstances[1].getActivityId());
-    assertFalse(asyncBeforeInstances[0].getId().equals(asyncBeforeInstances[1].getId()));
+    assertNotEquals(asyncBeforeInstances[0].getId(), asyncBeforeInstances[1].getId());
 
     TransitionInstance[] asyncEndEventInstances = tree.getTransitionInstances("theSubProcessEnd");
     assertEquals(1, asyncEndEventInstances.length);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CallActivityTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CallActivityTest.java
@@ -17,12 +17,7 @@
 package org.operaton.bpm.engine.test.bpmn.callactivity;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.util.HashMap;
 import java.util.List;
@@ -545,7 +540,7 @@ public class CallActivityTest extends PluggableProcessEngineTest {
     assertNull(taskService.getVariable(task.getId(), "subVariable"));
 
     String subProcessInstanceId = task.getProcessInstanceId();
-    assertFalse(processInstanceId.equals(subProcessInstanceId));
+    assertNotEquals(processInstanceId, subProcessInstanceId);
 
     // the variable "subVariable" is set on the sub process instance
     variable = runtimeService
@@ -596,7 +591,7 @@ public class CallActivityTest extends PluggableProcessEngineTest {
     assertNull(taskService.getVariable(task.getId(), "subVariable"));
 
     String subProcessInstanceId = task.getProcessInstanceId();
-    assertFalse(processInstanceId.equals(subProcessInstanceId));
+    assertNotEquals(processInstanceId, subProcessInstanceId);
 
     // the variable "subVariable" is set on the sub process instance
     variable = runtimeService

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/conditional/ConditionalStartEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/conditional/ConditionalStartEventTest.java
@@ -18,12 +18,7 @@ package org.operaton.bpm.engine.test.bpmn.event.conditional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.util.HashMap;
 import java.util.List;
@@ -131,16 +126,16 @@ public class ConditionalStartEventTest {
       if (processDefinition.getVersion() == 1) {
         for (EventSubscription subscription : newEventSubscriptions) {
           EventSubscriptionEntity subscriptionEntity = (EventSubscriptionEntity) subscription;
-          assertFalse(subscriptionEntity.getConfiguration().equals(processDefinition.getId()));
+          assertNotEquals(subscriptionEntity.getConfiguration(), processDefinition.getId());
         }
       } else {
         for (EventSubscription subscription : newEventSubscriptions) {
           EventSubscriptionEntity subscriptionEntity = (EventSubscriptionEntity) subscription;
-          assertTrue(subscriptionEntity.getConfiguration().equals(processDefinition.getId()));
+          assertEquals(subscriptionEntity.getConfiguration(), processDefinition.getId());
         }
       }
     }
-    assertFalse(eventSubscriptions.equals(newEventSubscriptions));
+    assertNotEquals(eventSubscriptions, newEventSubscriptions);
   }
 
   @Test
@@ -775,7 +770,6 @@ public class ConditionalStartEventTest {
   protected String deployModel(BpmnModelInstance model) {
     List<ProcessDefinition> deployedProcessDefinitions = testRule.deploy(model).getDeployedProcessDefinitions();
     assertEquals(1, deployedProcessDefinitions.size());
-    String definitionId2 = deployedProcessDefinitions.get(0).getId();
-    return definitionId2;
+    return deployedProcessDefinitions.get(0).getId();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageEventSubprocessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageEventSubprocessTest.java
@@ -23,10 +23,9 @@ import static org.operaton.bpm.engine.test.util.ExecutionAssert.describeExecutio
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
@@ -56,11 +55,7 @@ public class MessageEventSubprocessTest extends PluggableProcessEngineTest {
 
   @After
   public void tearDown() {
-    try {
-
-    } finally {
-      TestExecutionListener.reset();
-    }
+    TestExecutionListener.reset();
   }
 
   @Deployment
@@ -763,7 +758,7 @@ public class MessageEventSubprocessTest extends PluggableProcessEngineTest {
         .activityId("eventSubProcessTask")
         .singleResult();
 
-    assertFalse(processInstanceId.equals(((ExecutionEntity) task1Execution).getParentId()));
+    assertNotEquals(processInstanceId, ((ExecutionEntity) task1Execution).getParentId());
 
     // when (2)
     runtimeService.correlateMessage("secondMessage");
@@ -781,7 +776,7 @@ public class MessageEventSubprocessTest extends PluggableProcessEngineTest {
         .activityId("eventSubProcessTask")
         .singleResult();
 
-    assertFalse(processInstanceId.equals(((ExecutionEntity) task1Execution).getParentId()));
+    assertNotEquals(processInstanceId, ((ExecutionEntity) task1Execution).getParentId());
 
     Task task2 = taskService.createTaskQuery()
         .taskDefinitionKey("userTask")
@@ -793,10 +788,10 @@ public class MessageEventSubprocessTest extends PluggableProcessEngineTest {
         .activityId("eventSubProcessTask")
         .singleResult();
 
-    assertFalse(processInstanceId.equals(((ExecutionEntity) task2Execution).getParentId()));
+    assertNotEquals(processInstanceId, ((ExecutionEntity) task2Execution).getParentId());
 
     // both have the same parent (but it is not the process instance)
-    assertTrue(((ExecutionEntity) task1Execution).getParentId().equals(((ExecutionEntity) task2Execution).getParentId()));
+    assertEquals(((ExecutionEntity) task1Execution).getParentId(), ((ExecutionEntity) task2Execution).getParentId());
 
     assertEquals(1, runtimeService.createEventSubscriptionQuery().count());
 
@@ -827,7 +822,7 @@ public class MessageEventSubprocessTest extends PluggableProcessEngineTest {
         .activityId("eventSubProcessTask")
         .singleResult();
 
-    assertFalse(processInstanceId.equals(((ExecutionEntity) task1Execution).getParentId()));
+    assertNotEquals(processInstanceId, ((ExecutionEntity) task1Execution).getParentId());
 
     Task task2 = taskService.createTaskQuery()
         .taskDefinitionKey("task")
@@ -839,10 +834,10 @@ public class MessageEventSubprocessTest extends PluggableProcessEngineTest {
         .activityId("eventSubProcessTask")
         .singleResult();
 
-    assertFalse(processInstanceId.equals(((ExecutionEntity) task2Execution).getParentId()));
+    assertNotEquals(processInstanceId, ((ExecutionEntity) task2Execution).getParentId());
 
     // both have the same parent (but it is not the process instance)
-    assertTrue(((ExecutionEntity) task1Execution).getParentId().equals(((ExecutionEntity) task2Execution).getParentId()));
+    assertEquals(((ExecutionEntity) task1Execution).getParentId(), ((ExecutionEntity) task2Execution).getParentId());
 
     assertEquals(1, runtimeService.createEventSubscriptionQuery().count());
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageNonInterruptingBoundaryEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageNonInterruptingBoundaryEventTest.java
@@ -21,10 +21,9 @@ import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.describeA
 import static org.operaton.bpm.engine.test.util.ExecutionAssert.assertThat;
 import static org.operaton.bpm.engine.test.util.ExecutionAssert.describeExecutionTree;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.runtime.ActivityInstance;
@@ -280,7 +279,7 @@ public class MessageNonInterruptingBoundaryEventTest extends PluggableProcessEng
         .activityId("task1")
         .singleResult();
 
-    assertFalse(processInstanceId.equals(((ExecutionEntity) task1Execution).getParentId()));
+    assertNotEquals(processInstanceId, ((ExecutionEntity) task1Execution).getParentId());
 
     // when (2)
     runtimeService.correlateMessage("secondMessage");
@@ -298,7 +297,7 @@ public class MessageNonInterruptingBoundaryEventTest extends PluggableProcessEng
         .activityId("task1")
         .singleResult();
 
-    assertFalse(processInstanceId.equals(((ExecutionEntity) task1Execution).getParentId()));
+    assertNotEquals(processInstanceId, ((ExecutionEntity) task1Execution).getParentId());
 
     Task task2 = taskService.createTaskQuery()
         .taskDefinitionKey("task2")
@@ -310,9 +309,9 @@ public class MessageNonInterruptingBoundaryEventTest extends PluggableProcessEng
         .activityId("task1")
         .singleResult();
 
-    assertFalse(processInstanceId.equals(((ExecutionEntity) task2Execution).getParentId()));
+    assertNotEquals(processInstanceId, ((ExecutionEntity) task2Execution).getParentId());
 
-    assertTrue(((ExecutionEntity) task1Execution).getParentId().equals(((ExecutionEntity) task2Execution).getParentId()));
+    assertEquals(((ExecutionEntity) task1Execution).getParentId(), ((ExecutionEntity) task2Execution).getParentId());
 
     assertEquals(0, runtimeService.createEventSubscriptionQuery().count());
 
@@ -486,7 +485,7 @@ public class MessageNonInterruptingBoundaryEventTest extends PluggableProcessEng
         .activityId("innerTask")
         .singleResult();
 
-    assertFalse(processInstanceId.equals(((ExecutionEntity) task2Execution).getParentId()));
+    assertNotEquals(processInstanceId, ((ExecutionEntity) task2Execution).getParentId());
 
     // when (2)
     taskService.complete(task2.getId());
@@ -548,7 +547,7 @@ public class MessageNonInterruptingBoundaryEventTest extends PluggableProcessEng
         .activityId("innerTask")
         .singleResult();
 
-    assertFalse(processInstanceId.equals(((ExecutionEntity) innerTaskExecution).getParentId()));
+    assertNotEquals(processInstanceId, ((ExecutionEntity) innerTaskExecution).getParentId());
 
     // when (2)
     runtimeService.correlateMessage("secondMessage");
@@ -566,7 +565,7 @@ public class MessageNonInterruptingBoundaryEventTest extends PluggableProcessEng
         .activityId("innerTask")
         .singleResult();
 
-    assertFalse(processInstanceId.equals(((ExecutionEntity) innerTaskExecution).getParentId()));
+    assertNotEquals(processInstanceId, ((ExecutionEntity) innerTaskExecution).getParentId());
 
     Task task1 = taskService.createTaskQuery()
         .taskDefinitionKey("task1")
@@ -662,7 +661,7 @@ public class MessageNonInterruptingBoundaryEventTest extends PluggableProcessEng
         .activityId("innerTask")
         .singleResult();
 
-    assertFalse(processInstanceId.equals(((ExecutionEntity) innerTaskExecution).getParentId()));
+    assertNotEquals(processInstanceId, ((ExecutionEntity) innerTaskExecution).getParentId());
 
     task1 = taskService.createTaskQuery()
         .taskDefinitionKey("task1")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageStartEventSubscriptionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageStartEventSubscriptionTest.java
@@ -19,8 +19,8 @@ package org.operaton.bpm.engine.test.bpmn.event.message;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.List;
@@ -105,16 +105,16 @@ public class MessageStartEventSubscriptionTest {
       if (processDefinition.getVersion() == 1) {
         for (EventSubscription subscription : newEventSubscriptions) {
           EventSubscriptionEntity subscriptionEntity = (EventSubscriptionEntity) subscription;
-          assertFalse(subscriptionEntity.getConfiguration().equals(processDefinition.getId()));
+          assertNotEquals(subscriptionEntity.getConfiguration(), processDefinition.getId());
         }
       } else {
         for (EventSubscription subscription : newEventSubscriptions) {
           EventSubscriptionEntity subscriptionEntity = (EventSubscriptionEntity) subscription;
-          assertTrue(subscriptionEntity.getConfiguration().equals(processDefinition.getId()));
+          assertEquals(subscriptionEntity.getConfiguration(), processDefinition.getId());
         }
       }
     }
-    assertFalse(eventSubscriptions.equals(newEventSubscriptions));
+    assertNotEquals(eventSubscriptions, newEventSubscriptions);
   }
 
   @Test
@@ -455,7 +455,6 @@ public class MessageStartEventSubscriptionTest {
   protected String deployModel(BpmnModelInstance model) {
     List<ProcessDefinition> deployedProcessDefinitions = testRule.deploy(model).getDeployedProcessDefinitions();
     assertEquals(1, deployedProcessDefinitions.size());
-    String definitionId2 = deployedProcessDefinitions.get(0).getId();
-    return definitionId2;
+    return deployedProcessDefinitions.get(0).getId();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageStartEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/message/MessageStartEventTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.test.bpmn.event.message;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -141,16 +142,16 @@ public class MessageStartEventTest extends PluggableProcessEngineTest {
       if (processDefinition.getVersion() == 1) {
         for (EventSubscription subscription : newEventSubscriptions) {
           EventSubscriptionEntity subscriptionEntity = (EventSubscriptionEntity) subscription;
-          assertFalse(subscriptionEntity.getConfiguration().equals(processDefinition.getId()));
+          assertNotEquals(subscriptionEntity.getConfiguration(), processDefinition.getId());
         }
       } else {
         for (EventSubscription subscription : newEventSubscriptions) {
           EventSubscriptionEntity subscriptionEntity = (EventSubscriptionEntity) subscription;
-          assertTrue(subscriptionEntity.getConfiguration().equals(processDefinition.getId()));
+          assertEquals(subscriptionEntity.getConfiguration(), processDefinition.getId());
         }
       }
     }
-    assertFalse(eventSubscriptions.equals(newEventSubscriptions));
+    assertNotEquals(eventSubscriptions, newEventSubscriptions);
 
     repositoryService.deleteDeployment(deploymentId);
     repositoryService.deleteDeployment(newDeploymentId);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/timer/BoundaryTimerNonInterruptingEventTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.test.bpmn.event.timer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -581,7 +582,7 @@ public class BoundaryTimerNonInterruptingEventTest {
     assertEquals(1, jobQuery.count());
 
     String anotherJobId = jobQuery.singleResult().getId();
-    assertFalse(jobId.equals(anotherJobId));
+    assertNotEquals(jobId, anotherJobId);
   }
 
   @Deployment

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/timer/StartTimerEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/timer/StartTimerEventTest.java
@@ -1245,7 +1245,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     assertEquals(1, jobQuery.count());
 
     String anotherJobId = jobQuery.singleResult().getId();
-    assertFalse(jobId.equals(anotherJobId));
+    assertNotEquals(jobId, anotherJobId);
   }
 
   @Test
@@ -1412,7 +1412,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     assertEquals(1, jobQuery.count());
 
     String anotherJobId = jobQuery.singleResult().getId();
-    assertFalse(jobId.equals(anotherJobId));
+    assertNotEquals(jobId, anotherJobId);
   }
 
   @Test
@@ -1590,7 +1590,7 @@ public class StartTimerEventTest extends PluggableProcessEngineTest {
     Date newDuedate = jobQuery.singleResult().getDuedate();
     Date expectedDate = LocalDateTime.fromDateFields(jobQuery.singleResult().getCreateTime()).plusMinutes(2).toDate();
     assertTrue(oldDueDate.before(newDuedate));
-    assertTrue(expectedDate.equals(newDuedate));
+    assertEquals(expectedDate, newDuedate);
 
     managementService.executeJob(jobId);
     assertEquals(1, taskService.createTaskQuery().taskName("taskInSubprocess").list().size());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/iomapping/InputOutputTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.test.bpmn.iomapping;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -877,7 +878,7 @@ public class InputOutputTest extends PluggableProcessEngineTest {
     // first sequential mi execution
     Execution miExecution = runtimeService.createExecutionQuery().activityId("miTask").singleResult();
     assertNotNull(miExecution);
-    assertFalse(instance.getId().equals(miExecution.getId()));
+    assertNotEquals(instance.getId(), miExecution.getId());
     assertEquals(0, runtimeService.getVariable(miExecution.getId(), "loopCounter"));
 
     // input mapping
@@ -890,7 +891,7 @@ public class InputOutputTest extends PluggableProcessEngineTest {
     // second sequential mi execution
     miExecution = runtimeService.createExecutionQuery().activityId("miTask").singleResult();
     assertNotNull(miExecution);
-    assertFalse(instance.getId().equals(miExecution.getId()));
+    assertNotEquals(instance.getId(), miExecution.getId());
     assertEquals(1, runtimeService.getVariable(miExecution.getId(), "loopCounter"));
 
     // input mapping
@@ -927,7 +928,7 @@ public class InputOutputTest extends PluggableProcessEngineTest {
     // second sequential mi execution
     miScopeExecution = runtimeService.createExecutionQuery().activityId("task").singleResult();
     assertNotNull(miScopeExecution);
-    assertFalse(instance.getId().equals(miScopeExecution.getId()));
+    assertNotEquals(instance.getId(), miScopeExecution.getId());
     assertEquals(1, runtimeService.getVariable(miScopeExecution.getId(), "loopCounter"));
 
     // input mapping
@@ -955,14 +956,14 @@ public class InputOutputTest extends PluggableProcessEngineTest {
     Execution miExecution1 = runtimeService.createExecutionQuery().activityId("miTask")
         .variableValueEquals("loopCounter", 0).singleResult();
     assertNotNull(miExecution1);
-    assertFalse(instance.getId().equals(miExecution1.getId()));
+    assertNotEquals(instance.getId(), miExecution1.getId());
     counters.add((Integer) runtimeService.getVariableLocal(miExecution1.getId(), "miCounterValue"));
 
     // second mi execution
     Execution miExecution2 = runtimeService.createExecutionQuery().activityId("miTask")
         .variableValueEquals("loopCounter", 1).singleResult();
     assertNotNull(miExecution2);
-    assertFalse(instance.getId().equals(miExecution2.getId()));
+    assertNotEquals(instance.getId(), miExecution2.getId());
     counters.add((Integer) runtimeService.getVariableLocal(miExecution2.getId(), "miCounterValue"));
 
     assertTrue(counters.contains(1));
@@ -998,7 +999,7 @@ public class InputOutputTest extends PluggableProcessEngineTest {
     Execution miScopeExecution2 = runtimeService.createExecutionQuery().activityId("task")
         .variableValueEquals("loopCounter", 1).singleResult();
     assertNotNull(miScopeExecution2);
-    assertFalse(instance.getId().equals(miScopeExecution2.getId()));
+    assertNotEquals(instance.getId(), miScopeExecution2.getId());
     counters.add((Integer) runtimeService.getVariableLocal(miScopeExecution2.getId(), "miCounterValue"));
 
     assertTrue(counters.contains(1));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/parse/BpmnParseTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/parse/BpmnParseTest.java
@@ -531,9 +531,9 @@ public class BpmnParseTest {
     // Test that the conditions has been resolved
     for (PvmTransition transition : activity.getOutgoingTransitions()) {
       if (transition.getDestination().getId().equals("Task_2")) {
-        assertTrue(transition.getProperty("conditionText").equals("#{approved}"));
+        assertEquals("#{approved}", transition.getProperty("conditionText"));
       } else if (transition.getDestination().getId().equals("Task_3")) {
-        assertTrue(transition.getProperty("conditionText").equals("#{!approved}"));
+        assertEquals("#{!approved}", transition.getProperty("conditionText"));
       } else {
         fail("Something went wrong");
       }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/receivetask/ReceiveTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/receivetask/ReceiveTaskTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.bpmn.receivetask;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -194,7 +194,7 @@ public class ReceiveTaskTest extends PluggableProcessEngineTest {
     subscriptionList = getEventSubscriptionList();
     assertEquals(1, subscriptionList.size());
     subscription = subscriptionList.get(0);
-    assertFalse(firstSubscriptionId.equals(subscription.getId()));
+    assertNotEquals(firstSubscriptionId, subscription.getId());
 
     // then: we can signal the second waiting receive task
     runtimeService.signal(getExecutionId(processInstance.getId(), "waitState"));
@@ -230,7 +230,7 @@ public class ReceiveTaskTest extends PluggableProcessEngineTest {
     subscriptionList = getEventSubscriptionList();
     assertEquals(1, subscriptionList.size());
     subscription = subscriptionList.get(0);
-    assertFalse(firstSubscriptionId.equals(subscription.getId()));
+    assertNotEquals(firstSubscriptionId, subscription.getId());
 
     // then: we can trigger the second event subscription
     runtimeService.messageEventReceived(subscription.getEventName(), subscription.getExecutionId());
@@ -266,7 +266,7 @@ public class ReceiveTaskTest extends PluggableProcessEngineTest {
     subscriptionList = getEventSubscriptionList();
     assertEquals(1, subscriptionList.size());
     subscription = subscriptionList.get(0);
-    assertFalse(firstSubscriptionId.equals(subscription.getId()));
+    assertNotEquals(firstSubscriptionId, subscription.getId());
 
     // then: we can trigger the second event subscription
     runtimeService.correlateMessage(subscription.getEventName());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/shell/ShellTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/shell/ShellTaskTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.test.bpmn.shell;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 import org.operaton.bpm.engine.runtime.ProcessInstance;
@@ -54,7 +55,7 @@ public class ShellTaskTest extends PluggableProcessEngineTest {
 
   @Test
   public void testOsDetection() {
-    assertTrue(osType != OsType.UNKOWN);
+    assertNotSame(osType, OsType.UNKOWN);
   }
 
   @Deployment

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/processtask/ProcessTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/processtask/ProcessTaskTest.java
@@ -17,12 +17,7 @@
 package org.operaton.bpm.engine.test.cmmn.processtask;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.util.List;
 
@@ -546,7 +541,7 @@ public class ProcessTaskTest extends CmmnTest {
     assertEquals(processTaskId, processInstance.getSuperCaseExecutionId());
     // the business key has been set
     assertEquals("myOwnBusinessKey", processInstance.getBusinessKey());
-    assertFalse(businessKey.equals(processInstance.getBusinessKey()));
+    assertNotEquals(businessKey, processInstance.getBusinessKey());
 
     TaskEntity task = (TaskEntity) queryTask();
 
@@ -592,7 +587,7 @@ public class ProcessTaskTest extends CmmnTest {
         .list();
 
     assertEquals(2, variables.size());
-    assertFalse(variables.get(0).getName().equals(variables.get(1).getName()));
+    assertNotEquals(variables.get(0).getName(), variables.get(1).getName());
 
     for (VariableInstance variable : variables) {
       String name = variable.getName();
@@ -647,7 +642,7 @@ public class ProcessTaskTest extends CmmnTest {
         .list();
 
     assertEquals(2, variables.size());
-    assertFalse(variables.get(0).getName().equals(variables.get(1).getName()));
+    assertNotEquals(variables.get(0).getName(), variables.get(1).getName());
 
     for (VariableInstance variable : variables) {
       String name = variable.getName();
@@ -694,7 +689,7 @@ public class ProcessTaskTest extends CmmnTest {
         .list();
 
     assertEquals(2, variables.size());
-    assertFalse(variables.get(0).getName().equals(variables.get(1).getName()));
+    assertNotEquals(variables.get(0).getName(), variables.get(1).getName());
 
     for (VariableInstance variable : variables) {
       String name = variable.getName();
@@ -740,7 +735,7 @@ public class ProcessTaskTest extends CmmnTest {
         .list();
 
     assertEquals(2, variables.size());
-    assertFalse(variables.get(0).getName().equals(variables.get(1).getName()));
+    assertNotEquals(variables.get(0).getName(), variables.get(1).getName());
 
     for (VariableInstance variable : variables) {
       String name = variable.getName();
@@ -788,7 +783,7 @@ public class ProcessTaskTest extends CmmnTest {
         .list();
 
     assertEquals(2, variables.size());
-    assertFalse(variables.get(0).getName().equals(variables.get(1).getName()));
+    assertNotEquals(variables.get(0).getName(), variables.get(1).getName());
 
     for (VariableInstance variable : variables) {
       String name = variable.getName();
@@ -873,7 +868,7 @@ public class ProcessTaskTest extends CmmnTest {
         .list();
 
     assertEquals(2, variables.size());
-    assertFalse(variables.get(0).getName().equals(variables.get(1).getName()));
+    assertNotEquals(variables.get(0).getName(), variables.get(1).getName());
 
     for (VariableInstance variable : variables) {
       String name = variable.getName();
@@ -982,7 +977,7 @@ public class ProcessTaskTest extends CmmnTest {
         .list();
 
     assertEquals(2, variables.size());
-    assertFalse(variables.get(0).getName().equals(variables.get(1).getName()));
+    assertNotEquals(variables.get(0).getName(), variables.get(1).getName());
 
     for (VariableInstance variable : variables) {
       String name = variable.getName();
@@ -1033,7 +1028,7 @@ public class ProcessTaskTest extends CmmnTest {
         .list();
 
     assertEquals(2, variables.size());
-    assertFalse(variables.get(0).getName().equals(variables.get(1).getName()));
+    assertNotEquals(variables.get(0).getName(), variables.get(1).getName());
 
     for (VariableInstance variable : variables) {
       String name = variable.getName();
@@ -1081,7 +1076,7 @@ public class ProcessTaskTest extends CmmnTest {
         .list();
 
     assertEquals(2, variables.size());
-    assertFalse(variables.get(0).getName().equals(variables.get(1).getName()));
+    assertNotEquals(variables.get(0).getName(), variables.get(1).getName());
 
     for (VariableInstance variable : variables) {
       String name = variable.getName();
@@ -1128,7 +1123,7 @@ public class ProcessTaskTest extends CmmnTest {
         .list();
 
     assertEquals(2, variables.size());
-    assertFalse(variables.get(0).getName().equals(variables.get(1).getName()));
+    assertNotEquals(variables.get(0).getName(), variables.get(1).getName());
 
     for (VariableInstance variable : variables) {
       String name = variable.getName();
@@ -1180,7 +1175,7 @@ public class ProcessTaskTest extends CmmnTest {
         .list();
 
     assertEquals(2, variables.size());
-    assertFalse(variables.get(0).getName().equals(variables.get(1).getName()));
+    assertNotEquals(variables.get(0).getName(), variables.get(1).getName());
 
     for (VariableInstance variable : variables) {
       String name = variable.getName();
@@ -1232,7 +1227,7 @@ public class ProcessTaskTest extends CmmnTest {
         .list();
 
     assertEquals(2, variables.size());
-    assertFalse(variables.get(0).getName().equals(variables.get(1).getName()));
+    assertNotEquals(variables.get(0).getName(), variables.get(1).getName());
 
     for (VariableInstance variable : variables) {
       String name = variable.getName();
@@ -1337,7 +1332,7 @@ public class ProcessTaskTest extends CmmnTest {
         .list();
 
     assertEquals(2, variables.size());
-    assertFalse(variables.get(0).getName().equals(variables.get(1).getName()));
+    assertNotEquals(variables.get(0).getName(), variables.get(1).getName());
 
     for (VariableInstance variable : variables) {
       String name = variable.getName();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/repetition/RepetitionRuleTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/repetition/RepetitionRuleTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.cmmn.repetition;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -192,7 +192,7 @@ public class RepetitionRuleTest extends CmmnTest {
 
     assertEquals(1, query.count());
     assertTrue(query.singleResult().isAvailable());
-    assertFalse(milestoneId.equals(query.singleResult().getId()));
+    assertNotEquals(milestoneId, query.singleResult().getId());
   }
 
   @Deployment
@@ -298,7 +298,7 @@ public class RepetitionRuleTest extends CmmnTest {
 
     assertEquals(1, query.count());
     assertTrue(query.singleResult().isAvailable());
-    assertFalse(milestoneId.equals(query.singleResult().getId()));
+    assertNotEquals(milestoneId, query.singleResult().getId());
 
     // when (2)
     reenable(firstHumanTaskId);
@@ -311,7 +311,7 @@ public class RepetitionRuleTest extends CmmnTest {
 
     assertEquals(1, query.count());
     assertTrue(query.singleResult().isAvailable());
-    assertFalse(milestoneId.equals(query.singleResult().getId()));
+    assertNotEquals(milestoneId, query.singleResult().getId());
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/cmmn/repetition/RepetitionRuleTest.testRepeatTaskWithoutEntryCriteria.cmmn")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricActivityInstanceStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricActivityInstanceStateTest.java
@@ -513,7 +513,7 @@ public class HistoricActivityInstanceStateTest extends PluggableProcessEngineTes
     assertTrue("contains entry for activity <" + activityId + ">", found > 0);
 
     if (expectedCount != -1) {
-      assertTrue("contains <" + expectedCount + "> entries for activity <" + activityId + ">", found == expectedCount);
+      assertEquals("contains <" + expectedCount + "> entries for activity <" + activityId + ">", found, expectedCount);
     }
   }
 
@@ -546,7 +546,7 @@ public class HistoricActivityInstanceStateTest extends PluggableProcessEngineTes
     assertTrue("contains entry for activity <" + activityId + ">", found > 0);
 
     if (expectedCount != -1) {
-      assertTrue("contains <" + expectedCount + "> entries for activity <" + activityId + ">", found == expectedCount);
+      assertEquals("contains <" + expectedCount + "> entries for activity <" + activityId + ">", found, expectedCount);
     }
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorShutdownTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorShutdownTest.java
@@ -126,7 +126,7 @@ public class JobExecutorShutdownTest {
     // but the exclusive follow-up job is not executed and is not locked
     JobEntity secondAsyncJob = (JobEntity) engineRule.getManagementService().createJobQuery().singleResult();
     Assert.assertNotNull(secondAsyncJob);
-    Assert.assertFalse(secondAsyncJob.getId().equals(firstAsyncJob.getId()));
+    Assert.assertNotEquals(secondAsyncJob.getId(), firstAsyncJob.getId());
     Assert.assertNull(secondAsyncJob.getLockOwner());
     Assert.assertNull(secondAsyncJob.getLockExpirationTime());
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/entity/ExecutionSequenceCounterTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/entity/ExecutionSequenceCounterTest.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.test.standalone.entity;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -242,7 +243,7 @@ public class ExecutionSequenceCounterTest extends PluggableProcessEngineTest {
     ActivitySequenceCounterMap theService3Element = order.get(1);
     assertEquals("theService3", theService3Element.getActivityId());
 
-    assertTrue(theService1Element.getSequenceCounter() == theService3Element.getSequenceCounter());
+    assertEquals(theService1Element.getSequenceCounter(), theService3Element.getSequenceCounter());
 
     // when (2)
     String jobId = jobQuery.activityId("theService4").singleResult().getId();
@@ -303,7 +304,7 @@ public class ExecutionSequenceCounterTest extends PluggableProcessEngineTest {
     ActivitySequenceCounterMap theService3Element = order.get(1);
     assertEquals("theService3", theService3Element.getActivityId());
 
-    assertTrue(theService1Element.getSequenceCounter() == theService3Element.getSequenceCounter());
+    assertEquals(theService1Element.getSequenceCounter(), theService3Element.getSequenceCounter());
 
     // when (2)
     String jobId = jobQuery.activityId("theService2").singleResult().getId();
@@ -367,8 +368,8 @@ public class ExecutionSequenceCounterTest extends PluggableProcessEngineTest {
     ActivitySequenceCounterMap theService6Element = order.get(2);
     assertEquals("theService6", theService6Element.getActivityId());
 
-    assertTrue(theService1Element.getSequenceCounter() == theService3Element.getSequenceCounter());
-    assertTrue(theService3Element.getSequenceCounter() == theService6Element.getSequenceCounter());
+    assertEquals(theService1Element.getSequenceCounter(), theService3Element.getSequenceCounter());
+    assertEquals(theService3Element.getSequenceCounter(), theService6Element.getSequenceCounter());
 
     // when (2)
     String jobId = jobQuery.activityId("theService2").singleResult().getId();
@@ -552,7 +553,7 @@ public class ExecutionSequenceCounterTest extends PluggableProcessEngineTest {
     assertEquals("join", theJoin2Element.getActivityId());
     assertTrue(theJoin2Element.getSequenceCounter() > lastSequenceCounter);
 
-    assertFalse(theJoin1Element.getSequenceCounter() == theJoin2Element.getSequenceCounter());
+    assertNotEquals(theJoin1Element.getSequenceCounter(), theJoin2Element.getSequenceCounter());
 
     ActivitySequenceCounterMap theService4Element = order.get(8);
     assertEquals("theService4", theService4Element.getActivityId());
@@ -588,9 +589,9 @@ public class ExecutionSequenceCounterTest extends PluggableProcessEngineTest {
     ActivitySequenceCounterMap theJoin3Element = order.get(2);
     assertEquals("join", theJoin3Element.getActivityId());
 
-    assertFalse(theJoin1Element.getSequenceCounter() == theJoin2Element.getSequenceCounter());
-    assertFalse(theJoin2Element.getSequenceCounter() == theJoin3Element.getSequenceCounter());
-    assertFalse(theJoin3Element.getSequenceCounter() == theJoin1Element.getSequenceCounter());
+    assertNotEquals(theJoin1Element.getSequenceCounter(), theJoin2Element.getSequenceCounter());
+    assertNotEquals(theJoin2Element.getSequenceCounter(), theJoin3Element.getSequenceCounter());
+    assertNotEquals(theJoin3Element.getSequenceCounter(), theJoin1Element.getSequenceCounter());
 
     ActivitySequenceCounterMap theService7Element = order.get(3);
     assertEquals("theService7", theService7Element.getActivityId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/FullHistoryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/FullHistoryTest.java
@@ -1280,7 +1280,7 @@ public class FullHistoryTest {
      * execution id: On which execution it was set
      * activity id: in which activity was the process instance when setting the variable
      */
-    assertFalse(historicActivityInstance2.getExecutionId().equals(update2.getExecutionId()));
+    assertNotEquals(historicActivityInstance2.getExecutionId(), update2.getExecutionId());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/scripting/ScriptEngineCachingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/scripting/ScriptEngineCachingTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.standalone.scripting;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 import javax.script.ScriptEngine;
@@ -60,7 +60,7 @@ public class ScriptEngineCachingTest extends PluggableProcessEngineTest {
 
     // then
     assertNotNull(engine);
-    assertFalse(engine.equals(getScriptEngine(SCRIPT_LANGUAGE)));
+    assertNotEquals(engine, getScriptEngine(SCRIPT_LANGUAGE));
 
     processEngineConfiguration.setEnableScriptEngineCaching(true);
     getScriptingEngines().setEnableScriptEngineCaching(true);
@@ -89,7 +89,7 @@ public class ScriptEngineCachingTest extends PluggableProcessEngineTest {
 
     // then
     assertNotNull(engine);
-    assertFalse(engine.equals(processApplication.getScriptEngineForName(SCRIPT_LANGUAGE, false)));
+    assertNotEquals(engine, processApplication.getScriptEngineForName(SCRIPT_LANGUAGE, false));
   }
 
   @Test
@@ -131,10 +131,10 @@ public class ScriptEngineCachingTest extends PluggableProcessEngineTest {
 
     // then
     assertNotNull(engine);
-    assertFalse(engine.equals(getScriptEngineFromPa(SCRIPT_LANGUAGE, processApplication)));
+    assertNotEquals(engine, getScriptEngineFromPa(SCRIPT_LANGUAGE, processApplication));
 
     // not cached in pa
-    assertFalse(engine.equals(processApplication.getScriptEngineForName(SCRIPT_LANGUAGE, false)));
+    assertNotEquals(engine, processApplication.getScriptEngineForName(SCRIPT_LANGUAGE, false));
 
     repositoryService.deleteDeployment(deployment.getId(), true);
 
@@ -161,7 +161,7 @@ public class ScriptEngineCachingTest extends PluggableProcessEngineTest {
     assertEquals(engine, getScriptEngineFromPa(SCRIPT_LANGUAGE, processApplication));
 
     // not cached in pa
-    assertFalse(engine.equals(processApplication.getScriptEngineForName(SCRIPT_LANGUAGE, true)));
+    assertNotEquals(engine, processApplication.getScriptEngineForName(SCRIPT_LANGUAGE, true));
 
     repositoryService.deleteDeployment(deployment.getId(), true);
 


### PR DESCRIPTION
Resolve Sonar warnings of type java:S5785: JUnit assertTrue/assertFalse should be simplified to the corresponding dedicated assertion

related to #88