### PR TITLE
refactor: Rename constants

### DIFF
--- a/clients/java/client/src/main/java/org/operaton/bpm/client/impl/EngineClient.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/impl/EngineClient.java
@@ -40,13 +40,13 @@ import org.operaton.bpm.client.variable.impl.TypedValues;
 public class EngineClient {
 
   protected static final String EXTERNAL_TASK_RESOURCE_PATH = "/external-task";
-  protected static final String EXTERNAL_TASK__PROCESS_RESOURCE_PATH = "/process-instance";
+  protected static final String EXTERNAL_TASK_PROCESS_RESOURCE_PATH = "/process-instance";
   protected static final String FETCH_AND_LOCK_RESOURCE_PATH = EXTERNAL_TASK_RESOURCE_PATH + "/fetchAndLock";
   public static final String ID_PATH_PARAM = "{id}";
   protected static final String ID_RESOURCE_PATH = EXTERNAL_TASK_RESOURCE_PATH + "/" + ID_PATH_PARAM;
   public static final String LOCK_RESOURCE_PATH = ID_RESOURCE_PATH + "/lock";
   public static final String EXTEND_LOCK_RESOURCE_PATH = ID_RESOURCE_PATH + "/extendLock";
-  public static final String SET_VARIABLES_RESOURCE_PATH = EXTERNAL_TASK__PROCESS_RESOURCE_PATH + "/" + ID_PATH_PARAM + "/variables";
+  public static final String SET_VARIABLES_RESOURCE_PATH = EXTERNAL_TASK_PROCESS_RESOURCE_PATH + "/" + ID_PATH_PARAM + "/variables";
   public static final String UNLOCK_RESOURCE_PATH = ID_RESOURCE_PATH + "/unlock";
   public static final String COMPLETE_RESOURCE_PATH = ID_RESOURCE_PATH + "/complete";
   public static final String FAILURE_RESOURCE_PATH = ID_RESOURCE_PATH + "/failure";

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CustomJacksonDateFormatTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CustomJacksonDateFormatTest.java
@@ -55,9 +55,9 @@ public class CustomJacksonDateFormatTest extends AbstractRestServiceTest {
   protected static final String PROCESS_INSTANCE_VARIABLES_URL = SINGLE_PROCESS_INSTANCE_URL + "/variables";
   protected static final String SINGLE_PROCESS_INSTANCE_VARIABLE_URL = PROCESS_INSTANCE_VARIABLES_URL + "/{varId}";
 
-  protected static final SimpleDateFormat testDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-  protected static final Date testDate = new Date(1450282812000L);
-  protected static final String testDateFormatted = testDateFormat.format(testDate);
+  protected static final SimpleDateFormat TEST_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+  protected static final Date TEST_DATE = new Date(1450282812000L);
+  protected static final String TEST_DATE_FORMATTED = TEST_DATE_FORMAT.format(TEST_DATE);
 
   protected RuntimeServiceImpl runtimeServiceMock;
 
@@ -66,7 +66,7 @@ public class CustomJacksonDateFormatTest extends AbstractRestServiceTest {
     runtimeServiceMock = mock(RuntimeServiceImpl.class);
 
     when(runtimeServiceMock.getVariableTyped(EXAMPLE_PROCESS_INSTANCE_ID, EXAMPLE_VARIABLE_KEY, true))
-      .thenReturn(Variables.dateValue(testDate));
+      .thenReturn(Variables.dateValue(TEST_DATE));
 
     when(processEngine.getRuntimeService()).thenReturn(runtimeServiceMock);
   }
@@ -83,7 +83,7 @@ public class CustomJacksonDateFormatTest extends AbstractRestServiceTest {
         .pathParam("varId", EXAMPLE_VARIABLE_KEY)
       .then().expect()
         .statusCode(Status.OK.getStatusCode())
-        .body("value", is(testDateFormatted))
+        .body("value", is(TEST_DATE_FORMATTED))
         .body("type", is("Date"))
       .when()
         .get(SINGLE_PROCESS_INSTANCE_VARIABLE_URL);
@@ -91,7 +91,7 @@ public class CustomJacksonDateFormatTest extends AbstractRestServiceTest {
 
   @Test
   public void testSetDateVariable() {
-    String variableValue = testDateFormat.format(testDate);
+    String variableValue = TEST_DATE_FORMAT.format(TEST_DATE);
 
     Map<String, Object> variableJson = VariablesBuilder.getVariableValueMap(variableValue, "Date");
 
@@ -106,7 +106,7 @@ public class CustomJacksonDateFormatTest extends AbstractRestServiceTest {
         .put(SINGLE_PROCESS_INSTANCE_VARIABLE_URL);
 
     verify(runtimeServiceMock).setVariable(eq(EXAMPLE_PROCESS_INSTANCE_ID), eq(EXAMPLE_VARIABLE_KEY),
-      argThat(EqualsPrimitiveValue.dateValue(testDate)));
+      argThat(EqualsPrimitiveValue.dateValue(TEST_DATE)));
   }
 
 }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/FilterRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/FilterRestServiceInteractionTest.java
@@ -129,11 +129,11 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
   public static final String EXECUTE_LIST_FILTER_URL = SINGLE_FILTER_URL + "/list";
   public static final String EXECUTE_COUNT_FILTER_URL = SINGLE_FILTER_URL + "/count";
 
-  public static final TaskQuery extendingQuery = new TaskQueryImpl().taskName(MockProvider.EXAMPLE_TASK_NAME);
-  public static final TaskQueryDto extendingQueryDto = TaskQueryDto.fromQuery(extendingQuery);
-  public static final TaskQuery extendingOrQuery = new TaskQueryImpl().or().taskDescription(MockProvider.EXAMPLE_TASK_DESCRIPTION).endOr().or().taskName(MockProvider.EXAMPLE_TASK_NAME).endOr();
-  public static final TaskQueryDto extendingOrQueryDto = TaskQueryDto.fromQuery(extendingOrQuery);
-  public static final String invalidExtendingQuery = "abc";
+  public static final TaskQuery EXTENDING_QUERY = new TaskQueryImpl().taskName(MockProvider.EXAMPLE_TASK_NAME);
+  public static final TaskQueryDto EXTENDING_QUERY_DTO = TaskQueryDto.fromQuery(EXTENDING_QUERY);
+  public static final TaskQuery EXTENDING_OR_QUERY = new TaskQueryImpl().or().taskDescription(MockProvider.EXAMPLE_TASK_DESCRIPTION).endOr().or().taskName(MockProvider.EXAMPLE_TASK_NAME).endOr();
+  public static final TaskQueryDto EXTENDING_OR_QUERY_DTO = TaskQueryDto.fromQuery(EXTENDING_OR_QUERY);
+  public static final String INVALID_EXTENDING_QUERY = "abc";
 
   public static final String PROCESS_INSTANCE_A_ID = "processInstanceA";
   public static final String CASE_INSTANCE_A_ID = "caseInstanceA";
@@ -926,7 +926,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
       .header(ACCEPT_JSON_HEADER)
       .pathParam("id", EXAMPLE_FILTER_ID)
       .contentType(POST_JSON_CONTENT_TYPE)
-      .body(invalidExtendingQuery)
+      .body(INVALID_EXTENDING_QUERY)
     .then().expect()
       .statusCode(Status.BAD_REQUEST.getStatusCode())
     .when()
@@ -939,7 +939,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
       .header(ACCEPT_JSON_HEADER)
       .pathParam("id", EXAMPLE_FILTER_ID)
       .contentType(POST_JSON_CONTENT_TYPE)
-      .body(extendingQueryDto)
+      .body(EXTENDING_QUERY_DTO)
     .then().expect()
       .statusCode(Status.OK.getStatusCode())
     .when()
@@ -955,7 +955,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
       .header(ACCEPT_JSON_HEADER)
       .pathParam("id", EXAMPLE_FILTER_ID)
       .contentType(POST_JSON_CONTENT_TYPE)
-      .body(extendingOrQueryDto)
+      .body(EXTENDING_OR_QUERY_DTO)
     .then().expect()
       .statusCode(Status.OK.getStatusCode())
     .when()
@@ -1115,7 +1115,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
       .header(ACCEPT_JSON_HEADER)
       .pathParam("id", EXAMPLE_FILTER_ID)
       .contentType(POST_JSON_CONTENT_TYPE)
-      .body(extendingQueryDto)
+      .body(EXTENDING_QUERY_DTO)
     .then().expect()
       .statusCode(Status.OK.getStatusCode())
       .body("$.size()", equalTo(1))
@@ -1133,7 +1133,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
       .queryParams("firstResult", 1)
       .queryParams("maxResults", 2)
       .contentType(POST_JSON_CONTENT_TYPE)
-      .body(extendingQueryDto)
+      .body(EXTENDING_QUERY_DTO)
     .then().expect()
       .statusCode(Status.OK.getStatusCode())
       .body("$.size()", equalTo(1))
@@ -1149,7 +1149,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
       .header(ACCEPT_JSON_HEADER)
       .pathParam("id", EXAMPLE_FILTER_ID)
       .contentType(POST_JSON_CONTENT_TYPE)
-      .body(invalidExtendingQuery)
+      .body(INVALID_EXTENDING_QUERY)
     .then().expect()
       .statusCode(Status.BAD_REQUEST.getStatusCode())
     .when()
@@ -1205,7 +1205,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
       .header(ACCEPT_JSON_HEADER)
       .pathParam("id", EXAMPLE_FILTER_ID)
       .contentType(POST_JSON_CONTENT_TYPE)
-      .body(extendingQueryDto)
+      .body(EXTENDING_QUERY_DTO)
     .then().expect()
       .statusCode(Status.OK.getStatusCode())
       .body("count", equalTo(1))
@@ -1221,7 +1221,7 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
       .header(ACCEPT_JSON_HEADER)
       .pathParam("id", EXAMPLE_FILTER_ID)
       .contentType(POST_JSON_CONTENT_TYPE)
-      .body(invalidExtendingQuery)
+      .body(INVALID_EXTENDING_QUERY)
     .then().expect()
       .statusCode(Status.BAD_REQUEST.getStatusCode())
     .when()

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/DurationHelper.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/DurationHelper.java
@@ -35,7 +35,7 @@ import org.operaton.bpm.engine.impl.util.EngineUtilLogger;
  */
 public class DurationHelper {
 
-  public static final String PnW_PATTERN = "P\\d+W";
+  public static final String PNW_PATTERN = "P\\d+W";
   private static final int MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
   private static final EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
 
@@ -146,7 +146,7 @@ public class DurationHelper {
   }
 
   private Duration parsePeriod(String period) {
-    if (period.matches(PnW_PATTERN)) {
+    if (period.matches(PNW_PATTERN)) {
       return parsePnWDuration(period);
     }
     return datatypeFactory.newDuration(period);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/GroupAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/GroupAuthorizationTest.java
@@ -51,18 +51,18 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
 public class GroupAuthorizationTest extends AuthorizationTest {
 
-  public static final String testUserId = "testUser";
-  public static final List<String> testGroupIds = Arrays.asList("testGroup1", "testGroup2", "testGroup3");
+  public static final String TEST_USER_ID = "testUser";
+  public static final List<String> TEST_GROUP_IDS = Arrays.asList("testGroup1", "testGroup2", "testGroup3");
 
   @Before
   @Override
   public void setUp() {
-    createUser(testUserId);
-    for (String testGroupId : testGroupIds) {
-      createGroupAndAddUser(testGroupId, testUserId);
+    createUser(TEST_USER_ID);
+    for (String testGroupId : TEST_GROUP_IDS) {
+      createGroupAndAddUser(testGroupId, TEST_USER_ID);
     }
 
-    identityService.setAuthentication(testUserId, testGroupIds);
+    identityService.setAuthentication(TEST_USER_ID, TEST_GROUP_IDS);
     processEngineConfiguration.setAuthorizationEnabled(true);
   }
 
@@ -78,7 +78,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
 
       taskQuery.list();
 
-      verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(testGroupIds);
+      verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(TEST_GROUP_IDS);
       verify(authCheck).setAuthGroupIds(Collections.<String>emptyList());
 
       return null;
@@ -87,7 +87,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
 
   @Test
   public void testTaskQueryWithOneGroupAuthorization() {
-    createGroupGrantAuthorization(Resources.TASK, Authorization.ANY, testGroupIds.get(0));
+    createGroupGrantAuthorization(Resources.TASK, Authorization.ANY, TEST_GROUP_IDS.get(0));
 
     processEngineConfiguration.getCommandExecutorTxRequired().execute(commandContext -> {
       AuthorizationManager authorizationManager = spyOnSession(commandContext, AuthorizationManager.class);
@@ -98,8 +98,8 @@ public class GroupAuthorizationTest extends AuthorizationTest {
 
       taskQuery.list();
 
-      verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(testGroupIds);
-      verify(authCheck).setAuthGroupIds(testGroupIds.subList(0, 1));
+      verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(TEST_GROUP_IDS);
+      verify(authCheck).setAuthGroupIds(TEST_GROUP_IDS.subList(0, 1));
 
       return null;
     });
@@ -107,7 +107,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
 
   @Test
   public void testTaskQueryWithGroupAuthorization() {
-    for (String testGroupId : testGroupIds) {
+    for (String testGroupId : TEST_GROUP_IDS) {
       createGroupGrantAuthorization(Resources.TASK, Authorization.ANY, testGroupId);
     }
 
@@ -120,15 +120,15 @@ public class GroupAuthorizationTest extends AuthorizationTest {
 
       taskQuery.list();
 
-      verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(testGroupIds);
-      verify(authCheck, atLeastOnce()).setAuthGroupIds(testGroupIds);
+      verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(TEST_GROUP_IDS);
+      verify(authCheck, atLeastOnce()).setAuthGroupIds(TEST_GROUP_IDS);
       return null;
     });
   }
 
   @Test
   public void testTaskQueryWithUserWithoutGroups() {
-    identityService.setAuthentication(testUserId, null);
+    identityService.setAuthentication(TEST_USER_ID, null);
 
     processEngineConfiguration.getCommandExecutorTxRequired().execute(commandContext -> {
       AuthorizationManager authorizationManager = spyOnSession(commandContext, AuthorizationManager.class);
@@ -152,9 +152,9 @@ public class GroupAuthorizationTest extends AuthorizationTest {
       AuthorizationManager authorizationManager = spyOnSession(commandContext, AuthorizationManager.class);
       DbEntityManager dbEntityManager = spyOnSession(commandContext, DbEntityManager.class);
 
-      authorizationService.isUserAuthorized(testUserId, testGroupIds, Permissions.READ, Resources.TASK);
+      authorizationService.isUserAuthorized(TEST_USER_ID, TEST_GROUP_IDS, Permissions.READ, Resources.TASK);
 
-      verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(testGroupIds);
+      verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(TEST_GROUP_IDS);
 
       ArgumentCaptor<AuthorizationCheck> authorizationCheckArgument = forClass(AuthorizationCheck.class);
       verify(dbEntityManager).selectBoolean(eq("isUserAuthorizedForResource"), authorizationCheckArgument.capture());
@@ -168,21 +168,21 @@ public class GroupAuthorizationTest extends AuthorizationTest {
 
   @Test
   public void testCheckAuthorizationWithOneGroupAuthorizations() {
-    createGroupGrantAuthorization(Resources.TASK, Authorization.ANY, testGroupIds.get(0));
+    createGroupGrantAuthorization(Resources.TASK, Authorization.ANY, TEST_GROUP_IDS.get(0));
 
     processEngineConfiguration.getCommandExecutorTxRequired().execute(commandContext -> {
       AuthorizationManager authorizationManager = spyOnSession(commandContext, AuthorizationManager.class);
       DbEntityManager dbEntityManager = spyOnSession(commandContext, DbEntityManager.class);
 
-      authorizationService.isUserAuthorized(testUserId, testGroupIds, Permissions.READ, Resources.TASK);
+      authorizationService.isUserAuthorized(TEST_USER_ID, TEST_GROUP_IDS, Permissions.READ, Resources.TASK);
 
-      verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(testGroupIds);
+      verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(TEST_GROUP_IDS);
 
       ArgumentCaptor<AuthorizationCheck> authorizationCheckArgument = forClass(AuthorizationCheck.class);
       verify(dbEntityManager).selectBoolean(eq("isUserAuthorizedForResource"), authorizationCheckArgument.capture());
 
       AuthorizationCheck authorizationCheck = authorizationCheckArgument.getValue();
-      assertEquals(testGroupIds.subList(0, 1), authorizationCheck.getAuthGroupIds());
+      assertEquals(TEST_GROUP_IDS.subList(0, 1), authorizationCheck.getAuthGroupIds());
 
       return null;
     });
@@ -190,7 +190,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
 
   @Test
   public void testCheckAuthorizationWithGroupAuthorizations() {
-    for (String testGroupId : testGroupIds) {
+    for (String testGroupId : TEST_GROUP_IDS) {
       createGroupGrantAuthorization(Resources.TASK, Authorization.ANY, testGroupId);
     }
 
@@ -198,15 +198,15 @@ public class GroupAuthorizationTest extends AuthorizationTest {
       AuthorizationManager authorizationManager = spyOnSession(commandContext, AuthorizationManager.class);
       DbEntityManager dbEntityManager = spyOnSession(commandContext, DbEntityManager.class);
 
-      authorizationService.isUserAuthorized(testUserId, testGroupIds, Permissions.READ, Resources.TASK);
+      authorizationService.isUserAuthorized(TEST_USER_ID, TEST_GROUP_IDS, Permissions.READ, Resources.TASK);
 
-      verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(testGroupIds);
+      verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds(TEST_GROUP_IDS);
 
       ArgumentCaptor<AuthorizationCheck> authorizationCheckArgument = forClass(AuthorizationCheck.class);
       verify(dbEntityManager).selectBoolean(eq("isUserAuthorizedForResource"), authorizationCheckArgument.capture());
 
       AuthorizationCheck authorizationCheck = authorizationCheckArgument.getValue();
-      assertThat(authorizationCheck.getAuthGroupIds()).containsExactlyInAnyOrderElementsOf(testGroupIds);
+      assertThat(authorizationCheck.getAuthGroupIds()).containsExactlyInAnyOrderElementsOf(TEST_GROUP_IDS);
 
       return null;
     });
@@ -218,7 +218,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
       AuthorizationManager authorizationManager = spyOnSession(commandContext, AuthorizationManager.class);
       DbEntityManager dbEntityManager = spyOnSession(commandContext, DbEntityManager.class);
 
-      authorizationService.isUserAuthorized(testUserId, null, Permissions.READ, Resources.TASK);
+      authorizationService.isUserAuthorized(TEST_USER_ID, null, Permissions.READ, Resources.TASK);
 
       verify(authorizationManager, atLeastOnce()).filterAuthenticatedGroupIds((List<String>) null);
 
@@ -247,16 +247,16 @@ public class GroupAuthorizationTest extends AuthorizationTest {
     runtimeService.startProcessInstanceByKey("process");
 
     // a group authorization
-    createGroupGrantAuthorization(Resources.TASK, Authorization.ANY, testGroupIds.get(0));
+    createGroupGrantAuthorization(Resources.TASK, Authorization.ANY, TEST_GROUP_IDS.get(0));
 
     // a user authorization (i.e. no group id set)
     // this authorization is important to reproduce the bug in CAM-14306
-    createGrantAuthorization(Resources.TASK, Authorization.ANY, testUserId, Permissions.READ);
+    createGrantAuthorization(Resources.TASK, Authorization.ANY, TEST_USER_ID, Permissions.READ);
 
-    List<String> groupIds = new NullHostileList<>(testGroupIds);
+    List<String> groupIds = new NullHostileList<>(TEST_GROUP_IDS);
 
     // when
-    boolean isAuthorized = authorizationService.isUserAuthorized(testUserId, groupIds, Permissions.READ, Resources.TASK);
+    boolean isAuthorized = authorizationService.isUserAuthorized(TEST_USER_ID, groupIds, Permissions.READ, Resources.TASK);
 
     // then
     assertThat(isAuthorized).isTrue();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/StandaloneTaskGetVariableAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/StandaloneTaskGetVariableAuthorizationTest.java
@@ -71,7 +71,7 @@ public class StandaloneTaskGetVariableAuthorizationTest {
   protected TaskService taskService;
   protected RuntimeService runtimeService;
 
-  protected static final String userId = "userId";
+  protected static final String USER_ID = "userId";
   protected String taskId = "myTask";
   protected static final String VARIABLE_NAME = "aVariableName";
   protected static final String VARIABLE_VALUE = "aVariableValue";
@@ -84,13 +84,13 @@ public class StandaloneTaskGetVariableAuthorizationTest {
       scenario()
         .withoutAuthorizations()
         .failsDueToRequired(
-          grant(TASK, "taskId", userId, READ_VARIABLE)),
+          grant(TASK, "taskId", USER_ID, READ_VARIABLE)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "taskId", userId, READ_VARIABLE)),
+          grant(TASK, "taskId", USER_ID, READ_VARIABLE)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "*", userId, READ_VARIABLE))
+          grant(TASK, "*", USER_ID, READ_VARIABLE))
         .succeeds()
       );
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/HandleTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/HandleTaskAuthorizationTest.java
@@ -75,7 +75,7 @@ public class HandleTaskAuthorizationTest {
   protected RuntimeService runtimeService;
   protected RepositoryService repositoryService;
 
-  protected static final String userId = "userId";
+  protected static final String USER_ID = "userId";
   protected String deploymentId;
 
   protected static final String BPMN_BEHAVIOR_LOGGER = "org.operaton.bpm.engine.bpmn.behavior";
@@ -88,22 +88,22 @@ public class HandleTaskAuthorizationTest {
       scenario()
         .withoutAuthorizations()
         .failsDueToRequired(
-          grant(TASK, "taskId", userId, TASK_WORK),
-          grant(PROCESS_DEFINITION, PROCESS_KEY, userId, TASK_WORK),
-          grant(TASK, "taskId", userId, UPDATE),
-          grant(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_TASK)),
+          grant(TASK, "taskId", USER_ID, TASK_WORK),
+          grant(PROCESS_DEFINITION, PROCESS_KEY, USER_ID, TASK_WORK),
+          grant(TASK, "taskId", USER_ID, UPDATE),
+          grant(PROCESS_DEFINITION, PROCESS_KEY, USER_ID, UPDATE_TASK)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "taskId", userId, TASK_WORK)),
+          grant(TASK, "taskId", USER_ID, TASK_WORK)),
       scenario()
         .withAuthorizations(
-          grant(PROCESS_DEFINITION, PROCESS_KEY, userId, TASK_WORK)),
+          grant(PROCESS_DEFINITION, PROCESS_KEY, USER_ID, TASK_WORK)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "taskId", userId, UPDATE)),
+          grant(TASK, "taskId", USER_ID, UPDATE)),
       scenario()
         .withAuthorizations(
-          grant(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_TASK))
+          grant(PROCESS_DEFINITION, PROCESS_KEY, USER_ID, UPDATE_TASK))
         .succeeds()
       );
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/ProcessTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/ProcessTaskAuthorizationTest.java
@@ -49,7 +49,7 @@ public abstract class ProcessTaskAuthorizationTest {
 
 
   private static final String ONE_TASK_PROCESS = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml";
-  protected static final String userId = "userId";
+  protected static final String USER_ID = "userId";
   public static final String VARIABLE_NAME = "aVariableName";
   public static final String VARIABLE_VALUE = "aVariableValue";
   protected static final String PROCESS_KEY = "oneTaskProcess";

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/ProcessTaskReadPermissionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/ProcessTaskReadPermissionAuthorizationTest.java
@@ -44,20 +44,20 @@ public class ProcessTaskReadPermissionAuthorizationTest extends ProcessTaskAutho
       scenario()
         .withoutAuthorizations()
         .failsDueToRequired(
-          grant(TASK, "taskId", userId, READ),
-          grant(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_TASK)),
+          grant(TASK, "taskId", USER_ID, READ),
+          grant(PROCESS_DEFINITION, PROCESS_KEY, USER_ID, READ_TASK)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "taskId", userId, READ)),
+          grant(TASK, "taskId", USER_ID, READ)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "*", userId, READ)),
+          grant(TASK, "*", USER_ID, READ)),
       scenario()
         .withAuthorizations(
-          grant(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_TASK)),
+          grant(PROCESS_DEFINITION, PROCESS_KEY, USER_ID, READ_TASK)),
       scenario()
         .withAuthorizations(
-          grant(PROCESS_DEFINITION, "*", userId, READ_TASK))
+          grant(PROCESS_DEFINITION, "*", USER_ID, READ_TASK))
         .succeeds()
       );
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/ProcessTaskReadVariablePermissionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/ProcessTaskReadVariablePermissionAuthorizationTest.java
@@ -46,20 +46,20 @@ public class ProcessTaskReadVariablePermissionAuthorizationTest extends ProcessT
       scenario()
         .withoutAuthorizations()
         .failsDueToRequired(
-          grant(TASK, "taskId", userId, READ_VARIABLE),
-          grant(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_TASK_VARIABLE)),
+          grant(TASK, "taskId", USER_ID, READ_VARIABLE),
+          grant(PROCESS_DEFINITION, PROCESS_KEY, USER_ID, READ_TASK_VARIABLE)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "taskId", userId, READ_VARIABLE)),
+          grant(TASK, "taskId", USER_ID, READ_VARIABLE)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "*", userId, READ_VARIABLE)),
+          grant(TASK, "*", USER_ID, READ_VARIABLE)),
       scenario()
         .withAuthorizations(
-          grant(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_TASK_VARIABLE)),
+          grant(PROCESS_DEFINITION, PROCESS_KEY, USER_ID, READ_TASK_VARIABLE)),
       scenario()
         .withAuthorizations(
-          grant(PROCESS_DEFINITION, "*", userId, READ_TASK_VARIABLE))
+          grant(PROCESS_DEFINITION, "*", USER_ID, READ_TASK_VARIABLE))
         .succeeds()
       );
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/StandaloneTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/StandaloneTaskAuthorizationTest.java
@@ -60,7 +60,7 @@ public abstract class StandaloneTaskAuthorizationTest {
   protected TaskService taskService;
   protected RuntimeService runtimeService;
 
-  public static final String userId = "userId";
+  public static final String USER_ID = "userId";
   public String taskId = "myTask";
   public static final String VARIABLE_NAME = "aVariableName";
   public static final String VARIABLE_VALUE = "aVariableValue";

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/StandaloneTaskReadPermissionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/StandaloneTaskReadPermissionAuthorizationTest.java
@@ -42,13 +42,13 @@ public class StandaloneTaskReadPermissionAuthorizationTest extends StandaloneTas
       scenario()
         .withoutAuthorizations()
         .failsDueToRequired(
-          grant(TASK, "taskId", userId, READ)),
+          grant(TASK, "taskId", USER_ID, READ)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "taskId", userId, READ)),
+          grant(TASK, "taskId", USER_ID, READ)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "*", userId, READ))
+          grant(TASK, "*", USER_ID, READ))
         .succeeds()
       );
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/StandaloneTaskReadVariablePermissionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/StandaloneTaskReadVariablePermissionAuthorizationTest.java
@@ -44,13 +44,13 @@ public class StandaloneTaskReadVariablePermissionAuthorizationTest extends Stand
       scenario()
         .withoutAuthorizations()
         .failsDueToRequired(
-          grant(TASK, "taskId", userId, READ_VARIABLE)),
+          grant(TASK, "taskId", USER_ID, READ_VARIABLE)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "taskId", userId, READ_VARIABLE)),
+          grant(TASK, "taskId", USER_ID, READ_VARIABLE)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "*", userId, READ_VARIABLE))
+          grant(TASK, "*", USER_ID, READ_VARIABLE))
         .succeeds()
       );
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/updatevariable/ProcessTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/updatevariable/ProcessTaskAuthorizationTest.java
@@ -63,7 +63,7 @@ import org.junit.runners.Parameterized.Parameters;
 public class ProcessTaskAuthorizationTest {
 
   private static final String ONE_TASK_PROCESS = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml";
-  protected static final String userId = "userId";
+  protected static final String USER_ID = "userId";
   protected static final String VARIABLE_NAME = "aVariableName";
   protected static final String VARIABLE_VALUE = "aVariableValue";
   protected static final String PROCESS_KEY = "oneTaskProcess";
@@ -90,34 +90,34 @@ public class ProcessTaskAuthorizationTest {
       scenario()
         .withoutAuthorizations()
         .failsDueToRequired(
-          grant(TASK, "taskId", userId, UPDATE),
-          grant(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_TASK),
-          grant(TASK, "taskId", userId, UPDATE_VARIABLE),
-          grant(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_TASK_VARIABLE)),
+          grant(TASK, "taskId", USER_ID, UPDATE),
+          grant(PROCESS_DEFINITION, PROCESS_KEY, USER_ID, UPDATE_TASK),
+          grant(TASK, "taskId", USER_ID, UPDATE_VARIABLE),
+          grant(PROCESS_DEFINITION, PROCESS_KEY, USER_ID, UPDATE_TASK_VARIABLE)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "taskId", userId, UPDATE)),
+          grant(TASK, "taskId", USER_ID, UPDATE)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "*", userId, UPDATE)),
+          grant(TASK, "*", USER_ID, UPDATE)),
       scenario()
         .withAuthorizations(
-          grant(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_TASK)),
+          grant(PROCESS_DEFINITION, PROCESS_KEY, USER_ID, UPDATE_TASK)),
       scenario()
         .withAuthorizations(
-          grant(PROCESS_DEFINITION, "*", userId, UPDATE_TASK)),
+          grant(PROCESS_DEFINITION, "*", USER_ID, UPDATE_TASK)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "taskId", userId, UPDATE_VARIABLE)),
+          grant(TASK, "taskId", USER_ID, UPDATE_VARIABLE)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "*", userId, UPDATE_VARIABLE)),
+          grant(TASK, "*", USER_ID, UPDATE_VARIABLE)),
       scenario()
         .withAuthorizations(
-          grant(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_TASK_VARIABLE)),
+          grant(PROCESS_DEFINITION, PROCESS_KEY, USER_ID, UPDATE_TASK_VARIABLE)),
       scenario()
         .withAuthorizations(
-          grant(PROCESS_DEFINITION, "*", userId, UPDATE_TASK_VARIABLE))
+          grant(PROCESS_DEFINITION, "*", USER_ID, UPDATE_TASK_VARIABLE))
         .succeeds()
       );
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/updatevariable/StandaloneTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/updatevariable/StandaloneTaskAuthorizationTest.java
@@ -76,7 +76,7 @@ public class StandaloneTaskAuthorizationTest {
   protected RuntimeService runtimeService;
   protected HistoryService historyService;
 
-  protected static final String userId = "userId";
+  protected static final String USER_ID = "userId";
   protected String taskId = "myTask";
   protected static final String VARIABLE_NAME = "aVariableName";
   protected static final String VARIABLE_VALUE = "aVariableValue";
@@ -88,28 +88,28 @@ public class StandaloneTaskAuthorizationTest {
       scenario()
         .withoutAuthorizations()
         .failsDueToRequired(
-          grant(TASK, "taskId", userId, UPDATE),
-          grant(TASK, "taskId", userId, UPDATE_VARIABLE)),
+          grant(TASK, "taskId", USER_ID, UPDATE),
+          grant(TASK, "taskId", USER_ID, UPDATE_VARIABLE)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "taskId", userId, UPDATE)),
+          grant(TASK, "taskId", USER_ID, UPDATE)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "*", userId, UPDATE)),
+          grant(TASK, "*", USER_ID, UPDATE)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "taskId", userId, UPDATE_VARIABLE)),
+          grant(TASK, "taskId", USER_ID, UPDATE_VARIABLE)),
       scenario()
         .withAuthorizations(
-          grant(TASK, "*", userId, UPDATE_VARIABLE))
+          grant(TASK, "*", USER_ID, UPDATE_VARIABLE))
         .succeeds(),
       scenario()
         .withAuthorizations(
           grant(TASK, "*", "*", UPDATE),
-          revoke(TASK, "taskId", userId, UPDATE))
+          revoke(TASK, "taskId", USER_ID, UPDATE))
         .failsDueToRequired(
-          grant(TASK, "taskId", userId, UPDATE),
-          grant(TASK, "taskId", userId, UPDATE_VARIABLE))
+          grant(TASK, "taskId", USER_ID, UPDATE),
+          grant(TASK, "taskId", USER_ID, UPDATE_VARIABLE))
       );
   }
 
@@ -127,8 +127,8 @@ public class StandaloneTaskAuthorizationTest {
   public void tearDown() {
     authRule.deleteUsersAndGroups();
     taskService.deleteTask(taskId, true);
-    for (HistoricVariableInstance var : historyService.createHistoricVariableInstanceQuery().includeDeleted().list()) {
-      historyService.deleteHistoricVariableInstance(var.getId());
+    for (HistoricVariableInstance historicVariableInstance : historyService.createHistoricVariableInstanceQuery().includeDeleted().list()) {
+      historyService.deleteHistoricVariableInstance(historicVariableInstance.getId());
     }
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AuthorizationServiceAuthorizationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AuthorizationServiceAuthorizationsTest.java
@@ -56,7 +56,7 @@ import org.junit.Test;
  */
 public class AuthorizationServiceAuthorizationsTest extends PluggableProcessEngineTest {
 
-  private static final String jonny2 = "jonny2";
+  private static final String JONNY_2 = "jonny2";
 
   @After
   public void tearDown() {
@@ -78,7 +78,7 @@ public class AuthorizationServiceAuthorizationsTest extends PluggableProcessEngi
 
     // now enable authorizations:
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(JONNY_2);
 
     try {
       // we cannot create another authorization
@@ -88,7 +88,7 @@ public class AuthorizationServiceAuthorizationsTest extends PluggableProcessEngi
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(JONNY_2, e.getUserId());
       assertExceptionInfo(CREATE.getName(), AUTHORIZATION.resourceName(), null, info);
     }
 
@@ -104,7 +104,7 @@ public class AuthorizationServiceAuthorizationsTest extends PluggableProcessEngi
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(JONNY_2, e.getUserId());
       assertExceptionInfo(CREATE.getName(), AUTHORIZATION.resourceName(), null, info);
     }
   }
@@ -122,7 +122,7 @@ public class AuthorizationServiceAuthorizationsTest extends PluggableProcessEngi
 
     // turn on authorization
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(JONNY_2);
     var basePermsId = basePerms.getId();
 
     try {
@@ -133,7 +133,7 @@ public class AuthorizationServiceAuthorizationsTest extends PluggableProcessEngi
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(JONNY_2, e.getUserId());
       assertExceptionInfo(DELETE.getName(), AUTHORIZATION.resourceName(), basePerms.getId(), info);
     }
   }
@@ -151,7 +151,7 @@ public class AuthorizationServiceAuthorizationsTest extends PluggableProcessEngi
 
     // turn on authorization
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(JONNY_2);
 
     // fetch authhorization
     basePerms = authorizationService.createAuthorizationQuery().singleResult();
@@ -165,7 +165,7 @@ public class AuthorizationServiceAuthorizationsTest extends PluggableProcessEngi
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(JONNY_2, e.getUserId());
       assertExceptionInfo(UPDATE.getName(), AUTHORIZATION.resourceName(), basePerms.getId(), info);
     }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceAuthorizationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceAuthorizationsTest.java
@@ -71,7 +71,7 @@ import org.junit.Test;
  */
 public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTest {
 
-  private static final String jonny2 = "jonny2";
+  private static final String USER_ID = "jonny2";
 
   @After
   public void tearDown() {
@@ -91,7 +91,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     authorizationService.saveAuthorization(basePerms);
 
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     // when
     try {
@@ -114,7 +114,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     authorizationService.saveAuthorization(basePerms);
 
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     User newUser = identityService.newUser("jonny1");
 
@@ -125,7 +125,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(USER_ID, e.getUserId());
       assertExceptionInfo(CREATE.getName(), USER.resourceName(), null, info);
     }
   }
@@ -147,7 +147,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
 
     // turn on authorization
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     try {
       identityService.deleteUser("jonny1");
@@ -156,7 +156,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(USER_ID, e.getUserId());
       assertExceptionInfo(DELETE.getName(), USER.resourceName(), "jonny1", info);
     }
   }
@@ -164,14 +164,14 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
   @Test
   public void testTenantAuthorizationAfterDeleteUser() {
     // given jonny2 who is allowed to do user operations
-    User jonny = identityService.newUser(jonny2);
+    User jonny = identityService.newUser(USER_ID);
     identityService.saveUser(jonny);
 
     grantPermissions();
 
     // turn on authorization
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     // create user
     User jonny1 = identityService.newUser("jonny1");
@@ -215,7 +215,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
 
     // turn on authorization
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     // fetch user:
     User jonny1 = identityService.createUserQuery().singleResult();
@@ -227,7 +227,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(USER_ID, e.getUserId());
       assertExceptionInfo(UPDATE.getName(), USER.resourceName(), "jonny1", info);
     }
 
@@ -327,7 +327,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     authorizationService.saveAuthorization(basePerms);
 
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     // when
     try {
@@ -350,7 +350,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     authorizationService.saveAuthorization(basePerms);
 
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     Group group = identityService.newGroup("group1");
 
@@ -361,7 +361,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(USER_ID, e.getUserId());
       assertExceptionInfo(CREATE.getName(), GROUP.resourceName(), null, info);
     }
   }
@@ -383,7 +383,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
 
     // turn on authorization
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     try {
       identityService.deleteGroup("group1");
@@ -392,7 +392,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(USER_ID, e.getUserId());
       assertExceptionInfo(DELETE.getName(), GROUP.resourceName(), "group1", info);
     }
 
@@ -401,14 +401,14 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
   @Test
   public void testTenantAuthorizationAfterDeleteGroup() {
     // given jonny2 who is allowed to do group operations
-    User jonny = identityService.newUser(jonny2);
+    User jonny = identityService.newUser(USER_ID);
     identityService.saveUser(jonny);
 
     grantPermissions();
 
     // turn on authorization
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     // create group
     Group group1 = identityService.newGroup("group1");
@@ -453,7 +453,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
 
     // turn on authorization
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     // fetch user:
     group1 = identityService.createGroupQuery().singleResult();
@@ -466,7 +466,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(USER_ID, e.getUserId());
       assertExceptionInfo(UPDATE.getName(), GROUP.resourceName(), "group1", info);
     }
 
@@ -487,7 +487,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     authorizationService.saveAuthorization(basePerms);
 
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     // when
     try {
@@ -510,7 +510,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     authorizationService.saveAuthorization(basePerms);
 
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     Tenant tenant = identityService.newTenant("tenant");
 
@@ -521,7 +521,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(USER_ID, e.getUserId());
       assertExceptionInfo(CREATE.getName(), TENANT.resourceName(), null, info);
     }
   }
@@ -543,7 +543,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
 
     // turn on authorization
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     try {
       identityService.deleteTenant("tenant");
@@ -552,7 +552,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(USER_ID, e.getUserId());
       assertExceptionInfo(DELETE.getName(), TENANT.resourceName(), "tenant", info);
     }
   }
@@ -574,7 +574,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
 
     // turn on authorization
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     // fetch user:
     tenant = identityService.createTenantQuery().singleResult();
@@ -587,7 +587,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(USER_ID, e.getUserId());
       assertExceptionInfo(UPDATE.getName(), TENANT.resourceName(), "tenant", info);
     }
 
@@ -614,7 +614,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     authorizationService.saveAuthorization(basePerms);
 
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     try {
       identityService.createMembership("jonny1", "group1");
@@ -623,7 +623,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(USER_ID, e.getUserId());
       assertExceptionInfo(CREATE.getName(), GROUP_MEMBERSHIP.resourceName(), "group1", info);
     }
   }
@@ -646,7 +646,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     authorizationService.saveAuthorization(basePerms);
 
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     try {
       identityService.deleteMembership("jonny1", "group1");
@@ -655,7 +655,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(USER_ID, e.getUserId());
       assertExceptionInfo(DELETE.getName(), GROUP_MEMBERSHIP.resourceName(), "group1", info);
     }
   }
@@ -741,7 +741,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     authorizationService.saveAuthorization(basePerms);
 
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     try {
       identityService.createTenantUserMembership("tenant1", "jonny1");
@@ -750,7 +750,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(USER_ID, e.getUserId());
       assertExceptionInfo(CREATE.getName(), TENANT_MEMBERSHIP.resourceName(), "tenant1", info);
     }
   }
@@ -773,7 +773,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     authorizationService.saveAuthorization(basePerms);
 
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     try {
       identityService.createTenantGroupMembership("tenant1", "group1");
@@ -782,7 +782,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(USER_ID, e.getUserId());
       assertExceptionInfo(CREATE.getName(), TENANT_MEMBERSHIP.resourceName(), "tenant1", info);
     }
   }
@@ -805,7 +805,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     authorizationService.saveAuthorization(basePerms);
 
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     try {
       identityService.deleteTenantUserMembership("tenant1", "jonny1");
@@ -814,7 +814,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(USER_ID, e.getUserId());
       assertExceptionInfo(DELETE.getName(), TENANT_MEMBERSHIP.resourceName(), "tenant1", info);
     }
   }
@@ -837,7 +837,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     authorizationService.saveAuthorization(basePerms);
 
     processEngineConfiguration.setAuthorizationEnabled(true);
-    identityService.setAuthenticatedUserId(jonny2);
+    identityService.setAuthenticatedUserId(USER_ID);
 
     try {
       identityService.deleteTenantGroupMembership("tenant1", "group1");
@@ -846,7 +846,7 @@ public class IdentityServiceAuthorizationsTest extends PluggableProcessEngineTes
     } catch (AuthorizationException e) {
       assertEquals(1, e.getMissingAuthorizations().size());
       MissingAuthorization info = e.getMissingAuthorizations().get(0);
-      assertEquals(jonny2, e.getUserId());
+      assertEquals(USER_ID, e.getUserId());
       assertExceptionInfo(DELETE.getName(), TENANT_MEMBERSHIP.resourceName(), "tenant1", info);
     }
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyTaskServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyTaskServiceTest.java
@@ -38,15 +38,15 @@ import org.junit.Test;
  */
 public class MultiTenancyTaskServiceTest extends PluggableProcessEngineTest {
 
-  private static final String tenant1 = "the-tenant-1";
-  private static final String tenant2 = "the-tenant-2";
+  private static final String TENANT_1 = "the-tenant-1";
+  private static final String TENANT_2 = "the-tenant-2";
 
   @Test
   public void testStandaloneTaskCreateWithTenantId() {
 
     // given a transient task with tenant id
     Task task = taskService.newTask();
-    task.setTenantId(tenant1);
+    task.setTenantId(TENANT_1);
 
     // if
     // it is saved
@@ -55,7 +55,7 @@ public class MultiTenancyTaskServiceTest extends PluggableProcessEngineTest {
     // then
     // when I load it, the tenant id is preserved
     task = taskService.createTaskQuery().taskId(task.getId()).singleResult();
-    assertEquals(tenant1, task.getTenantId());
+    assertEquals(TENANT_1, task.getTenantId());
 
     // Finally, delete task
     deleteTasks(task);
@@ -71,7 +71,7 @@ public class MultiTenancyTaskServiceTest extends PluggableProcessEngineTest {
 
     // if
     // change the tenant id
-    task.setTenantId(tenant1);
+    task.setTenantId(TENANT_1);
 
     // then
     // an exception is thrown on 'save'
@@ -92,13 +92,13 @@ public class MultiTenancyTaskServiceTest extends PluggableProcessEngineTest {
 
     // given a persistent task with tenant id
     Task task = taskService.newTask();
-    task.setTenantId(tenant1);
+    task.setTenantId(TENANT_1);
     taskService.saveTask(task);
     task = taskService.createTaskQuery().singleResult();
 
     // if
     // change the tenant id
-    task.setTenantId(tenant2);
+    task.setTenantId(TENANT_2);
 
     // then
     // an exception is thrown on 'save'
@@ -119,14 +119,14 @@ public class MultiTenancyTaskServiceTest extends PluggableProcessEngineTest {
 
     // given a persistent task with a tenant id
     Task task = taskService.newTask();
-    task.setTenantId(tenant1);
+    task.setTenantId(TENANT_1);
     taskService.saveTask(task);
 
     // if
     // I create a subtask with a different tenant id
     Task subTask = taskService.newTask();
     subTask.setParentTaskId(task.getId());
-    subTask.setTenantId(tenant2);
+    subTask.setTenantId(TENANT_2);
 
     // then an exception is thrown on save
     try {
@@ -151,7 +151,7 @@ public class MultiTenancyTaskServiceTest extends PluggableProcessEngineTest {
     // I create a subtask with a different tenant id
     Task subTask = taskService.newTask();
     subTask.setParentTaskId(task.getId());
-    subTask.setTenantId(tenant1);
+    subTask.setTenantId(TENANT_1);
 
     // then an exception is thrown on save
     try {
@@ -170,7 +170,7 @@ public class MultiTenancyTaskServiceTest extends PluggableProcessEngineTest {
 
     // given a persistent task with a tenant id
     Task task = taskService.newTask();
-    task.setTenantId(tenant1);
+    task.setTenantId(TENANT_1);
     taskService.saveTask(task);
 
     // if
@@ -182,7 +182,7 @@ public class MultiTenancyTaskServiceTest extends PluggableProcessEngineTest {
     // then
     // the parent task's tenant id is propagated to the sub task
     subTask = taskService.createTaskQuery().taskId(subTask.getId()).singleResult();
-    assertEquals(tenant1, subTask.getTenantId());
+    assertEquals(TENANT_1, subTask.getTenantId());
 
     // Finally, delete task
     deleteTasks(subTask, task);
@@ -192,7 +192,7 @@ public class MultiTenancyTaskServiceTest extends PluggableProcessEngineTest {
   public void testStandaloneTaskPropagatesTenantIdToVariableInstance() {
     // given a task with tenant id
     Task task = taskService.newTask();
-    task.setTenantId(tenant1);
+    task.setTenantId(TENANT_1);
     taskService.saveTask(task);
 
     // if we set a variable for the task
@@ -201,7 +201,7 @@ public class MultiTenancyTaskServiceTest extends PluggableProcessEngineTest {
     // then a variable instance with the same tenant id is created
     VariableInstance variableInstance = runtimeService.createVariableInstanceQuery().singleResult();
     assertThat(variableInstance).isNotNull();
-    assertThat(variableInstance.getTenantId()).isEqualTo(tenant1);
+    assertThat(variableInstance.getTenantId()).isEqualTo(TENANT_1);
 
     deleteTasks(task);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricIdentityLinkLogsForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetHistoricIdentityLinkLogsForOptimizeTest.java
@@ -57,9 +57,9 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
 
   private OptimizeService optimizeService;
 
-  protected static final String userId = "testUser";
-  protected static final String assignerId = "testAssigner";
-  protected static final String groupId = "testGroup";
+  protected static final String USER_ID = "testUser";
+  protected static final String ASSIGNER_ID = "testAssigner";
+  protected static final String GROUP_ID = "testGroup";
 
   private IdentityService identityService;
   private RuntimeService runtimeService;
@@ -77,9 +77,9 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
     authorizationService = engineRule.getAuthorizationService();
     taskService = engineRule.getTaskService();
 
-    createUser(userId);
+    createUser(USER_ID);
     createGroup();
-    identityService.setAuthenticatedUserId(userId);
+    identityService.setAuthenticatedUserId(USER_ID);
   }
 
   @After
@@ -109,8 +109,8 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
     testHelper.deploy(simpleDefinition);
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
     String taskId = taskService.createTaskQuery().singleResult().getId();
-    identityService.setAuthenticatedUserId(assignerId);
-    taskService.addCandidateUser(taskId, userId);
+    identityService.setAuthenticatedUserId(ASSIGNER_ID);
+    taskService.addCandidateUser(taskId, USER_ID);
 
     // when
     List<OptimizeHistoricIdentityLinkLogEntity> identityLinkLogs =
@@ -133,19 +133,19 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
     testHelper.deploy(simpleDefinition);
     runtimeService.startProcessInstanceByKey("process");
     String taskId = taskService.createTaskQuery().singleResult().getId();
-    identityService.setAuthenticatedUserId(assignerId);
+    identityService.setAuthenticatedUserId(ASSIGNER_ID);
     Date now = new Date();
     ClockUtil.setCurrentTime(now);
-    taskService.addCandidateUser(taskId, userId);
+    taskService.addCandidateUser(taskId, USER_ID);
     Date nowPlus2Seconds = new Date(now.getTime() + 2000L);
     ClockUtil.setCurrentTime(nowPlus2Seconds);
-    taskService.deleteCandidateUser(taskId, userId);
+    taskService.deleteCandidateUser(taskId, USER_ID);
     Date nowPlus4Seconds = new Date(now.getTime() + 4000L);
     ClockUtil.setCurrentTime(nowPlus4Seconds);
-    taskService.addCandidateGroup(taskId, groupId);
+    taskService.addCandidateGroup(taskId, GROUP_ID);
     Date nowPlus6Seconds = new Date(now.getTime() + 6000L);
     ClockUtil.setCurrentTime(nowPlus6Seconds);
-    taskService.deleteCandidateGroup(taskId, groupId);
+    taskService.deleteCandidateGroup(taskId, GROUP_ID);
     Date nowPlus8Seconds = new Date(now.getTime() + 8000L);
     ClockUtil.setCurrentTime(nowPlus8Seconds);
 
@@ -155,16 +155,16 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
 
     // then
     assertThat(identityLinkLogs).hasSize(4);
-    assertThat(identityLinkLogs.get(0).getUserId()).isEqualTo(userId);
+    assertThat(identityLinkLogs.get(0).getUserId()).isEqualTo(USER_ID);
     assertThat(identityLinkLogs.get(0).getOperationType()).isEqualTo(IDENTITY_LINK_ADD);
     assertThat(identityLinkLogs.get(0).getType()).isEqualTo(IdentityLinkType.CANDIDATE);
-    assertThat(identityLinkLogs.get(1).getUserId()).isEqualTo(userId);
+    assertThat(identityLinkLogs.get(1).getUserId()).isEqualTo(USER_ID);
     assertThat(identityLinkLogs.get(1).getOperationType()).isEqualTo(IDENTITY_LINK_DELETE);
     assertThat(identityLinkLogs.get(1).getType()).isEqualTo(IdentityLinkType.CANDIDATE);
-    assertThat(identityLinkLogs.get(2).getGroupId()).isEqualTo(groupId);
+    assertThat(identityLinkLogs.get(2).getGroupId()).isEqualTo(GROUP_ID);
     assertThat(identityLinkLogs.get(2).getOperationType()).isEqualTo(IDENTITY_LINK_ADD);
     assertThat(identityLinkLogs.get(2).getType()).isEqualTo(IdentityLinkType.CANDIDATE);
-    assertThat(identityLinkLogs.get(3).getGroupId()).isEqualTo(groupId);
+    assertThat(identityLinkLogs.get(3).getGroupId()).isEqualTo(GROUP_ID);
     assertThat(identityLinkLogs.get(3).getOperationType()).isEqualTo(IDENTITY_LINK_DELETE);
     assertThat(identityLinkLogs.get(3).getType()).isEqualTo(IdentityLinkType.CANDIDATE);
   }
@@ -180,7 +180,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
       .done();
     testHelper.deploy(simpleDefinition);
     runtimeService.startProcessInstanceByKey("process");
-    identityService.setAuthenticatedUserId(assignerId);
+    identityService.setAuthenticatedUserId(ASSIGNER_ID);
     Date now = new Date();
     ClockUtil.setCurrentTime(now);
     claimAllUserTasks();
@@ -194,10 +194,10 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
 
     // then
     assertThat(identityLinkLogs).hasSize(2);
-    assertThat(identityLinkLogs.get(0).getUserId()).isEqualTo(userId);
+    assertThat(identityLinkLogs.get(0).getUserId()).isEqualTo(USER_ID);
     assertThat(identityLinkLogs.get(0).getOperationType()).isEqualTo(IDENTITY_LINK_ADD);
     assertThat(identityLinkLogs.get(0).getType()).isEqualTo(IdentityLinkType.ASSIGNEE);
-    assertThat(identityLinkLogs.get(1).getUserId()).isEqualTo(userId);
+    assertThat(identityLinkLogs.get(1).getUserId()).isEqualTo(USER_ID);
     assertThat(identityLinkLogs.get(1).getOperationType()).isEqualTo(IDENTITY_LINK_DELETE);
     assertThat(identityLinkLogs.get(0).getType()).isEqualTo(IdentityLinkType.ASSIGNEE);
   }
@@ -208,7 +208,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
     BpmnModelInstance simpleDefinition = Bpmn.createExecutableProcess("process")
       .startEvent()
       .userTask("userTask")
-        .operatonAssignee(userId)
+        .operatonAssignee(USER_ID)
       .endEvent()
       .done();
     testHelper.deploy(simpleDefinition);
@@ -216,15 +216,15 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
     String taskId = taskService.createTaskQuery().singleResult().getId();
     Date now = new Date();
     ClockUtil.setCurrentTime(now);
-    taskService.addCandidateUser(taskId, userId);
+    taskService.addCandidateUser(taskId, USER_ID);
 
     Date nowPlus2Seconds = new Date(now.getTime() + 2000L);
     ClockUtil.setCurrentTime(nowPlus2Seconds);
-    taskService.deleteCandidateUser(taskId, userId);
+    taskService.deleteCandidateUser(taskId, USER_ID);
 
     Date nowPlus4Seconds = new Date(now.getTime() + 4000L);
     ClockUtil.setCurrentTime(nowPlus4Seconds);
-    taskService.addCandidateUser(taskId, userId);
+    taskService.addCandidateUser(taskId, USER_ID);
 
     // when
     List<OptimizeHistoricIdentityLinkLogEntity> identityLinkLogs =
@@ -247,15 +247,15 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
     String taskId = taskService.createTaskQuery().singleResult().getId();
     Date now = new Date();
     ClockUtil.setCurrentTime(now);
-    taskService.addCandidateUser(taskId, userId);
+    taskService.addCandidateUser(taskId, USER_ID);
 
     Date nowPlus2Seconds = new Date(now.getTime() + 2000L);
     ClockUtil.setCurrentTime(nowPlus2Seconds);
-    taskService.deleteCandidateUser(taskId, userId);
+    taskService.deleteCandidateUser(taskId, USER_ID);
 
     Date nowPlus4Seconds = new Date(now.getTime() + 4000L);
     ClockUtil.setCurrentTime(nowPlus4Seconds);
-    taskService.addCandidateUser(taskId, userId);
+    taskService.addCandidateUser(taskId, USER_ID);
 
     // when
     List<OptimizeHistoricIdentityLinkLogEntity> identityLinkLogs =
@@ -278,15 +278,15 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
     String taskId = taskService.createTaskQuery().singleResult().getId();
     Date now = new Date();
     ClockUtil.setCurrentTime(now);
-    taskService.addCandidateUser(taskId, userId);
+    taskService.addCandidateUser(taskId, USER_ID);
 
     Date nowPlus2Seconds = new Date(now.getTime() + 2000L);
     ClockUtil.setCurrentTime(nowPlus2Seconds);
-    taskService.deleteCandidateUser(taskId, userId);
+    taskService.deleteCandidateUser(taskId, USER_ID);
 
     Date nowPlus4Seconds = new Date(now.getTime() + 4000L);
     ClockUtil.setCurrentTime(nowPlus4Seconds);
-    taskService.addCandidateUser(taskId, userId);
+    taskService.addCandidateUser(taskId, USER_ID);
 
     // when
     List<OptimizeHistoricIdentityLinkLogEntity> identityLinkLogs =
@@ -307,11 +307,11 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
     testHelper.deploy(simpleDefinition);
     runtimeService.startProcessInstanceByKey("process");
     String taskId = taskService.createTaskQuery().singleResult().getId();
-    taskService.addCandidateUser(taskId, userId);
-    taskService.deleteCandidateUser(taskId, userId);
-    taskService.addCandidateUser(taskId, userId);
-    taskService.deleteCandidateUser(taskId, userId);
-    taskService.addCandidateUser(taskId, userId);
+    taskService.addCandidateUser(taskId, USER_ID);
+    taskService.deleteCandidateUser(taskId, USER_ID);
+    taskService.addCandidateUser(taskId, USER_ID);
+    taskService.deleteCandidateUser(taskId, USER_ID);
+    taskService.addCandidateUser(taskId, USER_ID);
 
     // when
     List<OptimizeHistoricIdentityLinkLogEntity> identityLinkLogs =
@@ -334,15 +334,15 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
     String taskId = taskService.createTaskQuery().singleResult().getId();
     Date now = new Date();
     ClockUtil.setCurrentTime(now);
-    taskService.addCandidateUser(taskId, userId);
+    taskService.addCandidateUser(taskId, USER_ID);
 
     Date nowPlus2Seconds = new Date(now.getTime() + 2000L);
     ClockUtil.setCurrentTime(nowPlus2Seconds);
-    taskService.deleteCandidateUser(taskId, userId);
+    taskService.deleteCandidateUser(taskId, USER_ID);
 
     Date nowPlus4Seconds = new Date(now.getTime() + 4000L);
     ClockUtil.setCurrentTime(nowPlus4Seconds);
-    taskService.addCandidateUser(taskId, userId);
+    taskService.addCandidateUser(taskId, USER_ID);
 
     // when
     List<OptimizeHistoricIdentityLinkLogEntity> identityLinkLogs =
@@ -362,7 +362,7 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
   private void claimAllUserTasks() {
     List<Task> list = taskService.createTaskQuery().list();
     for (Task task : list) {
-      taskService.claim(task.getId(), userId);
+      taskService.claim(task.getId(), USER_ID);
     }
   }
 
@@ -379,17 +379,17 @@ public class GetHistoricIdentityLinkLogsForOptimizeTest {
   }
 
   protected void createGroup() {
-    Group group = identityService.newGroup(GetHistoricIdentityLinkLogsForOptimizeTest.groupId);
+    Group group = identityService.newGroup(GetHistoricIdentityLinkLogsForOptimizeTest.GROUP_ID);
     identityService.saveGroup(group);
   }
 
   private void assertThatIdentityLinksHaveAllImportantInformation(OptimizeHistoricIdentityLinkLogEntity identityLinkLog,
                                                                   ProcessInstance processInstance) {
     assertThat(identityLinkLog).isNotNull();
-    assertThat(identityLinkLog.getUserId()).isEqualTo(userId);
+    assertThat(identityLinkLog.getUserId()).isEqualTo(USER_ID);
     assertThat(identityLinkLog.getTaskId()).isEqualTo(taskService.createTaskQuery().singleResult().getId());
     assertThat(identityLinkLog.getType()).isEqualTo(IdentityLinkType.CANDIDATE);
-    assertThat(identityLinkLog.getAssignerId()).isEqualTo(assignerId);
+    assertThat(identityLinkLog.getAssignerId()).isEqualTo(ASSIGNER_ID);
     assertThat(identityLinkLog.getGroupId()).isNull();
     assertThat(identityLinkLog.getOperationType()).isEqualTo(IDENTITY_LINK_ADD);
     assertThat(identityLinkLog.getProcessDefinitionId()).isEqualTo(processInstance.getProcessDefinitionId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/diagram/ProcessDiagramParseTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/diagram/ProcessDiagramParseTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
  */
 public class ProcessDiagramParseTest {
 
-  private static final String resourcePath = "src/test/resources/org/operaton/bpm/engine/test/api/repository/diagram/testXxeParsingIsDisabled";
+  private static final String RESOURCE_PATH = "src/test/resources/org/operaton/bpm/engine/test/api/repository/diagram/testXxeParsingIsDisabled";
 
   @Rule
   public ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
@@ -60,8 +60,8 @@ public class ProcessDiagramParseTest {
   @Test
   public void testXxeParsingIsDisabled() {
     processEngineConfiguration.setEnableXxeProcessing(false);
-    final InputStream bpmnXmlStream = getResourceInputStream(resourcePath + ".bpmn20.xml");
-    final InputStream imageStream = getResourceInputStream(resourcePath + ".png");
+    final InputStream bpmnXmlStream = getResourceInputStream(RESOURCE_PATH + ".bpmn20.xml");
+    final InputStream imageStream = getResourceInputStream(RESOURCE_PATH + ".png");
     assertNotNull(bpmnXmlStream);
     var processEngineConfigurationImpl = engineRule.getProcessEngineConfiguration()
         .getCommandExecutorTxRequired();
@@ -81,8 +81,8 @@ public class ProcessDiagramParseTest {
   @Test
   public void testXxeParsingIsEnabled() {
     processEngineConfiguration.setEnableXxeProcessing(true);
-    final InputStream bpmnXmlStream = getResourceInputStream(resourcePath + ".bpmn20.xml");
-    final InputStream imageStream = getResourceInputStream(resourcePath + ".png");
+    final InputStream bpmnXmlStream = getResourceInputStream(RESOURCE_PATH + ".bpmn20.xml");
+    final InputStream imageStream = getResourceInputStream(RESOURCE_PATH + ".png");
     assertNotNull(bpmnXmlStream);
     var processEngineConfigurationImpl = engineRule.getProcessEngineConfiguration()
         .getCommandExecutorTxRequired();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIdentityLinkLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIdentityLinkLogQueryTest.java
@@ -47,7 +47,7 @@ import org.junit.Test;
 public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest {
   private static final String A_USER_ID = "aUserId";
   private static final String A_GROUP_ID = "aGroupId";
-  private static final int numberOfUsers = 3;
+  private static final int NUMBER_OF_USERS = 3;
   private static final String A_ASSIGNER_ID = "aAssignerId";
 
   private static final String INVALID_USER_ID = "InvalidUserId";
@@ -60,8 +60,8 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
   private static final String INVALID_PROCESS_DEFINITION_KEY = "InvalidProcessDefinitionKey";
   private static final String GROUP_1 = "Group1";
   private static final String USER_1 = "User1";
-  private static String PROCESS_DEFINITION_KEY = "oneTaskProcess";
-  private static String PROCESS_DEFINITION_KEY_MULTIPLE_CANDIDATE_USER = "oneTaskProcessForHistoricIdentityLinkWithMultipleCanidateUser";
+  private static final String PROCESS_DEFINITION_KEY = "oneTaskProcess";
+  private static final String PROCESS_DEFINITION_KEY_MULTIPLE_CANDIDATE_USER = "oneTaskProcessForHistoricIdentityLinkWithMultipleCanidateUser";
   private static final String IDENTITY_LINK_ADD="add";
   private static final String IDENTITY_LINK_DELETE="delete";
 
@@ -89,7 +89,7 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
     assertNull(historicIdentityLink.getGroupId());
     assertEquals(IDENTITY_LINK_ADD, historicIdentityLink.getOperationType());
     assertEquals(historicIdentityLink.getProcessDefinitionId(), processInstance.getProcessDefinitionId());
-    assertEquals(historicIdentityLink.getProcessDefinitionKey(), PROCESS_DEFINITION_KEY);
+    assertEquals(PROCESS_DEFINITION_KEY, historicIdentityLink.getProcessDefinitionKey());
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
@@ -116,7 +116,7 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
     assertEquals(A_GROUP_ID, historicIdentityLink.getGroupId());
     assertEquals(IDENTITY_LINK_ADD, historicIdentityLink.getOperationType());
     assertEquals(historicIdentityLink.getProcessDefinitionId(), processInstance.getProcessDefinitionId());
-    assertEquals(historicIdentityLink.getProcessDefinitionKey(), PROCESS_DEFINITION_KEY);
+    assertEquals(PROCESS_DEFINITION_KEY, historicIdentityLink.getProcessDefinitionKey());
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
@@ -414,12 +414,12 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
   }
 
   public void addUserIdentityLinks(String taskId) {
-    for (int userIndex = 1; userIndex <= numberOfUsers; userIndex++)
+    for (int userIndex = 1; userIndex <= NUMBER_OF_USERS; userIndex++)
       taskService.addUserIdentityLink(taskId, A_USER_ID + userIndex, IdentityLinkType.ASSIGNEE);
   }
 
   public void deleteUserIdentityLinks(String taskId) {
-    for (int userIndex = 1; userIndex <= numberOfUsers; userIndex++)
+    for (int userIndex = 1; userIndex <= NUMBER_OF_USERS; userIndex++)
       taskService.deleteUserIdentityLink(taskId, A_USER_ID + userIndex, IdentityLinkType.ASSIGNEE);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIdentityLinkLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIdentityLinkLogTest.java
@@ -45,11 +45,11 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
   private static final String A_USER_ID = "aUserId";
   private static final String B_USER_ID = "bUserId";
   private static final String C_USER_ID = "cUserId";
-  private static final int numberOfUsers = 3;
+  private static final int NUMBER_OF_USERS = 3;
   private static final String A_GROUP_ID = "aGroupId";
   private static final String INVALID_USER_ID = "InvalidUserId";
   private static final String A_ASSIGNER_ID = "aAssignerId";
-  private static String PROCESS_DEFINITION_KEY = "oneTaskProcess";
+  private static final String PROCESS_DEFINITION_KEY = "oneTaskProcess";
   private static final String GROUP_1 = "Group1";
   private static final String USER_1 = "User1";
   private static final String OWNER_1 = "Owner1";
@@ -442,12 +442,12 @@ public class HistoricIdentityLinkLogTest extends PluggableProcessEngineTest {
   }
 
   public void addUserIdentityLinks(String taskId) {
-    for (int userIndex = 1; userIndex <= numberOfUsers; userIndex++)
+    for (int userIndex = 1; userIndex <= NUMBER_OF_USERS; userIndex++)
       taskService.addUserIdentityLink(taskId, A_USER_ID + userIndex, IdentityLinkType.OWNER);
   }
 
   public void deleteUserIdentityLinks(String taskId) {
-    for (int userIndex = 1; userIndex <= numberOfUsers; userIndex++)
+    for (int userIndex = 1; userIndex <= NUMBER_OF_USERS; userIndex++)
       taskService.deleteUserIdentityLink(taskId, A_USER_ID + userIndex, IdentityLinkType.OWNER);
   }
 

--- a/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomXPathScriptTest.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomXPathScriptTest.java
@@ -35,15 +35,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 public abstract class XmlDomXPathScriptTest extends ScriptTest {
 
-  private static final String xml = "<root><child id=\"child\"><a id=\"a\"/><b id=\"b\"/><a id=\"c\"/></child></root>";
-  private static final String xmlWithNamespace = "<root xmlns:bar=\"http://operaton.org\" xmlns:foo=\"http://operaton.com\"><foo:child id=\"child\"><bar:a id=\"a\"/><foo:b id=\"b\"/><a id=\"c\"/></foo:child></root>";
-  private static final String xmlWithDefaultNamespace = "<root xmlns=\"http://operaton.com/example\" xmlns:bar=\"http://operaton.org\" xmlns:foo=\"http://operaton.com\"><foo:child id=\"child\"><bar:a id=\"a\"/><foo:b id=\"b\"/><a id=\"c\"/></foo:child></root>";
+  private static final String XML = "<root><child id=\"child\"><a id=\"a\"/><b id=\"b\"/><a id=\"c\"/></child></root>";
+  private static final String XML_WITH_NAMESPACE = "<root xmlns:bar=\"http://operaton.org\" xmlns:foo=\"http://operaton.com\"><foo:child id=\"child\"><bar:a id=\"a\"/><foo:b id=\"b\"/><a id=\"c\"/></foo:child></root>";
+  private static final String XML_WITH_DEFAULT_NAMESPACE = "<root xmlns=\"http://operaton.com/example\" xmlns:bar=\"http://operaton.org\" xmlns:foo=\"http://operaton.com\"><foo:child id=\"child\"><bar:a id=\"a\"/><foo:b id=\"b\"/><a id=\"c\"/></foo:child></root>";
 
   @Test
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
-        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "input", value = XML),
         @ScriptVariable(name = "expression", value = "/")
       }
     )
@@ -56,7 +56,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
-        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "input", value = XML),
         @ScriptVariable(name = "expression", value = "/")
       }
     )
@@ -69,7 +69,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
-        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "input", value = XML),
         @ScriptVariable(name = "expression", value = "/")
       }
     )
@@ -82,7 +82,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
-        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "input", value = XML),
         @ScriptVariable(name = "expression", value = "/")
       }
     )
@@ -95,7 +95,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
-        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "input", value = XML),
         @ScriptVariable(name = "expression", value = "/")
       }
     )
@@ -108,7 +108,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
-        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "input", value = XML),
         @ScriptVariable(name = "expression", value = "/")
       }
     )
@@ -121,7 +121,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
-        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "input", value = XML),
         @ScriptVariable(name = "expression", value = "/")
       }
     )
@@ -134,7 +134,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
-      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "input", value = XML),
       @ScriptVariable(name = "expression", value = "/root/child")
     }
   )
@@ -149,7 +149,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
-        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "input", value = XML),
         @ScriptVariable(name = "expression", value = "/root/nonExisting")
       }
     )
@@ -162,7 +162,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
-      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "input", value = XML),
       @ScriptVariable(name = "expression", value = "/root/child")
     }
   )
@@ -175,7 +175,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
-      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "input", value = XML),
       @ScriptVariable(name = "expression", value = "/root/child/a")
     }
   )
@@ -189,7 +189,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
-        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "input", value = XML),
         @ScriptVariable(name = "expression", value = "/root/child/nonExisting")
       }
     )
@@ -202,7 +202,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
-      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "input", value = XML),
       @ScriptVariable(name = "expression", value = "/root/child/@id")
     }
   )
@@ -216,7 +216,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
-        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "input", value = XML),
         @ScriptVariable(name = "expression", value = "/root/child/@nonExisting")
       }
     )
@@ -229,7 +229,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
-      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "input", value = XML),
       @ScriptVariable(name = "expression", value = "/root/child/@id")
     }
   )
@@ -242,7 +242,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
-      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "input", value = XML),
       @ScriptVariable(name = "expression", value = "/root/child/a/@id")
     }
   )
@@ -256,7 +256,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
       name = "XmlDomXPathScriptTest.xPath",
       variables = {
-        @ScriptVariable(name = "input", value = xml),
+        @ScriptVariable(name = "input", value = XML),
         @ScriptVariable(name = "expression", value = "/root/child/a/@nonExisting")
       }
     )
@@ -269,7 +269,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
-      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "input", value = XML),
       @ScriptVariable(name = "expression", value = "string(/root/child/@id)")
     }
   )
@@ -283,7 +283,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
-      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "input", value = XML),
       @ScriptVariable(name = "expression", value = "string(/root/child/@nonExisting)")
     }
   )
@@ -297,7 +297,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
-      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "input", value = XML),
       @ScriptVariable(name = "expression", value = "string(/)")
     }
   )
@@ -311,7 +311,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
-      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "input", value = XML),
       @ScriptVariable(name = "expression", value = "count(/root/child/a)")
     }
   )
@@ -325,7 +325,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
-      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "input", value = XML),
       @ScriptVariable(name = "expression", value = "count(/root/child/nonExisting)")
     }
   )
@@ -339,7 +339,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
-      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "input", value = XML),
       @ScriptVariable(name = "expression", value = "count(/)")
     }
   )
@@ -353,7 +353,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
-      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "input", value = XML),
       @ScriptVariable(name = "expression", value = "boolean(/root/child)")
     }
   )
@@ -367,7 +367,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
-      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "input", value = XML),
       @ScriptVariable(name = "expression", value = "boolean(/root/nonExisting)")
     }
   )
@@ -381,7 +381,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.xPath",
     variables = {
-      @ScriptVariable(name = "input", value = xml),
+      @ScriptVariable(name = "input", value = XML),
       @ScriptVariable(name = "expression", value = "boolean(/)")
     }
   )
@@ -395,7 +395,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.canQueryElementWithNamespace",
     variables = {
-      @ScriptVariable(name = "input", value = xmlWithNamespace),
+      @ScriptVariable(name = "input", value = XML_WITH_NAMESPACE),
       @ScriptVariable(name = "expression", value = "/root/a:child")
     }
   )
@@ -411,7 +411,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Test
   @Script(
     variables = {
-      @ScriptVariable(name = "input", value = xmlWithNamespace),
+      @ScriptVariable(name = "input", value = XML_WITH_NAMESPACE),
       @ScriptVariable(name = "expression", value = "/root/a:child")
     }
   )
@@ -428,7 +428,7 @@ public abstract class XmlDomXPathScriptTest extends ScriptTest {
   @Script(
     name = "XmlDomXPathScriptTest.canQueryElementWithNamespace",
     variables = {
-      @ScriptVariable(name = "input", value = xmlWithDefaultNamespace),
+      @ScriptVariable(name = "input", value = XML_WITH_DEFAULT_NAMESPACE),
       @ScriptVariable(name = "expression", value = "/:root/a:child")
     }
   )


### PR DESCRIPTION
Resolve Sonar warnings of type java:S115: Constant names should comply with a naming convention

related to #88