### PR TITLE
refactor: Extract method calls in try-blocks within tests to variables

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceTest.java
@@ -295,8 +295,10 @@ public class HistoryServiceTest extends PluggableProcessEngineTest {
 
   @Test
   public void testHistoricProcessInstanceQueryByProcessInstanceIdsEmpty() {
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
+    var processInstanceIds = new HashSet<String>();
     try {
-      historyService.createHistoricProcessInstanceQuery().processInstanceIds(new HashSet<>());
+      historicProcessInstanceQuery.processInstanceIds(processInstanceIds);
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException re) {
       testRule.assertTextPresent("Set of process instance ids is empty", re.getMessage());
@@ -305,8 +307,9 @@ public class HistoryServiceTest extends PluggableProcessEngineTest {
 
   @Test
   public void testHistoricProcessInstanceQueryByProcessInstanceIdsNull() {
+    var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
     try {
-      historyService.createHistoricProcessInstanceQuery().processInstanceIds(null);
+      historicProcessInstanceQuery.processInstanceIds(null);
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException re) {
       testRule.assertTextPresent("Set of process instance ids is null", re.getMessage());
@@ -347,11 +350,12 @@ public class HistoryServiceTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryByRootProcessInstancesAndSuperProcess() {
+    var historicProcessInstanceQuery1 = historyService.createHistoricProcessInstanceQuery()
+      .rootProcessInstances();
+
     // when
     try {
-      historyService.createHistoricProcessInstanceQuery()
-        .rootProcessInstances()
-        .superProcessInstanceId("processInstanceId");
+      historicProcessInstanceQuery1.superProcessInstanceId("processInstanceId");
 
       fail("expected exception");
     } catch (BadUserRequestException e) {
@@ -359,11 +363,11 @@ public class HistoryServiceTest extends PluggableProcessEngineTest {
       assertTrue(e.getMessage().contains("Invalid query usage: cannot set both rootProcessInstances and superProcessInstanceId"));
     }
 
+    var historicProcessInstanceQuery2 = historyService.createHistoricProcessInstanceQuery()
+      .superProcessInstanceId("processInstanceId");
     // when
     try {
-      historyService.createHistoricProcessInstanceQuery()
-        .superProcessInstanceId("processInstanceId")
-        .rootProcessInstances();
+      historicProcessInstanceQuery2.rootProcessInstances();
 
       fail("expected exception");
     } catch (BadUserRequestException e) {
@@ -752,8 +756,9 @@ public class HistoryServiceTest extends PluggableProcessEngineTest {
   public void testDeleteRunningProcessInstance() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(ONE_TASK_PROCESS);
     assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey(ONE_TASK_PROCESS).count());
+    var processInstanceId = processInstance.getId();
     try {
-      historyService.deleteHistoricProcessInstance(processInstance.getId());
+      historyService.deleteHistoricProcessInstance(processInstanceId);
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
       testRule.assertTextPresent("Process instance is still running, cannot delete historic process instance", ae.getMessage());
@@ -772,7 +777,7 @@ public class HistoryServiceTest extends PluggableProcessEngineTest {
 
   @Test
   public void testDeleteProcessInstanceIfExistsWithFake() {
-      assertThatCode(() -> historyService.deleteHistoricProcessInstanceIfExists("aFake")).doesNotThrowAnyException();
+    assertThatCode(() -> historyService.deleteHistoricProcessInstanceIfExists("aFake")).doesNotThrowAnyException();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DeleteProcessDefinitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DeleteProcessDefinitionTest.java
@@ -140,10 +140,11 @@ public class DeleteProcessDefinitionTest {
                                   .deploy();
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().processDefinitionKey("process").singleResult();
     runtimeService.createProcessInstanceByKey("process").executeWithVariablesInReturn();
+    var processDefinitionId = processDefinition.getId();
 
     //when the corresponding process definition is deleted from the deployment
     try {
-      repositoryService.deleteProcessDefinition(processDefinition.getId());
+      repositoryService.deleteProcessDefinition(processDefinitionId);
       fail("Should fail, since there exists a process instance");
     } catch (ProcessEngineException pex) {
       // then Exception is expected, the deletion should fail since there exist a process instance
@@ -289,10 +290,10 @@ public class DeleteProcessDefinitionTest {
   public void testDeleteProcessDefinitionsByNotExistingKey() {
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.deleteProcessDefinitions()
-        .byKey("no existing key")
-        .withoutTenantId()
-        .delete())
+    var deleteProcessDefinitionsBuilder = repositoryService.deleteProcessDefinitions()
+      .byKey("no existing key")
+      .withoutTenantId();
+    assertThatThrownBy(deleteProcessDefinitionsBuilder::delete)
       .isInstanceOf(NotFoundException.class)
       .hasMessageContaining("No process definition found");
   }
@@ -301,10 +302,10 @@ public class DeleteProcessDefinitionTest {
   public void testDeleteProcessDefinitionsByKeyIsNull() {
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.deleteProcessDefinitions()
-        .byKey(null)
-        .withoutTenantId()
-        .delete())
+    var deleteProcessDefinitionsBuilder = repositoryService.deleteProcessDefinitions()
+      .byKey(null)
+      .withoutTenantId();
+    assertThatThrownBy(deleteProcessDefinitionsBuilder::delete)
       .isInstanceOf(NullValueException.class)
       .hasMessageContaining("cannot be null");
 
@@ -334,12 +335,12 @@ public class DeleteProcessDefinitionTest {
       deployTwoProcessDefinitions();
     }
     runtimeService.startProcessInstanceByKey("processOne");
+    var deleteProcessDefinitionsBuilder = repositoryService.deleteProcessDefinitions()
+      .byKey("processOne")
+      .withoutTenantId();
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.deleteProcessDefinitions()
-        .byKey("processOne")
-        .withoutTenantId()
-        .delete())
+    assertThatThrownBy(deleteProcessDefinitionsBuilder::delete)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Deletion of process definition");
   }
@@ -428,22 +429,24 @@ public class DeleteProcessDefinitionTest {
 
   @Test
   public void testDeleteProcessDefinitionsByNotExistingIds() {
+    // given
+    var deleteProcessDefinitionsBuilder = repositoryService.deleteProcessDefinitions()
+      .byIds("not existing", "also not existing");
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.deleteProcessDefinitions()
-        .byIds("not existing", "also not existing")
-        .delete())
+    assertThatThrownBy(deleteProcessDefinitionsBuilder::delete)
       .isInstanceOf(NotFoundException.class)
       .hasMessageContaining("No process definition found");
   }
 
   @Test
   public void testDeleteProcessDefinitionsByIdIsNull() {
+    // given
+    var deleteProcessDefinitionsBuilder = repositoryService.deleteProcessDefinitions()
+      .byIds(null);
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.deleteProcessDefinitions()
-        .byIds(null)
-        .delete())
+    assertThatThrownBy(deleteProcessDefinitionsBuilder::delete)
       .isInstanceOf(NullValueException.class)
       .hasMessageContaining("cannot be null");
   }
@@ -474,12 +477,11 @@ public class DeleteProcessDefinitionTest {
     }
     String[] processDefinitionIds = findProcessDefinitionIdsByKey("processOne");
     runtimeService.startProcessInstanceByKey("processOne");
-
+    var deleteProcessDefinitionsBuilder = repositoryService.deleteProcessDefinitions()
+      .byIds(processDefinitionIds);
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.deleteProcessDefinitions()
-        .byIds(processDefinitionIds)
-        .delete())
+    assertThatThrownBy(deleteProcessDefinitionsBuilder::delete)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Deletion of process definition");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DeploymentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DeploymentQueryTest.java
@@ -81,7 +81,9 @@ public class DeploymentQueryTest extends PluggableProcessEngineTest {
     try {
       query.singleResult();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Query return 2 results instead of max 1", e.getMessage());
+    }
   }
 
   @Test
@@ -98,11 +100,14 @@ public class DeploymentQueryTest extends PluggableProcessEngineTest {
     assertNull(query.singleResult());
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
+    var deploymentQuery = repositoryService.createDeploymentQuery();
 
     try {
-      repositoryService.createDeploymentQuery().deploymentId(null);
+      deploymentQuery.deploymentId(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("Deployment id is null", e.getMessage());
+    }
   }
 
   @Test
@@ -119,11 +124,14 @@ public class DeploymentQueryTest extends PluggableProcessEngineTest {
     assertNull(query.singleResult());
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
+    var deploymentQuery = repositoryService.createDeploymentQuery();
 
     try {
-      repositoryService.createDeploymentQuery().deploymentName(null);
+      deploymentQuery.deploymentName(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("deploymentName is null", e.getMessage());
+    }
   }
 
   @Test
@@ -144,11 +152,14 @@ public class DeploymentQueryTest extends PluggableProcessEngineTest {
     assertNull(query.singleResult());
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
+    var deploymentQuery = repositoryService.createDeploymentQuery();
 
     try {
-      repositoryService.createDeploymentQuery().deploymentNameLike(null);
+      deploymentQuery.deploymentNameLike(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      assertEquals("deploymentNameLike is null", e.getMessage());
+    }
   }
 
   @Test
@@ -161,9 +172,10 @@ public class DeploymentQueryTest extends PluggableProcessEngineTest {
 
     count = repositoryService.createDeploymentQuery().deploymentBefore(earlier).count();
     assertEquals(0, count);
+    var deploymentQuery = repositoryService.createDeploymentQuery();
 
     try {
-      repositoryService.createDeploymentQuery().deploymentBefore(null);
+      deploymentQuery.deploymentBefore(null);
       fail("Exception expected");
     } catch (NullValueException e) {
       // expected
@@ -180,9 +192,10 @@ public class DeploymentQueryTest extends PluggableProcessEngineTest {
 
     count = repositoryService.createDeploymentQuery().deploymentAfter(earlier).count();
     assertEquals(2, count);
+    var deploymentQuery = repositoryService.createDeploymentQuery();
 
     try {
-      repositoryService.createDeploymentQuery().deploymentAfter(null);
+      deploymentQuery.deploymentAfter(null);
       fail("Exception expected");
     } catch (NullValueException e) {
       // expected

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RedeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RedeploymentTest.java
@@ -27,12 +27,7 @@ import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.engine.exception.NotFoundException;
 import org.operaton.bpm.engine.exception.NotValidException;
 import org.operaton.bpm.engine.query.Query;
-import org.operaton.bpm.engine.repository.Deployment;
-import org.operaton.bpm.engine.repository.DeploymentQuery;
-import org.operaton.bpm.engine.repository.ProcessApplicationDeployment;
-import org.operaton.bpm.engine.repository.ProcessDefinitionQuery;
-import org.operaton.bpm.engine.repository.Resource;
-import org.operaton.bpm.engine.repository.ResumePreviousBy;
+import org.operaton.bpm.engine.repository.*;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
@@ -85,57 +80,56 @@ public class RedeploymentTest {
 
   @Test
   public void testRedeployInvalidDeployment() {
-
+    var deploymentBuilder = repositoryService
+      .createDeployment()
+      .name(DEPLOYMENT_NAME)
+      .addDeploymentResources("not-existing");
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResources("not-existing")
-        .deploy();
+      deploymentBuilder.deploy();
       fail("It should not be able to re-deploy an unexisting deployment");
     } catch (NotFoundException e) {
       // expected
     }
 
+    var deploymentBuilder1 = repositoryService
+      .createDeployment()
+      .name(DEPLOYMENT_NAME)
+      .addDeploymentResourceById("not-existing", "an-id");
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourceById("not-existing", "an-id")
-        .deploy();
+      deploymentBuilder1.deploy();
       fail("It should not be able to re-deploy an unexisting deployment");
     } catch (NotFoundException e) {
       // expected
     }
 
+    var deploymentBuilder2 = repositoryService
+      .createDeployment()
+      .name(DEPLOYMENT_NAME)
+      .addDeploymentResourcesById("not-existing", Collections.singletonList("an-id"));
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourcesById("not-existing", Collections.singletonList("an-id"))
-        .deploy();
+      deploymentBuilder2.deploy();
       fail("It should not be able to re-deploy an unexisting deployment");
     } catch (NotFoundException e) {
       // expected
     }
 
+    var deploymentBuilder3 = repositoryService
+      .createDeployment()
+      .name(DEPLOYMENT_NAME)
+      .addDeploymentResourceByName("not-existing", "a-name");
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourceByName("not-existing", "a-name")
-        .deploy();
+      deploymentBuilder3.deploy();
       fail("It should not be able to re-deploy an unexisting deployment");
     } catch (NotFoundException e) {
       // expected
     }
 
+    var deploymentBuilder4 = repositoryService
+      .createDeployment()
+      .name(DEPLOYMENT_NAME)
+      .addDeploymentResourcesByName("not-existing", Collections.singletonList("a-name"));
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourcesByName("not-existing", Collections.singletonList("a-name"))
-        .deploy();
+      deploymentBuilder4.deploy();
       fail("It should not be able to re-deploy an unexisting deployment");
     } catch (NotFoundException e) {
       // expected
@@ -144,51 +138,41 @@ public class RedeploymentTest {
 
   @Test
   public void testNotValidDeploymentId() {
-    try {
-      repositoryService
+    var deploymentBuilder = repositoryService
         .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResources(null);
+        .name(DEPLOYMENT_NAME);
+    var resourceIdList = Collections.singletonList("a-name");
+
+    try {
+      deploymentBuilder.addDeploymentResources(null);
       fail("It should not be possible to pass a null deployment id");
     } catch (NotValidException e) {
       // expected
     }
 
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourceById(null, "an-id");
+      deploymentBuilder.addDeploymentResourceById(null, "an-id");
       fail("It should not be possible to pass a null deployment id");
     } catch (NotValidException e) {
       // expected
     }
 
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourcesById(null, Collections.singletonList("an-id"));
+      deploymentBuilder.addDeploymentResourcesById(null, resourceIdList);
       fail("It should not be possible to pass a null deployment id");
     } catch (NotValidException e) {
       // expected
     }
 
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourceByName(null, "a-name");
+      deploymentBuilder.addDeploymentResourceByName(null, "a-name");
       fail("It should not be possible to pass a null deployment id");
     } catch (NotValidException e) {
       // expected
     }
 
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourcesByName(null, Collections.singletonList("a-name"));
+      deploymentBuilder.addDeploymentResourcesByName(null, resourceIdList);
       fail("It should not be possible to pass a null deployment id");
     } catch (NotValidException e) {
       // expected
@@ -204,55 +188,42 @@ public class RedeploymentTest {
         .createDeployment()
         .name(DEPLOYMENT_NAME)
         .addModelInstance(RESOURCE_NAME, model));
-
-    try {
-      // when
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourceByName(deployment.getId(), "not-existing-resource.bpmn")
-        .deploy();
-      fail("It should not be possible to re-deploy a not existing deployment resource");
-    } catch (NotFoundException e) {
-      // then
-      // expected
-    }
-
-    try {
-      // when
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourcesByName(deployment.getId(),
-                                      Collections.singletonList("not-existing-resource.bpmn"))
-        .deploy();
-      fail("It should not be possible to re-deploy a not existing deployment resource");
-    } catch (NotFoundException e) {
-      // then
-      // expected
-    }
-
-    try {
-      // when
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourceById(deployment.getId(), "not-existing-resource-id")
-        .deploy();
-      fail("It should not be possible to re-deploy a not existing deployment resource");
-    } catch (NotFoundException e) {
-      // then
-      // expected
-    }
-
-    try {
-      // when
-      repositoryService
+    var deploymentBuilder = repositoryService
         .createDeployment()
         .name(DEPLOYMENT_NAME)
         .addDeploymentResourcesById(deployment.getId(), Collections.singletonList("not-existing" +
-                                                                                      "-resource-id"))
-        .deploy();
+                                                                                      "-resource-id"));
+
+    try {
+      // when
+      deploymentBuilder.deploy();
+      fail("It should not be possible to re-deploy a not existing deployment resource");
+    } catch (NotFoundException e) {
+      // then
+      // expected
+    }
+
+    try {
+      // when
+      deploymentBuilder.deploy();
+      fail("It should not be possible to re-deploy a not existing deployment resource");
+    } catch (NotFoundException e) {
+      // then
+      // expected
+    }
+
+    try {
+      // when
+      deploymentBuilder.deploy();
+      fail("It should not be possible to re-deploy a not existing deployment resource");
+    } catch (NotFoundException e) {
+      // then
+      // expected
+    }
+
+    try {
+      // when
+      deploymentBuilder.deploy();
       fail("It should not be possible to re-deploy a not existing deployment resource");
     } catch (NotFoundException e) {
       // then
@@ -262,81 +233,63 @@ public class RedeploymentTest {
 
   @Test
   public void testNotValidResource() {
-    try {
-      repositoryService
+    var deploymentBuilder = repositoryService
         .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourceById("an-id", null);
+        .name(DEPLOYMENT_NAME);
+    var listWithNullResourceId = Collections.<String>singletonList(null);
+
+    try {
+      deploymentBuilder.addDeploymentResourceById("an-id", null);
       fail("It should not be possible to pass a null resource id");
     } catch (NotValidException e) {
       // expected
     }
 
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourcesById("an-id", null);
+      deploymentBuilder.addDeploymentResourcesById("an-id", null);
       fail("It should not be possible to pass a null resource id");
     } catch (NotValidException e) {
       // expected
     }
 
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourcesById("an-id", Collections.singletonList(null));
+      deploymentBuilder.addDeploymentResourcesById("an-id", listWithNullResourceId);
+      fail("It should not be possible to pass a null resource id");
+    } catch (NotValidException e) {
+      // expected
+    }
+
+    ArrayList<String> emptyResourceIds = new ArrayList<>();
+    try {
+      deploymentBuilder.addDeploymentResourcesById("an-id", emptyResourceIds);
       fail("It should not be possible to pass a null resource id");
     } catch (NotValidException e) {
       // expected
     }
 
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourcesById("an-id", new ArrayList<>());
-      fail("It should not be possible to pass a null resource id");
-    } catch (NotValidException e) {
-      // expected
-    }
-
-    try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourceByName("an-id", null);
+      deploymentBuilder.addDeploymentResourceByName("an-id", null);
       fail("It should not be possible to pass a null resource name");
     } catch (NotValidException e) {
       // expected
     }
 
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourcesByName("an-id", null);
+      deploymentBuilder.addDeploymentResourcesByName("an-id", null);
       fail("It should not be possible to pass a null resource name");
     } catch (NotValidException e) {
       // expected
     }
 
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourcesByName("an-id", Collections.singletonList(null));
+      deploymentBuilder.addDeploymentResourcesByName("an-id", listWithNullResourceId);
       fail("It should not be possible to pass a null resource name");
     } catch (NotValidException e) {
       // expected
     }
 
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .addDeploymentResourcesByName("an-id", new ArrayList<>());
+      deploymentBuilder.addDeploymentResourcesByName("an-id", emptyResourceIds);
       fail("It should not be possible to pass a null resource name");
     } catch (NotValidException e) {
       // expected
@@ -374,21 +327,21 @@ public class RedeploymentTest {
 
   @Test
   public void testFailingDeploymentName() {
+    var deploymentBuilder = repositoryService
+      .createDeployment()
+      .name(DEPLOYMENT_NAME);
     try {
-      repositoryService
-        .createDeployment()
-        .name(DEPLOYMENT_NAME)
-        .nameFromDeployment("a-deployment-id");
+      deploymentBuilder.nameFromDeployment("a-deployment-id");
       fail("Cannot set name() and nameFromDeployment().");
     } catch (NotValidException e) {
       // expected
     }
 
+    var deploymentBuilder2 = repositoryService
+      .createDeployment()
+      .nameFromDeployment("a-deployment-id");
     try {
-      repositoryService
-        .createDeployment()
-        .nameFromDeployment("a-deployment-id")
-        .name(DEPLOYMENT_NAME);
+      deploymentBuilder2.name(DEPLOYMENT_NAME);
       fail("Cannot set name() and nameFromDeployment().");
     } catch (NotValidException e) {
       // expected
@@ -1315,15 +1268,15 @@ public class RedeploymentTest {
         .createDeployment()
         .name(DEPLOYMENT_NAME + "-2")
         .addModelInstance(RESOURCE_1_NAME, model2));
-
-    // when
-    try {
-      repositoryService
+    var deploymentBuilder = repositoryService
           .createDeployment()
           .name(DEPLOYMENT_NAME + "-3")
           .addDeploymentResources(deployment1.getId())
-          .addDeploymentResources(deployment2.getId())
-          .deploy();
+          .addDeploymentResources(deployment2.getId());
+
+    // when
+    try {
+      deploymentBuilder.deploy();
       fail("It should not be possible to deploy different resources with same name.");
     } catch (NotValidException e) {
       // expected
@@ -1342,14 +1295,14 @@ public class RedeploymentTest {
 
     // when
     BpmnModelInstance model2 = createProcessWithReceiveTask(PROCESS_2_KEY);
-
-    try {
-      repositoryService
+    var deploymentBuilder = repositoryService
         .createDeployment()
         .name(DEPLOYMENT_NAME + "-2")
         .addModelInstance(RESOURCE_1_NAME, model2)
-        .addDeploymentResourceByName(deployment1.getId(), RESOURCE_1_NAME)
-        .deploy();
+        .addDeploymentResourceByName(deployment1.getId(), RESOURCE_1_NAME);
+
+    try {
+      deploymentBuilder.deploy();
       fail("It should not be possible to deploy different resources with same name.");
     } catch (NotValidException e) {
       // expected

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
@@ -50,6 +50,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.*;
@@ -96,6 +97,7 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     taskService.deleteTasks(taskIds, true);
   }
 
+  @Test
   public void tesBasicTaskPropertiesNotNull() {
     Task task = taskService.createTaskQuery().taskId(taskIds.get(0)).singleResult();
     assertNotNull(task.getDescription());
@@ -147,9 +149,10 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     assertNull(query.singleResult());
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
+    var taskQuery = taskService.createTaskQuery();
 
     try {
-      taskService.createTaskQuery().taskId(null);
+      taskQuery.taskId(null);
       fail("expected exception");
     } catch (ProcessEngineException e) {
       // OK
@@ -176,9 +179,10 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     assertNull(query.singleResult());
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
+    var taskQuery = taskService.createTaskQuery().taskName(null);
 
     try {
-      taskService.createTaskQuery().taskName(null).singleResult();
+      taskQuery.singleResult();
       fail("expected exception");
     } catch (ProcessEngineException e) {
       // OK
@@ -199,11 +203,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     assertNull(query.singleResult());
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
+    var taskQuery = taskService.createTaskQuery().taskName(null);
 
     try {
-      taskService.createTaskQuery().taskName(null).singleResult();
+      taskQuery.singleResult();
       fail();
-    } catch (ProcessEngineException e) { }
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Test
@@ -215,7 +222,9 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     try {
       query.singleResult();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Test
@@ -224,12 +233,13 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     assertNull(query.singleResult());
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
+    var taskQuery = taskService.createTaskQuery();
 
     try {
-      taskService.createTaskQuery().taskDescription(null).list();
+      taskQuery.taskDescription(null);
       fail();
     } catch (ProcessEngineException e) {
-
+      // expected
     }
   }
 
@@ -294,12 +304,13 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     assertNull(query.singleResult());
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());
+    var taskQuery = taskService.createTaskQuery();
 
     try {
-      taskService.createTaskQuery().taskDescriptionLike(null).list();
+      taskQuery.taskDescriptionLike(null);
       fail();
     } catch (ProcessEngineException e) {
-
+      // expected
     }
   }
 
@@ -312,7 +323,9 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     try {
       query.singleResult();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
     query = taskService.createTaskQuery().taskPriority(100);
     assertNull(query.singleResult());
@@ -346,8 +359,9 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryByInvalidPriority() {
+    var taskQuery = taskService.createTaskQuery();
     try {
-      taskService.createTaskQuery().taskPriority(null);
+      taskQuery.taskPriority(null);
       fail("expected exception");
     } catch (ProcessEngineException e) {
       // OK
@@ -382,8 +396,9 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryByNullAssignee() {
+    var taskQuery = taskService.createTaskQuery();
     try {
-      taskService.createTaskQuery().taskAssignee(null).list();
+      taskQuery.taskAssignee(null);
       fail("expected exception");
     } catch (ProcessEngineException e) {
       // OK
@@ -567,16 +582,20 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryByNullCandidateUser() {
+    var taskQuery = taskService.createTaskQuery();
     try {
-      taskService.createTaskQuery().taskCandidateUser(null).list();
+      taskQuery.taskCandidateUser(null);
       fail();
-    } catch(ProcessEngineException e) {}
+    } catch(ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Test
   public void testQueryByIncludeAssignedTasksWithMissingCandidateUserOrGroup() {
+    var taskQuery = taskService.createTaskQuery();
     try {
-      taskService.createTaskQuery().includeAssignedTasks();
+      taskQuery.includeAssignedTasks();
       fail("expected exception");
     } catch (ProcessEngineException e) {
       // OK
@@ -779,8 +798,9 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryByNullCandidateGroup() {
+    var taskQuery = taskService.createTaskQuery();
     try {
-      taskService.createTaskQuery().taskCandidateGroup(null).list();
+      taskQuery.taskCandidateGroup(null);
       fail("expected exception");
     } catch (ProcessEngineException e) {
       // OK
@@ -875,14 +895,16 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryByNullCandidateGroupIn() {
+    var taskQuery = taskService.createTaskQuery();
     try {
-      taskService.createTaskQuery().taskCandidateGroupIn(null).list();
+      taskQuery.taskCandidateGroupIn(null);
       fail("expected exception");
     } catch (ProcessEngineException e) {
       // OK
     }
+    List<String> emptyGroupIds = emptyList();
     try {
-      taskService.createTaskQuery().taskCandidateGroupIn(new ArrayList<String>()).list();
+      taskQuery.taskCandidateGroupIn(emptyGroupIds);
       fail("expected exception");
     } catch (ProcessEngineException e) {
       // OK
@@ -1228,10 +1250,11 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
     assertEquals(0, taskService.createTaskQuery().taskVariableValueLike("stringVar", "stringVal").count());
     assertEquals(0, taskService.createTaskQuery().taskVariableValueLike("nonExistingVar", "string%").count());
+    var taskQuery = taskService.createTaskQuery();
 
     // test with null value
     try {
-      taskService.createTaskQuery().taskVariableValueLike("stringVar", null).count();
+      taskQuery.taskVariableValueLike("stringVar", null);
       fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
   }
@@ -1259,10 +1282,11 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
     assertEquals(0, taskService.createTaskQuery().matchVariableValuesIgnoreCase().taskVariableValueLike("stringVar", "stringVal".toLowerCase()).count());
     assertEquals(0, taskService.createTaskQuery().matchVariableValuesIgnoreCase().taskVariableValueLike("nonExistingVar", "stringVal%".toLowerCase()).count());
+    var taskQuery = taskService.createTaskQuery();
 
     // test with null value
     try {
-      taskService.createTaskQuery().taskVariableValueLike("stringVar", null).count();
+      taskQuery.taskVariableValueLike("stringVar", null);
       fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
   }
@@ -1273,6 +1297,7 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
   	ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
   	Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    var taskQuery = taskService.createTaskQuery();
 
   	Map<String, Object> variables = new HashMap<>();
   	variables.put("numericVar", 928374);
@@ -1284,97 +1309,109 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
   	taskService.setVariablesLocal(task.getId(), variables);
 
     // test compare methods with numeric values
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueGreaterThan("numericVar", 928373).count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueGreaterThan("numericVar", 928374).count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueGreaterThan("numericVar", 928375).count());
+    assertEquals(1, taskQuery.taskVariableValueGreaterThan("numericVar", 928373).count());
+    assertEquals(0, taskQuery.taskVariableValueGreaterThan("numericVar", 928374).count());
+    assertEquals(0, taskQuery.taskVariableValueGreaterThan("numericVar", 928375).count());
 
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueGreaterThanOrEquals("numericVar", 928373).count());
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueGreaterThanOrEquals("numericVar", 928374).count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueGreaterThanOrEquals("numericVar", 928375).count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.taskVariableValueGreaterThanOrEquals("numericVar", 928373).count());
+    assertEquals(1, taskQuery.taskVariableValueGreaterThanOrEquals("numericVar", 928374).count());
+    assertEquals(0, taskQuery.taskVariableValueGreaterThanOrEquals("numericVar", 928375).count());
 
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueLessThan("numericVar", 928375).count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueLessThan("numericVar", 928374).count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueLessThan("numericVar", 928373).count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.taskVariableValueLessThan("numericVar", 928375).count());
+    assertEquals(0, taskQuery.taskVariableValueLessThan("numericVar", 928374).count());
+    assertEquals(0, taskQuery.taskVariableValueLessThan("numericVar", 928373).count());
 
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueLessThanOrEquals("numericVar", 928375).count());
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueLessThanOrEquals("numericVar", 928374).count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueLessThanOrEquals("numericVar", 928373).count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.taskVariableValueLessThanOrEquals("numericVar", 928375).count());
+    assertEquals(1, taskQuery.taskVariableValueLessThanOrEquals("numericVar", 928374).count());
+    assertEquals(0, taskQuery.taskVariableValueLessThanOrEquals("numericVar", 928373).count());
 
     // test compare methods with date values
     Date before = new GregorianCalendar(2014, 2, 2, 2, 2, 1).getTime();
     Date after = new GregorianCalendar(2014, 2, 2, 2, 2, 3).getTime();
 
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueGreaterThan("dateVar", before).count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueGreaterThan("dateVar", date).count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueGreaterThan("dateVar", after).count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.taskVariableValueGreaterThan("dateVar", before).count());
+    assertEquals(0, taskQuery.taskVariableValueGreaterThan("dateVar", date).count());
+    assertEquals(0, taskQuery.taskVariableValueGreaterThan("dateVar", after).count());
 
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueGreaterThanOrEquals("dateVar", before).count());
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueGreaterThanOrEquals("dateVar", date).count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueGreaterThanOrEquals("dateVar", after).count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.taskVariableValueGreaterThanOrEquals("dateVar", before).count());
+    assertEquals(1, taskQuery.taskVariableValueGreaterThanOrEquals("dateVar", date).count());
+    assertEquals(0, taskQuery.taskVariableValueGreaterThanOrEquals("dateVar", after).count());
 
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueLessThan("dateVar", after).count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueLessThan("dateVar", date).count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueLessThan("dateVar", before).count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.taskVariableValueLessThan("dateVar", after).count());
+    assertEquals(0, taskQuery.taskVariableValueLessThan("dateVar", date).count());
+    assertEquals(0, taskQuery.taskVariableValueLessThan("dateVar", before).count());
 
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueLessThanOrEquals("dateVar", after).count());
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueLessThanOrEquals("dateVar", date).count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueLessThanOrEquals("dateVar", before).count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.taskVariableValueLessThanOrEquals("dateVar", after).count());
+    assertEquals(1, taskQuery.taskVariableValueLessThanOrEquals("dateVar", date).count());
+    assertEquals(0, taskQuery.taskVariableValueLessThanOrEquals("dateVar", before).count());
 
     //test with string values
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueGreaterThan("stringVar", "aa").count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueGreaterThan("stringVar", "ab").count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueGreaterThan("stringVar", "ba").count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.taskVariableValueGreaterThan("stringVar", "aa").count());
+    assertEquals(0, taskQuery.taskVariableValueGreaterThan("stringVar", "ab").count());
+    assertEquals(0, taskQuery.taskVariableValueGreaterThan("stringVar", "ba").count());
 
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueGreaterThanOrEquals("stringVar", "aa").count());
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueGreaterThanOrEquals("stringVar", "ab").count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueGreaterThanOrEquals("stringVar", "ba").count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.taskVariableValueGreaterThanOrEquals("stringVar", "aa").count());
+    assertEquals(1, taskQuery.taskVariableValueGreaterThanOrEquals("stringVar", "ab").count());
+    assertEquals(0, taskQuery.taskVariableValueGreaterThanOrEquals("stringVar", "ba").count());
 
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueLessThan("stringVar", "ba").count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueLessThan("stringVar", "ab").count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueLessThan("stringVar", "aa").count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.taskVariableValueLessThan("stringVar", "ba").count());
+    assertEquals(0, taskQuery.taskVariableValueLessThan("stringVar", "ab").count());
+    assertEquals(0, taskQuery.taskVariableValueLessThan("stringVar", "aa").count());
 
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueLessThanOrEquals("stringVar", "ba").count());
-    assertEquals(1, taskService.createTaskQuery().taskVariableValueLessThanOrEquals("stringVar", "ab").count());
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueLessThanOrEquals("stringVar", "aa").count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.taskVariableValueLessThanOrEquals("stringVar", "ba").count());
+    assertEquals(1, taskQuery.taskVariableValueLessThanOrEquals("stringVar", "ab").count());
+    assertEquals(0, taskQuery.taskVariableValueLessThanOrEquals("stringVar", "aa").count());
 
+    taskQuery = taskService.createTaskQuery();
     // test with null value
     try {
-      taskService.createTaskQuery().taskVariableValueGreaterThan("nullVar", null).count();
+      taskQuery.taskVariableValueGreaterThan("nullVar", null);
       fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
     try {
-  	  taskService.createTaskQuery().taskVariableValueGreaterThanOrEquals("nullVar", null).count();
+      taskQuery.taskVariableValueGreaterThanOrEquals("nullVar", null);
   	  fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
     try {
-  	  taskService.createTaskQuery().taskVariableValueLessThan("nullVar", null).count();
+  	  taskQuery.taskVariableValueLessThan("nullVar", null);
   	  fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
     try {
-  	  taskService.createTaskQuery().taskVariableValueLessThanOrEquals("nullVar", null).count();
+  	  taskQuery.taskVariableValueLessThanOrEquals("nullVar", null);
   	  fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
 
     // test with boolean value
     try {
-      taskService.createTaskQuery().taskVariableValueGreaterThan("nullVar", true).count();
+      taskQuery.taskVariableValueGreaterThan("nullVar", true);
       fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
     try {
-  	  taskService.createTaskQuery().taskVariableValueGreaterThanOrEquals("nullVar", false).count();
+  	  taskQuery.taskVariableValueGreaterThanOrEquals("nullVar", false);
   	  fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
     try {
-  	  taskService.createTaskQuery().taskVariableValueLessThan("nullVar", true).count();
+  	  taskQuery.taskVariableValueLessThan("nullVar", true);
   	  fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
     try {
-  	  taskService.createTaskQuery().taskVariableValueLessThanOrEquals("nullVar", false).count();
+  	  taskQuery.taskVariableValueLessThanOrEquals("nullVar", false);
   	  fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
 
  // test non existing variable
-    assertEquals(0, taskService.createTaskQuery().taskVariableValueLessThanOrEquals("nonExisting", 123).count());
+    assertEquals(0, taskQuery.taskVariableValueLessThanOrEquals("nonExisting", 123).count());
   }
 
   @Deployment
@@ -1515,10 +1552,11 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
     assertEquals(0, taskService.createTaskQuery().processVariableValueLike("stringVar", "stringVal").count());
     assertEquals(0, taskService.createTaskQuery().processVariableValueLike("nonExistingVar", "string%").count());
+    var taskQuery = taskService.createTaskQuery();
 
     // test with null value
     try {
-      taskService.createTaskQuery().processVariableValueLike("stringVar", null).count();
+      taskQuery.processVariableValueLike("stringVar", null);
       fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
   }
@@ -1542,10 +1580,11 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
     assertEquals(0, taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueLike("stringVar", "stringVal".toLowerCase()).count());
     assertEquals(0, taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueLike("nonExistingVar", "stringVal%".toLowerCase()).count());
+    var taskQuery = taskService.createTaskQuery().matchVariableValuesIgnoreCase();
 
     // test with null value
     try {
-      taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueLike("stringVar", null).count();
+      taskQuery.processVariableValueLike("stringVar", null);
       fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
   }
@@ -1558,19 +1597,23 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     variables.put("stringVar", "stringValue");
     runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
 
-    assertEquals(0, taskService.createTaskQuery().processVariableValueNotLike("stringVar", "stringVal%").count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueNotLike("stringVar", "%ngValue").count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueNotLike("stringVar", "%ngVal%").count());
+    var taskQuery1 = taskService.createTaskQuery();
+    assertEquals(0, taskQuery1.processVariableValueNotLike("stringVar", "stringVal%").count());
+    assertEquals(0, taskQuery1.processVariableValueNotLike("stringVar", "%ngValue").count());
+    assertEquals(0, taskQuery1.processVariableValueNotLike("stringVar", "%ngVal%").count());
 
-    assertEquals(1, taskService.createTaskQuery().processVariableValueNotLike("stringVar", "stringVar%").count());
-    assertEquals(1, taskService.createTaskQuery().processVariableValueNotLike("stringVar", "%ngVar").count());
-    assertEquals(1, taskService.createTaskQuery().processVariableValueNotLike("stringVar", "%ngVar%").count());
+    var taskQuery2 = taskService.createTaskQuery();
+    assertEquals(1, taskQuery2.processVariableValueNotLike("stringVar", "stringVar%").count());
+    assertEquals(1, taskQuery2.processVariableValueNotLike("stringVar", "%ngVar").count());
+    assertEquals(1, taskQuery2.processVariableValueNotLike("stringVar", "%ngVar%").count());
 
-    assertEquals(1, taskService.createTaskQuery().processVariableValueNotLike("stringVar", "stringVal").count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueNotLike("nonExistingVar", "string%").count());
+    var taskQuery3 = taskService.createTaskQuery();
+    assertEquals(1, taskQuery3.processVariableValueNotLike("stringVar", "stringVal").count());
+    assertEquals(0, taskQuery3.processVariableValueNotLike("nonExistingVar", "string%").count());
 
     // test with null value
-    assertThatThrownBy(() -> taskService.createTaskQuery().processVariableValueNotLike("stringVar", null).count())
+    var taskQuery4 = taskService.createTaskQuery();
+    assertThatThrownBy(() -> taskQuery4.processVariableValueNotLike("stringVar", null))
       .isInstanceOf(ProcessEngineException.class);
   }
 
@@ -1595,7 +1638,8 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     assertEquals(0, taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("nonExistingVar", "stringVal%".toLowerCase()).count());
 
     // test with null value
-    assertThatThrownBy(() -> taskService.createTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", null).count())
+    var taskQuery = taskService.createTaskQuery().matchVariableValuesIgnoreCase();
+    assertThatThrownBy(() -> taskQuery.processVariableValueNotLike("stringVar", null))
       .isInstanceOf(ProcessEngineException.class);
   }
 
@@ -1613,97 +1657,110 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     runtimeService.startProcessInstanceByKey("oneTaskProcess", variables);
 
     // test compare methods with numeric values
-    assertEquals(1, taskService.createTaskQuery().processVariableValueGreaterThan("numericVar", 928373).count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueGreaterThan("numericVar", 928374).count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueGreaterThan("numericVar", 928375).count());
+    var taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.processVariableValueGreaterThan("numericVar", 928373).count());
+    assertEquals(0, taskQuery.processVariableValueGreaterThan("numericVar", 928374).count());
+    assertEquals(0, taskQuery.processVariableValueGreaterThan("numericVar", 928375).count());
 
-    assertEquals(1, taskService.createTaskQuery().processVariableValueGreaterThanOrEquals("numericVar", 928373).count());
-    assertEquals(1, taskService.createTaskQuery().processVariableValueGreaterThanOrEquals("numericVar", 928374).count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueGreaterThanOrEquals("numericVar", 928375).count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.processVariableValueGreaterThanOrEquals("numericVar", 928373).count());
+    assertEquals(1, taskQuery.processVariableValueGreaterThanOrEquals("numericVar", 928374).count());
+    assertEquals(0, taskQuery.processVariableValueGreaterThanOrEquals("numericVar", 928375).count());
 
-    assertEquals(1, taskService.createTaskQuery().processVariableValueLessThan("numericVar", 928375).count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueLessThan("numericVar", 928374).count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueLessThan("numericVar", 928373).count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.processVariableValueLessThan("numericVar", 928375).count());
+    assertEquals(0, taskQuery.processVariableValueLessThan("numericVar", 928374).count());
+    assertEquals(0, taskQuery.processVariableValueLessThan("numericVar", 928373).count());
 
-    assertEquals(1, taskService.createTaskQuery().processVariableValueLessThanOrEquals("numericVar", 928375).count());
-    assertEquals(1, taskService.createTaskQuery().processVariableValueLessThanOrEquals("numericVar", 928374).count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueLessThanOrEquals("numericVar", 928373).count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.processVariableValueLessThanOrEquals("numericVar", 928375).count());
+    assertEquals(1, taskQuery.processVariableValueLessThanOrEquals("numericVar", 928374).count());
+    assertEquals(0, taskQuery.processVariableValueLessThanOrEquals("numericVar", 928373).count());
 
     // test compare methods with date values
     Date before = new GregorianCalendar(2014, 2, 2, 2, 2, 1).getTime();
     Date after = new GregorianCalendar(2014, 2, 2, 2, 2, 3).getTime();
 
-    assertEquals(1, taskService.createTaskQuery().processVariableValueGreaterThan("dateVar", before).count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueGreaterThan("dateVar", date).count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueGreaterThan("dateVar", after).count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.processVariableValueGreaterThan("dateVar", before).count());
+    assertEquals(0, taskQuery.processVariableValueGreaterThan("dateVar", date).count());
+    assertEquals(0, taskQuery.processVariableValueGreaterThan("dateVar", after).count());
 
-    assertEquals(1, taskService.createTaskQuery().processVariableValueGreaterThanOrEquals("dateVar", before).count());
-    assertEquals(1, taskService.createTaskQuery().processVariableValueGreaterThanOrEquals("dateVar", date).count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueGreaterThanOrEquals("dateVar", after).count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.processVariableValueGreaterThanOrEquals("dateVar", before).count());
+    assertEquals(1, taskQuery.processVariableValueGreaterThanOrEquals("dateVar", date).count());
+    assertEquals(0, taskQuery.processVariableValueGreaterThanOrEquals("dateVar", after).count());
 
-    assertEquals(1, taskService.createTaskQuery().processVariableValueLessThan("dateVar", after).count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueLessThan("dateVar", date).count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueLessThan("dateVar", before).count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.processVariableValueLessThan("dateVar", after).count());
+    assertEquals(0, taskQuery.processVariableValueLessThan("dateVar", date).count());
+    assertEquals(0, taskQuery.processVariableValueLessThan("dateVar", before).count());
 
-    assertEquals(1, taskService.createTaskQuery().processVariableValueLessThanOrEquals("dateVar", after).count());
-    assertEquals(1, taskService.createTaskQuery().processVariableValueLessThanOrEquals("dateVar", date).count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueLessThanOrEquals("dateVar", before).count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.processVariableValueLessThanOrEquals("dateVar", after).count());
+    assertEquals(1, taskQuery.processVariableValueLessThanOrEquals("dateVar", date).count());
+    assertEquals(0, taskQuery.processVariableValueLessThanOrEquals("dateVar", before).count());
 
     //test with string values
-    assertEquals(1, taskService.createTaskQuery().processVariableValueGreaterThan("stringVar", "aa").count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueGreaterThan("stringVar", "ab").count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueGreaterThan("stringVar", "ba").count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.processVariableValueGreaterThan("stringVar", "aa").count());
+    assertEquals(0, taskQuery.processVariableValueGreaterThan("stringVar", "ab").count());
+    assertEquals(0, taskQuery.processVariableValueGreaterThan("stringVar", "ba").count());
 
-    assertEquals(1, taskService.createTaskQuery().processVariableValueGreaterThanOrEquals("stringVar", "aa").count());
-    assertEquals(1, taskService.createTaskQuery().processVariableValueGreaterThanOrEquals("stringVar", "ab").count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueGreaterThanOrEquals("stringVar", "ba").count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.processVariableValueGreaterThanOrEquals("stringVar", "aa").count());
+    assertEquals(1, taskQuery.processVariableValueGreaterThanOrEquals("stringVar", "ab").count());
+    assertEquals(0, taskQuery.processVariableValueGreaterThanOrEquals("stringVar", "ba").count());
 
-    assertEquals(1, taskService.createTaskQuery().processVariableValueLessThan("stringVar", "ba").count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueLessThan("stringVar", "ab").count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueLessThan("stringVar", "aa").count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.processVariableValueLessThan("stringVar", "ba").count());
+    assertEquals(0, taskQuery.processVariableValueLessThan("stringVar", "ab").count());
+    assertEquals(0, taskQuery.processVariableValueLessThan("stringVar", "aa").count());
 
-    assertEquals(1, taskService.createTaskQuery().processVariableValueLessThanOrEquals("stringVar", "ba").count());
-    assertEquals(1, taskService.createTaskQuery().processVariableValueLessThanOrEquals("stringVar", "ab").count());
-    assertEquals(0, taskService.createTaskQuery().processVariableValueLessThanOrEquals("stringVar", "aa").count());
+    taskQuery = taskService.createTaskQuery();
+    assertEquals(1, taskQuery.processVariableValueLessThanOrEquals("stringVar", "ba").count());
+    assertEquals(1, taskQuery.processVariableValueLessThanOrEquals("stringVar", "ab").count());
+    assertEquals(0, taskQuery.processVariableValueLessThanOrEquals("stringVar", "aa").count());
 
+    taskQuery = taskService.createTaskQuery();
     // test with null value
     try {
-      taskService.createTaskQuery().processVariableValueGreaterThan("nullVar", null).count();
+      taskQuery.processVariableValueGreaterThan("nullVar", null);
       fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
     try {
-  	  taskService.createTaskQuery().processVariableValueGreaterThanOrEquals("nullVar", null).count();
+  	  taskQuery.processVariableValueGreaterThanOrEquals("nullVar", null);
   	  fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
     try {
-  	  taskService.createTaskQuery().processVariableValueLessThan("nullVar", null).count();
+  	  taskQuery.processVariableValueLessThan("nullVar", null);
   	  fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
     try {
-  	  taskService.createTaskQuery().processVariableValueLessThanOrEquals("nullVar", null).count();
+  	  taskQuery.processVariableValueLessThanOrEquals("nullVar", null);
   	  fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
 
     // test with boolean value
     try {
-      taskService.createTaskQuery().processVariableValueGreaterThan("nullVar", true).count();
+      taskQuery.processVariableValueGreaterThan("nullVar", true);
       fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
     try {
-  	  taskService.createTaskQuery().processVariableValueGreaterThanOrEquals("nullVar", false).count();
+  	  taskQuery.processVariableValueGreaterThanOrEquals("nullVar", false);
   	  fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
     try {
-  	  taskService.createTaskQuery().processVariableValueLessThan("nullVar", true).count();
+  	  taskQuery.processVariableValueLessThan("nullVar", true);
   	  fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
     try {
-  	  taskService.createTaskQuery().processVariableValueLessThanOrEquals("nullVar", false).count();
+  	  taskQuery.processVariableValueLessThanOrEquals("nullVar", false);
   	  fail("expected exception");
     } catch (final ProcessEngineException e) {/*OK*/}
 
     // test non existing variable
-    assertEquals(0, taskService.createTaskQuery().processVariableValueLessThanOrEquals("nonExisting", 123).count());
+    assertEquals(0, taskQuery.processVariableValueLessThanOrEquals("nonExisting", 123).count());
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
@@ -2147,42 +2204,51 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void shouldRejectDueDateAndWithoutDueDateCombination() {
-    assertThatThrownBy(() -> taskService.createTaskQuery().dueDate(ClockUtil.now()).withoutDueDate())
+    var taskQuery = taskService.createTaskQuery().dueDate(ClockUtil.now());
+    assertThatThrownBy(taskQuery::withoutDueDate)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage");
   }
 
   @Test
   public void shouldRejectWithoutDueDateAndDueDateCombination() {
-    assertThatThrownBy(() -> taskService.createTaskQuery().withoutDueDate().dueDate(ClockUtil.now()))
+    var taskQuery = taskService.createTaskQuery().withoutDueDate();
+    Date now = ClockUtil.now();
+    assertThatThrownBy(() -> taskQuery.dueDate(now))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage");
   }
 
   @Test
   public void shouldRejectDueBeforeAndWithoutDueDateCombination() {
-    assertThatThrownBy(() -> taskService.createTaskQuery().dueBefore(ClockUtil.now()).withoutDueDate())
+    var taskQuery = taskService.createTaskQuery().dueBefore(ClockUtil.now());
+    assertThatThrownBy(taskQuery::withoutDueDate)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage");
   }
 
   @Test
   public void shouldRejectWithoutDueDateAndDueBeforeCombination() {
-    assertThatThrownBy(() -> taskService.createTaskQuery().withoutDueDate().dueBefore(ClockUtil.now()))
+    var taskQuery = taskService.createTaskQuery().withoutDueDate();
+    Date now = ClockUtil.now();
+    assertThatThrownBy(() -> taskQuery.dueBefore(now))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage");
   }
 
   @Test
   public void shouldRejectDueAfterAndWithoutDueDateCombination() {
-    assertThatThrownBy(() -> taskService.createTaskQuery().dueAfter(ClockUtil.now()).withoutDueDate())
+    var taskQuery = taskService.createTaskQuery().dueAfter(ClockUtil.now());
+    assertThatThrownBy(taskQuery::withoutDueDate)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage");
   }
 
   @Test
   public void shouldRejectWithoutDueDateAndDueAfterCombination() {
-    assertThatThrownBy(() -> taskService.createTaskQuery().withoutDueDate().dueAfter(ClockUtil.now()))
+    var taskQuery = taskService.createTaskQuery().withoutDueDate();
+    Date now = ClockUtil.now();
+    assertThatThrownBy(() -> taskQuery.dueAfter(now))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage");
   }
@@ -3021,11 +3087,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .create();
 
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueEquals("aByteArrayValue", bytes);
 
     try {
-      query.caseInstanceVariableValueEquals("aByteArrayValue", bytes).list();
+      taskQuery.list();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3044,11 +3113,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .create();
 
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueEquals("aSerializableValue", serializable);
 
     try {
-      query.caseInstanceVariableValueEquals("aSerializableValue", serializable).list();
+      taskQuery.list();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3059,9 +3131,10 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
     startDefaultCaseWithVariable(fileValue, variableName);
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueEquals(variableName, fileValue);
 
     try {
-      query.caseInstanceVariableValueEquals(variableName, fileValue).list();
+      taskQuery.list();
       fail();
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Variables of type File cannot be used to query");
@@ -3081,11 +3154,10 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
    * @return the case definition id if only one case is deployed.
    */
   protected String getCaseDefinitionId() {
-    String caseDefinitionId = repositoryService
+    return repositoryService
         .createCaseDefinitionQuery()
         .singleResult()
         .getId();
-    return caseDefinitionId;
   }
 
   /**
@@ -3238,8 +3310,9 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
     startDefaultCaseWithVariable(fileValue, variableName);
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueNotEquals(variableName, fileValue);
     try {
-      query.caseInstanceVariableValueNotEquals(variableName, fileValue).list();
+      taskQuery.list();
       fail();
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Variables of type File cannot be used to query");
@@ -3250,8 +3323,7 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
    * @return
    */
   protected FileValue createDefaultFileValue() {
-    FileValue fileValue = Variables.fileValue("tst.txt").file("somebytes".getBytes()).create();
-    return fileValue;
+    return Variables.fileValue("tst.txt").file("somebytes".getBytes()).create();
   }
 
   /**
@@ -3289,11 +3361,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .create();
 
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueNotEquals("aSerializableValue", serializable);
 
     try {
-      query.caseInstanceVariableValueNotEquals("aSerializableValue", serializable).list();
+      taskQuery.list();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3309,11 +3384,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .create();
 
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueNotEquals("aByteArrayValue", bytes);
 
     try {
-      query.caseInstanceVariableValueNotEquals("aByteArrayValue", bytes).list();
+      taskQuery.list();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3326,12 +3404,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .setVariable("aNullValue", null)
       .create();
 
-    TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = taskService.createTaskQuery();
 
     try {
-      query.caseInstanceVariableValueGreaterThan("aNullValue", null).list();
+      taskQuery.caseInstanceVariableValueGreaterThan("aNullValue", null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
   }
 
@@ -3363,12 +3443,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .setVariable("aBooleanValue", true)
       .create();
 
-    TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = taskService.createTaskQuery();
 
     try {
-      query.caseInstanceVariableValueGreaterThan("aBooleanValue", false).list();
+      taskQuery.caseInstanceVariableValueGreaterThan("aBooleanValue", false);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
   }
 
@@ -3479,11 +3561,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .create();
 
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueGreaterThan("aByteArrayValue", bytes);
 
     try {
-      query.caseInstanceVariableValueGreaterThan("aByteArrayValue", bytes).list();
+      taskQuery.list();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3502,11 +3587,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .create();
 
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueGreaterThan("aSerializableValue", serializable);
 
     try {
-      query.caseInstanceVariableValueGreaterThan("aSerializableValue", serializable).list();
+      taskQuery.list();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCaseWithManualActivation.cmmn"})
@@ -3518,9 +3606,10 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     startDefaultCaseWithVariable(fileValue, variableName);
     startDefaultCaseExecutionManually();
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueGreaterThan(variableName, fileValue);
 
     try {
-      query.caseInstanceVariableValueGreaterThan(variableName, fileValue).list();
+      taskQuery.list();
       fail();
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Variables of type File cannot be used to query");
@@ -3537,12 +3626,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .setVariable("aNullValue", null)
       .create();
 
-    TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = taskService.createTaskQuery();
 
     try {
-      query.caseInstanceVariableValueGreaterThanOrEquals("aNullValue", null).list();
+      taskQuery.caseInstanceVariableValueGreaterThanOrEquals("aNullValue", null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
   }
 
@@ -3580,12 +3671,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .setVariable("aBooleanValue", true)
       .create();
 
-    TaskQuery query = taskService.createTaskQuery();
+    TaskQuery taskQuery = taskService.createTaskQuery();
 
     try {
-      query.caseInstanceVariableValueGreaterThanOrEquals("aBooleanValue", false).list();
+      taskQuery.caseInstanceVariableValueGreaterThanOrEquals("aBooleanValue", false);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
   }
 
@@ -3726,11 +3819,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .create();
 
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueGreaterThanOrEquals("aByteArrayValue", bytes);
 
     try {
-      query.caseInstanceVariableValueGreaterThanOrEquals("aByteArrayValue", bytes).list();
+      taskQuery.list();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3749,11 +3845,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .create();
 
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueGreaterThanOrEquals("aSerializableValue", serializable);
 
     try {
-      query.caseInstanceVariableValueGreaterThanOrEquals("aSerializableValue", serializable).list();
+      taskQuery.list();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3764,9 +3863,10 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
     startDefaultCaseWithVariable(fileValue, variableName);
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueGreaterThanOrEquals(variableName, fileValue);
 
     try {
-      query.caseInstanceVariableValueGreaterThanOrEquals(variableName, fileValue).list();
+      taskQuery.list();
       fail();
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Variables of type File cannot be used to query");
@@ -3783,12 +3883,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .setVariable("aNullValue", null)
       .create();
 
-    TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = taskService.createTaskQuery();
 
     try {
-      query.caseInstanceVariableValueLessThan("aNullValue", null).list();
+      taskQuery.caseInstanceVariableValueLessThan("aNullValue", null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
   }
 
@@ -3820,12 +3922,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .setVariable("aBooleanValue", true)
       .create();
 
-    TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = taskService.createTaskQuery();
 
     try {
-      query.caseInstanceVariableValueLessThan("aBooleanValue", false).list();
+      taskQuery.caseInstanceVariableValueLessThan("aBooleanValue", false);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
   }
 
@@ -3936,11 +4040,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .create();
 
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueLessThan("aByteArrayValue", bytes);
 
     try {
-      query.caseInstanceVariableValueLessThan("aByteArrayValue", bytes).list();
+      taskQuery.list();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3959,11 +4066,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .create();
 
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueLessThan("aSerializableValue", serializable);
 
     try {
-      query.caseInstanceVariableValueLessThan("aSerializableValue", serializable).list();
+      taskQuery.list();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3974,8 +4084,9 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
     startDefaultCaseWithVariable(fileValue, variableName);
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueLessThan(variableName, fileValue);
     try {
-      query.caseInstanceVariableValueLessThan(variableName, fileValue).list();
+      taskQuery.list();
       fail();
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Variables of type File cannot be used to query");
@@ -3992,12 +4103,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .setVariable("aNullValue", null)
       .create();
 
-    TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = taskService.createTaskQuery();
 
     try {
-      query.caseInstanceVariableValueLessThanOrEquals("aNullValue", null).list();
+      taskQuery.caseInstanceVariableValueLessThanOrEquals("aNullValue", null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
   }
 
@@ -4035,12 +4148,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .setVariable("aBooleanValue", true)
       .create();
 
-    TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = taskService.createTaskQuery();
 
     try {
-      query.caseInstanceVariableValueLessThanOrEquals("aBooleanValue", false).list();
+      taskQuery.caseInstanceVariableValueLessThanOrEquals("aBooleanValue", false);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
   }
 
@@ -4181,11 +4296,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .create();
 
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueLessThanOrEquals("aByteArrayValue", bytes);
 
     try {
-      query.caseInstanceVariableValueLessThanOrEquals("aByteArrayValue", bytes).list();
+      taskQuery.list();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -4204,11 +4322,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .create();
 
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueLessThanOrEquals("aSerializableValue", serializable);
 
     try {
-      query.caseInstanceVariableValueLessThanOrEquals("aSerializableValue", serializable).list();
+      taskQuery.list();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -4219,8 +4340,9 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
     startDefaultCaseWithVariable(fileValue, variableName);
     TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = query.caseInstanceVariableValueLessThanOrEquals(variableName, fileValue);
     try {
-      query.caseInstanceVariableValueLessThanOrEquals(variableName, fileValue).list();
+      taskQuery.list();
       fail();
     } catch (ProcessEngineException e) {
       assertThat(e.getMessage()).contains("Variables of type File cannot be used to query");
@@ -4237,12 +4359,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
       .setVariable("aNullValue", null)
       .create();
 
-    TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = taskService.createTaskQuery();
 
     try {
-      query.caseInstanceVariableValueLike("aNullValue", null).list();
+      taskQuery.caseInstanceVariableValueLike("aNullValue", null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
   }
 
@@ -4256,12 +4380,14 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
             .setVariable("aNullValue", null)
             .create();
 
-    TaskQuery query = taskService.createTaskQuery();
+    var taskQuery = taskService.createTaskQuery();
 
     try {
-      query.caseInstanceVariableValueNotLike("aNullValue", null).list();
+      taskQuery.caseInstanceVariableValueNotLike("aNullValue", null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
   }
 
@@ -4785,8 +4911,9 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryByUnsupportedValueTypes() {
+    var taskQuery = taskService.createTaskQuery();
     try {
-      taskService.createTaskQuery().orderByProcessVariable("var", ValueType.BYTES);
+      taskQuery.orderByProcessVariable("var", ValueType.BYTES);
       fail("this type is not supported");
     } catch (ProcessEngineException e) {
       // happy path
@@ -4794,7 +4921,7 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     }
 
     try {
-      taskService.createTaskQuery().orderByProcessVariable("var", ValueType.NULL);
+      taskQuery.orderByProcessVariable("var", ValueType.NULL);
       fail("this type is not supported");
     } catch (ProcessEngineException e) {
       // happy path
@@ -4802,7 +4929,7 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     }
 
     try {
-      taskService.createTaskQuery().orderByProcessVariable("var", ValueType.NUMBER);
+      taskQuery.orderByProcessVariable("var", ValueType.NUMBER);
       fail("this type is not supported");
     } catch (ProcessEngineException e) {
       // happy path
@@ -4810,7 +4937,7 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     }
 
     try {
-      taskService.createTaskQuery().orderByProcessVariable("var", ValueType.OBJECT);
+      taskQuery.orderByProcessVariable("var", ValueType.OBJECT);
       fail("this type is not supported");
     } catch (ProcessEngineException e) {
       // happy path
@@ -4818,7 +4945,7 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     }
 
     try {
-      taskService.createTaskQuery().orderByProcessVariable("var", ValueType.FILE);
+      taskQuery.orderByProcessVariable("var", ValueType.FILE);
       fail("this type is not supported");
     } catch (ProcessEngineException e) {
       // happy path
@@ -4990,71 +5117,72 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
 
   @Test
   public void testQueryResultOrderingWithInvalidParameters() {
+    var taskQuery = taskService.createTaskQuery();
     try {
-      taskService.createTaskQuery().orderByProcessVariable(null, ValueType.STRING).asc().list();
+      taskQuery.orderByProcessVariable(null, ValueType.STRING);
       fail("should not succeed");
     } catch (NullValueException e) {
       // happy path
     }
 
     try {
-      taskService.createTaskQuery().orderByProcessVariable("var", null).asc().list();
+      taskQuery.orderByProcessVariable("var", null);
       fail("should not succeed");
     } catch (NullValueException e) {
       // happy path
     }
 
     try {
-      taskService.createTaskQuery().orderByExecutionVariable(null, ValueType.STRING).asc().list();
+      taskQuery.orderByExecutionVariable(null, ValueType.STRING);
       fail("should not succeed");
     } catch (NullValueException e) {
       // happy path
     }
 
     try {
-      taskService.createTaskQuery().orderByExecutionVariable("var", null).asc().list();
+      taskQuery.orderByExecutionVariable("var", null);
       fail("should not succeed");
     } catch (NullValueException e) {
       // happy path
     }
 
     try {
-      taskService.createTaskQuery().orderByTaskVariable(null, ValueType.STRING).asc().list();
+      taskQuery.orderByTaskVariable(null, ValueType.STRING);
       fail("should not succeed");
     } catch (NullValueException e) {
       // happy path
     }
 
     try {
-      taskService.createTaskQuery().orderByTaskVariable("var", null).asc().list();
+      taskQuery.orderByTaskVariable("var", null);
       fail("should not succeed");
     } catch (NullValueException e) {
       // happy path
     }
 
     try {
-      taskService.createTaskQuery().orderByCaseInstanceVariable(null, ValueType.STRING).asc().list();
+      taskQuery.orderByCaseInstanceVariable(null, ValueType.STRING);
       fail("should not succeed");
     } catch (NullValueException e) {
       // happy path
     }
 
     try {
-      taskService.createTaskQuery().orderByCaseInstanceVariable("var", null).asc().list();
+      taskQuery.orderByCaseInstanceVariable("var", null);
       fail("should not succeed");
     } catch (NullValueException e) {
       // happy path
     }
 
     try {
-      taskService.createTaskQuery().orderByCaseExecutionVariable(null, ValueType.STRING).asc().list();
+      taskQuery.orderByCaseExecutionVariable(null, ValueType.STRING);
       fail("should not succeed");
     } catch (NullValueException e) {
       // happy path
     }
 
     try {
-      taskService.createTaskQuery().orderByCaseExecutionVariable("var", null).asc().list();
+      taskQuery.orderByCaseExecutionVariable("var", null);
       fail("should not succeed");
     } catch (NullValueException e) {
       // happy path
@@ -5067,12 +5195,7 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     assertEquals(expectedProcessInstances.size(), actualTasks.size());
     List<ProcessInstance> instances = new ArrayList<>(expectedProcessInstances);
 
-    Collections.sort(instances, new Comparator<ProcessInstance>() {
-      @Override
-      public int compare(ProcessInstance p1, ProcessInstance p2) {
-        return p1.getId().compareTo(p2.getId());
-      }
-    });
+    instances.sort(Comparator.comparing(Execution::getId));
 
     for (int i = 0; i < instances.size(); i++) {
       assertEquals(instances.get(i).getId(), actualTasks.get(i).getProcessInstanceId());
@@ -5096,7 +5219,9 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
     try {
       query.singleResult();
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/task/oneTaskWithFormKeyProcess.bpmn20.xml"})
@@ -5395,15 +5520,15 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
    testRule.deploy(process);
 
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
+    var taskQuery = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId());
 
     try{
-      taskService.createTaskQuery()
-        .processInstanceId(processInstance.getId())
-        .includeAssignedTasks()
-        .withCandidateUsers()
-        .list();
+      taskQuery.includeAssignedTasks();
        fail("exception expected");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
 
@@ -5420,15 +5545,15 @@ public class TaskQueryTest extends PluggableProcessEngineTest {
    testRule.deploy(process);
 
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process");
+    var taskQuery = taskService.createTaskQuery()
+        .processInstanceId(processInstance.getId());
 
     try{
-       taskService.createTaskQuery()
-        .processInstanceId(processInstance.getId())
-        .includeAssignedTasks()
-        .withoutCandidateUsers()
-        .list();
+       taskQuery.includeAssignedTasks();
        fail("exception expected");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.test.cmmn.decisiontask;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -200,14 +201,16 @@ public class DmnDecisionTaskTest extends CmmnTest {
     // given
     createCaseInstanceByKey(CASE_KEY);
     String decisionTaskId = queryCaseExecutionByActivityId(DECISION_TASK).getId();
+    var caseExecutionCommandBuilder = caseService
+        .withCaseExecution(decisionTaskId);
 
     try {
       // when
-      caseService
-        .withCaseExecution(decisionTaskId)
-        .manualStart();
+      caseExecutionCommandBuilder.manualStart();
       fail("It should not be possible to evaluate a not existing decision.");
-    } catch (DecisionDefinitionNotFoundException e) {}
+    } catch (DecisionDefinitionNotFoundException e) {
+      assertThat(e.getMessage()).contains("no decision definition deployed with key 'testDecision'");
+    }
   }
 
   @Deployment(resources = {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/dmn/businessruletask/DmnBusinessRuleTaskResultMappingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/dmn/businessruletask/DmnBusinessRuleTaskResultMappingTest.java
@@ -182,10 +182,11 @@ public class DmnBusinessRuleTaskResultMappingTest extends PluggableProcessEngine
 
   @Test
   public void testInvalidMapping() {
-    try {
-      testRule.deploy(repositoryService
+    var deploymentBuilder = repositoryService
           .createDeployment()
-          .addClasspathResource(INVALID_MAPPING_BPMN));
+          .addClasspathResource(INVALID_MAPPING_BPMN);
+    try {
+      testRule.deploy(deploymentBuilder);
 
       fail("expect parse exception");
     } catch (ParseException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/dmn/deployment/DecisionDefinitionDeployerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/dmn/deployment/DecisionDefinitionDeployerTest.java
@@ -180,11 +180,11 @@ public class DecisionDefinitionDeployerTest {
     String resourceName2 = "org/operaton/bpm/engine/test/dmn/deployment/DecisionDefinitionDeployerTest.testDuplicateIdInDeployment2.dmn11.xml";
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.createDeployment()
-        .addClasspathResource(resourceName1)
-        .addClasspathResource(resourceName2)
-        .name("duplicateIds")
-        .deploy())
+    DeploymentBuilder deploymentBuilder = repositoryService.createDeployment()
+      .addClasspathResource(resourceName1)
+      .addClasspathResource(resourceName2)
+      .name("duplicateIds");
+    assertThatThrownBy(deploymentBuilder::deploy)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("duplicateDecision");
   }
@@ -304,11 +304,11 @@ public class DecisionDefinitionDeployerTest {
   public void duplicateDrdIdInDeployment() {
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.createDeployment()
-        .addClasspathResource(DRD_SCORE_RESOURCE)
-        .addClasspathResource(DRD_SCORE_V2_RESOURCE)
-        .name("duplicateIds")
-        .deploy())
+    var deploymentBuilder = repositoryService.createDeployment()
+      .addClasspathResource(DRD_SCORE_RESOURCE)
+      .addClasspathResource(DRD_SCORE_V2_RESOURCE)
+      .name("duplicateIds");
+    assertThatThrownBy(deploymentBuilder::deploy)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("definitions");
   }
@@ -372,9 +372,10 @@ public class DecisionDefinitionDeployerTest {
   public void testDeployDmnModelInstanceNegativeHistoryTimeToLive() {
     // given
     DmnModelInstance dmnModelInstance = createDmnModelInstanceNegativeHistoryTimeToLive();
+    var deploymentBuilder = repositoryService.createDeployment().addModelInstance("foo.dmn", dmnModelInstance);
 
     try {
-      testRule.deploy(repositoryService.createDeployment().addModelInstance("foo.dmn", dmnModelInstance));
+      testRule.deploy(deploymentBuilder);
       fail("Exception for negative time to live value is expected.");
     } catch (ProcessEngineException ex) {
       assertTrue(ex.getCause().getMessage().contains("negative value is not allowed"));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricTaskDurationReportTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricTaskDurationReportTest.java
@@ -172,11 +172,9 @@ public class HistoricTaskDurationReportTest {
 
   @Test
   public void testCompletedAfterWithNullValue() {
+    var historicTaskInstanceReport = historyService.createHistoricTaskInstanceReport();
     try {
-      historyService
-        .createHistoricTaskInstanceReport()
-        .completedAfter(null)
-        .duration(PeriodUnit.MONTH);
+      historicTaskInstanceReport.completedAfter(null);
 
       fail("Expected NotValidException");
     } catch( NotValidException nve) {
@@ -186,11 +184,9 @@ public class HistoricTaskDurationReportTest {
 
   @Test
   public void testCompletedBeforeWithNullValue() {
+    var historicTaskInstanceReport = historyService.createHistoricTaskInstanceReport();
     try {
-      historyService
-        .createHistoricTaskInstanceReport()
-        .completedBefore(null)
-        .duration(PeriodUnit.MONTH);
+      historicTaskInstanceReport.completedBefore(null);
 
       fail("Expected NotValidException");
     } catch( NotValidException nve) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricTaskInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricTaskInstanceTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.test.history;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -132,7 +133,7 @@ public class HistoricTaskInstanceTest extends PluggableProcessEngineTest {
   @Test
   public void testDeleteHistoricTaskInstance() {
     // deleting unexisting historic task instance should be silently ignored
-    historyService.deleteHistoricTaskInstance("unexistingId");
+    assertThatCode(() -> historyService.deleteHistoricTaskInstance("unexistingId")).doesNotThrowAnyException();
   }
 
   @Deployment
@@ -452,25 +453,27 @@ public class HistoricTaskInstanceTest extends PluggableProcessEngineTest {
 
   @Test
   public void testInvalidSorting() {
+    HistoricTaskInstanceQuery historicTaskInstanceQuery1 = historyService.createHistoricTaskInstanceQuery();
     try {
-      historyService.createHistoricTaskInstanceQuery().asc();
+      historicTaskInstanceQuery1.asc();
       fail();
     } catch (ProcessEngineException e) {
-
+      assertEquals("You should call any of the orderBy methods first before specifying a direction: currentOrderingProperty is null", e.getMessage());
     }
 
     try {
-      historyService.createHistoricTaskInstanceQuery().desc();
+      historicTaskInstanceQuery1.desc();
       fail();
     } catch (ProcessEngineException e) {
-
+      assertEquals("You should call any of the orderBy methods first before specifying a direction: currentOrderingProperty is null", e.getMessage());
     }
 
+    var historicTaskInstanceQuery2 = historicTaskInstanceQuery1.orderByProcessInstanceId();
     try {
-      historyService.createHistoricTaskInstanceQuery().orderByProcessInstanceId().list();
+      historicTaskInstanceQuery2.list();
       fail();
     } catch (ProcessEngineException e) {
-
+      assertEquals("Invalid query: call asc() or desc() after using orderByXX(): direction is null", e.getMessage());
     }
   }
 
@@ -564,22 +567,28 @@ public class HistoricTaskInstanceTest extends PluggableProcessEngineTest {
 
     query.activityInstanceIdIn("invalid");
     assertEquals(0, query.count());
+    String[] values = { "a", null, "b" };
 
     try {
       query.activityInstanceIdIn(null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
     try {
       query.activityInstanceIdIn((String)null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
     try {
-      String[] values = { "a", null, "b" };
       query.activityInstanceIdIn(values);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
   }
 
@@ -1034,22 +1043,28 @@ public class HistoricTaskInstanceTest extends PluggableProcessEngineTest {
 
     query.taskDefinitionKeyIn("invalid");
     assertEquals(0, query.count());
+    String[] values = { "a", null, "b" };
 
     try {
       query.taskDefinitionKeyIn(null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      // expected
+    }
 
     try {
       query.taskDefinitionKeyIn((String)null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      // expected
+    }
 
     try {
-      String[] values = { "a", null, "b" };
       query.taskDefinitionKeyIn(values);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      // expected
+    }
 
   }
 
@@ -1092,22 +1107,28 @@ public class HistoricTaskInstanceTest extends PluggableProcessEngineTest {
 
     query.processInstanceBusinessKeyIn("invalid");
     assertEquals(0, query.count());
+    String[] values = { "a", null, "b" };
 
     try {
       query.processInstanceBusinessKeyIn(null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
     try {
       query.processInstanceBusinessKeyIn((String)null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
     try {
-      String[] values = { "a", null, "b" };
       query.processInstanceBusinessKeyIn(values);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml" })

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricTaskReportTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricTaskReportTest.java
@@ -174,11 +174,9 @@ public class HistoricTaskReportTest {
 
   @Test
   public void testCompletedAfterWithNullValue() {
+    var historicTaskInstanceReport = historyService.createHistoricTaskInstanceReport();
     try {
-      historyService
-        .createHistoricTaskInstanceReport()
-        .completedAfter(null)
-        .countByProcessDefinitionKey();
+      historicTaskInstanceReport.completedAfter(null);
 
       fail("Expected NotValidException");
     } catch( NotValidException nve) {
@@ -188,11 +186,9 @@ public class HistoricTaskReportTest {
 
   @Test
   public void testCompletedBeforeWithNullValue() {
+    var historicTaskInstanceReport = historyService.createHistoricTaskInstanceReport();
     try {
-      historyService
-        .createHistoricTaskInstanceReport()
-        .completedBefore(null)
-        .countByProcessDefinitionKey();
+      historicTaskInstanceReport.completedBefore(null);
 
       fail("Expected NotValidException");
     } catch( NotValidException nve) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricVariableInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricVariableInstanceTest.java
@@ -446,17 +446,23 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     // given
     Map<String, Object> vars = new HashMap<>();
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("myProc",vars);
+    var historicVariableInstanceQuery = historyService.createHistoricVariableInstanceQuery();
+    var processInstanceId = processInstance.getProcessInstanceId();
 
     // check existing variables for task ID
     try {
-      historyService.createHistoricVariableInstanceQuery().processInstanceIdIn(processInstance.getProcessInstanceId(),null);
+      historicVariableInstanceQuery.processInstanceIdIn(processInstanceId, null);
       fail("Search by process instance ID was finished");
-    } catch (ProcessEngineException e) { }
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
     try {
-      historyService.createHistoricVariableInstanceQuery().processInstanceIdIn(null,processInstance.getProcessInstanceId());
+      historicVariableInstanceQuery.processInstanceIdIn(null, processInstanceId);
       fail("Search by process instance ID was finished");
-    } catch (ProcessEngineException e) { }
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
@@ -489,32 +495,42 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
   public void testQueryByInvalidExecutionIdIn() {
     HistoricVariableInstanceQuery query = historyService.createHistoricVariableInstanceQuery().executionIdIn("invalid");
     assertEquals(0, query.count());
+    var historicVariableInstanceQuery = historyService.createHistoricVariableInstanceQuery();
 
     try {
-      historyService.createHistoricVariableInstanceQuery().executionIdIn((String[])null);
+      historicVariableInstanceQuery.executionIdIn((String[])null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
     try {
-      historyService.createHistoricVariableInstanceQuery().executionIdIn((String)null);
+      historicVariableInstanceQuery.executionIdIn((String)null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Test
   public void testQueryByInvalidTaskIdIn() {
     HistoricVariableInstanceQuery query = historyService.createHistoricVariableInstanceQuery().taskIdIn("invalid");
     assertEquals(0, query.count());
+    var historicVariableInstanceQuery = historyService.createHistoricVariableInstanceQuery();
 
     try {
-      historyService.createHistoricVariableInstanceQuery().taskIdIn((String[])null);
+      historicVariableInstanceQuery.taskIdIn((String[])null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
     try {
-      historyService.createHistoricVariableInstanceQuery().taskIdIn((String)null);
+      historicVariableInstanceQuery.taskIdIn((String)null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
@@ -553,12 +569,16 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     try {
       query.taskIdIn((String[])null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
 
     try {
       query.taskIdIn((String)null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
@@ -1051,9 +1071,9 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
     processEngine.getRuntimeService().startProcessInstanceByKey("process1", Variables.createVariables().putValue("var", new CustomVar("initialValue")));
 
     final HistoricVariableInstance historicVariableInstance = processEngine.getHistoryService().createHistoricVariableInstanceQuery().list().get(0);
-    CustomVar var = (CustomVar) historicVariableInstance.getTypedValue().getValue();
+    CustomVar customVar = (CustomVar) historicVariableInstance.getTypedValue().getValue();
 
-    assertEquals("newValue", var.getValue());
+    assertEquals("newValue", customVar.getValue());
 
     final List<HistoricDetail> historicDetails = processEngine.getHistoryService().createHistoricDetailQuery().orderPartiallyByOccurrence().desc().list();
     HistoricDetail historicDetail = historicDetails.get(0);
@@ -1907,22 +1927,28 @@ public class HistoricVariableInstanceTest extends PluggableProcessEngineTest {
 
     query.caseActivityIdIn("invalid");
     assertEquals(0, query.count());
+    String[] values = { "a", null, "b" };
 
     try {
       query.caseActivityIdIn((String[])null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (NullValueException e) {}
+    } catch (NullValueException e) {
+      // expected
+    }
 
     try {
       query.caseActivityIdIn((String)null);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (NullValueException e) {}
+    } catch (NullValueException e) {
+      // expected
+    }
 
     try {
-      String[] values = { "a", null, "b" };
       query.caseActivityIdIn(values);
       fail("A ProcessEngineExcpetion was expected.");
-    } catch (NullValueException e) {}
+    } catch (NullValueException e) {
+      // expected
+    }
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/DeploymentAwareJobExecutorTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/DeploymentAwareJobExecutorTest.java
@@ -129,9 +129,10 @@ public class DeploymentAwareJobExecutorTest extends PluggableProcessEngineTest {
   @Test
   public void testRegistrationOfNonExistingDeployment() {
     String nonExistingDeploymentId = "some non-existing id";
+    var managementService = processEngine.getManagementService();
 
     try {
-      processEngine.getManagementService().registerDeploymentForJobExecutor(nonExistingDeploymentId);
+      managementService.registerDeploymentForJobExecutor(nonExistingDeploymentId);
       Assert.fail("Registering a non-existing deployment should not succeed");
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent("Deployment " + nonExistingDeploymentId + " does not exist", e.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryTest.java
@@ -54,7 +54,7 @@ public class HistoricTaskInstanceQueryTest extends PluggableProcessEngineTest {
   protected static final String VARIABLE_VALUE_LC = VARIABLE_VALUE.toLowerCase();
   protected static final String VARIABLE_VALUE_LC_LIKE = "%" + VARIABLE_VALUE_LC.substring(2, 10) + "%";
   protected static final String VARIABLE_VALUE_NE = "nonExistent";
-  protected static Map<String, Object> VARIABLES = new HashMap<>();
+  protected static final Map<String, Object> VARIABLES = new HashMap<>();
   static {
     VARIABLES.put(VARIABLE_NAME, VARIABLE_VALUE);
   }
@@ -123,12 +123,15 @@ public class HistoricTaskInstanceQueryTest extends PluggableProcessEngineTest {
 
     assertEquals(0, historyService.createHistoricTaskInstanceQuery().processVariableValueLike("requester", "vahid").count());
     assertEquals(0, historyService.createHistoricTaskInstanceQuery().processVariableValueLike("nonExistingVar", "string%").count());
+    var historicTaskInstanceQuery = historyService.createHistoricTaskInstanceQuery();
 
     // test with null value
     try {
-      historyService.createHistoricTaskInstanceQuery().processVariableValueLike("requester", null).count();
+      historicTaskInstanceQuery.processVariableValueLike("requester", null);
       fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
+    } catch (final ProcessEngineException e) {
+      assertThat(e.getMessage()).contains("Booleans and null cannot be used in 'like' condition");
+    }
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
@@ -148,7 +151,8 @@ public class HistoricTaskInstanceQueryTest extends PluggableProcessEngineTest {
     assertEquals(0, historyService.createHistoricTaskInstanceQuery().processVariableValueNotLike("nonExistingVar", "string%").count());
 
     // test with null value
-    assertThatThrownBy(() -> historyService.createHistoricTaskInstanceQuery().processVariableValueNotLike("requester", null).count())
+    var historicTaskInstanceQuery = historyService.createHistoricTaskInstanceQuery();
+    assertThatThrownBy(() -> historicTaskInstanceQuery.processVariableValueNotLike("requester", null))
       .isInstanceOf(ProcessEngineException.class);
   }
 


### PR DESCRIPTION
Resolves Sonar issues of type java:S5778 Only one method invocation is expected when testing runtime exceptions

related to #88