### PR TITLE
fix: Adjust versioning scheme for SQL scripts package

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -91,6 +91,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: surefire-reports
+          name: surefire-reports-${{ matrix.test_suite }}-${{ matrix.container }}-${{ matrix.database }}
           path: ${{ github.workspace }}/**/target/surefire-reports/**
           retention-days: 30

--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -68,7 +68,6 @@ jobs:
           echo "project_version=$PROJECT_VERSION"
           echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
           echo "version=$RELEASE_VERSION"
-          ./mvnw help:evaluate -Dexpression=version.operaton.dbscheme -q -DforceStdout -f parent | tail -n 1
           DATABASE_VERSION=$(grep '<version.operaton.dbscheme>' parent/pom.xml | sed -e 's/.*<version.operaton.dbscheme>\(.*\)<\/version.operaton.dbscheme>.*/\1/')
           echo "database_version=$DATABASE_VERSION" >> $GITHUB_OUTPUT
           echo "database_version=$DATABASE_VERSION"

--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -40,6 +40,7 @@ jobs:
     outputs:
       version: ${{steps.maven-build.outputs.version}}
       project_version: ${{steps.maven-build.outputs.project_version}}
+      database_version: ${{steps.maven-build.outputs.database_version}}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -62,9 +63,11 @@ jobs:
         run: |
           .github/scripts/jacoco-create-flag-files.sh
           PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1)
+          DATABASE_VERSION=$(./mvnw help:evaluate -Dexpression=version.operaton.dbscheme -q -DforceStdout | tail -n 1)
           RELEASE_VERSION=$(echo $PROJECT_VERSION | sed 's/-SNAPSHOT//')
           SKIP_TESTS=${{ github.event.inputs.skip_tests || (github.event_name == 'schedule' && false) }}
           echo "project_version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
+          echo "database_version=$DATABASE_VERSION" >> $GITHUB_OUTPUT
           echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
           echo "skip_tests=$SKIP_TESTS"
           ./mvnw \
@@ -130,6 +133,7 @@ jobs:
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{secrets.OSSRH_PASSWORD}}
           JRELEASER_DRY_RUN: ${{ github.event_name == 'schedule' && false || github.event.inputs.dry_run }}
           JRELEASER_PRERELEASE_ENABLED: true
+          OPERATON_DATABASE_VERSION: ${{needs.build.outputs.database_version}}
 
       - name: Publish Test Report
         if: ${{ github.event_name == 'schedule' || github.event.inputs.skip_tests == 'false'}}

--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -18,12 +18,12 @@ on:
         description: 'Dry-Run: Skips remote operations when true'
         type: boolean
         required: true
-        default: true
+        default: false
       skip_tests:
         description: 'Skip test execution for faster build'
         type: boolean
         required: true
-        default: false
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -64,11 +64,13 @@ jobs:
           .github/scripts/jacoco-create-flag-files.sh
           PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1)
           RELEASE_VERSION=$(echo $PROJECT_VERSION | sed 's/-SNAPSHOT//')
-          SKIP_TESTS=${{ github.event.inputs.skip_tests || (github.event_name == 'schedule' && false) }}
           echo "project_version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
+          echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          echo "project_version=$PROJECT_VERSION"
+          echo "version=$RELEASE_VERSION"
           DATABASE_VERSION=$(./mvnw help:evaluate -Dexpression=version.operaton.dbscheme -q -DforceStdout -f parent | tail -n 1)
           echo "database_version=$DATABASE_VERSION" >> $GITHUB_OUTPUT
-          echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          SKIP_TESTS=${{ github.event.inputs.skip_tests || (github.event_name == 'schedule' && false) }}
           echo "skip_tests=$SKIP_TESTS"
           ./mvnw \
             -Pdistro,distro-run,distro-tomcat,distro-wildfly,distro-webjar,distro-starter,distro-serverless,h2-in-memory \

--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -63,10 +63,10 @@ jobs:
         run: |
           .github/scripts/jacoco-create-flag-files.sh
           PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1)
-          DATABASE_VERSION=$(./mvnw help:evaluate -Dexpression=version.operaton.dbscheme -q -DforceStdout -f parent | tail -n 1)
           RELEASE_VERSION=$(echo $PROJECT_VERSION | sed 's/-SNAPSHOT//')
           SKIP_TESTS=${{ github.event.inputs.skip_tests || (github.event_name == 'schedule' && false) }}
           echo "project_version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
+          DATABASE_VERSION=$(./mvnw help:evaluate -Dexpression=version.operaton.dbscheme -q -DforceStdout -f parent | tail -n 1)
           echo "database_version=$DATABASE_VERSION" >> $GITHUB_OUTPUT
           echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
           echo "skip_tests=$SKIP_TESTS"

--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           .github/scripts/jacoco-create-flag-files.sh
           PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1)
-          DATABASE_VERSION=$(./mvnw help:evaluate -Dexpression=version.operaton.dbscheme -q -DforceStdout | tail -n 1)
+          DATABASE_VERSION=$(./mvnw help:evaluate -Dexpression=version.operaton.dbscheme -q -DforceStdout -f parent | tail -n 1)
           RELEASE_VERSION=$(echo $PROJECT_VERSION | sed 's/-SNAPSHOT//')
           SKIP_TESTS=${{ github.event.inputs.skip_tests || (github.event_name == 'schedule' && false) }}
           echo "project_version=$PROJECT_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -69,7 +69,7 @@ jobs:
           echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
           echo "version=$RELEASE_VERSION"
           ./mvnw help:evaluate -Dexpression=version.operaton.dbscheme -q -DforceStdout -f parent | tail -n 1
-          DATABASE_VERSION=$(./mvnw help:evaluate -Dexpression=version.operaton.dbscheme -q -DforceStdout -f parent | tail -n 1)
+          DATABASE_VERSION=$(grep '<version.operaton.dbscheme>' parent/pom.xml | sed -e 's/.*<version.operaton.dbscheme>\(.*\)<\/version.operaton.dbscheme>.*/\1/')
           echo "database_version=$DATABASE_VERSION" >> $GITHUB_OUTPUT
           echo "database_version=$DATABASE_VERSION"
           SKIP_TESTS=${{ github.event.inputs.skip_tests || (github.event_name == 'schedule' && false) }}

--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -51,6 +51,11 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
       - name: Maven Build
         id: maven-build
         shell: bash

--- a/.github/workflows/nighly-build.yml
+++ b/.github/workflows/nighly-build.yml
@@ -65,11 +65,13 @@ jobs:
           PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1)
           RELEASE_VERSION=$(echo $PROJECT_VERSION | sed 's/-SNAPSHOT//')
           echo "project_version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
-          echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
           echo "project_version=$PROJECT_VERSION"
+          echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
           echo "version=$RELEASE_VERSION"
+          ./mvnw help:evaluate -Dexpression=version.operaton.dbscheme -q -DforceStdout -f parent | tail -n 1
           DATABASE_VERSION=$(./mvnw help:evaluate -Dexpression=version.operaton.dbscheme -q -DforceStdout -f parent | tail -n 1)
           echo "database_version=$DATABASE_VERSION" >> $GITHUB_OUTPUT
+          echo "database_version=$DATABASE_VERSION"
           SKIP_TESTS=${{ github.event.inputs.skip_tests || (github.event_name == 'schedule' && false) }}
           echo "skip_tests=$SKIP_TESTS"
           ./mvnw \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       version: ${{steps.version.outputs.version}}
+      database_version: ${{steps.maven-build.outputs.database_version}}
       is_prerelease: ${{steps.version.outputs.is_prerelease}}
     steps:
       - name: Checkout
@@ -35,6 +36,8 @@ jobs:
         run: |
           RELEASE_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1 | sed -e 's/-SNAPSHOT//')
           echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+          DATABASE_VERSION=$(./mvnw help:evaluate -Dexpression=version.operaton.dbscheme -q -DforceStdout -f parent | tail -n 1)
+          echo "database_version=$DATABASE_VERSION" >> $GITHUB_OUTPUT
           if [[ "$RELEASE_VERSION" == *"alpha"* || "$RELEASE_VERSION" == *"beta"* ]]; then
             echo "⚙ Releasing version '$RELEASE_VERSION' (Pre-Release)"
             echo "is_prerelease=true" >> $GITHUB_OUTPUT
@@ -135,6 +138,7 @@ jobs:
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{secrets.OSSRH_PASSWORD}}
           JRELEASER_DRY_RUN: ${{github.event.inputs.dry_run}}
           JRELEASER_PRERELEASE_ENABLED: false
+          OPERATON_DATABASE_VERSION: ${{needs.precheck.outputs.database_version}}
 
       - name: Publish Test Report
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,9 @@ jobs:
         run: |
           RELEASE_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout | tail -n 1 | sed -e 's/-SNAPSHOT//')
           echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
-          DATABASE_VERSION=$(./mvnw help:evaluate -Dexpression=version.operaton.dbscheme -q -DforceStdout -f parent | tail -n 1)
+          DATABASE_VERSION=$(grep '<version.operaton.dbscheme>' parent/pom.xml | sed -e 's/.*<version.operaton.dbscheme>\(.*\)<\/version.operaton.dbscheme>.*/\1/')
           echo "database_version=$DATABASE_VERSION" >> $GITHUB_OUTPUT
+          echo "database_version=$DATABASE_VERSION"
           if [[ "$RELEASE_VERSION" == *"alpha"* || "$RELEASE_VERSION" == *"beta"* ]]; then
             echo "⚙ Releasing version '$RELEASE_VERSION' (Pre-Release)"
             echo "is_prerelease=true" >> $GITHUB_OUTPUT

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -200,7 +200,7 @@ files:
     - path: 'distro/tomcat/distro/target/operaton-bpm-tomcat-{{projectVersion}}.zip'
     - path: 'distro/wildfly/distro/target/operaton-bpm-wildfly-{{projectVersion}}.tar.gz'
     - path: 'distro/wildfly/distro/target/operaton-bpm-wildfly-{{projectVersion}}.zip'
-    - path: 'distro/sql-script/target/operaton-sql-scripts-{{version.operaton.dbscheme}}.tar.gz'
+    - path: 'distro/sql-script/target/operaton-sql-scripts-{{OPERATON_DATABASE_VERSION}}.tar.gz'
     - path: 'distro/webjar/target/operaton-webapp-webjar-{{projectVersion}}.jar'
     - path: 'target/project-reports.zip'
 

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -200,7 +200,7 @@ files:
     - path: 'distro/tomcat/distro/target/operaton-bpm-tomcat-{{projectVersion}}.zip'
     - path: 'distro/wildfly/distro/target/operaton-bpm-wildfly-{{projectVersion}}.tar.gz'
     - path: 'distro/wildfly/distro/target/operaton-bpm-wildfly-{{projectVersion}}.zip'
-    - path: 'distro/sql-script/target/operaton-sql-scripts-{{projectVersion}}.tar.gz'
+    - path: 'distro/sql-script/target/operaton-sql-scripts-{{version.operaton.dbscheme}}.tar.gz'
     - path: 'distro/webjar/target/operaton-webapp-webjar-{{projectVersion}}.jar'
     - path: 'target/project-reports.zip'
 

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -18,10 +18,11 @@ project:
     - url: https://avatars.githubusercontent.com/u/185116948?s=200&v=4
       width: 200
       height: 200
-  java:
-    groupId: org.operaton
-    version: '17'
-    multiProject: false
+  languages:
+    java:
+      groupId: org.operaton
+      version: '17'
+      multiProject: false
   tags:
     - 'operaton'
     - 'bpmn'

--- a/spring-boot-starter/starter-security/pom.xml
+++ b/spring-boot-starter/starter-security/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-testing</artifactId>
-      <version>${version}</version>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Derive variable `OPERATON_DATABASE_VERSION` from property `version.operaton.dbscheme` and use it to qualify the path of the sql-scripts artifact.

Also:
- Fix usage of deprecated value `${version}` by `${project.version}`. This resolves a build warning.
- Change default value for input of nightly build
- Use setup-java in nightly build. The build was effectively using always Java 17 instead of specified versions.
- Fix deprecation of `java` section in `jreleaser.yml`

fixes https://github.com/operaton/operaton/issues/486