### PR TITLE
refactor: resolve Sonar warnings

### DIFF
--- a/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/format/json/JacksonJsonDataFormat.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/format/json/JacksonJsonDataFormat.java
@@ -101,10 +101,7 @@ public class JacksonJsonDataFormat implements DataFormat {
     try {
       return objectMapper.readValue(value, cls);
     }
-    catch (JsonParseException e) {
-      throw LOG.unableToReadValue(value, e);
-    }
-    catch (JsonMappingException e) {
+    catch (JsonParseException | JsonMappingException e) {
       throw LOG.unableToReadValue(value, e);
     }
     catch (IOException e) {
@@ -116,10 +113,7 @@ public class JacksonJsonDataFormat implements DataFormat {
     try {
       return objectMapper.readValue(value, type);
     }
-    catch (JsonParseException e) {
-      throw LOG.unableToReadValue(value, e);
-    }
-    catch (JsonMappingException e) {
+    catch (JsonParseException | JsonMappingException e) {
       throw LOG.unableToReadValue(value, e);
     }
     catch (IOException e) {

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/PathUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/PathUtil.java
@@ -28,8 +28,8 @@ public class PathUtil {
   public static String decodePathParam(String param) {
 
     return param
-      .replaceAll("%2F", "/")
-      .replaceAll("%5C", "\\\\");
+      .replace("%2F", "/")
+      .replace("%5C", "\\");
   }
 
 }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/URLEncodingUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/URLEncodingUtil.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.rest.util;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/URLEncodingUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/URLEncodingUtil.java
@@ -32,12 +32,7 @@ public class URLEncodingUtil {
    */
   public static String encode(String value) {
     if (value != null) {
-      try {
-        return URLEncoder.encode(value, StandardCharsets.UTF_8.toString()).replaceAll("\\+", "%20");
-      } catch (UnsupportedEncodingException ex) {
-        // should not happen
-        return value;
-      }
+      return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
     }
 
     return null;

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/PathUtilTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/PathUtilTest.java
@@ -3,10 +3,10 @@ package org.operaton.bpm.engine.rest.util;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class PathUtilTest {
+class PathUtilTest {
 
   @Test
-  public void testDecodePathParam() {
+  void testDecodePathParam() {
     // Test cases
     assertEquals("/path/to/resource", PathUtil.decodePathParam("%2Fpath%2Fto%2Fresource"));
     assertEquals("\\path\\to\\resource", PathUtil.decodePathParam("%5Cpath%5Cto%5Cresource"));

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/PathUtilTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/PathUtilTest.java
@@ -1,0 +1,16 @@
+package org.operaton.bpm.engine.rest.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PathUtilTest {
+
+  @Test
+  public void testDecodePathParam() {
+    // Test cases
+    assertEquals("/path/to/resource", PathUtil.decodePathParam("%2Fpath%2Fto%2Fresource"));
+    assertEquals("\\path\\to\\resource", PathUtil.decodePathParam("%5Cpath%5Cto%5Cresource"));
+    assertEquals("/path\\to/resource", PathUtil.decodePathParam("%2Fpath%5Cto%2Fresource"));
+    assertEquals("simplePath", PathUtil.decodePathParam("simplePath"));
+  }
+}

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/URLEncodingUtilTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/URLEncodingUtilTest.java
@@ -1,0 +1,22 @@
+package org.operaton.bpm.engine.rest.util;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class URLEncodingUtilTest {
+
+  @Test
+  public void testEncode() {
+    assertEquals("simple%20text", URLEncodingUtil.encode("simple text"));
+    assertEquals("%2Fpath%2Fto%2Fresource", URLEncodingUtil.encode("/path/to/resource"));
+    assertEquals("%5Cpath%5Cto%5Cresource", URLEncodingUtil.encode("\\path\\to\\resource"));
+    assertEquals("special%20characters%20%26%20symbols", URLEncodingUtil.encode("special characters & symbols"));
+  }
+
+  @Test
+  public void testBuildAttachmentValue() {
+    String fileName = "example file.txt";
+    String expected = "attachment; filename=\"example file.txt\"; filename*=UTF-8''example%20file.txt";
+    assertEquals(expected, URLEncodingUtil.buildAttachmentValue(fileName));
+  }
+}

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/URLEncodingUtilTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/URLEncodingUtilTest.java
@@ -3,10 +3,10 @@ package org.operaton.bpm.engine.rest.util;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class URLEncodingUtilTest {
+class URLEncodingUtilTest {
 
   @Test
-  public void testEncode() {
+  void testEncode() {
     assertEquals("simple%20text", URLEncodingUtil.encode("simple text"));
     assertEquals("%2Fpath%2Fto%2Fresource", URLEncodingUtil.encode("/path/to/resource"));
     assertEquals("%5Cpath%5Cto%5Cresource", URLEncodingUtil.encode("\\path\\to\\resource"));
@@ -14,7 +14,7 @@ public class URLEncodingUtilTest {
   }
 
   @Test
-  public void testBuildAttachmentValue() {
+  void testBuildAttachmentValue() {
     String fileName = "example file.txt";
     String expected = "attachment; filename=\"example file.txt\"; filename*=UTF-8''example%20file.txt";
     assertEquals(expected, URLEncodingUtil.buildAttachmentValue(fileName));

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/AbstractNativeQuery.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/AbstractNativeQuery.java
@@ -38,7 +38,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery< ? , ? >, U> imp
 
   private static final long serialVersionUID = 1L;
 
-  private static enum ResultType {
+  private enum ResultType {
     LIST, LIST_PAGE, SINGLE_RESULT, COUNT
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseExecutionEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseExecutionEntity.java
@@ -673,12 +673,7 @@ public class CaseExecutionEntity extends CmmnExecution implements CaseExecution,
     getCaseSentryParts().add(entity);
 
     String sentryId = sentryPart.getSentryId();
-    List<CmmnSentryPart> parts = sentries.get(sentryId);
-
-    if (parts == null) {
-      parts = new ArrayList<>();
-      sentries.put(sentryId, parts);
-    }
+    List<CmmnSentryPart> parts = sentries.computeIfAbsent(sentryId, k -> new ArrayList<>());
 
     parts.add(entity);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/form/engine/HtmlElementWriter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/form/engine/HtmlElementWriter.java
@@ -110,7 +110,7 @@ public class HtmlElementWriter {
   protected String escapeQuotes(String attributeValue){
     String escapedHtmlQuote = "&quot;";
     String escapedJavaQuote = "\"";
-    return attributeValue.replaceAll(escapedJavaQuote, escapedHtmlQuote);
+    return attributeValue.replace(escapedJavaQuote, escapedHtmlQuote);
   }
 
   protected void writeEndLine(HtmlWriteContext context) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/SetRemovalTimeToHistoricProcessInstancesBuilderImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/SetRemovalTimeToHistoricProcessInstancesBuilderImpl.java
@@ -142,7 +142,7 @@ public class SetRemovalTimeToHistoricProcessInstancesBuilderImpl implements SetR
     return chunkSize;
   }
 
-  public static enum Mode
+  public enum Mode
   {
     CALCULATED_REMOVAL_TIME,
     ABSOLUTE_REMOVAL_TIME,

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/JakartaTransactionInterceptor.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/JakartaTransactionInterceptor.java
@@ -49,9 +49,7 @@ public class JakartaTransactionInterceptor extends AbstractTransactionIntercepto
   protected void doBegin() {
     try {
       transactionManager.begin();
-    } catch (NotSupportedException e) {
-      throw new TransactionException("Unable to begin transaction", e);
-    } catch (SystemException e) {
+    } catch (NotSupportedException | SystemException e) {
       throw new TransactionException("Unable to begin transaction", e);
     }
   }
@@ -79,9 +77,7 @@ public class JakartaTransactionInterceptor extends AbstractTransactionIntercepto
     if (tx != null) {
       try {
         transactionManager.resume((Transaction) tx);
-      } catch (SystemException e) {
-        throw new TransactionException("Unable to resume transaction", e);
-      } catch (InvalidTransactionException e) {
+      } catch (SystemException | InvalidTransactionException e) {
         throw new TransactionException("Unable to resume transaction", e);
       }
     }
@@ -91,18 +87,11 @@ public class JakartaTransactionInterceptor extends AbstractTransactionIntercepto
   protected void doCommit() {
     try {
       transactionManager.commit();
-    } catch (HeuristicMixedException e) {
-      throw new TransactionException("Unable to commit transaction", e);
-    } catch (HeuristicRollbackException e) {
+    } catch (HeuristicMixedException | HeuristicRollbackException | SystemException e) {
       throw new TransactionException("Unable to commit transaction", e);
     } catch (RollbackException e) {
       handleRollbackException(e);
-    } catch (SystemException e) {
-      throw new TransactionException("Unable to commit transaction", e);
-    } catch (RuntimeException e) {
-      doRollback(true);
-      throw e;
-    } catch (Error e) {
+    } catch (RuntimeException | Error e) {
       doRollback(true);
       throw e;
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/JtaTransactionInterceptor.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/JtaTransactionInterceptor.java
@@ -51,9 +51,7 @@ public class JtaTransactionInterceptor extends AbstractTransactionInterceptor {
   protected void doBegin() {
     try {
       transactionManager.begin();
-    } catch (NotSupportedException e) {
-      throw new TransactionException("Unable to begin transaction", e);
-    } catch (SystemException e) {
+    } catch (NotSupportedException | SystemException e) {
       throw new TransactionException("Unable to begin transaction", e);
     }
   }
@@ -93,18 +91,11 @@ public class JtaTransactionInterceptor extends AbstractTransactionInterceptor {
   protected void doCommit() {
     try {
       transactionManager.commit();
-    } catch (HeuristicMixedException e) {
-      throw new TransactionException("Unable to commit transaction", e);
-    } catch (HeuristicRollbackException e) {
+    } catch (HeuristicMixedException | HeuristicRollbackException | SystemException e) {
       throw new TransactionException("Unable to commit transaction", e);
     } catch (RollbackException e) {
       handleRollbackException(e);
-    } catch (SystemException e) {
-      throw new TransactionException("Unable to commit transaction", e);
-    } catch (RuntimeException e) {
-      doRollback(true);
-      throw e;
-    } catch (Error e) {
+    } catch (RuntimeException | Error e) {
       doRollback(true);
       throw e;
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/JtaTransactionInterceptor.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/JtaTransactionInterceptor.java
@@ -79,9 +79,7 @@ public class JtaTransactionInterceptor extends AbstractTransactionInterceptor {
     if (tx != null) {
       try {
         transactionManager.resume((Transaction) tx);
-      } catch (SystemException e) {
-        throw new TransactionException("Unable to resume transaction", e);
-      } catch (InvalidTransactionException e) {
+      } catch (SystemException | InvalidTransactionException e) {
         throw new TransactionException("Unable to resume transaction", e);
       }
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -95,7 +95,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
   protected static final EnginePersistenceLogger LOG = ProcessEngineLogger.PERSISTENCE_LOGGER;
 
   protected static final List<VariableInstanceLifecycleListener<CoreVariableInstance>> DEFAULT_VARIABLE_LIFECYCLE_LISTENERS =
-      Arrays.<VariableInstanceLifecycleListener<CoreVariableInstance>>asList(
+      Arrays.asList(
           (VariableInstanceLifecycleListener) VariableInstanceEntityPersistenceListener.INSTANCE,
           (VariableInstanceLifecycleListener) VariableInstanceSequenceCounterListener.INSTANCE,
           (VariableInstanceLifecycleListener) VariableInstanceHistoryListener.INSTANCE
@@ -1803,7 +1803,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
     EscalationHandler.propagateEscalation(activityExecution, escalationCode);
   }
 
-  public static enum TaskState {
+  public enum TaskState {
 
     STATE_INIT ("Init"),
     STATE_CREATED ("Created"),
@@ -1813,7 +1813,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
 
     private String name;
 
-    private TaskState(String name) {
+    TaskState(String name) {
       this.name = name;
     }
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/CollectionUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/CollectionUtil.java
@@ -88,11 +88,7 @@ public class CollectionUtil {
   }
 
   public static <S, T> void addCollectionToMapOfSets(Map<S, Set<T>> map, S key, Collection<T> values) {
-    Set<T> set = map.get(key);
-    if (set == null) {
-      set = new HashSet<>();
-      map.put(key, set);
-    }
+    Set<T> set = map.computeIfAbsent(key, k -> new HashSet<>());
     set.addAll(values);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/LogUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/LogUtil.java
@@ -40,7 +40,7 @@ import org.operaton.bpm.engine.impl.pvm.PvmException;
 public class LogUtil {
 
 
-  public static enum ThreadLogMode {
+  public enum ThreadLogMode {
     NONE, INDENT, PRINT_ID;
 
   }

--- a/engine/src/test/java/org/operaton/bpm/container/impl/jmx/kernel/MBeanServiceContainerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/jmx/kernel/MBeanServiceContainerTest.java
@@ -34,7 +34,6 @@ import org.operaton.bpm.container.impl.jmx.kernel.util.StartServiceDeploymentOpe
 import org.operaton.bpm.container.impl.jmx.kernel.util.StopServiceDeploymentOperationStep;
 import org.operaton.bpm.container.impl.jmx.kernel.util.TestService;
 import org.operaton.bpm.container.impl.jmx.kernel.util.TestServiceType;
-import org.operaton.bpm.container.impl.spi.DeploymentOperation;
 import org.operaton.bpm.container.impl.spi.PlatformService;
 import org.junit.After;
 import org.junit.Before;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.java
@@ -57,7 +57,6 @@ import org.junit.runners.Parameterized;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyTaskQueryTest.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskEventsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskEventsTest.java
@@ -26,7 +26,6 @@ import static org.operaton.bpm.engine.task.IdentityLinkType.CANDIDATE;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/escalation/EscalationEventParseInvalidProcessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/escalation/EscalationEventParseInvalidProcessTest.java
@@ -27,7 +27,6 @@ import junit.framework.AssertionFailedError;
 import org.operaton.bpm.engine.ParseException;
 import org.operaton.bpm.engine.Problem;
 import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.repository.DeploymentBuilder;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.junit.Before;

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/Builder.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/Builder.java
@@ -36,7 +36,7 @@ public class Builder implements TreeBuilder {
 	/**
 	 * Feature enumeration type.
 	 */
-	public static enum Feature {
+	public enum Feature {
 		/**
 		 * Method invocations as in <code>${foo.bar(1)}</code> as specified in JSR 245,
 		 * maintenance release 2.

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/ExpressionFactoryImpl.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/ExpressionFactoryImpl.java
@@ -75,7 +75,7 @@ public class ExpressionFactoryImpl extends jakarta.el.ExpressionFactory {
 	 *
 	 * @since 2.2
 	 */
-	public static enum Profile {
+	public enum Profile {
 		/**
 		 * JEE5: none
 		 */

--- a/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSampleApplicationIT.java
+++ b/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSampleApplicationIT.java
@@ -25,7 +25,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.context.WebApplicationContext;
 
-public class OperatonBpmSampleApplicationIT extends AbstractSpringSecurityIT {
+class OperatonBpmSampleApplicationIT extends AbstractSpringSecurityIT {
 
   @Autowired
   private TestRestTemplate testRestTemplate;
@@ -42,7 +42,7 @@ public class OperatonBpmSampleApplicationIT extends AbstractSpringSecurityIT {
   }
 
   @Test
-  public void testWebappApiIsAvailableAndRequiresAuthorization() {
+  void testWebappApiIsAvailableAndRequiresAuthorization() {
     // given oauth2 client disabled
     // when calling the webapp api
     ResponseEntity<String> entity = testRestTemplate.getForEntity(baseUrl + "/operaton/api/engine/engine/default/user", String.class);

--- a/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSecurityAutoConfigOauth2ApplicationIT.java
+++ b/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSecurityAutoConfigOauth2ApplicationIT.java
@@ -36,7 +36,6 @@ import org.operaton.bpm.spring.boot.starter.security.oauth2.impl.OAuth2Authentic
 import org.operaton.bpm.webapp.impl.security.auth.ContainerBasedAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
@@ -44,6 +43,7 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -54,7 +54,7 @@ import jakarta.servlet.Filter;
 @AutoConfigureMockMvc
 @TestPropertySource("/oauth2-mock.properties")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-public class OperatonBpmSecurityAutoConfigOauth2ApplicationIT extends AbstractSpringSecurityIT {
+class OperatonBpmSecurityAutoConfigOauth2ApplicationIT extends AbstractSpringSecurityIT {
 
   protected static final String UNAUTHORIZED_USER = "mary";
 
@@ -67,7 +67,7 @@ public class OperatonBpmSecurityAutoConfigOauth2ApplicationIT extends AbstractSp
   @Autowired
   private ClientRegistrationRepository registrations;
 
-  @MockBean
+  @MockitoBean
   private OAuth2AuthorizedClientService authorizedClientService;
 
   @RegisterExtension
@@ -76,6 +76,7 @@ public class OperatonBpmSecurityAutoConfigOauth2ApplicationIT extends AbstractSp
 
   private OAuth2AuthenticationProvider spiedAuthenticationProvider;
 
+  @Override
   @BeforeEach
   public void setup() throws Exception {
     super.setup();
@@ -83,7 +84,7 @@ public class OperatonBpmSecurityAutoConfigOauth2ApplicationIT extends AbstractSp
   }
 
   @Test
-  public void testSpringSecurityAutoConfigurationCorrectlySet() {
+  void testSpringSecurityAutoConfigurationCorrectlySet() {
     // given oauth2 client configured
     // when retrieving config beans then only OAuth2AutoConfiguration is present
     assertThat(getBeanForClass(OperatonSpringSecurityOAuth2AutoConfiguration.class, mockMvc.getDispatcherServlet().getWebApplicationContext())).isNotNull();
@@ -91,7 +92,7 @@ public class OperatonBpmSecurityAutoConfigOauth2ApplicationIT extends AbstractSp
   }
 
   @Test
-  public void testWebappWithoutAuthentication() throws Exception {
+  void testWebappWithoutAuthentication() throws Exception {
     // given no authentication
 
     // when
@@ -105,7 +106,7 @@ public class OperatonBpmSecurityAutoConfigOauth2ApplicationIT extends AbstractSp
   }
 
   @Test
-  public void testWebappApiWithAuthorizedUser() throws Exception {
+  void testWebappApiWithAuthorizedUser() throws Exception {
     // given authorized oauth2 authentication token
     OAuth2AuthenticationToken authenticationToken = createToken(AUTHORIZED_USER);
     createAuthorizedClient(authenticationToken, registrations, authorizedClientService);
@@ -121,7 +122,7 @@ public class OperatonBpmSecurityAutoConfigOauth2ApplicationIT extends AbstractSp
   }
 
   @Test
-  public void testWebappWithUnauthorizedUser() throws Exception {
+  void testWebappWithUnauthorizedUser() throws Exception {
     // given unauthorized oauth2 authentication token
     OAuth2AuthenticationToken authenticationToken = createToken(UNAUTHORIZED_USER);
     createAuthorizedClient(authenticationToken, registrations, authorizedClientService);
@@ -142,7 +143,7 @@ public class OperatonBpmSecurityAutoConfigOauth2ApplicationIT extends AbstractSp
 
 
   @Test
-  public void testOauth2AuthenticationProvider() throws Exception {
+  void testOauth2AuthenticationProvider() throws Exception {
     // given authorized oauth2 authentication token
     ResultCaptor<AuthenticationResult> resultCaptor = new ResultCaptor<>();
     doAnswer(resultCaptor).when(spiedAuthenticationProvider).extractAuthenticatedUser(any(), any());

--- a/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/OAuth2GrantedAuthoritiesMapperIT.java
+++ b/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/OAuth2GrantedAuthoritiesMapperIT.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -34,7 +33,7 @@ import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource("/oauth2-mock.properties")
-public class OAuth2GrantedAuthoritiesMapperIT extends AbstractSpringSecurityIT {
+class OAuth2GrantedAuthoritiesMapperIT extends AbstractSpringSecurityIT {
 
   protected static final String GROUP_NAME_ATTRIBUTE = "groupName";
 
@@ -46,7 +45,7 @@ public class OAuth2GrantedAuthoritiesMapperIT extends AbstractSpringSecurityIT {
       .watch(OAuth2GrantedAuthoritiesMapper.class.getCanonicalName());
 
   @Test
-  public void testMappingNotOauth2Authorities() {
+  void testMappingNotOauth2Authorities() {
     // given
     List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("USER"));
     // when
@@ -56,7 +55,7 @@ public class OAuth2GrantedAuthoritiesMapperIT extends AbstractSpringSecurityIT {
   }
 
   @Test
-  public void testMappingGroupNotAvailable() {
+  void testMappingGroupNotAvailable() {
     // given
     List<GrantedAuthority> authorities = List.of(new OAuth2UserAuthority("USER", Map.of("name", "name")));
     // when
@@ -68,7 +67,7 @@ public class OAuth2GrantedAuthoritiesMapperIT extends AbstractSpringSecurityIT {
   }
 
   @Test
-  public void testMappingSingleAuthority() {
+  void testMappingSingleAuthority() {
     // given
     List<GrantedAuthority> authorities = List.of(new OAuth2UserAuthority("USER", Map.of(GROUP_NAME_ATTRIBUTE, "group")));
     // when
@@ -79,20 +78,20 @@ public class OAuth2GrantedAuthoritiesMapperIT extends AbstractSpringSecurityIT {
   }
 
   @Test
-  public void testMappingMultipleAuthorities() {
+  void testMappingMultipleAuthorities() {
     // given
     List<GrantedAuthority> authorities = List.of(new OAuth2UserAuthority("USER", Map.of(GROUP_NAME_ATTRIBUTE, List.of("group1", "group2"))));
     // when
     Collection<? extends GrantedAuthority> mappedAuthorities = authoritiesMapper.mapAuthorities(authorities);
     // then
     assertThat(mappedAuthorities).hasSize(2);
-    List<String> groups = mappedAuthorities.stream().map(GrantedAuthority::getAuthority).collect(Collectors.toList());
+    List<String> groups = mappedAuthorities.stream().map(GrantedAuthority::getAuthority).toList();
     assertThat(groups).contains("group1", "group2");
   }
 
 
   @Test
-  public void testMappingUnsupportedType() {
+  void testMappingUnsupportedType() {
     // given
     Object object = new Object();
     List<GrantedAuthority> authorities = List.of(new OAuth2UserAuthority("USER", Map.of(GROUP_NAME_ATTRIBUTE, object)));

--- a/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/OperatonIdentityProviderIT.java
+++ b/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/OperatonIdentityProviderIT.java
@@ -48,6 +48,7 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -70,7 +71,7 @@ public class OperatonIdentityProviderIT extends AbstractSpringSecurityIT {
   @Autowired
   private ClientRegistrationRepository registrations;
 
-  @MockBean
+  @MockitoBean
   private OAuth2AuthorizedClientService authorizedClientService;
 
   public static OAuth2IdentityProvider spiedIdentityProvider = spy(new OAuth2IdentityProvider());
@@ -79,13 +80,14 @@ public class OperatonIdentityProviderIT extends AbstractSpringSecurityIT {
     mockIdentityProviderFactory();
   }
 
+  @Override
   @BeforeEach
   public void setup() throws Exception {
     super.setup();
   }
 
   @Test
-  public void testIdentityProviderForUsersWithoutSpringSecurity() {
+  void testIdentityProviderForUsersWithoutSpringSecurity() {
     // given no spring security authentication
     User newUser = identityService.newUser("newUser");
     identityService.saveUser(newUser);
@@ -99,13 +101,13 @@ public class OperatonIdentityProviderIT extends AbstractSpringSecurityIT {
     assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
     verify(spiedIdentityProvider, atLeastOnce()).createUserQuery();
     UserQuery userQueryResult = resultCaptor.result;
-    assertThat(userQueryResult).isInstanceOf(DbUserQueryImpl.class);
-    assertThat(userQueryResult).isNotNull();
+    assertThat(userQueryResult)
+      .isInstanceOf(DbUserQueryImpl.class);
     assertThat(entity.getBody()).contains(newUser.getId());
   }
 
   @Test
-  public void testIdentityProviderForGroupsWithoutSpringSecurity() {
+  void testIdentityProviderForGroupsWithoutSpringSecurity() {
     // given no spring security authentication
     Group newGroup = identityService.newGroup("newGroup");
     identityService.saveGroup(newGroup);
@@ -120,12 +122,11 @@ public class OperatonIdentityProviderIT extends AbstractSpringSecurityIT {
     verify(spiedIdentityProvider, atLeastOnce()).createGroupQuery();
     GroupQuery groupQueryResult = resultCaptor.result;
     assertThat(groupQueryResult).isInstanceOf(DbGroupQueryImpl.class);
-    assertThat(groupQueryResult).isNotNull();
     assertThat(entity.getBody()).contains(newGroup.getId());
   }
 
   @Test
-  public void testIdentityProviderForUsersWithSpringSecurity() throws Exception {
+  void testIdentityProviderForUsersWithSpringSecurity() throws Exception {
     // given spring security context
     ResultCaptor<UserQuery> resultCaptor = new ResultCaptor<>();
     doAnswer(resultCaptor).when(spiedIdentityProvider).createUserQuery();
@@ -143,12 +144,11 @@ public class OperatonIdentityProviderIT extends AbstractSpringSecurityIT {
     verify(spiedIdentityProvider, atLeastOnce()).createUserQuery();
     UserQuery userQueryResult = resultCaptor.result;
     assertThat(userQueryResult).isInstanceOf(OAuth2IdentityProvider.OAuth2UserQuery.class);
-    assertThat(userQueryResult).isNotNull();
     assertThat(((OAuth2IdentityProvider.OAuth2UserQuery) userQueryResult).getId()).isEqualTo(AUTHORIZED_USER);
   }
 
   @Test
-  public void testIdentityProviderForGroupsWithSpringSecurity() throws Exception {
+  void testIdentityProviderForGroupsWithSpringSecurity() throws Exception {
     // given spring security context
     ResultCaptor<GroupQuery> resultCaptor = new ResultCaptor<>();
     doAnswer(resultCaptor).when(spiedIdentityProvider).createGroupQuery();
@@ -166,7 +166,6 @@ public class OperatonIdentityProviderIT extends AbstractSpringSecurityIT {
     verify(spiedIdentityProvider, atLeastOnce()).createGroupQuery();
     GroupQuery groupQueryResult = resultCaptor.result;
     assertThat(groupQueryResult).isInstanceOf(OAuth2IdentityProvider.OAuth2GroupQuery.class);
-    assertThat(groupQueryResult).isNotNull();
     assertThat(((OAuth2IdentityProvider.OAuth2GroupQuery) groupQueryResult).getUserId()).isEqualTo(AUTHORIZED_USER);
   }
 

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/CsrfPreventionFilter.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/CsrfPreventionFilter.java
@@ -140,11 +140,7 @@ public class CsrfPreventionFilter implements Filter {
 
     } catch (ClassNotFoundException e) {
       throw new ServletException("Cannot instantiate CSRF Prevention filter: Random class not found.", e);
-    } catch (InstantiationException e) {
-      throw new ServletException("Cannot instantiate CSRF Prevention filter: cannot instantiate provided Random class", e);
-    } catch (InvocationTargetException e) {
-      throw new ServletException("Cannot instantiate CSRF Prevention filter: cannot instantiate provided Random class", e);
-    } catch (NoSuchMethodException e) {
+    } catch (InstantiationException | InvocationTargetException | NoSuchMethodException e) {
       throw new ServletException("Cannot instantiate CSRF Prevention filter: cannot instantiate provided Random class", e);
     } catch (IllegalAccessException e) {
       throw new ServletException("Cannot instantiate CSRF Prevention filter: Random class constructor not accessible", e);


### PR DESCRIPTION
- java:S5786: remove public modifiers from JUnit5 tests
- remove obsolete assertions
- add `@Override` annotations
- remove unused imports
- java:S2147: collapse catch blocks
- java:S3824: Replace "Map.get()" and condition with a call to "Map.computeIfAbsent()"
- java:S2786: Remove redundant "static" qualifier
  nested enum types are implicitly static
- java:S5361: Replace call to "replaceAll()" by a call to the "replace()" method
  do not replace by regexp when not needed

related to #88