### PR TITLE
refactor: Immediately return expression instead of assigning it to a temporary variable

### DIFF
--- a/clients/java/client/src/test/java/org/operaton/bpm/client/task/ExternalTaskImplTest.java
+++ b/clients/java/client/src/test/java/org/operaton/bpm/client/task/ExternalTaskImplTest.java
@@ -195,7 +195,6 @@ class ExternalTaskImplTest {
     for (int i = 0; i < valueInfos.length; i++) {
       valueInfoI.put("vi" + (i + 1), valueInfos[i]);
     }
-    TypedValueField typedValueField = new TypedValueField() {{setType(typeI); setValue(valueI); setValueInfo(valueInfoI); }};
-    return typedValueField;
+    return new TypedValueField() {{setType(typeI); setValue(valueI); setValueInfo(valueInfoI); }};
   }
 }

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/deployment/processor/ProcessesXmlProcessor.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/deployment/processor/ProcessesXmlProcessor.java
@@ -172,12 +172,10 @@ public class ProcessesXmlProcessor implements DeploymentUnitProcessor {
 
     final ProcessesXmlParser processesXmlParser = new ProcessesXmlParser();
 
-    ProcessesXml processesXml = processesXmlParser.createParse()
+    return processesXmlParser.createParse()
       .sourceUrl(url)
       .execute()
       .getProcessesXml();
-
-    return processesXml;
 
   }
 

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/MscRuntimeContainerDelegate.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/MscRuntimeContainerDelegate.java
@@ -291,8 +291,7 @@ public class MscRuntimeContainerDelegate implements Service<MscRuntimeContainerD
 
   @SuppressWarnings("unchecked")
   protected ServiceController<ProcessEngine> getProcessEngineServiceController(ServiceName processEngineServiceName) {
-    ServiceController<ProcessEngine> serviceController = (ServiceController<ProcessEngine>) serviceContainer.getRequiredService(processEngineServiceName);
-    return serviceController;
+    return (ServiceController<ProcessEngine>) serviceContainer.getRequiredService(processEngineServiceName);
   }
 
   protected void startTrackingServices() {

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/ProcessApplicationStartService.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/ProcessApplicationStartService.java
@@ -314,8 +314,7 @@ public class ProcessApplicationStartService implements Service<ProcessApplicatio
 
   protected Class<?> getPaClass(AnnotationInstance annotation) throws ClassNotFoundException {
     String paClassName = ((MethodInfo)annotation.target()).declaringClass().name().toString();
-    Class<?> paClass = paModule.getClassLoader().loadClass(paClassName);
-    return paClass;
+    return paModule.getClassLoader().loadClass(paClassName);
   }
 
   @SuppressWarnings("unchecked")

--- a/distro/wildfly26/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/deployment/processor/ProcessApplicationDeploymentProcessor.java
+++ b/distro/wildfly26/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/deployment/processor/ProcessApplicationDeploymentProcessor.java
@@ -193,8 +193,7 @@ public class ProcessApplicationDeploymentProcessor implements DeploymentUnitProc
   }
 
   protected ComponentDescription getProcessApplicationComponent(DeploymentUnit deploymentUnit) {
-    ComponentDescription paComponentDescription = ProcessApplicationAttachments.getProcessApplicationComponent(deploymentUnit);
-    return paComponentDescription;
+    return ProcessApplicationAttachments.getProcessApplicationComponent(deploymentUnit);
   }
 
   @SuppressWarnings("unchecked")

--- a/distro/wildfly26/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/deployment/processor/ProcessesXmlProcessor.java
+++ b/distro/wildfly26/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/deployment/processor/ProcessesXmlProcessor.java
@@ -171,12 +171,10 @@ public class ProcessesXmlProcessor implements DeploymentUnitProcessor {
 
     final ProcessesXmlParser processesXmlParser = new ProcessesXmlParser();
 
-    ProcessesXml processesXml = processesXmlParser.createParse()
+    return processesXmlParser.createParse()
       .sourceUrl(url)
       .execute()
       .getProcessesXml();
-
-    return processesXml;
 
   }
 

--- a/distro/wildfly26/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/MscRuntimeContainerDelegate.java
+++ b/distro/wildfly26/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/MscRuntimeContainerDelegate.java
@@ -267,8 +267,7 @@ public class MscRuntimeContainerDelegate implements Service<MscRuntimeContainerD
 
   @SuppressWarnings("unchecked")
   protected ServiceController<ProcessEngine> getProcessEngineServiceController(ServiceName processEngineServiceName) {
-    ServiceController<ProcessEngine> serviceController = (ServiceController<ProcessEngine>) serviceContainer.getRequiredService(processEngineServiceName);
-    return serviceController;
+    return (ServiceController<ProcessEngine>) serviceContainer.getRequiredService(processEngineServiceName);
   }
 
   protected void startTrackingServices() {

--- a/distro/wildfly26/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/ProcessApplicationStartService.java
+++ b/distro/wildfly26/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/ProcessApplicationStartService.java
@@ -293,8 +293,7 @@ public class ProcessApplicationStartService implements Service<ProcessApplicatio
 
   protected Class<?> getPaClass(AnnotationInstance annotation) throws ClassNotFoundException {
     String paClassName = ((MethodInfo)annotation.target()).declaringClass().name().toString();
-    Class<?> paClass = paModule.getClassLoader().loadClass(paClassName);
-    return paClass;
+    return paModule.getClassLoader().loadClass(paClassName);
   }
 
   @SuppressWarnings("unchecked")

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/el/CdiResolver.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/el/CdiResolver.java
@@ -40,8 +40,7 @@ public class CdiResolver extends ELResolver {
 
   protected javax.el.ELResolver getWrappedResolver() {
     BeanManager beanManager = getBeanManager();
-    javax.el.ELResolver resolver = beanManager.getELResolver();
-    return resolver;
+    return beanManager.getELResolver();
   }
 
   @Override

--- a/engine-plugins/spin-plugin/src/test/java/org/operaton/spin/plugin/variables/JsonSerializationWithValidationOnMultipleEnginesTest.java
+++ b/engine-plugins/spin-plugin/src/test/java/org/operaton/spin/plugin/variables/JsonSerializationWithValidationOnMultipleEnginesTest.java
@@ -119,11 +119,10 @@ public class JsonSerializationWithValidationOnMultipleEnginesTest {
   }
 
   protected BpmnModelInstance getOneTaskModel() {
-    BpmnModelInstance oneTaskProcess = Bpmn.createExecutableProcess("oneTaskProcess")
+    return Bpmn.createExecutableProcess("oneTaskProcess")
         .startEvent()
         .userTask()
         .endEvent()
         .done();
-    return oneTaskProcess;
   }
 }

--- a/engine-rest/engine-rest-openapi-generator/src/main/java/org/operaton/bpm/engine/rest/openapi/generator/impl/TemplateParser.java
+++ b/engine-rest/engine-rest-openapi-generator/src/main/java/org/operaton/bpm/engine/rest/openapi/generator/impl/TemplateParser.java
@@ -112,9 +112,7 @@ public class TemplateParser {
         .create();
 
     JsonElement json = JsonParser.parseString(jsonString);
-    String formattedJson = gson.toJson(json);
-
-    return formattedJson;
+    return gson.toJson(json);
   }
 
   protected static String createOutputFile(String debugFile) {

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/LinkableDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/LinkableDto.java
@@ -38,8 +38,7 @@ public abstract class LinkableDto {
   }
   
   public AtomLink generateLink(URI linkUri, String method, String relation) {   
-    AtomLink link = new AtomLink(relation, linkUri.toString(), method);
-    return link;
+    return new AtomLink(relation, linkUri.toString(), method);
   }
   
 }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/history/impl/HistoricJobLogResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/history/impl/HistoricJobLogResourceImpl.java
@@ -60,8 +60,7 @@ public class HistoricJobLogResourceImpl implements HistoricJobLogResource {
   public String getStacktrace() {
     try {
       HistoryService historyService = engine.getHistoryService();
-      String stacktrace = historyService.getHistoricJobLogExceptionStacktrace(id);
-      return stacktrace;
+      return historyService.getHistoricJobLogExceptionStacktrace(id);
     } catch (AuthorizationException e) {
       throw e;
     } catch (ProcessEngineException e) {

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/identity/impl/GroupResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/identity/impl/GroupResourceImpl.java
@@ -56,9 +56,7 @@ public class GroupResourceImpl extends AbstractIdentityResource implements Group
       throw new InvalidRequestException(Status.NOT_FOUND, "Group with id " + resourceId + " does not exist");
     }
 
-    GroupDto group = GroupDto.fromGroup(dbGroup);
-
-    return group;
+    return GroupDto.fromGroup(dbGroup);
   }
 
   @Override

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/identity/impl/TenantResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/identity/impl/TenantResourceImpl.java
@@ -55,8 +55,7 @@ public class TenantResourceImpl extends AbstractIdentityResource implements Tena
       throw new InvalidRequestException(Status.NOT_FOUND, "Tenant with id " + resourceId + " does not exist");
     }
 
-    TenantDto dto = TenantDto.fromTenant(tenant);
-    return dto;
+    return TenantDto.fromTenant(tenant);
   }
 
   @Override

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/identity/impl/UserResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/identity/impl/UserResourceImpl.java
@@ -58,9 +58,7 @@ public class UserResourceImpl extends AbstractIdentityResource implements UserRe
       throw new InvalidRequestException(Status.NOT_FOUND, "User with id " + resourceId + " does not exist");
     }
 
-    UserProfileDto user = UserProfileDto.fromUser(dbUser);
-
-    return user;
+    return UserProfileDto.fromUser(dbUser);
   }
 
   @Override

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/impl/CaseExecutionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/impl/CaseExecutionResourceImpl.java
@@ -69,8 +69,7 @@ public class CaseExecutionResourceImpl implements CaseExecutionResource {
       throw new InvalidRequestException(Status.NOT_FOUND, "Case execution with id " + caseExecutionId + " does not exist.");
     }
 
-    CaseExecutionDto result = CaseExecutionDto.fromCaseExecution(execution);
-    return result;
+    return CaseExecutionDto.fromCaseExecution(execution);
   }
 
   @Override

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/impl/CaseInstanceResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/impl/CaseInstanceResourceImpl.java
@@ -68,8 +68,7 @@ public class CaseInstanceResourceImpl implements CaseInstanceResource {
       throw new InvalidRequestException(Status.NOT_FOUND, "Case instance with id " + caseInstanceId + " does not exist.");
     }
 
-    CaseInstanceDto result = CaseInstanceDto.fromCaseInstance(instance);
-    return result;
+    return CaseInstanceDto.fromCaseInstance(instance);
   }
 
   @Override

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/impl/JobResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/impl/JobResourceImpl.java
@@ -60,8 +60,7 @@ public class JobResourceImpl implements JobResource {
   public String getStacktrace() {
     try {
       ManagementService managementService = engine.getManagementService();
-      String stacktrace = managementService.getJobExceptionStacktrace(jobId);
-      return stacktrace;
+      return managementService.getJobExceptionStacktrace(jobId);
     } catch (AuthorizationException e) {
       throw e;
     } catch (ProcessEngineException e) {

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/impl/ProcessInstanceResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/impl/ProcessInstanceResourceImpl.java
@@ -61,8 +61,7 @@ public class ProcessInstanceResourceImpl implements ProcessInstanceResource {
       throw new InvalidRequestException(Status.NOT_FOUND, "Process instance with id " + processInstanceId + " does not exist");
     }
 
-    ProcessInstanceDto result = ProcessInstanceDto.fromProcessInstance(instance);
-    return result;
+    return ProcessInstanceDto.fromProcessInstance(instance);
   }
 
   @Override
@@ -103,8 +102,7 @@ public class ProcessInstanceResourceImpl implements ProcessInstanceResource {
       throw new InvalidRequestException(Status.NOT_FOUND, "Process instance with id " + processInstanceId + " does not exist");
     }
 
-    ActivityInstanceDto result = ActivityInstanceDto.fromActivityInstance(activityInstance);
-    return result;
+    return ActivityInstanceDto.fromActivityInstance(activityInstance);
   }
 
   @Override

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/EngineUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/EngineUtil.java
@@ -56,8 +56,7 @@ public class EngineUtil {
     Iterator<ProcessEngineProvider> iterator = serviceLoader.iterator();
 
     if (iterator.hasNext()) {
-      ProcessEngineProvider provider = iterator.next();
-      return provider;
+      return iterator.next();
     } else {
       throw new RestException(Status.INTERNAL_SERVER_ERROR, "No process engine provider found");
     }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DeploymentRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DeploymentRestServiceInteractionTest.java
@@ -122,8 +122,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
   private InputStream createMockDeploymentResourceBpmnDataNonExecutableProcess() {
     // do not close the input stream, will be done in implementation
     String model = Bpmn.convertToString(Bpmn.createProcess().startEvent().endEvent().done());
-    InputStream inputStream = new ByteArrayInputStream(model.getBytes());
-    return inputStream;
+    return new ByteArrayInputStream(model.getBytes());
   }
 
   private InputStream createMockDeploymentResourceSvgData() {

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/VariableTypeHelper.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/VariableTypeHelper.java
@@ -30,8 +30,6 @@ public class VariableTypeHelper {
   public static String toExpectedValueTypeName(ValueType type) {
     String typeName = type.getName();
 
-    String expectedName = typeName.substring(0, 1).toUpperCase() + typeName.substring(1);
-
-    return expectedName;
+    return typeName.substring(0, 1).toUpperCase() + typeName.substring(1);
   }
 }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/VariablesBuilder.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/VariablesBuilder.java
@@ -46,8 +46,7 @@ public class VariablesBuilder {
   }
 
   public static VariablesBuilder create() {
-    VariablesBuilder builder = new VariablesBuilder();
-    return builder;
+    return new VariablesBuilder();
   }
 
   public VariablesBuilder variable(String name, Object value, String type) {

--- a/engine-spring/core/src/main/java/org/operaton/bpm/engine/spring/components/scope/ProcessScope.java
+++ b/engine-spring/core/src/main/java/org/operaton/bpm/engine/spring/components/scope/ProcessScope.java
@@ -158,8 +158,7 @@ public class ProcessScope implements Scope, InitializingBean, BeanFactoryPostPro
                 ProcessInstance processInstance = Context.getBpmnExecutionContext().getProcessInstance();
                 Method method = methodInvocation.getMethod();
                 Object[] args = methodInvocation.getArguments();
-                Object result = method.invoke(processInstance, args);
-                return result;
+                return method.invoke(processInstance, args);
             }
         });
         return proxyFactoryBean.getProxy(this.classLoader);

--- a/engine/src/main/java/org/operaton/bpm/container/impl/deployment/ParseProcessesXmlStep.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/deployment/ParseProcessesXmlStep.java
@@ -152,12 +152,10 @@ public class ParseProcessesXmlStep extends DeploymentOperationStep {
 
     final ProcessesXmlParser processesXmlParser = new ProcessesXmlParser();
 
-    ProcessesXml processesXml = processesXmlParser.createParse()
+    return processesXmlParser.createParse()
       .sourceUrl(url)
       .execute()
       .getProcessesXml();
-
-    return processesXml;
 
   }
 

--- a/engine/src/main/java/org/operaton/bpm/container/impl/deployment/StartProcessEngineStep.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/deployment/StartProcessEngineStep.java
@@ -156,8 +156,7 @@ public class StartProcessEngineStep extends DeploymentOperationStep {
   protected JobExecutor getJobExecutorService(final PlatformServiceContainer serviceContainer) {
     // lookup container managed job executor
     String jobAcquisitionName = processEngineXml.getJobAcquisitionName();
-    JobExecutor jobExecutor = serviceContainer.getServiceValue(ServiceTypes.JOB_EXECUTOR, jobAcquisitionName);
-    return jobExecutor;
+    return serviceContainer.getServiceValue(ServiceTypes.JOB_EXECUTOR, jobAcquisitionName);
   }
 
   @SuppressWarnings("unchecked")

--- a/engine/src/main/java/org/operaton/bpm/container/impl/deployment/jobexecutor/StartJobExecutorStep.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/deployment/jobexecutor/StartJobExecutorStep.java
@@ -50,8 +50,7 @@ public class StartJobExecutorStep extends DeploymentOperationStep {
 
   private JobExecutorXml getJobExecutorXml(DeploymentOperation operationContext) {
     BpmPlatformXml bpmPlatformXml = operationContext.getAttachment(Attachments.BPM_PLATFORM_XML);
-    JobExecutorXml jobExecutorXml = bpmPlatformXml.getJobExecutor();
-    return jobExecutorXml;
+    return bpmPlatformXml.getJobExecutor();
   }
   
   

--- a/engine/src/main/java/org/operaton/bpm/container/impl/deployment/jobexecutor/StartManagedThreadPoolStep.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/deployment/jobexecutor/StartManagedThreadPoolStep.java
@@ -80,8 +80,7 @@ public class StartManagedThreadPoolStep extends DeploymentOperationStep {
 
   private JobExecutorXml getJobExecutorXml(DeploymentOperation operationContext) {
     BpmPlatformXml bpmPlatformXml = operationContext.getAttachment(Attachments.BPM_PLATFORM_XML);
-    JobExecutorXml jobExecutorXml = bpmPlatformXml.getJobExecutor();
-    return jobExecutorXml;
+    return bpmPlatformXml.getJobExecutor();
   }
 
   private int getQueueSize(JobExecutorXml jobExecutorXml) {

--- a/engine/src/main/java/org/operaton/bpm/engine/authorization/BatchPermissions.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/authorization/BatchPermissions.java
@@ -123,7 +123,6 @@ public enum BatchPermissions implements Permission {
   }
 
   public static Permission forName(String name) {
-    Permission permission = valueOf(name);
-    return permission;
+    return valueOf(name);
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/authorization/Permissions.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/authorization/Permissions.java
@@ -150,8 +150,7 @@ public enum Permissions implements Permission {
   }
 
   public static Permission forName(String name) {
-    Permission permission = valueOf(name);
-    return permission;
+    return valueOf(name);
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricDecisionInstanceStatisticsQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricDecisionInstanceStatisticsQueryImpl.java
@@ -43,22 +43,18 @@ public class HistoricDecisionInstanceStatisticsQueryImpl extends
   public long executeCount(CommandContext commandContext) {
     checkQueryOk();
 
-    long count = commandContext
+    return commandContext
         .getStatisticsManager()
         .getStatisticsCountGroupedByDecisionRequirementsDefinition(this);
-
-    return count;
   }
 
   @Override
   public List<HistoricDecisionInstanceStatistics> executeList(CommandContext commandContext, Page page) {
     checkQueryOk();
 
-    List<HistoricDecisionInstanceStatistics> statisticsList = commandContext
+    return commandContext
         .getStatisticsManager()
         .getStatisticsGroupedByDecisionRequirementsDefinition(this, page);
-
-    return statisticsList;
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/BatchEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/BatchEntity.java
@@ -469,8 +469,7 @@ public class BatchEntity implements Batch, DbEntity, HasDbReferences, Nameable, 
 
   @Override
   public Set<String> getReferencedEntityIds() {
-    Set<String> referencedEntityIds = new HashSet<>();
-    return referencedEntityIds;
+    return new HashSet<>();
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/deletion/DeleteHistoricProcessInstanceBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/deletion/DeleteHistoricProcessInstanceBatchConfigurationJsonConverter.java
@@ -49,9 +49,8 @@ public class DeleteHistoricProcessInstanceBatchConfigurationJsonConverter
 
   @Override
   public BatchConfiguration readConfiguration(JsonObject json) {
-    BatchConfiguration configuration = new BatchConfiguration(readProcessInstanceIds(json), readIdMappings(json),
+    return new BatchConfiguration(readProcessInstanceIds(json), readIdMappings(json),
         JsonUtil.getBoolean(json, FAIL_IF_NOT_EXISTS));
-    return configuration;
   }
 
   protected List<String> readProcessInstanceIds(JsonObject jsonObject) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/job/SetJobRetriesBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/job/SetJobRetriesBatchConfigurationJsonConverter.java
@@ -66,10 +66,8 @@ public class SetJobRetriesBatchConfigurationJsonConverter
       dueDate = new Date(JsonUtil.getLong(json, DUE_DATE));
     }
 
-    SetJobRetriesBatchConfiguration configuration = new SetJobRetriesBatchConfiguration(
+    return new SetJobRetriesBatchConfiguration(
         readJobIds(json), readIdMappings(json), JsonUtil.getInt(json, RETRIES), dueDate, isDueDateSet);
-
-    return configuration;
   }
 
   protected List<String> readJobIds(JsonObject jsonObject) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/update/UpdateProcessInstancesSuspendStateBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/update/UpdateProcessInstancesSuspendStateBatchConfigurationJsonConverter.java
@@ -45,11 +45,8 @@ public class UpdateProcessInstancesSuspendStateBatchConfigurationJsonConverter
 
   @Override
   public UpdateProcessInstancesSuspendStateBatchConfiguration readConfiguration(JsonObject json) {
-    UpdateProcessInstancesSuspendStateBatchConfiguration configuration =
-      new UpdateProcessInstancesSuspendStateBatchConfiguration(readProcessInstanceIds(json), readMappings(json),
+    return new UpdateProcessInstancesSuspendStateBatchConfiguration(readProcessInstanceIds(json), readMappings(json),
           JsonUtil.getBoolean(json, SUSPENDING));
-
-    return configuration;
   }
 
   protected List<String> readProcessInstanceIds(JsonObject jsonObject) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/diagram/ProcessDiagramLayoutFactory.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/diagram/ProcessDiagramLayoutFactory.java
@@ -205,8 +205,7 @@ public class ProcessDiagramLayoutFactory {
     } catch (IOException e) {
       throw new ProcessEngineException("Error while reading process diagram image.", e);
     }
-    DiagramNode diagramBoundsImage = getDiagramBoundsFromImage(image, offsetTop, offsetBottom);
-    return diagramBoundsImage;
+    return getDiagramBoundsFromImage(image, offsetTop, offsetBottom);
   }
 
   protected DiagramNode getDiagramBoundsFromImage(BufferedImage image, int offsetTop, int offsetBottom) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractCorrelateMessageCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractCorrelateMessageCmd.java
@@ -136,8 +136,7 @@ public abstract class AbstractCorrelateMessageCmd {
   }
 
   protected ExecutionEntity findProcessInstanceExecution(final CommandContext commandContext, final CorrelationHandlerResult handlerResult) {
-    ExecutionEntity execution = commandContext.getExecutionManager().findExecutionById(handlerResult.getExecution().getProcessInstanceId());
-    return execution;
+    return commandContext.getExecutionManager().findExecutionById(handlerResult.getExecution().getProcessInstanceId());
   }
 
   protected VariableMap resolveVariables() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractWritableIdentityServiceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractWritableIdentityServiceCmd.java
@@ -38,8 +38,7 @@ public abstract class AbstractWritableIdentityServiceCmd<T> implements Command<T
       throw new UnsupportedOperationException("This identity service implementation is read-only.");
     }
     
-    T result = executeCmd(commandContext);
-    return result; 
+    return executeCmd(commandContext); 
   }
 
   protected abstract T executeCmd(CommandContext commandContext);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivityBeforeInstantiationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivityBeforeInstantiationCmd.java
@@ -71,8 +71,7 @@ public class ActivityBeforeInstantiationCmd extends AbstractInstantiationCmd {
 
   @Override
   protected CoreModelElement getTargetElement(ProcessDefinitionImpl processDefinition) {
-    ActivityImpl activity = processDefinition.findActivity(activityId);
-    return activity;
+    return processDefinition.findActivity(activityId);
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivityInstanceCancellationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/ActivityInstanceCancellationCmd.java
@@ -59,9 +59,7 @@ public class ActivityInstanceCancellationCmd extends AbstractInstanceCancellatio
         describeFailure("Activity instance '" + activityInstanceId + "' does not exist"),
         "activityInstance",
         instanceToCancel);
-    ExecutionEntity scopeExecution = getScopeExecutionForActivityInstance(processInstance, mapping, instanceToCancel);
-
-    return scopeExecution;
+    return getScopeExecutionForActivityInstance(processInstance, mapping, instanceToCancel);
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessDiagramCmd.java
@@ -64,10 +64,8 @@ public class GetDeploymentProcessDiagramCmd implements Command<InputStream>, Ser
       return null;
     } else {
 
-      InputStream processDiagramStream = commandContext.runWithoutAuthorization(
+      return commandContext.runWithoutAuthorization(
           new GetDeploymentResourceCmd(deploymentId, resourceName));
-
-      return processDiagramStream;
     }
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessModelCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetDeploymentProcessModelCmd.java
@@ -59,10 +59,8 @@ public class GetDeploymentProcessModelCmd implements Command<InputStream>, Seria
     final String deploymentId = processDefinition.getDeploymentId();
     final String resourceName = processDefinition.getResourceName();
 
-    InputStream processModelStream = commandContext.runWithoutAuthorization(
+    return commandContext.runWithoutAuthorization(
         new GetDeploymentResourceCmd(deploymentId, resourceName));
-
-    return processModelStream;
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetIdentityLinksForProcessDefinitionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetIdentityLinksForProcessDefinitionCmd.java
@@ -49,8 +49,7 @@ public class GetIdentityLinksForProcessDefinitionCmd implements Command<List<Ide
 
     ensureNotNull("Cannot find process definition with id " + processDefinitionId, "processDefinition", processDefinition);
 
-    List<IdentityLink> identityLinks = (List) processDefinition.getIdentityLinks();
-    return identityLinks;
+    return (List) processDefinition.getIdentityLinks();
   }
   
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/RestartProcessInstancesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/RestartProcessInstancesCmd.java
@@ -259,8 +259,7 @@ public class RestartProcessInstancesCmd extends AbstractRestartProcessInstanceCm
 
     ensureNotEmpty("historicActivityInstances", historicActivityInstances);
 
-    HistoricActivityInstance startActivityInstance = historicActivityInstances.get(0);
-    return startActivityInstance;
+    return historicActivityInstances.get(0);
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/TransitionInstanceCancellationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/TransitionInstanceCancellationCmd.java
@@ -50,9 +50,7 @@ public class TransitionInstanceCancellationCmd extends AbstractInstanceCancellat
         "transitionInstance",
         instanceToCancel);
 
-    ExecutionEntity transitionExecution = commandContext.getExecutionManager().findExecutionById(instanceToCancel.getExecutionId());
-
-    return transitionExecution;
+    return commandContext.getExecutionManager().findExecutionById(instanceToCancel.getExecutionId());
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/TransitionInstantiationCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/TransitionInstantiationCmd.java
@@ -51,8 +51,7 @@ public class TransitionInstantiationCmd extends AbstractInstantiationCmd {
 
   @Override
   protected CoreModelElement getTargetElement(ProcessDefinitionImpl processDefinition) {
-    TransitionImpl transition = processDefinition.findTransition(transitionId);
-    return transition;
+    return processDefinition.findTransition(transitionId);
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/cmd/GetDeploymentCaseModelCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/cmd/GetDeploymentCaseModelCmd.java
@@ -57,10 +57,8 @@ public class GetDeploymentCaseModelCmd implements Command<InputStream>, Serializ
     final String deploymentId = caseDefinition.getDeploymentId();
     final String resourceName = caseDefinition.getResourceName();
 
-    InputStream inputStream = commandContext.runWithoutAuthorization(
+    return commandContext.runWithoutAuthorization(
         new GetDeploymentResourceCmd(deploymentId, resourceName));
-
-    return inputStream;
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseSentryPartEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseSentryPartEntity.java
@@ -204,8 +204,7 @@ public class CaseSentryPartEntity extends CmmnSentryPart implements DbEntity, Ha
 
   @Override
   public Set<String> getReferencedEntityIds() {
-    Set<String> referencedEntityIds = new HashSet<>();
-    return referencedEntityIds;
+    return new HashSet<>();
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseSentryPartQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseSentryPartQueryImpl.java
@@ -152,11 +152,9 @@ public class CaseSentryPartQueryImpl extends AbstractQuery<CaseSentryPartQueryIm
   @Override
   public List<CaseSentryPartEntity> executeList(CommandContext commandContext, Page page) {
     checkQueryOk();
-    List<CaseSentryPartEntity> result = commandContext
+    return commandContext
       .getCaseSentryPartManager()
       .findCaseSentryPartByQueryCriteria(this, page);
-
-    return result;
   }
 
   // getters /////////////////////////////////////////////

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/context/ProcessApplicationContextUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/context/ProcessApplicationContextUtil.java
@@ -116,9 +116,7 @@ public class ProcessApplicationContextUtil {
     ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
     ProcessApplicationManager processApplicationManager = processEngineConfiguration.getProcessApplicationManager();
 
-    ProcessApplicationReference processApplicationForDeployment = processApplicationManager.getProcessApplicationForDeployment(deploymentId);
-
-    return processApplicationForDeployment;
+    return processApplicationManager.getProcessApplicationForDeployment(deploymentId);
   }
 
   public static boolean areProcessApplicationsRegistered() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/batch/DeleteHistoricDecisionInstanceBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/batch/DeleteHistoricDecisionInstanceBatchConfigurationJsonConverter.java
@@ -42,8 +42,7 @@ public class DeleteHistoricDecisionInstanceBatchConfigurationJsonConverter exten
 
   @Override
   public BatchConfiguration readConfiguration(JsonObject json) {
-    BatchConfiguration configuration = new BatchConfiguration(readDecisionInstanceIds(json), readMappings(json));
-    return configuration;
+    return new BatchConfiguration(readDecisionInstanceIds(json), readMappings(json));
   }
 
   protected List<String> readDecisionInstanceIds(JsonObject jsonNode) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/form/handler/DefaultFormHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/form/handler/DefaultFormHandler.java
@@ -200,10 +200,9 @@ public class DefaultFormHandler implements FormHandler {
 
 
   protected FormTypes getFormTypes() {
-    FormTypes formTypes = Context
+    return Context
         .getProcessEngineConfiguration()
         .getFormTypes();
-    return formTypes;
   }
 
   protected void parseFormProperties(BpmnParse bpmnParse, ExpressionManager expressionManager, Element extensionElement) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/form/validator/FormValidators.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/form/validator/FormValidators.java
@@ -76,8 +76,7 @@ public class FormValidators {
 
       Class<? extends FormFieldValidator> validator = validators.get(name);
       if(validator != null) {
-        FormFieldValidator validatorInstance = createValidatorInstance(validator);
-        return validatorInstance;
+        return createValidatorInstance(validator);
 
       } else {
         bpmnParse.addError("Cannot find validator implementation for name '"+name+"'.", constraint);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/ProcessDataContext.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/ProcessDataContext.java
@@ -209,9 +209,7 @@ public class ProcessDataContext {
 
     sections.sealCurrentSection();
 
-    boolean newSectionCreated = numSections != sections.size();
-
-    return newSectionCreated;
+    return numSections != sections.size();
   }
 
   protected boolean hasNoMdcValues() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/HistoryCleanupJobHandlerConfiguration.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/HistoryCleanupJobHandlerConfiguration.java
@@ -84,8 +84,7 @@ public class HistoryCleanupJobHandlerConfiguration implements JobHandlerConfigur
    * @return date with delay
    */
   public Date getNextRunWithDelay(Date date) {
-    Date result = addSeconds(date, Math.min((int)(Math.pow(2., countEmptyRuns) * START_DELAY), MAX_DELAY));
-    return result;
+    return addSeconds(date, Math.min((int)(Math.pow(2., countEmptyRuns) * START_DELAY), MAX_DELAY));
   }
 
   private Date addSeconds(Date date, int amount) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/deploy/cache/BpmnModelInstanceCache.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/deploy/cache/BpmnModelInstanceCache.java
@@ -55,9 +55,8 @@ public class BpmnModelInstanceCache extends ModelInstanceCache<BpmnModelInstance
   @Override
   protected List<ProcessDefinition> getAllDefinitionsForDeployment(final String deploymentId) {
     final CommandContext commandContext = Context.getCommandContext();
-    List<ProcessDefinition> allDefinitionsForDeployment = commandContext.runWithoutAuthorization((Callable<List<ProcessDefinition>>) () -> new ProcessDefinitionQueryImpl()
+    return commandContext.runWithoutAuthorization(() -> new ProcessDefinitionQueryImpl()
         .deploymentId(deploymentId)
         .list());
-    return allDefinitionsForDeployment;
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/AuthorizationEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/AuthorizationEntity.java
@@ -322,14 +322,12 @@ public class AuthorizationEntity implements Authorization, DbEntity, HasDbRevisi
 
   @Override
   public Set<String> getReferencedEntityIds() {
-    Set<String> referencedEntityIds = new HashSet<>();
-    return referencedEntityIds;
+    return new HashSet<>();
   }
 
   @Override
   public Map<String, Class> getReferencedEntitiesIdAndClass() {
-    Map<String, Class> referenceIdAndClass = new HashMap<>();
-    return referenceIdAndClass;
+    return new HashMap<>();
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/EventSubscriptionEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/EventSubscriptionEntity.java
@@ -363,8 +363,7 @@ public class EventSubscriptionEntity implements EventSubscription, DbEntity, Has
 
   @Override
   public Set<String> getReferencedEntityIds() {
-    Set<String> referencedEntityIds = new HashSet<>();
-    return referencedEntityIds;
+    return new HashSet<>();
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExternalTaskEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExternalTaskEntity.java
@@ -618,8 +618,7 @@ public class ExternalTaskEntity implements ExternalTask, DbEntity,
 
   @Override
   public Set<String> getReferencedEntityIds() {
-    Set<String> referencedEntityIds = new HashSet<>();
-    return referencedEntityIds;
+    return new HashSet<>();
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/FilterEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/FilterEntity.java
@@ -238,13 +238,11 @@ public class FilterEntity implements Filter, Serializable, DbEntity, HasDbRevisi
 
   @Override
   public Set<String> getReferencedEntityIds() {
-    Set<String> referencedEntityIds = new HashSet<>();
-    return referencedEntityIds;
+    return new HashSet<>();
   }
 
   @Override
   public Map<String, Class> getReferencedEntitiesIdAndClass() {
-    Map<String, Class> referenceIdAndClass = new HashMap<>();
-    return referenceIdAndClass;
+    return new HashMap<>();
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/IdentityLinkEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/IdentityLinkEntity.java
@@ -76,8 +76,7 @@ public class IdentityLinkEntity implements Serializable, IdentityLink, DbEntity,
   }
 
   public static IdentityLinkEntity newIdentityLink() {
-    IdentityLinkEntity identityLinkEntity = new IdentityLinkEntity();
-     return identityLinkEntity;
+    return new IdentityLinkEntity();
   }
 
   public void insert() {
@@ -234,8 +233,7 @@ public class IdentityLinkEntity implements Serializable, IdentityLink, DbEntity,
 
   @Override
   public Set<String> getReferencedEntityIds() {
-    Set<String> referencedEntityIds = new HashSet<>();
-    return referencedEntityIds;
+    return new HashSet<>();
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/JobDefinitionEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/JobDefinitionEntity.java
@@ -206,14 +206,12 @@ public class JobDefinitionEntity implements JobDefinition, HasDbRevision, HasDbR
 
   @Override
   public Set<String> getReferencedEntityIds() {
-    Set<String> referencedEntityIds = new HashSet<>();
-    return referencedEntityIds;
+    return new HashSet<>();
   }
 
   @Override
   public Map<String, Class> getReferencedEntitiesIdAndClass() {
-    Map<String, Class> referenceIdAndClass = new HashMap<>();
-    return referenceIdAndClass;
+    return new HashMap<>();
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/JobEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/JobEntity.java
@@ -648,8 +648,7 @@ public abstract class JobEntity extends AcquirableJobEntity
 
   @Override
   public Set<String> getReferencedEntityIds() {
-    Set<String> referencedEntityIds = new HashSet<>();
-    return referencedEntityIds;
+    return new HashSet<>();
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/MeterLogEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/MeterLogEntity.java
@@ -118,13 +118,11 @@ public class MeterLogEntity implements DbEntity, HasDbReferences, Serializable {
 
   @Override
   public Set<String> getReferencedEntityIds() {
-    Set<String> referencedEntityIds = new HashSet<>();
-    return referencedEntityIds;
+    return new HashSet<>();
   }
 
   @Override
   public Map<String, Class> getReferencedEntitiesIdAndClass() {
-    Map<String, Class> referenceIdAndClass = new HashMap<>();
-    return referenceIdAndClass;
+    return new HashMap<>();
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TableDataManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TableDataManager.java
@@ -202,9 +202,8 @@ public class TableDataManager extends AbstractManager {
 
   protected long getTableCount(String tableName) {
     LOG.selectTableCountForTable(tableName);
-    Long count = (Long) getDbEntityManager().selectOne("selectTableCount",
+    return (Long) getDbEntityManager().selectOne("selectTableCount",
             Collections.singletonMap("tableName", tableName));
-    return count;
   }
 
   @SuppressWarnings("unchecked")

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -1740,8 +1740,7 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
 
   @Override
   public Set<String> getReferencedEntityIds() {
-    Set<String> referencedEntityIds = new HashSet<>();
-    return referencedEntityIds;
+    return new HashSet<>();
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskMeterLogEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskMeterLogEntity.java
@@ -95,13 +95,11 @@ public class TaskMeterLogEntity implements DbEntity, HasDbReferences, Serializab
 
   @Override
   public Set<String> getReferencedEntityIds() {
-    Set<String> referencedEntityIds = new HashSet<>();
-    return referencedEntityIds;
+    return new HashSet<>();
   }
 
   @Override
   public Map<String, Class> getReferencedEntitiesIdAndClass() {
-    Map<String, Class> referenceIdAndClass = new HashMap<>();
-    return referenceIdAndClass;
+    return new HashMap<>();
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/VariableInstanceEntity.java
@@ -741,8 +741,7 @@ public class VariableInstanceEntity implements VariableInstance, CoreVariableIns
 
   @Override
   public Set<String> getReferencedEntityIds() {
-    Set<String> referencedEntityIds = new HashSet<>();
-    return referencedEntityIds;
+    return new HashSet<>();
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/runtime/ConditionHandlerResult.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/runtime/ConditionHandlerResult.java
@@ -45,7 +45,6 @@ public class ConditionHandlerResult {
   }
 
   public static ConditionHandlerResult matchedProcessDefinition(ProcessDefinitionEntity processDefinition, ActivityImpl startActivityId) {
-    ConditionHandlerResult conditionHandlerResult = new ConditionHandlerResult(processDefinition, startActivityId);
-    return conditionHandlerResult;
+    return new ConditionHandlerResult(processDefinition, startActivityId);
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/test/PvmTestCase.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/test/PvmTestCase.java
@@ -58,8 +58,7 @@ public class PvmTestCase extends TestCase {
 
   public Object defaultManualActivation() {
     Expression expression = new FixedValue(true);
-    CaseControlRuleImpl caseControlRule = new CaseControlRuleImpl(expression);
-    return caseControlRule;
+    return new CaseControlRuleImpl(expression);
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/test/TestHelper.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/test/TestHelper.java
@@ -604,7 +604,6 @@ public abstract class TestHelper {
 
   public static Object defaultManualActivation() {
     Expression expression = new FixedValue(true);
-    CaseControlRuleImpl caseControlRule = new CaseControlRuleImpl(expression);
-    return caseControlRule;
+    return new CaseControlRuleImpl(expression);
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ParseUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ParseUtil.java
@@ -153,8 +153,7 @@ public class ParseUtil {
       jdkVendor = "OpenJDK";
     }
     String jdkVersion = System.getProperty("java.version");
-    JdkImpl jdk = new JdkImpl(jdkVersion, jdkVendor);
-    return jdk;
+    return new JdkImpl(jdkVersion, jdkVendor);
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/variable/serializer/AbstractSerializableValueSerializer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/variable/serializer/AbstractSerializableValueSerializer.java
@@ -87,8 +87,7 @@ public abstract class AbstractSerializableValueSerializer<T extends Serializable
           throw new ProcessEngineException("Cannot deserialize object in variable '"+valueFields.getName()+"': "+e.getMessage(), e);
         }
       }
-      T value = createDeserializedValue(deserializedObject, serializedStringValue, valueFields, asTransientValue);
-      return value;
+      return createDeserializedValue(deserializedObject, serializedStringValue, valueFields, asTransientValue);
     }
     else {
       return createSerializedValue(serializedStringValue, valueFields, asTransientValue);

--- a/engine/src/main/java/org/operaton/bpm/engine/repository/ResourceTypes.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/repository/ResourceTypes.java
@@ -50,8 +50,7 @@ public enum ResourceTypes implements ResourceType {
   }
 
   public static ResourceType forName(String name) {
-    ResourceType type = valueOf(name);
-    return type;
+    return valueOf(name);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/AbstractAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/AbstractAsyncOperationsTest.java
@@ -102,8 +102,7 @@ public abstract class AbstractAsyncOperationsTest {
 
   protected Job getSeedJob(Batch batch) {
     String seedJobDefinitionId = batch.getSeedJobDefinitionId();
-    Job seedJob = managementService.createJobQuery().jobDefinitionId(seedJobDefinitionId).singleResult();
-    return seedJob;
+    return managementService.createJobQuery().jobDefinitionId(seedJobDefinitionId).singleResult();
   }
 
   /**

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/AuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/AuthorizationTest.java
@@ -215,18 +215,15 @@ public abstract class AuthorizationTest extends PluggableProcessEngineTest {
   }
 
   protected Authorization createGlobalAuthorization(Resource resource, String resourceId) {
-    Authorization authorization = createAuthorization(AUTH_TYPE_GLOBAL, resource, resourceId);
-    return authorization;
+    return createAuthorization(AUTH_TYPE_GLOBAL, resource, resourceId);
   }
 
   protected Authorization createGrantAuthorization(Resource resource, String resourceId) {
-    Authorization authorization = createAuthorization(AUTH_TYPE_GRANT, resource, resourceId);
-    return authorization;
+    return createAuthorization(AUTH_TYPE_GRANT, resource, resourceId);
   }
 
   protected Authorization createRevokeAuthorization(Resource resource, String resourceId) {
-    Authorization authorization = createAuthorization(AUTH_TYPE_REVOKE, resource, resourceId);
-    return authorization;
+    return createAuthorization(AUTH_TYPE_REVOKE, resource, resourceId);
   }
 
   protected Authorization createAuthorization(int type, Resource resource, String resourceId) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ResourceAuthorizationProviderTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ResourceAuthorizationProviderTest.java
@@ -325,8 +325,7 @@ public class ResourceAuthorizationProviderTest {
   }
 
   protected Authorization createGrantAuthorization(Resource resource, String resourceId) {
-    Authorization authorization = createAuthorization(AUTH_TYPE_GRANT, resource, resourceId);
-    return authorization;
+    return createAuthorization(AUTH_TYPE_GRANT, resource, resourceId);
   }
 
   protected Authorization createAuthorization(int type, Resource resource, String resourceId) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/BatchStatisticsQueryAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/BatchStatisticsQueryAuthorizationTest.java
@@ -214,7 +214,6 @@ public class BatchStatisticsQueryAuthorizationTest {
         .mapEqualActivities()
         .build();
 
-    ProcessInstance pi = engineRule.getRuntimeService().startProcessInstanceById(sourceDefinition.getId());
-    return pi;
+    return engineRule.getRuntimeService().startProcessInstanceById(sourceDefinition.getId());
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/job/SetJobRetriesAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/job/SetJobRetriesAuthorizationTest.java
@@ -193,27 +193,24 @@ public class SetJobRetriesAuthorizationTest {
   // helper /////////////////////////////////////////////////////
 
   protected Job selectJobByProcessInstanceId(String processInstanceId) {
-    Job job = managementService
+    return managementService
         .createJobQuery()
         .processInstanceId(processInstanceId)
         .singleResult();
-    return job;
   }
 
   protected Job selectJobById(String jobId) {
-    Job job = managementService
+    return managementService
         .createJobQuery()
         .jobId(jobId)
         .singleResult();
-    return job;
   }
 
   protected JobDefinition selectJobDefinitionByProcessDefinitionKey(String processDefinitionKey) {
-    JobDefinition jobDefinition = managementService
+    return managementService
         .createJobDefinitionQuery()
         .processDefinitionKey(processDefinitionKey)
         .singleResult();
-    return jobDefinition;
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/job/UpdateJobAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/job/UpdateJobAuthorizationTest.java
@@ -456,19 +456,17 @@ public class UpdateJobAuthorizationTest {
   // helper /////////////////////////////////////////////////////
 
   protected Job selectJobByProcessInstanceId(String processInstanceId) {
-    Job job = managementService
+    return managementService
         .createJobQuery()
         .processInstanceId(processInstanceId)
         .singleResult();
-    return job;
   }
 
   protected Job selectJobById(String jobId) {
-    Job job = managementService
+    return managementService
         .createJobQuery()
         .jobId(jobId)
         .singleResult();
-    return job;
   }
 
   protected String selectJobDefinitionIdByProcessDefinitionKey(String processDefinitionKey) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseHistoryPropertyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseHistoryPropertyTest.java
@@ -142,16 +142,13 @@ public class DatabaseHistoryPropertyTest {
   }
 
   private static ProcessEngineImpl createProcessEngineImpl(String databaseSchemaUpdate, boolean executeSchemaOperations) {
-    ProcessEngineImpl processEngine =
-        (ProcessEngineImpl) new CustomStandaloneInMemProcessEngineConfiguration()
+    return (ProcessEngineImpl) new CustomStandaloneInMemProcessEngineConfiguration()
                .setExecuteSchemaOperations(executeSchemaOperations)
                .setProcessEngineName("database-history-test-engine")
                .setDatabaseSchemaUpdate(databaseSchemaUpdate)
                .setHistory(ProcessEngineConfiguration.HISTORY_FULL)
                .setJdbcUrl("jdbc:h2:mem:DatabaseHistoryPropertyTest")
                .buildProcessEngine();
-
-    return processEngine;
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupHistoricBatchTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupHistoricBatchTest.java
@@ -360,7 +360,7 @@ public class HistoryCleanupHistoricBatchTest {
   }
 
   private BpmnModelInstance createModelInstance() {
-    BpmnModelInstance instance = Bpmn.createExecutableProcess("process")
+    return Bpmn.createExecutableProcess("process")
         .operatonHistoryTimeToLive(180)
         .startEvent("start")
         .userTask("userTask1")
@@ -368,7 +368,6 @@ public class HistoryCleanupHistoricBatchTest {
         .userTask("userTask2")
         .endEvent("end")
         .done();
-    return instance;
   }
 
   private void prepareHistoricBatches(int batchesCount, int daysInThePast) {
@@ -404,8 +403,7 @@ public class HistoryCleanupHistoricBatchTest {
 
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(sourceProcessDefinition.getId());
 
-    Batch batch = runtimeService.newMigration(migrationPlan).processInstanceIds(Arrays.asList(processInstance.getId(), "unknownId")).executeAsync();
-    return batch;
+    return runtimeService.newMigration(migrationPlan).processInstanceIds(Arrays.asList(processInstance.getId(), "unknownId")).executeAsync();
   }
 
   private List<String> createMigrationBatchList(int migrationCountBatch) {
@@ -419,8 +417,7 @@ public class HistoryCleanupHistoricBatchTest {
   private Batch createModificationBatch() {
     BpmnModelInstance instance = createModelInstance();
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
-    Batch modificationBatch = modificationHelper.startAfterAsync("process", 1, "userTask1", processDefinition.getId());
-    return modificationBatch;
+    return modificationHelper.startAfterAsync("process", 1, "userTask1", processDefinition.getId());
   }
 
   private List<String> createCancelationBatchList(int cancelationCountBatch) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyJobCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyJobCmdsTenantCheckTest.java
@@ -621,10 +621,9 @@ public class MultiTenancyJobCmdsTenantCheckTest {
   }
 
   protected Job selectJobByProcessInstanceId(String processInstanceId) {
-    Job job = managementService
+    return managementService
         .createJobQuery()
         .processInstanceId(processInstanceId)
         .singleResult();
-    return job;
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/resources/HistoryByteArrayTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/resources/HistoryByteArrayTest.java
@@ -318,13 +318,12 @@ public class HistoryByteArrayTest {
     String encoding = "crazy-encoding";
     String mimeType = "martini/dry";
 
-    FileValue fileValue = Variables
+    return Variables
         .fileValue(fileName)
         .file("ABC".getBytes())
         .encoding(encoding)
         .mimeType(mimeType)
         .create();
-    return fileValue;
   }
 
   protected BpmnModelInstance createProcess() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/resources/RuntimeByteArrayTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/resources/RuntimeByteArrayTest.java
@@ -228,13 +228,12 @@ public class RuntimeByteArrayTest {
     String encoding = "crazy-encoding";
     String mimeType = "martini/dry";
 
-    FileValue fileValue = Variables
+    return Variables
         .fileValue(fileName)
         .file("ABC".getBytes())
         .encoding(encoding)
         .mimeType(mimeType)
         .create();
-    return fileValue;
   }
 
   protected BpmnModelInstance createProcess() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.java
@@ -3333,8 +3333,7 @@ public class RuntimeServiceTest {
   }
 
   private BpmnModelInstance prepareComplexProcess(String calledProcessA,String calledProcessB,String calledProcessC) {
-    BpmnModelInstance calling =
-        Bpmn.createExecutableProcess("calling")
+    return Bpmn.createExecutableProcess("calling")
           .startEvent()
           .parallelGateway("fork1")
             .subProcess()
@@ -3357,27 +3356,23 @@ public class RuntimeServiceTest {
             .endEvent()
 
         .done();
-    return calling;
   }
 
   private BpmnModelInstance prepareSimpleProcess(String name) {
-    BpmnModelInstance calledA = Bpmn.createExecutableProcess(name)
+    return Bpmn.createExecutableProcess(name)
         .startEvent()
         .userTask("Task" + name)
         .endEvent()
         .done();
-    return calledA;
   }
 
   private BpmnModelInstance prepareCallingProcess(String callingProcess, String calledProcess) {
-    BpmnModelInstance calling =
-        Bpmn.createExecutableProcess(callingProcess)
+    return Bpmn.createExecutableProcess(callingProcess)
           .startEvent()
           .callActivity()
             .calledElement(calledProcess)
           .endEvent()
           .done();
-    return calling;
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationTest.java
@@ -2602,7 +2602,7 @@ public class MessageCorrelationTest {
   }
 
   protected BpmnModelInstance createModelWithEventSubprocess(boolean isInterrupting, boolean isAsync) {
-    BpmnModelInstance targetModel = modify(Bpmn.createExecutableProcess("Process_1")
+    return modify(Bpmn.createExecutableProcess("Process_1")
         .startEvent()
         .subProcess("Subprocess_1")
           .embeddedSubProcess()
@@ -2628,7 +2628,6 @@ public class MessageCorrelationTest {
             .userTask("wrongOutcome")
             .endEvent("unhappyEnd")
             .done();
-    return targetModel;
   }
 
   protected BpmnModelInstance createModelWithBoundaryEvent(boolean isInterrupting, boolean isAsync) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationTimerBoundryEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationTimerBoundryEventTest.java
@@ -387,7 +387,7 @@ public class MigrationTimerBoundryEventTest {
   }
 
   protected BpmnModelInstance createModel(boolean isCancelActivity, String date) {
-    BpmnModelInstance model = Bpmn.createExecutableProcess()
+    return Bpmn.createExecutableProcess()
         .startEvent("startEvent")
         .userTask("userTask").name("User Task")
         .boundaryEvent("timer")
@@ -396,6 +396,5 @@ public class MigrationTimerBoundryEventTest {
         .userTask("afterTimer")
         .endEvent("endEvent")
         .done();
-    return model;
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/async/RetryCmdDeployment.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/async/RetryCmdDeployment.java
@@ -39,7 +39,7 @@ public class RetryCmdDeployment {
   }
 
   public static BpmnModelInstance prepareSignalEventProcess() {
-    BpmnModelInstance modelInstance = Bpmn.createExecutableProcess(PROCESS_ID)
+    return Bpmn.createExecutableProcess(PROCESS_ID)
         .startEvent()
           .intermediateThrowEvent(FAILING_EVENT)
             .operatonAsyncBefore(true)
@@ -49,7 +49,6 @@ public class RetryCmdDeployment {
             .operatonClass(FailingDelegate.class.getName())
         .endEvent()
         .done();
-    return modelInstance;
   }
 
   public static BpmnModelInstance prepareMessageEventProcess() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/start/StartEventOperatonFormDefinitionParseTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/start/StartEventOperatonFormDefinitionParseTest.java
@@ -66,9 +66,8 @@ public class StartEventOperatonFormDefinitionParseTest {
 
 private ProcessDefinitionEntity getProcessDefinition() {
   ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-  ProcessDefinitionEntity cachedProcessDefinition = processEngineConfiguration.getDeploymentCache()
+  return processEngineConfiguration.getDeploymentCache()
       .getProcessDefinitionCache().get(processDefinition.getId());
-  return cachedProcessDefinition;
 }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/parse/GlobalRetryConfigurationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/parse/GlobalRetryConfigurationTest.java
@@ -196,7 +196,7 @@ public class GlobalRetryConfigurationTest {
   }
 
   private BpmnModelInstance prepareSignalEventProcessWithoutRetry() {
-    BpmnModelInstance modelInstance = Bpmn.createExecutableProcess(PROCESS_ID)
+    return Bpmn.createExecutableProcess(PROCESS_ID)
         .startEvent()
           .intermediateThrowEvent(FAILING_EVENT)
             .operatonAsyncBefore(true)
@@ -205,22 +205,20 @@ public class GlobalRetryConfigurationTest {
             .operatonClass(FAILING_CLASS)
         .endEvent()
         .done();
-    return modelInstance;
   }
 
   private BpmnModelInstance prepareFailingServiceTask() {
-    BpmnModelInstance modelInstance = Bpmn.createExecutableProcess(PROCESS_ID)
+    return Bpmn.createExecutableProcess(PROCESS_ID)
         .startEvent()
         .serviceTask()
           .operatonClass(FAILING_CLASS)
           .operatonAsyncBefore()
         .endEvent()
         .done();
-    return modelInstance;
   }
 
   private BpmnModelInstance prepareFailingServiceTaskWithRetryCycle() {
-    BpmnModelInstance modelInstance = Bpmn.createExecutableProcess(PROCESS_ID)
+    return Bpmn.createExecutableProcess(PROCESS_ID)
         .startEvent()
         .serviceTask()
           .operatonClass(FAILING_CLASS)
@@ -228,22 +226,20 @@ public class GlobalRetryConfigurationTest {
           .operatonFailedJobRetryTimeCycle("R10/PT5M")
         .endEvent()
         .done();
-    return modelInstance;
   }
 
   private BpmnModelInstance prepareFailingBusinessRuleTask() {
-    BpmnModelInstance modelInstance = Bpmn.createExecutableProcess(PROCESS_ID)
+    return Bpmn.createExecutableProcess(PROCESS_ID)
         .startEvent()
         .businessRuleTask()
           .operatonClass(FAILING_CLASS)
           .operatonAsyncBefore()
         .endEvent()
         .done();
-    return modelInstance;
   }
 
   private BpmnModelInstance prepareFailingScriptTask() {
-    BpmnModelInstance bpmnModelInstance = Bpmn.createExecutableProcess(PROCESS_ID)
+    return Bpmn.createExecutableProcess(PROCESS_ID)
       .startEvent()
       .scriptTask()
         .scriptFormat("groovy")
@@ -252,11 +248,10 @@ public class GlobalRetryConfigurationTest {
       .userTask()
       .endEvent()
     .done();
-    return bpmnModelInstance;
   }
 
   private BpmnModelInstance prepareFailingSubProcess() {
-    BpmnModelInstance bpmnModelInstance = Bpmn.createExecutableProcess(PROCESS_ID)
+    return Bpmn.createExecutableProcess(PROCESS_ID)
       .startEvent()
       .subProcess()
         .embeddedSubProcess()
@@ -268,6 +263,5 @@ public class GlobalRetryConfigurationTest {
       .subProcessDone()
       .endEvent()
     .done();
-    return bpmnModelInstance;
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/parse/RetryIntervalsConfigurationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/parse/RetryIntervalsConfigurationTest.java
@@ -431,18 +431,17 @@ public class RetryIntervalsConfigurationTest extends AbstractAsyncOperationsTest
   }
 
   private BpmnModelInstance prepareProcessFailingServiceTask() {
-    BpmnModelInstance modelInstance = Bpmn.createExecutableProcess(PROCESS_ID)
+    return Bpmn.createExecutableProcess(PROCESS_ID)
         .startEvent()
         .serviceTask()
           .operatonClass(FAILING_CLASS)
           .operatonAsyncBefore()
         .endEvent()
         .done();
-    return modelInstance;
   }
 
   private BpmnModelInstance prepareProcessFailingServiceTaskWithRetryCycle(String retryTimeCycle) {
-    BpmnModelInstance modelInstance = Bpmn.createExecutableProcess(PROCESS_ID)
+    return Bpmn.createExecutableProcess(PROCESS_ID)
         .startEvent()
         .serviceTask()
           .operatonClass(FAILING_CLASS)
@@ -450,7 +449,6 @@ public class RetryIntervalsConfigurationTest extends AbstractAsyncOperationsTest
           .operatonFailedJobRetryTimeCycle(retryTimeCycle)
         .endEvent()
         .done();
-    return modelInstance;
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/AbstractTaskListenerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/AbstractTaskListenerTest.java
@@ -91,10 +91,8 @@ public abstract class AbstractTaskListenerTest {
       userTaskModelBuilder.operatonTaskListenerClass(customListenerEventType, taskListenerClass);
     }
 
-    BpmnModelInstance model = userTaskModelBuilder
+    return userTaskModelBuilder
         .endEvent()
         .done();
-
-    return model;
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/usertask/UserTaskOperatonFormDefinitionParseTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/usertask/UserTaskOperatonFormDefinitionParseTest.java
@@ -173,8 +173,7 @@ public class UserTaskOperatonFormDefinitionParseTest {
     ActivityImpl userTask = findActivityInDeployedProcessDefinition(activityId);
     assertThat(userTask).isNotNull();
 
-    TaskDefinition taskDefinition = ((UserTaskActivityBehavior) userTask.getActivityBehavior()).getTaskDecorator()
+    return ((UserTaskActivityBehavior) userTask.getActivityBehavior()).getTaskDecorator()
         .getTaskDefinition();
-    return taskDefinition;
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/CleanableHistoricBatchReportTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/CleanableHistoricBatchReportTest.java
@@ -365,14 +365,13 @@ public class CleanableHistoricBatchReportTest {
   }
 
   private BpmnModelInstance createModelInstance() {
-    BpmnModelInstance instance = Bpmn.createExecutableProcess("process")
+    return Bpmn.createExecutableProcess("process")
         .startEvent("start")
         .userTask("userTask1")
         .sequenceFlowId("seq")
         .userTask("userTask2")
         .endEvent("end")
         .done();
-    return instance;
   }
 
   private List<String> createMigrationBatchList(int migrationCountBatch) {
@@ -386,8 +385,7 @@ public class CleanableHistoricBatchReportTest {
   private Batch createModificationBatch() {
     BpmnModelInstance instance = createModelInstance();
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
-    Batch modificationBatch = modificationHelper.startAfterAsync("process", 1, "userTask1", processDefinition.getId());
-    return modificationBatch;
+    return modificationHelper.startAfterAsync("process", 1, "userTask1", processDefinition.getId());
   }
 
   private List<String> createCancelationBatchList(int cancelationCountBatch) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIdentityLinkLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIdentityLinkLogQueryTest.java
@@ -432,8 +432,7 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
     calendar.set(Calendar.MINUTE, minutes);
     calendar.set(Calendar.SECOND, 0);
     calendar.set(Calendar.MILLISECOND, 0);
-    Date morning = calendar.getTime();
-    return morning;
+    return calendar.getTime();
   }
 
   public Date newYearNoon(int minutes) {
@@ -445,8 +444,7 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
     calendar.set(Calendar.MINUTE, minutes);
     calendar.set(Calendar.SECOND, 0);
     calendar.set(Calendar.MILLISECOND, 0);
-    Date morning = calendar.getTime();
-    return morning;
+    return calendar.getTime();
   }
 
   public Date newYearEvening() {
@@ -458,8 +456,7 @@ public class HistoricIdentityLinkLogQueryTest extends PluggableProcessEngineTest
     calendar.set(Calendar.MINUTE, 0);
     calendar.set(Calendar.SECOND, 0);
     calendar.set(Calendar.MILLISECOND, 0);
-    Date morning = calendar.getTime();
-    return morning;
+    return calendar.getTime();
   }
 
   protected ProcessInstance startProcessInstance(String key) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/AcquirableJobCacheTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/AcquirableJobCacheTest.java
@@ -150,8 +150,7 @@ public class AcquirableJobCacheTest {
     return processEngineConfiguration.getCommandExecutorTxRequiresNew().execute(commandContext -> {
       JobManager jobManager = commandContext.getJobManager();
       List<AcquirableJobEntity> acquirableJobs = jobManager.findNextJobsToExecute(new Page(0, 100));
-      JobEntity job = jobManager.findJobById(acquirableJobs.get(0).getId());
-      return job;
+      return jobManager.findJobById(acquirableJobs.get(0).getId());
     });
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/entity/EntitySerializationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/entity/EntitySerializationTest.java
@@ -107,9 +107,7 @@ public class EntitySerializationTest {
   private Object readObject(byte[] data) throws IOException, ClassNotFoundException {
     InputStream buffer = new ByteArrayInputStream(data);
     ObjectInputStream inputStream = new ObjectInputStream(buffer);
-    Object object = inputStream.readObject();
-
-    return object;
+    return inputStream.readObject();
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/CustomHistoryLevelIncidentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/CustomHistoryLevelIncidentTest.java
@@ -275,16 +275,14 @@ public class CustomHistoryLevelIncidentTest {
 
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(sourceProcessDefinition.getId());
 
-    Batch batch = runtimeService.newMigration(migrationPlan).processInstanceIds(Arrays.asList(processInstance.getId(), "unknownId")).executeAsync();
-    return batch;
+    return runtimeService.newMigration(migrationPlan).processInstanceIds(Arrays.asList(processInstance.getId(), "unknownId")).executeAsync();
   }
 
   protected BpmnModelInstance createModelInstance() {
-    BpmnModelInstance instance = Bpmn.createExecutableProcess("process")
+    return Bpmn.createExecutableProcess("process")
         .startEvent("start")
         .userTask("userTask1")
         .endEvent("end")
         .done();
-    return instance;
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/util/ProcessEngineTestRule.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/util/ProcessEngineTestRule.java
@@ -364,8 +364,7 @@ public class ProcessEngineTestRule extends TestWatcher {
 
   public Object defaultManualActivation() {
     Expression expression = new FixedValue(true);
-    CaseControlRuleImpl caseControlRule = new CaseControlRuleImpl(expression);
-    return caseControlRule;
+    return new CaseControlRuleImpl(expression);
   }
 
 

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/builder/AbstractBaseElementBuilder.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/builder/AbstractBaseElementBuilder.java
@@ -202,8 +202,7 @@ public abstract class AbstractBaseElementBuilder<B extends AbstractBaseElementBu
   }
 
   protected ErrorEventDefinition createEmptyErrorEventDefinition() {
-    ErrorEventDefinition errorEventDefinition = createInstance(ErrorEventDefinition.class);
-    return errorEventDefinition;
+    return createInstance(ErrorEventDefinition.class);
   }
   
   protected ErrorEventDefinition createErrorEventDefinition(String errorCode) {
@@ -240,8 +239,7 @@ public abstract class AbstractBaseElementBuilder<B extends AbstractBaseElementBu
   }
 
   protected CompensateEventDefinition createCompensateEventDefinition() {
-    CompensateEventDefinition compensateEventDefinition = createInstance(CompensateEventDefinition.class);
-    return compensateEventDefinition;
+    return createInstance(CompensateEventDefinition.class);
   }
 
 

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/builder/EmbeddedSubProcessBuilder.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/builder/EmbeddedSubProcessBuilder.java
@@ -78,8 +78,7 @@ public class EmbeddedSubProcessBuilder extends AbstractEmbeddedSubProcessBuilder
     subProcessBuilder.resizeSubProcess(targetBpmnShape);
 
     // Return the eventSubProcessBuilder
-    EventSubProcessBuilder eventSubProcessBuilder = new EventSubProcessBuilder(subProcessBuilder.modelInstance, subProcess);
-    return eventSubProcessBuilder;
+    return new EventSubProcessBuilder(subProcessBuilder.modelInstance, subProcess);
 
   }
 

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilder.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilder.java
@@ -62,8 +62,7 @@ public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder> {
     resizeSubProcess(targetBpmnShape);
 
     // Return the eventSubProcessBuilder
-    EventSubProcessBuilder eventSubProcessBuilder = new EventSubProcessBuilder(modelInstance, subProcess);
-    return eventSubProcessBuilder;
+    return new EventSubProcessBuilder(modelInstance, subProcess);
 
   }
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelTest.java
@@ -60,8 +60,7 @@ public abstract class TestModelTest {
   }
 
   public static Egg createEgg(ModelInstance modelInstance, String id) {
-    Egg egg = modelInstance.newInstance(Egg.class, id);
-    return egg;
+    return modelInstance.newInstance(Egg.class, id);
   }
 
   protected void init (TestModelArgs args) {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/EjbPALifecycleCallbacksTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/EjbPALifecycleCallbacksTest.java
@@ -35,11 +35,9 @@ public class EjbPALifecycleCallbacksTest extends AbstractFoxPlatformIntegrationT
   @Deployment
   public static WebArchive createDeployment() {
 
-    WebArchive archive = ShrinkWrap.create(WebArchive.class, "test.war")
+    return ShrinkWrap.create(WebArchive.class, "test.war")
         .addClass(CustomEjbProcessApplication.class)
         .addClass(AbstractFoxPlatformIntegrationTest.class);
-
-    return archive;
 
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/PostDeployInjectDefaultEngineTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/PostDeployInjectDefaultEngineTest.java
@@ -39,10 +39,8 @@ public class PostDeployInjectDefaultEngineTest {
   @Deployment
   public static WebArchive createDeployment() {
     
-    WebArchive archive = ShrinkWrap.create(WebArchive.class, "test.war")
+    return ShrinkWrap.create(WebArchive.class, "test.war")
         .addClass(PostDeployInjectApp.class);
-
-    return archive;
     
   }
   

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/TestPostDeployFailure_JBOSS.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/TestPostDeployFailure_JBOSS.java
@@ -43,12 +43,10 @@ public class TestPostDeployFailure_JBOSS {
   @Deployment(managed=false, name=DEPLOYMENT)
   public static WebArchive createDeployment1() {
     
-    WebArchive archive = ShrinkWrap.create(WebArchive.class, "failingDeployment.war")
+    return ShrinkWrap.create(WebArchive.class, "failingDeployment.war")
         .addAsResource("META-INF/processes.xml", "META-INF/processes.xml")
         .addAsResource("org/operaton/bpm/integrationtest/invoice-it.bpmn20.xml")
         .addClass(PostDeployFailureApp.class);
-
-    return archive;
     
   }
   

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestAdditionalResourceSuffixes.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestAdditionalResourceSuffixes.java
@@ -42,7 +42,7 @@ public class TestAdditionalResourceSuffixes extends AbstractFoxPlatformIntegrati
   @Deployment
   public static WebArchive processArchive() {
 
-    WebArchive archive = ShrinkWrap.create(WebArchive.class, "test.war")
+    return ShrinkWrap.create(WebArchive.class, "test.war")
         .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
         .addAsLibraries(DeploymentHelper.getEngineCdi())
         .addAsResource("org/operaton/bpm/integrationtest/deployment/cfg/processes-additional-resource-suffixes.xml", "META-INF/processes.xml")
@@ -51,8 +51,6 @@ public class TestAdditionalResourceSuffixes extends AbstractFoxPlatformIntegrati
         .addAsResource("org/operaton/bpm/integrationtest/deployment/cfg/invoice-it.bpmn20.xml")
         .addAsResource("org/operaton/bpm/integrationtest/deployment/cfg/hello.groovy")
         .addAsResource("org/operaton/bpm/integrationtest/deployment/cfg/hello.py");
-
-    return archive;
   }
 
   @Test

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestCustomProcessesXmlFileLocation.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestCustomProcessesXmlFileLocation.java
@@ -39,15 +39,13 @@ public class TestCustomProcessesXmlFileLocation extends AbstractFoxPlatformInteg
   @Deployment
   public static WebArchive processArchive() {    
     
-    WebArchive archive = ShrinkWrap.create(WebArchive.class, "test.war")
+    return ShrinkWrap.create(WebArchive.class, "test.war")
         .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
         .addAsLibraries(DeploymentHelper.getEngineCdi())
         .addAsResource("org/operaton/bpm/integrationtest/deployment/cfg/processes.xml", "my/alternate/location/processes.xml")
         .addClass(AbstractFoxPlatformIntegrationTest.class)
         .addClass(CustomProcessApplication.class)
         .addAsResource("org/operaton/bpm/integrationtest/deployment/cfg/invoice-it.bpmn20.xml");
-    
-    return archive;
     
   }
   

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithNonExistingDS_JBOSS.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithNonExistingDS_JBOSS.java
@@ -63,15 +63,13 @@ public class TestWarDeploymentWithNonExistingDS_JBOSS {
   
   @Deployment(managed=false, name=DEPLOYMENT_WITH_SERVLET_PA)
   public static WebArchive createDeployment2() {
-    WebArchive archive = ShrinkWrap.create(WebArchive.class, "test2.war")
+    return ShrinkWrap.create(WebArchive.class, "test2.war")
         .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
         .addAsLibraries(DeploymentHelper.getEngineCdi())
         .addAsResource("META-INF/processes.xml", "META-INF/processes.xml")
         .addAsResource("persistence-nonexisting-ds.xml", "META-INF/persistence.xml")
         
         .addClass(CustomServletPA.class);
-    
-    return archive;
   }
   
   @Test

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaContextSwitchCustomSerializerTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaContextSwitchCustomSerializerTest.java
@@ -61,14 +61,12 @@ public class PaContextSwitchCustomSerializerTest extends AbstractFoxPlatformInte
 
   @Deployment(name = "pa4")
   public static WebArchive createDeployment2() {
-    WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "pa4.war")
+    return ShrinkWrap.create(WebArchive.class, "pa4.war")
         .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
         .addAsLibraries(DeploymentHelper.getEngineCdi())
         .addAsResource("META-INF/processes.xml")
         .addClass(AbstractFoxPlatformIntegrationTest.class)
         .addClass(ProcessApplication4.class);
-
-    return webArchive;
   }
 
   /**

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaContextSwitchTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaContextSwitchTest.java
@@ -66,14 +66,12 @@ public class PaContextSwitchTest extends AbstractFoxPlatformIntegrationTest {
 
   @Deployment(name = "pa2")
   public static WebArchive createDeployment2() {
-    WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "pa2.war")
+    return ShrinkWrap.create(WebArchive.class, "pa2.war")
         .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
         .addAsLibraries(DeploymentHelper.getEngineCdi())
         .addAsResource("META-INF/processes.xml")
         .addClass(AbstractFoxPlatformIntegrationTest.class)
         .addClass(ProcessApplication2.class);
-
-    return webArchive;
   }
 
   /**

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatAndPostDeployTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatAndPostDeployTest.java
@@ -41,7 +41,7 @@ public class PaDataFormatAndPostDeployTest extends AbstractFoxPlatformIntegratio
   @Deployment
   public static WebArchive createDeployment() {
 
-    WebArchive archive = ShrinkWrap.create(WebArchive.class, "test.war")
+    return ShrinkWrap.create(WebArchive.class, "test.war")
         .addClass(PaDataformatAndPostDeployApp.class)
         .addAsResource("META-INF/processes.xml")
         .addClass(AbstractFoxPlatformIntegrationTest.class)
@@ -51,8 +51,6 @@ public class PaDataFormatAndPostDeployTest extends AbstractFoxPlatformIntegratio
         .addClass(FooDataFormatProvider.class)
         .addClass(FooSpin.class)
         .addAsServiceProvider(DataFormatProvider.class, FooDataFormatProvider.class);
-
-    return archive;
 
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatProviderTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatProviderTest.java
@@ -45,7 +45,7 @@ public class PaDataFormatProviderTest extends AbstractFoxPlatformIntegrationTest
 
   @Deployment
   public static WebArchive createDeployment() {
-    WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "PaDataFormatTest.war")
+    return ShrinkWrap.create(WebArchive.class, "PaDataFormatTest.war")
         .addAsResource("META-INF/processes.xml")
         .addClass(AbstractFoxPlatformIntegrationTest.class)
         .addAsResource("org/operaton/bpm/integrationtest/oneTaskProcess.bpmn")
@@ -55,8 +55,6 @@ public class PaDataFormatProviderTest extends AbstractFoxPlatformIntegrationTest
         .addClass(FooSpin.class)
         .addAsServiceProvider(DataFormatProvider.class, FooDataFormatProvider.class)
         .addClass(ReferenceStoringProcessApplication.class);
-
-    return webArchive;
   }
 
   /**

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/JobPrioritizationFailureJavaSerializationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/JobPrioritizationFailureJavaSerializationTest.java
@@ -88,9 +88,8 @@ public class JobPrioritizationFailureJavaSerializationTest extends AbstractFoxPl
 
   @Deployment(name = "dummy-client", order = 2)
   public static WebArchive createDummyClientDeployment() {
-    final WebArchive webArchive = initWebArchiveDeployment("paJavaSerialization2.war", "org/operaton/bpm/integrationtest/processes-javaSerializationEnabled-pa2.xml")
+    return initWebArchiveDeployment("paJavaSerialization2.war", "org/operaton/bpm/integrationtest/processes-javaSerializationEnabled-pa2.xml")
       .addAsResource(new ByteArrayAsset(serializeJavaObjectValue(new PriorityBean())), PRIORITY_BEAN_INSTANCE_FILE);
-    return webArchive;
   }
 
   @After

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/TimeoutTaskListenerExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/TimeoutTaskListenerExecutionTest.java
@@ -34,11 +34,9 @@ public class TimeoutTaskListenerExecutionTest extends AbstractFoxPlatformIntegra
 
   @Deployment
   public static WebArchive processArchive() {
-    WebArchive archive = initWebArchiveDeployment()
+    return initWebArchiveDeployment()
             .addAsResource("org/operaton/bpm/integrationtest/jobexecutor/TimeoutTaskListenerExecution.bpmn20.xml")
             .addClass(SampleTaskListenerBean.class);
-
-    return archive;
   }
 
   @Test

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/TimerExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/TimerExecutionTest.java
@@ -37,11 +37,9 @@ public class TimerExecutionTest extends AbstractFoxPlatformIntegrationTest {
 
   @Deployment
   public static WebArchive processArchive() {
-    WebArchive archive = initWebArchiveDeployment()
+    return initWebArchiveDeployment()
             .addAsResource("org/operaton/bpm/integrationtest/jobexecutor/TimerExecution.bpmn20.xml")
             .addClass(SampleServiceBean.class);
-
-    return archive;
   }
 
   @Test

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/TimerRecalculationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/TimerRecalculationTest.java
@@ -45,11 +45,9 @@ public class TimerRecalculationTest extends AbstractFoxPlatformIntegrationTest {
 
   @Deployment
   public static WebArchive processArchive() {
-    WebArchive archive = initWebArchiveDeployment()
+    return initWebArchiveDeployment()
             .addAsResource("org/operaton/bpm/integrationtest/jobexecutor/TimerRecalculation.bpmn20.xml")
             .addClass(TimerExpressionBean.class);
-
-    return archive;
   }
 
   @Test

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/rest/EmbeddedEngineRest_WILDFLY.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/rest/EmbeddedEngineRest_WILDFLY.java
@@ -43,14 +43,12 @@ public class EmbeddedEngineRest_WILDFLY {
   @Deployment(managed=false, name = EMBEDDED_ENGINE_REST)
   public static WebArchive createDeployment() {
     JavaArchive[] engineRestClasses = getEngineRestClasses();
-    WebArchive archive = ShrinkWrap.create(WebArchive.class, "embedded-engine-rest.war")
+    return ShrinkWrap.create(WebArchive.class, "embedded-engine-rest.war")
         .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
         .addAsWebInfResource("jboss-deployment-structure.xml")
         .addAsManifestResource("org.operaton.bpm.engine.rest.spi.ProcessEngineProvider", "META-INF/services/org.operaton.bpm.engine.rest.spi.ProcessEngineProvider")
         .addAsLibraries(engineRestClasses)
         .addClasses(CustomRestApplication.class, CustomProcessEngineProvider.class);
-
-    return archive;
   }
 
   @Test

--- a/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7130/batch/deploymentaware/LegacyDeploymentAwarenessTest.java
+++ b/qa/test-db-instance-migration/test-migration/src/test/java/org/operaton/bpm/qa/upgrade/scenarios7130/batch/deploymentaware/LegacyDeploymentAwarenessTest.java
@@ -149,8 +149,7 @@ public class LegacyDeploymentAwarenessTest {
 
   protected Job getSeedJob(Batch batch) {
     String seedJobDefinitionId = batch.getSeedJobDefinitionId();
-    Job seedJob = managementService.createJobQuery().jobDefinitionId(seedJobDefinitionId).singleResult();
-    return seedJob;
+    return managementService.createJobQuery().jobDefinitionId(seedJobDefinitionId).singleResult();
   }
 
   protected void executeSeedJob(Batch batch) {

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/helper/ProcessEngineAwareExtension.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/helper/ProcessEngineAwareExtension.java
@@ -132,9 +132,7 @@ public class ProcessEngineAwareExtension extends QuarkusUnitTest {
     Method getMethod = instanceHandle.getClass().getMethod("get");
     getMethod.setAccessible(true);
 
-    Object bean = getMethod.invoke(instanceHandle);
-
-    return bean;
+    return getMethod.invoke(instanceHandle);
   }
 
 }

--- a/spin/dataformat-json-jackson/src/main/java/org/operaton/spin/impl/json/jackson/format/JacksonJsonDataFormatMapper.java
+++ b/spin/dataformat-json-jackson/src/main/java/org/operaton/spin/impl/json/jackson/format/JacksonJsonDataFormatMapper.java
@@ -86,8 +86,7 @@ public class JacksonJsonDataFormatMapper implements DataFormatMapper {
       return (T) mapInternalToJava(parameter, aClass, validator);
     } catch (ClassNotFoundException e) {
       JavaType javaType = format.constructJavaTypeFromCanonicalString(typeIdentifier);
-      T result = mapInternalToJava(parameter, javaType, validator);
-      return result;
+      return mapInternalToJava(parameter, javaType, validator);
     }
   }
 

--- a/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/cmmn/AbstractCaseAssert.java
+++ b/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/cmmn/AbstractCaseAssert.java
@@ -666,8 +666,7 @@ public abstract class AbstractCaseAssert<S extends AbstractCaseAssert<S, A>, A e
     } else {
       assertion.isEmpty();
     }
-    S self = (S) this;
-    return self;
+    return (S) this;
   }
 
 }

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageTest.java
@@ -137,8 +137,7 @@ public class StageTest extends ProcessAssertTestCase {
   }
 
   private CaseInstance givenCaseIsCreated() {
-    CaseInstance caseInstance = caseService().createCaseInstanceByKey("Case_StageTests");
-    return caseInstance;
+    return caseService().createCaseInstanceByKey("Case_StageTests");
   }
 
   private CaseInstance givenCaseIsCreatedAndStageSActive() {

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageWithSentryExitCriteriaTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageWithSentryExitCriteriaTest.java
@@ -105,8 +105,7 @@ public class StageWithSentryExitCriteriaTest extends ProcessAssertTestCase {
   }
 
   private CaseInstance givenCaseIsCreated() {
-    CaseInstance caseInstance = caseService().createCaseInstanceByKey("Case_StageWithSentryExitCriteriaTest");
-    return caseInstance;
+    return caseService().createCaseInstanceByKey("Case_StageWithSentryExitCriteriaTest");
   }
 
   private CaseInstance givenCaseIsCreatedAndStageSActive() {

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageWithSentryTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageWithSentryTest.java
@@ -71,8 +71,7 @@ public class StageWithSentryTest extends ProcessAssertTestCase {
   }
 
   private CaseInstance givenCaseIsCreated() {
-    CaseInstance caseInstance = caseService().createCaseInstanceByKey("Case_StageWithSentryTests");
-    return caseInstance;
+    return caseService().createCaseInstanceByKey("Case_StageWithSentryTests");
   }
 
 }

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskWithSentryExitCriteriaTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskWithSentryExitCriteriaTest.java
@@ -70,8 +70,7 @@ public class TaskWithSentryExitCriteriaTest extends ProcessAssertTestCase {
   }
 
   private CaseInstance givenCaseIsCreated() {
-    CaseInstance caseInstance = caseService().createCaseInstanceByKey("Case_TaskWithSentryExitCriteriaTest");
-    return caseInstance;
+    return caseService().createCaseInstanceByKey("Case_TaskWithSentryExitCriteriaTest");
   }
 
   private CaseInstance givenCaseIsCreatedAndTaskAActive() {

--- a/webapps/assembly/src/main/java/org/operaton/bpm/cockpit/impl/plugin/resources/IncidentRestService.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/cockpit/impl/plugin/resources/IncidentRestService.java
@@ -68,8 +68,7 @@ public class IncidentRestService extends AbstractPluginResource {
 
     paginateQueryParameters(queryParameter, firstResult, maxResults);
     configureExecutionQuery(queryParameter);
-    List<IncidentDto> matchingIncidents = getQueryService().executeQuery("selectIncidentWithCauseAndRootCauseIncidents", queryParameter);
-    return matchingIncidents;
+    return getQueryService().executeQuery("selectIncidentWithCauseAndRootCauseIncidents", queryParameter);
   }
 
   private void paginateQueryParameters(IncidentQueryDto queryParameter, Integer firstResult, Integer maxResults) {

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/authorization/AuthorizationTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/authorization/AuthorizationTest.java
@@ -140,8 +140,7 @@ public abstract class AuthorizationTest extends AbstractCockpitPluginTest {
   }
 
   protected Authorization createGrantAuthorization(Resource resource, String resourceId) {
-    Authorization authorization = createAuthorization(AUTH_TYPE_GRANT, resource, resourceId);
-    return authorization;
+    return createAuthorization(AUTH_TYPE_GRANT, resource, resourceId);
   }
 
   protected Authorization createAuthorization(int type, Resource resource, String resourceId) {


### PR DESCRIPTION
Resolves Sonar issues of type java:S1488 - Local variables should not be declared and then immediately returned or thrown

related to #88