### PR TITLE
refactor: Code of a lambda to have only one invocation possibly throwing a runtime exception

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/form/RetrieveOperatonFormRefTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/form/RetrieveOperatonFormRefTest.java
@@ -450,15 +450,15 @@ public class RetrieveOperatonFormRefTest {
     List<Deployment> deployments = repositoryService.createDeploymentQuery().list();
     List<OperatonFormDefinition> definitions = findAllOperatonFormDefinitionEntities(processEngineConfiguration);
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
+    String processDefinitionId = processDefinition.getId();
 
     // then
     assertThat(deployments).hasSize(1);
     assertThat(definitions).hasSize(1);
 
-    assertThatThrownBy(() -> {
-      formService.getDeployedStartForm(processDefinition.getId());
-    }).isInstanceOf(BadUserRequestException.class)
-    .hasMessageContaining("No Operaton Form Definition was found for Operaton Form Ref");
+    assertThatThrownBy(() -> formService.getDeployedStartForm(processDefinitionId))
+      .isInstanceOf(BadUserRequestException.class)
+      .hasMessageContaining("No Operaton Form Definition was found for Operaton Form Ref");
   }
 
   /* HELPER METHODS */

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceUserOperationLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceUserOperationLogTest.java
@@ -109,9 +109,10 @@ public class IdentityServiceUserOperationLogTest {
     identityService.saveUser(identityService.newUser(TEST_USER_ID));
     assertEquals(0, query.count());
     identityService.setAuthenticatedUserId("userId");
+    User newUser = identityService.newUser(TEST_USER_ID);
 
     // when/then
-    assertThatThrownBy(() -> identityService.saveUser(identityService.newUser(TEST_USER_ID)))
+    assertThatThrownBy(() -> identityService.saveUser(newUser))
       .isInstanceOf(ProcessEngineException.class);
 
     // then
@@ -235,9 +236,10 @@ public class IdentityServiceUserOperationLogTest {
     identityService.saveGroup(identityService.newGroup(TEST_GROUP_ID));
     assertEquals(0, query.count());
     identityService.setAuthenticatedUserId("userId");
+    Group newGroup = identityService.newGroup(TEST_GROUP_ID);
 
     // when/then
-    assertThatThrownBy(() -> identityService.saveGroup(identityService.newGroup(TEST_GROUP_ID)))
+    assertThatThrownBy(() -> identityService.saveGroup(newGroup))
       .isInstanceOf(ProcessEngineException.class);
 
     // and
@@ -313,9 +315,10 @@ public class IdentityServiceUserOperationLogTest {
     identityService.saveTenant(identityService.newTenant(TEST_TENANT_ID));
     assertEquals(0, query.count());
     identityService.setAuthenticatedUserId("userId");
+    Tenant newTenant = identityService.newTenant(TEST_TENANT_ID);
 
     // when/then
-    assertThatThrownBy(() -> identityService.saveTenant(identityService.newTenant(TEST_TENANT_ID)))
+    assertThatThrownBy(() -> identityService.saveTenant(newTenant))
       .isInstanceOf(ProcessEngineException.class);
 
     identityService.clearAuthentication();
@@ -385,8 +388,8 @@ public class IdentityServiceUserOperationLogTest {
 
     // then
     assertLogs(UserOperationLogEntry.OPERATION_TYPE_CREATE, EntityTypes.GROUP_MEMBERSHIP,
-        Triple.of("userId", (String) null, TEST_USER_ID),
-        Triple.of("groupId", (String) null, TEST_GROUP_ID));
+        Triple.of("userId", null, TEST_USER_ID),
+        Triple.of("groupId", null, TEST_GROUP_ID));
   }
 
   @Test
@@ -423,8 +426,8 @@ public class IdentityServiceUserOperationLogTest {
 
     // then
     assertLogs(UserOperationLogEntry.OPERATION_TYPE_DELETE, EntityTypes.GROUP_MEMBERSHIP,
-        Triple.of("userId", (String) null, TEST_USER_ID),
-        Triple.of("groupId", (String) null, TEST_GROUP_ID));
+        Triple.of("userId", null, TEST_USER_ID),
+        Triple.of("groupId", null, TEST_GROUP_ID));
   }
 
   @Test
@@ -455,8 +458,8 @@ public class IdentityServiceUserOperationLogTest {
 
     // then
     assertLogs(UserOperationLogEntry.OPERATION_TYPE_CREATE, EntityTypes.TENANT_MEMBERSHIP,
-        Triple.of("userId", (String) null, TEST_USER_ID),
-        Triple.of("tenantId", (String) null, TEST_TENANT_ID));
+        Triple.of("userId", null, TEST_USER_ID),
+        Triple.of("tenantId", null, TEST_TENANT_ID));
   }
 
   @Test
@@ -493,8 +496,8 @@ public class IdentityServiceUserOperationLogTest {
 
     // then
     assertLogs(UserOperationLogEntry.OPERATION_TYPE_DELETE, EntityTypes.TENANT_MEMBERSHIP,
-        Triple.of("userId", (String) null, TEST_USER_ID),
-        Triple.of("tenantId", (String) null, TEST_TENANT_ID));
+        Triple.of("userId", null, TEST_USER_ID),
+        Triple.of("tenantId", null, TEST_TENANT_ID));
   }
 
   @Test
@@ -525,8 +528,8 @@ public class IdentityServiceUserOperationLogTest {
 
     // then
     assertLogs(UserOperationLogEntry.OPERATION_TYPE_CREATE, EntityTypes.TENANT_MEMBERSHIP,
-        Triple.of("groupId", (String) null, TEST_GROUP_ID),
-        Triple.of("tenantId", (String) null, TEST_TENANT_ID));
+        Triple.of("groupId", null, TEST_GROUP_ID),
+        Triple.of("tenantId", null, TEST_TENANT_ID));
   }
 
   @Test
@@ -563,8 +566,8 @@ public class IdentityServiceUserOperationLogTest {
 
     // then
     assertLogs(UserOperationLogEntry.OPERATION_TYPE_DELETE, EntityTypes.TENANT_MEMBERSHIP,
-        Triple.of("groupId", (String) null, TEST_GROUP_ID),
-        Triple.of("tenantId", (String) null, TEST_TENANT_ID));
+        Triple.of("groupId", null, TEST_GROUP_ID),
+        Triple.of("tenantId", null, TEST_TENANT_ID));
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ActivateJobDefinitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ActivateJobDefinitionTest.java
@@ -58,6 +58,7 @@ public class ActivateJobDefinitionTest extends PluggableProcessEngineTest {
       managementService.activateJobDefinitionById(null);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
   }
 
@@ -67,39 +68,46 @@ public class ActivateJobDefinitionTest extends PluggableProcessEngineTest {
       managementService.activateJobDefinitionById(null, false);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
 
     try {
       managementService.activateJobDefinitionById(null, true);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
   }
 
   @Test
   public void testActivationByIdAndActivateJobsFlagAndExecutionDate_shouldThrowProcessEngineException() {
+    Date activationDate = new Date();
     try {
       managementService.activateJobDefinitionById(null, false, null);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
 
     try {
       managementService.activateJobDefinitionById(null, true, null);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
 
     try {
-      managementService.activateJobDefinitionById(null, false, new Date());
+      managementService.activateJobDefinitionById(null, false, activationDate);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
 
     try {
-      managementService.activateJobDefinitionById(null, true, new Date());
+      managementService.activateJobDefinitionById(null, true, activationDate);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
 
   }
@@ -125,7 +133,7 @@ public class ActivateJobDefinitionTest extends PluggableProcessEngineTest {
     managementService.activateJobDefinitionById(jobDefinition.getId());
 
     // then
-    // there exists a active job definition
+    // there exists an active job definition
     JobDefinitionQuery jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
     assertEquals(1, jobDefinitionQuery.active().count());
@@ -168,7 +176,7 @@ public class ActivateJobDefinitionTest extends PluggableProcessEngineTest {
     managementService.activateJobDefinitionById(jobDefinition.getId(), false);
 
     // then
-    // there exists a active job definition
+    // there exists an active job definition
     JobDefinitionQuery jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
     assertEquals(0, jobDefinitionQuery.suspended().count());
@@ -223,7 +231,7 @@ public class ActivateJobDefinitionTest extends PluggableProcessEngineTest {
     assertEquals(jobDefinition.getId(), activeJobDefinition.getId());
     assertFalse(activeJobDefinition.isSuspended());
 
-    // ...and a active job of the provided job definition
+    // ...and an active job of the provided job definition
     JobQuery jobQuery = managementService.createJobQuery();
 
     assertEquals(0, jobQuery.suspended().count());
@@ -453,6 +461,7 @@ public class ActivateJobDefinitionTest extends PluggableProcessEngineTest {
       managementService.activateJobDefinitionByProcessDefinitionId(null);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
   }
 
@@ -462,39 +471,46 @@ public class ActivateJobDefinitionTest extends PluggableProcessEngineTest {
       managementService.activateJobDefinitionByProcessDefinitionId(null, false);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
 
     try {
       managementService.activateJobDefinitionByProcessDefinitionId(null, true);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
   }
 
   @Test
   public void testActivationByProcessDefinitionIdAndActivateJobsFlagAndExecutionDate_shouldThrowProcessEngineException() {
+    Date activationDate = new Date();
     try {
       managementService.activateJobDefinitionByProcessDefinitionId(null, false, null);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
 
     try {
       managementService.activateJobDefinitionByProcessDefinitionId(null, true, null);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
 
     try {
-      managementService.activateJobDefinitionByProcessDefinitionId(null, false, new Date());
+      managementService.activateJobDefinitionByProcessDefinitionId(null, false, activationDate);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
 
     try {
-      managementService.activateJobDefinitionByProcessDefinitionId(null, true, new Date());
+      managementService.activateJobDefinitionByProcessDefinitionId(null, true, activationDate);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
 
   }
@@ -521,7 +537,7 @@ public class ActivateJobDefinitionTest extends PluggableProcessEngineTest {
     managementService.activateJobDefinitionByProcessDefinitionId(processDefinition.getId());
 
     // then
-    // there exists a active job definition
+    // there exists an active job definition
     JobDefinitionQuery jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
     assertEquals(0, jobDefinitionQuery.suspended().count());
@@ -849,6 +865,7 @@ public class ActivateJobDefinitionTest extends PluggableProcessEngineTest {
       managementService.activateJobDefinitionByProcessDefinitionKey(null);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
   }
 
@@ -858,39 +875,46 @@ public class ActivateJobDefinitionTest extends PluggableProcessEngineTest {
       managementService.activateJobDefinitionByProcessDefinitionKey(null, false);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
 
     try {
       managementService.activateJobDefinitionByProcessDefinitionKey(null, true);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
   }
 
   @Test
   public void testActivationByProcessDefinitionKeyAndActivateJobsFlagAndExecutionDate_shouldThrowProcessEngineException() {
+    Date activationDate = new Date();
     try {
       managementService.activateJobDefinitionByProcessDefinitionKey(null, false, null);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
 
     try {
       managementService.activateJobDefinitionByProcessDefinitionKey(null, true, null);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
 
     try {
-      managementService.activateJobDefinitionByProcessDefinitionKey(null, false, new Date());
+      managementService.activateJobDefinitionByProcessDefinitionKey(null, false, activationDate);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
 
     try {
-      managementService.activateJobDefinitionByProcessDefinitionKey(null, true, new Date());
+      managementService.activateJobDefinitionByProcessDefinitionKey(null, true, activationDate);
       fail("A ProcessEngineException was expected.");
     } catch (ProcessEngineException e) {
+      // expected
     }
 
   }
@@ -917,7 +941,7 @@ public class ActivateJobDefinitionTest extends PluggableProcessEngineTest {
     managementService.activateJobDefinitionByProcessDefinitionKey(processDefinition.getKey());
 
     // then
-    // there exists a active job definition
+    // there exists an active job definition
     JobDefinitionQuery jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
     assertEquals(0, jobDefinitionQuery.suspended().count());
@@ -1594,7 +1618,7 @@ public class ActivateJobDefinitionTest extends PluggableProcessEngineTest {
       .activate();
 
     // then
-    // there exists a active job definition
+    // there exists an active job definition
     assertEquals(1, query.active().count());
     assertEquals(0, query.suspended().count());
   }
@@ -1627,7 +1651,7 @@ public class ActivateJobDefinitionTest extends PluggableProcessEngineTest {
       .activate();
 
     // then
-    // there exists a active job definition
+    // there exists an active job definition
     assertEquals(1, query.active().count());
     assertEquals(0, query.suspended().count());
   }
@@ -1658,7 +1682,7 @@ public class ActivateJobDefinitionTest extends PluggableProcessEngineTest {
       .activate();
 
     // then
-    // there exists a active job definition
+    // there exists an active job definition
     assertEquals(1, query.active().count());
     assertEquals(0, query.suspended().count());
   }
@@ -1693,7 +1717,7 @@ public class ActivateJobDefinitionTest extends PluggableProcessEngineTest {
       .activate();
 
     // then
-    // there exists a active job definition
+    // there exists an active job definition
     assertEquals(1, jobQuery.active().count());
     assertEquals(0, jobQuery.suspended().count());
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancySignalReceiveTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancySignalReceiveTest.java
@@ -260,9 +260,13 @@ public class MultiTenancySignalReceiveTest {
 
   @Test
   public void failToSendSignalWithExecutionIdForTenant() {
+    // given
+    var signalEventReceivedBuilder = runtimeService.createSignalEvent("signal")
+      .executionId("id")
+      .tenantId(TENANT_ONE);
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.createSignalEvent("signal").executionId("id").tenantId(TENANT_ONE).send())
+    assertThatThrownBy(signalEventReceivedBuilder::send)
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("Cannot specify a tenant-id when deliver a signal to a single execution.");
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDecisionRequirementsDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDecisionRequirementsDefinitionQueryTest.java
@@ -183,9 +183,9 @@ public class MultiTenancyDecisionRequirementsDefinitionQueryTest {
 
     assertThat(query.count()).isEqualTo(1L);
 
-    DecisionRequirementsDefinition DecisionRequirementsDefinition = query.singleResult();
-    assertThat(DecisionRequirementsDefinition.getTenantId()).isEqualTo(TENANT_ONE);
-    assertThat(DecisionRequirementsDefinition.getVersion()).isEqualTo(2);
+    var decisionRequirementsDefinition = query.singleResult();
+    assertThat(decisionRequirementsDefinition.getTenantId()).isEqualTo(TENANT_ONE);
+    assertThat(decisionRequirementsDefinition.getVersion()).isEqualTo(2);
 
     query = repositoryService
         .createDecisionRequirementsDefinitionQuery()
@@ -195,9 +195,9 @@ public class MultiTenancyDecisionRequirementsDefinitionQueryTest {
 
     assertThat(query.count()).isEqualTo(1L);
 
-    DecisionRequirementsDefinition = query.singleResult();
-    assertThat(DecisionRequirementsDefinition.getTenantId()).isEqualTo(TENANT_TWO);
-    assertThat(DecisionRequirementsDefinition.getVersion()).isEqualTo(1);
+    decisionRequirementsDefinition = query.singleResult();
+    assertThat(decisionRequirementsDefinition.getTenantId()).isEqualTo(TENANT_TWO);
+    assertThat(decisionRequirementsDefinition.getVersion()).isEqualTo(1);
   }
 
   @Test
@@ -233,9 +233,9 @@ public class MultiTenancyDecisionRequirementsDefinitionQueryTest {
 
     assertThat(query.count()).isEqualTo(1L);
 
-    DecisionRequirementsDefinition DecisionRequirementsDefinition = query.singleResult();
-    assertThat(DecisionRequirementsDefinition.getTenantId()).isNull();
-    assertThat(DecisionRequirementsDefinition.getVersion()).isEqualTo(2);
+    var decisionRequirementsDefinition = query.singleResult();
+    assertThat(decisionRequirementsDefinition.getTenantId()).isNull();
+    assertThat(decisionRequirementsDefinition.getVersion()).isEqualTo(2);
   }
 
   @Test
@@ -272,41 +272,42 @@ public class MultiTenancyDecisionRequirementsDefinitionQueryTest {
 
   @Test
   public void failQueryByTenantIdNull() {
+    // given
+    var decisionRequirementsDefinitionQuery = repositoryService.createDecisionRequirementsDefinitionQuery();
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.createDecisionRequirementsDefinitionQuery()
-        .tenantIdIn((String) null))
+    assertThatThrownBy(() -> decisionRequirementsDefinitionQuery.tenantIdIn((String) null))
       .isInstanceOf(NullValueException.class);
   }
 
   @Test
 	public void querySortingAsc() {
     // exclude definitions without tenant id because of database-specific ordering
-    List<DecisionRequirementsDefinition> DecisionRequirementsDefinitions = repositoryService
+    var decisionRequirementsDefinitions = repositoryService
         .createDecisionRequirementsDefinitionQuery()
         .tenantIdIn(TENANT_ONE, TENANT_TWO)
         .orderByTenantId()
         .asc()
         .list();
 
-    assertThat(DecisionRequirementsDefinitions).hasSize(2);
-    assertThat(DecisionRequirementsDefinitions.get(0).getTenantId()).isEqualTo(TENANT_ONE);
-    assertThat(DecisionRequirementsDefinitions.get(1).getTenantId()).isEqualTo(TENANT_TWO);
+    assertThat(decisionRequirementsDefinitions).hasSize(2);
+    assertThat(decisionRequirementsDefinitions.get(0).getTenantId()).isEqualTo(TENANT_ONE);
+    assertThat(decisionRequirementsDefinitions.get(1).getTenantId()).isEqualTo(TENANT_TWO);
   }
 
   @Test
 	public void querySortingDesc() {
     // exclude definitions without tenant id because of database-specific ordering
-    List<DecisionRequirementsDefinition> DecisionRequirementsDefinitions = repositoryService
+    var decisionRequirementsDefinitions = repositoryService
         .createDecisionRequirementsDefinitionQuery()
         .tenantIdIn(TENANT_ONE, TENANT_TWO)
         .orderByTenantId()
         .desc()
         .list();
 
-    assertThat(DecisionRequirementsDefinitions).hasSize(2);
-    assertThat(DecisionRequirementsDefinitions.get(0).getTenantId()).isEqualTo(TENANT_TWO);
-    assertThat(DecisionRequirementsDefinitions.get(1).getTenantId()).isEqualTo(TENANT_ONE);
+    assertThat(decisionRequirementsDefinitions).hasSize(2);
+    assertThat(decisionRequirementsDefinitions.get(0).getTenantId()).isEqualTo(TENANT_TWO);
+    assertThat(decisionRequirementsDefinitions.get(1).getTenantId()).isEqualTo(TENANT_ONE);
   }
 
   @Test
@@ -319,7 +320,7 @@ public class MultiTenancyDecisionRequirementsDefinitionQueryTest {
 
   @Test
 	public void queryAuthenticatedTenant() {
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     DecisionRequirementsDefinitionQuery query = repositoryService.createDecisionRequirementsDefinitionQuery();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyProcessDefinitionSuspensionStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyProcessDefinitionSuspensionStateTest.java
@@ -32,7 +32,6 @@ import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -629,12 +628,12 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
         .processDefinitionKey(PROCESS_DEFINITION_KEY).tenantIdIn(TENANT_ONE).singleResult();
 
     engineRule.getIdentityService().setAuthentication("user", null, null);
+    var updateProcessDefinitionSuspensionStateBuilder = engineRule.getRepositoryService()
+      .updateProcessDefinitionSuspensionState()
+      .byProcessDefinitionId(processDefinition.getId());
 
     // when/then
-    assertThatThrownBy(() -> engineRule.getRepositoryService()
-        .updateProcessDefinitionSuspensionState()
-        .byProcessDefinitionId(processDefinition.getId())
-        .suspend())
+    assertThatThrownBy(updateProcessDefinitionSuspensionStateBuilder::suspend)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot update the process definition '"+ processDefinition.getId()
       + "' because it belongs to no authenticated tenant");
@@ -647,7 +646,7 @@ public class MultiTenancyProcessDefinitionSuspensionStateTest {
     assertThat(query.active().count()).isEqualTo(3L);
     assertThat(query.suspended().count()).isZero();
 
-    engineRule.getIdentityService().setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    engineRule.getIdentityService().setAuthentication("user", null, List.of(TENANT_ONE));
 
     engineRule.getRepositoryService()
       .updateProcessDefinitionSuspensionState()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyProcessInstanceSuspensionStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/suspensionstate/MultiTenancyProcessInstanceSuspensionStateTest.java
@@ -19,7 +19,7 @@ package org.operaton.bpm.engine.test.api.multitenancy.suspensionstate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.externaltask.ExternalTaskQuery;
@@ -534,12 +534,12 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
         .processDefinitionKey(PROCESS_DEFINITION_KEY).tenantIdIn(TENANT_ONE).singleResult();
 
     engineRule.getIdentityService().setAuthentication("user", null, null);
+    var updateProcessInstanceSuspensionStateBuilder = engineRule.getRuntimeService()
+      .updateProcessInstanceSuspensionState()
+      .byProcessDefinitionId(processDefinition.getId());
 
     // when/then
-    assertThatThrownBy(() -> engineRule.getRuntimeService()
-        .updateProcessInstanceSuspensionState()
-        .byProcessDefinitionId(processDefinition.getId())
-        .suspend())
+    assertThatThrownBy(updateProcessInstanceSuspensionStateBuilder::suspend)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot update the process definition '"
           + processDefinition.getId() +"' because it belongs to no authenticated tenant");
@@ -552,7 +552,7 @@ public class MultiTenancyProcessInstanceSuspensionStateTest {
     assertThat(query.active().count()).isEqualTo(3L);
     assertThat(query.suspended().count()).isZero();
 
-    engineRule.getIdentityService().setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    engineRule.getIdentityService().setAuthentication("user", null, List.of(TENANT_ONE));
 
     engineRule.getRuntimeService()
       .updateProcessInstanceSuspensionState()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyDeploymentCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyDeploymentCmdsTenantCheckTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.IdentityService;
@@ -87,7 +86,7 @@ public class MultiTenancyDeploymentCmdsTenantCheckTest {
 
   @Test
   public void createDeploymentWithAuthenticatedTenant() {
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     repositoryService.createDeployment().addModelInstance("emptyProcess.bpmn", emptyProcess)
       .tenantId(TENANT_ONE).deploy();
@@ -116,11 +115,12 @@ public class MultiTenancyDeploymentCmdsTenantCheckTest {
   @Test
   public void failToDeleteDeploymentNoAuthenticatedTenant() {
     Deployment deployment = testRule.deployForTenant(TENANT_ONE, emptyProcess);
+    String deploymentId = deployment.getId();
 
     identityService.setAuthentication("user", null, null);
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.deleteDeployment(deployment.getId()))
+    assertThatThrownBy(() -> repositoryService.deleteDeployment(deploymentId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot delete the deployment");
 
@@ -130,7 +130,7 @@ public class MultiTenancyDeploymentCmdsTenantCheckTest {
   public void deleteDeploymentWithAuthenticatedTenant() {
     Deployment deployment = testRule.deployForTenant(TENANT_ONE, emptyProcess);
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     repositoryService.deleteDeployment(deployment.getId());
 
@@ -161,11 +161,12 @@ public class MultiTenancyDeploymentCmdsTenantCheckTest {
   @Test
   public void failToGetDeploymentResourceNamesNoAuthenticatedTenant() {
     Deployment deployment = testRule.deployForTenant(TENANT_ONE, emptyProcess);
+    String deploymentId = deployment.getId();
 
     identityService.setAuthentication("user", null, null);
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.getDeploymentResourceNames(deployment.getId()))
+    assertThatThrownBy(() -> repositoryService.getDeploymentResourceNames(deploymentId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot get the deployment");
   }
@@ -174,7 +175,7 @@ public class MultiTenancyDeploymentCmdsTenantCheckTest {
   public void getDeploymentResourceNamesWithAuthenticatedTenant() {
     Deployment deployment = testRule.deployForTenant(TENANT_ONE, emptyProcess);
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     List<String> deploymentResourceNames = repositoryService.getDeploymentResourceNames(deployment.getId());
     assertThat(deploymentResourceNames).hasSize(1);
@@ -198,11 +199,12 @@ public class MultiTenancyDeploymentCmdsTenantCheckTest {
   @Test
   public void failToGetDeploymentResourcesNoAuthenticatedTenant() {
     Deployment deployment = testRule.deployForTenant(TENANT_ONE, emptyProcess);
+    String deploymentId = deployment.getId();
 
     identityService.setAuthentication("user", null, null);
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.getDeploymentResources(deployment.getId()))
+    assertThatThrownBy(() -> repositoryService.getDeploymentResources(deploymentId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot get the deployment");
   }
@@ -211,7 +213,7 @@ public class MultiTenancyDeploymentCmdsTenantCheckTest {
   public void getDeploymentResourcesWithAuthenticatedTenant() {
     Deployment deployment = testRule.deployForTenant(TENANT_ONE, emptyProcess);
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     List<Resource> deploymentResources = repositoryService.getDeploymentResources(deployment.getId());
     assertThat(deploymentResources).hasSize(1);
@@ -235,13 +237,15 @@ public class MultiTenancyDeploymentCmdsTenantCheckTest {
   @Test
   public void failToGetResourceAsStreamNoAuthenticatedTenant() {
     Deployment deployment = testRule.deployForTenant(TENANT_ONE, emptyProcess);
+    String deploymentId = deployment.getId();
 
-    Resource resource = repositoryService.getDeploymentResources(deployment.getId()).get(0);
+    Resource resource = repositoryService.getDeploymentResources(deploymentId).get(0);
+    String resourceName = resource.getName();
 
     identityService.setAuthentication("user", null, null);
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.getResourceAsStream(deployment.getId(), resource.getName()))
+    assertThatThrownBy(() -> repositoryService.getResourceAsStream(deploymentId, resourceName))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot get the deployment");
   }
@@ -252,7 +256,7 @@ public class MultiTenancyDeploymentCmdsTenantCheckTest {
 
     Resource resource = repositoryService.getDeploymentResources(deployment.getId()).get(0);
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     InputStream inputStream = repositoryService.getResourceAsStream(deployment.getId(), resource.getName());
     assertThat(inputStream).isNotNull();
@@ -279,13 +283,15 @@ public class MultiTenancyDeploymentCmdsTenantCheckTest {
   @Test
   public void failToGetResourceAsStreamByIdNoAuthenticatedTenant() {
     Deployment deployment = testRule.deployForTenant(TENANT_ONE, emptyProcess);
+    String deploymentId = deployment.getId();
 
-    Resource resource = repositoryService.getDeploymentResources(deployment.getId()).get(0);
+    Resource resource = repositoryService.getDeploymentResources(deploymentId).get(0);
+    String resourceId = resource.getId();
 
     identityService.setAuthentication("user", null, null);
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.getResourceAsStreamById(deployment.getId(), resource.getId()))
+    assertThatThrownBy(() -> repositoryService.getResourceAsStreamById(deploymentId, resourceId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot get the deployment");
   }
@@ -296,7 +302,7 @@ public class MultiTenancyDeploymentCmdsTenantCheckTest {
 
     Resource resource = repositoryService.getDeploymentResources(deployment.getId()).get(0);
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     InputStream inputStream = repositoryService.getResourceAsStreamById(deployment.getId(), resource.getId());
     assertThat(inputStream).isNotNull();
@@ -328,13 +334,13 @@ public class MultiTenancyDeploymentCmdsTenantCheckTest {
       .tenantId(TENANT_ONE)
       .deploy();
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_TWO));
+    identityService.setAuthentication("user", null, List.of(TENANT_TWO));
+    var deploymentBuilder = repositoryService.createDeployment()
+      .addDeploymentResources(deploymentOne.getId())
+      .tenantId(TENANT_TWO);
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.createDeployment()
-        .addDeploymentResources(deploymentOne.getId())
-        .tenantId(TENANT_TWO)
-        .deploy())
+    assertThatThrownBy(deploymentBuilder::deploy)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot get the deployment");
   }
@@ -347,7 +353,7 @@ public class MultiTenancyDeploymentCmdsTenantCheckTest {
       .tenantId(TENANT_ONE)
       .deploy();
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     repositoryService.createDeployment()
         .addDeploymentResources(deploymentOne.getId())

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyExecutionVariableCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyExecutionVariableCmdsTenantCheckTest.java
@@ -19,7 +19,7 @@ package org.operaton.bpm.engine.test.api.multitenancy.tenantcheck;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
@@ -81,7 +81,7 @@ public class MultiTenancyExecutionVariableCmdsTenantCheckTest {
   @Test
   public void getExecutionVariableWithAuthenticatedTenant() {
 
-    engineRule.getIdentityService().setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    engineRule.getIdentityService().setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     // then
     assertEquals(VARIABLE_VALUE_1, engineRule.getRuntimeService().getVariable(processInstanceId, VARIABLE_1));
@@ -91,9 +91,10 @@ public class MultiTenancyExecutionVariableCmdsTenantCheckTest {
   public void getExecutionVariableWithNoAuthenticatedTenant() {
 
     engineRule.getIdentityService().setAuthentication("aUserId", null);
+    var runtimeService = engineRule.getRuntimeService();
 
     // when/then
-    assertThatThrownBy(() -> engineRule.getRuntimeService().getVariable(processInstanceId, VARIABLE_1))
+    assertThatThrownBy(() -> runtimeService.getVariable(processInstanceId, VARIABLE_1))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot read the process instance '"
           + processInstanceId +"' because it belongs to no authenticated tenant.");
@@ -115,7 +116,7 @@ public class MultiTenancyExecutionVariableCmdsTenantCheckTest {
   @Test
   public void getExecutionVariableTypedWithAuthenticatedTenant() {
 
-    engineRule.getIdentityService().setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    engineRule.getIdentityService().setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     // then
     assertEquals(VARIABLE_VALUE_1, engineRule.getRuntimeService().getVariableTyped(processInstanceId, VARIABLE_1).getValue());
@@ -125,9 +126,10 @@ public class MultiTenancyExecutionVariableCmdsTenantCheckTest {
   public void getExecutionVariableTypedWithNoAuthenticatedTenant() {
 
     engineRule.getIdentityService().setAuthentication("aUserId", null);
+    var runtimeService = engineRule.getRuntimeService();
 
     // when/then
-    assertThatThrownBy(() -> engineRule.getRuntimeService().getVariableTyped(processInstanceId, VARIABLE_1))
+    assertThatThrownBy(() -> runtimeService.getVariableTyped(processInstanceId, VARIABLE_1))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot read the process instance '"
           + processInstanceId +"' because it belongs to no authenticated tenant.");
@@ -150,7 +152,7 @@ public class MultiTenancyExecutionVariableCmdsTenantCheckTest {
   @Test
   public void getExecutionVariablesWithAuthenticatedTenant() {
 
-    engineRule.getIdentityService().setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    engineRule.getIdentityService().setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     // then
     assertEquals(2, engineRule.getRuntimeService().getVariables(processInstanceId).size());
@@ -160,9 +162,10 @@ public class MultiTenancyExecutionVariableCmdsTenantCheckTest {
   public void getExecutionVariablesWithNoAuthenticatedTenant() {
 
     engineRule.getIdentityService().setAuthentication("aUserId", null);
+    var runtimeService = engineRule.getRuntimeService();
 
     // when/then
-    assertThatThrownBy(() -> engineRule.getRuntimeService().getVariables(processInstanceId).size())
+    assertThatThrownBy(() -> runtimeService.getVariables(processInstanceId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot read the process instance '"
           + processInstanceId +"' because it belongs to no authenticated tenant.");
@@ -184,7 +187,7 @@ public class MultiTenancyExecutionVariableCmdsTenantCheckTest {
   @Test
   public void setExecutionVariableWithAuthenticatedTenant() {
 
-    engineRule.getIdentityService().setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    engineRule.getIdentityService().setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     // then
     engineRule.getRuntimeService().setVariable(processInstanceId, "newVariable", "newValue");
@@ -195,9 +198,10 @@ public class MultiTenancyExecutionVariableCmdsTenantCheckTest {
   public void setExecutionVariableWithNoAuthenticatedTenant() {
 
     engineRule.getIdentityService().setAuthentication("aUserId", null);
+    var runtimeService = engineRule.getRuntimeService();
 
     // when/then
-    assertThatThrownBy(() -> engineRule.getRuntimeService().setVariable(processInstanceId, "newVariable", "newValue"))
+    assertThatThrownBy(() -> runtimeService.setVariable(processInstanceId, "newVariable", "newValue"))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot update the process instance '"
           + processInstanceId +"' because it belongs to no authenticated tenant.");
@@ -217,7 +221,7 @@ public class MultiTenancyExecutionVariableCmdsTenantCheckTest {
   @Test
   public void removeExecutionVariableWithAuthenticatedTenant() {
 
-    engineRule.getIdentityService().setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    engineRule.getIdentityService().setAuthentication("aUserId", null, List.of(TENANT_ONE));
     engineRule.getRuntimeService().removeVariable(processInstanceId, VARIABLE_1);
 
     // then
@@ -228,9 +232,10 @@ public class MultiTenancyExecutionVariableCmdsTenantCheckTest {
   public void removeExecutionVariableWithNoAuthenticatedTenant() {
 
     engineRule.getIdentityService().setAuthentication("aUserId", null);
+    var runtimeService = engineRule.getRuntimeService();
 
     // when/then
-    assertThatThrownBy(() -> engineRule.getRuntimeService().removeVariable(processInstanceId, VARIABLE_1))
+    assertThatThrownBy(() -> runtimeService.removeVariable(processInstanceId, VARIABLE_1))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot update the process instance '"
           + processInstanceId +"' because it belongs to no authenticated tenant.");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyExternalTaskCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyExternalTaskCmdsTenantCheckTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.ExternalTaskService;
@@ -89,7 +88,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
   @Test
   public void testFetchAndLockWithAuthenticatedTenant() {
 
-    identityService.setAuthentication("aUserId", null,  Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     // then
     List<LockedExternalTask> externalTasks = externalTaskService.fetchAndLock(1, WORKER_ID)
@@ -115,7 +114,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
   @Test
   public void testFetchAndLockWithDifferentTenant() {
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList("tenantTwo"));
+    identityService.setAuthentication("aUserId", null, List.of("tenantTwo"));
 
     // then external task cannot be fetched due to the absence of 'tenant1' authentication
     List<LockedExternalTask> externalTasks = externalTaskService.fetchAndLock(1, WORKER_ID)
@@ -141,7 +140,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
   @Test
   public void testFetchAndLockWithoutTenantId() {
     // given
-    identityService.setAuthentication("aUserId", null,  Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     // when
     List<LockedExternalTask> externalTasks = externalTaskService.fetchAndLock(1, WORKER_ID)
@@ -158,7 +157,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
     // given
     testRule.deploy("org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml");
     engineRule.getRuntimeService().startProcessInstanceByKey(PROCESS_DEFINITION_KEY_ONE).getId();
-    identityService.setAuthentication("aUserId", null,  Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     // when
     List<LockedExternalTask> externalTasks = externalTaskService.fetchAndLock(1, WORKER_ID)
@@ -224,7 +223,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
 
     assertEquals(1, externalTaskService.createExternalTaskQuery().active().count());
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     externalTaskService.complete(externalTaskId, WORKER_ID);
 
@@ -281,7 +280,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
       .execute()
       .get(0);
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     externalTaskService.handleFailure(task.getId(), WORKER_ID, ERROR_MESSAGE, 1, 0);
 
@@ -301,11 +300,12 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
       .topic(TOPIC_NAME, LOCK_TIME)
       .execute()
       .get(0);
+    String taskId = task.getId();
 
     identityService.setAuthentication("aUserId", null);
 
     // when/then
-    assertThatThrownBy(() -> externalTaskService.handleFailure(task.getId(), WORKER_ID, ERROR_MESSAGE, 1, 0))
+    assertThatThrownBy(() -> externalTaskService.handleFailure(taskId, WORKER_ID, ERROR_MESSAGE, 1, 0))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot update the process instance '"
           + processInstanceId +"' because it belongs to no authenticated tenant.");
@@ -342,7 +342,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
       .get(0)
       .getId();
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     // when
     externalTaskService.handleBpmnError(taskId, WORKER_ID, "ERROR-OCCURED");
@@ -400,7 +400,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
       .get(0)
       .getId();
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     // when
     externalTaskService.setRetries(externalTaskId, 5);
@@ -458,7 +458,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
       .get(0)
       .getId();
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     // when
     externalTaskService.setPriority(externalTaskId, 1);
@@ -517,7 +517,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
 
     assertThat(externalTaskService.createExternalTaskQuery().locked().count()).isEqualTo(1L);
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     // when
     externalTaskService.unlock(externalTaskId);
@@ -573,7 +573,7 @@ public class MultiTenancyExternalTaskCmdsTenantCheckTest {
 
     externalTaskService.handleFailure(externalTaskId,WORKER_ID,ERROR_MESSAGE,ERROR_DETAILS,1,1000L);
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     // when then
     assertThat(externalTaskService.getExternalTaskErrorDetails(externalTaskId)).isEqualTo(ERROR_DETAILS);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyFormServiceCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyFormServiceCmdsTenantCheckTest.java
@@ -20,8 +20,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.operaton.bpm.engine.FormService;
@@ -93,7 +93,7 @@ public class MultiTenancyFormServiceCmdsTenantCheckTest {
 
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY);
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     StartFormData startFormData = formService.getStartFormData(instance.getProcessDefinitionId());
 
@@ -109,13 +109,14 @@ public class MultiTenancyFormServiceCmdsTenantCheckTest {
     "org/operaton/bpm/engine/test/api/authorization/formKeyProcess.bpmn20.xml");
 
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY);
+    String processDefinitionId = instance.getProcessDefinitionId();
 
     identityService.setAuthentication("aUserId", null);
 
     // when/then
-    assertThatThrownBy(() -> formService.getStartFormData(instance.getProcessDefinitionId()))
+    assertThatThrownBy(() -> formService.getStartFormData(processDefinitionId))
       .isInstanceOf(ProcessEngineException.class)
-      .hasMessageContaining("Cannot get the process definition '" + instance.getProcessDefinitionId()
+      .hasMessageContaining("Cannot get the process definition '" + processDefinitionId
       +"' because it belongs to no authenticated tenant.");
 
   }
@@ -150,7 +151,7 @@ public class MultiTenancyFormServiceCmdsTenantCheckTest {
     String processDefinitionId = repositoryService.createProcessDefinitionQuery()
       .singleResult().getId();
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     assertNotNull(formService.getRenderedStartForm(processDefinitionId, "juel"));
   }
@@ -204,7 +205,7 @@ public class MultiTenancyFormServiceCmdsTenantCheckTest {
     Map<String, Object> properties = new HashMap<>();
     properties.put("employeeName", "demo");
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     assertNotNull(formService.submitStartForm(processDefinitionId, properties));
   }
@@ -261,7 +262,7 @@ public class MultiTenancyFormServiceCmdsTenantCheckTest {
 
     String processDefinitionId = runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY).getProcessDefinitionId();
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
     assertEquals("aStartFormKey", formService.getStartFormKey(processDefinitionId));
 
   }
@@ -305,7 +306,7 @@ public class MultiTenancyFormServiceCmdsTenantCheckTest {
 
     runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY);
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     String taskId = taskService.createTaskQuery().singleResult().getId();
 
@@ -370,7 +371,7 @@ public class MultiTenancyFormServiceCmdsTenantCheckTest {
 
     String taskId = taskService.createTaskQuery().processDefinitionId(processDefinitionId).singleResult().getId();
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     formService.submitTaskForm(taskId, null);
 
@@ -439,7 +440,7 @@ public class MultiTenancyFormServiceCmdsTenantCheckTest {
     formService.submitStartForm(procDefId, properties).getId();
 
     String taskId = taskService.createTaskQuery().singleResult().getId();
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     // then
     assertEquals("Mike is speaking in room 5b", formService.getRenderedTaskForm(taskId, "juel"));
@@ -504,7 +505,7 @@ public class MultiTenancyFormServiceCmdsTenantCheckTest {
 
     Task task = taskService.createTaskQuery().singleResult();
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
     assertEquals("aTaskFormKey", formService.getTaskFormKey(task.getProcessDefinitionId(), task.getTaskDefinitionKey()));
 
   }
@@ -518,13 +519,15 @@ public class MultiTenancyFormServiceCmdsTenantCheckTest {
     runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY);
 
     Task task = taskService.createTaskQuery().singleResult();
+    String processDefinitionId = task.getProcessDefinitionId();
+    String taskDefinitionKey = task.getTaskDefinitionKey();
 
     identityService.setAuthentication("aUserId", null);
 
     // when/then
-    assertThatThrownBy(() -> formService.getTaskFormKey(task.getProcessDefinitionId(), task.getTaskDefinitionKey()))
+    assertThatThrownBy(() -> formService.getTaskFormKey(processDefinitionId, taskDefinitionKey))
       .isInstanceOf(ProcessEngineException.class)
-      .hasMessageContaining("Cannot get the process definition '" + task.getProcessDefinitionId()
+      .hasMessageContaining("Cannot get the process definition '" + processDefinitionId
       +"' because it belongs to no authenticated tenant.");
 
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyFormVariablesCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyFormVariablesCmdsTenantCheckTest.java
@@ -19,7 +19,7 @@ package org.operaton.bpm.engine.test.api.multitenancy.tenantcheck;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
@@ -76,7 +76,7 @@ public class MultiTenancyFormVariablesCmdsTenantCheckTest {
   @Test
   public void testGetStartFormVariablesWithAuthenticatedTenant() {
 
-    engineRule.getIdentityService().setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    engineRule.getIdentityService().setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     assertEquals(4, engineRule.getFormService().getStartFormVariables(instance.getProcessDefinitionId()).size());
 
@@ -84,14 +84,15 @@ public class MultiTenancyFormVariablesCmdsTenantCheckTest {
 
   @Test
   public void testGetStartFormVariablesWithNoAuthenticatedTenant() {
-
     engineRule.getIdentityService().setAuthentication("aUserId", null);
+    String processDefinitionId = instance.getProcessDefinitionId();
+    var formService = engineRule.getFormService();
 
     // when/then
-    assertThatThrownBy(() -> engineRule.getFormService().getStartFormVariables(instance.getProcessDefinitionId()))
+    assertThatThrownBy(() -> formService.getStartFormVariables(processDefinitionId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot get the process definition '"
-          + instance.getProcessDefinitionId() +"' because it belongs to no authenticated tenant.");
+          + processDefinitionId +"' because it belongs to no authenticated tenant.");
 
   }
 
@@ -108,7 +109,7 @@ public class MultiTenancyFormVariablesCmdsTenantCheckTest {
   @Test
   public void testGetTaskFormVariablesWithAuthenticatedTenant() {
 
-    engineRule.getIdentityService().setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    engineRule.getIdentityService().setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     Task task = engineRule.getTaskService().createTaskQuery().singleResult();
 
@@ -120,14 +121,16 @@ public class MultiTenancyFormVariablesCmdsTenantCheckTest {
   public void testGetTaskFormVariablesWithNoAuthenticatedTenant() {
 
     Task task = engineRule.getTaskService().createTaskQuery().singleResult();
+    String taskId = task.getId();
 
     engineRule.getIdentityService().setAuthentication("aUserId", null);
+    var formService = engineRule.getFormService();
 
     // when/then
-    assertThatThrownBy(() -> engineRule.getFormService().getTaskFormVariables(task.getId()))
+    assertThatThrownBy(() -> formService.getTaskFormVariables(taskId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot read the task '"
-          + task.getId() +"' because it belongs to no authenticated tenant.");
+          + taskId +"' because it belongs to no authenticated tenant.");
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyHistoricDataCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyHistoricDataCmdsTenantCheckTest.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.engine.test.api.multitenancy.tenantcheck;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.CaseService;
@@ -138,7 +137,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     testRule.deployForTenant(TENANT_ONE, BPMN_PROCESS);
     String processInstanceId = startProcessInstance(null);
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     historyService.deleteHistoricProcessInstance(processInstanceId);
 
@@ -183,7 +182,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
   public void deleteHistoricTaskInstanceWithAuthenticatedTenant() {
     String taskId = createTaskForTenant(TENANT_ONE);
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     historyService.deleteHistoricTaskInstance(taskId);
 
@@ -228,7 +227,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     testRule.deployForTenant(TENANT_ONE, CMMN_PROCESS_WITH_MANUAL_ACTIVATION);
     String caseInstanceId = createAndCloseCaseInstance(null);
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     historyService.deleteHistoricCaseInstance(caseInstanceId);
 
@@ -279,7 +278,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     testRule.deployForTenant(TENANT_ONE, DMN);
     String decisionDefinitionId = evaluateDecisionTable(null);
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     historyService.deleteHistoricDecisionInstanceByDefinitionId(decisionDefinitionId);
 
@@ -318,11 +317,12 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     HistoricDecisionInstanceQuery query =
         historyService.createHistoricDecisionInstanceQuery();
     HistoricDecisionInstance historicDecisionInstance = query.includeInputs().includeOutputs().singleResult();
+    String historicDecisionInstanceId = historicDecisionInstance.getId();
 
     identityService.setAuthentication("user", null, null);
 
     // when/then
-    assertThatThrownBy(() -> historyService.deleteHistoricDecisionInstanceByInstanceId(historicDecisionInstance.getId()))
+    assertThatThrownBy(() -> historyService.deleteHistoricDecisionInstanceByInstanceId(historicDecisionInstanceId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot delete the historic decision instance");
   }
@@ -339,7 +339,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     HistoricDecisionInstance historicDecisionInstance = query.includeInputs().includeOutputs().singleResult();
 
     // when
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
     historyService.deleteHistoricDecisionInstanceByInstanceId(historicDecisionInstance.getId());
 
     // then
@@ -403,7 +403,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     HistoricJobLog log = historyService.createHistoricJobLogQuery()
         .processInstanceId(processInstanceId).failureLog().listPage(0, 1).get(0);
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     String historicJobLogExceptionStacktrace = historyService.getHistoricJobLogExceptionStacktrace(log.getId());
 
@@ -439,16 +439,11 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     identityService.setAuthentication("user", null, null);
 
     // when/then
-    assertThatThrownBy(() -> {
-        try {
-          historyService.deleteHistoricVariableInstance(variableInstanceId);
-        } finally {
-          cleanUpAfterVariableInstanceTest(processInstanceId);
-        }
-      })
+    assertThatThrownBy(() -> historyService.deleteHistoricVariableInstance(variableInstanceId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot delete the historic variable instance '" + variableInstanceId + "' because it belongs to no authenticated tenant.");
 
+    cleanUpAfterVariableInstanceTest(processInstanceId);
   }
 
   @Test
@@ -461,7 +456,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     assertThat(variableQuery.count()).isEqualTo(1L);
     String variableInstanceId = variableQuery.singleResult().getId();
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     historyService.deleteHistoricVariableInstance(variableInstanceId);
     assertThat(variableQuery.count()).isZero();
@@ -507,16 +502,11 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     identityService.setAuthentication("user", null, null);
 
     // when/then
-    assertThatThrownBy(() -> {
-        try {
-          historyService.deleteHistoricVariableInstancesByProcessInstanceId(processInstanceId);
-        } finally {
-          cleanUpAfterVariableInstanceTest(processInstanceId);
-        }
-      })
+    assertThatThrownBy(() -> historyService.deleteHistoricVariableInstancesByProcessInstanceId(processInstanceId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot delete the historic variable instances of process instance '" + processInstanceId + "' because it belongs to no authenticated tenant.");
 
+    cleanUpAfterVariableInstanceTest(processInstanceId);
   }
 
   @Test
@@ -529,7 +519,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
     HistoricVariableInstanceQuery variableQuery = historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstanceId);
     assertThat(variableQuery.count()).isEqualTo(1L);
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     historyService.deleteHistoricVariableInstancesByProcessInstanceId(processInstanceId);
     assertThat(variableQuery.count()).isZero();
@@ -612,7 +602,7 @@ public class MultiTenancyHistoricDataCmdsTenantCheckTest {
 
   protected String createTaskForTenant(String tenantId) {
     Task task = taskService.newTask();
-    task.setTenantId(TENANT_ONE);
+    task.setTenantId(tenantId);
 
     taskService.saveTask(task);
     taskService.complete(task.getId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyMessageCorrelationCmdTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyMessageCorrelationCmdTenantCheckTest.java
@@ -19,7 +19,7 @@ package org.operaton.bpm.engine.test.api.multitenancy.tenantcheck;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.operaton.bpm.engine.IdentityService;
 import org.operaton.bpm.engine.MismatchingMessageCorrelationException;
@@ -100,7 +100,7 @@ public class MultiTenancyMessageCorrelationCmdTenantCheckTest {
     testRule.deployForTenant(TENANT_ONE, MESSAGE_START_PROCESS);
     testRule.deployForTenant(TENANT_TWO, MESSAGE_START_PROCESS);
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     runtimeService.createMessageCorrelation("message")
       .correlateStartMessage();
@@ -160,7 +160,7 @@ public class MultiTenancyMessageCorrelationCmdTenantCheckTest {
     runtimeService.createProcessInstanceByKey("messageCatch").processDefinitionTenantId(TENANT_ONE).execute();
     runtimeService.createProcessInstanceByKey("messageCatch").processDefinitionTenantId(TENANT_TWO).execute();
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     runtimeService.createMessageCorrelation("message")
       .correlate();
@@ -223,7 +223,7 @@ public class MultiTenancyMessageCorrelationCmdTenantCheckTest {
     runtimeService.createProcessInstanceByKey("messageCatch").processDefinitionTenantId(TENANT_ONE).execute();
     runtimeService.createProcessInstanceByKey("messageCatch").processDefinitionTenantId(TENANT_TWO).execute();
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     runtimeService.createMessageCorrelation("message")
       .correlateAll();
@@ -264,11 +264,11 @@ public class MultiTenancyMessageCorrelationCmdTenantCheckTest {
         .processDefinitionTenantId(TENANT_ONE).execute();
 
     identityService.setAuthentication("user", null, null);
+    var messageCorrelationBuilder = runtimeService.createMessageCorrelation("message")
+      .processInstanceId(processInstance.getId());
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.createMessageCorrelation("message")
-        .processInstanceId(processInstance.getId())
-        .correlate())
+    assertThatThrownBy(messageCorrelationBuilder::correlate)
       .isInstanceOf(MismatchingMessageCorrelationException.class)
       .hasMessageContaining("Cannot correlate message");
   }
@@ -279,7 +279,7 @@ public class MultiTenancyMessageCorrelationCmdTenantCheckTest {
 
     ProcessInstance processInstance = runtimeService.createProcessInstanceByKey("messageCatch").execute();
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     runtimeService.createMessageCorrelation("message")
       .processInstanceId(processInstance.getId())
@@ -300,11 +300,11 @@ public class MultiTenancyMessageCorrelationCmdTenantCheckTest {
         processDefinitionKey("messageStart").tenantIdIn(TENANT_ONE).singleResult();
 
     identityService.setAuthentication("user", null, null);
+    var messageCorrelationBuilder = runtimeService.createMessageCorrelation("message")
+      .processDefinitionId(processDefinition.getId());
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.createMessageCorrelation("message")
-        .processDefinitionId(processDefinition.getId())
-        .correlateStartMessage())
+    assertThatThrownBy(messageCorrelationBuilder::correlateStartMessage)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot create an instance of the process definition");
 
@@ -317,7 +317,7 @@ public class MultiTenancyMessageCorrelationCmdTenantCheckTest {
     ProcessDefinition processDefinition = engineRule.getRepositoryService().createProcessDefinitionQuery().
         processDefinitionKey("messageStart").singleResult();
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     runtimeService.createMessageCorrelation("message")
       .processDefinitionId(processDefinition.getId())

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyMessageEventReceivedCmdTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyMessageEventReceivedCmdTenantCheckTest.java
@@ -19,7 +19,7 @@ package org.operaton.bpm.engine.test.api.multitenancy.tenantcheck;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.operaton.bpm.engine.IdentityService;
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -101,7 +101,7 @@ public class MultiTenancyMessageEventReceivedCmdTenantCheckTest {
       .messageEventSubscriptionName("message")
       .singleResult();
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     runtimeService.messageEventReceived("message", execution.getId());
 
@@ -148,11 +148,12 @@ public class MultiTenancyMessageEventReceivedCmdTenantCheckTest {
       .messageEventSubscriptionName("message")
       .tenantIdIn(TENANT_ONE)
       .singleResult();
+    String executionId = execution.getId();
 
     identityService.setAuthentication("user", null, null);
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.messageEventReceived("message", execution.getId()))
+    assertThatThrownBy(() -> runtimeService.messageEventReceived("message", executionId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot update the process instance");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyMigrationExecuteTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyMigrationExecuteTenantCheckTest.java
@@ -18,7 +18,8 @@ package org.operaton.bpm.engine.test.api.multitenancy.tenantcheck;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.migration.MigrationPlan;
@@ -62,10 +63,10 @@ public class MultiTenancyMigrationExecuteTenantCheckTest {
     ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceById(sourceDefinition.getId());
 
     // when
-    engineRule.getIdentityService().setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    engineRule.getIdentityService().setAuthentication("user", null, List.of(TENANT_ONE));
     engineRule.getRuntimeService()
       .newMigration(migrationPlan)
-      .processInstanceIds(Arrays.asList(processInstance.getId()))
+      .processInstanceIds(Collections.singletonList(processInstance.getId()))
       .execute();
 
     // then
@@ -86,13 +87,13 @@ public class MultiTenancyMigrationExecuteTenantCheckTest {
         .build();
 
     ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceById(sourceDefinition.getId());
-    engineRule.getIdentityService().setAuthentication("user", null, Arrays.asList(TENANT_TWO));
+    engineRule.getIdentityService().setAuthentication("user", null, List.of(TENANT_TWO));
+    var migrationPlanExecutionBuilder = engineRule.getRuntimeService()
+      .newMigration(migrationPlan)
+      .processInstanceIds(Collections.singletonList(processInstance.getId()));
 
     // when/then
-    assertThatThrownBy(() -> engineRule.getRuntimeService()
-        .newMigration(migrationPlan)
-        .processInstanceIds(Arrays.asList(processInstance.getId()))
-        .execute())
+    assertThatThrownBy(migrationPlanExecutionBuilder::execute)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot migrate process instance '" + processInstance.getId()
       + "' because it belongs to no authenticated tenant");
@@ -113,12 +114,12 @@ public class MultiTenancyMigrationExecuteTenantCheckTest {
 
     ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceById(sourceDefinition.getId());
     engineRule.getIdentityService().setAuthentication("user", null, null);
+    var migrationPlanExecutionBuilder = engineRule.getRuntimeService()
+      .newMigration(migrationPlan)
+      .processInstanceIds(Collections.singletonList(processInstance.getId()));
 
     // when/then
-    assertThatThrownBy(() -> engineRule.getRuntimeService()
-        .newMigration(migrationPlan)
-        .processInstanceIds(Arrays.asList(processInstance.getId()))
-        .execute())
+    assertThatThrownBy(migrationPlanExecutionBuilder::execute)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot migrate process instance '" + processInstance.getId()
       + "' because it belongs to no authenticated tenant");
@@ -142,7 +143,7 @@ public class MultiTenancyMigrationExecuteTenantCheckTest {
     engineRule.getIdentityService().setAuthentication("user", null, null);
     engineRule.getRuntimeService()
       .newMigration(migrationPlan)
-      .processInstanceIds(Arrays.asList(processInstance.getId()))
+      .processInstanceIds(Collections.singletonList(processInstance.getId()))
       .execute();
 
     // then
@@ -169,7 +170,7 @@ public class MultiTenancyMigrationExecuteTenantCheckTest {
     engineRule.getProcessEngineConfiguration().setTenantCheckEnabled(false);
     engineRule.getRuntimeService()
       .newMigration(migrationPlan)
-      .processInstanceIds(Arrays.asList(processInstance.getId()))
+      .processInstanceIds(Collections.singletonList(processInstance.getId()))
       .execute();
 
     // then

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyProcessDefinitionCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyProcessDefinitionCmdsTenantCheckTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.HistoryService;
@@ -32,10 +31,7 @@ import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.history.HistoryLevel;
-import org.operaton.bpm.engine.repository.Deployment;
-import org.operaton.bpm.engine.repository.DiagramLayout;
-import org.operaton.bpm.engine.repository.ProcessDefinition;
-import org.operaton.bpm.engine.repository.ProcessDefinitionQuery;
+import org.operaton.bpm.engine.repository.*;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
@@ -96,7 +92,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
 
   @Test
   public void getProcessModelWithAuthenticatedTenant() {
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     InputStream inputStream = repositoryService.getProcessModel(processDefinitionId);
 
@@ -125,7 +121,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
 
   @Test
   public void getProcessDiagramWithAuthenticatedTenant() {
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     InputStream inputStream = repositoryService.getProcessDiagram(processDefinitionId);
 
@@ -154,7 +150,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
 
   @Test
   public void getProcessDiagramLayoutWithAuthenticatedTenant() {
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     DiagramLayout diagramLayout = repositoryService.getProcessDiagramLayout(processDefinitionId);
 
@@ -183,7 +179,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
 
   @Test
   public void getProcessDefinitionWithAuthenticatedTenant() {
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     ProcessDefinition definition = repositoryService.getProcessDefinition(processDefinitionId);
 
@@ -212,7 +208,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
 
   @Test
   public void getBpmnModelInstanceWithAuthenticatedTenant() {
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     BpmnModelInstance modelInstance = repositoryService.getBpmnModelInstance(processDefinitionId);
 
@@ -232,13 +228,12 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
   @Test
   public void failToDeleteProcessDefinitionNoAuthenticatedTenant() {
     //given deployment with a process definition
-    List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
     //and user with no tenant authentication
     identityService.setAuthentication("user", null, null);
 
     // when/then
     //deletion should end in exception, since tenant authorization is missing
-    assertThatThrownBy(() -> repositoryService.deleteProcessDefinition(processDefinitions.get(0).getId()))
+    assertThatThrownBy(() -> repositoryService.deleteProcessDefinition(processDefinitionId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot delete the process definition");
   }
@@ -250,7 +245,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
     ProcessDefinitionQuery processDefinitionQuery = repositoryService.createProcessDefinitionQuery().deploymentId(deployment.getId());
     List<ProcessDefinition> processDefinitions = processDefinitionQuery.list();
     //and user with tenant authentication
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     //when delete process definition with authenticated user
     repositoryService.deleteProcessDefinition(processDefinitions.get(0).getId());
@@ -271,7 +266,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
     engineRule.getRuntimeService().createProcessInstanceByKey("process").executeWithVariablesInReturn();
 
     //and user with tenant authentication
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     //when the corresponding process definition is cascading deleted from the deployment
     repositoryService.deleteProcessDefinition(processDefinition.getId(), true);
@@ -340,12 +335,12 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
     }
 
     identityService.setAuthentication("user", null, null);
+    var deleteProcessDefinitionsBuilder = repositoryService.deleteProcessDefinitions()
+      .byKey("process")
+      .withoutTenantId();
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.deleteProcessDefinitions()
-        .byKey("process")
-        .withoutTenantId()
-        .delete())
+    assertThatThrownBy(deleteProcessDefinitionsBuilder::delete)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("No process definition found");
   }
@@ -375,7 +370,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
       deployProcessDefinitionWithTenant();
     }
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     // when
     repositoryService.deleteProcessDefinitions()
@@ -398,7 +393,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
 
     runtimeService.startProcessInstanceByKey("process");
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     // when
     repositoryService.deleteProcessDefinitions()
@@ -471,11 +466,11 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
     String[] processDefinitionIds = findProcessDefinitionIdsByKey("process");
 
     identityService.setAuthentication("user", null, null);
+    var deleteProcessDefinitionsBuilder = repositoryService.deleteProcessDefinitions()
+      .byIds(processDefinitionIds);
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.deleteProcessDefinitions()
-        .byIds(processDefinitionIds)
-        .delete())
+    assertThatThrownBy(deleteProcessDefinitionsBuilder::delete)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot delete the process definition");
 
@@ -490,7 +485,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
 
     String[] processDefinitionIds = findProcessDefinitionIdsByKey("process");
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     // when
     repositoryService.deleteProcessDefinitions()
@@ -514,7 +509,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
 
     runtimeService.startProcessInstanceByKey("process");
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     // when
     repositoryService.deleteProcessDefinitions()
@@ -580,7 +575,7 @@ public class MultiTenancyProcessDefinitionCmdsTenantCheckTest {
 
   @Test
   public void updateHistoryTimeToLiveWithAuthenticatedTenant() {
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     repositoryService.updateProcessDefinitionHistoryTimeToLive(processDefinitionId, 6);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancySignalReceiveCmdTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancySignalReceiveCmdTenantCheckTest.java
@@ -19,7 +19,7 @@ package org.operaton.bpm.engine.test.api.multitenancy.tenantcheck;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.operaton.bpm.engine.IdentityService;
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -100,7 +100,7 @@ public class MultiTenancySignalReceiveCmdTenantCheckTest {
     testRule.deployForTenant(TENANT_ONE, SIGNAL_START_PROCESS);
     testRule.deployForTenant(TENANT_TWO, SIGNAL_START_PROCESS);
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     runtimeService.createSignalEvent("signal").send();
 
@@ -156,7 +156,7 @@ public class MultiTenancySignalReceiveCmdTenantCheckTest {
     runtimeService.createProcessInstanceByKey("signalCatch").processDefinitionTenantId(TENANT_ONE).execute();
     runtimeService.createProcessInstanceByKey("signalCatch").processDefinitionTenantId(TENANT_TWO).execute();
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     runtimeService.createSignalEvent("signal").send();
 
@@ -215,7 +215,7 @@ public class MultiTenancySignalReceiveCmdTenantCheckTest {
     runtimeService.createProcessInstanceByKey("signalCatch").processDefinitionTenantId(TENANT_ONE).execute();
     runtimeService.createProcessInstanceByKey("signalCatch").processDefinitionTenantId(TENANT_TWO).execute();
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     runtimeService.createSignalEvent("signal").send();
 
@@ -257,7 +257,7 @@ public class MultiTenancySignalReceiveCmdTenantCheckTest {
       .signalEventSubscriptionName("signal")
       .singleResult();
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     runtimeService.createSignalEvent("signal").executionId(execution.getId()).send();
 
@@ -280,9 +280,11 @@ public class MultiTenancySignalReceiveCmdTenantCheckTest {
       .singleResult();
 
     identityService.setAuthentication("user", null, null);
+    var signalEventReceivedBuilder = runtimeService.createSignalEvent("signal")
+      .executionId(execution.getId());
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.createSignalEvent("signal").executionId(execution.getId()).send())
+    assertThatThrownBy(signalEventReceivedBuilder::send)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot update the process instance");
 
@@ -321,7 +323,7 @@ public class MultiTenancySignalReceiveCmdTenantCheckTest {
       .signalEventSubscriptionName("signal")
       .singleResult();
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     runtimeService.signal(execution.getId(), "signal", null, null);
 
@@ -367,11 +369,12 @@ public class MultiTenancySignalReceiveCmdTenantCheckTest {
       .processDefinitionKey("signalCatch")
       .signalEventSubscriptionName("signal")
       .singleResult();
+    String executionId = execution.getId();
 
     identityService.setAuthentication("user", null, null);
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.signal(execution.getId(), "signal", null, null))
+    assertThatThrownBy(() -> runtimeService.signal(executionId, "signal", null, null))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot update the process instance");
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyStartProcessInstanceByConditionCmdTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyStartProcessInstanceByConditionCmdTenantCheckTest.java
@@ -17,11 +17,8 @@
 package org.operaton.bpm.engine.test.api.multitenancy.tenantcheck;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -116,7 +113,7 @@ public class MultiTenancyStartProcessInstanceByConditionCmdTenantCheckTest {
 
     ensureEventSubscriptions(2);
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     Map<String, Object> variableMap = new HashMap<>();
     variableMap.put("foo", "bar");
@@ -147,7 +144,7 @@ public class MultiTenancyStartProcessInstanceByConditionCmdTenantCheckTest {
 
     ensureEventSubscriptions(2);
 
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     Map<String, Object> variableMap = new HashMap<>();
     variableMap.put("foo", "bar");
@@ -204,12 +201,13 @@ public class MultiTenancyStartProcessInstanceByConditionCmdTenantCheckTest {
 
     identityService.setAuthentication("user", null, null);
 
+    var conditionEvaluationBuilder = engineRule.getRuntimeService()
+      .createConditionEvaluation()
+      .setVariable("foo", "bar")
+      .processDefinitionId(processDefinition.getId());
+
     // when/then
-    assertThatThrownBy(() -> engineRule.getRuntimeService()
-        .createConditionEvaluation()
-        .setVariable("foo", "bar")
-        .processDefinitionId(processDefinition.getId())
-        .evaluateStartConditions())
+    assertThatThrownBy(conditionEvaluationBuilder::evaluateStartConditions)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot create an instance of the process definition");
   }
@@ -224,7 +222,7 @@ public class MultiTenancyStartProcessInstanceByConditionCmdTenantCheckTest {
     ProcessDefinition processDefinition = engineRule.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("conditionStart").singleResult();
 
     identityService = engineRule.getIdentityService();
-    identityService.setAuthentication("user", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("user", null, List.of(TENANT_ONE));
 
     // when
     List<ProcessInstance> instances = engineRule.getRuntimeService()
@@ -289,7 +287,7 @@ public class MultiTenancyStartProcessInstanceByConditionCmdTenantCheckTest {
       if (eventSubscriptionEntity.getConfiguration().equals(processDefId2)) {
         assertEquals(TENANT_ONE, eventSubscription.getTenantId());
       } else if (eventSubscriptionEntity.getConfiguration().equals(processDefId6)) {
-        assertEquals(null, eventSubscription.getTenantId());
+        assertNull(eventSubscription.getTenantId());
       } else if (eventSubscriptionEntity.getConfiguration().equals(processDefId7)) {
         assertEquals(TENANT_ONE, eventSubscription.getTenantId());
       } else {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyTaskServiceCmdsTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyTaskServiceCmdsTenantCheckTest.java
@@ -19,7 +19,7 @@ package org.operaton.bpm.engine.test.api.multitenancy.tenantcheck;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.operaton.bpm.engine.IdentityService;
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -86,7 +86,7 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
     task = taskService.newTask("newTask");
     task.setTenantId(TENANT_ONE);
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     taskService.saveTask(task);
     // then
@@ -130,7 +130,7 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
   @Test
   public void updateTaskWithAuthenticatedTenant() {
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
     task.setAssignee("aUser");
     taskService.saveTask(task);
 
@@ -169,7 +169,7 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
   @Test
   public void claimTaskWithAuthenticatedTenant() {
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     // then
     taskService.claim(task.getId(), "bUser");
@@ -178,14 +178,15 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
 
   @Test
   public void claimTaskWithNoAuthenticatedTenant() {
-
+    // given
+    String taskId = task.getId();
     identityService.setAuthentication("aUserId", null);
 
     // when/then
-    assertThatThrownBy(() -> taskService.claim(task.getId(), "bUser"))
+    assertThatThrownBy(() -> taskService.claim(taskId, "bUser"))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot work on task '"
-          + task.getId() +"' because it belongs to no authenticated tenant.");
+          + taskId +"' because it belongs to no authenticated tenant.");
 
   }
 
@@ -204,7 +205,7 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
   // complete the task test
   @Test
   public void completeTaskWithAuthenticatedTenant() {
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     // then
     taskService.complete(task.getId());
@@ -213,14 +214,15 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
 
   @Test
   public void completeTaskWithNoAuthenticatedTenant() {
-
+    // given
+    String taskId = task.getId();
     identityService.setAuthentication("aUserId", null);
 
     // when/then
-    assertThatThrownBy(() -> taskService.complete(task.getId()))
+    assertThatThrownBy(() -> taskService.complete(taskId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot work on task '"
-          + task.getId() +"' because it belongs to no authenticated tenant.");
+          + taskId +"' because it belongs to no authenticated tenant.");
   }
 
   @Test
@@ -238,7 +240,7 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
   @Test
   public void delegateTaskWithAuthenticatedTenant() {
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     taskService.delegateTask(task.getId(), "demo");
 
@@ -247,14 +249,15 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
 
   @Test
   public void delegateTaskWithNoAuthenticatedTenant() {
-
+    // given
+    String taskId = task.getId();
     identityService.setAuthentication("aUserId", null);
 
     // when/then
-    assertThatThrownBy(() -> taskService.delegateTask(task.getId(), "demo"))
+    assertThatThrownBy(() -> taskService.delegateTask(taskId, "demo"))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot assign the task '"
-          + task.getId() +"' because it belongs to no authenticated tenant.");
+          + taskId +"' because it belongs to no authenticated tenant.");
 
   }
 
@@ -273,7 +276,7 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
   @Test
   public void resolveTaskWithAuthenticatedTenant() {
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
 
     taskService.resolveTask(task.getId());
 
@@ -282,14 +285,15 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
 
   @Test
   public void resolveTaskWithNoAuthenticatedTenant() {
-
+    // given
+    String taskId = task.getId();
     identityService.setAuthentication("aUserId", null);
 
     // when/then
-    assertThatThrownBy(() -> taskService.resolveTask(task.getId()))
+    assertThatThrownBy(() -> taskService.resolveTask(taskId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot work on task '"
-          + task.getId() +"' because it belongs to no authenticated tenant.");
+          + taskId +"' because it belongs to no authenticated tenant.");
 
   }
 
@@ -308,8 +312,8 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
   @Test
   public void deleteTaskWithAuthenticatedTenant() {
 
-    identityService.setAuthentication("aUserId", null, Arrays.asList(TENANT_ONE));
-    task = createTaskforTenant();
+    identityService.setAuthentication("aUserId", null, List.of(TENANT_ONE));
+    task = createTaskForTenant();
     assertThat(taskService.createTaskQuery().taskId(task.getId()).count()).isEqualTo(1L);
 
     // then
@@ -321,14 +325,15 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
   public void deleteTaskWithNoAuthenticatedTenant() {
 
     try {
-      task = createTaskforTenant();
+      task = createTaskForTenant();
+      String taskId = task.getId();
       identityService.setAuthentication("aUserId", null);
 
       // when/then
-      assertThatThrownBy(() -> taskService.deleteTask(task.getId(), true))
+      assertThatThrownBy(() -> taskService.deleteTask(taskId, true))
         .isInstanceOf(ProcessEngineException.class)
         .hasMessageContaining("Cannot delete the task '"
-            + task.getId() +"' because it belongs to no authenticated tenant.");
+            + taskId +"' because it belongs to no authenticated tenant.");
 
     } finally {
       identityService.clearAuthentication();
@@ -345,7 +350,7 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
     identityService.setAuthentication("aUserId", null);
     engineRule.getProcessEngineConfiguration().setTenantCheckEnabled(false);
 
-    task = createTaskforTenant();
+    task = createTaskForTenant();
     assertThat(taskService.createTaskQuery().taskId(task.getId()).count()).isEqualTo(1L);
 
     // then
@@ -353,7 +358,7 @@ public class MultiTenancyTaskServiceCmdsTenantCheckTest {
     assertThat(taskService.createTaskQuery().taskId(task.getId()).count()).isZero();
   }
 
-  protected Task createTaskforTenant() {
+  protected Task createTaskForTenant() {
     Task newTask = taskService.newTask("newTask");
     newTask.setTenantId(TENANT_ONE);
     taskService.saveTask(newTask);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyUserOperationLogTenantCheckTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancyUserOperationLogTenantCheckTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_FULL;
 import static org.junit.Assert.assertNull;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.operaton.bpm.engine.EntityTypes;
 import org.operaton.bpm.engine.HistoryService;
@@ -103,7 +103,7 @@ public class MultiTenancyUserOperationLogTenantCheckTest {
   public void shouldSetAnnotationWithTenant() {
     // given
     testRule.deployForTenant(TENANT_ONE, MODEL);
-    identityService.setAuthentication(USER_ONE, null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication(USER_ONE, null, List.of(TENANT_ONE));
 
     runtimeService.startProcessInstanceByKey(PROCESS_NAME);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -126,7 +126,7 @@ public class MultiTenancyUserOperationLogTenantCheckTest {
   public void shouldThrowExceptionWhenSetAnnotationWithDifferentTenant() {
     // given
     testRule.deployForTenant(TENANT_ONE, MODEL);
-    identityService.setAuthentication(USER_ONE, null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication(USER_ONE, null, List.of(TENANT_ONE));
 
     runtimeService.startProcessInstanceByKey(PROCESS_NAME);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -134,11 +134,12 @@ public class MultiTenancyUserOperationLogTenantCheckTest {
     taskService.complete(taskId);
 
     UserOperationLogEntry singleResult = historyService.createUserOperationLogQuery().entityType(EntityTypes.TASK).singleResult();
+    String operationId = singleResult.getOperationId();
 
-    identityService.setAuthentication(USER_TWO, null, Arrays.asList(TENANT_TWO));
+    identityService.setAuthentication(USER_TWO, null, List.of(TENANT_TWO));
 
     // when/then
-    assertThatThrownBy(() -> historyService.setAnnotationForOperationLogById(singleResult.getOperationId(), AN_ANNOTATION))
+    assertThatThrownBy(() -> historyService.setAnnotationForOperationLogById(operationId, AN_ANNOTATION))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot update the user operation log entry '"
                             + singleResult.getId() +"' because it belongs to no authenticated tenant.");
@@ -148,7 +149,7 @@ public class MultiTenancyUserOperationLogTenantCheckTest {
   public void shouldThrowExceptionWhenSetAnnotationWithNoAuthenticatedTenant() {
     // given
     testRule.deployForTenant(TENANT_ONE, MODEL);
-    identityService.setAuthentication(USER_ONE, null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication(USER_ONE, null, List.of(TENANT_ONE));
 
     runtimeService.startProcessInstanceByKey(PROCESS_NAME);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -156,11 +157,12 @@ public class MultiTenancyUserOperationLogTenantCheckTest {
     taskService.complete(taskId);
 
     UserOperationLogEntry singleResult = historyService.createUserOperationLogQuery().entityType(EntityTypes.TASK).singleResult();
+    String operationId = singleResult.getOperationId();
 
     identityService.setAuthentication(USER_WITHOUT_TENANT, null);
 
     // when/then
-    assertThatThrownBy(() -> historyService.setAnnotationForOperationLogById(singleResult.getOperationId(), AN_ANNOTATION))
+    assertThatThrownBy(() -> historyService.setAnnotationForOperationLogById(operationId, AN_ANNOTATION))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot update the user operation log entry '"
                             + singleResult.getId() +"' because it belongs to no authenticated tenant.");
@@ -193,7 +195,7 @@ public class MultiTenancyUserOperationLogTenantCheckTest {
   @Test
   public void shouldClearAnnotationWithTenant() {
     testRule.deployForTenant(TENANT_ONE, MODEL);
-    identityService.setAuthentication(USER_ONE, null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication(USER_ONE, null, List.of(TENANT_ONE));
 
     runtimeService.startProcessInstanceByKey(PROCESS_NAME);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -218,7 +220,7 @@ public class MultiTenancyUserOperationLogTenantCheckTest {
   public void shouldThrowExceptionWhenClearAnnotationWithDifferentTenant() {
     // given
     testRule.deployForTenant(TENANT_ONE, MODEL);
-    identityService.setAuthentication(USER_ONE, null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication(USER_ONE, null, List.of(TENANT_ONE));
 
     runtimeService.startProcessInstanceByKey(PROCESS_NAME);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -226,12 +228,13 @@ public class MultiTenancyUserOperationLogTenantCheckTest {
     taskService.complete(taskId);
 
     UserOperationLogEntry singleResult = historyService.createUserOperationLogQuery().entityType(EntityTypes.TASK).singleResult();
-    historyService.setAnnotationForOperationLogById(singleResult.getOperationId(), AN_ANNOTATION);
+    String operationId = singleResult.getOperationId();
+    historyService.setAnnotationForOperationLogById(operationId, AN_ANNOTATION);
 
-    identityService.setAuthentication(USER_TWO, null, Arrays.asList(TENANT_TWO));
+    identityService.setAuthentication(USER_TWO, null, List.of(TENANT_TWO));
 
     // when/then
-    assertThatThrownBy(() ->  historyService.clearAnnotationForOperationLogById(singleResult.getOperationId()))
+    assertThatThrownBy(() ->  historyService.clearAnnotationForOperationLogById(operationId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot update the user operation log entry '"
                             + singleResult.getId() +"' because it belongs to no authenticated tenant.");
@@ -241,7 +244,7 @@ public class MultiTenancyUserOperationLogTenantCheckTest {
   public void shouldThrowExceptionWhenClearAnnotationWithNoAuthenticatedTenant() {
     // given
     testRule.deployForTenant(TENANT_ONE, MODEL);
-    identityService.setAuthentication(USER_ONE, null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication(USER_ONE, null, List.of(TENANT_ONE));
 
     runtimeService.startProcessInstanceByKey(PROCESS_NAME);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -249,12 +252,13 @@ public class MultiTenancyUserOperationLogTenantCheckTest {
     taskService.complete(taskId);
 
     UserOperationLogEntry singleResult = historyService.createUserOperationLogQuery().entityType(EntityTypes.TASK).singleResult();
-    historyService.setAnnotationForOperationLogById(singleResult.getOperationId(), AN_ANNOTATION);
+    String operationId = singleResult.getOperationId();
+    historyService.setAnnotationForOperationLogById(operationId, AN_ANNOTATION);
 
     identityService.setAuthentication(USER_WITHOUT_TENANT, null);
 
     // when/then
-    assertThatThrownBy(() ->  historyService.clearAnnotationForOperationLogById(singleResult.getOperationId()))
+    assertThatThrownBy(() ->  historyService.clearAnnotationForOperationLogById(operationId))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot update the user operation log entry '"
                             + singleResult.getId() +"' because it belongs to no authenticated tenant.");
@@ -284,7 +288,7 @@ public class MultiTenancyUserOperationLogTenantCheckTest {
   public void shouldDeleteWithTenant() {
     // given
     testRule.deployForTenant(TENANT_ONE, MODEL);
-    identityService.setAuthentication(USER_ONE, null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication(USER_ONE, null, List.of(TENANT_ONE));
 
     runtimeService.startProcessInstanceByKey(PROCESS_NAME);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -307,7 +311,7 @@ public class MultiTenancyUserOperationLogTenantCheckTest {
   public void shouldThrownExceptionWhenDeleteWithDifferentTenant() {
     // given
     testRule.deployForTenant(TENANT_ONE, MODEL);
-    identityService.setAuthentication(USER_ONE, null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication(USER_ONE, null, List.of(TENANT_ONE));
 
     runtimeService.startProcessInstanceByKey(PROCESS_NAME);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -317,7 +321,7 @@ public class MultiTenancyUserOperationLogTenantCheckTest {
     UserOperationLogEntry singleResult = historyService.createUserOperationLogQuery().entityType(EntityTypes.TASK).singleResult();
     String entryId = singleResult.getId();
 
-    identityService.setAuthentication(USER_TWO, null, Arrays.asList(TENANT_TWO));
+    identityService.setAuthentication(USER_TWO, null, List.of(TENANT_TWO));
 
     // when/then
     assertThatThrownBy(() -> historyService.deleteUserOperationLogEntry(entryId))
@@ -330,7 +334,7 @@ public class MultiTenancyUserOperationLogTenantCheckTest {
   public void shouldThrownExceptionWhenDeleteWithNoAuthenticatedTenant() {
     // given
     testRule.deployForTenant(TENANT_ONE, MODEL);
-    identityService.setAuthentication(USER_ONE, null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication(USER_ONE, null, List.of(TENANT_ONE));
 
     runtimeService.startProcessInstanceByKey(PROCESS_NAME);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -353,7 +357,7 @@ public class MultiTenancyUserOperationLogTenantCheckTest {
   public void shouldDeleteWhenTenantCheckDisabled() {
     // given
     testRule.deployForTenant(TENANT_ONE, MODEL);
-    identityService.setAuthentication(USER_ONE, null, Arrays.asList(TENANT_ONE));
+    identityService.setAuthentication(USER_ONE, null, List.of(TENANT_ONE));
 
     runtimeService.startProcessInstanceByKey(PROCESS_NAME);
     String taskId = taskService.createTaskQuery().singleResult().getId();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/CaseDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/CaseDefinitionQueryTest.java
@@ -114,7 +114,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
     }
 
     caseDefinitions = repositoryService.createCaseDefinitionQuery()
-      .caseDefinitionIdIn(ids.toArray(new String[ids.size()]))
+      .caseDefinitionIdIn(ids.toArray(new String[0]))
       .list();
 
     assertThat(ids).hasSize(caseDefinitions.size());
@@ -123,7 +123,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
     }
 
     assertThat(repositoryService.createCaseDefinitionQuery()
-        .caseDefinitionIdIn(ids.toArray(new String[ids.size()]))
+        .caseDefinitionIdIn(ids.toArray(new String[0]))
         .caseDefinitionId("nonExistent")
         .count()).isZero();
   }
@@ -132,8 +132,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByDeploymentId() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-      .deploymentId(deploymentOneId);
+    query.deploymentId(deploymentOneId);
 
     verifyQueryResults(query, 2);
   }
@@ -142,8 +141,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByInvalidDeploymentId() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-   query
-     .deploymentId("invalid");
+   query.deploymentId("invalid");
 
     verifyQueryResults(query, 0);
 
@@ -157,13 +155,11 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByName() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-      .caseDefinitionName("Two");
+    query.caseDefinitionName("Two");
 
     verifyQueryResults(query, 1);
 
-    query
-      .caseDefinitionName("One");
+    query.caseDefinitionName("One");
 
     verifyQueryResults(query, 2);
   }
@@ -172,8 +168,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByInvalidName() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-      .caseDefinitionName("invalid");
+    query.caseDefinitionName("invalid");
 
     verifyQueryResults(query, 0);
 
@@ -186,8 +181,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByNameLike() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-      .caseDefinitionNameLike("%w%");
+    query.caseDefinitionNameLike("%w%");
 
     verifyQueryResults(query, 1);
 
@@ -200,8 +194,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByInvalidNameLike() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-      .caseDefinitionNameLike("%invalid%");
+    query.caseDefinitionNameLike("%invalid%");
 
     verifyQueryResults(query, 0);
 
@@ -214,8 +207,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByResourceNameLike() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-        .caseDefinitionResourceNameLike("%ree%");
+    query.caseDefinitionResourceNameLike("%ree%");
 
     verifyQueryResults(query, 1);
 
@@ -228,8 +220,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByInvalidResourceNameLike() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-        .caseDefinitionResourceNameLike("%invalid%");
+    query.caseDefinitionResourceNameLike("%invalid%");
 
     verifyQueryResults(query, 0);
 
@@ -243,14 +234,12 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
     // case one
-    query
-      .caseDefinitionKey("one");
+    query.caseDefinitionKey("one");
 
     verifyQueryResults(query, 2);
 
     // case two
-    query
-      .caseDefinitionKey("two");
+    query.caseDefinitionKey("two");
 
     verifyQueryResults(query, 1);
   }
@@ -259,8 +248,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByInvalidKey() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-      .caseDefinitionKey("invalid");
+    query.caseDefinitionKey("invalid");
 
     verifyQueryResults(query, 0);
 
@@ -273,8 +261,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByKeyLike() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-      .caseDefinitionKeyLike("%o%");
+    query.caseDefinitionKeyLike("%o%");
 
     verifyQueryResults(query, 3);
 
@@ -287,8 +274,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByInvalidKeyLike() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-      .caseDefinitionKeyLike("%invalid%");
+    query.caseDefinitionKeyLike("%invalid%");
 
     verifyQueryResults(query, 0);
 
@@ -301,8 +287,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByCategory() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-      .caseDefinitionCategory("Examples");
+    query.caseDefinitionCategory("Examples");
 
     verifyQueryResults(query, 2);
   }
@@ -311,8 +296,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByInvalidCategory() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-      .caseDefinitionCategory("invalid");
+    query.caseDefinitionCategory("invalid");
 
     verifyQueryResults(query, 0);
 
@@ -325,13 +309,11 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByCategoryLike() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-      .caseDefinitionCategoryLike("%Example%");
+    query.caseDefinitionCategoryLike("%Example%");
 
     verifyQueryResults(query, 3);
 
-    query
-      .caseDefinitionCategoryLike("%amples2");
+    query.caseDefinitionCategoryLike("%amples2");
 
     verifyQueryResults(query, 1);
 
@@ -345,8 +327,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByInvalidCategoryLike() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-      .caseDefinitionCategoryLike("invalid");
+    query.caseDefinitionCategoryLike("invalid");
 
     verifyQueryResults(query, 0);
 
@@ -359,13 +340,11 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByVersion() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-      .caseDefinitionVersion(2);
+    query.caseDefinitionVersion(2);
 
     verifyQueryResults(query, 1);
 
-    query
-      .caseDefinitionVersion(1);
+    query.caseDefinitionVersion(1);
 
     verifyQueryResults(query, 3);
   }
@@ -374,8 +353,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByInvalidVersion() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-      .caseDefinitionVersion(3);
+    query.caseDefinitionVersion(3);
 
     verifyQueryResults(query, 0);
 
@@ -392,8 +370,7 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testQueryByLatest() {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
-    query
-      .latestVersion();
+    query.latestVersion();
 
     verifyQueryResults(query, 3);
 
@@ -404,7 +381,9 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
     verifyQueryResults(query, 1);
 
     query
-      .caseDefinitionKey("two").latestVersion();
+      .caseDefinitionKey("two")
+      .latestVersion();
+
     verifyQueryResults(query, 1);
   }
 
@@ -413,38 +392,28 @@ public class CaseDefinitionQueryTest extends AbstractDefinitionQueryTest {
     CaseDefinitionQuery query = repositoryService.createCaseDefinitionQuery();
 
     // when/then
-    assertThatThrownBy(() -> query
-        .caseDefinitionId("test")
-        .latestVersion()
-        .list())
+    var caseDefinitionQuery1 = query.caseDefinitionId("test").latestVersion();
+    assertThatThrownBy(caseDefinitionQuery1::list)
       .isInstanceOf(NotValidException.class);
 
     // and
-    assertThatThrownBy(() -> query
-        .caseDefinitionName("test")
-        .latestVersion()
-        .list())
+    var caseDefinitionQuery2 = query.caseDefinitionName("test").latestVersion();
+    assertThatThrownBy(caseDefinitionQuery2::list)
       .isInstanceOf(NotValidException.class);
 
     // and
-    assertThatThrownBy(() -> query
-        .caseDefinitionNameLike("test")
-        .latestVersion()
-        .list())
+    var caseDefinitionQuery3 = query.caseDefinitionNameLike("test").latestVersion();
+    assertThatThrownBy(caseDefinitionQuery3::list)
       .isInstanceOf(NotValidException.class);
 
     // and
-    assertThatThrownBy(() -> query
-        .caseDefinitionVersion(1)
-        .latestVersion()
-        .list())
+    var caseDefinitionQuery4 = query.caseDefinitionVersion(1).latestVersion();
+    assertThatThrownBy(caseDefinitionQuery4::list)
       .isInstanceOf(NotValidException.class);
 
     // and
-    assertThatThrownBy(() -> query
-        .deploymentId("test")
-        .latestVersion()
-        .list())
+    var caseDefinitionQuery5 = query.deploymentId("test").latestVersion();
+    assertThatThrownBy(caseDefinitionQuery5::list)
       .isInstanceOf(NotValidException.class);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DecisionDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DecisionDefinitionQueryTest.java
@@ -132,7 +132,7 @@ public class DecisionDefinitionQueryTest {
     }
 
     decisionDefinitions = repositoryService.createDecisionDefinitionQuery()
-      .decisionDefinitionIdIn(ids.toArray(new String[ids.size()]))
+      .decisionDefinitionIdIn(ids.toArray(new String[0]))
       .list();
 
     assertThat(decisionDefinitions).hasSize(ids.size());
@@ -495,34 +495,24 @@ public class DecisionDefinitionQueryTest {
     DecisionDefinitionQuery query = repositoryService.createDecisionDefinitionQuery();
 
     // when/then
-    assertThatThrownBy(() -> query
-        .decisionDefinitionId("test")
-        .latestVersion()
-        .list())
+    var decisionDefinitionQuery1 = query.decisionDefinitionId("test").latestVersion();
+    assertThatThrownBy(decisionDefinitionQuery1::list)
       .isInstanceOf(NotValidException.class);
 
-    assertThatThrownBy(() -> query
-        .decisionDefinitionName("test")
-        .latestVersion()
-        .list())
+    var decisionDefinitionQuery2 = query.decisionDefinitionName("test").latestVersion();
+    assertThatThrownBy(decisionDefinitionQuery2::list)
       .isInstanceOf(NotValidException.class);
 
-    assertThatThrownBy(() -> query
-        .decisionDefinitionNameLike("test")
-        .latestVersion()
-        .list())
+    var decisionDefinitionQuery3 = query.decisionDefinitionNameLike("test").latestVersion();
+    assertThatThrownBy(decisionDefinitionQuery3::list)
       .isInstanceOf(NotValidException.class);
 
-    assertThatThrownBy(() -> query
-        .decisionDefinitionVersion(1)
-        .latestVersion()
-        .list())
+    var decisionDefinitionQuery4 = query.decisionDefinitionVersion(1).latestVersion();
+    assertThatThrownBy(decisionDefinitionQuery4::list)
       .isInstanceOf(NotValidException.class);
 
-    assertThatThrownBy(() -> query
-        .deploymentId("test")
-        .latestVersion()
-        .list())
+    var decisionDefinitionQuery5 = query.deploymentId("test").latestVersion();
+    assertThatThrownBy(decisionDefinitionQuery5::list)
       .isInstanceOf(NotValidException.class);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/HistoryTimeToLiveDeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/HistoryTimeToLiveDeploymentTest.java
@@ -92,11 +92,11 @@ public class HistoryTimeToLiveDeploymentTest {
 
   @Test
   public void processWithoutHTTLShouldFail() {
-    assertThatThrownBy(() -> {
-      // when
-      testRule.deploy(repositoryService.createDeployment()
-          .addClasspathResource("org/operaton/bpm/engine/test/api/repository/version1.bpmn20.xml"));})
-
+    // given
+    var deploymentBuilder = repositoryService.createDeployment()
+      .addClasspathResource("org/operaton/bpm/engine/test/api/repository/version1.bpmn20.xml");
+    // when
+    assertThatThrownBy(() -> testRule.deploy(deploymentBuilder))
         // then
         .isInstanceOf(ParseException.class)
         .hasMessageContaining(EXPECTED_DEFAULT_CONFIG_MSG)
@@ -134,11 +134,11 @@ public class HistoryTimeToLiveDeploymentTest {
 
   @Test
   public void caseWithoutHTTLShouldFail() {
-    assertThatThrownBy(() -> {
-      // when
-      testRule.deploy(repositoryService.createDeployment()
-          .addClasspathResource("org/operaton/bpm/engine/test/api/cmmn/oneTaskCase2.cmmn"));})
-
+    // given
+    var deploymentBuilder = repositoryService.createDeployment()
+      .addClasspathResource("org/operaton/bpm/engine/test/api/cmmn/oneTaskCase2.cmmn");
+    // when
+    assertThatThrownBy(() -> testRule.deploy(deploymentBuilder))
         // then
         .isInstanceOf(ProcessEngineException.class)
         .hasCauseInstanceOf(NotValidException.class)
@@ -160,12 +160,10 @@ public class HistoryTimeToLiveDeploymentTest {
 
   @Test
   public void decisionWithoutHTTLShouldFail() {
-    assertThatThrownBy(() -> {
-      // when
-      testRule.deploy(repositoryService
-          .createDeployment()
-          .addClasspathResource("org/operaton/bpm/engine/test/api/dmn/Another_Example.dmn"));})
-
+    var deploymentBuilder = repositoryService.createDeployment()
+      .addClasspathResource("org/operaton/bpm/engine/test/api/dmn/Another_Example.dmn");
+    // when
+    assertThatThrownBy(() -> testRule.deploy(deploymentBuilder))
         // then
         .isInstanceOf(ProcessEngineException.class)
         .hasCauseInstanceOf(DmnTransformException.class)

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessDefinitionQueryTest.java
@@ -128,8 +128,9 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().deploymentId("invalid");
     verifyQueryResults(query, 0);
 
+    var processDefinitionQuery = repositoryService.createProcessDefinitionQuery();
     // when/then
-    assertThatThrownBy(() -> repositoryService.createProcessDefinitionQuery().deploymentId(null))
+    assertThatThrownBy(() -> processDefinitionQuery.deploymentId(null))
       .isInstanceOf(ProcessEngineException.class);
   }
 
@@ -238,8 +239,9 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionName("invalid");
     verifyQueryResults(query, 0);
 
+    var processDefinitionQuery = repositoryService.createProcessDefinitionQuery();
     // when/then
-    assertThatThrownBy(() -> repositoryService.createProcessDefinitionQuery().processDefinitionName(null))
+    assertThatThrownBy(() -> processDefinitionQuery.processDefinitionName(null))
       .isInstanceOf(ProcessEngineException.class);
   }
 
@@ -313,8 +315,9 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionKey("invalid");
     verifyQueryResults(query, 0);
 
+    var processDefinitionQuery = repositoryService.createProcessDefinitionQuery();
     // when/then
-    assertThatThrownBy(() -> repositoryService.createProcessDefinitionQuery().processDefinitionKey(null))
+    assertThatThrownBy(() -> processDefinitionQuery.processDefinitionKey(null))
       .isInstanceOf(ProcessEngineException.class);
   }
 
@@ -331,8 +334,9 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionKeyLike("%invalid%");
     verifyQueryResults(query, 0);
 
+    var processDefinitionQuery = repositoryService.createProcessDefinitionQuery();
     // when/then
-    assertThatThrownBy(() -> repositoryService.createProcessDefinitionQuery().processDefinitionKeyLike(null))
+    assertThatThrownBy(() -> processDefinitionQuery.processDefinitionKeyLike(null))
       .isInstanceOf(ProcessEngineException.class);
   }
 
@@ -347,8 +351,9 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionResourceNameLike("%invalid%");
     verifyQueryResults(query, 0);
 
+    var processDefinitionQuery = repositoryService.createProcessDefinitionQuery();
     // when/then
-    assertThatThrownBy(() -> repositoryService.createProcessDefinitionQuery().processDefinitionResourceNameLike(null))
+    assertThatThrownBy(() -> processDefinitionQuery.processDefinitionResourceNameLike(null))
       .isInstanceOf(ProcessEngineException.class);
   }
 
@@ -385,11 +390,13 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
     verifyQueryResults(query, 0);
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.createProcessDefinitionQuery().processDefinitionVersion(-1).list())
+    var query2 = repositoryService.createProcessDefinitionQuery();
+    assertThatThrownBy(() -> query2.processDefinitionVersion(-1))
       .isInstanceOf(ProcessEngineException.class);
 
     // and
-    assertThatThrownBy(() -> repositoryService.createProcessDefinitionQuery().processDefinitionVersion(null).list())
+    var query3 = repositoryService.createProcessDefinitionQuery();
+    assertThatThrownBy(() -> query3.processDefinitionVersion(null))
       .isInstanceOf(ProcessEngineException.class);
   }
 
@@ -421,15 +428,22 @@ public class ProcessDefinitionQueryTest extends AbstractDefinitionQueryTest {
   public void testInvalidUsageOfLatest() {
 
     // when/then
-    assertThatThrownBy(() -> repositoryService.createProcessDefinitionQuery().processDefinitionId("test").latestVersion().list())
+    var query1 = repositoryService.createProcessDefinitionQuery()
+      .processDefinitionId("test")
+      .latestVersion();
+    assertThatThrownBy(query1::list)
       .isInstanceOf(ProcessEngineException.class);
 
     // and
-    assertThatThrownBy(() -> repositoryService.createProcessDefinitionQuery().processDefinitionVersion(1).latestVersion().list())
+    var query2 = repositoryService.createProcessDefinitionQuery()
+      .processDefinitionVersion(1)
+      .latestVersion();
+    assertThatThrownBy(query2::list)
       .isInstanceOf(ProcessEngineException.class);
 
     // and
-    assertThatThrownBy(() -> repositoryService.createProcessDefinitionQuery().deploymentId("test").latestVersion().list())
+    var query3 = repositoryService.createProcessDefinitionQuery().deploymentId("test").latestVersion();
+    assertThatThrownBy(query3::list)
       .isInstanceOf(ProcessEngineException.class);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessDefinitionSuspensionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessDefinitionSuspensionTest.java
@@ -289,15 +289,16 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
     var processDefinitionId = processDefinition.getId();
     repositoryService.suspendProcessDefinitionById(processDefinitionId);
 
+    var emptyProperties = new HashMap<String,Object>();
     try {
-      formService.submitStartForm(processDefinitionId, new HashMap<>());
+      formService.submitStartForm(processDefinitionId, emptyProperties);
       fail();
     } catch (ProcessEngineException e) {
       testRule.assertTextPresentIgnoreCase("is suspended", e.getMessage());
     }
 
     try {
-      formService.submitStartForm(processDefinitionId, "someKey", new HashMap<>());
+      formService.submitStartForm(processDefinitionId, "someKey", emptyProperties);
       fail();
     } catch (ProcessEngineException e) {
       testRule.assertTextPresentIgnoreCase("is suspended", e.getMessage());
@@ -557,7 +558,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
     assertEquals(nrOfProcessDefinitions, repositoryService.createProcessDefinitionQuery().suspended().count());
     assertEquals(1, runtimeService.createProcessInstanceQuery().suspended().count());
 
-    // Activate again in 5 hourse from now
+    // Activate again in 5 hours from now
     repositoryService.activateProcessDefinitionByKey("oneTaskProcess", true, new Date(startTime.getTime() + (5 * hourInMs)));
     assertEquals(nrOfProcessDefinitions, repositoryService.createProcessDefinitionQuery().count());
     assertEquals(0, repositoryService.createProcessDefinitionQuery().active().count());
@@ -588,7 +589,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
   public void testSuspendById_shouldSuspendJobDefinitionAndRetainJob() {
     // given
 
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -631,7 +632,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
   public void testSuspendByKey_shouldSuspendJobDefinitionAndRetainJob() {
     // given
 
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -672,7 +673,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/repository/ProcessDefinitionSuspensionTest.testWithOneAsyncServiceTask.bpmn"})
   @Test
   public void testSuspendByIdAndIncludeInstancesFlag_shouldSuspendAlsoJobDefinitionAndRetainJob() {
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -713,7 +714,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/repository/ProcessDefinitionSuspensionTest.testWithOneAsyncServiceTask.bpmn"})
   @Test
   public void testSuspendByKeyAndIncludeInstancesFlag_shouldSuspendAlsoJobDefinitionAndRetainJob() {
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -754,7 +755,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/repository/ProcessDefinitionSuspensionTest.testWithOneAsyncServiceTask.bpmn"})
   @Test
   public void testSuspendByIdAndIncludeInstancesFlag_shouldSuspendJobDefinitionAndJob() {
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -795,7 +796,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/repository/ProcessDefinitionSuspensionTest.testWithOneAsyncServiceTask.bpmn"})
   @Test
   public void testSuspendByKeyAndIncludeInstancesFlag_shouldSuspendJobDefinitionAndJob() {
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -840,7 +841,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
     ClockUtil.setCurrentTime(startTime);
     final long hourInMs = 60 * 60 * 1000;
 
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -907,7 +908,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
     ClockUtil.setCurrentTime(startTime);
     final long hourInMs = 60 * 60 * 1000;
 
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -975,7 +976,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
     ClockUtil.setCurrentTime(startTime);
     final long hourInMs = 60 * 60 * 1000;
 
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -1043,7 +1044,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
     ClockUtil.setCurrentTime(startTime);
     final long hourInMs = 60 * 60 * 1000;
 
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -1349,7 +1350,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/repository/ProcessDefinitionSuspensionTest.testWithOneAsyncServiceTask.bpmn"})
   @Test
   public void testActivationById_shouldActivateJobDefinitionAndRetainJob() {
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -1399,7 +1400,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/repository/ProcessDefinitionSuspensionTest.testWithOneAsyncServiceTask.bpmn"})
   @Test
   public void testActivationByKey_shouldActivateJobDefinitionAndRetainJob() {
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -1449,7 +1450,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/repository/ProcessDefinitionSuspensionTest.testWithOneAsyncServiceTask.bpmn"})
   @Test
   public void testActivationByIdAndIncludeInstancesFlag_shouldActivateAlsoJobDefinitionAndRetainJob() {
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -1499,7 +1500,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/repository/ProcessDefinitionSuspensionTest.testWithOneAsyncServiceTask.bpmn"})
   @Test
   public void testActivationByKeyAndIncludeInstancesFlag_shouldActivateAlsoJobDefinitionAndRetainJob() {
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -1549,7 +1550,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/repository/ProcessDefinitionSuspensionTest.testWithOneAsyncServiceTask.bpmn"})
   @Test
   public void testActivationByIdAndIncludeInstancesFlag_shouldActivateJobDefinitionAndJob() {
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -1599,7 +1600,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/repository/ProcessDefinitionSuspensionTest.testWithOneAsyncServiceTask.bpmn"})
   @Test
   public void testActivationByKeyAndIncludeInstancesFlag_shouldActivateJobDefinitionAndJob() {
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -1653,7 +1654,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
     ClockUtil.setCurrentTime(startTime);
     final long hourInMs = 60 * 60 * 1000;
 
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -1681,7 +1682,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
     Job timerToActivateProcessDefinition = managementService.createJobQuery().timers().singleResult();
     assertNotNull(timerToActivateProcessDefinition);
 
-    // the job definition should still suspended
+    // the job definition should still be suspended
     JobDefinitionQuery jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
     assertEquals(0, jobDefinitionQuery.active().count());
@@ -1729,7 +1730,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
     ClockUtil.setCurrentTime(startTime);
     final long hourInMs = 60 * 60 * 1000;
 
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -1758,7 +1759,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
     Job timerToActivateProcessDefinition = managementService.createJobQuery().timers().singleResult();
     assertNotNull(timerToActivateProcessDefinition);
 
-    // the job definition should still suspended
+    // the job definition should still be suspended
     JobDefinitionQuery jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
     assertEquals(0, jobDefinitionQuery.active().count());
@@ -1806,7 +1807,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
     ClockUtil.setCurrentTime(startTime);
     final long hourInMs = 60 * 60 * 1000;
 
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -1835,7 +1836,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
     Job timerToActivateProcessDefinition = managementService.createJobQuery().timers().singleResult();
     assertNotNull(timerToActivateProcessDefinition);
 
-    // the job definition should still suspended
+    // the job definition should still be suspended
     JobDefinitionQuery jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
     assertEquals(0, jobDefinitionQuery.active().count());
@@ -1883,7 +1884,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
     ClockUtil.setCurrentTime(startTime);
     final long hourInMs = 60 * 60 * 1000;
 
-    // a process definition with a asynchronous continuation, so that there
+    // a process definition with an asynchronous continuation, so that there
     // exists a job definition
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
@@ -1912,7 +1913,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
     Job timerToActivateProcessDefinition = managementService.createJobQuery().timers().singleResult();
     assertNotNull(timerToActivateProcessDefinition);
 
-    // the job definition should still suspended
+    // the job definition should still be suspended
     JobDefinitionQuery jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
     assertEquals(0, jobDefinitionQuery.active().count());
@@ -2039,7 +2040,7 @@ public class ProcessDefinitionSuspensionTest extends PluggableProcessEngineTest 
     assertEquals(5, jobDefinitionQuery.active().count());
     assertEquals(0, jobDefinitionQuery.suspended().count());
 
-    // ...and the corresponding jobs should still suspended
+    // ...and the corresponding jobs should still be suspended
     JobQuery jobQuery = managementService.createJobQuery();
 
     assertEquals(0, jobQuery.active().count());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
@@ -87,13 +87,7 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  * @author Frederik Heremans
@@ -850,10 +844,10 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
     assertEquals(expectedResourceNames, new HashSet<>(resourceNames));
 
     InputStream resourceStream = repositoryService.getResourceAsStream(deploymentId, "org/operaton/bpm/engine/test/test/HelloWorld.string");
-    assertTrue(Arrays.equals("hello world".getBytes(), IoUtil.readInputStream(resourceStream, "test")));
+    assertArrayEquals("hello world".getBytes(), IoUtil.readInputStream(resourceStream, "test"));
 
     resourceStream = repositoryService.getResourceAsStream(deploymentId, "org/operaton/bpm/engine/test/test/TheAnswer.string");
-    assertTrue(Arrays.equals("42".getBytes(), IoUtil.readInputStream(resourceStream, "test")));
+    assertArrayEquals("42".getBytes(), IoUtil.readInputStream(resourceStream, "test"));
 
     repositoryService.deleteDeployment(deploymentId);
   }
@@ -925,7 +919,7 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
 
     //then
     decisionDefinition = repositoryService.getDecisionDefinition(decisionDefinition.getId());
-    assertEquals(null, decisionDefinition.getHistoryTimeToLive());
+    assertNull(decisionDefinition.getHistoryTimeToLive());
 
   }
 
@@ -972,7 +966,7 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
 
     //then
     processDefinition = findOnlyProcessDefinition();
-    assertEquals(null, processDefinition.getHistoryTimeToLive());
+    assertNull(processDefinition.getHistoryTimeToLive());
 
   }
 
@@ -1092,20 +1086,18 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
     // then
     caseDefinition = findOnlyCaseDefinition();
 
-    assertEquals(null, caseDefinition.getHistoryTimeToLive());
+    assertNull(caseDefinition.getHistoryTimeToLive());
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
   @Test
   public void shouldFailToUpdateHistoryTimeToLiveOnCaseDefinitionHTTLUpdate() {
-    assertThatThrownBy(() -> {
-      // given
-      CaseDefinition caseDefinition = findOnlyCaseDefinition();
-      processEngineConfiguration.setEnforceHistoryTimeToLive(true);
-
-      // when
-      repositoryService.updateCaseDefinitionHistoryTimeToLive(caseDefinition.getId(), null);
-    })
+    // given
+    CaseDefinition caseDefinition = findOnlyCaseDefinition();
+    processEngineConfiguration.setEnforceHistoryTimeToLive(true);
+    String caseDefinitionId = caseDefinition.getId();
+    // when
+    assertThatThrownBy(() -> repositoryService.updateCaseDefinitionHistoryTimeToLive(caseDefinitionId, null))
         // then
         .isInstanceOf(NotAllowedException.class)
         .hasMessage("Null historyTimeToLive values are not allowed");
@@ -1114,13 +1106,13 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
   @Test
   public void shouldFailToUpdateHistoryTimeToLiveOnProcessDefinitionHTTLUpdate() {
-    assertThatThrownBy(() -> {
-      // given
-      ProcessDefinition processDefinition = findOnlyProcessDefinition();
-      processEngineConfiguration.setEnforceHistoryTimeToLive(true);
+    // given
+    ProcessDefinition processDefinition = findOnlyProcessDefinition();
+    processEngineConfiguration.setEnforceHistoryTimeToLive(true);
+    String processDefinitionId = processDefinition.getId();
 
-      // when
-      repositoryService.updateProcessDefinitionHistoryTimeToLive(processDefinition.getId(), null);})
+    // when
+    assertThatThrownBy(() -> repositoryService.updateProcessDefinitionHistoryTimeToLive(processDefinitionId, null))
         // then
         .isInstanceOf(NotAllowedException.class)
         .hasMessage("Null historyTimeToLive values are not allowed");
@@ -1129,13 +1121,13 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/dmn/Example.dmn"})
   @Test
   public void shouldFailToUpdateHistoryTimeToLiveOnDecisionDefinitionHTTLUpdate() {
-    assertThatThrownBy(() -> {
-      // given
-      DecisionDefinition decisionDefinition = findOnlyDecisionDefinition();
-      processEngineConfiguration.setEnforceHistoryTimeToLive(true);
+    // given
+    DecisionDefinition decisionDefinition = findOnlyDecisionDefinition();
+    String decisionDefinitionId = decisionDefinition.getId();
+    processEngineConfiguration.setEnforceHistoryTimeToLive(true);
 
-      // when
-      repositoryService.updateDecisionDefinitionHistoryTimeToLive(decisionDefinition.getId(), null);})
+    // when
+    assertThatThrownBy(() -> repositoryService.updateDecisionDefinitionHistoryTimeToLive(decisionDefinitionId, null))
         // then
         .isInstanceOf(NotAllowedException.class)
         .hasMessage("Null historyTimeToLive values are not allowed");
@@ -1382,9 +1374,9 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
 
     assertThat(mappings).extracting("name", "version", "key","calledFromActivityIds", "versionTag", "callingProcessDefinitionId")
       .contains(
-        Tuple.tuple("Process One", 1, "processOne", Arrays.asList("tenant_reference_1"), null, callingProcessId),
-        Tuple.tuple("Second Test Process", 2, "process", Arrays.asList("latest_reference_1"), null, callingProcessId),
-        Tuple.tuple("Failing Process", 1, "failingProcess", Arrays.asList("version_tag_reference_1"), "ver_tag_2", callingProcessId));
+        Tuple.tuple("Process One", 1, "processOne", List.of("tenant_reference_1"), null, callingProcessId),
+        Tuple.tuple("Second Test Process", 2, "process", List.of("latest_reference_1"), null, callingProcessId),
+        Tuple.tuple("Failing Process", 1, "failingProcess", List.of("version_tag_reference_1"), "ver_tag_2", callingProcessId));
 
     for (CalledProcessDefinition called : mappings) {
       assertThat(called).isEqualToIgnoringGivenFields(repositoryService.getProcessDefinition(called.getId()), "calledFromActivityIds", "callingProcessDefinitionId");
@@ -1403,11 +1395,10 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
     List<ActivityImpl> callActivities = ((ProcessDefinitionImpl) repositoryService
       .getProcessDefinition(processDefinition.getId())).getActivities().stream()
       .filter(act -> act.getActivityBehavior() instanceof CallActivityBehavior)
-      .map(activity -> {
+      .peek(activity -> {
         CallableElement callableElement = ((CallActivityBehavior) activity.getActivityBehavior()).getCallableElement();
         CallableElement spy = Mockito.spy(callableElement);
         ((CallActivityBehavior) activity.getActivityBehavior()).setCallableElement(spy);
-        return activity;
       }).toList();
 
     //when
@@ -1502,7 +1493,7 @@ public class RepositoryServiceTest extends PluggableProcessEngineTest {
 
     assertThat(mappings).extracting("id","calledFromActivityIds", "callingProcessDefinitionId")
       .contains(
-        Tuple.tuple(otherTenantProcessOne, Arrays.asList("explicit_other_tenant_reference"), id));
+        Tuple.tuple(otherTenantProcessOne, List.of("explicit_other_tenant_reference"), id));
   }
 
   private String deployProcessString(String processString) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ExecutionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ExecutionQueryTest.java
@@ -23,7 +23,6 @@ import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.hierarch
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
@@ -149,8 +148,7 @@ public class ExecutionQueryTest extends PluggableProcessEngineTest {
     assertEquals(4, query.count());
 
     try {
-      var execution = query.singleResult();
-      assertThat(execution).isNotNull();
+      query.singleResult();
       fail();
     } catch (ProcessEngineException e) {
       // expected
@@ -224,7 +222,7 @@ public class ExecutionQueryTest extends PluggableProcessEngineTest {
       executionQuery.list();
       fail();
     } catch (ProcessEngineException e) {
-
+      // expected
     }
   }
 
@@ -1216,7 +1214,9 @@ public class ExecutionQueryTest extends PluggableProcessEngineTest {
     try {
       query.incidentId(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/runtime/failingProcessCreateOneIncident.bpmn20.xml"})
@@ -1247,7 +1247,9 @@ public class ExecutionQueryTest extends PluggableProcessEngineTest {
     try {
       query.incidentType(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/runtime/failingProcessCreateOneIncident.bpmn20.xml"})
@@ -1278,7 +1280,9 @@ public class ExecutionQueryTest extends PluggableProcessEngineTest {
     try {
       query.incidentMessage(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/runtime/failingProcessCreateOneIncident.bpmn20.xml"})
@@ -1307,7 +1311,9 @@ public class ExecutionQueryTest extends PluggableProcessEngineTest {
     try {
       query.incidentMessageLike(null);
       fail();
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/runtime/failingSubProcessCreateOneIncident.bpmn20.xml"})
@@ -1506,34 +1512,34 @@ public class ExecutionQueryTest extends PluggableProcessEngineTest {
   public void testProcessVariableValueEqualsNumber() {
     // long
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 123L));
+        Collections.singletonMap("var", 123L));
 
     // non-matching long
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 12345L));
+        Collections.singletonMap("var", 12345L));
 
     // short
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", (short) 123));
+        Collections.singletonMap("var", (short) 123));
 
     // double
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 123.0d));
+        Collections.singletonMap("var", 123.0d));
 
     // integer
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 123));
+        Collections.singletonMap("var", 123));
 
     // untyped null (should not match)
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", null));
+        Collections.singletonMap("var", null));
 
     // typed null (should not match)
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", Variables.longValue(null)));
+        Collections.singletonMap("var", Variables.longValue(null)));
 
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", "123"));
+        Collections.singletonMap("var", "123"));
 
     assertEquals(4, runtimeService.createExecutionQuery().processVariableValueEquals("var", Variables.numberValue(123)).count());
     assertEquals(4, runtimeService.createExecutionQuery().processVariableValueEquals("var", Variables.numberValue(123L)).count());
@@ -1555,34 +1561,34 @@ public class ExecutionQueryTest extends PluggableProcessEngineTest {
   public void testProcessVariableValueNumberComparison() {
     // long
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 123L));
+        Collections.singletonMap("var", 123L));
 
     // non-matching long
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 12345L));
+        Collections.singletonMap("var", 12345L));
 
     // short
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", (short) 123));
+        Collections.singletonMap("var", (short) 123));
 
     // double
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 123.0d));
+        Collections.singletonMap("var", 123.0d));
 
     // integer
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 123));
+        Collections.singletonMap("var", 123));
 
     // untyped null
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", null));
+        Collections.singletonMap("var", null));
 
     // typed null
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", Variables.longValue(null)));
+        Collections.singletonMap("var", Variables.longValue(null)));
 
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", "123"));
+        Collections.singletonMap("var", "123"));
 
     assertEquals(4, runtimeService.createExecutionQuery().processVariableValueNotEquals("var", Variables.numberValue(123)).count());
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/MessageCorrelationByLocalVariablesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/MessageCorrelationByLocalVariablesTest.java
@@ -28,10 +28,7 @@ import java.util.Map;
 
 import org.operaton.bpm.engine.MismatchingMessageCorrelationException;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
-import org.operaton.bpm.engine.runtime.Execution;
-import org.operaton.bpm.engine.runtime.MessageCorrelationResult;
-import org.operaton.bpm.engine.runtime.MessageCorrelationResultType;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.runtime.*;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
@@ -257,9 +254,13 @@ public class MessageCorrelationByLocalVariablesTest {
     correlationKeys.put("localVar", correlationKey);
     correlationKeys.put("constVar", "someValue");
 
+    var messageCorrelationBuilder = engineRule.getRuntimeService()
+      .createMessageCorrelation(messageName)
+      .localVariablesEqual(correlationKeys)
+      .setVariables(Variables.createVariables().putValue("newVar", "newValue"));
+
     // when/then
-    assertThatThrownBy(() -> engineRule.getRuntimeService().createMessageCorrelation(messageName)
-        .localVariablesEqual(correlationKeys).setVariables(Variables.createVariables().putValue("newVar", "newValue")).correlateWithResult())
+    assertThatThrownBy(messageCorrelationBuilder::correlateWithResult)
       .isInstanceOf(MismatchingMessageCorrelationException.class)
       .hasMessageContaining(String.format("Cannot correlate a message with name '%s' to a single execution", TEST_MESSAGE_NAME));
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationTest.java
@@ -253,9 +253,11 @@ public class ProcessInstanceModificationTest extends PluggableProcessEngineTest 
     // given two instances of the outer subprocess
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("doubleNestedSubprocess");
     String processInstanceId = processInstance.getId();
+    var processInstanceModificationInstantiationBuilder = runtimeService.createProcessInstanceModification(
+      processInstance.getId()).startBeforeActivity("subProcess", "noValidActivityInstanceId");
 
     try {
-      runtimeService.createProcessInstanceModification(processInstance.getId()).startBeforeActivity("subProcess", "noValidActivityInstanceId").execute();
+      processInstanceModificationInstantiationBuilder.execute();
       fail();
     } catch (NotValidException e) {
       // happy path
@@ -444,9 +446,11 @@ public class ProcessInstanceModificationTest extends PluggableProcessEngineTest 
     // given two instances of the outer subprocess
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("doubleNestedSubprocess");
     String processInstanceId = processInstance.getId();
+    var processInstanceModificationInstantiationBuilder1 = runtimeService.createProcessInstanceModification(processInstanceId)
+      .startTransition("flow5", "noValidActivityInstanceId");
 
     try {
-      runtimeService.createProcessInstanceModification(processInstance.getId()).startTransition("flow5", "noValidActivityInstanceId").execute();
+      processInstanceModificationInstantiationBuilder1.execute();
       fail();
     } catch (NotValidException e) {
       // happy path
@@ -454,8 +458,9 @@ public class ProcessInstanceModificationTest extends PluggableProcessEngineTest 
           + "Ancestor activity instance 'noValidActivityInstanceId' does not exist", e.getMessage());
     }
 
+    var processInstanceModificationInstantiationBuilder2 = runtimeService.createProcessInstanceModification(processInstanceId);
     try {
-      runtimeService.createProcessInstanceModification(processInstance.getId()).startTransition("flow5", null).execute();
+      processInstanceModificationInstantiationBuilder2.startTransition("flow5", null);
       fail();
     } catch (NotValidException e) {
       // happy path
@@ -464,9 +469,11 @@ public class ProcessInstanceModificationTest extends PluggableProcessEngineTest 
 
     ActivityInstance tree = runtimeService.getActivityInstance(processInstanceId);
     String subProcessTaskId = getInstanceIdForActivity(tree, "subProcessTask");
+    var processInstanceModificationInstantiationBuilder3 = runtimeService.createProcessInstanceModification(processInstanceId)
+      .startTransition("flow5", subProcessTaskId);
 
     try {
-      runtimeService.createProcessInstanceModification(processInstance.getId()).startTransition("flow5", subProcessTaskId).execute();
+      processInstanceModificationInstantiationBuilder3.execute();
       fail("should not succeed because subProcessTask is a child of subProcess");
     } catch (NotValidException e) {
       // happy path
@@ -632,10 +639,11 @@ public class ProcessInstanceModificationTest extends PluggableProcessEngineTest 
     // given two instances of the outer subprocess
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("doubleNestedSubprocess");
     String processInstanceId = processInstance.getId();
+    var processInstanceModificationInstantiationBuilder1 = runtimeService.createProcessInstanceModification(processInstanceId)
+      .startAfterActivity("innerSubProcessStart", "noValidActivityInstanceId");
 
     try {
-      runtimeService.createProcessInstanceModification(processInstance.getId()).startAfterActivity("innerSubProcessStart", "noValidActivityInstanceId")
-          .execute();
+      processInstanceModificationInstantiationBuilder1.execute();
       fail();
     } catch (NotValidException e) {
       // happy path
@@ -645,8 +653,9 @@ public class ProcessInstanceModificationTest extends PluggableProcessEngineTest 
           e.getMessage());
     }
 
+    var processInstanceModificationInstantiationBuilder2 = runtimeService.createProcessInstanceModification(processInstanceId);
     try {
-      runtimeService.createProcessInstanceModification(processInstance.getId()).startAfterActivity("innerSubProcessStart", null).execute();
+      processInstanceModificationInstantiationBuilder2.startAfterActivity("innerSubProcessStart", null);
       fail();
     } catch (NotValidException e) {
       // happy path
@@ -656,8 +665,10 @@ public class ProcessInstanceModificationTest extends PluggableProcessEngineTest 
     ActivityInstance tree = runtimeService.getActivityInstance(processInstanceId);
     String subProcessTaskId = getInstanceIdForActivity(tree, "subProcessTask");
 
+    var processInstanceModificationInstantiationBuilder3 = runtimeService.createProcessInstanceModification(processInstanceId)
+      .startAfterActivity("innerSubProcessStart", subProcessTaskId);
     try {
-      runtimeService.createProcessInstanceModification(processInstance.getId()).startAfterActivity("innerSubProcessStart", subProcessTaskId).execute();
+      processInstanceModificationInstantiationBuilder3.execute();
       fail("should not succeed because subProcessTask is a child of subProcess");
     } catch (NotValidException e) {
       // happy path
@@ -1473,17 +1484,22 @@ public class ProcessInstanceModificationTest extends PluggableProcessEngineTest 
   @Test
   public void testStartCompensationBoundary() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testProcess");
+    String processInstanceId = processInstance.getId();
 
+    var processInstanceModificationInstantiationBuilder1 = runtimeService.createProcessInstanceModification(processInstanceId)
+      .startBeforeActivity("compensateBoundaryEvent");
     try {
-      runtimeService.createProcessInstanceModification(processInstance.getId()).startBeforeActivity("compensateBoundaryEvent").execute();
+      processInstanceModificationInstantiationBuilder1.execute();
 
       fail("should not succeed");
     } catch (ProcessEngineException e) {
       testRule.assertTextPresent("compensation boundary event", e.getMessage());
     }
 
+    var processInstanceModificationInstantiationBuilder2 = runtimeService.createProcessInstanceModification(processInstanceId)
+      .startAfterActivity("compensateBoundaryEvent");
     try {
-      runtimeService.createProcessInstanceModification(processInstance.getId()).startAfterActivity("compensateBoundaryEvent").execute();
+      processInstanceModificationInstantiationBuilder2.execute();
 
       fail("should not succeed");
     } catch (ProcessEngineException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryOrTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryOrTest.java
@@ -68,91 +68,83 @@ public class ProcessInstanceQueryOrTest {
 
   @Test
   public void shouldThrowExceptionByMissingStartOr() {
+    // given
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery().or().endOr();
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.createProcessInstanceQuery()
-        .or()
-        .endOr()
-        .endOr())
+    assertThatThrownBy(processInstanceQuery::endOr)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set endOr() before or()");
   }
 
   @Test
   public void shouldThrowExceptionByNesting() {
+    // given
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery().or();
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.createProcessInstanceQuery()
-        .or()
-        .or()
-        .endOr()
-        .endOr()
-        .or()
-        .endOr())
+    assertThatThrownBy(processInstanceQuery::or)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set or() within 'or' query");
   }
 
   @Test
   public void shouldThrowExceptionOnOrderByProcessInstanceId() {
+    // given
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery()
+      .or();
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.createProcessInstanceQuery()
-        .or()
-        .orderByProcessInstanceId()
-        .endOr())
+    assertThatThrownBy(processInstanceQuery::orderByProcessInstanceId)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set orderByProcessInstanceId() within 'or' query");
   }
 
   @Test
   public void shouldThrowExceptionOnOrderByProcessDefinitionId() {
+    // given
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery()
+      .or();
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.createProcessInstanceQuery()
-        .or()
-        .orderByProcessDefinitionId()
-      .endOr())
+    assertThatThrownBy(processInstanceQuery::orderByProcessDefinitionId)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set orderByProcessDefinitionId() within 'or' query");
   }
 
   @Test
   public void shouldThrowExceptionOnOrderByProcessDefinitionKey() {
+    // given
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery()
+      .or();
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.createProcessInstanceQuery()
-        .or()
-          .orderByProcessDefinitionKey()
-        .endOr())
+    assertThatThrownBy(processInstanceQuery::orderByProcessDefinitionKey)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set orderByProcessDefinitionKey() within 'or' query");
 
   }
 
   @Test
-  public void shouldThrowExceptionOnOorderByTenantIdd() {
+  public void shouldThrowExceptionOnOrderByTenantId() {
+    // given
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery().or();
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.createProcessInstanceQuery()
-        .or()
-          .orderByTenantId()
-        .endOr())
+    assertThatThrownBy(processInstanceQuery::orderByTenantId)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set orderByTenantId() within 'or' query");
   }
 
   @Test
   public void shouldThrowExceptionOnOrderByBusinessKey() {
+    // given
+    var processInstanceQuery = runtimeService.createProcessInstanceQuery().or();
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.createProcessInstanceQuery()
-        .or()
-          .orderByBusinessKey()
-        .endOr())
+    assertThatThrownBy(processInstanceQuery::orderByBusinessKey)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set orderByBusinessKey() within 'or' query");
-
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -17,16 +17,8 @@
 package org.operaton.bpm.engine.test.api.runtime;
 
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -56,13 +48,10 @@ import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
+
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.processInstanceByBusinessKey;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.processInstanceByProcessDefinitionId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.processInstanceByProcessInstanceId;
@@ -266,14 +255,14 @@ public class ProcessInstanceQueryTest {
     runtimeService.startProcessInstanceById(oneTaskProcessDefinitionId);
 
     // assume
-    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(7l);
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(7L);
 
     // when
     ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery()
       .processDefinitionKeyIn(PROCESS_DEFINITION_KEY, PROCESS_DEFINITION_KEY_2);
 
     // then
-    assertThat(query.count()).isEqualTo(5l);
+    assertThat(query.count()).isEqualTo(5L);
     assertThat(query.list()).hasSize(5);
   }
 
@@ -322,14 +311,14 @@ public class ProcessInstanceQueryTest {
     runtimeService.startProcessInstanceById(oneTaskProcessDefinitionId);
 
     // assume
-    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(7l);
+    assertThat(runtimeService.createProcessInstanceQuery().count()).isEqualTo(7L);
 
     // when
     ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery()
       .processDefinitionKeyNotIn(PROCESS_DEFINITION_KEY, PROCESS_DEFINITION_KEY_2);
 
     // then
-    assertThat(query.count()).isEqualTo(2l);
+    assertThat(query.count()).isEqualTo(2L);
     assertThat(query.list()).hasSize(2);
   }
 
@@ -340,7 +329,7 @@ public class ProcessInstanceQueryTest {
       .processDefinitionKeyNotIn("not-existing-key");
 
     // then
-    assertThat(query.count()).isEqualTo(5l);
+    assertThat(query.count()).isEqualTo(5L);
     assertThat(query.list()).hasSize(5);
   }
 
@@ -522,7 +511,9 @@ public class ProcessInstanceQueryTest {
     try {
       processInstanceQuery.list(); // asc - desc not called -> exception
       fail();
-    }catch (ProcessEngineException ignored) {}
+    }catch (ProcessEngineException ignored) {
+      // expected
+    }
   }
 
   @Test
@@ -1382,8 +1373,9 @@ public class ProcessInstanceQueryTest {
   @Test
   public void testQueryByProcessInstanceIdsEmpty() {
     var processInstanceQuery = runtimeService.createProcessInstanceQuery();
+    Set<String> emptyProcessInstanceIds = emptySet();
     try {
-      processInstanceQuery.processInstanceIds(new HashSet<>());
+      processInstanceQuery.processInstanceIds(emptyProcessInstanceIds);
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException re) {
       assertThat(re.getMessage()).contains("Set of process instance ids is empty");
@@ -1492,7 +1484,9 @@ public class ProcessInstanceQueryTest {
     try {
       query.incidentId(null);
       fail();
-    } catch (ProcessEngineException ignored) {}
+    } catch (ProcessEngineException ignored) {
+      // expected
+    }
   }
 
   @Test
@@ -1523,7 +1517,9 @@ public class ProcessInstanceQueryTest {
     try {
       query.incidentType(null);
       fail();
-    } catch (ProcessEngineException ignored) {}
+    } catch (ProcessEngineException ignored) {
+      // expected
+    }
   }
 
   @Test
@@ -1554,7 +1550,9 @@ public class ProcessInstanceQueryTest {
     try {
       query.incidentMessage(null);
       fail();
-    } catch (ProcessEngineException ignored) {}
+    } catch (ProcessEngineException ignored) {
+      // expected
+    }
   }
 
   @Test
@@ -1583,7 +1581,9 @@ public class ProcessInstanceQueryTest {
     try {
       query.incidentMessageLike(null);
       fail();
-    } catch (ProcessEngineException ignored) {}
+    } catch (ProcessEngineException ignored) {
+      // expected
+    }
   }
 
   @Test
@@ -1699,7 +1699,9 @@ public class ProcessInstanceQueryTest {
     try {
       query.caseInstanceId(null);
       fail("The passed case instance should not be null.");
-    } catch (Exception ignored) {}
+    } catch (Exception ignored) {
+      // expected
+    }
 
   }
 
@@ -1737,23 +1739,23 @@ public class ProcessInstanceQueryTest {
   public void testProcessVariableValueEqualsNumber() {
     // long
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 123L));
+        Map.of("var", 123L));
 
     // non-matching long
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 12345L));
+        Map.of("var", 12345L));
 
     // short
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", (short) 123));
+        Map.of("var", (short) 123));
 
     // double
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 123.0d));
+        Map.of("var", 123.0d));
 
     // integer
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 123));
+        Map.of("var", 123));
 
     // untyped null (should not match)
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
@@ -1761,10 +1763,10 @@ public class ProcessInstanceQueryTest {
 
     // typed null (should not match)
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", Variables.longValue(null)));
+        Map.of("var", Variables.longValue(null)));
 
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", "123"));
+        Map.of("var", "123"));
 
     assertEquals(4, runtimeService.createProcessInstanceQuery().variableValueEquals("var", Variables.numberValue(123)).count());
     assertEquals(4, runtimeService.createProcessInstanceQuery().variableValueEquals("var", Variables.numberValue(123L)).count());
@@ -1779,23 +1781,23 @@ public class ProcessInstanceQueryTest {
   public void testProcessVariableValueNumberComparison() {
     // long
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 123L));
+        Map.of("var", 123L));
 
     // non-matching long
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 12345L));
+        Map.of("var", 12345L));
 
     // short
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", (short) 123));
+        Map.of("var", (short) 123));
 
     // double
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 123.0d));
+        Map.of("var", 123.0d));
 
     // integer
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", 123));
+        Map.of("var", 123));
 
     // untyped null
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
@@ -1803,10 +1805,10 @@ public class ProcessInstanceQueryTest {
 
     // typed null
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", Variables.longValue(null)));
+        Map.of("var", Variables.longValue(null)));
 
     runtimeService.startProcessInstanceByKey("oneTaskProcess",
-        Collections.<String, Object>singletonMap("var", "123"));
+        Map.of("var", "123"));
 
     assertEquals(4, runtimeService.createProcessInstanceQuery().variableValueNotEquals("var", Variables.numberValue(123)).count());
     assertEquals(1, runtimeService.createProcessInstanceQuery().variableValueGreaterThan("var", Variables.numberValue(123)).count());
@@ -1980,7 +1982,7 @@ public class ProcessInstanceQueryTest {
     assertEquals(5, instances.size());
 
     for (ProcessInstance returnedInstance : instances) {
-      assertFalse(returnedInstance.getId().equals(secondProcessInstance.getId()));
+      assertNotEquals(returnedInstance.getId(), secondProcessInstance.getId());
     }
 
     // cleanup

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceSuspensionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceSuspensionTest.java
@@ -16,18 +16,15 @@
  */
 package org.operaton.bpm.engine.test.api.runtime;
 
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 
-import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.SuspendedEntityInteractionException;
 import org.operaton.bpm.engine.externaltask.ExternalTask;
@@ -50,6 +47,8 @@ import org.junit.Test;
  * @author Joram Barrez
  */
 public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
+  private static final Map<String, String> emptyProperties = emptyMap();
+  private static final Map<String, Object> emptyProcessVariables = emptyMap();
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
   @Test
@@ -601,13 +600,13 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.setVariables(processInstance.getId(), new HashMap<String, Object>());
+      runtimeService.setVariables(processInstance.getId(), new HashMap<>());
     } catch (ProcessEngineException e) {
       fail("This should be possible");
     }
 
     try {
-      runtimeService.setVariablesLocal(processInstance.getId(), new HashMap<String, Object>());
+      runtimeService.setVariablesLocal(processInstance.getId(), new HashMap<>());
     } catch (ProcessEngineException e) {
       fail("This should be possible");
     }
@@ -658,13 +657,13 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.setVariables(processInstance.getId(), new HashMap<String, Object>());
+      runtimeService.setVariables(processInstance.getId(), new HashMap<>());
     } catch (ProcessEngineException e) {
       fail("This should be possible");
     }
 
     try {
-      runtimeService.setVariablesLocal(processInstance.getId(), new HashMap<String, Object>());
+      runtimeService.setVariablesLocal(processInstance.getId(), new HashMap<>());
     } catch (ProcessEngineException e) {
       fail("This should be possible");
     }
@@ -714,13 +713,13 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.setVariables(processInstance.getId(), new HashMap<String, Object>());
+      runtimeService.setVariables(processInstance.getId(), new HashMap<>());
     } catch (ProcessEngineException e) {
       fail("This should be possible");
     }
 
     try {
-      runtimeService.setVariablesLocal(processInstance.getId(), new HashMap<String, Object>());
+      runtimeService.setVariablesLocal(processInstance.getId(), new HashMap<>());
     } catch (ProcessEngineException e) {
       fail("This should be possible");
     }
@@ -735,7 +734,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     var taskQuery = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId();
 
     try {
-      formService.submitTaskFormData(taskQuery, new HashMap<>());
+      formService.submitTaskFormData(taskQuery, emptyProperties);
       fail();
     } catch(SuspendedEntityInteractionException e) {
       // This is expected
@@ -751,7 +750,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     var taskQuery = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId();
 
     try {
-      formService.submitTaskFormData(taskQuery, new HashMap<>());
+      formService.submitTaskFormData(taskQuery, emptyProperties);
       fail();
     } catch(SuspendedEntityInteractionException e) {
       // This is expected
@@ -767,7 +766,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     var taskQuery = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId();
 
     try {
-      formService.submitTaskFormData(taskQuery, new HashMap<>());
+      formService.submitTaskFormData(taskQuery, emptyProperties);
       fail();
     } catch(SuspendedEntityInteractionException e) {
       // This is expected
@@ -790,16 +789,14 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
       testRule.assertTextPresent("is suspended", e.getMessage());
-      assertTrue(e instanceof BadUserRequestException);
     }
 
     try {
-      runtimeService.signal(processInstanceId, new HashMap<>());
+      runtimeService.signal(processInstanceId, emptyProcessVariables);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
       testRule.assertTextPresent("is suspended", e.getMessage());
-      assertTrue(e instanceof BadUserRequestException);
     }
   }
 
@@ -819,16 +816,14 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
       testRule.assertTextPresent("is suspended", e.getMessage());
-      assertTrue(e instanceof BadUserRequestException);
     }
 
     try {
-      runtimeService.signal(processInstanceId, new HashMap<>());
+      runtimeService.signal(processInstanceId, emptyProcessVariables);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
       testRule.assertTextPresent("is suspended", e.getMessage());
-      assertTrue(e instanceof BadUserRequestException);
     }
   }
 
@@ -848,16 +843,14 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
       testRule.assertTextPresent("is suspended", e.getMessage());
-      assertTrue(e instanceof BadUserRequestException);
     }
 
     try {
-      runtimeService.signal(processInstanceId, new HashMap<>());
+      runtimeService.signal(processInstanceId, emptyProcessVariables);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
       testRule.assertTextPresent("is suspended", e.getMessage());
-      assertTrue(e instanceof BadUserRequestException);
     }
   }
 
@@ -879,7 +872,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.messageEventReceived("someMessage", executionId, new HashMap<>());
+      runtimeService.messageEventReceived("someMessage", executionId, emptyProcessVariables);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -905,7 +898,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.messageEventReceived("someMessage", executionId, new HashMap<>());
+      runtimeService.messageEventReceived("someMessage", executionId, emptyProcessVariables);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -931,7 +924,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.messageEventReceived("someMessage", executionId, new HashMap<>());
+      runtimeService.messageEventReceived("someMessage", executionId, emptyProcessVariables);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -970,7 +963,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.signalEventReceived(signal, executionId, new HashMap<>());
+      runtimeService.signalEventReceived(signal, executionId, emptyProcessVariables);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -1014,7 +1007,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.signalEventReceived(signal, executionId, new HashMap<>());
+      runtimeService.signalEventReceived(signal, executionId, emptyProcessVariables);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -1063,7 +1056,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
     }
 
     try {
-      runtimeService.signalEventReceived(signal, executionId, new HashMap<>());
+      runtimeService.signalEventReceived(signal, executionId, emptyProcessVariables);
       fail();
     } catch (SuspendedEntityInteractionException e) {
       // This is expected
@@ -1435,6 +1428,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
       taskService.saveTask(subTask);
       fail("Creating sub tasks for suspended task should not be possible");
     } catch (SuspendedEntityInteractionException e) {
+      // expected
     }
   }
 
@@ -1453,6 +1447,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
       taskService.saveTask(subTask);
       fail("Creating sub tasks for suspended task should not be possible");
     } catch (SuspendedEntityInteractionException e) {
+      // expected
     }
   }
 
@@ -1471,6 +1466,7 @@ public class ProcessInstanceSuspensionTest extends PluggableProcessEngineTest {
       taskService.saveTask(subTask);
       fail("Creating sub tasks for suspended task should not be possible");
     } catch (SuspendedEntityInteractionException e) {
+      // expected
     }
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RestartProcessInstanceSyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RestartProcessInstanceSyncTest.java
@@ -861,13 +861,14 @@ public class RestartProcessInstanceSyncTest {
     // given
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(ProcessModels.TWO_TASKS_PROCESS);
     ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinition.getId());
+    var restartProcessInstanceBuilder = runtimeService.restartProcessInstances(
+        processDefinition.getId())
+      .startBeforeActivity("userTask1")
+      .initialSetOfVariables()
+      .processInstanceIds(processInstance.getId());
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.restartProcessInstances(processDefinition.getId())
-        .startBeforeActivity("userTask1")
-        .initialSetOfVariables()
-        .processInstanceIds(processInstance.getId())
-        .execute())
+    assertThatThrownBy(restartProcessInstanceBuilder::execute)
       .isInstanceOf(ProcessEngineException.class);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceAsyncOperationsTest.java
@@ -179,9 +179,11 @@ public class RuntimeServiceAsyncOperationsTest extends AbstractAsyncOperationsTe
       "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
   @Test
   public void testDeleteProcessInstancesAsyncWithEmptyList() {
+    // given
+    List<String> emptyProcessInstanceIds = new ArrayList<>();
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.deleteProcessInstancesAsync(new ArrayList<String>(), null, TESTING_INSTANCE_DELETE))
+    assertThatThrownBy(() -> runtimeService.deleteProcessInstancesAsync(emptyProcessInstanceIds, null, TESTING_INSTANCE_DELETE))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("processInstanceIds is empty");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/SetVariablesBatchTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/SetVariablesBatchTest.java
@@ -436,10 +436,11 @@ public class SetVariablesBatchTest {
   public void shouldThrowException_TransientVariable() {
     // given
     String processInstanceId = runtimeService.startProcessInstanceByKey(PROCESS_KEY).getId();
+    List<String> processInstanceIds = Collections.singletonList(processInstanceId);
+    var variables = Variables.putValue("foo", Variables.stringValue("bar", true));
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.setVariablesAsync(Collections.singletonList(processInstanceId),
-        Variables.putValue("foo", Variables.stringValue("bar", true))))
+    assertThatThrownBy(() -> runtimeService.setVariablesAsync(processInstanceIds, variables))
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("ENGINE-13044 Setting transient variable 'foo' " +
           "asynchronously is currently not supported.");
@@ -450,14 +451,13 @@ public class SetVariablesBatchTest {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY);
     ProcessInstanceQuery runtimeQuery = runtimeService.createProcessInstanceQuery();
+    var variables = Variables.putValue("foo", Variables.serializedObjectValue()
+      .serializedValue("foo")
+      .serializationDataFormat(Variables.SerializationDataFormats.JAVA)
+      .create());
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.setVariablesAsync(runtimeQuery,
-        Variables.putValue("foo",
-            Variables.serializedObjectValue()
-                .serializedValue("foo")
-                .serializationDataFormat(Variables.SerializationDataFormats.JAVA)
-                .create())))
+    assertThatThrownBy(() -> runtimeService.setVariablesAsync(runtimeQuery, variables))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("ENGINE-17007 Cannot set variable with name foo. " +
           "Java serialization format is prohibited");
@@ -502,9 +502,10 @@ public class SetVariablesBatchTest {
   public void shouldThrowException_VariablesEmpty() {
     // given
     ProcessInstanceQuery runtimeQuery = runtimeService.createProcessInstanceQuery();
+    Map<String, Object> variables = Collections.emptyMap();
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.setVariablesAsync(runtimeQuery, Collections.emptyMap()))
+    assertThatThrownBy(() -> runtimeService.setVariablesAsync(runtimeQuery, variables))
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("variables is empty");
   }
@@ -742,7 +743,7 @@ public class SetVariablesBatchTest {
         engineRule.getTaskService().complete(task.getId());
 
         // when executing batch then no exception is thrown
-        batchRule.syncExec(batch);
+        assertThatCode(() -> batchRule.syncExec(batch)).doesNotThrowAnyException();
     }
 
     @Test
@@ -755,7 +756,7 @@ public class SetVariablesBatchTest {
         engineRule.getTaskService().complete(task.getId());
 
         // when executing batch then no exception is thrown
-        batchRule.syncExec(batch);
+        assertThatCode(() -> batchRule.syncExec(batch)).doesNotThrowAnyException();
     }
 
     @Test
@@ -768,7 +769,7 @@ public class SetVariablesBatchTest {
         engineRule.getTaskService().complete(task.getId());
 
         // when executing batch then no exception is thrown
-        batchRule.syncExec(batch);
+        assertThatCode(() -> batchRule.syncExec(batch)).doesNotThrowAnyException();
     }
 
     @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/TransientVariableTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/TransientVariableTest.java
@@ -18,14 +18,13 @@ package org.operaton.bpm.engine.test.api.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.*;
+
 import static org.operaton.bpm.engine.test.api.runtime.migration.models.ConditionalModels.CONDITIONAL_PROCESS_KEY;
 import static org.operaton.bpm.engine.test.api.runtime.migration.models.ConditionalModels.CONDITION_ID;
 import static org.operaton.bpm.engine.test.api.runtime.migration.models.ConditionalModels.USER_TASK_ID;
 import static org.operaton.bpm.engine.test.api.runtime.migration.models.ConditionalModels.VARIABLE_NAME;
 import static org.operaton.bpm.engine.test.api.runtime.migration.models.ConditionalModels.VAR_CONDITION;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -228,7 +227,7 @@ public class TransientVariableTest {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(CONDITIONAL_PROCESS_KEY);
 
     // then
-    assertEquals(true, processInstance.isEnded());
+    assertTrue(processInstance.isEnded());
   }
 
 
@@ -713,9 +712,10 @@ public class TransientVariableTest {
 
     testRule.deploy(model);
 
+    var variables = Variables.putValue("transient1", true).putValue("transient2", false);
+
     // when/then
-    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("process",
-        Variables.putValue("transient1", true).putValue("transient2", false)))
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("process", variables))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot set transient variable with name variable to non-transient variable and vice versa.");
   }
@@ -732,9 +732,10 @@ public class TransientVariableTest {
 
     testRule.deploy(model);
 
+    var variables = Variables.putValue("transient1", false).putValue("transient2", true);
+
     // when/then
-    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("process",
-        Variables.putValue("transient1", false).putValue("transient2", true)))
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("process", variables))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Cannot set transient variable with name variable to non-transient variable and vice versa.");
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/UpdateProcessInstancesSuspendStateAsyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/UpdateProcessInstancesSuspendStateAsyncTest.java
@@ -305,10 +305,11 @@ public class UpdateProcessInstancesSuspendStateAsyncTest {
   @Test
   public void testEmptyProcessInstanceListSuspendAsync() {
     // given
-    // nothing
+    var updateProcessInstancesSuspensionStateBuilder = runtimeService.updateProcessInstanceSuspensionState()
+      .byProcessInstanceIds();
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.updateProcessInstanceSuspensionState().byProcessInstanceIds().suspendAsync())
+    assertThatThrownBy(updateProcessInstancesSuspensionStateBuilder::suspendAsync)
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("No process instance ids given");
   }
@@ -316,10 +317,11 @@ public class UpdateProcessInstancesSuspendStateAsyncTest {
   @Test
   public void testEmptyProcessInstanceListActivateAsync() {
     // given
-    // nothing
+    var updateProcessInstancesSuspensionStateBuilder = runtimeService.updateProcessInstanceSuspensionState()
+      .byProcessInstanceIds();
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.updateProcessInstanceSuspensionState().byProcessInstanceIds().activateAsync())
+    assertThatThrownBy(updateProcessInstancesSuspensionStateBuilder::activateAsync)
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("No process instance ids given");
   }
@@ -332,9 +334,11 @@ public class UpdateProcessInstancesSuspendStateAsyncTest {
     // given
     ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneExternalTaskProcess");
     ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("twoExternalTaskProcess");
+    var updateProcessInstancesSuspensionStateBuilder = runtimeService.updateProcessInstanceSuspensionState()
+      .byProcessInstanceIds(Arrays.asList(processInstance1.getId(), processInstance2.getId(), null));
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.updateProcessInstanceSuspensionState().byProcessInstanceIds(Arrays.asList(processInstance1.getId(), processInstance2.getId(), null)).activateAsync())
+    assertThatThrownBy(updateProcessInstancesSuspensionStateBuilder::activateAsync)
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("Cannot be null");
   }
@@ -346,9 +350,11 @@ public class UpdateProcessInstancesSuspendStateAsyncTest {
     // given
     ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneExternalTaskProcess");
     ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("twoExternalTaskProcess");
+    var updateProcessInstancesSuspensionStateBuilder = runtimeService.updateProcessInstanceSuspensionState()
+      .byProcessInstanceIds(Arrays.asList(processInstance1.getId(), processInstance2.getId(), null));
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.updateProcessInstanceSuspensionState().byProcessInstanceIds(Arrays.asList(processInstance1.getId(), processInstance2.getId(), null)).suspendAsync())
+    assertThatThrownBy(updateProcessInstancesSuspensionStateBuilder::suspendAsync)
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("Cannot be null");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/UpdateProcessInstancesSuspendStateTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/UpdateProcessInstancesSuspendStateTest.java
@@ -80,7 +80,7 @@ public class UpdateProcessInstancesSuspendStateTest {
   @Test
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml",
     "org/operaton/bpm/engine/test/api/externaltask/twoExternalTaskProcess.bpmn20.xml"})
-  public void testBatchActivatationById() {
+  public void testBatchActivationById() {
     // given
     ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneExternalTaskProcess");
     ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("twoExternalTaskProcess");
@@ -124,7 +124,7 @@ public class UpdateProcessInstancesSuspendStateTest {
   @Test
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml",
     "org/operaton/bpm/engine/test/api/externaltask/twoExternalTaskProcess.bpmn20.xml"})
-  public void testBatchActivatationByIdArray() {
+  public void testBatchActivationByIdArray() {
     // given
     ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneExternalTaskProcess");
     ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("twoExternalTaskProcess");
@@ -171,7 +171,7 @@ public class UpdateProcessInstancesSuspendStateTest {
   @Test
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml",
     "org/operaton/bpm/engine/test/api/externaltask/twoExternalTaskProcess.bpmn20.xml"})
-  public void testBatchActivatationByProcessInstanceQuery() {
+  public void testBatchActivationByProcessInstanceQuery() {
     // given
     ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneExternalTaskProcess");
     ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("twoExternalTaskProcess");
@@ -221,7 +221,7 @@ public class UpdateProcessInstancesSuspendStateTest {
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml",
     "org/operaton/bpm/engine/test/api/externaltask/twoExternalTaskProcess.bpmn20.xml"})
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_ACTIVITY)
-  public void testBatchActivatationByHistoricProcessInstanceQuery() {
+  public void testBatchActivationByHistoricProcessInstanceQuery() {
     // given
     ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneExternalTaskProcess");
     ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("twoExternalTaskProcess");
@@ -248,10 +248,11 @@ public class UpdateProcessInstancesSuspendStateTest {
   @Test
   public void testEmptyProcessInstanceListSuspend() {
     // given
-    // nothing
+    var updateProcessInstancesSuspensionStateBuilder = runtimeService.updateProcessInstanceSuspensionState()
+      .byProcessInstanceIds();
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.updateProcessInstanceSuspensionState().byProcessInstanceIds().suspend())
+    assertThatThrownBy(updateProcessInstancesSuspensionStateBuilder::suspend)
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("No process instance ids given");
 
@@ -260,10 +261,11 @@ public class UpdateProcessInstancesSuspendStateTest {
   @Test
   public void testEmptyProcessInstanceListActivateUpdateProcessInstancesSuspendStateAsyncTest() {
     // given
-    // nothing
+    var updateProcessInstancesSuspensionStateBuilder = runtimeService.updateProcessInstanceSuspensionState()
+      .byProcessInstanceIds();
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.updateProcessInstanceSuspensionState().byProcessInstanceIds().activate())
+    assertThatThrownBy(updateProcessInstancesSuspensionStateBuilder::activate)
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("No process instance ids given");
 
@@ -277,9 +279,11 @@ public class UpdateProcessInstancesSuspendStateTest {
     // given
     ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneExternalTaskProcess");
     ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("twoExternalTaskProcess");
+    var updateProcessInstancesSuspensionStateBuilder = runtimeService.updateProcessInstanceSuspensionState()
+      .byProcessInstanceIds(Arrays.asList(processInstance1.getId(), processInstance2.getId(), null));
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.updateProcessInstanceSuspensionState().byProcessInstanceIds(Arrays.asList(processInstance1.getId(), processInstance2.getId(), null)).activate())
+    assertThatThrownBy(updateProcessInstancesSuspensionStateBuilder::activate)
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("Cannot be null");
 
@@ -292,9 +296,11 @@ public class UpdateProcessInstancesSuspendStateTest {
     // given
     ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneExternalTaskProcess");
     ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("twoExternalTaskProcess");
+    var updateProcessInstancesSuspensionStateBuilder = runtimeService.updateProcessInstanceSuspensionState()
+      .byProcessInstanceIds(Arrays.asList(processInstance1.getId(), processInstance2.getId(), null));
 
     // when/then
-    assertThatThrownBy(() -> runtimeService.updateProcessInstanceSuspensionState().byProcessInstanceIds(Arrays.asList(processInstance1.getId(), processInstance2.getId(), null)).suspend())
+    assertThatThrownBy(updateProcessInstancesSuspensionStateBuilder::suspend)
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("Cannot be null");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationTest.java
@@ -50,14 +50,7 @@ import org.operaton.bpm.engine.impl.digest._apacheCommonsCodec.Base64;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.util.StringUtil;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
-import org.operaton.bpm.engine.runtime.Execution;
-import org.operaton.bpm.engine.runtime.Job;
-import org.operaton.bpm.engine.runtime.MessageCorrelationResult;
-import org.operaton.bpm.engine.runtime.MessageCorrelationResultType;
-import org.operaton.bpm.engine.runtime.MessageCorrelationResultWithVariables;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.runtime.ProcessInstanceQuery;
-import org.operaton.bpm.engine.runtime.VariableInstance;
+import org.operaton.bpm.engine.runtime.*;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
@@ -165,7 +158,7 @@ public class MessageCorrelationTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationTest.testCatchingMessageEventCorrelation.bpmn20.xml")
   @Test
-  public void testOneMatchinProcessInstanceUsingFluentCorrelateAll() {
+  public void testOneMatchingProcessInstanceUsingFluentCorrelateAll() {
     Map<String, Object> variables = new HashMap<>();
     variables.put("aKey", "aValue");
     runtimeService.startProcessInstanceByKey("process", variables);
@@ -326,7 +319,7 @@ public class MessageCorrelationTest {
                                                               .correlateAllWithResult();
 
     assertEquals(2, resultList.size());
-    //then result should contains executions on which messages was correlated
+    //then result should contain executions on which messages was correlated
     for (MessageCorrelationResult result : resultList) {
       assertNotNull(result);
       assertEquals(MessageCorrelationResultType.Execution, result.getResultType());
@@ -347,7 +340,7 @@ public class MessageCorrelationTest {
                                                               .correlateAllWithResult();
 
     assertEquals(1, resultList.size());
-    //then result should contains process definitions and start event activity ids on which messages was correlated
+    //then result should contain process definitions and start event activity ids on which messages was correlated
     for (MessageCorrelationResult result : resultList) {
       checkProcessDefinitionMessageCorrelationResult(result, "theStart", "messageStartEvent");
     }
@@ -916,7 +909,7 @@ public class MessageCorrelationTest {
     List<MessageCorrelationResult> resultList = runtimeService.createMessageCorrelation("newInvoiceMessage")
             .correlateAllWithResult();
 
-    //then result should contains three entries
+    //then result should contain three entries
     //two of type execution und one of type process definition
     assertEquals(3, resultList.size());
     int executionResultCount = 0;
@@ -1614,9 +1607,9 @@ public class MessageCorrelationTest {
     ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceByKey("Process_1", variables);
 
     Map<String, Object> messageLocalPayload = new HashMap<>();
-    String outpuValue = "outputValue";
+    String outputValue = "outputValue";
     String localVarName = "testLocalVar";
-    messageLocalPayload.put(localVarName, outpuValue);
+    messageLocalPayload.put(localVarName, outputValue);
 
     // when
     MessageCorrelationResultWithVariables messageCorrelationResult = runtimeService
@@ -1633,7 +1626,7 @@ public class MessageCorrelationTest {
         .variableName(outputVarName)
         .singleResult();
     assertNotNull(variable);
-    assertEquals(outpuValue, variable.getValue());
+    assertEquals(outputValue, variable.getValue());
     assertEquals(processInstance.getId(), variable.getExecutionId());
 
     VariableInstance variableNonExisting = runtimeService
@@ -1668,9 +1661,9 @@ public class MessageCorrelationTest {
     ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceByKey("Process_1", variables);
 
     Map<String, Object> messageLocalPayload = new HashMap<>();
-    String outpuValue = "outputValue";
+    String outputValue = "outputValue";
     String localVarName = "testLocalVar";
-    messageLocalPayload.put(localVarName, outpuValue);
+    messageLocalPayload.put(localVarName, outputValue);
 
     // when
     runtimeService
@@ -1685,7 +1678,7 @@ public class MessageCorrelationTest {
         .variableName(outputVarName)
         .singleResult();
     assertNotNull(variable);
-    assertEquals(outpuValue, variable.getValue());
+    assertEquals(outputValue, variable.getValue());
     assertEquals(processInstance.getId(), variable.getExecutionId());
 
     VariableInstance variableNonExisting = runtimeService
@@ -1791,9 +1784,9 @@ public class MessageCorrelationTest {
     testRule.deploy(model);
 
     Map<String, Object> messagePayload = new HashMap<>();
-    String outpuValue = "outputValue";
+    String outputValue = "outputValue";
     String localVarName = "testLocalVar";
-    messagePayload.put(localVarName, outpuValue);
+    messagePayload.put(localVarName, outputValue);
 
     // when
     MessageCorrelationResult result = runtimeService
@@ -1843,7 +1836,7 @@ public class MessageCorrelationTest {
         .correlateAllWithResultAndVariables(true);
 
     assertEquals(2, resultList.size());
-    //then result should contains executions on which messages was correlated
+    //then result should contain executions on which messages was correlated
     for (MessageCorrelationResultWithVariables result : resultList) {
       assertNotNull(result);
       assertEquals(MessageCorrelationResultType.Execution, result.getResultType());
@@ -2172,9 +2165,9 @@ public class MessageCorrelationTest {
     engineRule.getRuntimeService().startProcessInstanceByKey("Process_1", variables);
 
     Map<String, Object> messagePayload = new HashMap<>();
-    String outpuValue = "outputValue";
+    String outputValue = "outputValue";
     String variableName = "testVar";
-    messagePayload.put(variableName, outpuValue);
+    messagePayload.put(variableName, outputValue);
 
     // when
     runtimeService
@@ -2191,7 +2184,7 @@ public class MessageCorrelationTest {
         .variableScopeIdIn(activityInstance.getId())
         .singleResult();
     assertThat(variable).isNotNull();
-    assertThat(variable.getValue()).isEqualTo(outpuValue);
+    assertThat(variable.getValue()).isEqualTo(outputValue);
   }
 
   @Test
@@ -2206,9 +2199,9 @@ public class MessageCorrelationTest {
     ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceByKey("Process_1", variables);
 
     Map<String, Object> messagePayload = new HashMap<>();
-    String outpuValue = "outputValue";
+    String outputValue = "outputValue";
     String variableName = "testVar";
-    messagePayload.put(variableName, outpuValue);
+    messagePayload.put(variableName, outputValue);
 
     // when
     runtimeService
@@ -2223,7 +2216,7 @@ public class MessageCorrelationTest {
         .variableScopeIdIn(processInstance.getId())
         .singleResult();
     assertThat(variable).isNotNull();
-    assertThat(variable.getValue()).isEqualTo(outpuValue);
+    assertThat(variable.getValue()).isEqualTo(outputValue);
   }
 
   @Test
@@ -2235,13 +2228,13 @@ public class MessageCorrelationTest {
     variables.put("processInstanceVar", "processInstanceVarValue");
     engineRule.getRuntimeService().startProcessInstanceByKey("Process_1", variables);
 
-    String outpuValue = "outputValue";
+    String outputValue = "outputValue";
     String variableName = "testVar";
 
     // when
     runtimeService
         .createMessageCorrelation("1")
-        .setVariableToTriggeredScope(variableName, outpuValue)
+        .setVariableToTriggeredScope(variableName, outputValue)
         .correlate();
 
     // then the scope is "afterMessage" activity
@@ -2253,7 +2246,7 @@ public class MessageCorrelationTest {
         .variableScopeIdIn(activityInstance.getId())
         .singleResult();
     assertThat(variable).isNotNull();
-    assertThat(variable.getValue()).isEqualTo(outpuValue);
+    assertThat(variable.getValue()).isEqualTo(outputValue);
   }
 
   @Test
@@ -2265,13 +2258,13 @@ public class MessageCorrelationTest {
     variables.put("processInstanceVar", "processInstanceVarValue");
     engineRule.getRuntimeService().startProcessInstanceByKey("Process_1", variables);
 
-    String outpuValue = "outputValue";
+    String outputValue = "outputValue";
     String variableName = "testVar";
 
     // when
     runtimeService
         .createMessageCorrelation("1")
-        .setVariableToTriggeredScope(variableName, outpuValue)
+        .setVariableToTriggeredScope(variableName, outputValue)
         .correlate();
 
     // then the scope is "afterMessage" activity
@@ -2283,7 +2276,7 @@ public class MessageCorrelationTest {
         .variableScopeIdIn(activityInstance.getId())
         .singleResult();
     assertThat(variable).isNotNull();
-    assertThat(variable.getValue()).isEqualTo(outpuValue);
+    assertThat(variable.getValue()).isEqualTo(outputValue);
   }
 
   @Test
@@ -2302,9 +2295,9 @@ public class MessageCorrelationTest {
     variables.put("processInstanceVar", "processInstanceVarValue");
 
     Map<String, Object> messagePayload = new HashMap<>();
-    String outpuValue = "outputValue";
+    String outputValue = "outputValue";
     String variableName = "testVar";
-    messagePayload.put(variableName, outpuValue);
+    messagePayload.put(variableName, outputValue);
 
     // when
     MessageCorrelationResult result = runtimeService
@@ -2319,7 +2312,7 @@ public class MessageCorrelationTest {
         .variableName(variableName)
         .singleResult();
     assertThat(variable).isNotNull();
-    assertThat(variable.getValue()).isEqualTo(outpuValue);
+    assertThat(variable.getValue()).isEqualTo(outputValue);
   }
 
   @Test
@@ -2341,9 +2334,9 @@ public class MessageCorrelationTest {
     engineRule.getRuntimeService().startProcessInstanceByKey("Process_1", variables);
 
     Map<String, Object> messagePayload = new HashMap<>();
-    String outpuValue = "outputValue";
+    String outputValue = "outputValue";
     String variableName = "testVar";
-    messagePayload.put(variableName, outpuValue);
+    messagePayload.put(variableName, outputValue);
 
     // when
     runtimeService
@@ -2373,13 +2366,10 @@ public class MessageCorrelationTest {
     variables.put("processInstanceVar", "processInstanceVarValue");
     engineRule.getRuntimeService().startProcessInstanceByKey("Process_1", variables);
 
-    String outpuValue = "outputValue";
+    var messageCorrelationBuilder = runtimeService.createMessageCorrelation("1");
 
     // when/then
-    assertThatThrownBy(() ->  runtimeService
-        .createMessageCorrelation("1")
-        .setVariableToTriggeredScope(null, outpuValue)
-        .correlate())
+    assertThatThrownBy(() -> messageCorrelationBuilder.setVariableToTriggeredScope(null, "outputValue"))
     .isInstanceOf(NullValueException.class)
     .hasMessageContaining("variableName");
   }
@@ -2396,9 +2386,9 @@ public class MessageCorrelationTest {
     engineRule.getRuntimeService().startProcessInstanceByKey("Process_1", variables);
 
     Map<String, Object> messagePayload = new HashMap<>();
-    String outpuValue = "outputValue";
+    String outputValue = "outputValue";
     String variableName = "testVar";
-    messagePayload.put(variableName, outpuValue);
+    messagePayload.put(variableName, outputValue);
 
 
     // when
@@ -2419,7 +2409,7 @@ public class MessageCorrelationTest {
         .variableScopeIdIn(activityInstance.getId())
         .singleResult();
     assertThat(variable).isNotNull();
-    assertThat(variable.getValue()).isEqualTo(outpuValue);
+    assertThat(variable.getValue()).isEqualTo(outputValue);
   }
 
   @Test
@@ -2434,9 +2424,9 @@ public class MessageCorrelationTest {
     ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceByKey("Process_1", variables);
 
     Map<String, Object> messagePayload = new HashMap<>();
-    String outpuValue = "outputValue";
+    String outputValue = "outputValue";
     String variableName = "testVar";
-    messagePayload.put(variableName, outpuValue);
+    messagePayload.put(variableName, outputValue);
 
     // when
     runtimeService
@@ -2454,7 +2444,7 @@ public class MessageCorrelationTest {
         .variableScopeIdIn(processInstance.getId())
         .singleResult();
     assertThat(variable).isNotNull();
-    assertThat(variable.getValue()).isEqualTo(outpuValue);
+    assertThat(variable.getValue()).isEqualTo(outputValue);
   }
 
   @Test
@@ -2466,13 +2456,13 @@ public class MessageCorrelationTest {
     variables.put("processInstanceVar", "processInstanceVarValue");
     engineRule.getRuntimeService().startProcessInstanceByKey("Process_1", variables);
 
-    String outpuValue = "outputValue";
+    String outputValue = "outputValue";
     String variableName = "testVar";
 
     // when
     runtimeService
         .createMessageCorrelation("1")
-        .setVariableToTriggeredScope(variableName, outpuValue)
+        .setVariableToTriggeredScope(variableName, outputValue)
         .correlate();
     Job asyncJob = engineRule.getManagementService().createJobQuery().singleResult();
     assertNotNull(asyncJob);
@@ -2487,7 +2477,7 @@ public class MessageCorrelationTest {
         .variableScopeIdIn(activityInstance.getId())
         .singleResult();
     assertThat(variable).isNotNull();
-    assertThat(variable.getValue()).isEqualTo(outpuValue);
+    assertThat(variable.getValue()).isEqualTo(outputValue);
   }
 
   @Test
@@ -2499,13 +2489,13 @@ public class MessageCorrelationTest {
     variables.put("processInstanceVar", "processInstanceVarValue");
     engineRule.getRuntimeService().startProcessInstanceByKey("Process_1", variables);
 
-    String outpuValue = "outputValue";
+    String outputValue = "outputValue";
     String variableName = "testVar";
 
     // when
     runtimeService
         .createMessageCorrelation("1")
-        .setVariableToTriggeredScope(variableName, outpuValue)
+        .setVariableToTriggeredScope(variableName, outputValue)
         .correlate();
     Job asyncJob = engineRule.getManagementService().createJobQuery().singleResult();
     assertNotNull(asyncJob);
@@ -2520,7 +2510,7 @@ public class MessageCorrelationTest {
         .variableScopeIdIn(activityInstance.getId())
         .singleResult();
     assertThat(variable).isNotNull();
-    assertThat(variable.getValue()).isEqualTo(outpuValue);
+    assertThat(variable.getValue()).isEqualTo(outputValue);
   }
 
   @Test
@@ -2543,9 +2533,9 @@ public class MessageCorrelationTest {
     engineRule.getRuntimeService().startProcessInstanceByKey("Process_1", variables);
 
     Map<String, Object> messagePayload = new HashMap<>();
-    String outpuValue = "outputValue";
+    String outputValue = "outputValue";
     String variableName = "testVar";
-    messagePayload.put(variableName, outpuValue);
+    messagePayload.put(variableName, outputValue);
 
     Job asyncJob = engineRule.getManagementService().createJobQuery().singleResult();
     assertNotNull(asyncJob);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationUserOperationLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationUserOperationLogTest.java
@@ -246,8 +246,10 @@ public class MessageCorrelationUserOperationLogTest {
     runtimeService.startProcessInstanceByKey(SINGLE_INTERMEDIATE_MESSAGE_PROCESS).getId();
     identityService.setAuthenticatedUserId(USER_ID);
 
+    var messageCorrelationBuilder = runtimeService.createMessageCorrelation(INTERMEDIATE_MESSAGE_NAME);
+
     // when
-    assertThatThrownBy(() -> runtimeService.createMessageCorrelation(INTERMEDIATE_MESSAGE_NAME).correlateAll())
+    assertThatThrownBy(messageCorrelationBuilder::correlateAll)
 
     // then
     .isInstanceOf(ProcessEngineException.class)

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationBoundaryEventsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationBoundaryEventsTest.java
@@ -607,15 +607,15 @@ public class MigrationBoundaryEventsTest {
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(sourceProcess);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(sourceProcess);
 
+    var migrationInstructionBuilder = rule.getRuntimeService()
+      .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+      .mapActivities(USER_TASK_ID, USER_TASK_ID)
+      .mapActivities(BOUNDARY_ID, BOUNDARY_ID);
+
     // when conditional boundary event is migrated without update event trigger
-    // then
-    assertThatThrownBy(() -> rule.getRuntimeService()
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities(USER_TASK_ID, USER_TASK_ID)
-        .mapActivities(BOUNDARY_ID, BOUNDARY_ID)
-        .build())
+    assertThatThrownBy(migrationInstructionBuilder::build)
+      // then
       .isInstanceOf(MigrationPlanValidationException.class)
       .hasMessageContaining(MIGRATION_CONDITIONAL_VALIDATION_ERROR_MSG);
-
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationEventSubProcessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationEventSubProcessTest.java
@@ -388,13 +388,14 @@ public class MigrationEventSubProcessTest {
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(CONDITIONAL_EVENT_SUBPROCESS_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(CONDITIONAL_EVENT_SUBPROCESS_PROCESS);
 
+    var migrationInstructionBuilder = rule.getRuntimeService()
+      .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+      .mapActivities(USER_TASK_ID, USER_TASK_ID)
+      .mapActivities(EVENT_SUB_PROCESS_START_ID, EVENT_SUB_PROCESS_START_ID);
+
     // when conditional event sub process is migrated without update event trigger
-    // then
-    assertThatThrownBy(() -> rule.getRuntimeService()
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities(USER_TASK_ID, USER_TASK_ID)
-        .mapActivities(EVENT_SUB_PROCESS_START_ID, EVENT_SUB_PROCESS_START_ID)
-        .build())
+    assertThatThrownBy(migrationInstructionBuilder::build)
+      // then
       .isInstanceOf(MigrationPlanValidationException.class)
       .hasMessageContaining(MIGRATION_CONDITIONAL_VALIDATION_ERROR_MSG);
   }
@@ -653,13 +654,13 @@ public class MigrationEventSubProcessTest {
     testHelper.createProcessInstanceAndMigrate(migrationPlan, variables);
 
     // then
-    String resolvedsignalName = "new" + EventSubProcessModels.MESSAGE_NAME + "-foo";
+    String resolvedSignalName = "new" + EventSubProcessModels.MESSAGE_NAME + "-foo";
     testHelper.assertEventSubscriptionMigrated(
       EVENT_SUB_PROCESS_START_ID, EventSubProcessModels.SIGNAL_NAME,
-      EVENT_SUB_PROCESS_START_ID, resolvedsignalName);
+      EVENT_SUB_PROCESS_START_ID, resolvedSignalName);
 
     // and it is possible to successfully complete the migrated instance
-    rule.getRuntimeService().signalEventReceived(resolvedsignalName);
+    rule.getRuntimeService().signalEventReceived(resolvedSignalName);
     testHelper.completeTask(EVENT_SUB_PROCESS_TASK_ID);
     testHelper.assertProcessEnded(testHelper.snapshotBeforeMigration.getProcessInstanceId());
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationIntermediateConditionalEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationIntermediateConditionalEventTest.java
@@ -92,12 +92,13 @@ public class MigrationIntermediateConditionalEventTest {
     ProcessDefinition sourceProcessDefinition = testHelper.deployAndGetDefinition(ONE_CONDITION_PROCESS);
     ProcessDefinition targetProcessDefinition = testHelper.deployAndGetDefinition(ONE_CONDITION_PROCESS);
 
+    var migrationInstructionBuilder = rule.getRuntimeService()
+      .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
+      .mapActivities(CONDITION_ID, CONDITION_ID);
+
     //when conditional event is migrated without update event trigger
-    // then
-    assertThatThrownBy(() -> rule.getRuntimeService()
-        .createMigrationPlan(sourceProcessDefinition.getId(), targetProcessDefinition.getId())
-        .mapActivities(CONDITION_ID, CONDITION_ID)
-        .build())
+    assertThatThrownBy(migrationInstructionBuilder::build)
+      // then
       .isInstanceOf(MigrationPlanValidationException.class)
       .hasMessageContaining(MIGRATION_CONDITIONAL_VALIDATION_ERROR_MSG);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/SetProcessDefinitionVersionCmdTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/SetProcessDefinitionVersionCmdTest.java
@@ -101,9 +101,11 @@ public class SetProcessDefinitionVersionCmdTest extends PluggableProcessEngineTe
 
   @Test
   public void testSetProcessDefinitionVersionNonExistingPI() {
+    // given
     CommandExecutor commandExecutor = processEngineConfiguration.getCommandExecutorTxRequired();
+    var setProcessDefinitionVersionCmd = new SetProcessDefinitionVersionCmd("42", 23);
     try {
-      commandExecutor.execute(new SetProcessDefinitionVersionCmd("42", 23));
+      commandExecutor.execute(setProcessDefinitionVersionCmd);
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
        testRule.assertTextPresent("No process instance found for id = '42'.", ae.getMessage());
@@ -136,8 +138,10 @@ public class SetProcessDefinitionVersionCmdTest extends PluggableProcessEngineTe
     ProcessInstance pi = runtimeService.startProcessInstanceByKey("receiveTask");
 
     CommandExecutor commandExecutor = processEngineConfiguration.getCommandExecutorTxRequired();
+    var setProcessDefinitionVersionCmd = new SetProcessDefinitionVersionCmd(pi.getId(), 23);
+
     try {
-      commandExecutor.execute(new SetProcessDefinitionVersionCmd(pi.getId(), 23));
+      commandExecutor.execute(setProcessDefinitionVersionCmd);
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
        testRule.assertTextPresent("no processes deployed with key = 'receiveTask', version = '23'", ae.getMessage());
@@ -440,7 +444,7 @@ public class SetProcessDefinitionVersionCmdTest extends PluggableProcessEngineTe
     CommandExecutor commandExecutor = processEngineConfiguration.getCommandExecutorTxRequired();
     commandExecutor.execute(new SetProcessDefinitionVersionCmd(instance.getId(), 2));
 
-    // then the the job should also be migrated
+    // then the job should also be migrated
     Job migratedJob = managementService.createJobQuery().singleResult();
     assertNotNull(migratedJob);
     assertEquals(job.getId(), migratedJob.getId());
@@ -500,7 +504,7 @@ public class SetProcessDefinitionVersionCmdTest extends PluggableProcessEngineTe
     commandExecutor.execute(new SetProcessDefinitionVersionCmd(asyncBeforeInstance.getId(), 2));
     commandExecutor.execute(new SetProcessDefinitionVersionCmd(asyncAfterInstance.getId(), 2));
 
-    // then the the job's definition reference should also be migrated
+    // then the job's definition reference should also be migrated
     Job migratedAsyncBeforeJob = managementService.createJobQuery()
         .processInstanceId(asyncBeforeInstance.getId()).singleResult();
     assertEquals(asyncBeforeJob.getId(), migratedAsyncBeforeJob.getId());
@@ -544,7 +548,7 @@ public class SetProcessDefinitionVersionCmdTest extends PluggableProcessEngineTe
     CommandExecutor commandExecutor = processEngineConfiguration.getCommandExecutorTxRequired();
     commandExecutor.execute(new SetProcessDefinitionVersionCmd(instance.getId(), 2));
 
-    // then the the incident should also be migrated
+    // then the incident should also be migrated
     Incident migratedIncident = runtimeService.createIncidentQuery().singleResult();
     assertNotNull(migratedIncident);
     assertEquals(newDefinition.getId(), migratedIncident.getProcessDefinitionId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/batch/BatchSetVariablesMigrationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/batch/BatchSetVariablesMigrationTest.java
@@ -189,11 +189,12 @@ public class BatchSetVariablesMigrationTest {
         .mapEqualActivities()
         .setVariables(Variables.putValue("foo", Variables.stringValue("bar", true))).build();
 
+    var migrationPlanExecutionBuilder = engineRule.getRuntimeService()
+      .newMigration(migrationPlan)
+      .processInstanceIds(processInstanceId);
+
     // when/then
-    assertThatThrownBy(() -> engineRule.getRuntimeService()
-          .newMigration(migrationPlan)
-          .processInstanceIds(processInstanceId)
-          .executeAsync())
+    assertThatThrownBy(migrationPlanExecutionBuilder::executeAsync)
         .isInstanceOf(BadUserRequestException.class)
         .hasMessageContaining("ENGINE-13044 Setting transient variable 'foo' " +
             "asynchronously is currently not supported.");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryExpressionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryExpressionTest.java
@@ -36,7 +36,6 @@ import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -456,7 +455,7 @@ public class TaskQueryExpressionTest {
     assertTrue(taskQuery.getFollowUpDate().after(queryDate));
     assertTrue(taskQuery.getFollowUpAfter().after(queryDate));
 
-    // candidates has to be tested separately cause they have to be set exclusively
+    // candidates has to be tested separately because they have to be set exclusively
 
     taskQuery = (TaskQueryImpl) taskQuery()
       .taskCandidateGroup(queryString)
@@ -548,7 +547,7 @@ public class TaskQueryExpressionTest {
     assertThat(taskQuery.getFollowUpDate()).isEqualTo(queryDate);
     assertThat(taskQuery.getFollowUpAfter()).isEqualTo(queryDate);
 
-    // candidates has to be tested separately cause they have to be set exclusively
+    // candidates has to be tested separately because they have to be set exclusively
 
     taskQuery = (TaskQueryImpl) taskQuery()
       .taskCandidateGroupExpression(testStringExpression)
@@ -627,42 +626,48 @@ public class TaskQueryExpressionTest {
 
   @Test
   public void shouldRejectDueDateExpressionAndWithoutDueDateCombination() {
-    assertThatThrownBy(() -> taskService.createTaskQuery().dueDateExpression("").withoutDueDate())
+    var taskQuery = taskService.createTaskQuery().dueDateExpression("");
+    assertThatThrownBy(taskQuery::withoutDueDate)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage");
   }
 
   @Test
   public void shouldRejectWithoutDueDateAndDueDateExpressionCombination() {
-    assertThatThrownBy(() -> taskService.createTaskQuery().withoutDueDate().dueDateExpression(""))
+    var taskQuery = taskService.createTaskQuery().withoutDueDate();
+    assertThatThrownBy(() -> taskQuery.dueDateExpression(""))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage");
   }
 
   @Test
   public void shouldRejectDueAfterExpressionAndWithoutDueDateCombination() {
-    assertThatThrownBy(() -> taskService.createTaskQuery().dueAfterExpression("").withoutDueDate())
+    var taskQuery = taskService.createTaskQuery().dueAfterExpression("");
+    assertThatThrownBy(taskQuery::withoutDueDate)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage");
   }
 
   @Test
   public void shouldRejectWithoutDueDateAndDueAfterExpressionCombination() {
-    assertThatThrownBy(() -> taskService.createTaskQuery().withoutDueDate().dueAfterExpression(""))
+    var taskQuery = taskService.createTaskQuery().withoutDueDate();
+    assertThatThrownBy(() -> taskQuery.dueAfterExpression(""))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage");
   }
 
   @Test
   public void shouldRejectDueBeforeExpressionAndWithoutDueDateCombination() {
-    assertThatThrownBy(() -> taskService.createTaskQuery().dueBeforeExpression("").withoutDueDate())
+    var taskQuery = taskService.createTaskQuery().dueBeforeExpression("");
+    assertThatThrownBy(taskQuery::withoutDueDate)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage");
   }
 
   @Test
   public void shouldRejectWithoutDueDateAndDueBeforeExpressionCombination() {
-    assertThatThrownBy(() -> taskService.createTaskQuery().withoutDueDate().dueBeforeExpression(""))
+    var taskQuery = taskService.createTaskQuery().withoutDueDate();
+    assertThatThrownBy(() -> taskQuery.dueBeforeExpression(""))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage");
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryOrTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryOrTest.java
@@ -88,102 +88,92 @@ public class TaskQueryOrTest {
 
   @Test
   public void shouldThrowExceptionByMissingStartOr() {
+    // given
+    var taskQuery = taskService.createTaskQuery().or().endOr();
 
     // when/then
-    assertThatThrownBy(() -> taskService.createTaskQuery()
-        .or()
-        .endOr()
-        .endOr())
+    assertThatThrownBy(taskQuery::endOr)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set endOr() before or()");
   }
 
   @Test
   public void shouldThrowExceptionByNesting() {
+    // given
+    var taskQuery = taskService.createTaskQuery().or();
     // when/then
-    assertThatThrownBy(() -> taskService.createTaskQuery()
-        .or()
-          .or()
-          .endOr()
-        .endOr()
-        .or()
-        .endOr())
+
+    assertThatThrownBy(taskQuery::or)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set or() within 'or' query");
   }
 
   @Test
   public void shouldThrowExceptionByWithCandidateGroupsApplied() {
+    // given
+    var taskQuery = taskService.createTaskQuery().or();
     // when/then
-    assertThatThrownBy(() -> taskService.createTaskQuery()
-        .or()
-          .withCandidateGroups()
-        .endOr())
+    assertThatThrownBy(taskQuery::withCandidateGroups)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set withCandidateGroups() within 'or' query");
   }
 
   @Test
   public void shouldThrowExceptionByWithoutCandidateGroupsApplied() {
+    // given
+    var taskQuery = taskService.createTaskQuery().or();
     // when/then
-    assertThatThrownBy(() -> taskService.createTaskQuery()
-        .or()
-          .withoutCandidateGroups()
-        .endOr())
+    assertThatThrownBy(taskQuery::withoutCandidateGroups)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set withoutCandidateGroups() within 'or' query");
   }
 
   @Test
   public void shouldThrowExceptionByWithCandidateUsersApplied() {
+    // given
+    var taskQuery = taskService.createTaskQuery().or();
     // when/then
-    assertThatThrownBy(() -> taskService.createTaskQuery()
-        .or()
-          .withCandidateUsers()
-        .endOr())
+    assertThatThrownBy(taskQuery::withCandidateUsers)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set withCandidateUsers() within 'or' query");
   }
 
   @Test
   public void shouldThrowExceptionByWithoutCandidateUsersApplied() {
+    // given
+    var taskQuery = taskService.createTaskQuery().or();
     // when/then
-    assertThatThrownBy(() -> taskService.createTaskQuery()
-        .or()
-          .withoutCandidateUsers()
-        .endOr())
+    assertThatThrownBy(taskQuery::withoutCandidateUsers)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set withoutCandidateUsers() within 'or' query");
   }
 
   @Test
   public void shouldThrowExceptionByOrderingApplied() {
+    // given
+    var taskQuery = taskService.createTaskQuery().or();
     // when/then
-    assertThatThrownBy(() -> taskService.createTaskQuery()
-        .or()
-          .orderByCaseExecutionId()
-        .endOr())
+    assertThatThrownBy(taskQuery::orderByCaseExecutionId)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set orderByCaseExecutionId() within 'or' query");
   }
 
   @Test
   public void shouldThrowExceptionByInitializeFormKeysInOrQuery() {
+    // given
+    var taskQuery = taskService.createTaskQuery().or();
     // when/then
-    assertThatThrownBy(() -> taskService.createTaskQuery()
-        .or()
-          .initializeFormKeys()
-        .endOr())
+    assertThatThrownBy(taskQuery::initializeFormKeys)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set initializeFormKeys() within 'or' query");
   }
 
   @Test
   public void shouldThrowExceptionOnTenantIdsAndWithoutTenantIdInAndQuery() {
+    // given
+    var taskQuery = taskService.createTaskQuery().tenantIdIn("tenant1", "tenant2");
     // when/then
-    assertThatThrownBy(() -> taskService.createTaskQuery()
-        .tenantIdIn("tenant1", "tenant2")
-        .withoutTenantId())
+    assertThatThrownBy(taskQuery::withoutTenantId)
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Invalid query usage: cannot set both tenantIdIn and withoutTenantId filters.");
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskServiceTest.java
@@ -256,7 +256,9 @@ public class TaskServiceTest {
     try {
       taskService.saveTask(task);
       fail("It should not be possible to save a task with a non existing parent task.");
-    } catch (NotValidException e) {}
+    } catch (NotValidException e) {
+      // expected
+    }
   }
 
   @Test
@@ -379,7 +381,7 @@ public class TaskServiceTest {
     taskService.saveTask(task);
     String taskId = task.getId();
 
-    // Deleting comments of a task that doesnt have any comments should silently ignored
+    // Deleting comments of a task that doesn't have any comments should be silently ignored
     assertThatCode(() -> taskService.deleteTaskComments(taskId))
       .doesNotThrowAnyException();
 
@@ -615,7 +617,7 @@ public class TaskServiceTest {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
     String processInstanceId = processInstance.getId();
 
-    // Deleting comments of a task that doesn't have any comments should silently ignored
+    // Deleting comments of a task that doesn't have any comments should be silently ignored
     assertThatCode(() -> taskService.deleteProcessInstanceComments(processInstanceId))
       .doesNotThrowAnyException();
   }
@@ -813,7 +815,9 @@ public class TaskServiceTest {
         taskService.createComment(taskId, null, null);
         fail("Expected process engine exception");
       }
-      catch (ProcessEngineException e) {}
+      catch (ProcessEngineException e) {
+        // expected
+      }
       finally {
         taskService.deleteTask(task.getId(), true);
       }
@@ -828,7 +832,9 @@ public class TaskServiceTest {
         taskService.createComment(null, null, "test");
         fail("Expected process engine exception");
       }
-      catch (ProcessEngineException e){}
+      catch (ProcessEngineException e){
+        // expected
+      }
     }
   }
 
@@ -2108,8 +2114,9 @@ public class TaskServiceTest {
 
   @Test
   public void testSetDueDateUnexistingTaskId() {
+    Date dueDate = new Date();
     try {
-      taskService.setDueDate("unexistingtask", new Date());
+      taskService.setDueDate("unexistingtask", dueDate);
       fail("ProcessEngineException expected");
     } catch (NotFoundException ae) {
       testRule.assertTextPresent("Cannot find task with id unexistingtask", ae.getMessage());
@@ -2118,8 +2125,9 @@ public class TaskServiceTest {
 
   @Test
   public void testSetDueDateNullTaskId() {
+    Date dueDate = new Date();
     try {
-      taskService.setDueDate(null, new Date());
+      taskService.setDueDate(null, dueDate);
       fail("ProcessEngineException expected");
     } catch (NullValueException ae) {
       testRule.assertTextPresent("taskId is null", ae.getMessage());
@@ -2145,8 +2153,9 @@ public class TaskServiceTest {
 
   @Test
   public void testSetFollowUpDateUnexistingTaskId() {
+    Date followUpDate = new Date();
     try {
-      taskService.setFollowUpDate("unexistingtask", new Date());
+      taskService.setFollowUpDate("unexistingtask", followUpDate);
       fail("ProcessEngineException expected");
     } catch (NotFoundException ae) {
       testRule.assertTextPresent("Cannot find task with id unexistingtask", ae.getMessage());
@@ -2155,8 +2164,9 @@ public class TaskServiceTest {
 
   @Test
   public void testSetFollowUpDateNullTaskId() {
+    Date followUpDate = new Date();
     try {
-      taskService.setFollowUpDate(null, new Date());
+      taskService.setFollowUpDate(null, followUpDate);
       fail("ProcessEngineException expected");
     } catch (NullValueException ae) {
       testRule.assertTextPresent("taskId is null", ae.getMessage());
@@ -2181,7 +2191,7 @@ public class TaskServiceTest {
   }
 
   /**
-   * @see http://jira.codehaus.org/browse/ACT-1059
+   * @see <a href="http://jira.codehaus.org/browse/ACT-1059">ACT-1059</a>
    */
   @Test
   public void testSetDelegationState() {
@@ -2434,39 +2444,41 @@ public class TaskServiceTest {
     runtimeService.startProcessInstanceByKey("oneTaskProcess");
     Task task = taskService.createTaskQuery().singleResult();
     assertNotNull(task);
+    String taskId = task.getId();
+    List<String> taskIds = List.of(taskId);
 
     try {
-      taskService.deleteTask(task.getId());
+      taskService.deleteTask(taskId);
     } catch(ProcessEngineException ae) {
       assertEquals("The task cannot be deleted because is part of a running process", ae.getMessage());
     }
 
     try {
-      taskService.deleteTask(task.getId(), true);
+      taskService.deleteTask(taskId, true);
     } catch(ProcessEngineException ae) {
       assertEquals("The task cannot be deleted because is part of a running process", ae.getMessage());
     }
 
     try {
-      taskService.deleteTask(task.getId(), "test");
+      taskService.deleteTask(taskId, "test");
     } catch(ProcessEngineException ae) {
       assertEquals("The task cannot be deleted because is part of a running process", ae.getMessage());
     }
 
     try {
-      taskService.deleteTasks(Arrays.asList(task.getId()));
+      taskService.deleteTasks(Collections.singletonList(taskId));
     } catch(ProcessEngineException ae) {
       assertEquals("The task cannot be deleted because is part of a running process", ae.getMessage());
     }
 
     try {
-      taskService.deleteTasks(Arrays.asList(task.getId()), true);
+      taskService.deleteTasks(taskIds, true);
     } catch(ProcessEngineException ae) {
       assertEquals("The task cannot be deleted because is part of a running process", ae.getMessage());
     }
 
     try {
-      taskService.deleteTasks(Arrays.asList(task.getId()), "test");
+      taskService.deleteTasks(taskIds, "test");
     } catch(ProcessEngineException ae) {
       assertEquals("The task cannot be deleted because is part of a running process", ae.getMessage());
     }
@@ -2495,7 +2507,7 @@ public class TaskServiceTest {
     Task task = taskService.createTaskQuery().singleResult();
     assertNotNull(task);
     String taskId = task.getId();
-    var taskIds = Arrays.asList(task.getId());
+    var taskIds = Collections.singletonList(task.getId());
 
     try {
       taskService.deleteTask(taskId);
@@ -2652,10 +2664,13 @@ public class TaskServiceTest {
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_AUDIT)
   @Test
   public void testCreateTaskAttachmentWithNullTaskAndProcessInstance() {
+    var content = new ByteArrayInputStream("someContent".getBytes());
     try {
-      taskService.createAttachment("web page", null, null, "weatherforcast", "temperatures and more", new ByteArrayInputStream("someContent".getBytes()));
+      taskService.createAttachment("web page", null, null, "weatherforcast", "temperatures and more", content);
       fail("expected process engine exception");
-    } catch (ProcessEngineException e) {}
+    } catch (ProcessEngineException e) {
+      // expected
+    }
   }
 
   @Deployment(resources={
@@ -2682,7 +2697,9 @@ public class TaskServiceTest {
       try {
         taskService.deleteAttachment(null);
         fail("expected process engine exception");
-      } catch (ProcessEngineException e) {}
+      } catch (ProcessEngineException e) {
+        // expected
+      }
     }
   }
 
@@ -2712,7 +2729,9 @@ public class TaskServiceTest {
       try {
         taskService.deleteTaskAttachment(null, null);
         fail("expected process engine exception");
-      } catch (ProcessEngineException e) {}
+      } catch (ProcessEngineException e) {
+        // expected
+      }
     }
   }
 
@@ -2723,7 +2742,9 @@ public class TaskServiceTest {
       try {
         taskService.deleteTaskAttachment(null, "myAttachmentId");
         fail("expected process engine exception");
-      } catch(ProcessEngineException e) {}
+      } catch(ProcessEngineException e) {
+        // expected
+      }
     }
   }
 
@@ -2782,6 +2803,7 @@ public class TaskServiceTest {
       ((TaskServiceImpl) taskService).updateVariablesLocal("nonExistingId", modifications, deletions);
       fail("expected process engine exception");
     } catch (ProcessEngineException e) {
+      // expected
     }
   }
 
@@ -2800,6 +2822,7 @@ public class TaskServiceTest {
       ((TaskServiceImpl) taskService).updateVariablesLocal(null, modifications, deletions);
       fail("expected process engine exception");
     } catch (ProcessEngineException e) {
+      // expected
     }
   }
 
@@ -2850,6 +2873,7 @@ public class TaskServiceTest {
       ((TaskServiceImpl) taskService).updateVariables("nonExistingId", modifications, deletions);
       fail("expected process engine exception");
     } catch (ProcessEngineException e) {
+      // expected
     }
   }
 
@@ -2868,6 +2892,7 @@ public class TaskServiceTest {
       ((TaskServiceImpl) taskService).updateVariables(null, modifications, deletions);
       fail("expected process engine exception");
     } catch (ProcessEngineException e) {
+      // expected
     }
   }
 
@@ -2921,7 +2946,7 @@ public class TaskServiceTest {
     // this works
     VariableMap variablesTyped = taskService.getVariablesTyped(taskId, false);
     assertNotNull(variablesTyped.getValueTyped("broken"));
-    variablesTyped = taskService.getVariablesTyped(taskId, Arrays.asList("broken"), false);
+    variablesTyped = taskService.getVariablesTyped(taskId, List.of("broken"), false);
     assertNotNull(variablesTyped.getValueTyped("broken"));
 
     // this does not
@@ -2933,7 +2958,7 @@ public class TaskServiceTest {
 
     // this does not
     try {
-      taskService.getVariablesTyped(taskId, Arrays.asList("broken"), true);
+      taskService.getVariablesTyped(taskId, List.of("broken"), true);
     } catch(ProcessEngineException e) {
       testRule.assertTextPresent("Cannot deserialize object", e.getMessage());
     }
@@ -2970,7 +2995,7 @@ public class TaskServiceTest {
     // this works
     VariableMap variablesTyped = taskService.getVariablesLocalTyped(taskId, false);
     assertNotNull(variablesTyped.getValueTyped("broken"));
-    variablesTyped = taskService.getVariablesLocalTyped(taskId, Arrays.asList("broken"), false);
+    variablesTyped = taskService.getVariablesLocalTyped(taskId, List.of("broken"), false);
     assertNotNull(variablesTyped.getValueTyped("broken"));
 
     // this does not
@@ -2982,7 +3007,7 @@ public class TaskServiceTest {
 
     // this does not
     try {
-      taskService.getVariablesLocalTyped(taskId, Arrays.asList("broken"), true);
+      taskService.getVariablesLocalTyped(taskId, List.of("broken"), true);
     } catch(ProcessEngineException e) {
       testRule.assertTextPresent("Cannot deserialize object", e.getMessage());
     }
@@ -3012,8 +3037,8 @@ public class TaskServiceTest {
     // then
     VariableInstance variable = runtimeService.createVariableInstanceQuery().singleResult();
 
-    assertEquals(variable.getName(), variableName);
-    assertEquals(variable.getValue(), variableValue);
+    assertEquals(variableName, variable.getName());
+    assertEquals(variableValue, variable.getValue());
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3042,8 +3067,8 @@ public class TaskServiceTest {
     // then
     VariableInstance variable = runtimeService.createVariableInstanceQuery().singleResult();
 
-    assertEquals(variable.getName(), variableName);
-    assertEquals(variable.getValue(), variableAnotherValue);
+    assertEquals(variableName, variable.getName());
+    assertEquals(variableAnotherValue, variable.getValue());
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/twoTasksProcess.bpmn20.xml"})
@@ -3066,8 +3091,8 @@ public class TaskServiceTest {
     // then
     VariableInstance variable = runtimeService.createVariableInstanceQuery().singleResult();
 
-    assertEquals(variable.getName(), variableName);
-    assertEquals(variable.getValue(), variableAnotherValue);
+    assertEquals(variableName, variable.getName());
+    assertEquals(variableAnotherValue, variable.getValue());
   }
 
   @Deployment(resources={"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3232,9 +3257,10 @@ public class TaskServiceTest {
     // given
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
     Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    String taskId = task.getId();
 
     // when/then
-    assertThatThrownBy(() -> taskService.handleBpmnError(task.getId(), ""))
+    assertThatThrownBy(() -> taskService.handleBpmnError(taskId, ""))
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("errorCode is empty");
   }
@@ -3245,9 +3271,10 @@ public class TaskServiceTest {
     // given
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
     Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+    String taskId = task.getId();
 
     // when/then
-    assertThatThrownBy(() -> taskService.handleBpmnError(task.getId(), null))
+    assertThatThrownBy(() -> taskService.handleBpmnError(taskId, null))
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("errorCode is null");
   }
@@ -3345,13 +3372,14 @@ public class TaskServiceTest {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(PROCESS_KEY);
     Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
     assertEquals(USER_TASK_THROW_ESCALATION, task.getTaskDefinitionKey());
+    String taskId = task.getId();
 
     // when/then
-    assertThatThrownBy(() -> taskService.handleEscalation(task.getId(), ""))
+    assertThatThrownBy(() -> taskService.handleEscalation(taskId, ""))
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("escalationCode is empty");
 
-    assertThatThrownBy(() -> taskService.handleEscalation(task.getId(), null))
+    assertThatThrownBy(() -> taskService.handleEscalation(taskId, null))
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("escalationCode is null");
   }
@@ -3370,9 +3398,10 @@ public class TaskServiceTest {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(PROCESS_KEY);
     Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
     assertEquals(USER_TASK_THROW_ESCALATION, task.getTaskDefinitionKey());
+    String taskId = task.getId();
 
     // when/then
-    assertThatThrownBy(() -> taskService.handleEscalation(task.getId(), ESCALATION_CODE))
+    assertThatThrownBy(() -> taskService.handleEscalation(taskId, ESCALATION_CODE))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("Execution with id '" + task.getTaskDefinitionKey()
       + "' throws an escalation event with escalationCode '" + ESCALATION_CODE


### PR DESCRIPTION
Also:
- add comment "expected" in empty catch blocks in tests
- replace Arrays.asList() by List.of()
- simplify assertions
- fix typos / grammar issues in comments

Resolves Sonar issues of type java:S5778 Only one method invocation is expected when testing runtime exceptions

related to #88