### PR TITLE
chore: Fix blocker sonar issues in test code

### DIFF
--- a/engine-cdi/core/src/test/java/org/operaton/bpm/engine/cdi/test/impl/context/MultiInstanceTest.java
+++ b/engine-cdi/core/src/test/java/org/operaton/bpm/engine/cdi/test/impl/context/MultiInstanceTest.java
@@ -16,14 +16,19 @@
  */
 package org.operaton.bpm.engine.cdi.test.impl.context;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 
-import org.operaton.bpm.engine.cdi.BusinessProcess;
-import org.operaton.bpm.engine.cdi.test.CdiProcessEngineTestCase;
-import org.operaton.bpm.engine.test.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.operaton.bpm.engine.cdi.BusinessProcess;
+import org.operaton.bpm.engine.cdi.test.CdiProcessEngineTestCase;
+import org.operaton.bpm.engine.impl.persistence.entity.ProcessInstanceWithVariablesImpl;
+import org.operaton.bpm.engine.test.Deployment;
 
 /**
  * @author Daniel Meyer
@@ -38,7 +43,13 @@ public class MultiInstanceTest extends CdiProcessEngineTestCase {
 
     BusinessProcess businessProcess = getBeanInstance(BusinessProcess.class);
     businessProcess.setVariable("list", Arrays.asList("1","2"));
-    businessProcess.startProcessByKey("miParallelScriptTask");
+    var process = (ProcessInstanceWithVariablesImpl) businessProcess.startProcessByKey("miParallelScriptTask");
+    
+    assertFalse(process.isEnded());
+    assertFalse(process.isSuspended());
+    assertTrue(process.getExecutionEntity().isActive());
+    assertEquals(Arrays.asList("1","2"), process.getVariables().get("list"));
+    assertEquals("waitState", process.getExecutionEntity().getCurrentActivityId());
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/application/impl/event/ProcessApplicationEventListenerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/event/ProcessApplicationEventListenerTest.java
@@ -17,12 +17,18 @@
 package org.operaton.bpm.application.impl.event;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.operaton.bpm.application.impl.EmbeddedProcessApplication;
 import org.operaton.bpm.engine.ManagementService;
 import org.operaton.bpm.engine.RepositoryService;
@@ -39,11 +45,6 @@ import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.util.ProcessEngineBootstrapRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
 
 /**
  * @author Daniel Meyer
@@ -92,7 +93,9 @@ public class ProcessApplicationEventListenerTest {
     managementService.registerProcessApplication(deploymentId, processApplication.getReference());
     // I can start a process event though the process app does not provide an
     // event listener.
-    runtimeService.startProcessInstanceByKey("startToEnd");
+    ProcessInstance process = runtimeService.startProcessInstanceByKey("startToEnd");
+    
+    assertTrue(process.isEnded());
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/FormAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/FormAuthorizationTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.InputStream;
 
@@ -511,11 +512,9 @@ public class FormAuthorizationTest extends AuthorizationTest {
     createTask(taskId);
     createGrantAuthorization(TASK, taskId, userId, READ);
 
-    try {
-      // when
-      // Standalone task, no TaskFormData available
-      formService.getRenderedTaskForm(taskId);
-    } catch (NullValueException e) {}
+    // when
+    // Standalone task, no TaskFormData available
+    assertThrows(NullValueException.class, () -> formService.getRenderedTaskForm(taskId));
 
     deleteTask(taskId, true);
   }
@@ -528,11 +527,9 @@ public class FormAuthorizationTest extends AuthorizationTest {
     createTask(taskId);
     createGrantAuthorization(TASK, taskId, userId, READ_VARIABLE);
 
-    try {
-      // when
-      // Standalone task, no TaskFormData available
-      formService.getRenderedTaskForm(taskId);
-    } catch (NullValueException e) {}
+    // when
+    // Standalone task, no TaskFormData available
+    assertThrows(NullValueException.class, () -> formService.getRenderedTaskForm(taskId));
 
     deleteTask(taskId, true);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/IncidentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/IncidentAuthorizationTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Test.None;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
@@ -379,7 +380,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
       .hasMessageMatching(getMissingPermissionMessageRegex(UPDATE_INSTANCE, PROCESS_DEFINITION));
   }
 
-  @Test
+  @Test(expected = None.class)
   public void shouldAllowSetAnnotationWithUpdatePermissionOnAnyInstance() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -395,7 +396,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     // then no error is thrown
   }
 
-  @Test
+  @Test(expected = None.class)
   public void shouldAllowSetAnnotationWithUpdatePermissionOnInstance() {
     // given
     ProcessInstance instance = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -411,7 +412,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     // then no error is thrown
   }
 
-  @Test
+  @Test(expected = None.class)
   public void shouldAllowSetAnnotationWithUpdateInstancePermissionOnAnyDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -427,7 +428,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     // then no error is thrown
   }
 
-  @Test
+  @Test(expected = None.class)
   public void shouldAllowSetAnnotationWithUpdateInstancePermissionOnOneTaskDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -459,7 +460,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
       .hasMessageMatching(getMissingPermissionMessageRegex(UPDATE_INSTANCE, PROCESS_DEFINITION));
   }
 
-  @Test
+  @Test(expected = None.class)
   public void shouldAllowClearAnnotationWithUpdatePermissionOnAnyInstance() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -475,7 +476,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     // then no error is thrown
   }
 
-  @Test
+  @Test(expected = None.class)
   public void shouldAllowClearAnnotationWithUpdatePermissionOnInstance() {
     // given
     ProcessInstance instance = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -491,7 +492,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     // then no error is thrown
   }
 
-  @Test
+  @Test(expected = None.class)
   public void shouldAllowClearAnnotationWithUpdateInstancePermissionOnAnyDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -507,7 +508,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     // then no error is thrown
   }
 
-  @Test
+  @Test(expected = None.class)
   public void shouldAllowClearAnnotationWithUpdateInstancePermissionOnOneTaskDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -540,7 +541,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     cleanupStandalonIncident(jobId);
   }
 
-  @Test
+  @Test(expected = None.class)
   public void shouldAllowClearAnnotationOnStandaloneIncidentWithoutAuthorization() {
     // given
     String jobId = createStandaloneIncident();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseTableSchemaTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseTableSchemaTest.java
@@ -33,6 +33,7 @@ import org.apache.ibatis.datasource.pooled.PooledDataSource;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Test.None;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertTrue;
@@ -61,7 +62,7 @@ public class DatabaseTableSchemaTest {
     connection.close();
   }
 
-  @Test
+  @Test(expected=None.class)
   public void testPerformDatabaseSchemaOperationCreateTwice() throws Exception {
 
     Connection connection = pooledDataSource.getConnection();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterTaskQueryTest.java
@@ -16,12 +16,39 @@
  */
 package org.operaton.bpm.engine.test.api.filter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.operaton.bpm.engine.EntityTypes;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.filter.Filter;
 import org.operaton.bpm.engine.identity.Group;
 import org.operaton.bpm.engine.identity.User;
-import org.operaton.bpm.engine.impl.*;
+import org.operaton.bpm.engine.impl.Direction;
+import org.operaton.bpm.engine.impl.QueryEntityRelationCondition;
+import org.operaton.bpm.engine.impl.QueryOperator;
+import org.operaton.bpm.engine.impl.QueryOrderingProperty;
+import org.operaton.bpm.engine.impl.TaskQueryImpl;
+import org.operaton.bpm.engine.impl.TaskQueryProperty;
+import org.operaton.bpm.engine.impl.TaskQueryVariableValue;
+import org.operaton.bpm.engine.impl.VariableOrderProperty;
 import org.operaton.bpm.engine.impl.json.JsonTaskQueryConverter;
 import org.operaton.bpm.engine.impl.persistence.entity.FilterEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.SuspensionState;
@@ -39,22 +66,7 @@ import org.operaton.bpm.engine.variable.type.ValueType;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
-import java.util.*;
-
 import com.google.gson.JsonObject;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * @author Sebastian Menski
@@ -1267,7 +1279,7 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
 
     saveQuery(query);
 
-    long count = filterService.count(testFilter.getId(), (Query) null);
+    long count = filterService.count(testFilter.getId(), (Query<?, ?>) null);
     assertEquals(3, count);
   }
 
@@ -2403,7 +2415,7 @@ public class FilterTaskQueryTest extends PluggableProcessEngineTest {
 
     // when deserializing the query
     // then there is no exception
-    queryConverter.toObject(jsonObject);
+    assertNotNull(queryConverter.toObject(jsonObject));
   }
 
   protected void saveQuery(TaskQuery query) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AdminGroupsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AdminGroupsTest.java
@@ -38,6 +38,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.Test.None;
 import org.junit.rules.RuleChain;
 
 public class AdminGroupsTest {
@@ -95,7 +96,7 @@ public class AdminGroupsTest {
       .hasMessageContaining("Required admin authenticated group or user.");
   }
 
-  @Test
+  @Test(expected = None.class)
   public void testWithAdminGroup() {
     processEngineConfiguration.getAdminGroups().add("adminGroup");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AdminUsersTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AdminUsersTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.test.api.identity;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertNotNull;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Authorization.AUTH_TYPE_GRANT;
 import static org.operaton.bpm.engine.authorization.Permissions.READ;
@@ -116,9 +117,7 @@ public class AdminUsersTest {
     authorizationService.saveAuthorization(userAuth);
     processEngineConfiguration.setAuthorizationEnabled(true);
 
-    // when
-    managementService.getProperties();
-
-    // then no exception
+    // when/then no exception
+    assertNotNull(managementService.getProperties());
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AuthorizationServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AuthorizationServiceTest.java
@@ -46,6 +46,7 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -100,14 +101,19 @@ public class AuthorizationServiceTest extends PluggableProcessEngineTest {
     Authorization grantAuthorization = authorizationService.createNewAuthorization(AUTH_TYPE_GRANT);
     // I can set userId = null
     grantAuthorization.setUserId(null);
+    assertNull(grantAuthorization.getUserId());
     // I can set userId = ANY
     grantAuthorization.setUserId(ANY);
+    assertEquals(ANY, grantAuthorization.getUserId());
     // I can set anything else:
     grantAuthorization.setUserId("something");
+    assertEquals("something", grantAuthorization.getUserId());
     // I can set groupId = null
     grantAuthorization.setGroupId(null);
+    assertNull(grantAuthorization.getGroupId());
     // I can set anything else:
     grantAuthorization.setGroupId("something");
+    assertEquals("something", grantAuthorization.getGroupId());
   }
 
   @Test
@@ -115,14 +121,19 @@ public class AuthorizationServiceTest extends PluggableProcessEngineTest {
     Authorization revokeAuthorization = authorizationService.createNewAuthorization(AUTH_TYPE_REVOKE);
     // I can set userId = null
     revokeAuthorization.setUserId(null);
+    assertNull(revokeAuthorization.getUserId());
     // I can set userId = ANY
     revokeAuthorization.setUserId(ANY);
+    assertEquals(ANY, revokeAuthorization.getUserId());
     // I can set anything else:
     revokeAuthorization.setUserId("something");
+    assertEquals("something", revokeAuthorization.getUserId());
     // I can set groupId = null
     revokeAuthorization.setGroupId(null);
+    assertNull(revokeAuthorization.getGroupId());
     // I can set anything else:
     revokeAuthorization.setGroupId("something");
+    assertEquals("something", revokeAuthorization.getGroupId());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/ReadOnlyIdentityServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/ReadOnlyIdentityServiceTest.java
@@ -17,6 +17,8 @@
 package org.operaton.bpm.engine.test.api.identity;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.operaton.bpm.engine.IdentityService;
@@ -173,14 +175,14 @@ public class ReadOnlyIdentityServiceTest {
 
   @Test
   public void checkPassword() {
-    identityService.checkPassword("user", "password");
+    assertFalse(identityService.checkPassword("user", "password"));
   }
 
   @Test
   public void createQuery() {
-    identityService.createUserQuery().list();
-    identityService.createGroupQuery().list();
-    identityService.createTenantQuery().list();
+    assertNotNull(identityService.createUserQuery().list());
+    assertNotNull(identityService.createGroupQuery().list());
+    assertNotNull(identityService.createTenantQuery().list());
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/HistoryTimeToLiveDeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/HistoryTimeToLiveDeploymentTest.java
@@ -37,6 +37,9 @@ import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
 import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.commons.testing.ProcessEngineLoggingRule;
+
+import static org.junit.Assert.assertNotNull;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -210,7 +213,7 @@ public class HistoryTimeToLiveDeploymentTest {
     // then
     processEngineConfiguration.setEnforceHistoryTimeToLive(true);
     processEngineConfiguration.getDeploymentCache().purgeCache();
-    repositoryService.getProcessDefinition(definitions.getDeployedProcessDefinitions().get(0).getId());
+    assertNotNull(repositoryService.getProcessDefinition(definitions.getDeployedProcessDefinitions().get(0).getId()));
   }
 
   @Test
@@ -225,7 +228,7 @@ public class HistoryTimeToLiveDeploymentTest {
     // then
     processEngineConfiguration.setEnforceHistoryTimeToLive(true);
     processEngineConfiguration.getDeploymentCache().purgeCache();
-    repositoryService.getDecisionDefinition(definitions.getDeployedDecisionDefinitions().get(0).getId());
+    assertNotNull(repositoryService.getDecisionDefinition(definitions.getDeployedDecisionDefinitions().get(0).getId()));
   }
 
   @Test
@@ -240,7 +243,7 @@ public class HistoryTimeToLiveDeploymentTest {
     // then
     processEngineConfiguration.setEnforceHistoryTimeToLive(true);
     processEngineConfiguration.getDeploymentCache().purgeCache();
-    repositoryService.getCaseDefinition(definitions.getDeployedCaseDefinitions().get(0).getId());
+    assertNotNull(repositoryService.getCaseDefinition(definitions.getDeployedCaseDefinitions().get(0).getId()));
   }
 
   @Test


### PR DESCRIPTION
Add assertions to tests lacking them where they make sense. Add `@Test(expected = None.class)` to indicate when only the absense of an exception is required.

relates to: #88