### PR TITLE
refactor: Resolve Sonar warnings

### DIFF
--- a/clients/java/client/src/main/java/org/operaton/bpm/client/impl/ExternalTaskClientBuilderImpl.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/impl/ExternalTaskClientBuilderImpl.java
@@ -302,9 +302,7 @@ public class ExternalTaskClientBuilderImpl implements ExternalTaskClientBuilder 
 
     // object
     Map<String, DataFormat> dataFormats = lookupDataFormats();
-    dataFormats.forEach((key, format) -> {
-      valueMappers.addMapper(new ObjectValueMapper(key, format));
-    });
+    dataFormats.forEach((key, format) -> valueMappers.addMapper(new ObjectValueMapper(key, format)));
 
     // json/xml
     valueMappers.addMapper(new JsonValueMapper());

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/util/ProgrammaticBeanLookup.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/util/ProgrammaticBeanLookup.java
@@ -133,7 +133,7 @@ public class ProgrammaticBeanLookup {
       commandContext.registerCommandContextListener(new CreationalContextReleaseListener(creationalContext));
 
     } else {
-      LOG.warning("Obtained instance of @Dependent scoped bean "+bean +" outside of process engine command context. "
+      LOG.warning(() -> "Obtained instance of @Dependent scoped bean "+bean +" outside of process engine command context. "
           + "Bean instance will not be destroyed. This is likely to create a memory leak. Please use a normal scope like @ApplicationScoped for this bean.");
 
     }

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/jsf/TaskForm.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/jsf/TaskForm.java
@@ -77,7 +77,7 @@ public class TaskForm implements Serializable {
         return;
       }
       // return it anyway but log an info message
-      log.log(Level.INFO, "Called startTask method without proper parameter (taskId='"+taskId+"'; callbackUrl='"+callbackUrl+"') even if it seems we are not called by an AJAX Postback. Are you using the operatonTaskForm bean correctly?");
+      log.log(Level.INFO, () -> "Called startTask method without proper parameter (taskId='"+taskId+"'; callbackUrl='"+callbackUrl+"') even if it seems we are not called by an AJAX Postback. Are you using the operatonTaskForm bean correctly?");
       return;
     }
     // Note that we always run in a conversation
@@ -103,7 +103,7 @@ public class TaskForm implements Serializable {
         return;
       }
       // return it anyway but log an info message
-      log.log(Level.INFO, "Called startTask method without proper parameter (taskId='"+taskId+"'; callbackUrl='"+callbackUrl+"') even if it seems we are not called by an AJAX Postback. Are you using the operatonTaskForm bean correctly?");
+      log.log(Level.INFO, () -> "Called startTask method without proper parameter (taskId='"+taskId+"'; callbackUrl='"+callbackUrl+"') even if it seems we are not called by an AJAX Postback. Are you using the operatonTaskForm bean correctly?");
       return;
     }
     // Note that we always run in a conversation
@@ -125,7 +125,7 @@ public class TaskForm implements Serializable {
   }
 
   /**
-   * @deprecated use {@link startProcessInstanceByIdForm()} instead
+   * @deprecated use {@link #startProcessInstanceByIdForm()} instead
    *
    * @param processDefinitionId
    * @param callbackUrl

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/evaluation/ExpressionEvaluationHandler.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/evaluation/ExpressionEvaluationHandler.java
@@ -157,7 +157,7 @@ public class ExpressionEvaluationHandler {
   public boolean isFeelExpressionLanguage(String expressionLanguage) {
     ensureNotNull("expressionLanguage", expressionLanguage);
     return expressionLanguage.equals(DefaultDmnEngineConfiguration.FEEL_EXPRESSION_LANGUAGE) ||
-      expressionLanguage.toLowerCase().equals(DefaultDmnEngineConfiguration.FEEL_EXPRESSION_LANGUAGE_ALTERNATIVE) ||
+      expressionLanguage.equalsIgnoreCase(DefaultDmnEngineConfiguration.FEEL_EXPRESSION_LANGUAGE_ALTERNATIVE) ||
       expressionLanguage.equals(DefaultDmnEngineConfiguration.FEEL_EXPRESSION_LANGUAGE_DMN12) ||
       expressionLanguage.equals(DefaultDmnEngineConfiguration.FEEL_EXPRESSION_LANGUAGE_DMN13) ||
       expressionLanguage.equals(DefaultDmnEngineConfiguration.FEEL_EXPRESSION_LANGUAGE_DMN14) ||

--- a/engine-spring/core/src/main/java/org/operaton/bpm/engine/spring/components/aop/util/Scopifier.java
+++ b/engine-spring/core/src/main/java/org/operaton/bpm/engine/spring/components/aop/util/Scopifier.java
@@ -21,7 +21,6 @@ import org.springframework.beans.factory.config.BeanDefinitionHolder;
 import org.springframework.beans.factory.config.BeanDefinitionVisitor;
 import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.util.StringValueResolver;
 
 /**
  * this class was copied wholesale from Spring 3.1's RefreshScope, which Dave Syer wrote.
@@ -45,12 +44,7 @@ public class Scopifier extends BeanDefinitionVisitor {
 	}
 
 	public Scopifier(BeanDefinitionRegistry registry, String scope, boolean proxyTargetClass, boolean scoped) {
-		super(new StringValueResolver() {
-      @Override
-      public String resolveStringValue(String value) {
-				return value;
-			}
-		});
+		super(value -> value);
 		this.registry = registry;
 		this.proxyTargetClass = proxyTargetClass;
 		this.scope = scope;

--- a/engine-spring/core/src/main/java/org/operaton/bpm/engine/spring/components/config/xml/StateHandlerAnnotationBeanFactoryPostProcessor.java
+++ b/engine-spring/core/src/main/java/org/operaton/bpm/engine/spring/components/config/xml/StateHandlerAnnotationBeanFactoryPostProcessor.java
@@ -51,7 +51,7 @@ public class StateHandlerAnnotationBeanFactoryPostProcessor implements BeanFacto
 
         if (!beanAlreadyConfigured(registry, registryBeanName, ActivitiStateHandlerRegistry.class)) {
             String registryName = ActivitiStateHandlerRegistry.class.getName();
-            log.info("registering a " + registryName + " instance under bean name " + ActivitiContextUtils.ACTIVITI_REGISTRY_BEAN_NAME + ".");
+            log.info(() -> "registering a " + registryName + " instance under bean name " + ActivitiContextUtils.ACTIVITI_REGISTRY_BEAN_NAME + ".");
 
             RootBeanDefinition rootBeanDefinition = new RootBeanDefinition();
             rootBeanDefinition.setBeanClassName(registryName);

--- a/engine-spring/core/src/main/java/org/operaton/bpm/engine/spring/components/scope/ProcessScope.java
+++ b/engine-spring/core/src/main/java/org/operaton/bpm/engine/spring/components/scope/ProcessScope.java
@@ -83,7 +83,7 @@ public class ProcessScope implements Scope, InitializingBean, BeanFactoryPostPro
 
         ExecutionEntity executionEntity = null;
         try {
-            logger.fine(() -> "returning scoped object having beanName '" + name + "' for conversation ID '" + this.getConversationId() + "'. ");
+            logger.fine("returning scoped object having beanName '" + name + "' for conversation ID '" + this.getConversationId() + "'. ");
 
             ProcessInstance processInstance = Context.getBpmnExecutionContext().getProcessInstance();
             executionEntity = (ExecutionEntity) processInstance;
@@ -102,8 +102,7 @@ public class ProcessScope implements Scope, InitializingBean, BeanFactoryPostPro
             logger.warning("couldn't return value from process scope! " + StringUtil.getStackTrace(th));
         } finally {
             if (executionEntity != null) {
-              String executionEntityId = executionEntity.getId();
-              logger.fine(() -> "set variable '" + name + "' on executionEntity# " + executionEntityId);
+                logger.fine("set variable '" + name + "' on executionEntity# " + executionEntity.getId());
             }
         }
         return null;

--- a/engine-spring/core/src/main/java/org/operaton/bpm/engine/spring/components/scope/ProcessScope.java
+++ b/engine-spring/core/src/main/java/org/operaton/bpm/engine/spring/components/scope/ProcessScope.java
@@ -83,7 +83,7 @@ public class ProcessScope implements Scope, InitializingBean, BeanFactoryPostPro
 
         ExecutionEntity executionEntity = null;
         try {
-            logger.fine("returning scoped object having beanName '" + name + "' for conversation ID '" + this.getConversationId() + "'. ");
+            logger.fine(() -> "returning scoped object having beanName '" + name + "' for conversation ID '" + this.getConversationId() + "'. ");
 
             ProcessInstance processInstance = Context.getBpmnExecutionContext().getProcessInstance();
             executionEntity = (ExecutionEntity) processInstance;
@@ -102,7 +102,8 @@ public class ProcessScope implements Scope, InitializingBean, BeanFactoryPostPro
             logger.warning("couldn't return value from process scope! " + StringUtil.getStackTrace(th));
         } finally {
             if (executionEntity != null) {
-                logger.fine("set variable '" + name + "' on executionEntity# " + executionEntity.getId());
+              String executionEntityId = executionEntity.getId();
+              logger.fine(() -> "set variable '" + name + "' on executionEntity# " + executionEntityId);
             }
         }
         return null;
@@ -110,7 +111,7 @@ public class ProcessScope implements Scope, InitializingBean, BeanFactoryPostPro
 
   @Override
   public void registerDestructionCallback(String name, Runnable callback) {
-        logger.fine("no support for registering descruction callbacks implemented currently. registerDestructionCallback('" + name + "',callback) will do nothing.");
+        logger.fine(() -> "no support for registering descruction callbacks implemented currently. registerDestructionCallback('" + name + "',callback) will do nothing.");
     }
 
     private String getExecutionId() {
@@ -120,7 +121,7 @@ public class ProcessScope implements Scope, InitializingBean, BeanFactoryPostPro
   @Override
   public Object remove(String name) {
 
-        logger.fine("remove '" + name + "'");
+        logger.fine(() -> "remove '" + name + "'");
         return runtimeService.getVariable(getExecutionId(), name);
     }
 
@@ -150,7 +151,7 @@ public class ProcessScope implements Scope, InitializingBean, BeanFactoryPostPro
           public Object invoke(MethodInvocation methodInvocation) throws Throwable {
                 String methodName = methodInvocation.getMethod().getName();
 
-                logger.info("method invocation for " + methodName + ".");
+                logger.info(() -> "method invocation for " + methodName + ".");
                 if (methodName.equals("toString"))
                     return "SharedProcessInstance";
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/ErrorEventDefinition.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/ErrorEventDefinition.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.bpmn.parser;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Comparator;
 
@@ -29,13 +30,9 @@ import org.operaton.bpm.engine.ProcessEngineException;
  */
 public class ErrorEventDefinition implements Serializable {
 
-  public static Comparator<ErrorEventDefinition> comparator = new Comparator<>() {
-    @Override
-    public int compare(ErrorEventDefinition o1, ErrorEventDefinition o2) {
-      return o2.getPrecedence().compareTo(o1.getPrecedence());
-    }
-  };
+  public static Comparator<ErrorEventDefinition> comparator = (o1, o2) -> o2.getPrecedence().compareTo(o1.getPrecedence());
 
+  @Serial
   private static final long serialVersionUID = 1L;
 
   protected final String handlerActivityId;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/CronExpression.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/CronExpression.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.calendar;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.text.ParseException;
 import java.util.Calendar;
@@ -143,7 +144,7 @@ import java.util.TreeSet;
  * the month&quot;. So if the 15th is a Saturday, the trigger will fire on
  * Friday the 14th. If the 15th is a Sunday, the trigger will fire on Monday the
  * 16th. If the 15th is a Tuesday, then it will fire on Tuesday the 15th.
- * However if you specify &quot;1W&quot; as the value for day-of-month, and the
+ * However, if you specify &quot;1W&quot; as the value for day-of-month, and the
  * 1st is a Saturday, the trigger will fire on Monday the 3rd, as it will not
  * 'jump' over the boundary of a month's days.  The 'W' character can only be
  * specified when the day-of-month is a single day, not a range or list of days.
@@ -197,6 +198,7 @@ import java.util.TreeSet;
  */
 public class CronExpression implements Serializable, Cloneable {
 
+    @Serial
     private static final long serialVersionUID = 12423409423L;
 
     protected static final int SECOND = 0;
@@ -389,7 +391,7 @@ public class CronExpression implements Serializable, Cloneable {
             throw pe;
         } catch (Exception e) {
             throw new ParseException("Illegal cron expression format ("
-                    + e.toString() + ")", 0);
+                    + e + ")", 0);
         }
     }
 
@@ -735,8 +737,7 @@ public class CronExpression implements Serializable, Cloneable {
 
         TreeSet<Integer> set = getSet(type);
         switch(type) {
-            case SECOND:
-            case MINUTE:
+            case SECOND,MINUTE:
                 if ((val < 0 || val > 59 || end > 59) && (val != ALL_SPEC_INT)) {
                     throw new ParseException("Minute and Second values must be between 0 and 59", -1);
                 }
@@ -1180,12 +1181,9 @@ public class CronExpression implements Serializable, Cloneable {
                         daysToAdd = dow + (7 - cDow);
                     }
 
-                    boolean dayShifted = false;
-                    if (daysToAdd > 0) {
-                        dayShifted = true;
-                    }
+                    boolean dayShifted = daysToAdd > 0;
 
-                    day += daysToAdd;
+                  day += daysToAdd;
                     int weekOfMonth = day / 7;
                     if (day % 7 > 0) {
                         weekOfMonth++;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/operation/DbOperationManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/operation/DbOperationManager.java
@@ -256,14 +256,11 @@ public class DbOperationManager {
           Map<String, Class> dependentEntities = hasDbReferences.getDependentEntities();
 
           if (dependentEntities != null) {
-            dependentEntities.forEach((id, type) -> {
-
-              deletes.getOrDefault(type, defaultValue).forEach(o -> {
-                if (id.equals(o.getEntity().getId())) {
-                  o.setDependency(operation);
-                }
-              });
-            });
+            dependentEntities.forEach((id, type) -> deletes.getOrDefault(type, defaultValue).forEach(o -> {
+              if (id.equals(o.getEntity().getId())) {
+                o.setDependency(operation);
+              }
+            }));
           }
 
         }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/producer/DefaultDmnHistoryEventProducer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/producer/DefaultDmnHistoryEventProducer.java
@@ -68,35 +68,19 @@ public class DefaultDmnHistoryEventProducer implements DmnHistoryEventProducer {
 
   @Override
   public HistoryEvent createDecisionEvaluatedEvt(final DelegateExecution execution, final DmnDecisionEvaluationEvent evaluationEvent) {
-    return createHistoryEvent(evaluationEvent, new HistoricDecisionInstanceSupplier() {
-
-      @Override
-      public HistoricDecisionInstanceEntity createHistoricDecisionInstance(DmnDecisionLogicEvaluationEvent evaluationEvent, HistoricDecisionInstanceEntity rootDecisionInstance) {
-        return createDecisionEvaluatedEvt(evaluationEvent, (ExecutionEntity) execution);
-      }
-    });
+    return createHistoryEvent(evaluationEvent,
+      (evaluationEvent1, rootDecisionInstance) -> createDecisionEvaluatedEvt(evaluationEvent1, (ExecutionEntity) execution));
   }
 
   @Override
   public HistoryEvent createDecisionEvaluatedEvt(final DelegateCaseExecution execution, final DmnDecisionEvaluationEvent evaluationEvent) {
-    return createHistoryEvent(evaluationEvent, new HistoricDecisionInstanceSupplier() {
-
-      @Override
-      public HistoricDecisionInstanceEntity createHistoricDecisionInstance(DmnDecisionLogicEvaluationEvent evaluationEvent, HistoricDecisionInstanceEntity rootDecisionInstance) {
-        return createDecisionEvaluatedEvt(evaluationEvent, (CaseExecutionEntity) execution);
-      }
-    });
+    return createHistoryEvent(evaluationEvent,
+      (evaluationEvent1, rootDecisionInstance) -> createDecisionEvaluatedEvt(evaluationEvent1, (CaseExecutionEntity) execution));
   }
 
   @Override
   public HistoryEvent createDecisionEvaluatedEvt(final DmnDecisionEvaluationEvent evaluationEvent) {
-    return createHistoryEvent(evaluationEvent, new HistoricDecisionInstanceSupplier() {
-
-      @Override
-      public HistoricDecisionInstanceEntity createHistoricDecisionInstance(DmnDecisionLogicEvaluationEvent evaluationEvent, HistoricDecisionInstanceEntity rootDecisionInstance) {
-        return createDecisionEvaluatedEvt(evaluationEvent, rootDecisionInstance);
-      }
-    });
+    return createHistoryEvent(evaluationEvent, this::createDecisionEvaluatedEvt);
   }
 
   protected interface HistoricDecisionInstanceSupplier {
@@ -227,8 +211,8 @@ public class DefaultDmnHistoryEventProducer implements DmnHistoryEventProducer {
       initDecisionInstanceEventForDecisionLiteralExpression(event, expressionEvaluationEvent);
 
     } else {
-      event.setInputs(Collections.<HistoricDecisionInputInstance> emptyList());
-      event.setOutputs(Collections.<HistoricDecisionOutputInstance> emptyList());
+      event.setInputs(Collections.emptyList());
+      event.setOutputs(Collections.emptyList());
     }
   }
 
@@ -312,13 +296,13 @@ public class DefaultDmnHistoryEventProducer implements DmnHistoryEventProducer {
 
   protected void initDecisionInstanceEventForDecisionLiteralExpression(HistoricDecisionInstanceEntity event, DmnDecisionLiteralExpressionEvaluationEvent evaluationEvent) {
     // no inputs for expression
-    event.setInputs(Collections.<HistoricDecisionInputInstance> emptyList());
+    event.setInputs(Collections.emptyList());
 
     HistoricDecisionOutputInstanceEntity outputInstance = new HistoricDecisionOutputInstanceEntity(event.getRootProcessInstanceId(), event.getRemovalTime());
     outputInstance.setVariableName(evaluationEvent.getOutputName());
     outputInstance.setValue(evaluationEvent.getOutputValue());
 
-    event.setOutputs(Collections.<HistoricDecisionOutputInstance> singletonList(outputInstance));
+    event.setOutputs(Collections.singletonList(outputInstance));
   }
 
   protected void setReferenceToProcessInstance(HistoricDecisionInstanceEntity event, ExecutionEntity execution) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/ExecuteJobHelper.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/ExecuteJobHelper.java
@@ -28,16 +28,8 @@ public class ExecuteJobHelper {
 
   private static final JobExecutorLogger LOG = ProcessEngineLogger.JOB_EXECUTOR_LOGGER;
 
-  public static ExceptionLoggingHandler LOGGING_HANDLER = new ExceptionLoggingHandler() {
-
-    @Override
-    public void exceptionWhileExecutingJob(String jobId, Throwable exception) {
-
-      // Default behavior, just log exception
-      LOG.exceptionWhileExecutingJob(jobId, exception);
-    }
-
-  };
+  // Default behavior, just log exception
+  public static ExceptionLoggingHandler LOGGING_HANDLER = LOG::exceptionWhileExecutingJob;
 
   private ExecuteJobHelper() {
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/MigrateProcessInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/MigrateProcessInstanceCmd.java
@@ -189,11 +189,9 @@ public class MigrateProcessInstanceCmd extends AbstractMigrationCmd implements C
 
       walker.addPreVisitor(visitor);
 
-      walker.walkUntil(element -> {
-        // walk until top of instance tree is reached or until
-        // a node is reached for which we have not yet visited every child
-        return element == null || !visitor.hasVisitedAll(element.getChildScopeInstances());
-      });
+      // walk until top of instance tree is reached or until
+      // a node is reached for which we have not yet visited every child
+      walker.walkUntil(element -> element == null || !visitor.hasVisitedAll(element.getChildScopeInstances()));
     }
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationActivityNotifyListenerEnd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationActivityNotifyListenerEnd.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.impl.pvm.runtime.operation;
 
 import org.operaton.bpm.engine.delegate.ExecutionListener;
 import org.operaton.bpm.engine.impl.pvm.process.ScopeImpl;
-import org.operaton.bpm.engine.impl.pvm.runtime.Callback;
 import org.operaton.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
 
 /**
@@ -39,15 +38,11 @@ public class PvmAtomicOperationActivityNotifyListenerEnd extends PvmAtomicOperat
   protected void eventNotificationsCompleted(PvmExecutionImpl execution) {
 
     // perform activity end behavior
-    execution.dispatchDelayedEventsAndPerformOperation(new Callback<>() {
-
-      @Override
-      public Void callback(PvmExecutionImpl execution) {
-        execution.leaveActivityInstance();
-        execution.setActivityInstanceId(null);
-        execution.performOperation(ACTIVITY_END);
-        return null;
-      }
+    execution.dispatchDelayedEventsAndPerformOperation(execution1 -> {
+      execution1.leaveActivityInstance();
+      execution1.setActivityInstanceId(null);
+      execution1.performOperation(ACTIVITY_END);
+      return null;
     });
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationProcessStart.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationProcessStart.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.impl.pvm.runtime.operation;
 
 import org.operaton.bpm.engine.delegate.ExecutionListener;
 import org.operaton.bpm.engine.impl.pvm.process.ScopeImpl;
-import org.operaton.bpm.engine.impl.pvm.runtime.Callback;
 import org.operaton.bpm.engine.impl.pvm.runtime.LegacyBehavior;
 import org.operaton.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
 
@@ -64,21 +63,15 @@ public class PvmAtomicOperationProcessStart extends AbstractPvmEventAtomicOperat
 
   protected void eventNotificationsCompleted(PvmExecutionImpl execution) {
 
-    execution.continueIfExecutionDoesNotAffectNextOperation(new Callback<>() {
-      @Override
-      public Void callback(PvmExecutionImpl execution) {
-        execution.dispatchEvent(null);
-        return null;
-      }
-    }, new Callback<>() {
-      @Override
-      public Void callback(PvmExecutionImpl execution) {
+    execution.continueIfExecutionDoesNotAffectNextOperation(execution1 -> {
+      execution1.dispatchEvent(null);
+      return null;
+    }, execution2 -> {
 
-        execution.setIgnoreAsync(true);
-        execution.performOperation(ACTIVITY_START_CREATE_SCOPE);
+      execution2.setIgnoreAsync(true);
+      execution2.performOperation(ACTIVITY_START_CREATE_SCOPE);
 
-        return null;
-      }
+      return null;
     }, execution);
 
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationTransitionNotifyListenerEnd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/operation/PvmAtomicOperationTransitionNotifyListenerEnd.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.impl.pvm.runtime.operation;
 
 import org.operaton.bpm.engine.delegate.ExecutionListener;
 import org.operaton.bpm.engine.impl.pvm.process.ScopeImpl;
-import org.operaton.bpm.engine.impl.pvm.runtime.Callback;
 import org.operaton.bpm.engine.impl.pvm.runtime.PvmExecutionImpl;
 
 
@@ -46,14 +45,10 @@ public class PvmAtomicOperationTransitionNotifyListenerEnd extends PvmAtomicOper
       execution.setProcessInstanceStarting(false);
     }
 
-    execution.dispatchDelayedEventsAndPerformOperation(new Callback<>() {
-
-      @Override
-      public Void callback(PvmExecutionImpl execution) {
-        execution.leaveActivityInstance();
-        execution.performOperation(TRANSITION_DESTROY_SCOPE);
-        return null;
-      }
+    execution.dispatchDelayedEventsAndPerformOperation(execution1 -> {
+      execution1.leaveActivityInstance();
+      execution1.performOperation(TRANSITION_DESTROY_SCOPE);
+      return null;
     });
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/variables/scope/TargetVariableScopeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/variables/scope/TargetVariableScopeTest.java
@@ -68,7 +68,7 @@ public class TargetVariableScopeTest {
   public void testExecutionWithDelegateProcess() {
     // Given we create a new process instance
     VariableMap variables = Variables.createVariables().putValue("orderIds", List.of(new int[] { 1, 2, 3 }));
-    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("Process_MultiInstanceCallAcitivity",variables);
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("Process_MultiInstanceCallActivity",variables);
 
     // it runs without any problems
     assertThat(processInstance.isEnded()).isTrue();
@@ -79,7 +79,7 @@ public class TargetVariableScopeTest {
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/variables/scope/TargetVariableScopeTest.testExecutionWithScriptTargetScope.bpmn","org/operaton/bpm/engine/test/api/variables/scope/doer.bpmn"})
   public void testExecutionWithScriptTargetScope () {
     VariableMap variables = Variables.createVariables().putValue("orderIds", List.of(new int[] { 1, 2, 3 }));
-    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("Process_MultiInstanceCallAcitivity",variables);
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("Process_MultiInstanceCallActivity",variables);
 
     // it runs without any problems
     assertThat(processInstance.isEnded()).isTrue();
@@ -90,12 +90,12 @@ public class TargetVariableScopeTest {
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/variables/scope/TargetVariableScopeTest.testExecutionWithoutProperTargetScope.bpmn","org/operaton/bpm/engine/test/api/variables/scope/doer.bpmn"})
   public void testExecutionWithoutProperTargetScope () {
     VariableMap variables = Variables.createVariables().putValue("orderIds", List.of(new int[] { 1, 2, 3 }));
-    ProcessDefinition processDefinition = engineRule.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("Process_MultiInstanceCallAcitivity").singleResult();
+    ProcessDefinition processDefinition = engineRule.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("Process_MultiInstanceCallActivity").singleResult();
     RuntimeService runtimeService1 = runtimeService;
 
     // when/then
     //fails due to inappropriate variable scope target
-    assertThatThrownBy(() -> runtimeService1.startProcessInstanceByKey("Process_MultiInstanceCallAcitivity",variables))
+    assertThatThrownBy(() -> runtimeService1.startProcessInstanceByKey("Process_MultiInstanceCallActivity",variables))
       .isInstanceOf(ScriptEvaluationException.class)
       .hasMessageContaining("Unable to evaluate script while executing activity 'CallActivity_1' in the process definition with id '"
           + processDefinition.getId() + "': org.operaton.bpm.engine.ProcessEngineException: ENGINE-20011 "

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/variables/scope/TargetVariableScopeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/variables/scope/TargetVariableScopeTest.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.test.api.variables.scope;
 
 import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -45,6 +44,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * @author Askar Akhmerov
@@ -67,8 +67,8 @@ public class TargetVariableScopeTest {
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/variables/scope/TargetVariableScopeTest.testExecutionWithDelegateProcess.bpmn","org/operaton/bpm/engine/test/api/variables/scope/doer.bpmn"})
   public void testExecutionWithDelegateProcess() {
     // Given we create a new process instance
-    VariableMap variables = Variables.createVariables().putValue("orderIds", Arrays.asList(new int[]{1, 2, 3}));
-    ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceByKey("Process_MultiInstanceCallAcitivity",variables);
+    VariableMap variables = Variables.createVariables().putValue("orderIds", List.of(new int[] { 1, 2, 3 }));
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("Process_MultiInstanceCallAcitivity",variables);
 
     // it runs without any problems
     assertThat(processInstance.isEnded()).isTrue();
@@ -78,8 +78,8 @@ public class TargetVariableScopeTest {
   @Test
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/variables/scope/TargetVariableScopeTest.testExecutionWithScriptTargetScope.bpmn","org/operaton/bpm/engine/test/api/variables/scope/doer.bpmn"})
   public void testExecutionWithScriptTargetScope () {
-    VariableMap variables = Variables.createVariables().putValue("orderIds", Arrays.asList(new int[]{1, 2, 3}));
-    ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceByKey("Process_MultiInstanceCallAcitivity",variables);
+    VariableMap variables = Variables.createVariables().putValue("orderIds", List.of(new int[] { 1, 2, 3 }));
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("Process_MultiInstanceCallAcitivity",variables);
 
     // it runs without any problems
     assertThat(processInstance.isEnded()).isTrue();
@@ -89,12 +89,13 @@ public class TargetVariableScopeTest {
   @Test
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/variables/scope/TargetVariableScopeTest.testExecutionWithoutProperTargetScope.bpmn","org/operaton/bpm/engine/test/api/variables/scope/doer.bpmn"})
   public void testExecutionWithoutProperTargetScope () {
-    VariableMap variables = Variables.createVariables().putValue("orderIds", Arrays.asList(new int[]{1, 2, 3}));
+    VariableMap variables = Variables.createVariables().putValue("orderIds", List.of(new int[] { 1, 2, 3 }));
     ProcessDefinition processDefinition = engineRule.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("Process_MultiInstanceCallAcitivity").singleResult();
+    RuntimeService runtimeService1 = runtimeService;
 
     // when/then
     //fails due to inappropriate variable scope target
-    assertThatThrownBy(() -> engineRule.getRuntimeService().startProcessInstanceByKey("Process_MultiInstanceCallAcitivity",variables))
+    assertThatThrownBy(() -> runtimeService1.startProcessInstanceByKey("Process_MultiInstanceCallAcitivity",variables))
       .isInstanceOf(ScriptEvaluationException.class)
       .hasMessageContaining("Unable to evaluate script while executing activity 'CallActivity_1' in the process definition with id '"
           + processDefinition.getId() + "': org.operaton.bpm.engine.ProcessEngineException: ENGINE-20011 "
@@ -167,12 +168,13 @@ public class TargetVariableScopeTest {
         .done();
 
     ProcessDefinition processDefinition = testHelper.deployAndGetDefinition(instance);
+    String processDefinitionId = processDefinition.getId();
 
-    VariableMap variables = Variables.createVariables().putValue("orderIds", Arrays.asList(new int[]{1, 2, 3}));
+    VariableMap variables = Variables.createVariables().putValue("orderIds", List.of(new int[] { 1, 2, 3 }));
 
     // when/then
     //fails due to inappropriate variable scope target
-    assertThatThrownBy(() -> engineRule.getRuntimeService().startProcessInstanceById(processDefinition.getId(),variables))
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceById(processDefinitionId, variables))
       .isInstanceOf(ProcessEngineException.class)
       .hasMessageContaining("org.operaton.bpm.engine.ProcessEngineException: ENGINE-20011 Scope with specified activity Id SubProcess_2 and execution");
 
@@ -218,7 +220,7 @@ public class TargetVariableScopeTest {
       .endEvent()
       .done());
 
-    engineRule.getRuntimeService().startProcessInstanceByKey("process");
+    assertThatCode(() -> runtimeService.startProcessInstanceByKey("process")).doesNotThrowAnyException();
   }
 
   @Test
@@ -229,7 +231,7 @@ public class TargetVariableScopeTest {
       .endEvent()
       .done());
 
-    engineRule.getRuntimeService().startProcessInstanceByKey("process");
+    assertThatCode(() -> runtimeService.startProcessInstanceByKey("process")).doesNotThrowAnyException();
   }
 
   @Test
@@ -240,7 +242,7 @@ public class TargetVariableScopeTest {
         .operatonExecutionListenerClass(ExecutionListener.EVENTNAME_END, ExecutionListener.class)
       .done());
 
-    engineRule.getRuntimeService().startProcessInstanceByKey("process");
+    assertThatCode(() -> runtimeService.startProcessInstanceByKey("process")).doesNotThrowAnyException();
   }
 
   @Test
@@ -257,7 +259,7 @@ public class TargetVariableScopeTest {
     modelInstance.<SequenceFlow>getModelElementById("sequenceFlow").builder().addExtensionElement(listener);
 
     testHelper.deploy(modelInstance);
-    engineRule.getRuntimeService().startProcessInstanceByKey("process");
+    assertThatCode(() -> runtimeService.startProcessInstanceByKey("process")).doesNotThrowAnyException();
   }
 
   @Test
@@ -269,7 +271,7 @@ public class TargetVariableScopeTest {
       .endEvent()
       .done());
 
-    engineRule.getRuntimeService().startProcessInstanceByKey("process");
+    assertThatCode(() -> runtimeService.startProcessInstanceByKey("process")).doesNotThrowAnyException();
   }
 
   @Test
@@ -285,7 +287,7 @@ public class TargetVariableScopeTest {
       .endEvent()
       .done());
 
-    engineRule.getRuntimeService().startProcessInstanceByKey("process");
+    assertThatCode(() -> runtimeService.startProcessInstanceByKey("process")).doesNotThrowAnyException();
   }
 
   @Test
@@ -300,7 +302,7 @@ public class TargetVariableScopeTest {
       .endEvent()
       .done());
 
-    engineRule.getRuntimeService().startProcessInstanceByKey("process");
+    assertThatCode(() -> runtimeService.startProcessInstanceByKey("process")).doesNotThrowAnyException();
   }
 
   @Test
@@ -315,7 +317,7 @@ public class TargetVariableScopeTest {
       .endEvent()
       .done());
 
-    engineRule.getRuntimeService().startProcessInstanceByKey("process");
+    assertThatCode(() -> runtimeService.startProcessInstanceByKey("process")).doesNotThrowAnyException();
   }
 
   @Test
@@ -331,7 +333,7 @@ public class TargetVariableScopeTest {
       .endEvent()
       .done());
 
-    engineRule.getRuntimeService().startProcessInstanceByKey("process");
+    assertThatCode(() -> runtimeService.startProcessInstanceByKey("process")).doesNotThrowAnyException();
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/errorcode/DeadlockTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/errorcode/DeadlockTest.java
@@ -90,8 +90,7 @@ public class DeadlockTest {
   public void shouldProvokeDeadlock() throws InterruptedException {
     String databaseType = engineRule.getProcessEngineConfiguration().getDatabaseType();
     switch (databaseType) {
-    case DbSqlSessionFactory.MARIADB:
-    case DbSqlSessionFactory.MYSQL:
+    case DbSqlSessionFactory.MARIADB,DbSqlSessionFactory.MYSQL:
       provokeDeadlock();
       assertThat(sqlException.getSQLState()).isEqualTo(MARIADB_MYSQL.getSqlState());
       assertThat(sqlException.getErrorCode()).isEqualTo(MARIADB_MYSQL.getErrorCode());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobAcquisitionLoggingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobAcquisitionLoggingTest.java
@@ -71,7 +71,7 @@ public class JobAcquisitionLoggingTest {
             + " jobs for the process engine '" + processEngineConfiguration.getProcessEngineName() + "'");
 
     // asserting for a minimum occurrence as acquisition cycle should have started
-    assertThat(filteredLogList.size()).isGreaterThanOrEqualTo(1);
+    assertThat(filteredLogList).isNotEmpty();
   }
 
   @Test
@@ -94,6 +94,6 @@ public class JobAcquisitionLoggingTest {
             + processEngineConfiguration.getProcessEngineName() + "' : ");
 
     // Then observe the log appearing minimum 1 time, considering minimum 1 acquisition cycle
-    assertThat(filteredLogList.size()).isGreaterThanOrEqualTo(1);
+    assertThat(filteredLogList).isNotEmpty();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutionLoggingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutionLoggingTest.java
@@ -62,7 +62,7 @@ public class JobExecutionLoggingTest {
   @Test
   @Deployment(resources = { "org/operaton/bpm/engine/test/jobexecutor/SimpleAsyncDelayProcess.bpmn20.xml" })
   public void shouldLogJobsQueuedForExecution() {
-    // Replace job executor with one that has custom threadpool executor settings
+    // Replace job executor with one that has custom thread pool executor settings
     JobExecutionLoggingTest.TestJobExecutor testJobExecutor = new JobExecutionLoggingTest.TestJobExecutor();
     testJobExecutor.setMaxJobsPerAcquisition(10);
     processEngineConfiguration.setJobExecutor(testJobExecutor);
@@ -84,13 +84,13 @@ public class JobExecutionLoggingTest {
         + ": " + testJobExecutor.queueSize + ")");
 
     // Then minimum one instance of filled queue log will be available.
-    assertThat(filteredLogList.size()).isGreaterThanOrEqualTo(1);
+    assertThat(filteredLogList).isNotEmpty();
   }
 
   @Test
   @Deployment(resources = { "org/operaton/bpm/engine/test/jobexecutor/SimpleAsyncDelayProcess.bpmn20.xml" })
   public void shouldLogJobsInExecution() {
-    // Replace job executor with one that has custom threadpool executor settings
+    // Replace job executor with one that has custom thread pool executor settings
     JobExecutionLoggingTest.TestJobExecutor testJobExecutor = new JobExecutionLoggingTest.TestJobExecutor();
     processEngineConfiguration.setJobExecutor(testJobExecutor);
     testJobExecutor.registerProcessEngine(processEngineConfiguration.getProcessEngine());
@@ -109,13 +109,13 @@ public class JobExecutionLoggingTest {
             + "' : 1");
 
     // Since the execution will be happening for a while the check is made for more than one occurrence of the log.
-    assertThat(filteredLogList.size()).isGreaterThanOrEqualTo(1);
+    assertThat(filteredLogList).isNotEmpty();
   }
 
   @Test
   @Deployment(resources = { "org/operaton/bpm/engine/test/jobexecutor/SimpleAsyncDelayProcess.bpmn20.xml" })
   public void shouldLogAvailableJobExecutionThreads() {
-    // Replace job executor with one that has custom threadpool executor settings
+    // Replace job executor with one that has custom thread pool executor settings
     JobExecutionLoggingTest.TestJobExecutor testJobExecutor = new JobExecutionLoggingTest.TestJobExecutor();
     processEngineConfiguration.setJobExecutor(testJobExecutor);
     testJobExecutor.registerProcessEngine(processEngineConfiguration.getProcessEngine());
@@ -134,7 +134,7 @@ public class JobExecutionLoggingTest {
             + "' : 2");
 
     // Since the execution will be happening for a while the check is made for more than one occurrence of the log.
-    assertThat(filteredLogList.size()).isGreaterThanOrEqualTo(1);
+    assertThat(filteredLogList).isNotEmpty();
   }
 
   @Test
@@ -161,7 +161,7 @@ public class JobExecutionLoggingTest {
             + "' : ");
 
     // Minimum occurrences of the log is three
-    assertThat(filteredLogList.size()).isGreaterThanOrEqualTo(3);
+    assertThat(filteredLogList).hasSizeGreaterThanOrEqualTo(3);
   }
 
   public static class TestJobExecutor extends DefaultJobExecutor {

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/api/variables/scope/TargetVariableScopeTest.testExecutionWithDelegateProcess.bpmn
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/api/variables/scope/TargetVariableScopeTest.testExecutionWithDelegateProcess.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:operaton="http://operaton.org/schema/1.0/bpmn" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="_QXbGsM1tEeSUBcAXNpvE3Q" targetNamespace="http://operaton.org/schema/1.0/bpmn" exporter="Camunda Modeler" exporterVersion="1.3.0-dev" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
-  <bpmn2:process id="Process_MultiInstanceCallAcitivity" isExecutable="true">
+  <bpmn2:process id="Process_MultiInstanceCallActivity" isExecutable="true">
     <bpmn2:startEvent id="StartEvent_1" name="pro &#10;&#10;Orderpackage">
       <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
     </bpmn2:startEvent>
@@ -44,7 +44,7 @@
     </bpmn2:endEvent>
   </bpmn2:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_MultiInstanceCallAcitivity">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_MultiInstanceCallActivity">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_22" bpmnElement="StartEvent_1">
         <dc:Bounds x="342" y="293" width="36" height="36" />
         <bpmndi:BPMNLabel>

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/api/variables/scope/TargetVariableScopeTest.testExecutionWithScriptTargetScope.bpmn
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/api/variables/scope/TargetVariableScopeTest.testExecutionWithScriptTargetScope.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:operaton="http://operaton.org/schema/1.0/bpmn" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="_QXbGsM1tEeSUBcAXNpvE3Q" targetNamespace="http://camunda.org/schema/1.0/bpmn" exporter="Camunda Modeler" exporterVersion="1.3.0-dev" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
-  <bpmn2:process id="Process_MultiInstanceCallAcitivity" isExecutable="true">
+  <bpmn2:process id="Process_MultiInstanceCallActivity" isExecutable="true">
     <bpmn2:startEvent id="StartEvent_1" name="pro &#10;&#10;Orderpackage">
       <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
     </bpmn2:startEvent>
@@ -46,7 +46,7 @@
     </bpmn2:endEvent>
   </bpmn2:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_MultiInstanceCallAcitivity">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_MultiInstanceCallActivity">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_22" bpmnElement="StartEvent_1">
         <dc:Bounds x="342" y="293" width="36" height="36" />
         <bpmndi:BPMNLabel>

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/api/variables/scope/TargetVariableScopeTest.testExecutionWithoutProperTargetScope.bpmn
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/api/variables/scope/TargetVariableScopeTest.testExecutionWithoutProperTargetScope.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:operaton="http://operaton.org/schema/1.0/bpmn" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="_QXbGsM1tEeSUBcAXNpvE3Q" targetNamespace="http://camunda.org/schema/1.0/bpmn" exporter="Camunda Modeler" exporterVersion="1.3.0-dev" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
-  <bpmn2:process id="Process_MultiInstanceCallAcitivity" isExecutable="true">
+  <bpmn2:process id="Process_MultiInstanceCallActivity" isExecutable="true">
     <bpmn2:startEvent id="StartEvent_1" name="pro &#10;&#10;Orderpackage">
       <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
     </bpmn2:startEvent>
@@ -46,7 +46,7 @@
     </bpmn2:endEvent>
   </bpmn2:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_MultiInstanceCallAcitivity">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_MultiInstanceCallActivity">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_22" bpmnElement="StartEvent_1">
         <dc:Bounds x="342" y="293" width="36" height="36" />
         <bpmndi:BPMNLabel>

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/BpmnModelConstants.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/BpmnModelConstants.java
@@ -46,6 +46,7 @@ public final class BpmnModelConstants {
   /** Xml Schema is the default type language */
   public static final String XML_SCHEMA_NS = "http://www.w3.org/2001/XMLSchema";
 
+  /** The XPath namespace */
   public static final String XPATH_NS = "http://www.w3.org/1999/XPath";
 
   /**

--- a/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/impl/CmmnModelConstants.java
+++ b/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/impl/CmmnModelConstants.java
@@ -37,6 +37,7 @@ public class CmmnModelConstants {
   /** Xml Schema is the default type language */
   public static final String XML_SCHEMA_NS = "http://www.w3.org/2001/XMLSchema";
 
+  /** The XPath namespace */
   public static final String XPATH_NS = "http://www.w3.org/1999/XPath";
 
   /** Operaton namespace */

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/DomUtil.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/DomUtil.java
@@ -199,7 +199,7 @@ public final class DomUtil {
 
     @Override
     public void warning(SAXParseException spe) {
-      LOGGER.warning(getParseExceptionInfo(spe));
+      LOGGER.warning(() -> getParseExceptionInfo(spe));
     }
 
     @Override

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/impl/parser/ParserTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/impl/parser/ParserTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.model.xml.impl.parser;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelInstance;
@@ -25,7 +26,6 @@ import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import java.io.InputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ParserTest {
 
@@ -46,23 +46,27 @@ class ParserTest {
 
   @Test
   void shouldProhibitExternalSchemaAccessViaSystemProperty() {
-    // given
-    // the external schema access property is not supported on certain
-    // IBM JDK versions, in which case schema access cannot be restricted
-    Assumptions.assumeTrue(doesJdkSupportExternalSchemaAccessProperty());
+    Assertions.assertThatThrownBy(() -> {
+      // given
+      // the external schema access property is not supported on certain
+      // IBM JDK versions, in which case schema access cannot be restricted
+      Assumptions.assumeTrue(doesJdkSupportExternalSchemaAccessProperty());
 
-    TestModelParser modelParser = new TestModelParser();
-    String testXml = "org/operaton/bpm/model/xml/impl/parser/ExternalSchemaAccess.xml";
-    InputStream testXmlAsStream = this.getClass().getClassLoader().getResourceAsStream(testXml);
-    System.setProperty(ACCESS_EXTERNAL_SCHEMA_PROP, "");
+      System.setProperty(ACCESS_EXTERNAL_SCHEMA_PROP, "");
 
-    // when
-    assertThatThrownBy(() -> modelParser.parseModelFromStream(testXmlAsStream))
-      // then
-      .isInstanceOf(ModelParseException.class)
-      .hasMessage("SAXException while parsing input stream");
+      try {
+        TestModelParser modelParser = new TestModelParser();
+        String testXml = "org/operaton/bpm/model/xml/impl/parser/ExternalSchemaAccess.xml";
+        InputStream testXmlAsStream = this.getClass().getClassLoader().getResourceAsStream(testXml);
 
-    System.clearProperty(ACCESS_EXTERNAL_SCHEMA_PROP);
+        // when
+        modelParser.parseModelFromStream(testXmlAsStream);
+      } finally {
+        System.clearProperty(ACCESS_EXTERNAL_SCHEMA_PROP);
+      }
+    }) // then
+            .isInstanceOf(ModelParseException.class)
+            .hasMessage("SAXException while parsing input stream");
 
   }
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/impl/parser/ParserTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/impl/parser/ParserTest.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.model.xml.impl.parser;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelInstance;
@@ -26,6 +25,7 @@ import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import java.io.InputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ParserTest {
 
@@ -46,27 +46,23 @@ class ParserTest {
 
   @Test
   void shouldProhibitExternalSchemaAccessViaSystemProperty() {
-    Assertions.assertThatThrownBy(() -> {
-      // given
-      // the external schema access property is not supported on certain
-      // IBM JDK versions, in which case schema access cannot be restricted
-      Assumptions.assumeTrue(doesJdkSupportExternalSchemaAccessProperty());
+    // given
+    // the external schema access property is not supported on certain
+    // IBM JDK versions, in which case schema access cannot be restricted
+    Assumptions.assumeTrue(doesJdkSupportExternalSchemaAccessProperty());
 
-      System.setProperty(ACCESS_EXTERNAL_SCHEMA_PROP, "");
+    TestModelParser modelParser = new TestModelParser();
+    String testXml = "org/operaton/bpm/model/xml/impl/parser/ExternalSchemaAccess.xml";
+    InputStream testXmlAsStream = this.getClass().getClassLoader().getResourceAsStream(testXml);
+    System.setProperty(ACCESS_EXTERNAL_SCHEMA_PROP, "");
 
-      try {
-        TestModelParser modelParser = new TestModelParser();
-        String testXml = "org/operaton/bpm/model/xml/impl/parser/ExternalSchemaAccess.xml";
-        InputStream testXmlAsStream = this.getClass().getClassLoader().getResourceAsStream(testXml);
+    // when
+    assertThatThrownBy(() -> modelParser.parseModelFromStream(testXmlAsStream))
+      // then
+      .isInstanceOf(ModelParseException.class)
+      .hasMessage("SAXException while parsing input stream");
 
-        // when
-        modelParser.parseModelFromStream(testXmlAsStream);
-      } finally {
-        System.clearProperty(ACCESS_EXTERNAL_SCHEMA_PROP);
-      }
-    }) // then
-            .isInstanceOf(ModelParseException.class)
-            .hasMessage("SAXException while parsing input stream");
+    System.clearProperty(ACCESS_EXTERNAL_SCHEMA_PROP);
 
   }
 

--- a/qa/ensure-clean-db-plugin/src/main/java/org/operaton/qa/impl/EnsureCleanDbPlugin.java
+++ b/qa/ensure-clean-db-plugin/src/main/java/org/operaton/qa/impl/EnsureCleanDbPlugin.java
@@ -75,7 +75,7 @@ public class EnsureCleanDbPlugin implements BpmPlatformPlugin {
           if (!cachePurgeReport.isEmpty()) {
             builder.append(CACHE_IS_NOT_CLEAN).append(cachePurgeReport.getPurgeReportAsString());
           }
-          logger.log(Level.INFO, builder.toString());
+          logger.info(builder::toString);
         }
       }
       catch(Throwable e) {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/FeelEngineIT.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/FeelEngineIT.java
@@ -72,7 +72,7 @@ public class FeelEngineIT extends AbstractFoxPlatformIntegrationTest {
         .singleResult();
 
     assertThat(hdi.getOutputs()).hasSize(1);
-    assertThat(hdi.getOutputs().get(0).getValue()).isEqualTo(true);
+    assertThat(hdi.getOutputs().get(0).getValue()).isEqualTo(Boolean.TRUE);
   }
 
   @Test
@@ -90,7 +90,7 @@ public class FeelEngineIT extends AbstractFoxPlatformIntegrationTest {
         .singleResult();
 
     assertThat(hdi.getOutputs()).hasSize(1);
-    assertThat(hdi.getOutputs().get(0).getValue()).isEqualTo(true);
+    assertThat(hdi.getOutputs().get(0).getValue()).isEqualTo(Boolean.TRUE);
   }
 
   // HELPER

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebappUiIntegrationTest.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebappUiIntegrationTest.java
@@ -71,14 +71,11 @@ public class AbstractWebappUiIntegrationTest extends AbstractWebIntegrationTest 
 
   public static ExpectedCondition<Boolean> currentURIIs(final URI pageURI) {
 
-    return new ExpectedCondition<>() {
-      @Override
-      public Boolean apply(WebDriver webDriver) {
-        try {
-          return new URI(webDriver.getCurrentUrl()).equals(pageURI);
-        } catch (URISyntaxException e) {
-          return false;
-        }
+    return webDriver -> {
+      try {
+        return new URI(webDriver.getCurrentUrl()).equals(pageURI);
+      } catch (URISyntaxException e) {
+        return false;
       }
     };
 
@@ -86,12 +83,7 @@ public class AbstractWebappUiIntegrationTest extends AbstractWebIntegrationTest 
 
   public static ExpectedCondition<Boolean> containsCurrentUrl(final String url) {
 
-    return new ExpectedCondition<>() {
-      @Override
-      public Boolean apply(WebDriver webDriver) {
-        return webDriver.getCurrentUrl().contains(url);
-      }
-    };
+    return webDriver -> webDriver.getCurrentUrl().contains(url);
 
   }
 

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/rest/RestIT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/rest/RestIT.java
@@ -89,7 +89,7 @@ public class RestIT extends AbstractWebIntegrationTest {
       if (definitionJson.getString("key").equals("ReviewInvoice")) {
         assertEquals("http://bpmn.io/schema/bpmn", definitionJson.getString("category"));
         assertEquals("Review Invoice", definitionJson.getString("name"));
-        assertTrue(definitionJson.getString("resource").equals("reviewInvoice.bpmn"));
+        assertEquals("reviewInvoice.bpmn", definitionJson.getString("resource"));
       } else if (definitionJson.getString("key").equals("invoice")) {
         assertEquals("http://www.omg.org/spec/BPMN/20100524/MODEL", definitionJson.getString("category"));
         assertEquals("Invoice Receipt", definitionJson.getString("name"));
@@ -331,7 +331,7 @@ public class RestIT extends AbstractWebIntegrationTest {
     MediaType actual = response.getType();
     assertEquals(200, response.getStatus());
     // use startsWith cause sometimes server also returns quality parameters (e.g. websphere/wink)
-    assertTrue("Expected: " + expected + " Actual: " + actual, actual.toString().startsWith(expected.toString()));
+    assertTrue("Expected: " + expected + " Actual: " + actual, actual.toString().startsWith(expected));
   }
 
 }

--- a/webapps/assembly/src/main/java/org/operaton/bpm/admin/impl/web/SetupResource.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/admin/impl/web/SetupResource.java
@@ -77,12 +77,9 @@ public class SetupResource {
       throw LOGGER.invalidRequestEngineNotFoundForName(processEngineName);
     }
 
-    SecurityActions.runWithoutAuthentication(new SecurityAction<Void>() {
-      @Override
-      public Void execute() {
-        createInitialUserInternal(processEngineName, user, processEngine);
-        return null;
-      }
+    SecurityActions.runWithoutAuthentication((SecurityAction<Void>) () -> {
+      createInitialUserInternal(processEngineName, user, processEngine);
+      return null;
     }, processEngine);
 
   }

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/engine/ProcessEnginesFilter.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/engine/ProcessEnginesFilter.java
@@ -28,7 +28,6 @@ import org.operaton.bpm.tasklist.TasklistRuntimeDelegate;
 import org.operaton.bpm.webapp.impl.IllegalWebAppConfigurationException;
 import org.operaton.bpm.webapp.impl.filter.AbstractTemplateFilter;
 import org.operaton.bpm.webapp.impl.security.SecurityActions;
-import org.operaton.bpm.webapp.impl.security.SecurityActions.SecurityAction;
 import org.operaton.bpm.webapp.impl.security.filter.headersec.provider.impl.ContentSecurityPolicyProvider;
 import org.operaton.bpm.webapp.impl.util.ServletContextUtil;
 import org.operaton.bpm.webapp.plugin.spi.AppPlugin;
@@ -76,7 +75,7 @@ public class ProcessEnginesFilter extends AbstractTemplateFilter {
   public static final String PLUGIN_PACKAGES_PLACEHOLDER = "$PLUGIN_PACKAGES";
   public static final String CSP_NONCE_PLACEHOLDER = "$CSP_NONCE";
 
-  public static Pattern APP_PREFIX_PATTERN = Pattern.compile("/app/(?:([\\w-]+?)/(?:(index\\.html|[\\w-]+)?/?([^?]*)?)?)?");
+  public static final Pattern APP_PREFIX_PATTERN = Pattern.compile("/app/(?:([\\w-]+?)/(?:(index\\.html|[\\w-]+)?/?([^?]*)?)?)?");
 
   protected final CockpitRuntimeDelegate cockpitRuntimeDelegate;
   protected final AdminRuntimeDelegate adminRuntimeDelegate;
@@ -251,14 +250,8 @@ public class ProcessEnginesFilter extends AbstractTemplateFilter {
 
     } else {
 
-      return SecurityActions.runWithoutAuthentication(new SecurityAction<Boolean>() {
-        @Override
-        public Boolean execute() {
-          return processEngine.getIdentityService()
-              .createUserQuery()
-              .memberOfGroup(Groups.OPERATON_ADMIN).count() == 0;
-        }
-      }, processEngine);
+      return SecurityActions.runWithoutAuthentication(
+        () -> processEngine.getIdentityService().createUserQuery().memberOfGroup(Groups.OPERATON_ADMIN).count() == 0, processEngine);
 
     }
 
@@ -323,7 +316,7 @@ public class ProcessEnginesFilter extends AbstractTemplateFilter {
       builder.append(definition);
     }
 
-    return "[" + builder.toString() + "]";
+    return "[" + builder + "]";
   }
 
   protected <T extends AppPlugin> CharSequence createPluginDependenciesStr(String appName) {
@@ -342,7 +335,7 @@ public class ProcessEnginesFilter extends AbstractTemplateFilter {
       builder.append(definition);
     }
 
-    return "[" + builder.toString() + "]";
+    return "[" + builder + "]";
   }
 
   @SuppressWarnings("unchecked")

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/SecurityFilterConfig.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/SecurityFilterConfig.java
@@ -89,7 +89,7 @@ public class SecurityFilterConfig {
       this.authorizer = authorizer;
     }
     public String[] getParsedMethods() {
-      if(methods == null || methods.isEmpty() || methods.equals("*") || methods.toUpperCase().equals("ALL")) {
+      if(methods == null || methods.isEmpty() || methods.equals("*") || methods.equalsIgnoreCase("ALL")) {
         return new String[0];
       } else {
         return methods.split(",");

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/headersec/provider/impl/StrictTransportSecurityProvider.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/headersec/provider/impl/StrictTransportSecurityProvider.java
@@ -45,7 +45,7 @@ public class StrictTransportSecurityProvider extends HeaderSecurityProvider {
     MAX_AGE("hstsMaxAge"),
     INCLUDE_SUBDOMAINS_DISABLED("hstsIncludeSubdomainsDisabled");
 
-    protected String name;
+    private final String name;
 
     Parameters(String name) {
       this.name = name;
@@ -60,9 +60,7 @@ public class StrictTransportSecurityProvider extends HeaderSecurityProvider {
   @Override
   public Map<String, String> initParams() {
 
-    Arrays.asList(Parameters.values()).forEach(parameter -> {
-      initParams.put(parameter.getName(), null);
-    });
+    Arrays.asList(Parameters.values()).forEach(parameter -> initParams.put(parameter.getName(), null));
 
     return initParams;
   }


### PR DESCRIPTION
- Use deferred log message evaluation
  resolves Sonar issues of type java:S2629 - "Preconditions" and logging arguments should not require evaluation
- add missing assertions
- java:S5778 Only one method invocation is expected when testing runtime exceptions
- java:S6208 Merge previous cases into one using comma-separated label
  Comma-separated labels should be used in Switch with colon case
- Convert to expression lambda
- Replace toUpperCase()/toLowerCase() and equals() calls with a single equalsIgnoreCase() call
- java:S5838 Use dedicated AssertJ assertions

related to #88