### PR TITLE
feat(test): New ParameterizedTestExtension

### DIFF
--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/dmn/engine/test/junit5/ParameterizedTestExtensionTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/dmn/engine/test/junit5/ParameterizedTestExtensionTest.java
@@ -1,0 +1,68 @@
+/*/*
+ * Copyright and/or licensed under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. This file is licensed to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.dmn.engine.test.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameterized;
+import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameters;
+
+/**
+ * This test uses the ParameterizedTestExtension and demonstrates that the
+ * passed parameters are actually available in the @BeforeEach method.
+ */
+@Parameterized
+public class ParameterizedTestExtensionTest {
+
+	protected String requestUrl;
+	protected boolean alreadyAuthenticated;
+
+	public ParameterizedTestExtensionTest(String requestUrl, boolean alreadyAuthenticated) {
+		this.requestUrl = requestUrl;
+		this.alreadyAuthenticated = alreadyAuthenticated;
+	}
+
+	@Parameters
+	public static Collection<Object[]> getRequestUrls() {
+		return Arrays.asList(new Object[][] { { "/app/cockpit/default/", true }, { "/app/cockpit/engine2/", false }, });
+	}
+
+	@BeforeEach
+	public void setup() throws Exception {
+		requestUrl = requestUrl + "processed/";
+	}
+
+	@AfterEach
+	public void teardown() {
+		requestUrl = null;
+	}
+
+	@TestTemplate
+	public void ensureBeforeEachCanProcessParamaters() throws Exception {
+		if (alreadyAuthenticated) {
+			assertEquals("/app/cockpit/default/processed/", requestUrl);
+		} else {
+			assertEquals("/app/cockpit/engine2/processed/", requestUrl);
+		}
+	}
+
+}


### PR DESCRIPTION
Add an extension for JUnit 5 to help migration of JUnit 4 Tests like ContainerAuthenticationFilterTest that are annotated with @RunWith(Parameterized.class). The extension implements the same mechanism for JUnit 5 such that the required code changes are minimal.

For the review please take into account the license header. I started a discussion at: 
https://forum.operaton.org/t/license-header-for-new-files/195

relates to #216, #27