### PR TITLE
fix(webapps/assembly): Fix selectPDStatistics Query

### DIFF
--- a/webapps/assembly/src/main/resources/org/operaton/bpm/cockpit/plugin/base/queries/processDefinition.xml
+++ b/webapps/assembly/src/main/resources/org/operaton/bpm/cockpit/plugin/base/queries/processDefinition.xml
@@ -97,7 +97,7 @@
 
               <!-- incidents -->
               left outer join
-                  <!-- Sum all incidents grouped by process definition and incident type-->
+                  <!-- Sum all incidents grouped by process definition -->
                   (
                     select
                         I.PROC_DEF_ID_

--- a/webapps/assembly/src/main/resources/org/operaton/bpm/cockpit/plugin/base/queries/processDefinition.xml
+++ b/webapps/assembly/src/main/resources/org/operaton/bpm/cockpit/plugin/base/queries/processDefinition.xml
@@ -101,7 +101,6 @@
                   (
                     select
                         I.PROC_DEF_ID_
-                      , I.INCIDENT_TYPE_
                       , count(I.ID_) as INCIDENT_COUNT_
                     from
                         ${prefix}ACT_RU_INCIDENT I
@@ -111,7 +110,7 @@
                       <include refid="org.operaton.bpm.engine.impl.persistence.entity.TenantEntity.queryTenantCheckWithPrefix" />
                     </where>
                     group by
-                        I.PROC_DEF_ID_, I.INCIDENT_TYPE_
+                        I.PROC_DEF_ID_
                   ) INC
               on
                   PROCDEF.ID_ = INC.PROC_DEF_ID_

--- a/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/ProcessDefinitionRestServiceTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/cockpit/plugin/base/ProcessDefinitionRestServiceTest.java
@@ -29,6 +29,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.SuspensionState;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.rest.dto.CountResultDto;
 import org.operaton.bpm.engine.runtime.Execution;
+import org.operaton.bpm.engine.runtime.Incident;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.junit.After;
@@ -391,5 +392,74 @@ public class ProcessDefinitionRestServiceTest extends AbstractCockpitPluginTest 
     // verify order by incidents
     verifyOrderedResult("incidents", "asc", Arrays.asList("p2", "B", "p1", "A"));
     verifyOrderedResult("incidents", "desc", Arrays.asList("A", "p1", "B", "p2"));
+  }
+
+  @Test
+  public void shouldReturnCorrectStatistics() {
+    // given a process with two process instances
+    deployProcesses(1, "A", "Process A", 2, 0, "tenant1");
+
+    var processInstances = runtimeService.createExecutionQuery()
+        .processDefinitionKey("A")
+        .list();
+
+    assertThat(processInstances).hasSize(2);
+
+    var processIncidents = runtimeService.createIncidentQuery()
+        .processDefinitionKeyIn("A")
+        .list();
+
+    assertIncidentSize(processIncidents, 0);
+
+    var pi1 = processInstances.get(0);
+    var pi2 = processInstances.get(1);
+
+    // and two different (failedJob, failedExternalTask) incidents occur for each process instance
+
+    addIncidentToProcess(pi1, "failedJob");
+    addIncidentToProcess(pi1, "failedExternalTask");
+
+    addIncidentToProcess(pi2, "failedJob");
+    addIncidentToProcess(pi2, "failedExternalTask");
+
+    processIncidents = runtimeService.createIncidentQuery()
+        .processDefinitionKeyIn("A")
+        .list();
+
+    assertIncidentSize(processIncidents, 4);
+
+    assertIncidentSize(processIncidents, "failedJob", 2);
+    assertIncidentSize(processIncidents, "failedExternalTask", 2);
+
+    // when
+    var results = resource.queryStatistics(uriInfo, 0, 50);
+
+    // then statistics should be correct
+    assertThat(results)
+        .withFailMessage("The result should contain one entry (process definition 'Process A')")
+        .hasSize(1);
+
+    assertThat(results.get(0).getInstances())
+        .withFailMessage("The number of process instances should be 2")
+        .isEqualTo(2);
+
+    assertThat(results.get(0).getIncidents())
+        .withFailMessage("The total number of incidents should be 4")
+        .isEqualTo(4);
+  }
+
+  private void addIncidentToProcess(Execution processInstance, String incidentType) {
+    runtimeService.createIncident(incidentType, processInstance.getId(), "someConfig", "The message of failure");
+  }
+
+  private void assertIncidentSize(List<Incident> incidents, int size) {
+    assertThat(incidents.size()).isEqualTo(size);
+  }
+
+  private void assertIncidentSize(List<Incident> incidents, String incidentType, int size) {
+    assertThat(incidents.stream()
+        .filter(incident -> incidentType.equals(incident.getIncidentType()))
+        .count())
+        .isEqualTo(size);
   }
 }


### PR DESCRIPTION
Context: The query selectPDStatistics calculates the total processInstances wrong.
Used-by: ProcessDefinitionRestService#getStatisticsCount

Why: The group by incidentType part of the query should not be used for counting the total process instances.

Tests: The commit adds a test which expects the correct statistics returned when process instances related to incidents with different types are used.

Co-authored-by: Petros Savvidis <petros.savvidis@camunda.com>
Related to https://jira.camunda.com/browse/SUPPORT-24279

Backported commit 586037c29a from the camunda-bpm-platform repository.
Original author: Miklas Boskamp <20189772+mboskamp@users.noreply.github.com>