### PR TITLE
build: Improve Integration Test pipeline

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,7 @@
 name: Integration Tests
 
 on:
-  workflow_dispatch:        # Allows manual trigger
+  workflow_dispatch:
     inputs:
       java_version:
         description: 'Java version to use'
@@ -13,7 +13,7 @@ on:
           - '["17"]'
           - '["21"]'
           - '["17", "21"]'
-      test_suite:
+      testsuite:
         description: 'Integration test suite to run'
         type: choice
         required: true
@@ -26,10 +26,13 @@ on:
         description: 'Container to use for integration tests'
         type: choice
         required: true
-        default: '["tomcat"]'
+        default: '["tomcat", "wildfly"]'
         options:
           - '["tomcat"]'
+          - '["tomcat9"]'
           - '["wildfly"]'
+          - '["wildfly26"]'
+          - '["tomcat", "tomcat9", "wildfly", "wildfly26"]'
           - '["tomcat", "wildfly"]'
       database:
         description: 'Database to use for integration tests'
@@ -38,8 +41,8 @@ on:
         default: '["h2"]'
         options:
           - '["h2"]'
-          - '["postgres"]'
-          - '["h2", "postgres"]'
+          - '["postgresql"]'
+          - '["h2", "postgresql"]'
 
 permissions:
   contents: read
@@ -55,9 +58,10 @@ jobs:
     name: Build
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         java: ${{ fromJson(github.event.inputs.java_version || '["17", "21"]') }}
-        test_suite: ${{ fromJson(github.event.inputs.test_suite || '["engine", "webapps"]') }}
+        testsuite: ${{ fromJson(github.event.inputs.testsuite || '["engine", "webapps"]') }}
         container: ${{ fromJson(github.event.inputs.container || '["tomcat", "wildfly"]') }}
         database: ${{ fromJson(github.event.inputs.database || '["h2", "postgres"]') }}
     steps:
@@ -80,17 +84,25 @@ jobs:
         id: maven-build
         shell: bash
         run: |
-          ./mvnw -P${{ matrix.test_suite }}-integration,${{ matrix.container }},${{ matrix.database }} clean install
+          ./mvnw -DskipTests -Pdistro,distro-webjar,distro-${{ matrix.container }},${{ matrix.container }},h2-in-memory clean install
+      - name: Execute Integration Tests
+        id: maven-integration-tests
+        shell: bash
+        run: |
+          ./mvnw -P${{ matrix.testsuite }}-integration,${{ matrix.container }},${{ matrix.database }} verify -f qa
       - name: Publish Test Report
         if: always()
         uses: mikepenz/action-junit-report@v4
         with:
           report_paths: ${{ github.workspace }}/**/target/surefire-reports/*.xml
           require_passed_tests: true
-      - name: Upload Surefire Reports
+      - name: Upload Artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: surefire-reports-${{ matrix.test_suite }}-${{ matrix.container }}-${{ matrix.database }}
-          path: ${{ github.workspace }}/**/target/surefire-reports/**
+          name: surefire-reports-${{ matrix.testsuite }}-${{ matrix.container }}-${{ matrix.database }}
+          path: |
+            ${{ github.workspace }}/**/target/surefire-reports/**
+            ${{ github.workspace }}/qa/**/target/**/logs/**
+            ${{ github.workspace }}/**/target/cargo.log
           retention-days: 30

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/BusinessProcess.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/BusinessProcess.java
@@ -87,21 +87,11 @@ public class BusinessProcess implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private final ProcessEngine processEngine;
+  @Inject private ProcessEngine processEngine;
 
-  private final ContextAssociationManager associationManager;
+  @Inject private ContextAssociationManager associationManager;
 
-  private final Instance<Conversation> conversationInstance;
-
-  @Inject
-  public BusinessProcess(
-    ProcessEngine processEngine,
-    ContextAssociationManager associationManager,
-    Instance<Conversation> conversationInstance){
-    this.processEngine = processEngine;
-    this.associationManager = associationManager;
-    this.conversationInstance = conversationInstance;
-  }
+  @Inject private Instance<Conversation> conversationInstance;
 
   public ProcessInstance startProcessById(String processDefinitionId) {
     assertCommandContextNotActive();

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/CurrentProcessInstance.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/CurrentProcessInstance.java
@@ -32,24 +32,20 @@ import org.operaton.bpm.engine.task.Task;
  * Allows to access executions and tasks of a managed process instance via
  * dependency injection. A process instance can be managed, using the
  * {@link BusinessProcess}-bean.
- *
+ * 
  * The producer methods provided by this class have been extracted from the
  * {@link BusinessProcess}-bean in order to allow for specializing it.
- *
+ * 
  * @author Falko Menge
  */
 public class CurrentProcessInstance {
 
-  private final BusinessProcess businessProcess;
-
   @Inject
-  public CurrentProcessInstance(BusinessProcess businessProcess) {
-    this.businessProcess = businessProcess;
-  }
+  private BusinessProcess businessProcess;
 
   /**
    * Returns the {@link ProcessInstance} currently associated or 'null'
-   *
+   * 
    * @throws ProcessEngineCdiException
    *           if no {@link Execution} is associated. Use
    *           {@link BusinessProcess#isAssociated()} to check whether an
@@ -97,7 +93,7 @@ public class CurrentProcessInstance {
 
   /**
    * Returns the currently associated {@link Task} or 'null'
-   *
+   * 
    * @throws ProcessEngineCdiException
    *           if no {@link Task} is associated. Use
    *           {@link BusinessProcess#isTaskAssociated()} to check whether an

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/ProcessVariables.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/ProcessVariables.java
@@ -44,19 +44,9 @@ public class ProcessVariables {
 
   private final Logger logger = Logger.getLogger(ProcessVariables.class.getName());
 
-  private final BusinessProcess businessProcess;
-  private final ProcessVariableMap processVariableMap;
-  private final ProcessVariableLocalMap processVariableLocalMap;
-
-  @Inject
-  public ProcessVariables(
-    BusinessProcess businessProcess,
-    ProcessVariableMap processVariableMap,
-    ProcessVariableLocalMap processVariableLocalMap) {
-    this.businessProcess = businessProcess;
-    this.processVariableMap = processVariableMap;
-    this.processVariableLocalMap = processVariableLocalMap;
-  }
+  @Inject private BusinessProcess businessProcess;
+  @Inject private ProcessVariableMap processVariableMap;
+  @Inject private ProcessVariableLocalMap processVariableLocalMap;
 
   protected String getVariableName(InjectionPoint ip) {
     String variableName = ip.getAnnotated().getAnnotation(ProcessVariable.class).value();

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/compat/FoxTaskForm.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/compat/FoxTaskForm.java
@@ -16,15 +16,10 @@
  */
 package org.operaton.bpm.engine.cdi.compat;
 
-import javax.enterprise.context.Conversation;
 import javax.enterprise.context.ConversationScoped;
-import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Typed;
-import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.cdi.BusinessProcess;
 import org.operaton.bpm.engine.cdi.jsf.TaskForm;
 
 @ConversationScoped
@@ -33,9 +28,4 @@ import org.operaton.bpm.engine.cdi.jsf.TaskForm;
 public class FoxTaskForm extends TaskForm {
 
   private static final long serialVersionUID = 9042602064970870095L;
-
-  @Inject
-  public FoxTaskForm(BusinessProcess businessProcess, RepositoryService repositoryService, Instance<Conversation> conversationInstance) {
-    super(businessProcess, repositoryService, conversationInstance);
-  }
 }

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/compat/OperatonTaskForm.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/compat/OperatonTaskForm.java
@@ -16,15 +16,10 @@
  */
 package org.operaton.bpm.engine.cdi.compat;
 
-import javax.enterprise.context.Conversation;
 import javax.enterprise.context.ConversationScoped;
-import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Typed;
-import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.cdi.BusinessProcess;
 import org.operaton.bpm.engine.cdi.jsf.TaskForm;
 
 @ConversationScoped
@@ -33,9 +28,4 @@ import org.operaton.bpm.engine.cdi.jsf.TaskForm;
 public class OperatonTaskForm extends TaskForm {
 
   private static final long serialVersionUID = 9042602064970870095L;
-
-  @Inject
-  public OperatonTaskForm(BusinessProcess businessProcess, RepositoryService repositoryService, Instance<Conversation> conversationInstance) {
-    super(businessProcess, repositoryService, conversationInstance);
-  }
 }

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/annotation/CompleteTaskInterceptor.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/annotation/CompleteTaskInterceptor.java
@@ -30,7 +30,7 @@ import org.operaton.bpm.engine.cdi.annotation.CompleteTask;
 
 /**
  * {@link Interceptor} for handling the {@link CompleteTask}-Annotation
- *
+ * 
  * @author Daniel Meyer
  */
 @Interceptor
@@ -39,12 +39,7 @@ public class CompleteTaskInterceptor implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  BusinessProcess businessProcess;
-
-  @Inject
-  public CompleteTaskInterceptor(BusinessProcess businessProcess) {
-    this.businessProcess = businessProcess;
-  }
+  @Inject BusinessProcess businessProcess;
 
   @AroundInvoke
   public Object invoke(InvocationContext ctx) throws Exception {
@@ -52,8 +47,8 @@ public class CompleteTaskInterceptor implements Serializable {
       Object result = ctx.proceed();
 
       CompleteTask completeTaskAnnotation = ctx.getMethod().getAnnotation(CompleteTask.class);
-      boolean endConversation = completeTaskAnnotation.endConversation();
-      businessProcess.completeTask(endConversation);
+      boolean endConversation = completeTaskAnnotation.endConversation();    
+      businessProcess.completeTask(endConversation);     
 
       return result;
     } catch (InvocationTargetException e) {

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/annotation/StartProcessInterceptor.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/annotation/StartProcessInterceptor.java
@@ -45,12 +45,7 @@ public class StartProcessInterceptor implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  BusinessProcess businessProcess;
-
-  @Inject
-  public StartProcessInterceptor(BusinessProcess businessProcess) {
-    this.businessProcess = businessProcess;
-  }
+  @Inject BusinessProcess businessProcess;
 
   @AroundInvoke
   public Object invoke(InvocationContext ctx) throws Exception {

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/context/ConversationScopedAssociation.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/context/ConversationScopedAssociation.java
@@ -16,17 +16,9 @@
  */
 package org.operaton.bpm.engine.cdi.impl.context;
 
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
-
 import javax.enterprise.context.ConversationScoped;
-import javax.inject.Inject;
 import java.io.Serializable;
 
 @ConversationScoped
 public class ConversationScopedAssociation extends ScopedAssociation implements Serializable {
-    @Inject
-    public ConversationScopedAssociation(RuntimeService runtimeService, TaskService taskService) {
-        super(runtimeService, taskService);
-    }
 }

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/context/DefaultContextAssociationManager.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/context/DefaultContextAssociationManager.java
@@ -54,12 +54,7 @@ public class DefaultContextAssociationManager implements ContextAssociationManag
 
   protected static final Logger log = Logger.getLogger(DefaultContextAssociationManager.class.getName());
 
-  private final BeanManager beanManager;
-
-  @Inject
-  public DefaultContextAssociationManager(BeanManager beanManager) {
-    this.beanManager = beanManager;
-  }
+  @Inject private BeanManager beanManager;
 
   protected Class< ? extends ScopedAssociation> getBroadestActiveContext() {
     for (Class< ? extends ScopedAssociation> scopeType : getAvailableScopedAssociationClasses()) {

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/context/RequestScopedAssociation.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/context/RequestScopedAssociation.java
@@ -16,17 +16,9 @@
  */
 package org.operaton.bpm.engine.cdi.impl.context;
 
-import org.operaton.bpm.engine.RuntimeService;
-import org.operaton.bpm.engine.TaskService;
-
 import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
 import java.io.Serializable;
 
 @RequestScoped
 public class RequestScopedAssociation extends ScopedAssociation implements Serializable {
-    @Inject
-    public RequestScopedAssociation(RuntimeService runtimeService, TaskService taskService) {
-        super(runtimeService, taskService);
-    }
 }

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/context/ScopedAssociation.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/impl/context/ScopedAssociation.java
@@ -29,15 +29,11 @@ import javax.inject.Inject;
 
 public class ScopedAssociation {
 
-  private final RuntimeService runtimeService;
-
-  private final TaskService taskService;
+  @Inject
+  private RuntimeService runtimeService;
 
   @Inject
-  public ScopedAssociation(RuntimeService runtimeService, TaskService taskService) {
-    this.runtimeService = runtimeService;
-    this.taskService = taskService;
-  }
+  private TaskService taskService;
 
   protected VariableMap cachedVariables = new VariableMapImpl();
   protected VariableMap cachedVariablesLocal = new VariableMapImpl();

--- a/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/jsf/TaskForm.java
+++ b/engine-cdi/core/src/main/java/org/operaton/bpm/engine/cdi/jsf/TaskForm.java
@@ -45,21 +45,14 @@ public class TaskForm implements Serializable {
   protected String processDefinitionId;
   protected String processDefinitionKey;
 
+  @Inject
   protected BusinessProcess businessProcess;
 
+  @Inject
   protected RepositoryService repositoryService;
 
-  protected Instance<Conversation> conversationInstance;
-
   @Inject
-  public TaskForm(
-    BusinessProcess businessProcess,
-    RepositoryService repositoryService,
-    Instance<Conversation> conversationInstance) {
-    this.businessProcess = businessProcess;
-    this.repositoryService = repositoryService;
-    this.conversationInstance = conversationInstance;
-  }
+  protected Instance<Conversation> conversationInstance;
 
   /**
    * @deprecated use {@link startTaskForm()} instead

--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
         <plugin>
           <groupId>org.codehaus.cargo</groupId>
           <artifactId>cargo-maven3-plugin</artifactId>
-          <version>1.10.16</version>
+          <version>1.10.17</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>

--- a/qa/README.md
+++ b/qa/README.md
@@ -13,31 +13,34 @@ We have different maven profiles for selecting
 
 In order to configure the build, compose the profiles for runtime container, testsuite, database. Example:
 
-```
+```shell
 mvn clean install -Pengine-integration,tomcat,h2
 ```
 
 Here's another example for using wildfly as the runtime container:
 
-```
+```shell
 mvn clean install -Pengine-integration,wildfly,h2
 ```
 
 If you want to test against an XA database, just add the corresponding XA database profile to the mvn cmdline above. Example:
 
-```
+```shell
 mvn clean install -Pengine-integration,wildfly,postgresql,postgresql-xa
 ```
 
 You can select multiple testsuites but only a single database and a single runtime container. This is valid:
 
-```
+```shell
 mvn clean install -Pengine-integration,webapps-integration,tomcat,postgresql
 ```
 
 There is a special profile for Wildfly Application Server:
 
-* Domain mode: `mvn clean install -Pengine-integration,h2,wildfly-domain`
+* Domain mode: 
+```shell
+mvn clean install -Pengine-integration,h2,wildfly-domain`
+```
 
 ### Running tests with the Maven Wrapper
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/jobexecution/ClassloadingDuringJobExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/jobexecution/ClassloadingDuringJobExecutionTest.java
@@ -35,7 +35,8 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(Arquillian.class)
 public class ClassloadingDuringJobExecutionTest extends AbstractFoxPlatformIntegrationTest {
-  protected static String process = """
+  protected static String process =
+    """
     <?xml version="1.0" encoding="UTF-8"?>
     <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:operaton="http://operaton.org/schema/1.0/bpmn" targetNamespace="Examples">
       <process id="Process_1" name="ServiceTask_Throw_BMPN_Error" isExecutable="true" operaton:historyTimeToLive="P180D">
@@ -56,7 +57,7 @@ public class ClassloadingDuringJobExecutionTest extends AbstractFoxPlatformInteg
         </serviceTask>
       </process>
     </definitions>
-  """;
+    """;
 
   @Deployment(name="clientDeployment")
   public static WebArchive clientDeployment() {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/SLSBExceptionInDelegateTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/SLSBExceptionInDelegateTest.java
@@ -50,7 +50,7 @@ public class SLSBExceptionInDelegateTest extends AbstractFoxPlatformIntegrationT
   @Test
   public void testOriginalExceptionFromEjbReachesCaller() {
       runtimeService.startProcessInstanceByKey("callProcessWithExceptionFromEjb");
-      Job job = managementService.createJobQuery().singleResult();
+      Job job = managementService.createJobQuery().processDefinitionKey("callProcessWithExceptionFromEjb").singleResult();
       managementService.setJobRetries(job.getId(), 1);
       
       waitForJobExecutorToProcessAllJobs();

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/SLSBExceptionInDelegateTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/SLSBExceptionInDelegateTest.java
@@ -50,7 +50,7 @@ public class SLSBExceptionInDelegateTest extends AbstractFoxPlatformIntegrationT
   @Test
   public void testOriginalExceptionFromEjbReachesCaller() {
       runtimeService.startProcessInstanceByKey("callProcessWithExceptionFromEjb");
-      Job job = managementService.createJobQuery().processDefinitionKey("callProcessWithExceptionFromEjb").singleResult();
+      Job job = managementService.createJobQuery().processDefinitionKey("testProcessEjbWithException").singleResult();
       managementService.setJobRetries(job.getId(), 1);
       
       waitForJobExecutorToProcessAllJobs();

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/migration/MigrationContextSwitchBeansTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/migration/MigrationContextSwitchBeansTest.java
@@ -113,7 +113,7 @@ public class MigrationContextSwitchBeansTest extends AbstractFoxPlatformIntegrat
       .execute();
 
     // then
-    Job timerJob = managementService.createJobQuery().singleResult();
+    Job timerJob = managementService.createJobQuery().processDefinitionKey("boundaryProcess").singleResult();
     Assert.assertNotNull(timerJob);
     Assert.assertNotNull(timerJob.getDuedate());
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/GroovyAsyncScriptExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/GroovyAsyncScriptExecutionTest.java
@@ -33,24 +33,25 @@ import static org.junit.Assert.assertNotNull;
 @RunWith(Arquillian.class)
 public class GroovyAsyncScriptExecutionTest extends AbstractFoxPlatformIntegrationTest {
 
-  protected static String process = """
-    <?xml version="1.0" encoding="UTF-8"?>
-    <definitions id="definitions" 
-      xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
-      xmlns:operaton="http://operaton.org/schema/1.0/bpmn"
-      targetNamespace="Examples">
-      <process id="process" isExecutable="true" operaton:historyTimeToLive="P180D">
-        <startEvent id="theStart" />
-        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theScriptTask" />
-        <scriptTask id="theScriptTask" name="Execute script" scriptFormat="groovy" operaton:asyncBefore="true">
-          <script>execution.setVariable("foo", S("&lt;bar /&gt;").name())</script>
-        </scriptTask>
-        <sequenceFlow id="flow2" sourceRef="theScriptTask" targetRef="theTask" />
-        <userTask id="theTask" name="my task" />
-        <sequenceFlow id="flow3" sourceRef="theTask" targetRef="theEnd" />
-        <endEvent id="theEnd" />
-      </process>
-    </definitions>
+  protected static String process =
+  """
+  <?xml version="1.0" encoding="UTF-8"?>
+  <definitions id="definitions"
+    xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:operaton="http://operaton.org/schema/1.0/bpmn"
+    targetNamespace="Examples">
+    <process id="process" isExecutable="true" operaton:historyTimeToLive="P180D">
+      <startEvent id="theStart" />
+      <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theScriptTask" />
+      <scriptTask id="theScriptTask" name="Execute script" scriptFormat="groovy" operaton:asyncBefore="true">
+        <script>execution.setVariable("foo", S("&lt;bar /&gt;").name())</script>
+      </scriptTask>
+      <sequenceFlow id="flow2" sourceRef="theScriptTask" targetRef="theTask" />
+      <userTask id="theTask" name="my task" />
+      <sequenceFlow id="flow3" sourceRef="theTask" targetRef="theEnd" />
+      <endEvent id="theEnd" />
+    </process>
+  </definitions>
   """;
 
   @Deployment(name="clientDeployment")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/AsyncJobExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/AsyncJobExecutionTest.java
@@ -86,7 +86,7 @@ public class AsyncJobExecutionTest extends AbstractFoxPlatformIntegrationTest {
 
     // then
     // the job exists with no retries, and an incident is raised
-    Job job = managementService.createJobQuery().singleResult();
+    Job job = managementService.createJobQuery().processDefinitionKey("failingTransactionListener").singleResult();
 
     assertNotNull(job);
     assertEquals(0, job.getRetries());

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/AsyncJobExecutionWithRollbackTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/AsyncJobExecutionWithRollbackTest.java
@@ -71,7 +71,7 @@ public class AsyncJobExecutionWithRollbackTest extends AbstractFoxPlatformIntegr
 
     // then
     // the job exists with no retries, and an incident is raised
-    Job job = managementService.createJobQuery().singleResult();
+    Job job = managementService.createJobQuery().processDefinitionKey("txRollbackServiceTask").singleResult();
 
     assertNotNull(job);
     assertEquals(0, job.getRetries());
@@ -89,7 +89,7 @@ public class AsyncJobExecutionWithRollbackTest extends AbstractFoxPlatformIntegr
 
     // then
     // the job exists with no retries, and an incident is raised
-    Job job = managementService.createJobQuery().singleResult();
+    Job job = managementService.createJobQuery().processDefinitionKey("txRollbackServiceTaskWithCustomRetryCycle").singleResult();
 
     assertNotNull(job);
     assertEquals(0, job.getRetries());

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/FailedJobCommandTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/FailedJobCommandTest.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.jobexecutor;
 
+import java.util.function.Supplier;
+import org.operaton.bpm.engine.runtime.JobQuery;
 import org.operaton.bpm.integrationtest.jobexecutor.beans.FailingSLSB;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -40,15 +42,16 @@ public class FailedJobCommandTest extends AbstractFoxPlatformIntegrationTest {
   @Test
   public void testJobRetriesDecremented() {
     runtimeService.startProcessInstanceByKey("theProcess");
+    Supplier<JobQuery> createQuery = () -> managementService.createJobQuery().processDefinitionKey("theProcess");
 
-    Assert.assertEquals(1, managementService.createJobQuery().withRetriesLeft().count());
+    Assert.assertEquals(1, createQuery.get().withRetriesLeft().count());
 
     waitForJobExecutorToProcessAllJobs();
 
     // now the retries = 0
 
-    Assert.assertEquals(0, managementService.createJobQuery().withRetriesLeft().count());
-    Assert.assertEquals(1, managementService.createJobQuery().noRetriesLeft().count());
+    Assert.assertEquals(0, createQuery.get().withRetriesLeft().count());
+    Assert.assertEquals(1, createQuery.get().noRetriesLeft().count());
 
   }
 
@@ -58,15 +61,16 @@ public class FailedJobCommandTest extends AbstractFoxPlatformIntegrationTest {
     for(int i = 0; i < 50; i++) {
       runtimeService.startProcessInstanceByKey("theProcess");
     }
+    Supplier<JobQuery> createQuery = () -> managementService.createJobQuery().processDefinitionKey("theProcess");
 
-    Assert.assertEquals(50, managementService.createJobQuery().withRetriesLeft().count());
+    Assert.assertEquals(50, createQuery.get().withRetriesLeft().count());
 
     waitForJobExecutorToProcessAllJobs(6 * 60 * 1000);
 
     // now the retries = 0
 
-    Assert.assertEquals(0, managementService.createJobQuery().withRetriesLeft().count());
-    Assert.assertEquals(51, managementService.createJobQuery().noRetriesLeft().count());
+    Assert.assertEquals(0, createQuery.get().withRetriesLeft().count());
+    Assert.assertEquals(51, createQuery.get().noRetriesLeft().count());
 
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/JobPrioritizationFailureTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/JobPrioritizationFailureTest.java
@@ -92,7 +92,7 @@ public class JobPrioritizationFailureTest extends AbstractFoxPlatformIntegration
     processInstance = runtimeService.startProcessInstanceByKey("priorityProcess");
 
     // then the job was created successfully and has the default priority on bean evaluation failure
-    Job job = managementService.createJobQuery().singleResult();
+    Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
     Assert.assertEquals(DefaultJobPriorityProvider.DEFAULT_PRIORITY_ON_RESOLUTION_FAILURE, job.getPriority());
   }
 
@@ -112,7 +112,7 @@ public class JobPrioritizationFailureTest extends AbstractFoxPlatformIntegration
 
     // then the job was created successfully and has the default priority although
     // the bean could not be resolved due to a missing class
-    Job job = managementService.createJobQuery().singleResult();
+    Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
     Assert.assertEquals(DefaultJobPriorityProvider.DEFAULT_PRIORITY_ON_RESOLUTION_FAILURE, job.getPriority());
   }
 
@@ -132,7 +132,7 @@ public class JobPrioritizationFailureTest extends AbstractFoxPlatformIntegration
 
     // then the job was created successfully and has the default priority although
     // the bean could not be resolved due to a missing class
-    Job job = managementService.createJobQuery().singleResult();
+    Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
     Assert.assertEquals(DefaultJobPriorityProvider.DEFAULT_PRIORITY_ON_RESOLUTION_FAILURE, job.getPriority());
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/JobPrioritizationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/JobPrioritizationTest.java
@@ -61,7 +61,7 @@ public class JobPrioritizationTest extends AbstractFoxPlatformIntegrationTest {
     // given
     processInstance = runtimeService.startProcessInstanceByKey("priorityProcess");
 
-    Job job = managementService.createJobQuery().singleResult();
+    Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
 
     // then
     Assert.assertEquals(PriorityBean.PRIORITY, job.getPriority());
@@ -74,7 +74,7 @@ public class JobPrioritizationTest extends AbstractFoxPlatformIntegrationTest {
     // given
     processInstance = runtimeService.startProcessInstanceByKey("serviceTaskProcess");
 
-    Job job = managementService.createJobQuery().singleResult();
+    Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
 
     // then
     Assert.assertEquals(PriorityBean.PRIORITY, job.getPriority());
@@ -96,7 +96,7 @@ public class JobPrioritizationTest extends AbstractFoxPlatformIntegrationTest {
       .execute();
 
     // then
-    Job job = managementService.createJobQuery().singleResult();
+    Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
     Assert.assertEquals(PriorityBean.PRIORITY, job.getPriority());
   }
 
@@ -109,7 +109,7 @@ public class JobPrioritizationTest extends AbstractFoxPlatformIntegrationTest {
       .execute();
 
     // then
-    Job job = managementService.createJobQuery().singleResult();
+    Job job = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
     Assert.assertEquals(PriorityBean.PRIORITY, job.getPriority());
   }
 
@@ -123,7 +123,7 @@ public class JobPrioritizationTest extends AbstractFoxPlatformIntegrationTest {
     taskService.complete(task.getId());
 
     // then
-    Job asyncAfterJob = managementService.createJobQuery().singleResult();
+    Job asyncAfterJob = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
     Assert.assertEquals(PriorityBean.PRIORITY, asyncAfterJob.getPriority());
   }
 
@@ -136,7 +136,7 @@ public class JobPrioritizationTest extends AbstractFoxPlatformIntegrationTest {
     runtimeService.correlateMessage("Message");
 
     // then
-    Job asyncAfterJob = managementService.createJobQuery().singleResult();
+    Job asyncAfterJob = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
     Assert.assertEquals(PriorityBean.PRIORITY, asyncAfterJob.getPriority());
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/TimerRecalculationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/TimerRecalculationTest.java
@@ -56,9 +56,10 @@ public class TimerRecalculationTest extends AbstractFoxPlatformIntegrationTest {
     Map<String, Object> variables = new HashMap<>();
     variables.put("timerExpression", "PT10S");
     ProcessInstance instance = runtimeService.startProcessInstanceByKey("TimerRecalculationProcess", variables);
+    String processInstanceId = instance.getId();
 
-    ProcessInstanceQuery instancesQuery = runtimeService.createProcessInstanceQuery().processInstanceId(instance.getId());
-    JobQuery jobQuery = managementService.createJobQuery();
+    ProcessInstanceQuery instancesQuery = runtimeService.createProcessInstanceQuery().processInstanceId(processInstanceId);
+    JobQuery jobQuery = managementService.createJobQuery().processInstanceId(processInstanceId);
     assertEquals(1, instancesQuery.count());
     assertEquals(1, jobQuery.count());
     
@@ -66,7 +67,7 @@ public class TimerRecalculationTest extends AbstractFoxPlatformIntegrationTest {
     Date oldDueDate = job.getDuedate();
     
     // when
-    runtimeService.setVariable(instance.getId(),  "timerExpression", "PT1S");
+    runtimeService.setVariable(processInstanceId,  "timerExpression", "PT1S");
     managementService.recalculateJobDuedate(job.getId(), true);
 
     // then

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/beans/DemoVariableClass.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/beans/DemoVariableClass.java
@@ -17,11 +17,14 @@
 package org.operaton.bpm.integrationtest.jobexecutor.beans;
 
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 
+@SuppressWarnings("unused")
 public class DemoVariableClass implements Serializable {
   
+  @Serial
   private static final long serialVersionUID = 1L;
   private boolean booleanProperty;
   private byte byteProperty;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/beans/ManagedJobExecutorBean.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/beans/ManagedJobExecutorBean.java
@@ -27,6 +27,7 @@ import org.operaton.bpm.engine.cdi.impl.ManagedJobExecutor;
 
 @Startup
 @Singleton
+@SuppressWarnings("unused")
 public class ManagedJobExecutorBean {
 
   @Resource

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/beans/PriorityBean.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/beans/PriorityBean.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.integrationtest.jobexecutor.beans;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import javax.ejb.Stateless;
@@ -27,8 +28,10 @@ import javax.inject.Named;
  */
 @Named
 @Stateless
+@SuppressWarnings("unused")
 public class PriorityBean implements Serializable {
 
+  @Serial
   private static final long serialVersionUID = 1L;
 
   public static final int PRIORITY = 52;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/beans/SampleServiceBean.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/beans/SampleServiceBean.java
@@ -35,6 +35,7 @@ public class SampleServiceBean implements JavaDelegate {
     called = true;
   }
 
+  @SuppressWarnings("unused")
   public boolean isCalled() {
     return called;
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/beans/TimerExpressionBean.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/beans/TimerExpressionBean.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.integrationtest.jobexecutor.beans;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import javax.inject.Inject;
@@ -35,6 +36,7 @@ import org.operaton.bpm.engine.variable.value.TypedValue;
 @Named
 public class TimerExpressionBean implements Serializable {
 
+  @Serial
   private static final long serialVersionUID = 1L;
   
   @Inject
@@ -44,6 +46,7 @@ public class TimerExpressionBean implements Serializable {
   @Inject
   RuntimeService runtimeService;
 
+  @SuppressWarnings("unused")
   public String getTimerDuration() {
     if (timerExpression == null) {
       VariableInstance variable = runtimeService

--- a/qa/integration-tests-webapps/shared-engine/pom.xml
+++ b/qa/integration-tests-webapps/shared-engine/pom.xml
@@ -90,6 +90,7 @@
                 <append>false</append>
                 <home>${jboss.runtime}</home>
                 <timeout>${cargo.timeout}</timeout>
+                <output>${project.build.directory}/cargo.log</output>
               </container>
               <configuration>
                 <type>standalone</type>
@@ -199,6 +200,7 @@
                 <append>false</append>
                 <home>${jboss.runtime}</home>
                 <timeout>${cargo.timeout}</timeout>
+                <output>${project.build.directory}/cargo.log</output>
               </container>
               <configuration>
                 <type>standalone</type>
@@ -309,6 +311,7 @@
                 <append>false</append>
                 <home>${tomcat.runtime}</home>
                 <timeout>${cargo.timeout}</timeout>
+                <output>${project.build.directory}/cargo.log</output>
               </container>
               <configuration>
                 <type>standalone</type>
@@ -422,6 +425,7 @@
                 <append>false</append>
                 <home>${tomcat.runtime}</home>
                 <timeout>${cargo.timeout}</timeout>
+                <output>${project.build.directory}/cargo.log</output>
               </container>
               <configuration>
                 <type>standalone</type>

--- a/qa/integration-tests-webapps/shared-engine/pom.xml
+++ b/qa/integration-tests-webapps/shared-engine/pom.xml
@@ -83,6 +83,7 @@
               </execution>
             </executions>
             <configuration>
+              <skip>${skipTests}</skip>
               <!-- Container configuration -->
               <container>
                 <type>installed</type>
@@ -193,6 +194,7 @@
               </execution>
             </executions>
             <configuration>
+              <skip>${skipTests}</skip>
               <!-- Container configuration -->
               <container>
                 <type>installed</type>
@@ -304,6 +306,7 @@
               </execution>
             </executions>
             <configuration>
+              <skip>${skipTests}</skip>
               <!-- Container configuration -->
               <container>
                 <type>installed</type>
@@ -418,6 +421,7 @@
               </execution>
             </executions>
             <configuration>
+              <skip>${skipTests}</skip>
               <!-- Container configuration -->
               <container>
                 <type>installed</type>


### PR DESCRIPTION
- rename parameter 'test_suite' -> 'testsuite' (was causing problems)
- add options to build tomcat9/wildfly26
- default to test 'tomcat' & 'wildfly'
- split execution of integration tests from job 'maven-build' to new job 'maven-integration-tests'
- upload more build artifacts
- write & archive cargo output