### PR TITLE
refactor: JUnit 4 to AssertJ & resolve Sonar issues and code warnings

### DIFF
--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/feel/JuelFeelBehaviorTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/feel/JuelFeelBehaviorTest.java
@@ -26,7 +26,7 @@ import java.util.Date;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 class JuelFeelBehaviorTest extends FeelBehavior {
 
@@ -54,7 +54,7 @@ class JuelFeelBehaviorTest extends FeelBehavior {
     getVariables().putValue("myDate", new Date());
 
     // when
-    assertThrows(FeelException.class, this::evaluateDecision);
+    assertThatExceptionOfType(FeelException.class).isThrownBy(this::evaluateDecision);
   }
 
 }

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/type/DmnDataTypeTransformerTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/type/DmnDataTypeTransformerTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 /**
  * Tests the build-in {@link DmnDataTypeTransformer}s.
@@ -86,7 +86,7 @@ class DmnDataTypeTransformerTest extends DmnEngineTest {
   @Test
   void invalidStringValueForBooleanType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("boolean");
-    assertThrows(IllegalArgumentException.class, () -> typeTransformer.transform("NaB"));
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> typeTransformer.transform("NaB"));
   }
 
   @Test
@@ -105,31 +105,31 @@ class DmnDataTypeTransformerTest extends DmnEngineTest {
   @Test
   void invalidStringValueForIntegerType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("integer");
-    assertThrows(IllegalArgumentException.class, () -> typeTransformer.transform("4.2"));
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> typeTransformer.transform("4.2"));
   }
 
   @Test
   void invalidDoubleValueForIntegerType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("integer");
-    assertThrows(IllegalArgumentException.class, () -> typeTransformer.transform(4.2));
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> typeTransformer.transform(4.2));
   }
 
   @Test
   void invalidLongValueForIntegerType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("integer");
-    assertThrows(IllegalArgumentException.class, () -> typeTransformer.transform(Long.MAX_VALUE));
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> typeTransformer.transform(Long.MAX_VALUE));
   }
 
   @Test
   void invalidIntegerMinValueForIntegerType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("integer");
-    assertThrows(IllegalArgumentException.class, () -> typeTransformer.transform(Integer.MIN_VALUE - 1L));
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> typeTransformer.transform(Integer.MIN_VALUE - 1L));
   }
 
   @Test
   void invalidIntegerMaxValueForIntegerType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("integer");
-    assertThrows(IllegalArgumentException.class, () -> typeTransformer.transform(Integer.MAX_VALUE + 1L));
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> typeTransformer.transform(Integer.MAX_VALUE + 1L));
   }
 
   @Test
@@ -148,19 +148,19 @@ class DmnDataTypeTransformerTest extends DmnEngineTest {
   @Test
   void invalidStringValueForLongType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("long");
-    assertThrows(IllegalArgumentException.class, () -> typeTransformer.transform("4.2"));
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> typeTransformer.transform("4.2"));
   }
 
   @Test
   void invalidDoubleValueForLongType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("long");
-    assertThrows(IllegalArgumentException.class, () -> typeTransformer.transform(4.2));
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> typeTransformer.transform(4.2));
   }
 
   @Test
   void invalidDoubleMinValueForLongType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("long");
-    assertThrows(IllegalArgumentException.class, () -> typeTransformer.transform(Double.MIN_VALUE));
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> typeTransformer.transform(Double.MIN_VALUE));
   }
 
   @Test
@@ -181,7 +181,7 @@ class DmnDataTypeTransformerTest extends DmnEngineTest {
   @Test
   void invalidStringValueForDoubleType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("double");
-    assertThrows(IllegalArgumentException.class, () -> typeTransformer.transform("NaD"));
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> typeTransformer.transform("NaD"));
   }
 
   @Test
@@ -293,7 +293,7 @@ class DmnDataTypeTransformerTest extends DmnEngineTest {
   @Test
   void invalidStringForDateType() {
     DmnDataTypeTransformer typeTransformer = registry.getTransformer("date");
-    assertThrows(IllegalArgumentException.class, () -> typeTransformer.transform("18.09.2015 12:00:00"));
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> typeTransformer.transform("18.09.2015 12:00:00"));
   }
 
   protected Date toDate(String date, String timeZone) {

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/AuthorizationRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/AuthorizationRestServiceQueryTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.rest;
 import static io.restassured.RestAssured.expect;
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -152,7 +153,7 @@ public class AuthorizationRestServiceQueryTest extends AbstractRestServiceTest {
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one authorization returned.", 1, instances.size());
-    Assert.assertNotNull("The returned authorization should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned authorization should not be null.").isNotNull();
 
     Authorization mockAuthorization = mockAuthorizations.get(0);
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/BatchRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/BatchRestServiceInteractionTest.java
@@ -17,12 +17,11 @@
 package org.operaton.bpm.engine.rest;
 
 import static java.util.Collections.singletonMap;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import static io.restassured.RestAssured.given;
 import static org.operaton.bpm.engine.rest.util.JsonPathUtil.from;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -319,7 +318,7 @@ public class BatchRestServiceInteractionTest extends AbstractRestServiceTest {
     String returnedStartTime = from(batchJson).getString("startTime");
     String returnedExecStartTime = from(batchJson).getString("executionStartTime");
 
-    assertNotNull("The returned batch should not be null.", batch);
+    assertThat(batch).as("The returned batch should not be null.").isNotNull();
     assertEquals(MockProvider.EXAMPLE_BATCH_ID, batch.getId());
     assertEquals(MockProvider.EXAMPLE_BATCH_TYPE, batch.getType());
     assertEquals(MockProvider.EXAMPLE_BATCH_TOTAL_JOBS, batch.getTotalJobs());

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/BatchRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/BatchRestServiceQueryTest.java
@@ -17,11 +17,10 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.util.JsonPathUtil.from;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -269,7 +268,7 @@ public class BatchRestServiceQueryTest extends AbstractRestServiceTest {
     BatchDto batch = from(batchListJson).getObject("[0]", BatchDto.class);
     String returnedStartTime = from(batchListJson).getString("[0].startTime");
 
-    assertNotNull("The returned batch should not be null.", batch);
+    assertThat(batch).as("The returned batch should not be null.").isNotNull();
     assertEquals(MockProvider.EXAMPLE_BATCH_ID, batch.getId());
     assertEquals(MockProvider.EXAMPLE_BATCH_TYPE, batch.getType());
     assertEquals(MockProvider.EXAMPLE_BATCH_TOTAL_JOBS, batch.getTotalJobs());
@@ -282,7 +281,7 @@ public class BatchRestServiceQueryTest extends AbstractRestServiceTest {
     assertEquals(MockProvider.EXAMPLE_TENANT_ID, batch.getTenantId());
     assertEquals(MockProvider.EXAMPLE_USER_ID, batch.getCreateUserId());
     assertEquals(MockProvider.EXAMPLE_HISTORIC_BATCH_START_TIME, returnedStartTime);
-    assertTrue(batch.isSuspended());
+    assertThat(batch.isSuspended()).isTrue();
   }
 
 }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/BatchRestServiceStatisticsTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/BatchRestServiceStatisticsTest.java
@@ -17,11 +17,10 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.util.JsonPathUtil.from;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -315,7 +314,7 @@ public class BatchRestServiceStatisticsTest extends AbstractRestServiceTest {
     BatchStatisticsDto batchStatistics = from(batchStatisticsListJson).getObject("[0]", BatchStatisticsDto.class);
     String returnedStartTime = from(batchStatisticsListJson).getString("[0].startTime");
 
-    assertNotNull("The returned batch statistics should not be null.", batchStatistics);
+    assertThat(batchStatistics).as("The returned batch statistics should not be null.").isNotNull();
     assertEquals(MockProvider.EXAMPLE_BATCH_ID, batchStatistics.getId());
     assertEquals(MockProvider.EXAMPLE_BATCH_TYPE, batchStatistics.getType());
     assertEquals(MockProvider.EXAMPLE_BATCH_TOTAL_JOBS, batchStatistics.getTotalJobs());
@@ -331,7 +330,7 @@ public class BatchRestServiceStatisticsTest extends AbstractRestServiceTest {
     assertEquals(MockProvider.EXAMPLE_BATCH_REMAINING_JOBS, batchStatistics.getRemainingJobs());
     assertEquals(MockProvider.EXAMPLE_BATCH_COMPLETED_JOBS, batchStatistics.getCompletedJobs());
     assertEquals(MockProvider.EXAMPLE_BATCH_FAILED_JOBS, batchStatistics.getFailedJobs());
-    assertTrue(batchStatistics.isSuspended());
+    assertThat(batchStatistics.isSuspended()).isTrue();
   }
 
 }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
@@ -153,8 +153,9 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
         .get(XML_DEFINITION_URL);
 
     String responseContent = response.asString();
-    assertThat(responseContent).contains(MockProvider.EXAMPLE_CASE_DEFINITION_ID);
-    assertThat(responseContent).contains("<?xml");
+    assertThat(responseContent)
+      .contains("<?xml")
+      .contains(MockProvider.EXAMPLE_CASE_DEFINITION_ID);
   }
 
   @Test
@@ -223,7 +224,7 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
     when(repositoryServiceMock.createCaseDefinitionQuery().caseDefinitionKey(nonExistingKey)).thenReturn(caseDefinitionQueryMock);
     when(caseDefinitionQueryMock.latestVersion()).thenReturn(caseDefinitionQueryMock);
     when(caseDefinitionQueryMock.singleResult()).thenReturn(null);
-    when(caseDefinitionQueryMock.list()).thenReturn(Collections.<CaseDefinition> emptyList());
+    when(caseDefinitionQueryMock.list()).thenReturn(Collections.emptyList());
 
     given()
       .pathParam("key", nonExistingKey)

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.rest;
 
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -137,7 +138,7 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
   private InputStream createMockCaseDefinitionCmmnXml() {
     // do not close the input stream, will be done in implementation
     InputStream cmmnXmlInputStream = ReflectUtil.getResourceAsStream("cases/case-model.cmmn");
-    Assert.assertNotNull(cmmnXmlInputStream);
+    assertThat(cmmnXmlInputStream).isNotNull();
     return cmmnXmlInputStream;
   }
 
@@ -152,8 +153,8 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
         .get(XML_DEFINITION_URL);
 
     String responseContent = response.asString();
-    Assert.assertTrue(responseContent.contains(MockProvider.EXAMPLE_CASE_DEFINITION_ID));
-    Assert.assertTrue(responseContent.contains("<?xml"));
+    assertThat(responseContent).contains(MockProvider.EXAMPLE_CASE_DEFINITION_ID);
+    assertThat(responseContent).contains("<?xml");
   }
 
   @Test
@@ -188,8 +189,8 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
         .get(XML_DEFINITION_BY_KEY_URL);
 
     String responseContent = response.asString();
-    Assert.assertTrue(responseContent.contains(MockProvider.EXAMPLE_CASE_DEFINITION_ID));
-    Assert.assertTrue(responseContent.contains("<?xml"));
+    assertThat(responseContent).contains(MockProvider.EXAMPLE_CASE_DEFINITION_ID);
+    assertThat(responseContent).contains("<?xml");
   }
 
   @Test
@@ -573,7 +574,7 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
 
     // compare input stream with response body bytes
     byte[] expected = IoUtil.readInputStream(new FileInputStream(file), "case diagram");
-    Assert.assertArrayEquals(expected, actual);
+    assertThat(actual).containsExactly(expected);
   }
 
   @Test
@@ -600,7 +601,7 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
 
     // compare input stream with response body bytes
     byte[] expected = IoUtil.readInputStream(new FileInputStream(file), "case diagram");
-    Assert.assertArrayEquals(expected, actual);
+    assertThat(actual).containsExactly(expected);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
@@ -189,8 +189,9 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
         .get(XML_DEFINITION_BY_KEY_URL);
 
     String responseContent = response.asString();
-    assertThat(responseContent).contains(MockProvider.EXAMPLE_CASE_DEFINITION_ID);
-    assertThat(responseContent).contains("<?xml");
+    assertThat(responseContent)
+      .contains(MockProvider.EXAMPLE_CASE_DEFINITION_ID)
+      .contains("<?xml");
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
@@ -92,7 +92,7 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
   protected static final String UPDATE_HISTORY_TIME_TO_LIVE_URL = SINGLE_CASE_DEFINITION_URL + "/history-time-to-live";
 
   @ClassRule
-  public static TestContainerRule rule = new TestContainerRule();
+  public static final TestContainerRule rule = new TestContainerRule();
 
   private RepositoryService repositoryServiceMock;
   private CaseService caseServiceMock;
@@ -528,7 +528,7 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
         .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())
         .contentType(ContentType.JSON)
         .body("type", equalTo(RestException.class.getSimpleName()))
-        .body("message", containsString("Cannot instantiate case definition aCaseDefnitionId: expected exception"))
+        .body("message", containsString("Cannot instantiate case definition aCaseDefinitionId: expected exception"))
     .when()
       .post(CREATE_INSTANCE_URL);
   }
@@ -547,7 +547,7 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
         .statusCode(Status.INTERNAL_SERVER_ERROR.getStatusCode())
         .contentType(ContentType.JSON)
         .body("type", equalTo(RestException.class.getSimpleName()))
-        .body("message", containsString("Cannot instantiate case definition aCaseDefnitionId: expected exception"))
+        .body("message", containsString("Cannot instantiate case definition aCaseDefinitionId: expected exception"))
     .when()
       .post(CREATE_INSTANCE_BY_KEY_URL);
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ConditionRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ConditionRestServiceTest.java
@@ -18,9 +18,8 @@ package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -98,9 +97,9 @@ public class ConditionRestServiceTest extends AbstractRestServiceTest {
     .when()
       .post(CONDITION_URL);
 
-    assertNotNull(response);
+    assertThat(response).isNotNull();
     String content = response.asString();
-    assertTrue(!content.isEmpty());
+    assertThat(!content.isEmpty()).isTrue();
     checkResult(content);
 
     verify(runtimeServiceMock).createConditionEvaluation();

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DecisionDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DecisionDefinitionRestServiceInteractionTest.java
@@ -94,7 +94,6 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
 
   private RepositoryService repositoryServiceMock;
   private DecisionDefinitionQuery decisionDefinitionQueryMock;
-  private DecisionService decisionServiceMock;
   private DecisionsEvaluationBuilder decisionEvaluationBuilderMock;
 
   @Before
@@ -133,7 +132,7 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
     decisionEvaluationBuilderMock = mock(DecisionsEvaluationBuilder.class);
     when(decisionEvaluationBuilderMock.variables(anyMap())).thenReturn(decisionEvaluationBuilderMock);
 
-    decisionServiceMock = mock(DecisionService.class);
+    DecisionService decisionServiceMock = mock(DecisionService.class);
     when(decisionServiceMock.evaluateDecisionById(MockProvider.EXAMPLE_DECISION_DEFINITION_ID)).thenReturn(decisionEvaluationBuilderMock);
     when(decisionServiceMock.evaluateDecisionByKey(MockProvider.EXAMPLE_DECISION_DEFINITION_KEY)).thenReturn(decisionEvaluationBuilderMock);
 
@@ -151,8 +150,9 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
         .get(XML_DEFINITION_URL);
 
     String responseContent = response.asString();
-    assertThat(responseContent).contains(MockProvider.EXAMPLE_DECISION_DEFINITION_ID);
-    assertThat(responseContent).contains("<?xml");
+    assertThat(responseContent)
+      .contains("<?xml")
+      .contains(MockProvider.EXAMPLE_DECISION_DEFINITION_ID);
   }
 
   @Test
@@ -189,8 +189,9 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
         .get(XML_DEFINITION_BY_KEY_URL);
 
     String responseContent = response.asString();
-    assertThat(responseContent).contains(MockProvider.EXAMPLE_DECISION_DEFINITION_ID);
-    assertThat(responseContent).contains("<?xml");
+    assertThat(responseContent)
+      .contains("<?xml")
+      .contains(MockProvider.EXAMPLE_DECISION_DEFINITION_ID);
   }
 
   @Test
@@ -224,7 +225,7 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
     when(repositoryServiceMock.createDecisionDefinitionQuery().decisionDefinitionKey(nonExistingKey)).thenReturn(decisionDefinitionQueryMock);
     when(decisionDefinitionQueryMock.latestVersion()).thenReturn(decisionDefinitionQueryMock);
     when(decisionDefinitionQueryMock.singleResult()).thenReturn(null);
-    when(decisionDefinitionQueryMock.list()).thenReturn(Collections.<DecisionDefinition> emptyList());
+    when(decisionDefinitionQueryMock.list()).thenReturn(Collections.emptyList());
 
     given()
       .pathParam("key", nonExistingKey)

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DecisionDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DecisionDefinitionRestServiceInteractionTest.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.rest;
 
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -124,7 +125,7 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
   private InputStream createMockDecisionDefinitionDmnXml() {
     // do not close the input stream, will be done in implementation
     InputStream dmnXmlInputStream = ReflectUtil.getResourceAsStream("decisions/decision-model.dmn");
-    Assert.assertNotNull(dmnXmlInputStream);
+    assertThat(dmnXmlInputStream).isNotNull();
     return dmnXmlInputStream;
   }
 
@@ -150,8 +151,8 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
         .get(XML_DEFINITION_URL);
 
     String responseContent = response.asString();
-    Assert.assertTrue(responseContent.contains(MockProvider.EXAMPLE_DECISION_DEFINITION_ID));
-    Assert.assertTrue(responseContent.contains("<?xml"));
+    assertThat(responseContent).contains(MockProvider.EXAMPLE_DECISION_DEFINITION_ID);
+    assertThat(responseContent).contains("<?xml");
   }
 
   @Test
@@ -188,8 +189,8 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
         .get(XML_DEFINITION_BY_KEY_URL);
 
     String responseContent = response.asString();
-    Assert.assertTrue(responseContent.contains(MockProvider.EXAMPLE_DECISION_DEFINITION_ID));
-    Assert.assertTrue(responseContent.contains("<?xml"));
+    assertThat(responseContent).contains(MockProvider.EXAMPLE_DECISION_DEFINITION_ID);
+    assertThat(responseContent).contains("<?xml");
   }
 
   @Test
@@ -338,7 +339,7 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
 
     // compare input stream with response body bytes
     byte[] expected = IoUtil.readInputStream(new FileInputStream(file), "decision diagram");
-    Assert.assertArrayEquals(expected, actual);
+    assertThat(actual).containsExactly(expected);
   }
 
   @Test
@@ -365,7 +366,7 @@ public class DecisionDefinitionRestServiceInteractionTest extends AbstractRestSe
 
     // compare input stream with response body bytes
     byte[] expected = IoUtil.readInputStream(new FileInputStream(file), "decision diagram");
-    Assert.assertArrayEquals(expected, actual);
+    assertThat(actual).containsExactly(expected);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DecisionRequirementsDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DecisionRequirementsDefinitionRestServiceInteractionTest.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.rest;
 
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -45,13 +46,13 @@ import org.operaton.bpm.engine.repository.DecisionRequirementsDefinitionQuery;
 import org.operaton.bpm.engine.rest.exception.RestException;
 import org.operaton.bpm.engine.rest.helper.MockProvider;
 import org.operaton.bpm.engine.rest.util.container.TestContainerRule;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+
 /**
  *
  * @author Deivarayan Azhagappan
@@ -224,8 +225,8 @@ public class DecisionRequirementsDefinitionRestServiceInteractionTest extends Ab
         .get(XML_DEFINITION_URL);
 
     String responseContent = response.asString();
-    Assert.assertTrue(responseContent.contains(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID));
-    Assert.assertTrue(responseContent.contains("<?xml"));
+    assertThat(responseContent).contains(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID);
+    assertThat(responseContent).contains("<?xml");
   }
 
   // DRD retrieval
@@ -245,7 +246,7 @@ public class DecisionRequirementsDefinitionRestServiceInteractionTest extends Ab
     verify(repositoryServiceMock).getDecisionRequirementsDiagram(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID);
 
     byte[] expected = IoUtil.readInputStream(new FileInputStream(getFile()), "decision requirements diagram");
-    Assert.assertArrayEquals(expected, actual);
+    assertThat(actual).containsExactly(expected);
   }
 
   protected void setUpRuntimeData(DecisionRequirementsDefinition mockDecisionRequirementsDefinition) throws FileNotFoundException, URISyntaxException {
@@ -269,7 +270,7 @@ public class DecisionRequirementsDefinitionRestServiceInteractionTest extends Ab
   protected InputStream createMockDecisionRequirementsDefinitionDmnXml() {
     // do not close the input stream, will be done in implementation
     InputStream dmnXmlInputStream = ReflectUtil.getResourceAsStream("decisions/decision-requirements-model.dmn");
-    Assert.assertNotNull(dmnXmlInputStream);
+    assertThat(dmnXmlInputStream).isNotNull();
     return dmnXmlInputStream;
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DecisionRequirementsDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DecisionRequirementsDefinitionRestServiceInteractionTest.java
@@ -225,8 +225,9 @@ public class DecisionRequirementsDefinitionRestServiceInteractionTest extends Ab
         .get(XML_DEFINITION_URL);
 
     String responseContent = response.asString();
-    assertThat(responseContent).contains(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID);
-    assertThat(responseContent).contains("<?xml");
+    assertThat(responseContent)
+      .contains(MockProvider.EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID)
+      .contains("<?xml");
   }
 
   // DRD retrieval

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DeploymentRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DeploymentRestServiceInteractionTest.java
@@ -38,7 +38,6 @@ import java.util.*;
 import io.restassured.http.ContentType;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.Response;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -48,7 +47,6 @@ import static io.restassured.path.json.JsonPath.from;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTest {
@@ -887,7 +885,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
   }
 
   @Test
-  public void testGetDeploymentHtmlpResourceData() {
+  public void testGetDeploymentHtmlResourceData() {
     Resource resource = MockProvider.createMockDeploymentHtmlResource();
 
     List<Resource> resources = new ArrayList<>();
@@ -1427,19 +1425,19 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     List<HashMap<String, Object>> errors = problems.get("errors");
     HashMap<String, Object> error = errors.get(0);
-    assertEquals(EXAMPLE_PROBLEM_COLUMN, error.get("column"));
-    assertEquals(EXAMPLE_PROBLEM_LINE, error.get("line"));
-    assertEquals(message, error.get("message"));
-    assertEquals(EXAMPLE_PROBLEM_ELEMENT_ID, error.get("mainElementId"));
-    assertEquals(EXAMPLE_ELEMENT_IDS, error.get("еlementIds"));
+    assertThat(error).containsEntry("column", EXAMPLE_PROBLEM_COLUMN)
+                     .containsEntry("line", EXAMPLE_PROBLEM_LINE)
+                     .containsEntry("message", message)
+                     .containsEntry("mainElementId", EXAMPLE_PROBLEM_ELEMENT_ID)
+                     .containsEntry("еlementIds", EXAMPLE_ELEMENT_IDS);
 
     List<HashMap<String, Object>> warnings = problems.get("warnings");
     HashMap<String, Object> warning = warnings.get(0);
-    assertEquals(EXAMPLE_PROBLEM_COLUMN_2, warning.get("column"));
-    assertEquals(EXAMPLE_PROBLEM_LINE_2, warning.get("line"));
-    assertEquals(EXAMPLE_EXCEPTION_MESSAGE, warning.get("message"));
-    assertEquals(EXAMPLE_PROBLEM_ELEMENT_ID_2, warning.get("mainElementId"));
-    assertEquals(EXAMPLE_ELEMENT_IDS, warning.get("еlementIds"));
+    assertThat(warning).containsEntry("column", EXAMPLE_PROBLEM_COLUMN_2)
+                       .containsEntry("line", EXAMPLE_PROBLEM_LINE_2)
+                       .containsEntry("message", EXAMPLE_EXCEPTION_MESSAGE)
+                       .containsEntry("mainElementId", EXAMPLE_PROBLEM_ELEMENT_ID_2)
+                       .containsEntry("еlementIds", EXAMPLE_ELEMENT_IDS);
   }
 
   @Test
@@ -1951,13 +1949,13 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
     Map<String, HashMap<String, Object>>  deployedDecisionDefinitions = path.getMap(PROPERTY_DEPLOYED_DECISION_DEFINITIONS);
     Map<String, HashMap<String, Object>>  deployedDecisionRequirementsDefinitions = path.getMap(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS);
 
-    assertEquals(1, deployedProcessDefinitions.size());
+    assertThat(deployedProcessDefinitions).hasSize(1);
     assertThat(deployedProcessDefinitions.get(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID)).isNotNull();
-    assertEquals(1, deployedCaseDefinitions.size());
+    assertThat(deployedCaseDefinitions).hasSize(1);
     assertThat(deployedCaseDefinitions.get(EXAMPLE_CASE_DEFINITION_ID)).isNotNull();
-    assertEquals(1, deployedDecisionDefinitions.size());
+    assertThat(deployedDecisionDefinitions).hasSize(1);
     assertThat(deployedDecisionDefinitions.get(EXAMPLE_DECISION_DEFINITION_ID)).isNotNull();
-    assertEquals(1, deployedDecisionRequirementsDefinitions.size());
+    assertThat(deployedDecisionRequirementsDefinitions).hasSize(1);
     assertThat(deployedDecisionRequirementsDefinitions.get(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID)).isNotNull();
   }
 
@@ -1967,14 +1965,14 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     Map<String, HashMap<String, Object>> deployedProcessDefinitionDtos = path.getMap(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS);
 
-    assertEquals(1, deployedProcessDefinitionDtos.size());
+    assertThat(deployedProcessDefinitionDtos).hasSize(1);
     HashMap processDefinitionDto = deployedProcessDefinitionDtos.get(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
     assertThat(processDefinitionDto).isNotNull();
     verifyBpmnDeployment(processDefinitionDto);
 
-    assertThat(path.get(PROPERTY_DEPLOYED_CASE_DEFINITIONS)).isNull();
-    assertThat(path.get(PROPERTY_DEPLOYED_DECISION_DEFINITIONS)).isNull();
-    assertThat(path.get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS)).isNull();
+    assertThat(path.<String>get(PROPERTY_DEPLOYED_CASE_DEFINITIONS)).isNull();
+    assertThat(path.<String>get(PROPERTY_DEPLOYED_DECISION_DEFINITIONS)).isNull();
+    assertThat(path.<String>get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS)).isNull();
   }
 
   private void verifyCmmnDeploymentValues(Deployment mockDeployment, String responseContent) {
@@ -1983,14 +1981,14 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     Map<String, HashMap<String, Object>> deployedCaseDefinitions = path.getMap(PROPERTY_DEPLOYED_CASE_DEFINITIONS);
 
-    assertEquals(1, deployedCaseDefinitions.size());
+    assertThat(deployedCaseDefinitions).hasSize(1);
     HashMap caseDefinitionDto = deployedCaseDefinitions.get(EXAMPLE_CASE_DEFINITION_ID);
     assertThat(caseDefinitionDto).isNotNull();
     verifyCmnDeployment(caseDefinitionDto);
 
-    assertThat(path.get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS)).isNull();
-    assertThat(path.get(PROPERTY_DEPLOYED_DECISION_DEFINITIONS)).isNull();
-    assertThat(path.get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS)).isNull();
+    assertThat(path.<String>get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS)).isNull();
+    assertThat(path.<String>get(PROPERTY_DEPLOYED_DECISION_DEFINITIONS)).isNull();
+    assertThat(path.<String>get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS)).isNull();
   }
 
   private void verifyDmnDeploymentValues(Deployment mockDeployment, String responseContent) {
@@ -1999,14 +1997,14 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     Map<String, HashMap<String, Object>> deployedDecisionDefinitions = path.getMap(PROPERTY_DEPLOYED_DECISION_DEFINITIONS);
 
-    assertEquals(1, deployedDecisionDefinitions.size());
+    assertThat(deployedDecisionDefinitions).hasSize(1);
     HashMap decisionDefinitionDto = deployedDecisionDefinitions.get(EXAMPLE_DECISION_DEFINITION_ID);
     assertThat(decisionDefinitionDto).isNotNull();
     verifyDmnDeployment(decisionDefinitionDto);
 
-    assertThat(path.get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS)).isNull();
-    assertThat(path.get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS)).isNull();
-    assertThat(path.get(PROPERTY_DEPLOYED_CASE_DEFINITIONS)).isNull();
+    assertThat(path.<String>get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS)).isNull();
+    assertThat(path.<String>get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS)).isNull();
+    assertThat(path.<String>get(PROPERTY_DEPLOYED_CASE_DEFINITIONS)).isNull();
   }
 
   private void verifyDrdDeploymentValues(Deployment mockDeployment, String responseContent) {
@@ -2018,72 +2016,73 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
     Map<String, HashMap<String, Object>> deployedDecisionRequirementsDefinitions =
       path.getMap(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS);
 
-    assertEquals(1, deployedDecisionDefinitions.size());
+    assertThat(deployedDecisionDefinitions).hasSize(1);
     HashMap decisionDefinitionDto = deployedDecisionDefinitions.get(EXAMPLE_DECISION_DEFINITION_ID);
     assertThat(decisionDefinitionDto).isNotNull();
     verifyDmnDeployment(decisionDefinitionDto);
 
-    assertEquals(1, deployedDecisionRequirementsDefinitions.size());
+    assertThat(deployedDecisionRequirementsDefinitions).hasSize(1);
     HashMap decisionRequirementsDefinitionDto = deployedDecisionRequirementsDefinitions.get(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID);
     assertThat(decisionRequirementsDefinitionDto).isNotNull();
     verifyDrdDeployment(decisionRequirementsDefinitionDto);
 
-    assertThat(path.get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS)).isNull();
-    assertThat(path.get(PROPERTY_DEPLOYED_CASE_DEFINITIONS)).isNull();
+    assertThat(path.<String>get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS)).isNull();
+    assertThat(path.<String>get(PROPERTY_DEPLOYED_CASE_DEFINITIONS)).isNull();
   }
 
   private void verifyBpmnDeployment(HashMap<String, Object> dto) {
-    assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, dto.get("id"));
-    assertEquals(EXAMPLE_PROCESS_DEFINITION_CATEGORY, dto.get("category"));
-    assertEquals(EXAMPLE_PROCESS_DEFINITION_NAME, dto.get("name"));
-    assertEquals(EXAMPLE_PROCESS_DEFINITION_KEY, dto.get("key"));
-    assertEquals(EXAMPLE_PROCESS_DEFINITION_DESCRIPTION, dto.get("description"));
-    assertEquals(EXAMPLE_PROCESS_DEFINITION_VERSION, dto.get("version"));
-    assertEquals(EXAMPLE_PROCESS_DEFINITION_RESOURCE_NAME, dto.get("resource"));
-    assertEquals(EXAMPLE_DEPLOYMENT_ID, dto.get("deploymentId"));
-    assertEquals(EXAMPLE_PROCESS_DEFINITION_DIAGRAM_RESOURCE_NAME, dto.get("diagram"));
-    assertEquals(EXAMPLE_PROCESS_DEFINITION_IS_SUSPENDED, dto.get("suspended"));
+    assertThat(dto).containsEntry("id", MockProvider.EXAMPLE_PROCESS_DEFINITION_ID)
+                   .containsEntry("category", EXAMPLE_PROCESS_DEFINITION_CATEGORY)
+                   .containsEntry("name", EXAMPLE_PROCESS_DEFINITION_NAME)
+                   .containsEntry("key", EXAMPLE_PROCESS_DEFINITION_KEY)
+                   .containsEntry("description", EXAMPLE_PROCESS_DEFINITION_DESCRIPTION)
+                   .containsEntry("version", EXAMPLE_PROCESS_DEFINITION_VERSION)
+                   .containsEntry("resource", EXAMPLE_PROCESS_DEFINITION_RESOURCE_NAME)
+                   .containsEntry("deploymentId", EXAMPLE_DEPLOYMENT_ID)
+                   .containsEntry("diagram", EXAMPLE_PROCESS_DEFINITION_DIAGRAM_RESOURCE_NAME)
+                   .containsEntry("suspended", EXAMPLE_PROCESS_DEFINITION_IS_SUSPENDED);
   }
+
   private void verifyCmnDeployment(HashMap<String, Object> dto) {
-    assertEquals(EXAMPLE_CASE_DEFINITION_ID, dto.get("id"));
-    assertEquals(EXAMPLE_CASE_DEFINITION_CATEGORY, dto.get("category"));
-    assertEquals(EXAMPLE_CASE_DEFINITION_NAME, dto.get("name"));
-    assertEquals(EXAMPLE_CASE_DEFINITION_KEY, dto.get("key"));
-    assertEquals(EXAMPLE_CASE_DEFINITION_VERSION, dto.get("version"));
-    assertEquals(EXAMPLE_CASE_DEFINITION_RESOURCE_NAME, dto.get("resource"));
-    assertEquals(EXAMPLE_DEPLOYMENT_ID, dto.get("deploymentId"));
+    assertThat(dto).containsEntry("id", EXAMPLE_CASE_DEFINITION_ID)
+                   .containsEntry("category", EXAMPLE_CASE_DEFINITION_CATEGORY)
+                   .containsEntry("name", EXAMPLE_CASE_DEFINITION_NAME)
+                   .containsEntry("key", EXAMPLE_CASE_DEFINITION_KEY)
+                   .containsEntry("version", EXAMPLE_CASE_DEFINITION_VERSION)
+                   .containsEntry("resource", EXAMPLE_CASE_DEFINITION_RESOURCE_NAME)
+                   .containsEntry("deploymentId", EXAMPLE_DEPLOYMENT_ID);
   }
 
   private void verifyDmnDeployment(HashMap<String, Object> dto) {
-    assertEquals(EXAMPLE_DECISION_DEFINITION_ID, dto.get("id"));
-    assertEquals(EXAMPLE_DECISION_DEFINITION_CATEGORY, dto.get("category"));
-    assertEquals(EXAMPLE_DECISION_DEFINITION_NAME, dto.get("name"));
-    assertEquals(EXAMPLE_DECISION_DEFINITION_KEY, dto.get("key"));
-    assertEquals(EXAMPLE_DECISION_DEFINITION_VERSION, dto.get("version"));
-    assertEquals(EXAMPLE_DECISION_DEFINITION_RESOURCE_NAME, dto.get("resource"));
-    assertEquals(EXAMPLE_DEPLOYMENT_ID, dto.get("deploymentId"));
-    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID, dto.get("decisionRequirementsDefinitionId"));
-    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_KEY, dto.get("decisionRequirementsDefinitionKey"));
+    assertThat(dto).containsEntry("id", EXAMPLE_DECISION_DEFINITION_ID)
+                   .containsEntry("category", EXAMPLE_DECISION_DEFINITION_CATEGORY)
+                   .containsEntry("name", EXAMPLE_DECISION_DEFINITION_NAME)
+                   .containsEntry("key", EXAMPLE_DECISION_DEFINITION_KEY)
+                   .containsEntry("version", EXAMPLE_DECISION_DEFINITION_VERSION)
+                   .containsEntry("resource", EXAMPLE_DECISION_DEFINITION_RESOURCE_NAME)
+                   .containsEntry("deploymentId", EXAMPLE_DEPLOYMENT_ID)
+                   .containsEntry("decisionRequirementsDefinitionId", EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID)
+                   .containsEntry("decisionRequirementsDefinitionKey", EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_KEY);
   }
 
   private void verifyDrdDeployment(HashMap<String, Object> dto) {
-    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID, dto.get("id"));
-    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_CATEGORY, dto.get("category"));
-    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_NAME, dto.get("name"));
-    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_KEY, dto.get("key"));
-    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_VERSION, dto.get("version"));
-    assertEquals(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_RESOURCE_NAME, dto.get("resource"));
-    assertEquals(EXAMPLE_DEPLOYMENT_ID, dto.get("deploymentId"));
+    assertThat(dto).containsEntry("id", EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID)
+                   .containsEntry("category", EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_CATEGORY)
+                   .containsEntry("name", EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_NAME)
+                   .containsEntry("key", EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_KEY)
+                   .containsEntry("version", EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_VERSION)
+                   .containsEntry("resource", EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_RESOURCE_NAME)
+                   .containsEntry("deploymentId", EXAMPLE_DEPLOYMENT_ID);
   }
 
   private void verifyDeploymentValuesEmptyDefinitions(Deployment mockDeployment, String responseContent) {
     JsonPath path = from(responseContent);
     verifyStandardDeploymentValues(mockDeployment, path);
 
-    assertThat(path.get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS)).isNull();
-    assertThat(path.get(PROPERTY_DEPLOYED_CASE_DEFINITIONS)).isNull();
-    assertThat(path.get(PROPERTY_DEPLOYED_DECISION_DEFINITIONS)).isNull();
-    assertThat(path.get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS)).isNull();
+    assertThat(path.<String>get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS)).isNull();
+    assertThat(path.<String>get(PROPERTY_DEPLOYED_CASE_DEFINITIONS)).isNull();
+    assertThat(path.<String>get(PROPERTY_DEPLOYED_DECISION_DEFINITIONS)).isNull();
+    assertThat(path.<String>get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS)).isNull();
   }
 
   private void verifyStandardDeploymentValues(Deployment mockDeployment, JsonPath path) {
@@ -2091,19 +2090,21 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
     String returnedName = path.get("name");
     Date returnedDeploymentTime = DateTimeUtil.parseDate(path.<String>get("deploymentTime"));
 
-    assertEquals(mockDeployment.getId(), returnedId);
-    assertEquals(mockDeployment.getName(), returnedName);
-    assertEquals(mockDeployment.getDeploymentTime(), returnedDeploymentTime);
+    assertThat(returnedId).isEqualTo(mockDeployment.getId());
+    assertThat(returnedName).isEqualTo(mockDeployment.getName());
+    assertThat(returnedDeploymentTime).isEqualTo(mockDeployment.getDeploymentTime());
   }
 
   private void verifyDeploymentLink(Deployment mockDeployment, String responseContent) {
     List<Map<String, String>> returnedLinks = from(responseContent).getList("links");
-    assertEquals(1, returnedLinks.size());
+    assertThat(returnedLinks).hasSize(1);
 
     Map<String, String> returnedLink = returnedLinks.get(0);
-    assertEquals(HttpMethod.GET, returnedLink.get("method"));
+    assertThat(returnedLink)
+      .containsEntry("method", HttpMethod.GET)
+      .containsEntry("rel", "self");
+
     assertThat(returnedLink.get("href")).endsWith(RESOURCE_URL + "/" + mockDeployment.getId());
-    assertEquals("self", returnedLink.get("rel"));
   }
 
   private void verifyDeploymentResource(Resource mockDeploymentResource, Response response) {
@@ -2114,15 +2115,15 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
     String returnedName = path.get("name");
     String returnedDeploymentId = path.get("deploymentId");
 
-    assertEquals(mockDeploymentResource.getId(), returnedId);
-    assertEquals(mockDeploymentResource.getName(), returnedName);
-    assertEquals(mockDeploymentResource.getDeploymentId(), returnedDeploymentId);
+    assertThat(returnedId).isEqualTo(mockDeploymentResource.getId());
+    assertThat(returnedName).isEqualTo(mockDeploymentResource.getName());
+    assertThat(returnedDeploymentId).isEqualTo(mockDeploymentResource.getDeploymentId());
   }
 
   @SuppressWarnings("unchecked")
   private void verifyDeploymentResources(List<Resource> mockDeploymentResources, Response response) {
     List list = response.as(List.class);
-    assertEquals(1, list.size());
+    assertThat(list).hasSize(1);
 
     LinkedHashMap<String, String> resourceHashMap = (LinkedHashMap<String, String>) list.get(0);
 
@@ -2132,9 +2133,9 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     Resource deploymentResource = mockDeploymentResources.get(0);
 
-    assertEquals(deploymentResource.getId(), returnedId);
-    assertEquals(deploymentResource.getName(), returnedName);
-    assertEquals(deploymentResource.getDeploymentId(), returnedDeploymentId);
+    assertThat(returnedId).isEqualTo(deploymentResource.getId());
+    assertThat(returnedName).isEqualTo(deploymentResource.getName());
+    assertThat(returnedDeploymentId).isEqualTo(deploymentResource.getDeploymentId());
   }
 
   private List<Problem> mockProblems(int column, int line, String message, String elementId) {

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DeploymentRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DeploymentRestServiceInteractionTest.java
@@ -38,18 +38,17 @@ import java.util.*;
 import io.restassured.http.ContentType;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.Response;
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTest {
@@ -115,7 +114,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
   private InputStream createMockDeploymentResourceBpmnData() {
     // do not close the input stream, will be done in implementation
     InputStream bpmn20XmlIn = ReflectUtil.getResourceAsStream("processes/fox-invoice_en_long_id.bpmn");
-    assertNotNull(bpmn20XmlIn);
+    assertThat(bpmn20XmlIn).isNotNull();
     return bpmn20XmlIn;
   }
 
@@ -128,7 +127,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
   private InputStream createMockDeploymentResourceSvgData() {
     // do not close the input stream, will be done in implementation
     InputStream image = ReflectUtil.getResourceAsStream("processes/diagram.svg");
-    assertNotNull(image);
+    assertThat(image).isNotNull();
     return image;
   }
 
@@ -273,7 +272,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertTrue(responseContent.contains("<?xml"));
+    assertThat(responseContent).contains("<?xml");
 
   }
 
@@ -300,7 +299,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertTrue(responseContent.contains("<?xml"));
+    assertThat(responseContent).contains("<?xml");
   }
 
   @Test
@@ -328,7 +327,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -356,7 +355,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -384,7 +383,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -412,7 +411,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -440,7 +439,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -468,7 +467,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -496,7 +495,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -522,7 +521,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -548,7 +547,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -576,7 +575,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -604,7 +603,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -632,7 +631,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -660,7 +659,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -688,7 +687,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -716,7 +715,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -744,7 +743,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -772,7 +771,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -800,7 +799,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -828,7 +827,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -856,7 +855,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -884,7 +883,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -912,7 +911,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -940,7 +939,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -968,7 +967,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
         .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -996,7 +995,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -1024,7 +1023,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
       .when().get(SINGLE_RESOURCE_DATA_URL);
 
     String responseContent = response.asString();
-    assertNotNull(responseContent);
+    assertThat(responseContent).isNotNull();
   }
 
   @Test
@@ -1953,13 +1952,13 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
     Map<String, HashMap<String, Object>>  deployedDecisionRequirementsDefinitions = path.getMap(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS);
 
     assertEquals(1, deployedProcessDefinitions.size());
-    assertNotNull(deployedProcessDefinitions.get(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
+    assertThat(deployedProcessDefinitions.get(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID)).isNotNull();
     assertEquals(1, deployedCaseDefinitions.size());
-    assertNotNull(deployedCaseDefinitions.get(EXAMPLE_CASE_DEFINITION_ID));
+    assertThat(deployedCaseDefinitions.get(EXAMPLE_CASE_DEFINITION_ID)).isNotNull();
     assertEquals(1, deployedDecisionDefinitions.size());
-    assertNotNull(deployedDecisionDefinitions.get(EXAMPLE_DECISION_DEFINITION_ID));
+    assertThat(deployedDecisionDefinitions.get(EXAMPLE_DECISION_DEFINITION_ID)).isNotNull();
     assertEquals(1, deployedDecisionRequirementsDefinitions.size());
-    assertNotNull(deployedDecisionRequirementsDefinitions.get(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID));
+    assertThat(deployedDecisionRequirementsDefinitions.get(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID)).isNotNull();
   }
 
   private void verifyBpmnDeploymentValues(Deployment mockDeployment, String responseContent) {
@@ -1970,12 +1969,12 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     assertEquals(1, deployedProcessDefinitionDtos.size());
     HashMap processDefinitionDto = deployedProcessDefinitionDtos.get(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
-    assertNotNull(processDefinitionDto);
+    assertThat(processDefinitionDto).isNotNull();
     verifyBpmnDeployment(processDefinitionDto);
 
-    assertNull(path.get(PROPERTY_DEPLOYED_CASE_DEFINITIONS));
-    assertNull(path.get(PROPERTY_DEPLOYED_DECISION_DEFINITIONS));
-    assertNull(path.get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS));
+    assertThat(path.get(PROPERTY_DEPLOYED_CASE_DEFINITIONS)).isNull();
+    assertThat(path.get(PROPERTY_DEPLOYED_DECISION_DEFINITIONS)).isNull();
+    assertThat(path.get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS)).isNull();
   }
 
   private void verifyCmmnDeploymentValues(Deployment mockDeployment, String responseContent) {
@@ -1986,12 +1985,12 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     assertEquals(1, deployedCaseDefinitions.size());
     HashMap caseDefinitionDto = deployedCaseDefinitions.get(EXAMPLE_CASE_DEFINITION_ID);
-    assertNotNull(caseDefinitionDto);
+    assertThat(caseDefinitionDto).isNotNull();
     verifyCmnDeployment(caseDefinitionDto);
 
-    assertNull(path.get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS));
-    assertNull(path.get(PROPERTY_DEPLOYED_DECISION_DEFINITIONS));
-    assertNull(path.get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS));
+    assertThat(path.get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS)).isNull();
+    assertThat(path.get(PROPERTY_DEPLOYED_DECISION_DEFINITIONS)).isNull();
+    assertThat(path.get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS)).isNull();
   }
 
   private void verifyDmnDeploymentValues(Deployment mockDeployment, String responseContent) {
@@ -2002,12 +2001,12 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     assertEquals(1, deployedDecisionDefinitions.size());
     HashMap decisionDefinitionDto = deployedDecisionDefinitions.get(EXAMPLE_DECISION_DEFINITION_ID);
-    assertNotNull(decisionDefinitionDto);
+    assertThat(decisionDefinitionDto).isNotNull();
     verifyDmnDeployment(decisionDefinitionDto);
 
-    assertNull(path.get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS));
-    assertNull(path.get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS));
-    assertNull(path.get(PROPERTY_DEPLOYED_CASE_DEFINITIONS));
+    assertThat(path.get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS)).isNull();
+    assertThat(path.get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS)).isNull();
+    assertThat(path.get(PROPERTY_DEPLOYED_CASE_DEFINITIONS)).isNull();
   }
 
   private void verifyDrdDeploymentValues(Deployment mockDeployment, String responseContent) {
@@ -2021,16 +2020,16 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     assertEquals(1, deployedDecisionDefinitions.size());
     HashMap decisionDefinitionDto = deployedDecisionDefinitions.get(EXAMPLE_DECISION_DEFINITION_ID);
-    assertNotNull(decisionDefinitionDto);
+    assertThat(decisionDefinitionDto).isNotNull();
     verifyDmnDeployment(decisionDefinitionDto);
 
     assertEquals(1, deployedDecisionRequirementsDefinitions.size());
     HashMap decisionRequirementsDefinitionDto = deployedDecisionRequirementsDefinitions.get(EXAMPLE_DECISION_REQUIREMENTS_DEFINITION_ID);
-    assertNotNull(decisionRequirementsDefinitionDto);
+    assertThat(decisionRequirementsDefinitionDto).isNotNull();
     verifyDrdDeployment(decisionRequirementsDefinitionDto);
 
-    assertNull(path.get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS));
-    assertNull(path.get(PROPERTY_DEPLOYED_CASE_DEFINITIONS));
+    assertThat(path.get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS)).isNull();
+    assertThat(path.get(PROPERTY_DEPLOYED_CASE_DEFINITIONS)).isNull();
   }
 
   private void verifyBpmnDeployment(HashMap<String, Object> dto) {
@@ -2081,10 +2080,10 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
     JsonPath path = from(responseContent);
     verifyStandardDeploymentValues(mockDeployment, path);
 
-    assertNull(path.get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS));
-    assertNull(path.get(PROPERTY_DEPLOYED_CASE_DEFINITIONS));
-    assertNull(path.get(PROPERTY_DEPLOYED_DECISION_DEFINITIONS));
-    assertNull(path.get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS));
+    assertThat(path.get(PROPERTY_DEPLOYED_PROCESS_DEFINITIONS)).isNull();
+    assertThat(path.get(PROPERTY_DEPLOYED_CASE_DEFINITIONS)).isNull();
+    assertThat(path.get(PROPERTY_DEPLOYED_DECISION_DEFINITIONS)).isNull();
+    assertThat(path.get(PROPERTY_DEPLOYED_DECISION_REQUIREMENTS_DEFINITIONS)).isNull();
   }
 
   private void verifyStandardDeploymentValues(Deployment mockDeployment, JsonPath path) {
@@ -2103,7 +2102,7 @@ public class DeploymentRestServiceInteractionTest extends AbstractRestServiceTes
 
     Map<String, String> returnedLink = returnedLinks.get(0);
     assertEquals(HttpMethod.GET, returnedLink.get("method"));
-    assertTrue(returnedLink.get("href").endsWith(RESOURCE_URL + "/" + mockDeployment.getId()));
+    assertThat(returnedLink.get("href")).endsWith(RESOURCE_URL + "/" + mockDeployment.getId());
     assertEquals("self", returnedLink.get("rel"));
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DeploymentRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/DeploymentRestServiceQueryTest.java
@@ -136,7 +136,7 @@ public class DeploymentRestServiceQueryTest extends AbstractRestServiceTest {
     String content = response.asString();
     List<String> deployments = from(content).getList("");
     Assert.assertEquals("There should be one deployment returned.", 1, deployments.size());
-    Assert.assertNotNull("There should be one deployment returned", deployments.get(0));
+    assertThat(deployments.get(0)).as("There should be one deployment returned").isNotNull();
 
     String returnedId = from(content).getString("[0].id");
     String returnedName = from(content).getString("[0].name");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/EventSubscriptionRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/EventSubscriptionRestServiceQueryTest.java
@@ -100,7 +100,7 @@ public class EventSubscriptionRestServiceQueryTest extends AbstractRestServiceTe
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one event subscription returned.", 1, instances.size());
-    Assert.assertNotNull("There should be one event subscription returned", instances.get(0));
+    assertThat(instances.get(0)).as("There should be one event subscription returned").isNotNull();
 
     String returnedEventSubscriptionId = from(content).getString("[0].id");
     String returnedEventType = from(content).getString("[0].eventType");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExecutionRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExecutionRestServiceQueryTest.java
@@ -161,7 +161,7 @@ public class ExecutionRestServiceQueryTest extends
     String content = response.asString();
     List<String> executions = from(content).getList("");
     Assert.assertEquals("There should be one execution returned.", 1, executions.size());
-    Assert.assertNotNull("There should be one execution returned", executions.get(0));
+    assertThat(executions.get(0)).as("There should be one execution returned").isNotNull();
 
     String returnedExecutionId = from(content).getString("[0].id");
     Boolean returnedIsEnded = from(content).getBoolean("[0].ended");
@@ -182,8 +182,7 @@ public class ExecutionRestServiceQueryTest extends
 
     String content = response.asString();
     String returnedProcessInstanceId = from(content).getString("[0].processInstanceId");
-    Assert.assertNull("Should be null, as it is also null in the original execution on the server.",
-        returnedProcessInstanceId);
+    assertThat(returnedProcessInstanceId).as("Should be null, as it is also null in the original execution on the server.").isNull();
   }
 
   private List<Execution> createIncompleteMockExecutions() {

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExternalTaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExternalTaskRestServiceQueryTest.java
@@ -126,7 +126,7 @@ public class ExternalTaskRestServiceQueryTest extends AbstractRestServiceTest {
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one external task returned.", 1, instances.size());
-    Assert.assertNotNull("The returned external task should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned external task should not be null.").isNotNull();
 
     String activityId = from(content).getString("[0].activityId");
     String activityInstanceId = from(content).getString("[0].activityInstanceId");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/FilterRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/FilterRestServiceInteractionTest.java
@@ -638,15 +638,17 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
 
   @SuppressWarnings("unchecked")
   protected void assertSorting(Map<String, Object> sorting, String sortBy, String sortOrder, String parametersVariable, ValueType parametersType) {
-    assertThat(sorting).containsEntry("sortBy", sortBy);
-    assertThat(sorting).containsEntry("sortOrder", sortOrder);
+    assertThat(sorting)
+            .containsEntry("sortBy", sortBy)
+            .containsEntry("sortOrder", sortOrder);
     if (parametersVariable == null) {
       assertThat(sorting.containsKey("parameters")).isFalse();
     }
     else {
       Map<String, Object> parameters = (Map<String, Object>) sorting.get("parameters");
-      assertThat(parameters).containsEntry("variable", parametersVariable);
-      assertThat(parameters).containsEntry("type", VariableValueDto.toRestApiTypeName(parametersType.getName()));
+      assertThat(parameters)
+              .containsEntry("variable", parametersVariable)
+              .containsEntry("type", VariableValueDto.toRestApiTypeName(parametersType.getName()));
     }
   }
 
@@ -1894,10 +1896,11 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
 
   @SuppressWarnings("unchecked")
   protected void verifyVariableValue(Map<String, Object> variable, String name, String value, String scopeResourcePath, String scopeId, String variablesName) {
-    assertThat(variable).containsEntry("name", name);
-    assertThat(variable).containsEntry("value", value);
-    assertThat(variable).containsEntry("type", "String");
-    assertThat(variable).containsEntry("valueInfo", Collections.emptyMap());
+    assertThat(variable)
+            .containsEntry("name", name)
+            .containsEntry("value", value)
+            .containsEntry("type", "String")
+            .containsEntry("valueInfo", Collections.emptyMap());
     assertThat(variable.get("_embedded")).isNull();
     Map<String, Map<String, String>> links = (Map<String, Map<String, String>>) variable.get("_links");
     assertThat(links).hasSize(1);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/GroupRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/GroupRestServiceQueryTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.rest;
 import static io.restassured.RestAssured.expect;
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -126,7 +127,7 @@ public class GroupRestServiceQueryTest extends AbstractRestServiceTest {
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one group returned.", 1, instances.size());
-    Assert.assertNotNull("The returned group should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned group should not be null.").isNotNull();
 
     String returendName = from(content).getString("[0].name");
     String returendType = from(content).getString("[0].type");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/IncidentRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/IncidentRestServiceQueryTest.java
@@ -338,7 +338,7 @@ public class IncidentRestServiceQueryTest extends AbstractRestServiceTest {
     String content = response.asString();
     List<String> incidents = from(content).getList("");
     Assert.assertEquals("There should be one incident returned.", 1, incidents.size());
-    Assert.assertNotNull("The returned incident should not be null.", incidents.get(0));
+    assertThat(incidents.get(0)).as("The returned incident should not be null.").isNotNull();
 
     String returnedId = from(content).getString("[0].id");
     String returnedProcessDefinitionId = from(content).getString("[0].processDefinitionId");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/JobRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/JobRestServiceInteractionTest.java
@@ -17,10 +17,10 @@
 package org.operaton.bpm.engine.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -1805,7 +1805,7 @@ public class JobRestServiceInteractionTest extends AbstractRestServiceTest {
 
   protected void verifyBatchJson(String batchJson) {
     BatchDto batch = JsonPathUtil.from(batchJson).getObject("", BatchDto.class);
-    assertNotNull("The returned batch should not be null.", batch);
+    assertThat(batch).as("The returned batch should not be null.").isNotNull();
     assertEquals(MockProvider.EXAMPLE_BATCH_ID, batch.getId());
     assertEquals(MockProvider.EXAMPLE_BATCH_TYPE, batch.getType());
     assertEquals(MockProvider.EXAMPLE_BATCH_TOTAL_JOBS, batch.getTotalJobs());

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/JobRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/JobRestServiceQueryTest.java
@@ -148,7 +148,7 @@ public class JobRestServiceQueryTest extends AbstractRestServiceTest {
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one job returned.", 1, instances.size());
-    Assert.assertNotNull("The returned job should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned job should not be null.").isNotNull();
 
     String returnedJobId = from(content).getString("[0].id");
     String returnedProcessInstanceId = from(content).getString("[0].processInstanceId");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/MessageRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/MessageRestServiceTest.java
@@ -62,9 +62,6 @@ import static org.mockito.Mockito.when;
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -207,9 +204,9 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     .when().post(MESSAGE_URL);
 
     //then
-    assertNotNull(response);
+    assertThat(response).isNotNull();
     String content = response.asString();
-    assertTrue(!content.isEmpty());
+    assertThat(!content.isEmpty()).isTrue();
     checkExecutionResult(content, 0);
 
     verify(runtimeServiceMock).createMessageCorrelation(messageName);
@@ -223,7 +220,7 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     //execution should be filled and process instance should be null
     assertEquals(MockProvider.EXAMPLE_EXECUTION_ID, from(content).get("[" + idx + "].execution.id"));
     assertEquals(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID, from(content).get("[" + idx + "].execution.processInstanceId"));
-    assertNull(from(content).get("[" + idx + "].processInstance"));
+    assertThat(from(content).get("[" + idx + "].processInstance")).isNull();
   }
 
   @Test
@@ -245,9 +242,9 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     .when().post(MESSAGE_URL);
 
     //then
-    assertNotNull(response);
+    assertThat(response).isNotNull();
     String content = response.asString();
-    assertTrue(!content.isEmpty());
+    assertThat(!content.isEmpty()).isTrue();
     checkProcessInstanceResult(content, 0);
 
     verify(runtimeServiceMock).createMessageCorrelation(messageName);
@@ -355,9 +352,9 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     .when().post(MESSAGE_URL);
 
     //then
-    assertNotNull(response);
+    assertThat(response).isNotNull();
     String content = response.asString();
-    assertTrue(!content.isEmpty());
+    assertThat(!content.isEmpty()).isTrue();
 
     List<HashMap> results = from(content).getList("");
     assertEquals(2, results.size());
@@ -388,10 +385,10 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
            .statusCode(Status.OK.getStatusCode())
     .when().post(MESSAGE_URL);
 
-    //then
-    assertNotNull(response);
+   //then
+   assertThat(response).isNotNull();
     String content = response.asString();
-    assertTrue(!content.isEmpty());
+   assertThat(!content.isEmpty()).isTrue();
 
     List<HashMap> results = from(content).getList("");
     assertEquals(2, results.size());
@@ -423,15 +420,15 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     .when().post(MESSAGE_URL);
 
     //then
-    assertNotNull(response);
+    assertThat(response).isNotNull();
     String content = response.asString();
-    assertTrue(!content.isEmpty());
+    assertThat(!content.isEmpty()).isTrue();
 
     List<HashMap> results = from(content).getList("");
     assertEquals(4, results.size());
     for (int i = 0; i < 2; i++) {
       String resultType = from(content).get("[" + i + "].resultType");
-      assertNotNull(resultType);
+      assertThat(resultType).isNotNull();
       if (resultType.equals(MessageCorrelationResultType.Execution.name())) {
         checkExecutionResult(content, i);
       } else {
@@ -462,9 +459,9 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     .when().post(MESSAGE_URL);
 
     //then
-    assertNotNull(response);
+    assertThat(response).isNotNull();
     String content = response.asString();
-    assertTrue(content.isEmpty());
+    assertThat(content).isEmpty();
 
     verify(runtimeServiceMock).createMessageCorrelation(messageName);
     verify(messageCorrelationBuilderMock).correlateAllWithResult();
@@ -1256,9 +1253,9 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     .when().post(MESSAGE_URL);
 
     // then
-    assertNotNull(response);
+    assertThat(response).isNotNull();
     String content = response.asString();
-    assertTrue(!content.isEmpty());
+    assertThat(!content.isEmpty()).isTrue();
     checkVariablesInResult(content, 0);
     checkExecutionResult(content, 0);
 
@@ -1287,9 +1284,9 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     .when().post(MESSAGE_URL);
 
     // then
-    assertNotNull(response);
+    assertThat(response).isNotNull();
     String content = response.asString();
-    assertTrue(!content.isEmpty());
+    assertThat(!content.isEmpty()).isTrue();
 
     List<HashMap<Object, Object>> results = from(content).getList("");
     assertEquals(1, results.size());

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/MessageRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/MessageRestServiceTest.java
@@ -220,7 +220,7 @@ public class MessageRestServiceTest extends AbstractRestServiceTest {
     //execution should be filled and process instance should be null
     assertEquals(MockProvider.EXAMPLE_EXECUTION_ID, from(content).get("[" + idx + "].execution.id"));
     assertEquals(MockProvider.EXAMPLE_PROCESS_INSTANCE_ID, from(content).get("[" + idx + "].execution.processInstanceId"));
-    assertThat(from(content).get("[" + idx + "].processInstance")).isNull();
+    assertThat(from(content).<String>get("[" + idx + "].processInstance")).isNull();
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
@@ -117,9 +117,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
   private RuntimeService runtimeServiceMock;
   private RepositoryService repositoryServiceMock;
   private FormService formServiceMock;
-  private ManagementService managementServiceMock;
   private ProcessDefinitionQuery processDefinitionQueryMock;
-  private ProcessInstanceWithVariables mockInstance;
   private ProcessInstantiationBuilder mockInstantiationBuilder;
 
   @Before
@@ -127,7 +125,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
     ProcessDefinition mockDefinition = MockProvider.createMockDefinition();
     setUpRuntimeDataForDefinition(mockDefinition);
 
-    managementServiceMock = mock(ManagementService.class);
+    var managementServiceMock = mock(ManagementService.class);
     when(processEngine.getManagementService()).thenReturn(managementServiceMock);
     when(managementServiceMock.getProcessApplicationForDeployment(MockProvider.EXAMPLE_DEPLOYMENT_ID)).thenReturn(MockProvider.EXAMPLE_PROCESS_APPLICATION_NAME);
 
@@ -143,7 +141,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
   }
 
   private void setUpRuntimeDataForDefinition(ProcessDefinition mockDefinition) {
-    mockInstance = MockProvider.createMockInstanceWithVariables();
+    var mockInstance = MockProvider.createMockInstanceWithVariables();
 
     // we replace this mock with every test in order to have a clean one (in terms of invocations) for verification
     runtimeServiceMock = mock(RuntimeService.class);
@@ -182,8 +180,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
 
   private InputStream createMockProcessDefinitionBpmn20Xml() {
     // do not close the input stream, will be done in implementation
-    InputStream bpmn20XmlIn = null;
-    bpmn20XmlIn = ReflectUtil.getResourceAsStream("processes/fox-invoice_en_long_id.bpmn");
+    InputStream bpmn20XmlIn = ReflectUtil.getResourceAsStream("processes/fox-invoice_en_long_id.bpmn");
     assertThat(bpmn20XmlIn).isNotNull();
     return bpmn20XmlIn;
   }
@@ -239,8 +236,9 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
     .when().get(XML_DEFINITION_URL);
 
     String responseContent = response.asString();
-    assertThat(responseContent).contains(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
-    assertThat(responseContent).contains("<?xml");
+    assertThat(responseContent)
+      .contains("<?xml")
+      .contains(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
   }
 
   @Test
@@ -2760,8 +2758,9 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
     .when().get(XML_DEFINITION_BY_KEY_URL);
 
     String responseContent = response.asString();
-    assertThat(responseContent).contains(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
-    assertThat(responseContent).contains("<?xml");
+    assertThat(responseContent)
+      .contains("<?xml")
+      .contains(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
@@ -57,7 +57,6 @@ import java.util.*;
 
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
-import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -67,6 +66,7 @@ import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -184,7 +184,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
     // do not close the input stream, will be done in implementation
     InputStream bpmn20XmlIn = null;
     bpmn20XmlIn = ReflectUtil.getResourceAsStream("processes/fox-invoice_en_long_id.bpmn");
-    Assert.assertNotNull(bpmn20XmlIn);
+    assertThat(bpmn20XmlIn).isNotNull();
     return bpmn20XmlIn;
   }
 
@@ -239,8 +239,8 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
     .when().get(XML_DEFINITION_URL);
 
     String responseContent = response.asString();
-    Assert.assertTrue(responseContent.contains(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
-    Assert.assertTrue(responseContent.contains("<?xml"));
+    assertThat(responseContent).contains(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
+    assertThat(responseContent).contains("<?xml");
   }
 
   @Test
@@ -266,7 +266,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
 
     // compare input stream with response body bytes
     byte[] expected = IoUtil.readInputStream(new FileInputStream(file), "process diagram");
-    Assert.assertArrayEquals(expected, actual);
+    assertThat(actual).containsExactly(expected);
   }
 
   @Test
@@ -293,7 +293,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
 
     // compare input stream with response body bytes
     byte[] expected = IoUtil.readInputStream(new FileInputStream(file), "process diagram");
-    Assert.assertArrayEquals(expected, actual);
+    assertThat(actual).containsExactly(expected);
   }
 
   @Test
@@ -462,7 +462,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
         .get(RENDERED_FORM_URL);
 
     String responseContent = response.asString();
-    Assertions.assertThat(responseContent).isEqualTo(expectedResult);
+    assertThat(responseContent).isEqualTo(expectedResult);
   }
 
   @Test
@@ -480,7 +480,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
           .get(RENDERED_FORM_URL);
 
     String responseContent = new String(response.asByteArray(), EncodingUtil.DEFAULT_ENCODING);
-    Assertions.assertThat(responseContent).isEqualTo(expectedResult);
+    assertThat(responseContent).isEqualTo(expectedResult);
   }
 
   @Test
@@ -2760,8 +2760,8 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
     .when().get(XML_DEFINITION_BY_KEY_URL);
 
     String responseContent = response.asString();
-    Assert.assertTrue(responseContent.contains(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID));
-    Assert.assertTrue(responseContent.contains("<?xml"));
+    assertThat(responseContent).contains(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID);
+    assertThat(responseContent).contains("<?xml");
   }
 
   @Test
@@ -2832,7 +2832,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
         .get(RENDERED_FORM_BY_KEY_URL);
 
     String responseContent = response.asString();
-    Assertions.assertThat(responseContent).isEqualTo(expectedResult);
+    assertThat(responseContent).isEqualTo(expectedResult);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessDefinitionRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessDefinitionRestServiceQueryTest.java
@@ -163,7 +163,7 @@ public class ProcessDefinitionRestServiceQueryTest extends AbstractRestServiceTe
     String content = response.asString();
     List<String> definitions = from(content).getList("");
     Assert.assertEquals("There should be one process definition returned.", 1, definitions.size());
-    Assert.assertNotNull("There should be one process definition returned", definitions.get(0));
+    assertThat(definitions.get(0)).as("There should be one process definition returned").isNotNull();
 
     String returnedDefinitionKey = from(content).getString("[0].key");
     String returnedDefinitionId = from(content).getString("[0].id");
@@ -252,8 +252,7 @@ public class ProcessDefinitionRestServiceQueryTest extends AbstractRestServiceTe
 
     String content = response.asString();
     String returnedResourceName = from(content).getString("[0].resource");
-    Assert.assertNull("Should be null, as it is also null in the original process definition on the server.",
-        returnedResourceName);
+    assertThat(returnedResourceName).as("Should be null, as it is also null in the original process definition on the server.").isNull();
   }
 
   private List<ProcessDefinition> createIncompleteMockDefinitions() {

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
@@ -30,7 +30,6 @@ import static org.operaton.bpm.engine.rest.util.DateTimeUtils.withTimezone;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -61,7 +60,6 @@ import java.util.List;
 import java.util.Map;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response.Status;
-import org.assertj.core.api.Assertions;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.BadUserRequestException;
 import org.operaton.bpm.engine.ProcessEngineException;
@@ -4414,7 +4412,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
         captor.capture()
     );
 
-    Assertions.assertThat(captor.getValue()).containsEntry("foo", "bar");
+    assertThat(captor.getValue()).containsEntry("foo", "bar");
 
     verifyBatchJson(response.asString());
   }
@@ -4857,7 +4855,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
 
   protected void verifyBatchJson(String batchJson) {
     BatchDto batch = JsonPathUtil.from(batchJson).getObject("", BatchDto.class);
-    assertNotNull("The returned batch should not be null.", batch);
+    assertThat(batch).as("The returned batch should not be null.").isNotNull();
     assertEquals(MockProvider.EXAMPLE_BATCH_ID, batch.getId());
     assertEquals(MockProvider.EXAMPLE_BATCH_TYPE, batch.getType());
     assertEquals(MockProvider.EXAMPLE_BATCH_TOTAL_JOBS, batch.getTotalJobs());

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceQueryTest.java
@@ -153,7 +153,7 @@ public class ProcessInstanceRestServiceQueryTest extends
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one process definition returned.", 1, instances.size());
-    Assert.assertNotNull("There should be one process definition returned", instances.get(0));
+    assertThat(instances.get(0)).as("There should be one process definition returned").isNotNull();
 
     String returnedInstanceId = from(content).getString("[0].id");
     Boolean returnedIsEnded = from(content).getBoolean("[0].ended");
@@ -180,8 +180,7 @@ public class ProcessInstanceRestServiceQueryTest extends
 
     String content = response.asString();
     String returnedBusinessKey = from(content).getString("[0].businessKey");
-    Assert.assertNull("Should be null, as it is also null in the original process instance on the server.",
-        returnedBusinessKey);
+    assertThat(returnedBusinessKey).as("Should be null, as it is also null in the original process instance on the server.").isNull();
   }
 
   private List<ProcessInstance> createIncompleteMockInstances() {

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskReportRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskReportRestServiceTest.java
@@ -37,8 +37,8 @@ import org.junit.Test;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -117,7 +117,7 @@ public class TaskReportRestServiceTest extends AbstractRestServiceTest {
     String content = response.asString();
     List<String> reports = from(content).getList("");
     Assert.assertEquals("There should be one report returned.", 1, reports.size());
-    Assert.assertNotNull("The returned report should not be null.", reports.get(0));
+    assertThat(reports.get(0)).as("The returned report should not be null.").isNotNull();
 
     String returnedGroup = from(content).getString("[0].groupName");
     int returnedCount = from(content).getInt("[0].taskCount");
@@ -157,9 +157,9 @@ public class TaskReportRestServiceTest extends AbstractRestServiceTest {
         .get(CANDIDATE_GROUP_REPORT_URL);
 
     String responseContent = response.asString();
-    assertTrue(responseContent.contains(TaskReportResultToCsvConverter.CANDIDATE_GROUP_HEADER));
-    assertTrue(responseContent.contains(EXAMPLE_GROUP_ID));
-    assertTrue(responseContent.contains(String.valueOf(EXAMPLE_TASK_COUNT_BY_CANDIDATE_GROUP)));
+    assertThat(responseContent).contains(TaskReportResultToCsvConverter.CANDIDATE_GROUP_HEADER);
+    assertThat(responseContent).contains(EXAMPLE_GROUP_ID);
+    assertThat(responseContent).contains(String);
   }
 
   @Test
@@ -177,8 +177,8 @@ public class TaskReportRestServiceTest extends AbstractRestServiceTest {
           .get(CANDIDATE_GROUP_REPORT_URL);
 
     String responseContent = response.asString();
-    assertTrue(responseContent.contains(TaskReportResultToCsvConverter.CANDIDATE_GROUP_HEADER));
-    assertTrue(responseContent.contains(EXAMPLE_GROUP_ID));
-    assertTrue(responseContent.contains(String.valueOf(EXAMPLE_TASK_COUNT_BY_CANDIDATE_GROUP)));
+    assertThat(responseContent).contains(TaskReportResultToCsvConverter.CANDIDATE_GROUP_HEADER);
+    assertThat(responseContent).contains(EXAMPLE_GROUP_ID);
+    assertThat(responseContent).contains(String);
   }
 }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskReportRestServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskReportRestServiceTest.java
@@ -157,9 +157,9 @@ public class TaskReportRestServiceTest extends AbstractRestServiceTest {
         .get(CANDIDATE_GROUP_REPORT_URL);
 
     String responseContent = response.asString();
-    assertThat(responseContent).contains(TaskReportResultToCsvConverter.CANDIDATE_GROUP_HEADER);
-    assertThat(responseContent).contains(EXAMPLE_GROUP_ID);
-    assertThat(responseContent).contains(String);
+    assertThat(responseContent).contains(TaskReportResultToCsvConverter.CANDIDATE_GROUP_HEADER)
+      .contains(EXAMPLE_GROUP_ID)
+      .contains(String.valueOf(EXAMPLE_TASK_COUNT_BY_CANDIDATE_GROUP));
   }
 
   @Test
@@ -177,8 +177,9 @@ public class TaskReportRestServiceTest extends AbstractRestServiceTest {
           .get(CANDIDATE_GROUP_REPORT_URL);
 
     String responseContent = response.asString();
-    assertThat(responseContent).contains(TaskReportResultToCsvConverter.CANDIDATE_GROUP_HEADER);
-    assertThat(responseContent).contains(EXAMPLE_GROUP_ID);
-    assertThat(responseContent).contains(String);
+    assertThat(responseContent)
+      .contains(TaskReportResultToCsvConverter.CANDIDATE_GROUP_HEADER)
+      .contains(EXAMPLE_GROUP_ID)
+      .contains(String.valueOf(EXAMPLE_TASK_COUNT_BY_CANDIDATE_GROUP));
   }
 }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceInteractionTest.java
@@ -48,9 +48,6 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -80,7 +77,6 @@ import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response.Status;
 
-import org.assertj.core.api.Assertions;
 import org.operaton.bpm.ProcessApplicationService;
 import org.operaton.bpm.application.ProcessApplicationInfo;
 import org.operaton.bpm.container.RuntimeContainerDelegate;
@@ -438,23 +434,23 @@ public class TaskRestServiceInteractionTest extends
     Assert.assertEquals("There should be two users returned.", 2, embeddedUsers.size());
 
     Map<String, Object> embeddedUser = embeddedUsers.get(0);
-    assertNotNull("The returned user should not be null.", embeddedUser);
+    assertThat(embeddedUser).as("The returned user should not be null.").isNotNull();
     assertEquals(MockProvider.EXAMPLE_TASK_ASSIGNEE_NAME, embeddedUser.get("id"));
     assertEquals(MockProvider.EXAMPLE_USER_FIRST_NAME, embeddedUser.get("firstName"));
     assertEquals(MockProvider.EXAMPLE_USER_LAST_NAME, embeddedUser.get("lastName"));
     assertEquals(MockProvider.EXAMPLE_USER_EMAIL, embeddedUser.get("email"));
-    assertNull(embeddedUser.get("_embedded"));
+    assertThat(embeddedUser.get("_embedded")).isNull();
     Map<String, Object> links = (Map<String, Object>) embeddedUser.get("_links");
     assertEquals(1, links.size());
     assertHalLink(links, "self", UserRestService.PATH + "/" + MockProvider.EXAMPLE_TASK_ASSIGNEE_NAME);
 
     embeddedUser = embeddedUsers.get(1);
-    assertNotNull("The returned user should not be null.", embeddedUser);
+    assertThat(embeddedUser).as("The returned user should not be null.").isNotNull();
     assertEquals(MockProvider.EXAMPLE_TASK_OWNER, embeddedUser.get("id"));
     assertEquals(MockProvider.EXAMPLE_USER_FIRST_NAME, embeddedUser.get("firstName"));
     assertEquals(MockProvider.EXAMPLE_USER_LAST_NAME, embeddedUser.get("lastName"));
     assertEquals(MockProvider.EXAMPLE_USER_EMAIL, embeddedUser.get("email"));
-    assertNull(embeddedUser.get("_embedded"));
+    assertThat(embeddedUser.get("_embedded")).isNull();
     links = (Map<String, Object>) embeddedUser.get("_links");
     assertEquals(1, links.size());
     assertHalLink(links, "self", UserRestService.PATH + "/" + MockProvider.EXAMPLE_TASK_OWNER);
@@ -464,21 +460,21 @@ public class TaskRestServiceInteractionTest extends
     Assert.assertEquals("There should be two groups returned.", 2, embeddedGroups.size());
 
     Map<String, Object> embeddedGroup = embeddedGroups.get(0);
-    assertNotNull("The returned group should not be null.", embeddedGroup);
+    assertThat(embeddedGroup).as("The returned group should not be null.").isNotNull();
     assertEquals(MockProvider.EXAMPLE_GROUP_ID, embeddedGroup.get("id"));
     assertEquals(MockProvider.EXAMPLE_GROUP_NAME, embeddedGroup.get("name"));
     assertEquals(MockProvider.EXAMPLE_GROUP_TYPE, embeddedGroup.get("type"));
-    assertNull(embeddedGroup.get("_embedded"));
+    assertThat(embeddedGroup.get("_embedded")).isNull();
     links = (Map<String, Object>) embeddedGroup.get("_links");
     assertEquals(1, links.size());
     assertHalLink(links, "self", GroupRestService.PATH + "/" + MockProvider.EXAMPLE_GROUP_ID);
 
     embeddedGroup = embeddedGroups.get(1);
-    assertNotNull("The returned group should not be null.", embeddedGroup);
+    assertThat(embeddedGroup).as("The returned group should not be null.").isNotNull();
     assertEquals(MockProvider.EXAMPLE_GROUP_ID2, embeddedGroup.get("id"));
     assertEquals(MockProvider.EXAMPLE_GROUP_NAME, embeddedGroup.get("name"));
     assertEquals(MockProvider.EXAMPLE_GROUP_TYPE, embeddedGroup.get("type"));
-    assertNull(embeddedGroup.get("_embedded"));
+    assertThat(embeddedGroup.get("_embedded")).isNull();
     links = (Map<String, Object>) embeddedGroup.get("_links");
     assertEquals(1, links.size());
     assertHalLink(links, "self", GroupRestService.PATH + "/" + MockProvider.EXAMPLE_GROUP_ID2);
@@ -487,7 +483,7 @@ public class TaskRestServiceInteractionTest extends
     List<Map<String,Object>> embeddedDefinitions = from(content).getList("_embedded.processDefinition");
     Assert.assertEquals("There should be one processDefinition returned.", 1, embeddedDefinitions.size());
     Map<String, Object> embeddedProcessDefinition = embeddedDefinitions.get(0);
-    Assert.assertNotNull("The returned processDefinition should not be null.", embeddedProcessDefinition);
+    assertThat(embeddedProcessDefinition).as("The returned processDefinition should not be null.").isNotNull();
     Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, embeddedProcessDefinition.get("id"));
     Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_KEY, embeddedProcessDefinition.get("key"));
     Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_CATEGORY, embeddedProcessDefinition.get("category"));
@@ -513,7 +509,7 @@ public class TaskRestServiceInteractionTest extends
     List<Map<String,Object>> embeddedCaseDefinitions = from(content).getList("_embedded.caseDefinition");
     Assert.assertEquals("There should be one caseDefinition returned.", 1, embeddedCaseDefinitions.size());
     Map<String, Object> embeddedCaseDefinition = embeddedCaseDefinitions.get(0);
-    Assert.assertNotNull("The returned caseDefinition should not be null.", embeddedCaseDefinition);
+    assertThat(embeddedCaseDefinition).as("The returned caseDefinition should not be null.").isNotNull();
     Assert.assertEquals(MockProvider.EXAMPLE_CASE_DEFINITION_ID, embeddedCaseDefinition.get("id"));
     Assert.assertEquals(MockProvider.EXAMPLE_CASE_DEFINITION_KEY, embeddedCaseDefinition.get("key"));
     Assert.assertEquals(MockProvider.EXAMPLE_CASE_DEFINITION_CATEGORY, embeddedCaseDefinition.get("category"));
@@ -543,7 +539,7 @@ public class TaskRestServiceInteractionTest extends
   @SuppressWarnings("unchecked")
   protected void assertHalLink(Map<String, Object> links, String key, String expectedLink) {
     Map<String, Object> linkObject = (Map<String, Object>) links.get(key);
-    Assert.assertNotNull(linkObject);
+    assertThat(linkObject).isNotNull();
 
     String actualLink = (String) linkObject.get("href");
     Assert.assertEquals(expectedLink, actualLink);
@@ -551,12 +547,12 @@ public class TaskRestServiceInteractionTest extends
 
   @SuppressWarnings("unchecked")
   protected void assertEmbeddedIdentityLink(IdentityLink expected, Map<String, Object> actual) {
-    assertNotNull("Embedded indentity link should not be null", actual);
+    assertThat(actual).as("Embedded indentity link should not be null").isNotNull();
     assertEquals(expected.getType(), actual.get("type"));
     assertEquals(expected.getUserId(), actual.get("userId"));
     assertEquals(expected.getGroupId(), actual.get("groupId"));
     assertEquals(expected.getTaskId(), actual.get("taskId"));
-    assertNull(actual.get("_embedded"));
+    assertThat(actual.get("_embedded")).isNull();
 
     Map<String, Object> links = (Map<String, Object>) actual.get("_links");
     if (expected.getUserId() != null) {
@@ -700,7 +696,7 @@ public class TaskRestServiceInteractionTest extends
         .get(RENDERED_FORM_URL);
 
     String responseContent = response.asString();
-    Assertions.assertThat(responseContent).isEqualTo(expectedResult);
+    assertThat(responseContent).isEqualTo(expectedResult);
   }
 
   @Test
@@ -718,7 +714,7 @@ public class TaskRestServiceInteractionTest extends
           .get(RENDERED_FORM_URL);
 
     String responseContent = new String(response.asByteArray(), EncodingUtil.DEFAULT_ENCODING);
-    Assertions.assertThat(responseContent).isEqualTo(expectedResult);
+    assertThat(responseContent).isEqualTo(expectedResult);
   }
 
   @Test
@@ -4116,7 +4112,7 @@ public class TaskRestServiceInteractionTest extends
 
     Map<String, String> returnedLink = returnedLinks.get(0);
     assertEquals(HttpMethod.GET, returnedLink.get("method"));
-    assertTrue(returnedLink.get("href").endsWith(SINGLE_TASK_COMMENTS_URL.replace("{id}", mockTaskComment.getTaskId()) + "/" + mockTaskComment.getId()));
+    assertThat(returnedLink.get("href")).endsWith(SINGLE_TASK_COMMENTS_URL.replace("{id}", mockTaskComment.getTaskId()) + "/" + mockTaskComment.getId());
     assertEquals("self", returnedLink.get("rel"));
   }
 
@@ -4177,7 +4173,7 @@ public class TaskRestServiceInteractionTest extends
 
     Map<String, String> returnedLink = returnedLinks.get(0);
     assertEquals(HttpMethod.GET, returnedLink.get("method"));
-    assertTrue(returnedLink.get("href").endsWith(SINGLE_TASK_ATTACHMENTS_URL.replace("{id}", mockTaskAttachment.getTaskId()) + "/" + mockTaskAttachment.getId()));
+    assertThat(returnedLink.get("href")).endsWith(SINGLE_TASK_ATTACHMENTS_URL.replace("{id}", mockTaskAttachment.getTaskId()) + "/" + mockTaskAttachment.getId());
     assertEquals("self", returnedLink.get("rel"));
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
@@ -278,7 +278,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     String content = response.asString();
     List<Map<String,Object>> instances = from(content).getList("_embedded.task");
     Assert.assertEquals("There should be one task returned.", 1, instances.size());
-    Assert.assertNotNull("The returned task should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned task should not be null.").isNotNull();
 
     Map<String, Object> taskObject = instances.get(0);
 
@@ -331,14 +331,14 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     // validate links
     Map<String,Object> selfReference = from(content).getMap("_links.self");
-    Assert.assertNotNull(selfReference);
+    assertThat(selfReference).isNotNull();
     Assert.assertEquals("/task", selfReference.get("href"));
 
     // validate embedded assignees:
     List<Map<String,Object>> embeddedAssignees = from(content).getList("_embedded.assignee");
     Assert.assertEquals("There should be one assignee returned.", 1, embeddedAssignees.size());
     Map<String, Object> embeddedAssignee = embeddedAssignees.get(0);
-    Assert.assertNotNull("The returned assignee should not be null.", embeddedAssignee);
+    assertThat(embeddedAssignee).as("The returned assignee should not be null.").isNotNull();
     Assert.assertEquals(MockProvider.EXAMPLE_USER_ID, embeddedAssignee.get("id"));
     Assert.assertEquals(MockProvider.EXAMPLE_USER_FIRST_NAME, embeddedAssignee.get("firstName"));
     Assert.assertEquals(MockProvider.EXAMPLE_USER_LAST_NAME, embeddedAssignee.get("lastName"));
@@ -348,7 +348,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     List<Map<String,Object>> embeddedOwners = from(content).getList("_embedded.owner");
     Assert.assertEquals("There should be one owner returned.", 1, embeddedOwners.size());
     Map<String, Object> embeddedOwner = embeddedOwners.get(0);
-    Assert.assertNotNull("The returned owner should not be null.", embeddedOwner);
+    assertThat(embeddedOwner).as("The returned owner should not be null.").isNotNull();
     Assert.assertEquals(MockProvider.EXAMPLE_USER_ID, embeddedOwner.get("id"));
     Assert.assertEquals(MockProvider.EXAMPLE_USER_FIRST_NAME, embeddedOwner.get("firstName"));
     Assert.assertEquals(MockProvider.EXAMPLE_USER_LAST_NAME, embeddedOwner.get("lastName"));
@@ -358,7 +358,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     List<Map<String,Object>> embeddedDefinitions = from(content).getList("_embedded.processDefinition");
     Assert.assertEquals("There should be one processDefinition returned.", 1, embeddedDefinitions.size());
     Map<String, Object> embeddedProcessDefinition = embeddedDefinitions.get(0);
-    Assert.assertNotNull("The returned processDefinition should not be null.", embeddedProcessDefinition);
+    assertThat(embeddedProcessDefinition).as("The returned processDefinition should not be null.").isNotNull();
     Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, embeddedProcessDefinition.get("id"));
     Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_KEY, embeddedProcessDefinition.get("key"));
     Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_CATEGORY, embeddedProcessDefinition.get("category"));
@@ -376,7 +376,7 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     List<Map<String,Object>> embeddedCaseDefinitions = from(content).getList("_embedded.caseDefinition");
     Assert.assertEquals("There should be one caseDefinition returned.", 1, embeddedCaseDefinitions.size());
     Map<String, Object> embeddedCaseDefinition = embeddedCaseDefinitions.get(0);
-    Assert.assertNotNull("The returned caseDefinition should not be null.", embeddedCaseDefinition);
+    assertThat(embeddedCaseDefinition).as("The returned caseDefinition should not be null.").isNotNull();
     Assert.assertEquals(MockProvider.EXAMPLE_CASE_DEFINITION_ID, embeddedCaseDefinition.get("id"));
     Assert.assertEquals(MockProvider.EXAMPLE_CASE_DEFINITION_KEY, embeddedCaseDefinition.get("key"));
     Assert.assertEquals(MockProvider.EXAMPLE_CASE_DEFINITION_CATEGORY, embeddedCaseDefinition.get("category"));

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/UserRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/UserRestServiceQueryTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.rest;
 import static io.restassured.RestAssured.expect;
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -243,7 +244,7 @@ public class UserRestServiceQueryTest extends AbstractRestServiceTest {
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one user returned.", 1, instances.size());
-    Assert.assertNotNull("The returned user should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned user should not be null.").isNotNull();
 
     String returendLastName = from(content).getString("[0].lastName");
     String returnedFirstName = from(content).getString("[0].firstName");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/VariableInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/VariableInstanceRestServiceQueryTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.rest;
 import static io.restassured.RestAssured.expect;
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -334,7 +335,7 @@ public class VariableInstanceRestServiceQueryTest extends AbstractRestServiceTes
     String content = response.asString();
     List<String> variables = from(content).getList("");
     Assert.assertEquals("There should be one variable instance returned.", 1, variables.size());
-    Assert.assertNotNull("There should be one variable instance returned", variables.get(0));
+    assertThat(variables.get(0)).as("There should be one variable instance returned").isNotNull();
 
     verify(mockedQuery).disableBinaryFetching();
     // requirement to not break existing API; should be:
@@ -377,7 +378,7 @@ public class VariableInstanceRestServiceQueryTest extends AbstractRestServiceTes
     String content = response.asString();
     List<String> variables = from(content).getList("");
     Assert.assertEquals("There should be one process definition returned.", 1, variables.size());
-    Assert.assertNotNull("There should be one process definition returned", variables.get(0));
+    assertThat(variables.get(0)).as("There should be one process definition returned").isNotNull();
 
     verify(mockedQuery).disableBinaryFetching();
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/MockProvider.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/MockProvider.java
@@ -771,8 +771,8 @@ public abstract class MockProvider {
   public static final String EXAMPLE_HIST_IDENTITY_LINK_ROOT_PROC_INST_ID = "aRootProcInstId";
 
   // case definition
-  public static final String EXAMPLE_CASE_DEFINITION_ID = "aCaseDefnitionId";
-  public static final String ANOTHER_EXAMPLE_CASE_DEFINITION_ID = "anotherCaseDefnitionId";
+  public static final String EXAMPLE_CASE_DEFINITION_ID = "aCaseDefinitionId";
+  public static final String ANOTHER_EXAMPLE_CASE_DEFINITION_ID = "anotherCaseDefinitionId";
   public static final String EXAMPLE_CASE_DEFINITION_ID_LIST = EXAMPLE_CASE_DEFINITION_ID + "," + ANOTHER_EXAMPLE_CASE_DEFINITION_ID;
   public static final String EXAMPLE_CASE_DEFINITION_KEY = "aCaseDefinitionKey";
   public static final int EXAMPLE_CASE_DEFINITION_VERSION = 1;

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricBatchReportServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricBatchReportServiceTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.rest.history;
 import static io.restassured.RestAssured.expect;
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
@@ -122,7 +123,7 @@ public class CleanableHistoricBatchReportServiceTest extends AbstractRestService
     String content = response.asString();
     List<String> reportResults = from(content).getList("");
     Assert.assertEquals("There should be two report results returned.", 2, reportResults.size());
-    Assert.assertNotNull(reportResults.get(0));
+    assertThat(reportResults.get(0)).isNotNull();
 
     String returnedBatchType = from(content).getString("[0].batchType");
     int returnedTTL = from(content).getInt("[0].historyTimeToLive");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricCaseInstanceReportServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricCaseInstanceReportServiceTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.rest.history;
 import static io.restassured.RestAssured.expect;
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.anyString;
@@ -147,7 +148,7 @@ public class CleanableHistoricCaseInstanceReportServiceTest extends AbstractRest
     String content = response.asString();
     List<String> reportResults = from(content).getList("");
     Assert.assertEquals("There should be two report results returned.", 2, reportResults.size());
-    Assert.assertNotNull(reportResults.get(0));
+    assertThat(reportResults.get(0)).isNotNull();
 
     String returnedDefinitionId = from(content).getString("[0].caseDefinitionId");
     String returnedDefinitionKey = from(content).getString("[0].caseDefinitionKey");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricDecisionInstanceReportServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricDecisionInstanceReportServiceTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.rest.history;
 import static io.restassured.RestAssured.expect;
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.anyString;
@@ -148,7 +149,7 @@ public class CleanableHistoricDecisionInstanceReportServiceTest extends Abstract
     String content = response.asString();
     List<String> reportResults = from(content).getList("");
     Assert.assertEquals("There should be two report results returned.", 2, reportResults.size());
-    Assert.assertNotNull(reportResults.get(0));
+    assertThat(reportResults.get(0)).isNotNull();
 
     String returnedDefinitionId = from(content).getString("[0].decisionDefinitionId");
     String returnedDefinitionKey = from(content).getString("[0].decisionDefinitionKey");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricProcessInstanceReportServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricProcessInstanceReportServiceTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.rest.history;
 import static io.restassured.RestAssured.expect;
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.anyString;
@@ -145,7 +146,7 @@ public class CleanableHistoricProcessInstanceReportServiceTest extends AbstractR
     String content = response.asString();
     List<String> reportResults = from(content).getList("");
     Assert.assertEquals("There should be two report results returned.", 2, reportResults.size());
-    Assert.assertNotNull(reportResults.get(0));
+    assertThat(reportResults.get(0)).isNotNull();
 
     String returnedDefinitionId = from(content).getString("[0].processDefinitionId");
     String returnedDefinitionKey = from(content).getString("[0].processDefinitionKey");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricActivityInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricActivityInstanceRestServiceQueryTest.java
@@ -392,7 +392,7 @@ public class HistoricActivityInstanceRestServiceQueryTest extends AbstractRestSe
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one activity instance returned.", 1, instances.size());
-    Assert.assertNotNull("The returned activity instance should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned activity instance should not be null.").isNotNull();
 
     String returnedId = from(content).getString("[0].id");
     String returnedParentActivityInstanceId = from(content).getString("[0].parentActivityInstanceId");
@@ -570,7 +570,7 @@ public class HistoricActivityInstanceRestServiceQueryTest extends AbstractRestSe
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one activity instance returned.", 1, instances.size());
-    Assert.assertNotNull("The returned activity instance should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned activity instance should not be null.").isNotNull();
 
     String returnedProcessInstanceId = from(content).getString("[0].processInstanceId");
     String returnedProcessDefinitionId = from(content).getString("[0].processDefinitionId");
@@ -602,7 +602,7 @@ public class HistoricActivityInstanceRestServiceQueryTest extends AbstractRestSe
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one activity instance returned.", 1, instances.size());
-    Assert.assertNotNull("The returned activity instance should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned activity instance should not be null.").isNotNull();
 
     String returnedProcessInstanceId = from(content).getString("[0].processInstanceId");
     String returnedProcessDefinitionId = from(content).getString("[0].processDefinitionId");
@@ -635,13 +635,13 @@ public class HistoricActivityInstanceRestServiceQueryTest extends AbstractRestSe
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one activity instance returned.", 1, instances.size());
-    Assert.assertNotNull("The returned activity instance should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned activity instance should not be null.").isNotNull();
 
     String returnedProcessDefinitionId = from(content).getString("[0].processDefinitionId");
     String returnedActivityEndTime = from(content).getString("[0].endTime");
 
     Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, returnedProcessDefinitionId);
-    Assert.assertNull(returnedActivityEndTime);
+    assertThat(returnedActivityEndTime).isNull();
   }
 
   @Test
@@ -670,13 +670,13 @@ public class HistoricActivityInstanceRestServiceQueryTest extends AbstractRestSe
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one activity instance returned.", 1, instances.size());
-    Assert.assertNotNull("The returned activity instance should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned activity instance should not be null.").isNotNull();
 
     String returnedProcessDefinitionId = from(content).getString("[0].processDefinitionId");
     String returnedActivityEndTime = from(content).getString("[0].endTime");
 
     Assert.assertEquals(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, returnedProcessDefinitionId);
-    Assert.assertNull(returnedActivityEndTime);
+    assertThat(returnedActivityEndTime).isNull();
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricActivityStatisticsRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricActivityStatisticsRestServiceQueryTest.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.rest.history;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.util.DateTimeUtils.DATE_FORMAT_WITH_TIMEZONE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
@@ -320,8 +321,8 @@ public class HistoricActivityStatisticsRestServiceQueryTest extends AbstractRest
     List<String> result = from(content).getList("");
     Assert.assertEquals(2, result.size());
 
-    Assert.assertNotNull(result.get(0));
-    Assert.assertNotNull(result.get(1));
+    assertThat(result.get(0)).isNotNull();
+    assertThat(result.get(1)).isNotNull();
 
     String id = from(content).getString("[0].id");
     long instances = from(content).getLong("[0].instances");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricBatchRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricBatchRestServiceInteractionTest.java
@@ -17,11 +17,11 @@
 package org.operaton.bpm.engine.rest.history;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_BATCH_ID;
 import static org.operaton.bpm.engine.rest.util.JsonPathUtil.from;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
@@ -341,7 +341,7 @@ public class HistoricBatchRestServiceInteractionTest extends AbstractRestService
 
   protected void verifyBatchJson(String batchJson) {
     BatchDto batch = JsonPathUtil.from(batchJson).getObject("", BatchDto.class);
-    assertNotNull("The returned batch should not be null.", batch);
+    assertThat(batch).as("The returned batch should not be null.").isNotNull();
     assertEquals(MockProvider.EXAMPLE_BATCH_ID, batch.getId());
     assertEquals(MockProvider.EXAMPLE_BATCH_TYPE, batch.getType());
     assertEquals(MockProvider.EXAMPLE_BATCH_TOTAL_JOBS, batch.getTotalJobs());
@@ -355,7 +355,7 @@ public class HistoricBatchRestServiceInteractionTest extends AbstractRestService
 
   protected void verifyHistoricBatchJson(String historicBatchJson) {
     HistoricBatchDto historicBatch = from(historicBatchJson).getObject("", HistoricBatchDto.class);
-    assertNotNull("The returned historic batch should not be null.", historicBatch);
+    assertThat(historicBatch).as("The returned historic batch should not be null.").isNotNull();
     assertEquals(MockProvider.EXAMPLE_BATCH_ID, historicBatch.getId());
     assertEquals(MockProvider.EXAMPLE_BATCH_TYPE, historicBatch.getType());
     assertEquals(MockProvider.EXAMPLE_BATCH_TOTAL_JOBS, historicBatch.getTotalJobs());

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricBatchRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricBatchRestServiceQueryTest.java
@@ -17,10 +17,10 @@
 package org.operaton.bpm.engine.rest.history;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.rest.util.JsonPathUtil.from;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -303,7 +303,7 @@ public class HistoricBatchRestServiceQueryTest extends AbstractRestServiceTest {
     assertEquals("There should be one historic batch returned.", 1, batches.size());
 
     HistoricBatchDto historicBatch = from(historicBatchListJson).getObject("[0]", HistoricBatchDto.class);
-    assertNotNull("The returned historic batch should not be null.", historicBatch);
+    assertThat(historicBatch).as("The returned historic batch should not be null.").isNotNull();
     assertEquals(MockProvider.EXAMPLE_BATCH_ID, historicBatch.getId());
     assertEquals(MockProvider.EXAMPLE_BATCH_TYPE, historicBatch.getType());
     assertEquals(MockProvider.EXAMPLE_BATCH_TOTAL_JOBS, historicBatch.getTotalJobs());

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricCaseActivityInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricCaseActivityInstanceRestServiceQueryTest.java
@@ -330,7 +330,7 @@ public class HistoricCaseActivityInstanceRestServiceQueryTest extends AbstractRe
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals(1, instances.size());
-    Assert.assertNotNull(instances.get(0));
+    assertThat(instances.get(0)).isNotNull();
 
     String returnedId = from(content).getString("[0].id");
     String returnedParentCaseActivityInstanceId = from(content).getString("[0].parentCaseActivityInstanceId");
@@ -510,7 +510,7 @@ public class HistoricCaseActivityInstanceRestServiceQueryTest extends AbstractRe
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals(1, instances.size());
-    Assert.assertNotNull(instances.get(0));
+    assertThat(instances.get(0)).isNotNull();
 
     String returnedCaseDefinitionId = from(content).getString("[0].caseDefinitionId");
     String returnedActivityEndTime = from(content).getString("[0].endTime");
@@ -540,13 +540,13 @@ public class HistoricCaseActivityInstanceRestServiceQueryTest extends AbstractRe
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals(1, instances.size());
-    Assert.assertNotNull(instances.get(0));
+    assertThat(instances.get(0)).isNotNull();
 
     String returnedCaseDefinitionId = from(content).getString("[0].caseDefinitionId");
     String returnedActivityEndTime = from(content).getString("[0].endTime");
 
     Assert.assertEquals(MockProvider.EXAMPLE_CASE_DEFINITION_ID, returnedCaseDefinitionId);
-    Assert.assertNull(returnedActivityEndTime);
+    assertThat(returnedActivityEndTime).isNull();
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricCaseActivityStatisticsRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricCaseActivityStatisticsRestServiceQueryTest.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.rest.history;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -85,8 +86,8 @@ public class HistoricCaseActivityStatisticsRestServiceQueryTest extends Abstract
     List<String> result = from(content).getList("");
     Assert.assertEquals(2, result.size());
 
-    Assert.assertNotNull(result.get(0));
-    Assert.assertNotNull(result.get(1));
+    assertThat(result.get(0)).isNotNull();
+    assertThat(result.get(1)).isNotNull();
 
     String id = from(content).getString("[0].id");
     long available = from(content).getLong("[0].available");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricCaseInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricCaseInstanceRestServiceQueryTest.java
@@ -332,7 +332,7 @@ public class HistoricCaseInstanceRestServiceQueryTest extends AbstractRestServic
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals(1, instances.size());
-    Assert.assertNotNull(instances.get(0));
+    assertThat(instances.get(0)).isNotNull();
 
     String returnedCaseInstanceId = from(content).getString("[0].id");
     String returnedCaseInstanceBusinessKey = from(content).getString("[0].businessKey");
@@ -633,7 +633,7 @@ public class HistoricCaseInstanceRestServiceQueryTest extends AbstractRestServic
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals(1, instances.size());
-    Assert.assertNotNull(instances.get(0));
+    assertThat(instances.get(0)).isNotNull();
 
     String returnedCaseInstanceId = from(content).getString("[0].id");
     String returnedCloseTime = from(content).getString("[0].closeTime");
@@ -667,7 +667,7 @@ public class HistoricCaseInstanceRestServiceQueryTest extends AbstractRestServic
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals(1, instances.size());
-    Assert.assertNotNull(instances.get(0));
+    assertThat(instances.get(0)).isNotNull();
 
     String returnedCaseInstanceId = from(content).getString("[0].id");
     String returnedCloseTime = from(content).getString("[0].closeTime");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDecisionInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDecisionInstanceRestServiceInteractionTest.java
@@ -23,7 +23,6 @@ import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_DECISION_
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_DECISION_INSTANCE_ID;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyString;
@@ -579,7 +578,7 @@ public class HistoricDecisionInstanceRestServiceInteractionTest extends Abstract
 
   protected void verifyBatchJson(String batchJson) {
     BatchDto batch = JsonPathUtil.from(batchJson).getObject("", BatchDto.class);
-    assertNotNull("The returned batch should not be null.", batch);
+    assertThat(batch).as("The returned batch should not be null.").isNotNull();
     assertEquals(MockProvider.EXAMPLE_BATCH_ID, batch.getId());
     assertEquals(MockProvider.EXAMPLE_BATCH_TYPE, batch.getType());
     assertEquals(MockProvider.EXAMPLE_BATCH_TOTAL_JOBS, batch.getTotalJobs());

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDecisionInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDecisionInstanceRestServiceQueryTest.java
@@ -53,7 +53,6 @@ import org.operaton.bpm.engine.rest.util.container.TestContainerRule;
 import org.operaton.bpm.engine.variable.value.BytesValue;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
 import org.operaton.bpm.engine.variable.value.StringValue;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -238,7 +237,7 @@ public class HistoricDecisionInstanceRestServiceQueryTest extends AbstractRestSe
     String content = response.asString();
     List<String> instances = from(content).getList("");
     assertEquals(1, instances.size());
-    Assert.assertNotNull(instances.get(0));
+    assertThat(instances.get(0)).isNotNull();
 
     String returnedHistoricDecisionInstanceId = from(content).getString("[0].id");
     String returnedDecisionDefinitionId = from(content).getString("[0].decisionDefinitionId");
@@ -324,7 +323,7 @@ public class HistoricDecisionInstanceRestServiceQueryTest extends AbstractRestSe
     String content = response.asString();
     List<String> instances = from(content).getList("");
     assertEquals(1, instances.size());
-    Assert.assertNotNull(instances.get(0));
+    assertThat(instances.get(0)).isNotNull();
 
     List<Map<String, Object>> returnedInputs = from(content).getList("[0].inputs");
     List<Map<String, Object>> returnedOutputs = from(content).getList("[0].outputs");
@@ -358,7 +357,7 @@ public class HistoricDecisionInstanceRestServiceQueryTest extends AbstractRestSe
     String content = response.asString();
     List<String> instances = from(content).getList("");
     assertEquals(1, instances.size());
-    Assert.assertNotNull(instances.get(0));
+    assertThat(instances.get(0)).isNotNull();
 
     List<Map<String, Object>> returnedInputs = from(content).getList("[0].inputs");
     List<Map<String, Object>> returnedOutputs = from(content).getList("[0].outputs");
@@ -393,7 +392,7 @@ public class HistoricDecisionInstanceRestServiceQueryTest extends AbstractRestSe
     String content = response.asString();
     List<String> instances = from(content).getList("");
     assertEquals(1, instances.size());
-    Assert.assertNotNull(instances.get(0));
+    assertThat(instances.get(0)).isNotNull();
 
     List<Map<String, Object>> returnedInputs = from(content).getList("[0].inputs");
     List<Map<String, Object>> returnedOutputs = from(content).getList("[0].outputs");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDetailRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricDetailRestServiceQueryTest.java
@@ -562,8 +562,8 @@ public class HistoricDetailRestServiceQueryTest extends AbstractRestServiceTest 
     String content = response.asString();
     List<String> details = from(content).getList("");
     Assert.assertEquals("There should be two activity instance returned.", 2, details.size());
-    Assert.assertNotNull("The returned details should not be null.", details.get(0));
-    Assert.assertNotNull("The returned details should not be null.", details.get(1));
+    assertThat(details.get(0)).as("The returned details should not be null.").isNotNull();
+    assertThat(details.get(1)).as("The returned details should not be null.").isNotNull();
 
     // note: element [0] is asserted as part of the fluent rest-assured invocation
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricIdentityLinkLogRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricIdentityLinkLogRestServiceQueryTest.java
@@ -257,7 +257,7 @@ public class HistoricIdentityLinkLogRestServiceQueryTest extends AbstractRestSer
     String content = response.asString();
     List<String> identityLinks = from(content).getList("");
     Assert.assertEquals("There should be one incident returned.", 1, identityLinks.size());
-    Assert.assertNotNull("The returned incident should not be null.", identityLinks.get(0));
+    assertThat(identityLinks.get(0)).as("The returned incident should not be null.").isNotNull();
 
     String returnedAssignerId = from(content).getString("[0].assignerId");
     String returnedTenantId = from(content).getString("[0].tenantId");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricIncidentRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricIncidentRestServiceQueryTest.java
@@ -366,7 +366,7 @@ public class HistoricIncidentRestServiceQueryTest extends AbstractRestServiceTes
     String content = response.asString();
     List<String> incidents = from(content).getList("");
     Assert.assertEquals("There should be one incident returned.", 1, incidents.size());
-    Assert.assertNotNull("The returned incident should not be null.", incidents.get(0));
+    assertThat(incidents.get(0)).as("The returned incident should not be null.").isNotNull();
 
     String returnedId = from(content).getString("[0].id");
     String returnedProcessDefinitionKey = from(content).getString("[0].processDefinitionKey");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricJobLogRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricJobLogRestServiceQueryTest.java
@@ -435,7 +435,7 @@ public class HistoricJobLogRestServiceQueryTest extends AbstractRestServiceTest 
     String content = response.asString();
     List<String> logs = from(content).getList("");
     Assert.assertEquals("There should be one historic job log returned.", 1, logs.size());
-    Assert.assertNotNull("The returned historic job log should not be null.", logs.get(0));
+    assertThat(logs.get(0)).as("The returned historic job log should not be null.").isNotNull();
 
     verifyHistoricJobLogEntries(content);
   }
@@ -463,7 +463,7 @@ public class HistoricJobLogRestServiceQueryTest extends AbstractRestServiceTest 
     String content = response.asString();
     List<String> logs = from(content).getList("");
     Assert.assertEquals("There should be one historic job log returned.", 1, logs.size());
-    Assert.assertNotNull("The returned historic job log should not be null.", logs.get(0));
+    assertThat(logs.get(0)).as("The returned historic job log should not be null.").isNotNull();
 
     verifyHistoricJobLogEntries(content);
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceInteractionTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -578,7 +577,7 @@ public class HistoricProcessInstanceRestServiceInteractionTest extends AbstractR
 
   protected void verifyBatchJson(String batchJson) {
     BatchDto batch = JsonPathUtil.from(batchJson).getObject("", BatchDto.class);
-    assertNotNull("The returned batch should not be null.", batch);
+    assertThat(batch).as("The returned batch should not be null.").isNotNull();
     assertEquals(MockProvider.EXAMPLE_BATCH_ID, batch.getId());
     assertEquals(MockProvider.EXAMPLE_BATCH_TYPE, batch.getType());
     assertEquals(MockProvider.EXAMPLE_BATCH_TOTAL_JOBS, batch.getTotalJobs());

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
@@ -410,7 +410,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one process instance returned.", 1, instances.size());
-    Assert.assertNotNull("The returned process instance should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned process instance should not be null.").isNotNull();
 
     String returnedProcessInstanceId = from(content).getString("[0].id");
     String returnedProcessInstanceBusinessKey = from(content).getString("[0].businessKey");
@@ -749,7 +749,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one process instance returned.", 1, instances.size());
-    Assert.assertNotNull("The returned process instance should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned process instance should not be null.").isNotNull();
 
     String returnedProcessInstanceId = from(content).getString("[0].id");
     String returnedEndTime = from(content).getString("[0].endTime");
@@ -784,7 +784,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one process instance returned.", 1, instances.size());
-    Assert.assertNotNull("The returned process instance should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned process instance should not be null.").isNotNull();
 
     String returnedProcessInstanceId = from(content).getString("[0].id");
     String returnedEndTime = from(content).getString("[0].endTime");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
@@ -410,7 +410,10 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one process instance returned.", 1, instances.size());
-    assertThat(instances.get(0)).as("The returned process instance should not be null.").isNotNull();
+    assertThat(instances)
+      .first()
+      .as("The returned process instance should not be null.")
+      .isNotNull();
 
     String returnedProcessInstanceId = from(content).getString("[0].id");
     String returnedProcessInstanceBusinessKey = from(content).getString("[0].businessKey");
@@ -749,7 +752,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one process instance returned.", 1, instances.size());
-    assertThat(instances.get(0)).as("The returned process instance should not be null.").isNotNull();
+    assertThat(instances).first().as("The returned process instance should not be null.").isNotNull();
 
     String returnedProcessInstanceId = from(content).getString("[0].id");
     String returnedEndTime = from(content).getString("[0].endTime");
@@ -784,7 +787,7 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one process instance returned.", 1, instances.size());
-    assertThat(instances.get(0)).as("The returned process instance should not be null.").isNotNull();
+    assertThat(instances).first().as("The returned process instance should not be null.").isNotNull();
 
     String returnedProcessInstanceId = from(content).getString("[0].id");
     String returnedEndTime = from(content).getString("[0].endTime");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceReportTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceReportTest.java
@@ -421,11 +421,11 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
         .when().get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 
     String responseContent = response.asString();
-    assertThat(responseContent).contains(ReportResultToCsvConverter.DURATION_HEADER);
-    assertThat(responseContent).contains(MONTH);
-    assertThat(responseContent).contains(String);
-    assertThat(responseContent).contains(String);
-    assertThat(responseContent).contains(String);
+    assertThat(responseContent).contains(ReportResultToCsvConverter.DURATION_HEADER)
+      .contains(MONTH.toString())
+      .contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_AVG))
+      .contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MIN))
+      .contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MAX));
   }
 
   @Test
@@ -444,11 +444,12 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
       .when().get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 
     String responseContent = response.asString();
-    assertThat(responseContent).contains(ReportResultToCsvConverter.DURATION_HEADER);
-    assertThat(responseContent).contains(QUARTER);
-    assertThat(responseContent).contains(String);
-    assertThat(responseContent).contains(String);
-    assertThat(responseContent).contains(String);
+    assertThat(responseContent)
+      .contains(ReportResultToCsvConverter.DURATION_HEADER)
+      .contains(QUARTER.toString())
+      .contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_AVG))
+      .contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MIN))
+      .contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MAX));
   }
 
   @Test
@@ -467,11 +468,12 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
         .when().get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 
     String responseContent = response.asString();
-    assertThat(responseContent).contains(ReportResultToCsvConverter.DURATION_HEADER);
-    assertThat(responseContent).contains(MONTH);
-    assertThat(responseContent).contains(String);
-    assertThat(responseContent).contains(String);
-    assertThat(responseContent).contains(String);
+    assertThat(responseContent)
+      .contains(ReportResultToCsvConverter.DURATION_HEADER)
+      .contains(MONTH.toString())
+      .contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_AVG))
+      .contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MIN))
+      .contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MAX));
   }
 
   @Test
@@ -490,11 +492,12 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
       .when().get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 
     String responseContent = response.asString();
-    assertThat(responseContent).contains(ReportResultToCsvConverter.DURATION_HEADER);
-    assertThat(responseContent).contains(QUARTER);
-    assertThat(responseContent).contains(String);
-    assertThat(responseContent).contains(String);
-    assertThat(responseContent).contains(String);
+    assertThat(responseContent)
+      .contains(ReportResultToCsvConverter.DURATION_HEADER)
+      .contains(QUARTER.toString())
+      .contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_AVG))
+      .contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MIN))
+      .contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MAX));
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceReportTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceReportTest.java
@@ -44,9 +44,9 @@ import org.junit.Test;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.path.json.JsonPath.from;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
@@ -209,7 +209,7 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
     String content = response.asString();
     List<String> reports = from(content).getList("");
     Assert.assertEquals("There should be one report returned.", 1, reports.size());
-    Assert.assertNotNull("The returned report should not be null.", reports.get(0));
+    assertThat(reports.get(0)).as("The returned report should not be null.").isNotNull();
 
     long returnedAvg = from(content).getLong("[0].average");
     long returnedMax = from(content).getLong("[0].maximum");
@@ -239,7 +239,7 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
     String content = response.asString();
     List<String> reports = from(content).getList("");
     Assert.assertEquals("There should be one report returned.", 1, reports.size());
-    Assert.assertNotNull("The returned report should not be null.", reports.get(0));
+    assertThat(reports.get(0)).as("The returned report should not be null.").isNotNull();
 
     long returnedAvg = from(content).getLong("[0].average");
     long returnedMax = from(content).getLong("[0].maximum");
@@ -421,11 +421,11 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
         .when().get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 
     String responseContent = response.asString();
-    assertTrue(responseContent.contains(ReportResultToCsvConverter.DURATION_HEADER));
-    assertTrue(responseContent.contains(MONTH.toString()));
-    assertTrue(responseContent.contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_AVG)));
-    assertTrue(responseContent.contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MIN)));
-    assertTrue(responseContent.contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MAX)));
+    assertThat(responseContent).contains(ReportResultToCsvConverter.DURATION_HEADER);
+    assertThat(responseContent).contains(MONTH);
+    assertThat(responseContent).contains(String);
+    assertThat(responseContent).contains(String);
+    assertThat(responseContent).contains(String);
   }
 
   @Test
@@ -444,11 +444,11 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
       .when().get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 
     String responseContent = response.asString();
-    assertTrue(responseContent.contains(ReportResultToCsvConverter.DURATION_HEADER));
-    assertTrue(responseContent.contains(QUARTER.toString()));
-    assertTrue(responseContent.contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_AVG)));
-    assertTrue(responseContent.contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MIN)));
-    assertTrue(responseContent.contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MAX)));
+    assertThat(responseContent).contains(ReportResultToCsvConverter.DURATION_HEADER);
+    assertThat(responseContent).contains(QUARTER);
+    assertThat(responseContent).contains(String);
+    assertThat(responseContent).contains(String);
+    assertThat(responseContent).contains(String);
   }
 
   @Test
@@ -467,11 +467,11 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
         .when().get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 
     String responseContent = response.asString();
-    assertTrue(responseContent.contains(ReportResultToCsvConverter.DURATION_HEADER));
-    assertTrue(responseContent.contains(MONTH.toString()));
-    assertTrue(responseContent.contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_AVG)));
-    assertTrue(responseContent.contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MIN)));
-    assertTrue(responseContent.contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MAX)));
+    assertThat(responseContent).contains(ReportResultToCsvConverter.DURATION_HEADER);
+    assertThat(responseContent).contains(MONTH);
+    assertThat(responseContent).contains(String);
+    assertThat(responseContent).contains(String);
+    assertThat(responseContent).contains(String);
   }
 
   @Test
@@ -490,11 +490,11 @@ public class HistoricProcessInstanceRestServiceReportTest extends AbstractRestSe
       .when().get(HISTORIC_PROCESS_INSTANCE_REPORT_URL);
 
     String responseContent = response.asString();
-    assertTrue(responseContent.contains(ReportResultToCsvConverter.DURATION_HEADER));
-    assertTrue(responseContent.contains(QUARTER.toString()));
-    assertTrue(responseContent.contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_AVG)));
-    assertTrue(responseContent.contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MIN)));
-    assertTrue(responseContent.contains(String.valueOf(EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_MAX)));
+    assertThat(responseContent).contains(ReportResultToCsvConverter.DURATION_HEADER);
+    assertThat(responseContent).contains(QUARTER);
+    assertThat(responseContent).contains(String);
+    assertThat(responseContent).contains(String);
+    assertThat(responseContent).contains(String);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricTaskInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricTaskInstanceRestServiceQueryTest.java
@@ -460,7 +460,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one historic task instance returned.", 1, instances.size());
-    Assert.assertNotNull("The returned historic task instance should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned historic task instance should not be null.").isNotNull();
 
     verifyHistoricTaskInstanceEntries(content);
   }
@@ -482,7 +482,7 @@ public class HistoricTaskInstanceRestServiceQueryTest extends AbstractRestServic
     String content = response.asString();
     List<String> instances = from(content).getList("");
     Assert.assertEquals("There should be one historic task instance returned.", 1, instances.size());
-    Assert.assertNotNull("The returned historic task instance should not be null.", instances.get(0));
+    assertThat(instances.get(0)).as("The returned historic task instance should not be null.").isNotNull();
 
     verifyHistoricTaskInstanceEntries(content);
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/EqualsListTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/EqualsListTest.java
@@ -16,8 +16,7 @@
  */
 package org.operaton.bpm.engine.rest.standalone;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +42,7 @@ public class EqualsListTest {
 
   @Test
   public void testListsSame() {
-    assertTrue(new EqualsList(list1).matches(list1));
+    assertThat(new EqualsList(list1).matches(list1)).isTrue();
   }
 
   @Test
@@ -51,23 +50,23 @@ public class EqualsListTest {
     list1.add("aString");
     list2.add("aString");
 
-    assertTrue(new EqualsList(list1).matches(list2));
-    assertTrue(new EqualsList(list2).matches(list1));
+    assertThat(new EqualsList(list1).matches(list2)).isTrue();
+    assertThat(new EqualsList(list2).matches(list1)).isTrue();
   }
 
   @Test
   public void testListsNotEqual() {
     list1.add("aString");
 
-    assertFalse(new EqualsList(list1).matches(list2));
-    assertFalse(new EqualsList(list2).matches(list1));
+    assertThat(new EqualsList(list1).matches(list2)).isFalse();
+    assertThat(new EqualsList(list2).matches(list1)).isFalse();
   }
 
   @Test
   public void testListsNull() {
-    assertFalse(new EqualsList(null).matches(list1));
-    assertFalse(new EqualsList(list1).matches(null));
-    assertTrue(new EqualsList(null).matches(null));
+    assertThat(new EqualsList(null).matches(list1)).isFalse();
+    assertThat(new EqualsList(list1).matches(null)).isFalse();
+    assertThat(new EqualsList(null).matches(null)).isTrue();
   }
 
 }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/EqualsMapTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/EqualsMapTest.java
@@ -23,8 +23,7 @@ import org.operaton.bpm.engine.rest.helper.EqualsMap;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Thorben Lindhauer
@@ -43,7 +42,7 @@ public class EqualsMapTest {
 
   @Test
   public void testMapsSame() {
-    assertTrue(new EqualsMap(map1).matches(map1));
+    assertThat(new EqualsMap(map1).matches(map1)).isTrue();
   }
 
   @Test
@@ -51,23 +50,23 @@ public class EqualsMapTest {
     map1.put("aKey", "aValue");
     map2.put("aKey", "aValue");
 
-    assertTrue(new EqualsMap(map1).matches(map2));
-    assertTrue(new EqualsMap(map2).matches(map1));
+    assertThat(new EqualsMap(map1).matches(map2)).isTrue();
+    assertThat(new EqualsMap(map2).matches(map1)).isTrue();
   }
 
   @Test
   public void testMapsNotEqual() {
     map1.put("aKey", "aValue");
 
-    assertFalse(new EqualsMap(map1).matches(map2));
-    assertFalse(new EqualsMap(map2).matches(map1));
+    assertThat(new EqualsMap(map1).matches(map2)).isFalse();
+    assertThat(new EqualsMap(map2).matches(map1)).isFalse();
   }
 
   @Test
   public void testMapsNull() {
-    assertFalse(new EqualsMap(null).matches(map1));
-    assertFalse(new EqualsMap(map1).matches(null));
-    assertTrue(new EqualsMap(null).matches(null));
+    assertThat(new EqualsMap(null).matches(map1)).isFalse();
+    assertThat(new EqualsMap(map1).matches(null)).isFalse();
+    assertThat(new EqualsMap(null).matches(null)).isTrue();
   }
 
 }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/HalResourceCacheTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/HalResourceCacheTest.java
@@ -44,11 +44,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
@@ -74,8 +72,8 @@ public class HalResourceCacheTest extends AbstractRestServiceTest {
   public void testResourceRetrieval() {
     cache.put("hello", "world");
 
-    assertNull(cache.get(null));
-    assertNull(cache.get("unknown"));
+    assertThat(cache.get(null)).isNull();
+    assertThat(cache.get("unknown")).isNull();
     assertEquals("world", cache.get("hello"));
   }
 
@@ -93,12 +91,12 @@ public class HalResourceCacheTest extends AbstractRestServiceTest {
     for (int i = 0; i < 2 * cache.getCapacity(); i++) {
       cache.put("id" + i, i);
     }
-    assertTrue(cache.size() <= cache.getCapacity());
+    assertThat(cache.size() <= cache.getCapacity()).isTrue();
 
     // old entries should be removed
-    assertNull(cache.get("a"));
-    assertNull(cache.get("b"));
-    assertNull(cache.get("c"));
+    assertThat(cache.get("a")).isNull();
+    assertThat(cache.get("b")).isNull();
+    assertThat(cache.get("c")).isNull();
   }
 
   @Test
@@ -110,7 +108,7 @@ public class HalResourceCacheTest extends AbstractRestServiceTest {
 
     forwardTime(cache.getSecondsToLive() + 1);
 
-    assertNull(cache.get("hello"));
+    assertThat(cache.get("hello")).isNull();
     assertEquals(0, cache.size());
   }
 
@@ -150,7 +148,7 @@ public class HalResourceCacheTest extends AbstractRestServiceTest {
     contextListener.configureCaches(contextParameter);
 
     Cache userCache = Hal.getInstance().getHalRelationCache(HalUser.class);
-    assertNotNull(userCache);
+    assertThat(userCache).isNotNull();
     assertEquals(123, ((DefaultHalResourceCache) userCache).getCapacity());
     assertEquals(123, ((DefaultHalResourceCache) userCache).getSecondsToLive());
   }
@@ -190,7 +188,7 @@ public class HalResourceCacheTest extends AbstractRestServiceTest {
 
     // cache exists and is empty
     DefaultHalResourceCache userCache = (DefaultHalResourceCache) Hal.getInstance().getHalRelationCache(HalUser.class);
-    assertNotNull(userCache);
+    assertThat(userCache).isNotNull();
     assertEquals(0, userCache.size());
 
     // get link resolver and resolve user
@@ -198,7 +196,7 @@ public class HalResourceCacheTest extends AbstractRestServiceTest {
     List<HalResource<?>> halUsers = linkResolver.resolveLinks(userIds, processEngine);
 
     // mocked user was resolved
-    assertNotNull(halUsers);
+    assertThat(halUsers).isNotNull();
     assertEquals(1, halUsers.size());
     HalUser halUser = (HalUser) halUsers.get(0);
     assertEquals("kermit", halUser.getFirstName());
@@ -213,7 +211,7 @@ public class HalResourceCacheTest extends AbstractRestServiceTest {
     halUsers = linkResolver.resolveLinks(userIds, processEngine);
 
     // cached mocked user was resolved with old name
-    assertNotNull(halUsers);
+    assertThat(halUsers).isNotNull();
     assertEquals(1, halUsers.size());
     halUser = (HalUser) halUsers.get(0);
     assertEquals("kermit", halUser.getFirstName());
@@ -224,7 +222,7 @@ public class HalResourceCacheTest extends AbstractRestServiceTest {
     halUsers = linkResolver.resolveLinks(userIds, processEngine);
 
     // new mocked user was resolved with old name
-    assertNotNull(halUsers);
+    assertThat(halUsers).isNotNull();
     assertEquals(1, halUsers.size());
     halUser = (HalUser) halUsers.get(0);
     assertEquals("fritz", halUser.getFirstName());
@@ -252,7 +250,7 @@ public class HalResourceCacheTest extends AbstractRestServiceTest {
 
     // cache exists and is empty
     DefaultHalResourceCache identityLinkCache = (DefaultHalResourceCache) Hal.getInstance().getHalRelationCache(HalIdentityLink.class);
-    assertNotNull(identityLinkCache);
+    assertThat(identityLinkCache).isNotNull();
     assertEquals(0, identityLinkCache.size());
 
     // get link resolver and resolve identity link

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/HalResourceCacheTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/HalResourceCacheTest.java
@@ -91,7 +91,7 @@ public class HalResourceCacheTest extends AbstractRestServiceTest {
     for (int i = 0; i < 2 * cache.getCapacity(); i++) {
       cache.put("id" + i, i);
     }
-    assertThat(cache.size() <= cache.getCapacity()).isTrue();
+    assertThat(cache.size()).isLessThanOrEqualTo(cache.getCapacity());
 
     // old entries should be removed
     assertThat(cache.get("a")).isNull();
@@ -157,7 +157,7 @@ public class HalResourceCacheTest extends AbstractRestServiceTest {
   public void testCacheInvalidParameterName() {
     HalRelationCacheConfiguration configuration = new HalRelationCacheConfiguration();
     configuration.setCacheImplementationClass(DefaultHalResourceCache.class);
-    configuration.addCacheConfiguration(HalUser.class, Collections.<String, Object>singletonMap("unknown", "property"));
+    configuration.addCacheConfiguration(HalUser.class, Collections.singletonMap("unknown", "property"));
 
     assertThatThrownBy(() -> contextListener.configureCaches(configuration))
       .isInstanceOf(HalRelationCacheConfigurationException.class)
@@ -173,7 +173,7 @@ public class HalResourceCacheTest extends AbstractRestServiceTest {
     when(user.getFirstName()).thenReturn("kermit");
     UserQuery userQuery = mock(UserQuery.class);
     when(userQuery.userIdIn(Mockito.any())).thenReturn(userQuery);
-    when(userQuery.listPage(anyInt(), anyInt())).thenReturn(Arrays.asList(user));
+    when(userQuery.listPage(anyInt(), anyInt())).thenReturn(List.of(user));
     when(processEngine.getIdentityService().createUserQuery()).thenReturn(userQuery);
 
     // configure cache

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/PathUtilTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/PathUtilTest.java
@@ -1,16 +1,17 @@
 package org.operaton.bpm.engine.rest.util;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class PathUtilTest {
 
   @Test
   void testDecodePathParam() {
     // Test cases
-    assertEquals("/path/to/resource", PathUtil.decodePathParam("%2Fpath%2Fto%2Fresource"));
-    assertEquals("\\path\\to\\resource", PathUtil.decodePathParam("%5Cpath%5Cto%5Cresource"));
-    assertEquals("/path\\to/resource", PathUtil.decodePathParam("%2Fpath%5Cto%2Fresource"));
-    assertEquals("simplePath", PathUtil.decodePathParam("simplePath"));
+    assertThat(PathUtil.decodePathParam("%2Fpath%2Fto%2Fresource")).isEqualTo("/path/to/resource");
+    assertThat(PathUtil.decodePathParam("%5Cpath%5Cto%5Cresource")).isEqualTo("\\path\\to\\resource");
+    assertThat(PathUtil.decodePathParam("%2Fpath%5Cto%2Fresource")).isEqualTo("/path\\to/resource");
+    assertThat(PathUtil.decodePathParam("simplePath")).isEqualTo("simplePath");
   }
 }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/URLEncodingUtilTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/util/URLEncodingUtilTest.java
@@ -1,22 +1,23 @@
 package org.operaton.bpm.engine.rest.util;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class URLEncodingUtilTest {
 
   @Test
   void testEncode() {
-    assertEquals("simple%20text", URLEncodingUtil.encode("simple text"));
-    assertEquals("%2Fpath%2Fto%2Fresource", URLEncodingUtil.encode("/path/to/resource"));
-    assertEquals("%5Cpath%5Cto%5Cresource", URLEncodingUtil.encode("\\path\\to\\resource"));
-    assertEquals("special%20characters%20%26%20symbols", URLEncodingUtil.encode("special characters & symbols"));
+    assertThat(URLEncodingUtil.encode("simple text")).isEqualTo("simple%20text");
+    assertThat(URLEncodingUtil.encode("/path/to/resource")).isEqualTo("%2Fpath%2Fto%2Fresource");
+    assertThat(URLEncodingUtil.encode("\\path\\to\\resource")).isEqualTo("%5Cpath%5Cto%5Cresource");
+    assertThat(URLEncodingUtil.encode("special characters & symbols")).isEqualTo("special%20characters%20%26%20symbols");
   }
 
   @Test
   void testBuildAttachmentValue() {
     String fileName = "example file.txt";
     String expected = "attachment; filename=\"example file.txt\"; filename*=UTF-8''example%20file.txt";
-    assertEquals(expected, URLEncodingUtil.buildAttachmentValue(fileName));
+    assertThat(URLEncodingUtil.buildAttachmentValue(fileName)).isEqualTo(expected);
   }
 }

--- a/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/components/scope/ScopingTest.java
+++ b/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/components/scope/ScopingTest.java
@@ -40,7 +40,6 @@ import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * tests the scoped beans
@@ -103,7 +102,7 @@ public class ScopingTest {
 		ProcessInstance processInstance = processEngine.getRuntimeService().startProcessInstanceByKey("component-waiter", vars);
 		StatefulObject scopedObject = (StatefulObject) processEngine.getRuntimeService().getVariable(processInstance.getId(), "scopedTarget.c1");
     assertThat(scopedObject).as("the scopedObject can't be null").isNotNull();
-		assertTrue(StringUtils.hasText(scopedObject.getName()), "the 'name' property can't be null.");
+    assertThat(StringUtils.hasText(scopedObject.getName())).as("the 'name' property can't be null.").isTrue();
     assertThat(scopedObject.getVisitedCount()).isEqualTo(2);
 
 		// the process has paused

--- a/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/transaction/SpringTransactionIntegrationTest.java
+++ b/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/transaction/SpringTransactionIntegrationTest.java
@@ -113,8 +113,7 @@ class SpringTransactionIntegrationTest extends SpringProcessEngineTestCase {
     assertThat(job.getExceptionMessage()).isEqualTo("Transaction rolled back because it has been marked as rollback-only");
 
     String stacktrace = managementService.getJobExceptionStacktrace(job.getId());
-    assertThat(stacktrace).isNotNull();
-    assertThat(stacktrace.contains("Transaction rolled back because it has been marked as rollback-only")).as("unexpected stacktrace, was <" + stacktrace + ">").isTrue();
+    assertThat(stacktrace).isNotNull().contains("Transaction rolled back because it has been marked as rollback-only");
   }
 
   @Deployment
@@ -131,8 +130,7 @@ class SpringTransactionIntegrationTest extends SpringProcessEngineTestCase {
     assertThat(job.getExceptionMessage()).isEqualTo("Transaction rolled back because it has been marked as rollback-only");
 
     String stacktrace = managementService.getJobExceptionStacktrace(job.getId());
-    assertThat(stacktrace).isNotNull();
-    assertThat(stacktrace.contains("Transaction rolled back because it has been marked as rollback-only")).as("unexpected stacktrace, was <" + stacktrace + ">").isTrue();
+    assertThat(stacktrace).isNotNull().contains("Transaction rolled back because it has been marked as rollback-only");
   }
 
   @Deployment
@@ -149,8 +147,7 @@ class SpringTransactionIntegrationTest extends SpringProcessEngineTestCase {
     assertThat(job.getExceptionMessage()).isEqualTo("exception in transaction listener");
 
     String stacktrace = managementService.getJobExceptionStacktrace(job.getId());
-    assertThat(stacktrace).isNotNull();
-    assertThat(stacktrace.contains("java.lang.RuntimeException: exception in transaction listener")).as("unexpected stacktrace, was <" + stacktrace + ">").isTrue();
+    assertThat(stacktrace).isNotNull().contains("java.lang.RuntimeException: exception in transaction listener");
   }
 
 }

--- a/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/transaction/SpringTransactionIntegrationTest.java
+++ b/engine-spring/core/src/test/java/org/operaton/bpm/engine/spring/test/transaction/SpringTransactionIntegrationTest.java
@@ -32,7 +32,6 @@ import org.springframework.test.context.ContextConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 /**
@@ -115,7 +114,7 @@ class SpringTransactionIntegrationTest extends SpringProcessEngineTestCase {
 
     String stacktrace = managementService.getJobExceptionStacktrace(job.getId());
     assertThat(stacktrace).isNotNull();
-    assertTrue(stacktrace.contains("Transaction rolled back because it has been marked as rollback-only"), "unexpected stacktrace, was <" + stacktrace + ">");
+    assertThat(stacktrace.contains("Transaction rolled back because it has been marked as rollback-only")).as("unexpected stacktrace, was <" + stacktrace + ">").isTrue();
   }
 
   @Deployment
@@ -133,7 +132,7 @@ class SpringTransactionIntegrationTest extends SpringProcessEngineTestCase {
 
     String stacktrace = managementService.getJobExceptionStacktrace(job.getId());
     assertThat(stacktrace).isNotNull();
-    assertTrue(stacktrace.contains("Transaction rolled back because it has been marked as rollback-only"), "unexpected stacktrace, was <" + stacktrace + ">");
+    assertThat(stacktrace.contains("Transaction rolled back because it has been marked as rollback-only")).as("unexpected stacktrace, was <" + stacktrace + ">").isTrue();
   }
 
   @Deployment
@@ -151,7 +150,7 @@ class SpringTransactionIntegrationTest extends SpringProcessEngineTestCase {
 
     String stacktrace = managementService.getJobExceptionStacktrace(job.getId());
     assertThat(stacktrace).isNotNull();
-    assertTrue(stacktrace.contains("java.lang.RuntimeException: exception in transaction listener"), "unexpected stacktrace, was <" + stacktrace + ">");
+    assertThat(stacktrace.contains("java.lang.RuntimeException: exception in transaction listener")).as("unexpected stacktrace, was <" + stacktrace + ">").isTrue();
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/container/impl/deployment/DeployProcessArchivesStep.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/deployment/DeployProcessArchivesStep.java
@@ -41,7 +41,7 @@ public class DeployProcessArchivesStep extends DeploymentOperationStep {
 
   @Override
   public String getName() {
-    return "Deploy process archvies";
+    return "Deploy process archives";
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/container/impl/deployment/UndeployProcessArchiveStep.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/deployment/UndeployProcessArchiveStep.java
@@ -51,7 +51,7 @@ public class UndeployProcessArchiveStep extends DeploymentOperationStep {
 
   @Override
   public String getName() {
-    return "Undeploying process archvie "+processArchvieName;
+    return "Undeploying process archive "+processArchvieName;
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/JobDefinitionQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/JobDefinitionQueryImpl.java
@@ -187,7 +187,7 @@ public class JobDefinitionQueryImpl extends AbstractQuery<JobDefinitionQuery, Jo
     checkQueryOk();
     return commandContext
       .getJobDefinitionManager()
-      .findJobDefnitionByQueryCriteria(this, page);
+      .findJobDefinitionByQueryCriteria(this, page);
   }
 
   // getters /////////////////////////////////////////////

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/JobDefinitionManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/JobDefinitionManager.java
@@ -48,7 +48,7 @@ public class JobDefinitionManager extends AbstractManager {
   }
 
   @SuppressWarnings("unchecked")
-  public List<JobDefinition> findJobDefnitionByQueryCriteria(JobDefinitionQueryImpl jobDefinitionQuery, Page page) {
+  public List<JobDefinition> findJobDefinitionByQueryCriteria(JobDefinitionQueryImpl jobDefinitionQuery, Page page) {
     configureQuery(jobDefinitionQuery);
     return getDbEntityManager().selectList("selectJobDefinitionByQueryCriteria", jobDefinitionQuery, page);
   }

--- a/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionClassDeploymentTest.java
+++ b/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionClassDeploymentTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.test.junit5;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.test.Deployment;
@@ -29,14 +29,12 @@ class ProcessEngineExtensionClassDeploymentTest {
 
   @Test
   void testDeploymentOnClassLevel(ProcessEngine processEngine) {
-    assertNotNull(processEngine.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTest").singleResult(),
-        "No process deployed with class annotation");
+    assertThat(processEngine.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTest").singleResult()).as("No process deployed with class annotation").isNotNull();
   }
 
   @Test
   @Deployment
   void testDeploymentOnMethodOverridesClass(ProcessEngine processEngine) {
-    assertNotNull(processEngine.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTestOverride").singleResult(),
-        "No process deployed for method");
+    assertThat(processEngine.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTestOverride").singleResult()).as("No process deployed for method").isNotNull();
   }
 }

--- a/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionClassDeploymentTest.java
+++ b/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionClassDeploymentTest.java
@@ -29,12 +29,18 @@ class ProcessEngineExtensionClassDeploymentTest {
 
   @Test
   void testDeploymentOnClassLevel(ProcessEngine processEngine) {
-    assertThat(processEngine.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTest").singleResult()).as("No process deployed with class annotation").isNotNull();
+    var processDefinition = processEngine.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTest").singleResult();
+    assertThat(processDefinition)
+      .as("No process deployed with class annotation")
+      .isNotNull();
   }
 
   @Test
   @Deployment
   void testDeploymentOnMethodOverridesClass(ProcessEngine processEngine) {
-    assertThat(processEngine.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTestOverride").singleResult()).as("No process deployed for method").isNotNull();
+    var processDefinition = processEngine.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTestOverride").singleResult();
+    assertThat(processDefinition)
+      .as("No process deployed for method")
+      .isNotNull();
   }
 }

--- a/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionParentClassDeploymentTest.java
+++ b/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionParentClassDeploymentTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.test.junit5;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.operaton.bpm.engine.ProcessEngine;
 import org.junit.jupiter.api.Test;
@@ -27,8 +27,7 @@ class ProcessEngineExtensionParentClassDeploymentTest extends ProcessEngineExten
 
   @Test
   void testDeploymentOnParentClassLevel(ProcessEngine processEngine) {
-    assertNotNull(processEngine.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTest").singleResult(),
-        "process is not deployed");
+    assertThat(processEngine.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTest").singleResult()).as("process is not deployed").isNotNull();
   }
 
 }

--- a/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionParentClassDeploymentTest.java
+++ b/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionParentClassDeploymentTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.test.junit5;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.operaton.bpm.engine.ProcessEngine;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -27,7 +28,10 @@ class ProcessEngineExtensionParentClassDeploymentTest extends ProcessEngineExten
 
   @Test
   void testDeploymentOnParentClassLevel(ProcessEngine processEngine) {
-    assertThat(processEngine.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTest").singleResult()).as("process is not deployed").isNotNull();
+    var processDefinition = processEngine.getRepositoryService().createProcessDefinitionQuery().processDefinitionKey("testHelperDeploymentTest").singleResult();
+    assertThat(processDefinition)
+      .as("process is not deployed")
+      .isNotNull();
   }
 
 }

--- a/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionRequiredHistoryLevelAuditTest.java
+++ b/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionRequiredHistoryLevelAuditTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class ProcessEngineExtensionRequiredHistoryLevelAuditTest {
 
   @RegisterExtension
-  ProcessEngineExtension extension = ProcessEngineExtension.builder()
+  static ProcessEngineExtension extension = ProcessEngineExtension.builder()
       .configurationResource("audithistory.operaton.cfg.xml")
       .build();
 
@@ -40,6 +40,7 @@ class ProcessEngineExtensionRequiredHistoryLevelAuditTest {
   @Test
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_AUDIT)
   void testRequiredHistoryLevelMatch() {
-    assertThat(extension.getProcessEngineConfiguration().getHistoryLevel().getName()).isEqualTo(ProcessEngineConfiguration.HISTORY_AUDIT);
+    String historyLevel = extension.getProcessEngineConfiguration().getHistoryLevel().getName();
+    assertThat(historyLevel).isEqualTo(ProcessEngineConfiguration.HISTORY_AUDIT);
   }
 }

--- a/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionRequiredHistoryLevelAuditTest.java
+++ b/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtensionRequiredHistoryLevelAuditTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.junit5;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
@@ -498,6 +498,7 @@ public class ProcessBuilderTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   void testProcessOperatonExtensions() {
     modelInstance = Bpmn.createProcess(PROCESS_ID)
       .operatonJobPriority("${somePriority}")
@@ -1011,17 +1012,8 @@ public class ProcessBuilderTest {
 
   @Test
   void testSubProcessBuilderWrongScope() {
-    try {
-      modelInstance = Bpmn.createProcess()
-        .startEvent()
-        .subProcessDone()
-        .endEvent()
-        .done();
-      fail("Exception expected");
-    }
-    catch (Exception e) {
-      assertThat(e).isInstanceOf(BpmnModelException.class);
-    }
+    var endEventBuilder = Bpmn.createProcess().startEvent();
+    assertThatThrownBy(endEventBuilder::subProcessDone).isInstanceOf(BpmnModelException.class);
   }
 
   @Test

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Fail.fail;
 import static org.junit.jupiter.api.Assertions.*;
 
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/validation/ValidateProcessTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/validation/ValidateProcessTest.java
@@ -30,7 +30,7 @@ import org.operaton.bpm.model.xml.validation.ValidationResultType;
 import org.operaton.bpm.model.xml.validation.ValidationResults;
 import org.operaton.bpm.model.bpmn.instance.Process;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Daniel Meyer

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/AbstractModelElementInstanceTest.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/AbstractModelElementInstanceTest.java
@@ -30,7 +30,7 @@ import org.w3c.dom.DOMException;
 
 import java.util.Collection;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.model.xml.test.assertions.ModelAssertions.assertThat;
 
 // TODO Move class to test sources

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/impl/parser/ParserTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/impl/parser/ParserTest.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.model.xml.impl.parser;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.model.xml.ModelInstance;
@@ -26,6 +25,7 @@ import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import java.io.InputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ParserTest {
 
@@ -46,7 +46,7 @@ class ParserTest {
 
   @Test
   void shouldProhibitExternalSchemaAccessViaSystemProperty() {
-    Assertions.assertThatThrownBy(() -> {
+    assertThatThrownBy(() -> {
       // given
       // the external schema access property is not supported on certain
       // IBM JDK versions, in which case schema access cannot be restricted

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AlternativeNsTest.java
@@ -35,8 +35,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Ronny Bräunlich
@@ -239,7 +237,7 @@ class AlternativeNsTest extends TestModelTest {
     donald.setAttributeValueNs(YET_ANOTHER_NS, "canHazExtendedWings", "false");
     assertThatThereIsNoNewerNamespaceUrl(modelInstance);
 
-    assertTrue(plucky.canHazExtendedWings());
+    assertThat(plucky.canHazExtendedWings()).isTrue();
     assertThatThereIsNoNewerNamespaceUrl(modelInstance);
   }
 
@@ -249,7 +247,7 @@ class AlternativeNsTest extends TestModelTest {
     for (int i = 0; i < attributes.getLength(); i++) {
       Node item = attributes.item(i);
       String nodeValue = item.getNodeValue();
-      assertNotEquals(TestModelConstants.NEWER_NAMESPACE, nodeValue, "Found newer namespace url which shouldn't exist");
+      assertThat(nodeValue).as("Found newer namespace url which shouldn't exist").isNotEqualTo(TestModelConstants.NEWER_NAMESPACE);
     }
   }
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AnimalTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/AnimalTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAMESPACE;
 
 /**

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/UnknownAnimalTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/instance/UnknownAnimalTest.java
@@ -24,6 +24,7 @@ import org.operaton.bpm.model.xml.instance.DomDocument;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import org.operaton.bpm.model.xml.type.ModelElementType;
+import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAMESPACE;
 
 import java.io.InputStream;
@@ -35,7 +36,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Sebastian Menski

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/ModelElementTypeTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/ModelElementTypeTest.java
@@ -23,7 +23,7 @@ import org.operaton.bpm.model.xml.impl.util.ModelTypeException;
 import org.operaton.bpm.model.xml.testmodel.TestModelParser;
 import org.operaton.bpm.model.xml.testmodel.instance.*;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.model.xml.test.assertions.ModelAssertions.assertThat;
 import static org.operaton.bpm.model.xml.testmodel.TestModelConstants.MODEL_NAMESPACE;
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/child/ChildElementCollectionTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/child/ChildElementCollectionTest.java
@@ -33,7 +33,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.model.xml.test.assertions.ModelAssertions.assertThat;
 
 /**

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/reference/ReferenceTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/type/reference/ReferenceTest.java
@@ -33,7 +33,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.model.xml.test.assertions.ModelAssertions.assertThat;
 
 /**

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/PostDeployInjectDefaultEngineTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/PostDeployInjectDefaultEngineTest.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.deployment.callbacks;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.junit.Assert;
@@ -46,11 +48,11 @@ public class PostDeployInjectDefaultEngineTest {
   
   @Test
   public void test() {
-    Assert.assertNotNull("processEngine must be injected", PostDeployInjectApp.processEngine);
-    Assert.assertNotNull("processApplicationInfo must be injected", PostDeployInjectApp.processApplicationInfo);
+    assertThat(PostDeployInjectApp.processEngine).as("processEngine must be injected").isNotNull();
+    assertThat(PostDeployInjectApp.processApplicationInfo).as("processApplicationInfo must be injected").isNotNull();
     
     List<ProcessEngine> processEngines = PostDeployInjectApp.processEngines;
-    Assert.assertNotNull("processEngines must be injected", processEngines);
+    assertThat(processEngines).as("processEngines must be injected").isNotNull();
     
     // the app did no do a deployment so no engines are in the list
     Assert.assertEquals(0, processEngines.size());

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/PostDeployInjectDefaultEngineTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/PostDeployInjectDefaultEngineTest.java
@@ -54,7 +54,7 @@ public class PostDeployInjectDefaultEngineTest {
     List<ProcessEngine> processEngines = PostDeployInjectApp.processEngines;
     assertThat(processEngines).as("processEngines must be injected").isNotNull();
     
-    // the app did no do a deployment so no engines are in the list
+    // the app did not do a deployment so no engines are in the list
     Assert.assertEquals(0, processEngines.size());
     
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/TestPostDeployFailure_JBOSS.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/TestPostDeployFailure_JBOSS.java
@@ -16,10 +16,11 @@
  */
 package org.operaton.bpm.integrationtest.deployment.callbacks;
 
-import org.junit.Assert;
-
 import org.operaton.bpm.integrationtest.deployment.callbacks.apps.PostDeployFailureApp;
+
 import org.jboss.arquillian.container.test.api.Deployer;
+
+import static org.assertj.core.api.Assertions.fail;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -55,7 +56,7 @@ public class TestPostDeployFailure_JBOSS {
     
     try {
       deployer.deploy(DEPLOYMENT);
-      Assert.fail("failure expected");
+      fail("failure expected");
     } catch (Exception e) {
       // expected
     }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/apps/CustomEjbProcessApplication.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/apps/CustomEjbProcessApplication.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.deployment.callbacks.apps;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import jakarta.ejb.ConcurrencyManagement;
 import jakarta.ejb.ConcurrencyManagementType;
 import jakarta.ejb.Local;
@@ -29,7 +31,6 @@ import org.operaton.bpm.application.PreUndeploy;
 import org.operaton.bpm.application.ProcessApplication;
 import org.operaton.bpm.application.ProcessApplicationInterface;
 import org.operaton.bpm.engine.ProcessEngine;
-import org.junit.Assert;
 
 /**
  * Custom {@link org.operaton.bpm.application.impl.JakartaEjbProcessApplication} with PA lifecycle callbacks
@@ -48,12 +49,12 @@ public class CustomEjbProcessApplication extends org.operaton.bpm.application.im
 
   @PostDeploy
   public void postDeploy(ProcessEngine processEngine) {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
   }
 
   @PreUndeploy
   public void preUnDeploy(ProcessEngine processEngine) {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestAdditionalResourceSuffixes.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestAdditionalResourceSuffixes.java
@@ -30,8 +30,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Sebastian Menski
@@ -55,7 +55,7 @@ public class TestAdditionalResourceSuffixes extends AbstractFoxPlatformIntegrati
 
   @Test
   public void testDeployProcessArchive() {
-    assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
 
     ProcessDefinitionQuery processDefinitionQuery = repositoryService.createProcessDefinitionQuery()

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestCustomProcessesXmlFileLocation.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestCustomProcessesXmlFileLocation.java
@@ -19,7 +19,10 @@ package org.operaton.bpm.integrationtest.deployment.cfg;
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -51,7 +54,7 @@ public class TestCustomProcessesXmlFileLocation extends AbstractFoxPlatformInteg
   
   @Test
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     long count = repositoryService.createProcessDefinitionQuery()
       .processDefinitionKey("invoice-it")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestDeploymentSource.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestDeploymentSource.java
@@ -19,7 +19,10 @@ package org.operaton.bpm.integrationtest.deployment.cfg;
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.engine.repository.ProcessApplicationDeployment;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -41,12 +44,12 @@ public class TestDeploymentSource extends AbstractFoxPlatformIntegrationTest {
 
   @Test
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
 
     org.operaton.bpm.engine.repository.Deployment deployment = repositoryService.createDeploymentQuery().singleResult();
 
-    Assert.assertNotNull(deployment);
+    assertThat(deployment).isNotNull();
     Assert.assertEquals(ProcessApplicationDeployment.PROCESS_APPLICATION_DEPLOYMENT_SOURCE, deployment.getSource());
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_onePaAsLib.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_onePaAsLib.java
@@ -48,7 +48,7 @@ public class TestFoxPlatformClientAsEjbModule_onePaAsLib extends AbstractFoxPlat
 
   /**
    * Deployment layout
-   *
+   * <pre>
    * test-application.ear
    *    |-- lib /
    *        |-- processes.jar
@@ -61,7 +61,7 @@ public class TestFoxPlatformClientAsEjbModule_onePaAsLib extends AbstractFoxPlat
    *        |-- META-INF/MANIFEST.MF =================================||
    *        |-- WEB-INF/beans.xml
    *        |-- + test classes
-   *
+   * </pre>
    */
   @Deployment
   public static EnterpriseArchive onePaAsLib() {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_onePaAsLib.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_onePaAsLib.java
@@ -21,7 +21,10 @@ import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.engine.cdi.impl.util.ProgrammaticBeanLookup;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
@@ -85,7 +88,7 @@ public class TestFoxPlatformClientAsEjbModule_onePaAsLib extends AbstractFoxPlat
   @Test
   public void testOnePaAsLib() {
     ProcessEngine processEngine = ProgrammaticBeanLookup.lookup(ProcessEngine.class);
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     long count = repositoryService.createProcessDefinitionQuery()
       .processDefinitionKey("testDeployProcessArchive")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_pasAsEjbModule.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_pasAsEjbModule.java
@@ -49,7 +49,7 @@ public class TestFoxPlatformClientAsEjbModule_pasAsEjbModule extends AbstractFox
 
   /**
    * This only works if EAR classloader isolation is turned OFF (which is the default in WildFly)
-   *
+   * <pre>
    * test-application.ear
    *    |-- pa.jar
    *        |-- META-INF/processes.xml
@@ -62,10 +62,10 @@ public class TestFoxPlatformClientAsEjbModule_pasAsEjbModule extends AbstractFox
    *        |-- META-INF/MANIFEST.MF
    *        |-- WEB-INF/beans.xml
    *        |-- + test classes
-   *
+   * </pre>
    */
   @Deployment
-  public static EnterpriseArchive paAsEjbModule() throws Exception {
+  public static EnterpriseArchive paAsEjbModule() {
 
     JavaArchive processArchive1Jar = ShrinkWrap.create(JavaArchive.class, "pa.jar")
       .addClass(EeComponent.class) // need to add at least one EE component, otherwise the jar is not detected as an EJB module by Jboss AS

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_pasAsEjbModule.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_pasAsEjbModule.java
@@ -22,7 +22,10 @@ import org.operaton.bpm.engine.cdi.impl.util.ProgrammaticBeanLookup;
 import org.operaton.bpm.integrationtest.deployment.ear.beans.EeComponent;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -86,7 +89,7 @@ public class TestFoxPlatformClientAsEjbModule_pasAsEjbModule extends AbstractFox
   @Test
   public void testPaAsEjbModule() {
     ProcessEngine processEngine = ProgrammaticBeanLookup.lookup(ProcessEngine.class);
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     long count = repositoryService.createProcessDefinitionQuery()
       .processDefinitionKey("paAsEjbModule-process")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_twoPasAsLib.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_twoPasAsLib.java
@@ -49,7 +49,7 @@ public class TestFoxPlatformClientAsEjbModule_twoPasAsLib extends AbstractFoxPla
 
   /**
    * Deployment layout
-   *
+   * <pre>
    * test-application.ear
    *    |-- lib /
    *        |-- processes1.jar
@@ -65,7 +65,7 @@ public class TestFoxPlatformClientAsEjbModule_twoPasAsLib extends AbstractFoxPla
    *        |-- META-INF/MANIFEST.MF =================================||
    *        |-- WEB-INF/beans.xml
    *        |-- + test classes
-   *
+   * </pre>
    */
   @Deployment
   public static EnterpriseArchive twoPasAsLib() {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_twoPasAsLib.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_twoPasAsLib.java
@@ -21,7 +21,10 @@ import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.engine.cdi.impl.util.ProgrammaticBeanLookup;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
@@ -94,7 +97,7 @@ public class TestFoxPlatformClientAsEjbModule_twoPasAsLib extends AbstractFoxPla
   @Test
   public void testTwoPasAsLib() {
     ProcessEngine processEngine = ProgrammaticBeanLookup.lookup(ProcessEngine.class);
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     long count = repositoryService.createProcessDefinitionQuery()
       .processDefinitionKey("process1")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsLibInWebModule.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsLibInWebModule.java
@@ -20,7 +20,10 @@ import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.engine.cdi.impl.util.ProgrammaticBeanLookup;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -70,7 +73,7 @@ public class TestFoxPlatformClientAsLibInWebModule extends AbstractFoxPlatformIn
   @Test
   public void testDeployProcessArchive() {
     ProcessEngine processEngine = ProgrammaticBeanLookup.lookup(ProcessEngine.class);
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     long count = repositoryService.createProcessDefinitionQuery()
       .processDefinitionKey("testDeployProcessArchive")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsLibInWebModule.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsLibInWebModule.java
@@ -46,7 +46,7 @@ public class TestFoxPlatformClientAsLibInWebModule extends AbstractFoxPlatformIn
 
   /**
    * Deployment layout
-   *
+   * <pre>
    * test-application.ear
    *    |-- test.war
    *        |-- lib /
@@ -54,7 +54,7 @@ public class TestFoxPlatformClientAsLibInWebModule extends AbstractFoxPlatformIn
    *        |-- WEB-INF/classes
    *            |-- META-INF/processes.xml
    *        |-- org/operaton/bpm/integrationtest/testDeployProcessArchive.bpmn20.xml
-   *
+   * </pre>
    */
   @Deployment
   public static EnterpriseArchive deployment() {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestPaAnnotatedEjb.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestPaAnnotatedEjb.java
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith;
 public class TestPaAnnotatedEjb extends AbstractFoxPlatformIntegrationTest {
 
   /**
-   *
+   * <pre>
    * test-application.ear
    *    |-- pa.jar
    *        |-- AbstractFoxPlatformIntegrationTest.class
@@ -52,7 +52,7 @@ public class TestPaAnnotatedEjb extends AbstractFoxPlatformIntegrationTest {
    *
    *    |-- operaton-engine-cdi.jar
    *        |-- META-INF/MANIFEST.MF
-   *
+   * </pre>
    */
   @Deployment
   public static EnterpriseArchive paAsEjbModule() {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestPaAnnotatedEjb.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestPaAnnotatedEjb.java
@@ -20,13 +20,15 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.integrationtest.deployment.ear.beans.AnnotatedEjbPa;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -72,7 +74,7 @@ public class TestPaAnnotatedEjb extends AbstractFoxPlatformIntegrationTest {
   public void testPaAnnotatedEjb() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("process1");
 
-    Assert.assertNotNull(processInstance);
+    assertThat(processInstance).isNotNull();
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestPaAsEjbJar.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestPaAsEjbJar.java
@@ -43,7 +43,7 @@ import org.junit.runner.RunWith;
 public class TestPaAsEjbJar extends AbstractFoxPlatformIntegrationTest {
 
   /**
-   *
+   * <pre>
    * test-application.ear
    *    |-- pa.jar
    *        |-- DefaultEjbProcessApplication.class
@@ -56,10 +56,10 @@ public class TestPaAsEjbJar extends AbstractFoxPlatformIntegrationTest {
    *
    *    |-- operaton-engine-cdi.jar
    *        |-- META-INF/MANIFEST.MF
-   *
+   * </pre>
    */
   @Deployment
-  public static EnterpriseArchive paAsEjbModule() throws Exception {
+  public static EnterpriseArchive paAsEjbModule() {
 
     JavaArchive processArchive1Jar = ShrinkWrap.create(JavaArchive.class, "pa.jar")
       .addClass(DefaultEjbProcessApplication.class)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestPaAsEjbJar.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestPaAsEjbJar.java
@@ -22,7 +22,10 @@ import org.operaton.bpm.engine.cdi.impl.util.ProgrammaticBeanLookup;
 import org.operaton.bpm.integrationtest.deployment.ear.beans.NamedCdiBean;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -75,7 +78,7 @@ public class TestPaAsEjbJar extends AbstractFoxPlatformIntegrationTest {
   @Test
   public void testPaAsEjbModule() {
     ProcessEngine processEngine = ProgrammaticBeanLookup.lookup(ProcessEngine.class);
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
 
     runtimeService.startProcessInstanceByKey("paAsEjbJar-process");
     Assert.assertEquals(1, runtimeService.createProcessInstanceQuery().count());

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/jar/TestJarDeployment.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/jar/TestJarDeployment.java
@@ -19,7 +19,10 @@ package org.operaton.bpm.integrationtest.deployment.jar;
 import org.operaton.bpm.application.impl.ejb.DefaultEjbProcessApplication;
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.container.test.api.OverProtocol;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -51,7 +54,7 @@ public class TestJarDeployment extends AbstractFoxPlatformIntegrationTest {
   
   @Test
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     long count = repositoryService.createProcessDefinitionQuery()
       .processDefinitionKey("testDeployProcessArchive")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/spring/CustomSpringServletProcessApplication.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/spring/CustomSpringServletProcessApplication.java
@@ -32,11 +32,13 @@ public class CustomSpringServletProcessApplication extends SpringServletProcessA
   private boolean isPreUndeployInvoked = false;
 
   @PostDeploy
+  @SuppressWarnings("unused")
   public void postDeploy() {
     isPostDeployInvoked = true;
   }
 
   @PreUndeploy
+  @SuppressWarnings("unused")
   public void preUndeploy() {
     isPreUndeployInvoked = true;
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/spring/CustomSpringServletProcessApplication.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/spring/CustomSpringServletProcessApplication.java
@@ -19,7 +19,8 @@ package org.operaton.bpm.integrationtest.deployment.spring;
 import org.operaton.bpm.application.PostDeploy;
 import org.operaton.bpm.application.PreUndeploy;
 import org.operaton.bpm.engine.spring.application.SpringServletProcessApplication;
-import org.junit.Assert;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Daniel Meyer
@@ -42,16 +43,16 @@ public class CustomSpringServletProcessApplication extends SpringServletProcessA
 
   @Override
   public void start() {
-    Assert.assertFalse(isPostDeployInvoked);
+    assertThat(isPostDeployInvoked).isFalse();
     super.start();
-    Assert.assertTrue("@PostDeploy Method not invoked", isPostDeployInvoked);
+    assertThat(isPostDeployInvoked).as("@PostDeploy Method not invoked").isTrue();
   }
 
   @Override
   public void stop() {
-    Assert.assertFalse(isPreUndeployInvoked);
+    assertThat(isPreUndeployInvoked).isFalse();
     super.stop();
-    Assert.assertTrue("@PreUndeploy Method not invoked", isPreUndeployInvoked);
+    assertThat(isPreUndeployInvoked).as("@PreUndeploy Method not invoked").isTrue();
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/spring/SpringLookupManagedProcessEngineTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/spring/SpringLookupManagedProcessEngineTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * <p>Integration test making sure that we can lookup a managed process engine 
+ * <p>Integration test making sure that we can look up a managed process engine
  * and expose it as a Spring Bean inside a Spring Application</p>
  * 
  * @author Daniel Meyer

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/spring/SpringLookupManagedProcessEngineTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/spring/SpringLookupManagedProcessEngineTest.java
@@ -18,11 +18,13 @@ package org.operaton.bpm.integrationtest.deployment.spring;
 
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -49,7 +51,7 @@ public class SpringLookupManagedProcessEngineTest extends AbstractFoxPlatformInt
     
   @Test
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(processEngine);   
+    assertThat(processEngine).isNotNull();   
   }
   
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/spring/SpringServletPALifecycleTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/spring/SpringServletPALifecycleTest.java
@@ -20,11 +20,13 @@ import org.operaton.bpm.BpmPlatform;
 import org.operaton.bpm.ProcessApplicationService;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -48,7 +50,7 @@ public class SpringServletPALifecycleTest extends AbstractFoxPlatformIntegration
   @Test
   public void test() {
     ProcessApplicationService processApplicationService = BpmPlatform.getProcessApplicationService();
-    Assert.assertNotNull(processApplicationService.getProcessApplicationInfo("pa"));
+    assertThat(processApplicationService.getProcessApplicationInfo("pa")).isNotNull();
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestMultipleClasspathRoots.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestMultipleClasspathRoots.java
@@ -24,7 +24,10 @@ import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 import org.operaton.bpm.integrationtest.util.TestHelper;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
@@ -102,7 +105,7 @@ public class TestMultipleClasspathRoots extends AbstractFoxPlatformIntegrationTe
   @Test
   public void testMultipleClasspathRoots() {
     ProcessEngine processEngine = ProgrammaticBeanLookup.lookup(ProcessEngine.class);
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
 
     RepositoryService repositoryService = processEngine.getRepositoryService();
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestResourceName.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestResourceName.java
@@ -25,7 +25,10 @@ import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 import org.operaton.bpm.integrationtest.util.TestHelper;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
@@ -150,7 +153,7 @@ public class TestResourceName extends AbstractFoxPlatformIntegrationTest {
   @Test
   public void testResourceName() {
     ProcessEngine processEngine = ProgrammaticBeanLookup.lookup(ProcessEngine.class);
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
 
     RepositoryService repositoryService = processEngine.getRepositoryService();
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeployment.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeployment.java
@@ -17,13 +17,15 @@
 package org.operaton.bpm.integrationtest.deployment.war;
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 
 
 @RunWith(Arquillian.class)
@@ -37,7 +39,7 @@ public class TestWarDeployment extends AbstractFoxPlatformIntegrationTest {
 
   @Test
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     long count = repositoryService.createProcessDefinitionQuery()
       .processDefinitionKey("testDeployProcessArchive")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentCustomPAName.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentCustomPAName.java
@@ -29,6 +29,8 @@ import org.junit.runner.RunWith;
 
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Thorben Lindhauer
  *
@@ -50,7 +52,7 @@ public class TestWarDeploymentCustomPAName extends AbstractFoxPlatformIntegratio
     Set<String> paNames = BpmPlatform.getProcessApplicationService().getProcessApplicationNames();
 
     Assert.assertEquals(1, paNames.size());
-    Assert.assertTrue(paNames.contains(CustomNameServletPA.NAME));
+    assertThat(paNames).contains(CustomNameServletPA.NAME);
 
   }
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentDeployAllOnSingleChange.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentDeployAllOnSingleChange.java
@@ -18,14 +18,16 @@ package org.operaton.bpm.integrationtest.deployment.war;
 
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 
 
 @RunWith(Arquillian.class)
@@ -52,7 +54,7 @@ public class TestWarDeploymentDeployAllOnSingleChange extends AbstractFoxPlatfor
   @Test
   @OperateOnDeployment(value=PA2)
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     long count = repositoryService.createProcessDefinitionQuery()
       .processDefinitionKey("testDeployProcessArchive")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentDeployChangedOnly.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentDeployChangedOnly.java
@@ -18,14 +18,16 @@ package org.operaton.bpm.integrationtest.deployment.war;
 
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 
 
 @RunWith(Arquillian.class)
@@ -52,7 +54,7 @@ public class TestWarDeploymentDeployChangedOnly extends AbstractFoxPlatformInteg
   @Test
   @OperateOnDeployment(value=PA2)
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     long count = repositoryService.createProcessDefinitionQuery()
       .processDefinitionKey("testDeployProcessArchive")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentDeployChangedOnlyWithJarAsLib.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentDeployChangedOnlyWithJarAsLib.java
@@ -22,7 +22,10 @@ import org.operaton.bpm.engine.cdi.impl.util.ProgrammaticBeanLookup;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -109,7 +112,7 @@ public class TestWarDeploymentDeployChangedOnlyWithJarAsLib extends AbstractFoxP
   @OperateOnDeployment(value=PA2)
   public void testDeployProcessArchive() {
     ProcessEngine processEngine = ProgrammaticBeanLookup.lookup(ProcessEngine.class);
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
 
     RepositoryService repositoryService = processEngine.getRepositoryService();
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentDuplicateFiltering.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentDuplicateFiltering.java
@@ -17,14 +17,16 @@
 package org.operaton.bpm.integrationtest.deployment.war;
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 
 
 @RunWith(Arquillian.class)
@@ -49,7 +51,7 @@ public class TestWarDeploymentDuplicateFiltering extends AbstractFoxPlatformInte
   @Test
   @OperateOnDeployment(value=PA2)
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     long count = repositoryService.createProcessDefinitionQuery()
       .processDefinitionKey("testDeployProcessArchive")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentEmptyProcessesXml.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentEmptyProcessesXml.java
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 /**
@@ -48,7 +48,7 @@ public class TestWarDeploymentEmptyProcessesXml extends AbstractFoxPlatformInteg
 
   @Test
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
 
     List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery()
@@ -70,7 +70,7 @@ public class TestWarDeploymentEmptyProcessesXml extends AbstractFoxPlatformInteg
         containsProcessApplication = true;
       }
     }
-    assertTrue(containsProcessApplication);
+    assertThat(containsProcessApplication).isTrue();
 
 
     // manually delete process definition here (to clean up)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentIsDeployChangedOnly.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentIsDeployChangedOnly.java
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 package org.operaton.bpm.integrationtest.deployment.war;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import java.util.List;
 import java.util.Set;
 
@@ -56,7 +59,7 @@ public class TestWarDeploymentIsDeployChangedOnly extends AbstractFoxPlatformInt
   @Test
   @OperateOnDeployment(value=PA2)
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     long count = repositoryService.createProcessDefinitionQuery()
       .processDefinitionKey("testDeployProcessArchive")
@@ -73,12 +76,12 @@ public class TestWarDeploymentIsDeployChangedOnly extends AbstractFoxPlatformInt
       List<ProcessApplicationDeploymentInfo> deploymentInfo = processApplicationInfo.getDeploymentInfo();
       if(deploymentInfo.size() == 2) {
         if(resumedRegistrationFound) {
-          Assert.fail("Cannot have two registrations");
+          fail("Cannot have two registrations");
         }
         resumedRegistrationFound = true;
       }
     }
-    Assert.assertTrue("Previous version of the deployment was not resumed", resumedRegistrationFound);
+    assertThat(resumedRegistrationFound).as("Previous version of the deployment was not resumed").isTrue();
 
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePrevious.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePrevious.java
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 package org.operaton.bpm.integrationtest.deployment.war;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import java.util.List;
 import java.util.Set;
 
@@ -31,7 +34,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 
 
 @RunWith(Arquillian.class)
@@ -56,7 +58,7 @@ public class TestWarDeploymentResumePrevious extends AbstractFoxPlatformIntegrat
   @Test
   @OperateOnDeployment(value=PA2)
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     long count = repositoryService.createProcessDefinitionQuery()
       .processDefinitionKey("testDeployProcessArchive")
@@ -73,12 +75,12 @@ public class TestWarDeploymentResumePrevious extends AbstractFoxPlatformIntegrat
       List<ProcessApplicationDeploymentInfo> deploymentInfo = processApplicationInfo.getDeploymentInfo();
       if(deploymentInfo.size() == 2) {
         if(resumedRegistrationFound) {
-          Assert.fail("Cannot have two registrations");
+          fail("Cannot have two registrations");
         }
         resumedRegistrationFound = true;
       }
     }
-    Assert.assertTrue("Previous version of the deployment was not resumed", resumedRegistrationFound);
+    assertThat(resumedRegistrationFound).as("Previous version of the deployment was not resumed").isTrue();
 
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePreviousOff.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePreviousOff.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.integrationtest.deployment.war;
 import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Set;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePreviousOff.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePreviousOff.java
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 package org.operaton.bpm.integrationtest.deployment.war;
+import static org.assertj.core.api.Assertions.fail;
+
 import java.util.List;
 import java.util.Set;
 
@@ -31,7 +33,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 
 
 @RunWith(Arquillian.class)
@@ -56,7 +57,7 @@ public class TestWarDeploymentResumePreviousOff extends AbstractFoxPlatformInteg
   @Test
   @OperateOnDeployment(value=PA2)
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     long count = repositoryService.createProcessDefinitionQuery()
       .processDefinitionKey("testDeployProcessArchive")
@@ -71,7 +72,7 @@ public class TestWarDeploymentResumePreviousOff extends AbstractFoxPlatformInteg
       ProcessApplicationInfo processApplicationInfo = processApplicationService.getProcessApplicationInfo(paName);
       List<ProcessApplicationDeploymentInfo> deploymentInfo = processApplicationInfo.getDeploymentInfo();
       if(deploymentInfo.size() == 2) {
-        Assert.fail("Previous version of the deployment must not be resumed");
+        fail("Previous version of the deployment must not be resumed");
       }
     }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePreviousOnDeploymentName.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePreviousOnDeploymentName.java
@@ -16,10 +16,10 @@
  */
 package org.operaton.bpm.integrationtest.deployment.war;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
 
 import java.util.List;
 import java.util.Set;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePreviousOnDeploymentName.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePreviousOnDeploymentName.java
@@ -60,7 +60,7 @@ public class TestWarDeploymentResumePreviousOnDeploymentName extends AbstractFox
   public void testDeployProcessArchive() {
     assertThat(processEngine, is(notNullValue()));
     RepositoryService repositoryService = processEngine.getRepositoryService();
-    //since we have two processes deployed for PA2 we gotta check that both are present
+    //since we have two processes deployed for PA2 we got to check that both are present
     long count = repositoryService.createProcessDefinitionQuery().processDefinitionKey("testDeployProcessArchive").count();
 
     assertThat(count, is(1L));

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePreviousOnProcessDefinitionKey.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentResumePreviousOnProcessDefinitionKey.java
@@ -16,10 +16,10 @@
  */
 package org.operaton.bpm.integrationtest.deployment.war;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
 
 import java.util.List;
 import java.util.Set;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithBrokenBpmnXml.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithBrokenBpmnXml.java
@@ -17,13 +17,15 @@
 package org.operaton.bpm.integrationtest.deployment.war;
 
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployer;
+
+import static org.assertj.core.api.Assertions.fail;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -60,7 +62,7 @@ public class TestWarDeploymentWithBrokenBpmnXml {
   public void testXmlInvalid() {
     try {
       deployer.deploy(DEPLOYMENT);
-      Assert.fail("exception expected");
+      fail("exception expected");
     }catch (Exception e) {
       // expected
     } 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithCmmn.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithCmmn.java
@@ -17,13 +17,15 @@
 package org.operaton.bpm.integrationtest.deployment.war;
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 
 
 @RunWith(Arquillian.class)
@@ -37,7 +39,7 @@ public class TestWarDeploymentWithCmmn extends AbstractFoxPlatformIntegrationTes
 
   @Test
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     long count = repositoryService.createCaseDefinitionQuery()
         .caseDefinitionKey("testDeployProcessArchiveWithCmmn")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithDmn.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithDmn.java
@@ -17,7 +17,10 @@
 package org.operaton.bpm.integrationtest.deployment.war;
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -36,7 +39,7 @@ public class TestWarDeploymentWithDmn extends AbstractFoxPlatformIntegrationTest
 
   @Test
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     long count = repositoryService.createDecisionDefinitionQuery()
       .decisionDefinitionKey("testDeployProcessArchiveWithDmn")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithNonExistingDS_JBOSS.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithNonExistingDS_JBOSS.java
@@ -36,7 +36,7 @@ import org.junit.runner.RunWith;
 
 /**
  * <p>This test makes sure that if we deploy a process application which contains a persistence.xml 
- * file which references a non existing datasource, the MSC does not run into a deadlock.</p>
+ * file which references a non-existing datasource, the MSC does not run into a deadlock.</p>
  * 
  * @author Daniel Meyer
  *

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithNonExistingDS_JBOSS.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithNonExistingDS_JBOSS.java
@@ -20,14 +20,16 @@ package org.operaton.bpm.integrationtest.deployment.war;
 import org.operaton.bpm.integrationtest.deployment.war.apps.CustomServletPA;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployer;
+
+import static org.assertj.core.api.Assertions.fail;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -78,14 +80,14 @@ public class TestWarDeploymentWithNonExistingDS_JBOSS {
 
     try {
       deployer.deploy(DEPLOYMENT_WITH_EJB_PA);
-      Assert.fail("Deployment exception expected");
+      fail("Deployment exception expected");
     } catch(Exception e) {
       // expected
     }
     
     try {
       deployer.deploy(DEPLOYMENT_WITH_SERVLET_PA);
-      Assert.fail("Deployment exception expected");
+      fail("Deployment exception expected");
     } catch(Exception e) {
       // expected
     }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithProcessEnginePlugin.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithProcessEnginePlugin.java
@@ -36,8 +36,9 @@ import static org.junit.Assert.assertEquals;
 /**
  * Assert that we can deploy a WAR with a process engine plugin
  * which ships and requires groovy as a dependency for scripting purposes.
- *
- * Does not work on JBoss, see https://app.camunda.com/jira/browse/CAM-1778
+ * <p>
+ * Does not work on JBoss, see <a href="https://app.camunda.com/jira/browse/CAM-1778">CAM-1778</a>
+ * </p>
  */
 @RunWith(Arquillian.class)
 public class TestWarDeploymentWithProcessEnginePlugin extends AbstractFoxPlatformIntegrationTest {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithProcessEnginePlugin.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithProcessEnginePlugin.java
@@ -26,10 +26,10 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 
@@ -59,7 +59,7 @@ public class TestWarDeploymentWithProcessEnginePlugin extends AbstractFoxPlatfor
   @Test
   public void testPAGroovyProcessEnginePlugin() {
     ProcessEngine groovyEngine = processEngineService.getProcessEngine("groovy");
-    Assert.assertNotNull(groovyEngine);
+    assertThat(groovyEngine).isNotNull();
 
     ProcessInstance pi = groovyEngine.getRuntimeService().startProcessInstanceByKey("groovy");
     HistoricProcessInstance hpi = groovyEngine.getHistoryService()
@@ -70,7 +70,7 @@ public class TestWarDeploymentWithProcessEnginePlugin extends AbstractFoxPlatfor
   @Test
   public void testPAGroovyAsyncProcessEnginePlugin() {
     ProcessEngine groovyEngine = processEngineService.getProcessEngine("groovy");
-    Assert.assertNotNull(groovyEngine);
+    assertThat(groovyEngine).isNotNull();
 
     ProcessInstance pi = groovyEngine.getRuntimeService().startProcessInstanceByKey("groovyAsync");
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithoutProcessDefinitions.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithoutProcessDefinitions.java
@@ -18,7 +18,10 @@ package org.operaton.bpm.integrationtest.deployment.war;
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.cdi.impl.util.ProgrammaticBeanLookup;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -40,7 +43,7 @@ public class TestWarDeploymentWithoutProcessDefinitions extends AbstractFoxPlatf
 
   @Test
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(ProgrammaticBeanLookup.lookup(ProcessEngine.class));
+    assertThat(ProgrammaticBeanLookup.lookup(ProcessEngine.class)).isNotNull();
 
     // no deployment has been constructed
     Assert.assertEquals(0, repositoryService.createDeploymentQuery().deploymentName("pa").count());

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithoutProcessesXml.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithoutProcessesXml.java
@@ -20,11 +20,13 @@ import org.operaton.bpm.engine.cdi.impl.util.ProgrammaticBeanLookup;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,7 +54,7 @@ public class TestWarDeploymentWithoutProcessesXml extends AbstractFoxPlatformInt
   
   @Test
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(ProgrammaticBeanLookup.lookup(ProcessEngine.class));
+    assertThat(ProgrammaticBeanLookup.lookup(ProcessEngine.class)).isNotNull();
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/bpmnmodelapi/DelegationCodeBpmnModelRetrievalTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/bpmnmodelapi/DelegationCodeBpmnModelRetrievalTest.java
@@ -21,7 +21,10 @@ import org.operaton.bpm.integrationtest.functional.bpmnmodelapi.beans.BpmnElemen
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -59,8 +62,8 @@ public class DelegationCodeBpmnModelRetrievalTest extends AbstractFoxPlatformInt
 
     BpmnElementRetrievalDelegate delegate = ProgrammaticBeanLookup.lookup(BpmnElementRetrievalDelegate.class);
 
-    Assert.assertNotNull(delegate.getBpmnModelElementInstance());
-    Assert.assertNotNull(delegate.getBpmnModelInstance());
+    assertThat(delegate.getBpmnModelElementInstance()).isNotNull();
+    assertThat(delegate.getBpmnModelInstance()).isNotNull();
     Assert.assertEquals(TEST_PROCESS, delegate.getBpmnModelInstance().getDefinitions().getRootElements().iterator().next().getId());
   }
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/bpmnmodelapi/RepositoryServiceBpmnModelRetrievalTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/bpmnmodelapi/RepositoryServiceBpmnModelRetrievalTest.java
@@ -20,11 +20,13 @@ import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -51,7 +53,7 @@ public class RepositoryServiceBpmnModelRetrievalTest extends AbstractFoxPlatform
       .singleResult();
 
     BpmnModelInstance bpmnModelInstance = repositoryService.getBpmnModelInstance(processDefinition.getId());
-    Assert.assertNotNull(bpmnModelInstance);
+    assertThat(bpmnModelInstance).isNotNull();
 
   }
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanCallActivityResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanCallActivityResolutionTest.java
@@ -93,10 +93,11 @@ public class CdiBeanCallActivityResolutionTest extends AbstractFoxPlatformIntegr
 
     Task afterCallActivityTask = taskService.createTaskQuery().singleResult();
     assertThat(afterCallActivityTask).isNotNull();
+    assertThat(afterCallActivityTask.getTaskDefinitionKey()).isEqualTo("afterCallActivity");
     Assert.assertEquals("afterCallActivity", afterCallActivityTask.getTaskDefinitionKey());
 
     String variable = (String) runtimeService.getVariable(processInstance.getId(), "var");
-    Assert.assertEquals("valuevalue", variable);
+    assertThat(variable).isEqualTo("valuevalue");
   }
 
   @Test

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanCallActivityResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanCallActivityResolutionTest.java
@@ -24,7 +24,10 @@ import org.operaton.bpm.integrationtest.functional.cdi.beans.ProcessVariableBean
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -89,7 +92,7 @@ public class CdiBeanCallActivityResolutionTest extends AbstractFoxPlatformIntegr
         Variables.createVariables().putValue("var", "value"));
 
     Task afterCallActivityTask = taskService.createTaskQuery().singleResult();
-    Assert.assertNotNull(afterCallActivityTask);
+    assertThat(afterCallActivityTask).isNotNull();
     Assert.assertEquals("afterCallActivity", afterCallActivityTask.getTaskDefinitionKey());
 
     String variable = (String) runtimeService.getVariable(processInstance.getId(), "var");
@@ -110,7 +113,7 @@ public class CdiBeanCallActivityResolutionTest extends AbstractFoxPlatformIntegr
 
     // then
     Task afterCallActivityTask = taskService.createTaskQuery().singleResult();
-    Assert.assertNotNull(afterCallActivityTask);
+    assertThat(afterCallActivityTask).isNotNull();
     Assert.assertEquals("afterCallActivityTask", afterCallActivityTask.getTaskDefinitionKey());
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanResolutionOnDeploymentTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanResolutionOnDeploymentTest.java
@@ -21,12 +21,14 @@ import org.operaton.bpm.integrationtest.functional.cdi.beans.TimerStartBean;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -60,6 +62,6 @@ public class CdiBeanResolutionOnDeploymentTest extends AbstractFoxPlatformIntegr
   @OperateOnDeployment("clientDeployment")
   public void testTimerStartWithBeanExpression() {
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
-    Assert.assertNotNull(processDefinition);
+    assertThat(processDefinition).isNotNull();
   }
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanResolutionTest.java
@@ -22,7 +22,10 @@ import org.operaton.bpm.integrationtest.functional.cdi.beans.ExampleBean;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -69,7 +72,7 @@ public class CdiBeanResolutionTest extends AbstractFoxPlatformIntegrationTest {
   @OperateOnDeployment("clientDeployment")
   public void testResolveBean() {
     // assert that we cannot resolve the bean here:
-    Assert.assertNull(ProgrammaticBeanLookup.lookup("exampleBean"));
+    assertThat(ProgrammaticBeanLookup.lookup("exampleBean")).isNull();
 
     Assert.assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey("testResolveBean").count());
     // but the process engine can:
@@ -96,7 +99,7 @@ public class CdiBeanResolutionTest extends AbstractFoxPlatformIntegrationTest {
   @OperateOnDeployment("clientDeployment")
   public void testResolveCdiStandaloneProcessEngineConfigBean() {
 
-    Assert.assertNotNull(ProgrammaticBeanLookup.lookup(CdiStandaloneProcessEngineConfiguration.class));
+    assertThat(ProgrammaticBeanLookup.lookup(CdiStandaloneProcessEngineConfiguration.class)).isNotNull();
 
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanSignallableActivityBehaviorResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanSignallableActivityBehaviorResolutionTest.java
@@ -22,12 +22,14 @@ import org.operaton.bpm.integrationtest.functional.cdi.beans.ExampleSignallableA
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -63,7 +65,7 @@ public class CdiBeanSignallableActivityBehaviorResolutionTest extends AbstractFo
   @OperateOnDeployment("clientDeployment")
   public void testResolveClass() {
     // assert that we cannot resolve the bean here:
-    Assert.assertNull(ProgrammaticBeanLookup.lookup("exampleSignallableActivityBehaviorBean"));
+    assertThat(ProgrammaticBeanLookup.lookup("exampleSignallableActivityBehaviorBean")).isNull();
 
     // but the process can since it performs context switch to the process archive for execution
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testResolveBean");

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanSignallableActivityBehaviorResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanSignallableActivityBehaviorResolutionTest.java
@@ -43,7 +43,7 @@ import org.junit.runner.RunWith;
 public class CdiBeanSignallableActivityBehaviorResolutionTest extends AbstractFoxPlatformIntegrationTest {
 
   @Deployment
-  public static WebArchive createProcessArchiveDeplyoment() {
+  public static WebArchive createProcessArchiveDeployment() {
     return initWebArchiveDeployment()
             .addClass(ExampleSignallableActivityBehaviorBean.class)
             .addAsResource("org/operaton/bpm/integrationtest/functional/cdi/CdiBeanSignallableActivityBehaviorResolutionTest.testResolveBean.bpmn20.xml");

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiCallActivityVersionTagTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiCallActivityVersionTagTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.integrationtest.functional.cdi;
 
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.integrationtest.functional.cdi.beans.VersionTagBean;
@@ -61,7 +61,7 @@ public class CdiCallActivityVersionTagTest extends AbstractFoxPlatformIntegratio
 
     // then
     ProcessInstance subInstance = runtimeService.createProcessInstanceQuery().processDefinitionKey("subProcess").superProcessInstanceId(processInstance.getId()).singleResult();
-    assertNotNull(subInstance);
+    assertThat(subInstance).isNotNull();
 
   }
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiDelegateBeanResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiDelegateBeanResolutionTest.java
@@ -24,7 +24,8 @@ import org.operaton.bpm.integrationtest.util.TestContainer;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -34,10 +35,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * <p>Deploys two different applications, a process archive and a cleint application.</p>
+ * <p>Deploys two different applications, a process archive and a client application.</p>
  *
  * <p>This test ensures that when the process is started from the client,
- * it is able to make the context switch to the process archvie and resolve cdi beans
+ * it is able to make the context switch to the process archive and resolve cdi beans
  * from the process archive.</p>
  *
  *
@@ -71,13 +72,9 @@ public class CdiDelegateBeanResolutionTest extends AbstractFoxPlatformIntegratio
   @Test
   @OperateOnDeployment("clientDeployment")
   public void testResolveBean() {
-    try {
-      // assert that we cannot resolve the bean here:
-      ProgrammaticBeanLookup.lookup("exampleDelegateBean");
-      fail("exception expected");
-    }catch (Throwable e) {
-      // expected
-    }
+    assertThatCode(() -> ProgrammaticBeanLookup.lookup("exampleDelegateBean"))
+      .as("Expected to lookup bean")
+      .doesNotThrowAnyException();
 
     Assert.assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey("testResolveBean").count());
     // but the process engine can:

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiDelegateBeanResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiDelegateBeanResolutionTest.java
@@ -21,7 +21,10 @@ import org.operaton.bpm.integrationtest.functional.cdi.beans.ExampleDelegateBean
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.fail;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -71,7 +74,7 @@ public class CdiDelegateBeanResolutionTest extends AbstractFoxPlatformIntegratio
     try {
       // assert that we cannot resolve the bean here:
       ProgrammaticBeanLookup.lookup("exampleDelegateBean");
-      Assert.fail("exception expected");
+      fail("exception expected");
     }catch (Throwable e) {
       // expected
     }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/deployment/RedeployCaseClassloadingTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/deployment/RedeployCaseClassloadingTest.java
@@ -20,7 +20,10 @@ import org.operaton.bpm.engine.runtime.VariableInstanceQuery;
 import org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleCaseExecutionListener;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -84,7 +87,7 @@ public class RedeployCaseClassloadingTest extends AbstractFoxPlatformIntegration
         .variableName("listener")
         .caseInstanceIdIn(caseInstanceId);
 
-    Assert.assertNotNull(query.singleResult());
+    assertThat(query.singleResult()).isNotNull();
     Assert.assertEquals("listener-notified", query.singleResult().getValue());
 
     caseService
@@ -100,7 +103,7 @@ public class RedeployCaseClassloadingTest extends AbstractFoxPlatformIntegration
       .complete();
 
     // then (2)
-    Assert.assertNotNull(query.singleResult());
+    assertThat(query.singleResult()).isNotNull();
     Assert.assertEquals("listener-notified", query.singleResult().getValue());
 
     repositoryService.deleteDeployment(deployment2.getId(), true, true);

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/deployment/RedeployProcessClassloadingTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/deployment/RedeployProcessClassloadingTest.java
@@ -19,12 +19,14 @@ package org.operaton.bpm.integrationtest.functional.classloading.deployment;
 import org.operaton.bpm.integrationtest.functional.classloading.deployment.beans.MyCustomDelegate;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -69,7 +71,7 @@ public class RedeployProcessClassloadingTest extends AbstractFoxPlatformIntegrat
     String id = runtimeService.startProcessInstanceByKey("process").getId();
 
     // then
-    Assert.assertTrue((Boolean) runtimeService.getVariable(id, "executed"));
+    assertThat((Boolean) runtimeService.getVariable(id, "executed")).isTrue();
 
     repositoryService.deleteDeployment(deployment2.getId(), true);
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/ear/TestJavaDelegateResolution_ClientAsLibInWebModule.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/ear/TestJavaDelegateResolution_ClientAsLibInWebModule.java
@@ -37,7 +37,7 @@ import org.junit.runner.RunWith;
  * <p>Deploys an EAR application which contains a WAR process archive, and a client application deployed as a war</p>
  *
  * <p>This test ensures that when the process is started from the client,
- * it is able to make the context switch to the process archvie and resolve classes from the
+ * it is able to make the context switch to the process archive and resolve classes from the
  * process archive.</p>
  *
  *

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/ear/TestJavaDelegateResolution_ClientAsLibInWebModule.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/ear/TestJavaDelegateResolution_ClientAsLibInWebModule.java
@@ -19,7 +19,10 @@ package org.operaton.bpm.integrationtest.functional.classloading.ear;
 import org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleDelegate;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.fail;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -70,7 +73,7 @@ public class TestJavaDelegateResolution_ClientAsLibInWebModule extends AbstractF
     // assert that we cannot load the delegate here:
     try {
       Class.forName("org.operaton.bpm.integrationtest.functional.classloading.ExampleDelegate");
-      Assert.fail("CNFE expected");
+      fail("CNFE expected");
     }catch (ClassNotFoundException e) {
       // expected
     }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/jobexecution/ClassloadingByJobPriorityTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/jobexecution/ClassloadingByJobPriorityTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.integrationtest.functional.classloading.jobexecution;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.util.List;
@@ -79,7 +79,7 @@ public class ClassloadingByJobPriorityTest extends AbstractFoxPlatformIntegratio
 
     // then
     List<Job> availableJobs = configuration.getManagementService().createJobQuery().noRetriesLeft().list();
-    assertTrue(availableJobs.isEmpty());
+    assertThat(availableJobs).isEmpty();
   }
 
   protected static Asset modelAsAsset(BpmnModelInstance modelInstance) {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/jobexecution/ClassloadingDuringJobExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/jobexecution/ClassloadingDuringJobExecutionTest.java
@@ -27,8 +27,7 @@ import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * See CAM-10258
@@ -80,11 +79,11 @@ public class ClassloadingDuringJobExecutionTest extends AbstractFoxPlatformInteg
 
     // then
     List<Job> failedJobs = managementService.createJobQuery().noRetriesLeft().list();
-    assertTrue(!failedJobs.isEmpty());
+    assertThat(!failedJobs.isEmpty()).isTrue();
     for (Job job : failedJobs) {
       String jobExceptionStacktrace = managementService.getJobExceptionStacktrace(job.getId());
-      assertFalse(jobExceptionStacktrace.contains("ClassNotFoundException"));
-      assertTrue(jobExceptionStacktrace.contains("Test error thrown"));
+      assertThat(jobExceptionStacktrace).doesNotContain("ClassNotFoundException");
+      assertThat(jobExceptionStacktrace).contains("Test error thrown");
     }
     // clean up
     repositoryService.deleteDeployment(deploymentId, true);

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/variables/DeserializableVariableTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/variables/DeserializableVariableTest.java
@@ -29,11 +29,12 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * <p>Ensures that process variables can be deserialized on a
@@ -70,7 +71,7 @@ public class DeserializableVariableTest extends AbstractFoxPlatformIntegrationTe
     ProcessInstance pi = runtimeService.startProcessInstanceByKey("testDeserializeVariable");
 
     // when
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult());
+    assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult()).isNull();
     runtimeService.restartProcessInstances(pi.getProcessDefinitionId())
       .startAfterActivity("servicetask1")
       .processInstanceIds(pi.getId())
@@ -83,7 +84,7 @@ public class DeserializableVariableTest extends AbstractFoxPlatformIntegrationTe
     List<HistoricVariableInstance> variableInstances = historyService.createHistoricVariableInstanceQuery().disableCustomObjectDeserialization().list();
     for (HistoricVariableInstance variable : variableInstances) {
       if (variable.getProcessInstanceId() != pi.getId() && variable instanceof HistoricVariableInstanceEntity variableEntity) {
-        Assert.assertNotNull(variableEntity.getByteArrayValue());
+        assertThat(variableEntity.getByteArrayValue()).isNotNull();
       }
     }
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/variables/SerializableVariableTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/variables/SerializableVariableTest.java
@@ -19,10 +19,12 @@ import org.operaton.bpm.integrationtest.functional.classloading.variables.beans.
 import org.operaton.bpm.integrationtest.functional.classloading.variables.beans.SerializableVariable;
 import org.operaton.bpm.integrationtest.functional.classloading.variables.beans.SetVariableDelegate;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,7 +54,7 @@ public class SerializableVariableTest extends AbstractFoxPlatformIntegrationTest
 
     waitForJobExecutorToProcessAllJobs();
 
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(pid).singleResult());
+    assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(pid).singleResult()).isNull();
 
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/variables/beans/GetVariableDelegate.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/variables/beans/GetVariableDelegate.java
@@ -18,7 +18,8 @@ package org.operaton.bpm.integrationtest.functional.classloading.variables.beans
 
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.JavaDelegate;
-import org.junit.Assert;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Daniel Meyer
@@ -31,7 +32,7 @@ public class GetVariableDelegate implements JavaDelegate {
     
     SerializableVariable variable = (SerializableVariable) execution.getVariable("var1");
 
-    Assert.assertNotNull(variable);
+    assertThat(variable).isNotNull();
   }
 
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseExecutionListenerResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseExecutionListenerResolutionTest.java
@@ -23,6 +23,7 @@ import org.operaton.bpm.integrationtest.util.TestContainer;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseExecutionListenerResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseExecutionListenerResolutionTest.java
@@ -20,7 +20,11 @@ import org.operaton.bpm.engine.runtime.VariableInstanceQuery;
 import org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleCaseExecutionListener;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.fail;
+
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -60,7 +64,7 @@ public class CaseExecutionListenerResolutionTest extends AbstractFoxPlatformInte
     // assert that we cannot load the delegate here:
     try {
       Class.forName("org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleCaseExecutionListener");
-      Assert.fail("CNFE expected");
+      fail("CNFE expected");
     }catch (ClassNotFoundException e) {
       // expected
     }
@@ -81,7 +85,7 @@ public class CaseExecutionListenerResolutionTest extends AbstractFoxPlatformInte
         .variableName("listener")
         .caseInstanceIdIn(caseInstanceId);
 
-    Assert.assertNotNull(query.singleResult());
+    assertThat(query.singleResult()).isNotNull();
     Assert.assertEquals("listener-notified", query.singleResult().getValue());
 
     caseService
@@ -96,7 +100,7 @@ public class CaseExecutionListenerResolutionTest extends AbstractFoxPlatformInte
       .withCaseExecution(humanTaskId)
       .complete();
 
-    Assert.assertNotNull(query.singleResult());
+    assertThat(query.singleResult()).isNotNull();
     Assert.assertEquals("listener-notified", query.singleResult().getValue());
 
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseVariableListenerResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseVariableListenerResolutionTest.java
@@ -23,6 +23,7 @@ import org.operaton.bpm.integrationtest.util.TestContainer;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseVariableListenerResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseVariableListenerResolutionTest.java
@@ -20,7 +20,11 @@ import org.operaton.bpm.engine.runtime.VariableInstanceQuery;
 import org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleCaseVariableListener;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.fail;
+
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -60,7 +64,7 @@ public class CaseVariableListenerResolutionTest extends AbstractFoxPlatformInteg
     // assert that we cannot load the delegate here:
     try {
       Class.forName("org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleCaseVariableListener");
-      Assert.fail("CNFE expected");
+      fail("CNFE expected");
     }catch (ClassNotFoundException e) {
       // expected
     }
@@ -87,7 +91,7 @@ public class CaseVariableListenerResolutionTest extends AbstractFoxPlatformInteg
       .variableName("variable")
       .caseInstanceIdIn(caseInstanceId);
 
-    Assert.assertNotNull(query.singleResult());
+    assertThat(query.singleResult()).isNotNull();
     Assert.assertEquals("listener-notified-1", query.singleResult().getValue());
 
     caseService
@@ -95,7 +99,7 @@ public class CaseVariableListenerResolutionTest extends AbstractFoxPlatformInteg
       .setVariable("variable", "manual-start")
       .manualStart();
 
-    Assert.assertNotNull(query.singleResult());
+    assertThat(query.singleResult()).isNotNull();
     Assert.assertEquals("listener-notified-2", query.singleResult().getValue());
 
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/JavaDelegateResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/JavaDelegateResolutionTest.java
@@ -35,7 +35,7 @@ import org.operaton.bpm.integrationtest.util.TestContainer;
  * <p>Deploys two different WAR applications, a process archive and a client application.</p>
  *
  * <p>This test ensures that when the process is started from the client,
- * it is able to make the context switch to the process archvie and resolve classes from the
+ * it is able to make the context switch to the process archive and resolve classes from the
  * process archive.</p>
  *
  *

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/JavaDelegateResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/JavaDelegateResolutionTest.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.functional.classloading.war;
 
+import static org.assertj.core.api.Assertions.fail;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -67,7 +69,7 @@ public class JavaDelegateResolutionTest extends AbstractFoxPlatformIntegrationTe
     // assert that we cannot load the delegate here:
     try {
       Class.forName("org.operaton.bpm.integrationtest.functional.classloading.ExampleDelegate");
-      Assert.fail("CNFE expected");
+      fail("CNFE expected");
     }catch (ClassNotFoundException e) {
       // expected
     }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/SignallableActivityBehaviorResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/SignallableActivityBehaviorResolutionTest.java
@@ -20,7 +20,10 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleSignallableActivityBehavior;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.fail;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -63,7 +66,7 @@ public class SignallableActivityBehaviorResolutionTest extends AbstractFoxPlatfo
     // assert that we cannot load the delegate here:
     try {
       Class.forName("org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleSignallableActivityBehavior");
-      Assert.fail("CNFE expected");
+      fail("CNFE expected");
     }catch (ClassNotFoundException e) {
       // expected
     }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/TaskListenerResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/TaskListenerResolutionTest.java
@@ -22,12 +22,16 @@ import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleTaskListener;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -58,7 +62,7 @@ public class TaskListenerResolutionTest extends AbstractFoxPlatformIntegrationTe
     // assert that we cannot load the delegate here:
     try {
       Class.forName("org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleTaskListener");
-      Assert.fail("CNFE expected");
+      fail("CNFE expected");
     }catch (ClassNotFoundException e) {
       // expected
     }
@@ -70,12 +74,12 @@ public class TaskListenerResolutionTest extends AbstractFoxPlatformIntegrationTe
     taskService.setAssignee(task.getId(), "john doe");
 
     Execution execution = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).singleResult();
-    Assert.assertNotNull(runtimeService.getVariable(execution.getId(), "listener"));
+    assertThat(runtimeService.getVariable(execution.getId(), "listener")).isNotNull();
     runtimeService.removeVariable(execution.getId(), "listener");
 
     taskService.complete(task.getId());
 
-    Assert.assertNotNull(runtimeService.getVariable(execution.getId(), "listener"));
+    assertThat(runtimeService.getVariable(execution.getId(), "listener")).isNotNull();
 
     // the delegate expression listener should execute successfully
     runtimeService.removeVariable(execution.getId(), "listener");
@@ -83,12 +87,12 @@ public class TaskListenerResolutionTest extends AbstractFoxPlatformIntegrationTe
     task = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
 
     taskService.setAssignee(task.getId(), "john doe");
-    Assert.assertNotNull(runtimeService.getVariable(execution.getId(), "listener"));
+    assertThat(runtimeService.getVariable(execution.getId(), "listener")).isNotNull();
     runtimeService.removeVariable(execution.getId(), "listener");
 
     taskService.complete(task.getId());
 
-    Assert.assertNotNull(runtimeService.getVariable(execution.getId(), "listener"));
+    assertThat(runtimeService.getVariable(execution.getId(), "listener")).isNotNull();
 
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/condition/ConditionalStartEventTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/condition/ConditionalStartEventTest.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.functional.condition;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 
@@ -57,7 +57,7 @@ public class ConditionalStartEventTest extends AbstractFoxPlatformIntegrationTes
 
     assertEquals(1, instances.size());
 
-    assertNotNull(runtimeService.createProcessInstanceQuery().processDefinitionKey("conditionalEventProcess").singleResult());
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionKey("conditionalEventProcess").singleResult()).isNotNull();
 
     VariableInstance vars = runtimeService.createVariableInstanceQuery().singleResult();
     assertEquals(vars.getProcessInstanceId(), instances.get(0).getId());

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/connect/PaConnectSupportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/connect/PaConnectSupportTest.java
@@ -22,6 +22,9 @@ import static org.junit.Assert.assertEquals;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.connect.Connectors;
+import org.operaton.connect.spi.Connector;
+import org.operaton.connect.spi.ConnectorRequest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -48,12 +51,12 @@ public class PaConnectSupportTest extends AbstractFoxPlatformIntegrationTest {
 
   @Test
   public void httpConnectorShouldBeAvailable() {
-    assertThat(Connectors.http()).isNotNull();
+    assertThat(Connectors.<Connector<?>>http()).isNotNull();
   }
 
   @Test
   public void soapConnectorShouldBeAvailable() {
-    assertThat(Connectors.soap()).isNotNull();
+    assertThat(Connectors.<Connector<?>>soap()).isNotNull();
   }
 
   @Test

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/connect/PaConnectSupportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/connect/PaConnectSupportTest.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.functional.connect;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
@@ -48,12 +48,12 @@ public class PaConnectSupportTest extends AbstractFoxPlatformIntegrationTest {
 
   @Test
   public void httpConnectorShouldBeAvailable() {
-    assertNotNull(Connectors.http());
+    assertThat(Connectors.http()).isNotNull();
   }
 
   @Test
   public void soapConnectorShouldBeAvailable() {
-    assertNotNull(Connectors.soap());
+    assertThat(Connectors.soap()).isNotNull();
   }
 
   @Test
@@ -63,7 +63,7 @@ public class PaConnectSupportTest extends AbstractFoxPlatformIntegrationTest {
 
     runtimeService.startProcessInstanceByKey("testProcess");
     Task task = taskService.createTaskQuery().singleResult();
-    assertNotNull(task);
+    assertThat(task).isNotNull();
     String payload = (String) taskService.getVariable(task.getId(), "payload");
     assertEquals("Hello world!", payload);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/connect/PaConnectSupportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/connect/PaConnectSupportTest.java
@@ -23,7 +23,6 @@ import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.connect.Connectors;
 import org.operaton.connect.spi.Connector;
-import org.operaton.connect.spi.ConnectorRequest;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -32,7 +31,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * <p>Smoketest Make sure operaton connect can be used in a process application </p>
+ * <p>Smoke-test Make sure operaton connect can be used in a process application </p>
  *
  * @author Daniel Meyer
  */

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/CallActivityContextSwitchTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/CallActivityContextSwitchTest.java
@@ -16,6 +16,9 @@
  */
 package org.operaton.bpm.integrationtest.functional.context;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -83,7 +86,7 @@ public class CallActivityContextSwitchTest extends AbstractFoxPlatformIntegratio
     // we cannot load the class
     try {
       new CalledProcessDelegate();
-      Assert.fail("exception expected");
+      fail("exception expected");
     }catch (NoClassDefFoundError e) {
       // expected
     }
@@ -98,7 +101,7 @@ public class CallActivityContextSwitchTest extends AbstractFoxPlatformIntegratio
     processVariables.put("calledElement", "calledProcessSyncNoWait");
     ProcessInstance pi = runtimeService.startProcessInstanceByKey("mainProcessSyncNoWait", processVariables);
 
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult());
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult()).isNull();
   }
 
   @Test
@@ -123,8 +126,8 @@ public class CallActivityContextSwitchTest extends AbstractFoxPlatformIntegratio
 
     taskService.complete(taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult().getId());
 
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult());
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult());
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult()).isNull();
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult()).isNull();
   }
 
   @Test
@@ -151,8 +154,8 @@ public class CallActivityContextSwitchTest extends AbstractFoxPlatformIntegratio
 
     taskService.complete(taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult().getId());
 
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult());
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult());
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult()).isNull();
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult()).isNull();
   }
 
   @Test
@@ -179,8 +182,8 @@ public class CallActivityContextSwitchTest extends AbstractFoxPlatformIntegratio
 
     taskService.complete(taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult().getId());
 
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult());
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult());
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult()).isNull();
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult()).isNull();
   }
 
   @Test
@@ -207,8 +210,8 @@ public class CallActivityContextSwitchTest extends AbstractFoxPlatformIntegratio
 
     taskService.complete(taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult().getId());
 
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult());
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult());
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult()).isNull();
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult()).isNull();
   }
 
   // the same in main process but called process async
@@ -228,8 +231,8 @@ public class CallActivityContextSwitchTest extends AbstractFoxPlatformIntegratio
       .processDefinitionKey("calledProcessASync")
       .singleResult();
 
-    Assert.assertNotNull(calledPi);
-    Assert.assertNull(runtimeService.getVariable(calledPi.getId(), "calledDelegate"));
+    assertThat(calledPi).isNotNull();
+    assertThat(runtimeService.getVariable(calledPi.getId(), "calledDelegate")).isNull();
 
     waitForJobExecutorToProcessAllJobs();
 
@@ -241,8 +244,8 @@ public class CallActivityContextSwitchTest extends AbstractFoxPlatformIntegratio
 
     taskService.complete(taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult().getId());
 
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult());
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult());
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult()).isNull();
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult()).isNull();
   }
 
   @Test
@@ -269,8 +272,8 @@ public class CallActivityContextSwitchTest extends AbstractFoxPlatformIntegratio
 
     taskService.complete(taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult().getId());
 
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult());
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult());
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult()).isNull();
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult()).isNull();
   }
 
   @Test
@@ -297,8 +300,8 @@ public class CallActivityContextSwitchTest extends AbstractFoxPlatformIntegratio
 
     taskService.complete(taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult().getId());
 
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult());
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult());
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult()).isNull();
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult()).isNull();
   }
 
   @Test
@@ -327,8 +330,8 @@ public class CallActivityContextSwitchTest extends AbstractFoxPlatformIntegratio
 
     taskService.complete(taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult().getId());
 
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult());
-    Assert.assertNull(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult());
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(pi.getId()).singleResult()).isNull();
+    assertThat(runtimeService.createProcessInstanceQuery().processDefinitionId(calledPi.getId()).singleResult()).isNull();
   }
 
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/SetVariablesMigrationContextSwitchTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/SetVariablesMigrationContextSwitchTest.java
@@ -33,7 +33,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,6 +40,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assert.fail;
 
 @RunWith(Arquillian.class)
@@ -126,7 +126,7 @@ public class SetVariablesMigrationContextSwitchTest extends AbstractFoxPlatformI
     }
 
     // then
-    Assert.assertNotNull(runtimeService.getVariableTyped(pi, "foo", false));
+    assertThat(runtimeService.getVariableTyped(pi, "foo", false)).isNotNull();
   }
 
   @Test
@@ -161,7 +161,7 @@ public class SetVariablesMigrationContextSwitchTest extends AbstractFoxPlatformI
         .execute();
 
     // then
-    Assert.assertNotNull(runtimeService.getVariableTyped(pi, "foo", false));
+    assertThat(runtimeService.getVariableTyped(pi, "foo", false)).isNotNull();
   }
 
   protected static Asset modelAsAsset(BpmnModelInstance modelInstance) {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/SetVariablesMigrationContextSwitchTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/SetVariablesMigrationContextSwitchTest.java
@@ -21,11 +21,17 @@ import org.operaton.bpm.engine.migration.MigrationPlan;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.engine.variable.Variables;
+import org.operaton.bpm.engine.variable.value.ObjectValue;
 import org.operaton.bpm.integrationtest.functional.context.classes.MyPojo;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Collections;
+import java.util.List;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -36,12 +42,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.ByteArrayOutputStream;
-import java.util.Collections;
-import java.util.List;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.junit.Assert.fail;
 
 @RunWith(Arquillian.class)
 public class SetVariablesMigrationContextSwitchTest extends AbstractFoxPlatformIntegrationTest {
@@ -126,7 +128,7 @@ public class SetVariablesMigrationContextSwitchTest extends AbstractFoxPlatformI
     }
 
     // then
-    assertThat(runtimeService.getVariableTyped(pi, "foo", false)).isNotNull();
+    assertThat(runtimeService.<ObjectValue>getVariableTyped(pi, "foo", false)).isNotNull();
   }
 
   @Test
@@ -161,7 +163,7 @@ public class SetVariablesMigrationContextSwitchTest extends AbstractFoxPlatformI
         .execute();
 
     // then
-    assertThat(runtimeService.getVariableTyped(pi, "foo", false)).isNotNull();
+    assertThat(runtimeService.<ObjectValue>getVariableTyped(pi, "foo", false)).isNotNull();
   }
 
   protected static Asset modelAsAsset(BpmnModelInstance modelInstance) {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/database/PurgeDatabaseTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/database/PurgeDatabaseTest.java
@@ -35,6 +35,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.fail;
+
 import java.util.List;
 import java.util.Map;
 
@@ -57,7 +60,7 @@ public class PurgeDatabaseTest extends AbstractFoxPlatformIntegrationTest {
 
   @Test
   public void testPurgeDatabase() {
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     VariableMap variableMap = Variables.putValue("var", "value");
     runtimeService.startProcessInstanceByKey("testDeployProcessArchive", variableMap);
     runtimeService.startProcessInstanceByKey("testDeployProcessArchive", variableMap);
@@ -112,7 +115,7 @@ public class PurgeDatabaseTest extends AbstractFoxPlatformIntegrationTest {
             }
           });
       }
-      Assert.fail(outputMessage.toString());
+      fail(outputMessage.toString());
     }
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/database/PurgeDatabaseTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/database/PurgeDatabaseTest.java
@@ -27,19 +27,19 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.Arrays;
-
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * @author Christopher Zell <christopher.zell@camunda.com>

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/drools/TestDeploymentWithDroolsTaskFails.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/drools/TestDeploymentWithDroolsTaskFails.java
@@ -17,14 +17,16 @@
 package org.operaton.bpm.integrationtest.functional.drools;
 
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
+
 import org.jboss.arquillian.container.test.api.Deployer;
+
+import static org.assertj.core.api.Assertions.fail;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -57,7 +59,7 @@ public class TestDeploymentWithDroolsTaskFails {
   public void testDeployDroolsFails() {
     try {
       deployer.deploy("deployment");
-      Assert.fail("exception expected");
+      fail("exception expected");
     }catch (Exception e) {
       // expected
     }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/el/DecisionContextSwitchTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/el/DecisionContextSwitchTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.integrationtest.functional.el;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
@@ -33,7 +34,6 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -108,7 +108,7 @@ public class DecisionContextSwitchTest extends AbstractFoxPlatformIntegrationTes
     }
 
     if(dmnDeployment == null) {
-      Assert.fail("Expected to find DMN deployment");
+      fail("Expected to find DMN deployment");
     }
 
     org.operaton.bpm.engine.repository.Deployment deployment2 = repositoryService
@@ -146,7 +146,7 @@ public class DecisionContextSwitchTest extends AbstractFoxPlatformIntegrationTes
     }
 
     if(dmnDeployment == null) {
-      Assert.fail("Expected to find DMN deployment");
+      fail("Expected to find DMN deployment");
     }
 
     org.operaton.bpm.engine.repository.Deployment deployment2 = repositoryService

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/el/ElResolveStartFormDataTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/el/ElResolveStartFormDataTest.java
@@ -19,7 +19,10 @@ package org.operaton.bpm.integrationtest.functional.el;
 import org.operaton.bpm.engine.form.StartFormData;
 import org.operaton.bpm.integrationtest.functional.el.beans.ResolveFormDataBean;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -46,7 +49,7 @@ public class ElResolveStartFormDataTest extends AbstractFoxPlatformIntegrationTe
     StartFormData formData = formService.getStartFormData(processDefinitionId);
     Object defaultValue = formData.getFormFields().get(0).getValue().getValue();
 
-    Assert.assertNotNull(defaultValue);
+    assertThat(defaultValue).isNotNull();
     Assert.assertEquals("testString123", defaultValue);
   }
 
@@ -57,7 +60,7 @@ public class ElResolveStartFormDataTest extends AbstractFoxPlatformIntegrationTe
     StartFormData formData = formService.getStartFormData(processDefinitionId);
 
     String label = formData.getFormFields().get(0).getLabel();
-    Assert.assertNotNull(label);
+    assertThat(label).isNotNull();
     Assert.assertEquals("testString123", label);
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/el/ElResolveTaskFormDataTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/el/ElResolveTaskFormDataTest.java
@@ -21,7 +21,10 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.integrationtest.functional.el.beans.ResolveFormDataBean;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
@@ -49,7 +52,7 @@ public class ElResolveTaskFormDataTest extends AbstractFoxPlatformIntegrationTes
     TaskFormData formData = formService.getTaskFormData(task.getId());
     Object defaultValue = formData.getFormFields().get(0).getValue().getValue();
 
-    Assert.assertNotNull(defaultValue);
+    assertThat(defaultValue).isNotNull();
     Assert.assertEquals("testString123", defaultValue);
   }
 
@@ -61,7 +64,7 @@ public class ElResolveTaskFormDataTest extends AbstractFoxPlatformIntegrationTes
     TaskFormData formData = formService.getTaskFormData(task.getId());
 
     String label = formData.getFormFields().get(0).getLabel();
-    Assert.assertNotNull(label);
+    assertThat(label).isNotNull();
     Assert.assertEquals("testString123", label);
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/el/ElResolverLookupTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/el/ElResolverLookupTest.java
@@ -18,11 +18,13 @@ package org.operaton.bpm.integrationtest.functional.el;
 
 import org.operaton.bpm.integrationtest.functional.el.beans.ResolveExpressionBean;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -51,6 +53,6 @@ public class ElResolverLookupTest extends AbstractFoxPlatformIntegrationTest {
     // is present
     runtimeService.startProcessInstanceByKey("elServiceTaskProcess");
 
-    Assert.assertNotNull(taskService.createTaskQuery().singleResult());
+    assertThat(taskService.createTaskQuery().singleResult()).isNotNull();
   }
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/el/ResolveBeanFromDmnTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/el/ResolveBeanFromDmnTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.integrationtest.functional.el;
 
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.operaton.bpm.engine.runtime.VariableInstance;
 import org.operaton.bpm.engine.task.Task;
@@ -48,11 +48,11 @@ public class ResolveBeanFromDmnTest extends AbstractFoxPlatformIntegrationTest {
     runtimeService.startProcessInstanceByKey("testProcess");
 
     Task task = taskService.createTaskQuery().singleResult();
-    assertNotNull(task);
+    assertThat(task).isNotNull();
 
     VariableInstance decisionResult = runtimeService.createVariableInstanceQuery().variableName("result").singleResult();
-    assertNotNull("The variable 'result' should exist", decisionResult);
-    assertNotNull("The value of the variable 'result' should not be null", decisionResult.getValue());
+    assertThat(decisionResult).as("The variable 'result' should exist").isNotNull();
+    assertThat(decisionResult.getValue()).as("The value of the variable 'result' should not be null").isNotNull();
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/error/CatchErrorFromProcessApplicationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/error/CatchErrorFromProcessApplicationTest.java
@@ -16,10 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.functional.error;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
 import java.util.Map;
@@ -70,11 +68,11 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowExceptionInExecute() {
     String pi = runtimeService.startProcessInstanceByKey("testProcess", throwException()).getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskException", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -85,11 +83,11 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowErrorInExecute() {
     String pi = runtimeService.startProcessInstanceByKey("testProcess", throwError()).getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskError", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -100,20 +98,20 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowExceptionInSignal() {
     String pi = runtimeService.startProcessInstanceByKey("testProcess").getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Execution serviceTask = runtimeService.createExecutionQuery().processInstanceId(pi).activityId("serviceTask").singleResult();
-    assertNotNull(serviceTask);
+    assertThat(serviceTask).isNotNull();
 
     runtimeService.setVariables(pi, throwException());
     runtimeService.signal(serviceTask.getId());
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertTrue((Boolean) runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat((Boolean) runtimeService.getVariable(pi, "signaled")).isTrue();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskException", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -124,20 +122,20 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowErrorInSignal() {
     String pi = runtimeService.startProcessInstanceByKey("testProcess").getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Execution serviceTask = runtimeService.createExecutionQuery().processInstanceId(pi).activityId("serviceTask").singleResult();
-    assertNotNull(serviceTask);
+    assertThat(serviceTask).isNotNull();
 
     runtimeService.setVariables(pi, throwError());
     runtimeService.signal(serviceTask.getId());
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertTrue((Boolean) runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat((Boolean) runtimeService.getVariable(pi, "signaled")).isTrue();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskError", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -148,11 +146,11 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowExceptionInExecuteSequentialMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessSequentialMI", throwException()).getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskException", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -163,11 +161,11 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowErrorInExecuteSequentialMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessSequentialMI", throwError()).getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskError", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -178,8 +176,8 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowExceptionInSignalSequentialMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessSequentialMI").getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     // signal 2 times to execute first sequential behaviors
     runtimeService.setVariables(pi, leaveExecution());
@@ -187,16 +185,16 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
     runtimeService.setVariables(pi, leaveExecution());
 
     Execution serviceTask = runtimeService.createExecutionQuery().processInstanceId(pi).activityId("serviceTask").singleResult();
-    assertNotNull(serviceTask);
+    assertThat(serviceTask).isNotNull();
 
     runtimeService.setVariables(pi, throwException());
     runtimeService.signal(serviceTask.getId());
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertTrue((Boolean) runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat((Boolean) runtimeService.getVariable(pi, "signaled")).isTrue();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskException", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -207,8 +205,8 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowErrorInSignalSequentialMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessSequentialMI").getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     // signal 2 times to execute first sequential behaviors
     runtimeService.setVariables(pi, leaveExecution());
@@ -217,16 +215,16 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
 
     runtimeService.signal(runtimeService.createExecutionQuery().processInstanceId(pi).activityId("serviceTask").singleResult().getId());
     Execution serviceTask = runtimeService.createExecutionQuery().processInstanceId(pi).activityId("serviceTask").singleResult();
-    assertNotNull(serviceTask);
+    assertThat(serviceTask).isNotNull();
 
     runtimeService.setVariables(pi, throwError());
     runtimeService.signal(serviceTask.getId());
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertTrue((Boolean) runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat((Boolean) runtimeService.getVariable(pi, "signaled")).isTrue();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskError", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -237,11 +235,11 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowExceptionInExecuteParallelMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessParallelMI", throwException()).getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskException", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -252,11 +250,11 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowErrorInExecuteParallelMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessParallelMI", throwError()).getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskError", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -267,20 +265,20 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowExceptionInSignalParallelMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessParallelMI").getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Execution serviceTask = runtimeService.createExecutionQuery().processInstanceId(pi).activityId("serviceTask").list().get(3);
-    assertNotNull(serviceTask);
+    assertThat(serviceTask).isNotNull();
 
     runtimeService.setVariables(pi, throwException());
     runtimeService.signal(serviceTask.getId());
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertTrue((Boolean) runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat((Boolean) runtimeService.getVariable(pi, "signaled")).isTrue();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskException", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -291,20 +289,20 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowErrorInSignalParallelMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessParallelMI").getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Execution serviceTask = runtimeService.createExecutionQuery().processInstanceId(pi).activityId("serviceTask").list().get(3);
-    assertNotNull(serviceTask);
+    assertThat(serviceTask).isNotNull();
 
     runtimeService.setVariables(pi, throwError());
     runtimeService.signal(serviceTask.getId());
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertTrue((Boolean) runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat((Boolean) runtimeService.getVariable(pi, "signaled")).isTrue();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskError", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -315,11 +313,11 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowExceptionInDelegateExpressionExecute() {
     String pi = runtimeService.startProcessInstanceByKey("testProcess", throwException()).getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskException", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -330,11 +328,11 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowErrorInDelegateExpressionExecute() {
     String pi = runtimeService.startProcessInstanceByKey("testProcess", throwError()).getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskError", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -345,20 +343,20 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowExceptionInDelegateExpressionSignal() {
     String pi = runtimeService.startProcessInstanceByKey("testProcess").getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Execution serviceTask = runtimeService.createExecutionQuery().processInstanceId(pi).activityId("serviceTask").singleResult();
-    assertNotNull(serviceTask);
+    assertThat(serviceTask).isNotNull();
 
     runtimeService.setVariables(pi, throwException());
     runtimeService.signal(serviceTask.getId());
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertTrue((Boolean) runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat((Boolean) runtimeService.getVariable(pi, "signaled")).isTrue();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskException", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -369,20 +367,20 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowErrorInDelegateExpressionSignal() {
     String pi = runtimeService.startProcessInstanceByKey("testProcess").getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Execution serviceTask = runtimeService.createExecutionQuery().processInstanceId(pi).activityId("serviceTask").singleResult();
-    assertNotNull(serviceTask);
+    assertThat(serviceTask).isNotNull();
 
     runtimeService.setVariables(pi, throwError());
     runtimeService.signal(serviceTask.getId());
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertTrue((Boolean) runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat((Boolean) runtimeService.getVariable(pi, "signaled")).isTrue();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskError", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -393,11 +391,11 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowExceptionInDelegateExpressionExecuteSequentialMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessSequentialMI", throwException()).getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskException", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -408,11 +406,11 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowErrorInDelegateExpressionExecuteSequentialMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessSequentialMI", throwError()).getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskError", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -423,8 +421,8 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowExceptionInDelegateExpressionSignalSequentialMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessSequentialMI").getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     // signal 2 times to execute first sequential behaviors
     runtimeService.setVariables(pi, leaveExecution());
@@ -432,16 +430,16 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
     runtimeService.setVariables(pi, leaveExecution());
 
     Execution serviceTask = runtimeService.createExecutionQuery().processInstanceId(pi).activityId("serviceTask").singleResult();
-    assertNotNull(serviceTask);
+    assertThat(serviceTask).isNotNull();
 
     runtimeService.setVariables(pi, throwException());
     runtimeService.signal(serviceTask.getId());
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertTrue((Boolean) runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat((Boolean) runtimeService.getVariable(pi, "signaled")).isTrue();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskException", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -452,8 +450,8 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowErrorInDelegateExpressionSignalSequentialMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessSequentialMI").getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     // signal 2 times to execute first sequential behaviors
     runtimeService.setVariables(pi, leaveExecution());
@@ -462,16 +460,16 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
 
     runtimeService.signal(runtimeService.createExecutionQuery().processInstanceId(pi).activityId("serviceTask").singleResult().getId());
     Execution serviceTask = runtimeService.createExecutionQuery().processInstanceId(pi).activityId("serviceTask").singleResult();
-    assertNotNull(serviceTask);
+    assertThat(serviceTask).isNotNull();
 
     runtimeService.setVariables(pi, throwError());
     runtimeService.signal(serviceTask.getId());
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertTrue((Boolean) runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat((Boolean) runtimeService.getVariable(pi, "signaled")).isTrue();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskError", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -482,11 +480,11 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowExceptionInDelegateExpressionExecuteParallelMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessParallelMI", throwException()).getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskException", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -497,11 +495,11 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowErrorInDelegateExpressionExecuteParallelMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessParallelMI", throwError()).getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskError", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -512,20 +510,20 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowExceptionInDelegateExpressionSignalParallelMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessParallelMI").getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Execution serviceTask = runtimeService.createExecutionQuery().processInstanceId(pi).activityId("serviceTask").list().get(3);
-    assertNotNull(serviceTask);
+    assertThat(serviceTask).isNotNull();
 
     runtimeService.setVariables(pi, throwException());
     runtimeService.signal(serviceTask.getId());
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertTrue((Boolean) runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat((Boolean) runtimeService.getVariable(pi, "signaled")).isTrue();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskException", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());
@@ -536,20 +534,20 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
   public void testThrowErrorInDelegateExpressionSignalParallelMultiInstance() {
     String pi = runtimeService.startProcessInstanceByKey("testProcessParallelMI").getId();
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertNull(runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat(runtimeService.getVariable(pi, "signaled")).isNull();
 
     Execution serviceTask = runtimeService.createExecutionQuery().processInstanceId(pi).activityId("serviceTask").list().get(3);
-    assertNotNull(serviceTask);
+    assertThat(serviceTask).isNotNull();
 
     runtimeService.setVariables(pi, throwError());
     runtimeService.signal(serviceTask.getId());
 
-    assertTrue((Boolean) runtimeService.getVariable(pi, "executed"));
-    assertTrue((Boolean) runtimeService.getVariable(pi, "signaled"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
+    assertThat((Boolean) runtimeService.getVariable(pi, "signaled")).isTrue();
 
     Task userTask = taskService.createTaskQuery().processInstanceId(pi).singleResult();
-    assertNotNull(userTask);
+    assertThat(userTask).isNotNull();
     assertEquals("userTaskError", userTask.getTaskDefinitionKey());
 
     taskService.complete(userTask.getId());

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/event/CdiProcessApplicationEventSupportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/event/CdiProcessApplicationEventSupportTest.java
@@ -24,7 +24,10 @@ import org.operaton.bpm.integrationtest.functional.event.beans.ExecutionListener
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -61,7 +64,7 @@ public class CdiProcessApplicationEventSupportTest extends AbstractFoxPlatformIn
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testProcess");
 
     Integer listenerInvocationCount = (Integer) runtimeService.getVariable(processInstance.getId(), ExecutionListenerProcessApplication.LISTENER_INVOCATION_COUNT);
-    Assert.assertNotNull(listenerInvocationCount);
+    assertThat(listenerInvocationCount).isNotNull();
     Assert.assertEquals(6, listenerInvocationCount.intValue());
 
     Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/event/ProcessApplicationExecutionListenerTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/event/ProcessApplicationExecutionListenerTest.java
@@ -21,7 +21,10 @@ import org.operaton.bpm.integrationtest.functional.event.beans.ExecutionListener
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -57,7 +60,7 @@ public class ProcessApplicationExecutionListenerTest extends AbstractFoxPlatform
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testProcess");
 
     Integer listenerInvocationCount = (Integer) runtimeService.getVariable(processInstance.getId(), ExecutionListenerProcessApplication.LISTENER_INVOCATION_COUNT);
-    Assert.assertNotNull(listenerInvocationCount);
+    assertThat(listenerInvocationCount).isNotNull();
     Assert.assertEquals(5, listenerInvocationCount.intValue());
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/event/ProcessApplicationTaskListenerTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/event/ProcessApplicationTaskListenerTest.java
@@ -27,11 +27,12 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Map;
 
 /**
@@ -72,10 +73,10 @@ public class ProcessApplicationTaskListenerTest extends AbstractFoxPlatformInteg
     boolean updateEventFired = (Boolean) runtimeService.getVariable(processInstance.getId(), TaskListener.EVENTNAME_UPDATE);
     boolean completeEventFired = (Boolean) runtimeService.getVariable(processInstance.getId(), TaskListener.EVENTNAME_COMPLETE);
 
-    Assert.assertTrue(createEventFired);
-    Assert.assertFalse(assignmentEventFired);
-    Assert.assertFalse(completeEventFired);
-    Assert.assertFalse(updateEventFired);
+    assertThat(createEventFired).isTrue();
+    assertThat(assignmentEventFired).isFalse();
+    assertThat(completeEventFired).isFalse();
+    assertThat(updateEventFired).isFalse();
 
     Task task = taskService.createTaskQuery().processDefinitionKey("testProcess").singleResult();
     taskService.claim(task.getId(), "jonny");
@@ -85,10 +86,10 @@ public class ProcessApplicationTaskListenerTest extends AbstractFoxPlatformInteg
     updateEventFired = (Boolean) runtimeService.getVariable(processInstance.getId(), TaskListener.EVENTNAME_UPDATE);
     completeEventFired = (Boolean) runtimeService.getVariable(processInstance.getId(), TaskListener.EVENTNAME_COMPLETE);
 
-    Assert.assertTrue(createEventFired);
-    Assert.assertTrue(assignmentEventFired);
-    Assert.assertTrue(updateEventFired);
-    Assert.assertFalse(completeEventFired);
+    assertThat(createEventFired).isTrue();
+    assertThat(assignmentEventFired).isTrue();
+    assertThat(updateEventFired).isTrue();
+    assertThat(completeEventFired).isFalse();
 
     taskService.complete(task.getId());
 
@@ -97,9 +98,9 @@ public class ProcessApplicationTaskListenerTest extends AbstractFoxPlatformInteg
     updateEventFired = (Boolean) runtimeService.getVariable(processInstance.getId(), TaskListener.EVENTNAME_UPDATE);
     completeEventFired = (Boolean) runtimeService.getVariable(processInstance.getId(), TaskListener.EVENTNAME_COMPLETE);
 
-    Assert.assertTrue(createEventFired);
-    Assert.assertTrue(assignmentEventFired);
-    Assert.assertTrue(updateEventFired);
-    Assert.assertTrue(completeEventFired);
+    assertThat(createEventFired).isTrue();
+    assertThat(assignmentEventFired).isTrue();
+    assertThat(updateEventFired).isTrue();
+    assertThat(completeEventFired).isTrue();
   }
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/jpa/AsyncPersistenceDelegateBean.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/jpa/AsyncPersistenceDelegateBean.java
@@ -18,9 +18,10 @@ package org.operaton.bpm.integrationtest.functional.jpa;
 
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.JavaDelegate;
-import org.junit.Assert;
 
 import jakarta.enterprise.context.ApplicationScoped;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import jakarta.inject.Named;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -41,7 +42,7 @@ public class AsyncPersistenceDelegateBean implements JavaDelegate {
     // this means that we obtain a seperate entity manager since
     // we are invoked in a new transaction
 
-    Assert.assertFalse(em.contains(entity));
+    assertThat(em.contains(entity)).isFalse();
 
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/jpa/PersistenceDelegateBean.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/jpa/PersistenceDelegateBean.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.functional.jpa;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Named;
 import jakarta.persistence.EntityManager;
@@ -23,7 +25,6 @@ import jakarta.persistence.PersistenceContext;
 
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.JavaDelegate;
-import org.junit.Assert;
 
 @Named
 @ApplicationScoped
@@ -41,7 +42,7 @@ public class PersistenceDelegateBean implements JavaDelegate {
     // this means that we obtain the same entity manager we used to
     // persist the entity before starting the process
 
-    Assert.assertTrue(em.contains(entity));
+    assertThat(em.contains(entity)).isTrue();
 
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/message/IntermediateMessageCatchEventTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/message/IntermediateMessageCatchEventTest.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.functional.message;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import org.operaton.bpm.engine.runtime.Execution;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -44,7 +44,7 @@ public class IntermediateMessageCatchEventTest extends AbstractFoxPlatformIntegr
 
     Execution execution = runtimeService.createExecutionQuery().messageEventSubscriptionName("Test Message").singleResult();
 
-    assertNotNull(execution);
+    assertThat(execution).isNotNull();
 
     runtimeService.createMessageCorrelation("Test Message").correlate();
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/metadata/engine/TestMultipleProcessEnginesXmlsInLibrary.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/metadata/engine/TestMultipleProcessEnginesXmlsInLibrary.java
@@ -17,12 +17,14 @@
 package org.operaton.bpm.integrationtest.functional.metadata.engine;
 
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -50,9 +52,9 @@ public class TestMultipleProcessEnginesXmlsInLibrary extends AbstractFoxPlatform
   
   @Test
   public void testDeployProcessArchive() {
-    Assert.assertNotNull(processEngineService.getProcessEngine("engine1"));
-    Assert.assertNotNull(processEngineService.getProcessEngine("engine2"));
-    Assert.assertNotNull(processEngineService.getProcessEngine("engine3"));
+    assertThat(processEngineService.getProcessEngine("engine1")).isNotNull();
+    assertThat(processEngineService.getProcessEngine("engine2")).isNotNull();
+    assertThat(processEngineService.getProcessEngine("engine3")).isNotNull();
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/metadata/engine/TestProcessEnginesXmlFails.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/metadata/engine/TestProcessEnginesXmlFails.java
@@ -17,7 +17,10 @@
 package org.operaton.bpm.integrationtest.functional.metadata.engine;
 
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
+
 import org.jboss.arquillian.container.test.api.Deployer;
+
+import static org.assertj.core.api.Assertions.fail;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -25,7 +28,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -62,7 +64,7 @@ public class TestProcessEnginesXmlFails {
   public void testDeployProcessArchive() {
     try {
       deployer.deploy("deployment");
-      Assert.fail("exception expected");
+      fail("exception expected");
     }catch (Exception e) {
       // expected
     }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/metadata/engine/TestProcessEnginesXmlInLibrary.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/metadata/engine/TestProcessEnginesXmlInLibrary.java
@@ -17,12 +17,14 @@
 package org.operaton.bpm.integrationtest.functional.metadata.engine;
 
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -48,7 +50,7 @@ public class TestProcessEnginesXmlInLibrary extends AbstractFoxPlatformIntegrati
   
   @Test
   public void testDeployProcessArchive() {
-   Assert.assertNotNull(processEngineService.getProcessEngine("engine1"));
+    assertThat(processEngineService.getProcessEngine("engine1")).isNotNull();
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/metadata/engine/TestProcessEnginesXmlInProcessApplication.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/metadata/engine/TestProcessEnginesXmlInProcessApplication.java
@@ -19,11 +19,13 @@ package org.operaton.bpm.integrationtest.functional.metadata.engine;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,7 +54,7 @@ public class TestProcessEnginesXmlInProcessApplication extends AbstractFoxPlatfo
   
   @Test
   public void testDeployProcessArchive() {
-   Assert.assertNotNull(processEngineService.getProcessEngine("engine1"));
+    assertThat(processEngineService.getProcessEngine("engine1")).isNotNull();
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/migration/MigrationContextSwitchBeansTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/migration/MigrationContextSwitchBeansTest.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.functional.migration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
@@ -34,7 +36,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -114,8 +115,8 @@ public class MigrationContextSwitchBeansTest extends AbstractFoxPlatformIntegrat
 
     // then
     Job timerJob = managementService.createJobQuery().processDefinitionKey("boundaryProcess").singleResult();
-    Assert.assertNotNull(timerJob);
-    Assert.assertNotNull(timerJob.getDuedate());
+    assertThat(timerJob).isNotNull();
+    assertThat(timerJob.getDuedate()).isNotNull();
   }
 
   protected static Asset modelAsAsset(BpmnModelInstance modelInstance) {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/migration/MigrationContextSwitchClassesTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/migration/MigrationContextSwitchClassesTest.java
@@ -32,11 +32,12 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.ByteArrayOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Arrays;
 
 /**
@@ -135,7 +136,7 @@ public class MigrationContextSwitchClassesTest extends AbstractFoxPlatformIntegr
       .execute();
 
     // then
-    Assert.assertTrue((Boolean)runtimeService.getVariable(pi, InstantiationListener.VARIABLE_NAME));
+    assertThat((Boolean) runtimeService.getVariable(pi, InstantiationListener.VARIABLE_NAME)).isTrue();
   }
 
 
@@ -169,7 +170,7 @@ public class MigrationContextSwitchClassesTest extends AbstractFoxPlatformIntegr
       .execute();
 
     // then
-    Assert.assertTrue((Boolean)runtimeService.getVariable(pi, RemovalListener.VARIABLE_NAME));
+    assertThat((Boolean) runtimeService.getVariable(pi, RemovalListener.VARIABLE_NAME)).isTrue();
   }
 
   protected static Asset modelAsAsset(BpmnModelInstance modelInstance) {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/modification/ModificationContextSwitchTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/modification/ModificationContextSwitchTest.java
@@ -20,12 +20,14 @@ import org.operaton.bpm.engine.runtime.ProcessInstanceModificationInstantiationB
 import org.operaton.bpm.integrationtest.functional.modification.beans.ExampleDelegate;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -60,7 +62,7 @@ public class ModificationContextSwitchTest extends AbstractFoxPlatformIntegratio
     // given
     // process instance is in state "waitState"
     String pi = runtimeService.startProcessInstanceByKey("testProcess").getId();
-    Assert.assertNull(runtimeService.getVariable(pi, "executed"));
+    assertThat(runtimeService.getVariable(pi, "executed")).isNull();
 
     // if
     // we modify the process instance to start the next task:
@@ -70,7 +72,7 @@ public class ModificationContextSwitchTest extends AbstractFoxPlatformIntegratio
     // then
     // the modification does not fail
     modification.execute();
-    Assert.assertTrue((Boolean)runtimeService.getVariable(pi, "executed"));
+    assertThat((Boolean) runtimeService.getVariable(pi, "executed")).isTrue();
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/AbstractPaLocalScriptEngineTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/AbstractPaLocalScriptEngineTest.java
@@ -16,9 +16,6 @@
  */
 package org.operaton.bpm.integrationtest.functional.scriptengine;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-
 import org.operaton.bpm.application.ProcessApplicationInterface;
 import org.operaton.bpm.application.ProcessApplicationReference;
 import org.operaton.bpm.application.ProcessApplicationUnavailableException;
@@ -29,9 +26,13 @@ import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
+
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Roman Smirnov
@@ -73,7 +74,7 @@ public abstract class AbstractPaLocalScriptEngineTest extends AbstractFoxPlatfor
       }
     });
 
-    assertNotNull(reference);
+    assertThat(reference).isNotNull();
 
     ProcessApplicationInterface processApplication = null;
     try {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/AbstractScriptEngineSupportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/AbstractScriptEngineSupportTest.java
@@ -25,8 +25,8 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Sebastian Menski
@@ -65,8 +65,8 @@ public abstract class AbstractScriptEngineSupportTest extends AbstractFoxPlatfor
   public void variableFooShouldBeBar() {
     Object foo = runtimeService.getVariable(processInstanceId, "foo");
     Object bar = runtimeService.getVariable(processInstanceId, "bar");
-    assertNotNull(foo);
-    assertNotNull(bar);
+    assertThat(foo).isNotNull();
+    assertThat(bar).isNotNull();
     assertEquals("bar", foo);
     assertEquals("baz", bar);
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/AbstractTemplateScriptEngineSupportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/AbstractTemplateScriptEngineSupportTest.java
@@ -26,8 +26,8 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Sebastian Menski
@@ -63,7 +63,7 @@ public abstract class AbstractTemplateScriptEngineSupportTest extends AbstractFo
     processInstanceId = runtimeService.startProcessInstanceByKey(PROCESS_ID, variables).getId();
 
     Object result = runtimeService.getVariable(processInstanceId, RESULT_VARIABLE);
-    assertNotNull(result);
+    assertThat(result).isNotNull();
     assertEquals(EXPECTED_RESULT, result);
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/GroovyAsyncScriptExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/GroovyAsyncScriptExecutionTest.java
@@ -27,8 +27,8 @@ import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 @RunWith(Arquillian.class)
 public class GroovyAsyncScriptExecutionTest extends AbstractFoxPlatformIntegrationTest {
@@ -76,7 +76,7 @@ public class GroovyAsyncScriptExecutionTest extends AbstractFoxPlatformIntegrati
     waitForJobExecutorToProcessAllJobs(30000);
 
     Object foo = runtimeService.getVariable(processInstanceId, "foo");
-    assertNotNull(foo);
+    assertThat(foo).isNotNull();
     assertEquals("bar", foo);
 
     repositoryService.deleteDeployment(deploymentId, true);

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/GroovyPaClassImportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/GroovyPaClassImportTest.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.functional.scriptengine;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import org.operaton.bpm.integrationtest.functional.scriptengine.classes.CustomClass;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
@@ -89,7 +89,7 @@ public class GroovyPaClassImportTest extends AbstractFoxPlatformIntegrationTest 
     // then start process 2
     String processInstanceId = runtimeService.startProcessInstanceByKey("process2").getId();
     Object foo = runtimeService.getVariable(processInstanceId, "greeting");
-    assertNotNull(foo);
+    assertThat(foo).isNotNull();
     assertEquals("Hi Ho", foo);
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/OperatonScriptResourceTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/OperatonScriptResourceTest.java
@@ -25,8 +25,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Daniel Meyer
@@ -53,7 +53,7 @@ public class OperatonScriptResourceTest extends AbstractFoxPlatformIntegrationTe
       .processInstanceId(pi.getId())
       .singleResult();
 
-    assertNotNull(variable);
+    assertThat(variable).isNotNull();
     assertEquals("executed", variable.getName());
     assertEquals(true, variable.getValue());
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/PaLocalScriptEngineCallActivityConditionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/PaLocalScriptEngineCallActivityConditionTest.java
@@ -21,7 +21,10 @@ import org.operaton.bpm.integrationtest.functional.scriptengine.engine.AbstractS
 import org.operaton.bpm.integrationtest.functional.scriptengine.engine.AlwaysTrueScriptEngineFactory;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.TestContainer;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -77,7 +80,7 @@ public class PaLocalScriptEngineCallActivityConditionTest extends AbstractFoxPla
 
     // then the conditional flow leaving the call activity has been taken
     Task afterCallActivityTask = taskService.createTaskQuery().singleResult();
-    Assert.assertNotNull(afterCallActivityTask);
+    assertThat(afterCallActivityTask).isNotNull();
     Assert.assertEquals("afterCallActivityTask", afterCallActivityTask.getTaskDefinitionKey());
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/PaLocalScriptEngineDisabledCacheTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/PaLocalScriptEngineDisabledCacheTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.integrationtest.functional.scriptengine;
 
-import static org.junit.Assert.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.operaton.bpm.application.AbstractProcessApplication;
 import org.operaton.bpm.integrationtest.functional.scriptengine.engine.AbstractScriptEngineFactory;
@@ -45,7 +45,7 @@ public class PaLocalScriptEngineDisabledCacheTest extends AbstractPaLocalScriptE
   @Test
   public void shouldNotCacheScriptEngine() {
     AbstractProcessApplication processApplication = (AbstractProcessApplication) getProcessApplication();
-    assertNotEquals(processApplication.getScriptEngineForName(SCRIPT_FORMAT, false), processApplication.getScriptEngineForName(SCRIPT_FORMAT, false));
+    assertThat(processApplication.getScriptEngineForName(SCRIPT_FORMAT, false)).isNotEqualTo(processApplication.getScriptEngineForName(SCRIPT_FORMAT, false));
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/PaLocalScriptEngineSupportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/PaLocalScriptEngineSupportTest.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.functional.scriptengine;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import org.operaton.bpm.integrationtest.functional.scriptengine.engine.AbstractScriptEngineFactory;
 import org.operaton.bpm.integrationtest.functional.scriptengine.engine.DummyScriptEngineFactory;
@@ -47,7 +47,7 @@ public class PaLocalScriptEngineSupportTest extends AbstractPaLocalScriptEngineT
   public void shouldSetVariable() {
     String processInstanceId = runtimeService.startProcessInstanceByKey(PROCESS_ID).getId();
     Object scriptValue = runtimeService.getVariable(processInstanceId, "scriptValue");
-    assertNotNull(scriptValue);
+    assertThat(scriptValue).isNotNull();
     assertEquals(SCRIPT_TEXT, scriptValue);
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/PythonPaClassImportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/PythonPaClassImportTest.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.functional.scriptengine;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import org.operaton.bpm.integrationtest.functional.scriptengine.classes.CustomClass;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
@@ -89,7 +89,7 @@ public class PythonPaClassImportTest extends AbstractFoxPlatformIntegrationTest 
     // then start process 2
     String processInstanceId = runtimeService.startProcessInstanceByKey("process2").getId();
     Object foo = runtimeService.getVariable(processInstanceId, "greeting");
-    assertNotNull(foo);
+    assertThat(foo).isNotNull();
     assertEquals("Hi Ho", foo);
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/slf4j/Slf4jClassloadingTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/slf4j/Slf4jClassloadingTest.java
@@ -54,7 +54,7 @@ public class Slf4jClassloadingTest extends AbstractFoxPlatformIntegrationTest {
     ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
 
     // verify that a SLF4J backend is used which is not the NOP logger
-    assertThat(loggerFactory instanceof NOPLoggerFactory).as("Should not use NOPLoggerFactory").isFalse();
+    assertThat(loggerFactory).as("Should not use NOPLoggerFactory").isNotInstanceOf(NOPLoggerFactory.class);
 
     // should either use slf4j-jdk14 or slf4j-jboss-logmanager
     String loggerFactoryClassName = loggerFactory.getClass().getCanonicalName();

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/slf4j/Slf4jClassloadingTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/slf4j/Slf4jClassloadingTest.java
@@ -28,8 +28,7 @@ import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.NOPLoggerFactory;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Arquillian.class)
 public class Slf4jClassloadingTest extends AbstractFoxPlatformIntegrationTest {
@@ -55,12 +54,11 @@ public class Slf4jClassloadingTest extends AbstractFoxPlatformIntegrationTest {
     ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
 
     // verify that a SLF4J backend is used which is not the NOP logger
-    assertFalse("Should not use NOPLoggerFactory", loggerFactory instanceof NOPLoggerFactory);
+    assertThat(loggerFactory instanceof NOPLoggerFactory).as("Should not use NOPLoggerFactory").isFalse();
 
     // should either use slf4j-jdk14 or slf4j-jboss-logmanager
     String loggerFactoryClassName = loggerFactory.getClass().getCanonicalName();
-    assertTrue("Should use slf4j-jdk14 or slf4j-jboss-logmanager",
-        JDK14_LOGGER_FACTORY.equals(loggerFactoryClassName) || JBOSS_SLF4J_LOGGER_FACTORY.equals(loggerFactoryClassName));
+    assertThat(JDK14_LOGGER_FACTORY.equals(loggerFactoryClassName) || JBOSS_SLF4J_LOGGER_FACTORY.equals(loggerFactoryClassName)).as("Should use slf4j-jdk14 or slf4j-jboss-logmanager").isTrue();
   }
 
   @Test

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatAndPostDeployTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatAndPostDeployTest.java
@@ -23,11 +23,13 @@ import org.operaton.bpm.integrationtest.functional.spin.dataformat.FooDataFormat
 import org.operaton.bpm.integrationtest.functional.spin.dataformat.FooSpin;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.spin.spi.DataFormatProvider;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -56,8 +58,8 @@ public class PaDataFormatAndPostDeployTest extends AbstractFoxPlatformIntegratio
 
   @Test
   public void shouldDeployApp() {
-    Assert.assertNotNull(BpmPlatform.getProcessApplicationService()
-        .getProcessApplicationInfo(PaDataformatAndPostDeployApp.PA_NAME));
+    assertThat(BpmPlatform.getProcessApplicationService()
+      .getProcessApplicationInfo(PaDataformatAndPostDeployApp.PA_NAME)).isNotNull();
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatConfiguratorFailingTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatConfiguratorFailingTest.java
@@ -29,12 +29,13 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Thorben Lindhauer
@@ -86,6 +87,6 @@ public class PaDataFormatConfiguratorFailingTest {
   @OperateOnDeployment("checkDeployment")
   public void testNoProcessApplicationIsDeployed() {
     Set<String> registeredPAs = BpmPlatform.getProcessApplicationService().getProcessApplicationNames();
-    Assert.assertTrue(registeredPAs.isEmpty());
+    assertThat(registeredPAs).isEmpty();
   }
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatProviderTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatProviderTest.java
@@ -73,7 +73,7 @@ public class PaDataFormatProviderTest extends AbstractFoxPlatformIntegrationTest
               .serializationDataFormat(FooDataFormat.NAME)
               .objectTypeName(Foo.class.getName())));
 
-    ObjectValue objectValue = null;
+    ObjectValue objectValue;
     try {
       ProcessApplicationContext.setCurrentProcessApplication(ReferenceStoringProcessApplication.INSTANCE);
       objectValue = runtimeService.getVariableTyped(pi.getId(), "serializedObject", true);
@@ -82,8 +82,7 @@ public class PaDataFormatProviderTest extends AbstractFoxPlatformIntegrationTest
     }
 
     Object value = objectValue.getValue();
-    assertThat(value).isNotNull();
-    assertThat(value instanceof Foo).isTrue();
+    assertThat(value).isInstanceOf(Foo.class);
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatProviderTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatProviderTest.java
@@ -30,10 +30,10 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.variable.Variables.serializedObjectValue;
 
 /**
@@ -82,8 +82,8 @@ public class PaDataFormatProviderTest extends AbstractFoxPlatformIntegrationTest
     }
 
     Object value = objectValue.getValue();
-    Assert.assertNotNull(value);
-    Assert.assertTrue(value instanceof Foo);
+    assertThat(value).isNotNull();
+    assertThat(value instanceof Foo).isTrue();
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataformatAndPostDeployApp.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataformatAndPostDeployApp.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.integrationtest.functional.spin;
 
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.operaton.bpm.application.PostDeploy;
 import org.operaton.bpm.application.ProcessApplication;
@@ -36,7 +36,7 @@ public class PaDataformatAndPostDeployApp extends org.operaton.bpm.application.i
   @PostDeploy
   public void onPaDeployed(ProcessEngine e) {
 
-    assertNotNull(getVariableSerializers());
+    assertThat(getVariableSerializers()).isNotNull();
 
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaSpinSupportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaSpinSupportTest.java
@@ -41,7 +41,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * <p>Smoketest Make sure operaton spin can be used in a process application </p>
+ * <p>Smoke-test Make sure operaton spin can be used in a process application </p>
  *
  * @author Daniel Meyer
  */

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaSpinSupportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaSpinSupportTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.integrationtest.functional.spin;
 import static org.operaton.bpm.engine.variable.Variables.serializedObjectValue;
 import static org.operaton.spin.Spin.JSON;
 import static org.operaton.spin.Spin.XML;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.io.InputStream;
@@ -86,7 +87,7 @@ public class PaSpinSupportTest extends AbstractFoxPlatformIntegrationTest {
       }
     }
 
-    Assert.assertTrue(spinPluginFound);
+    assertThat(spinPluginFound).isTrue();
   }
 
   @Test

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/SpinJsonPathTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/SpinJsonPathTest.java
@@ -19,13 +19,14 @@ package org.operaton.bpm.integrationtest.functional.spin;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.fail;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import static org.junit.Assert.fail;
 
 @RunWith(Arquillian.class)
 public class SpinJsonPathTest extends AbstractFoxPlatformIntegrationTest {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/AsyncJobExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/AsyncJobExecutionTest.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.functional.transactions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import java.util.HashMap;
 
@@ -89,10 +89,10 @@ public class AsyncJobExecutionTest extends AbstractFoxPlatformIntegrationTest {
     // the job exists with no retries, and an incident is raised
     Job job = managementService.createJobQuery().processDefinitionKey("failingTransactionListener").singleResult();
 
-    assertNotNull(job);
+    assertThat(job).isNotNull();
     assertEquals(0, job.getRetries());
-    assertNotNull(job.getExceptionMessage());
-    assertNotNull(managementService.getJobExceptionStacktrace(job.getId()));
+    assertThat(job.getExceptionMessage()).isNotNull();
+    assertThat(managementService.getJobExceptionStacktrace(job.getId())).isNotNull();
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/AsyncJobExecutionWithRollbackTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/AsyncJobExecutionWithRollbackTest.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.functional.transactions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import jakarta.inject.Inject;
 
@@ -73,10 +73,10 @@ public class AsyncJobExecutionWithRollbackTest extends AbstractFoxPlatformIntegr
     // the job exists with no retries, and an incident is raised
     Job job = managementService.createJobQuery().processDefinitionKey("txRollbackServiceTask").singleResult();
 
-    assertNotNull(job);
+    assertThat(job).isNotNull();
     assertEquals(0, job.getRetries());
-    assertNotNull(job.getExceptionMessage());
-    assertNotNull(managementService.getJobExceptionStacktrace(job.getId()));
+    assertThat(job.getExceptionMessage()).isNotNull();
+    assertThat(managementService.getJobExceptionStacktrace(job.getId())).isNotNull();
   }
 
   @Test
@@ -91,10 +91,10 @@ public class AsyncJobExecutionWithRollbackTest extends AbstractFoxPlatformIntegr
     // the job exists with no retries, and an incident is raised
     Job job = managementService.createJobQuery().processDefinitionKey("txRollbackServiceTaskWithCustomRetryCycle").singleResult();
 
-    assertNotNull(job);
+    assertThat(job).isNotNull();
     assertEquals(0, job.getRetries());
-    assertNotNull(job.getExceptionMessage());
-    assertNotNull(managementService.getJobExceptionStacktrace(job.getId()));
+    assertThat(job.getExceptionMessage()).isNotNull();
+    assertThat(managementService.getJobExceptionStacktrace(job.getId())).isNotNull();
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/TransactionIntegrationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/TransactionIntegrationTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 
 import jakarta.inject.Inject;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import jakarta.transaction.Status;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/TransactionIntegrationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/TransactionIntegrationTest.java
@@ -27,6 +27,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import jakarta.inject.Inject;
+
+import static org.assertj.core.api.Assertions.fail;
+
 import jakarta.transaction.Status;
 import jakarta.transaction.UserTransaction;
 
@@ -68,13 +71,13 @@ public class TransactionIntegrationTest extends AbstractFoxPlatformIntegrationTe
                         
       try {
         runtimeService.startProcessInstanceByKey("testProcessFailure");
-        Assert.fail("Exception expected");
+        fail("Exception expected");
       }catch (Exception ex) {
         if(!(ex instanceof RuntimeException)) {
-          Assert.fail("Wrong exception of type "+ex+" RuntimeException expected!");
+          fail("Wrong exception of type " + ex + " RuntimeException expected!");
         }    
         if(!ex.getMessage().contains("I'm a complete failure!")) {
-          Assert.fail("Different message expected");
+          fail("Different message expected");
         }
       }
       
@@ -112,8 +115,8 @@ public class TransactionIntegrationTest extends AbstractFoxPlatformIntegrationTe
       ProcessInstance processInstance = runtimeService.createProcessInstanceQuery()
         .processInstanceId(id)
         .singleResult();
-      
-      Assert.assertNull(processInstance);
+
+      assertThat(processInstance).isNull();
       
       utx.commit();
     }catch (Exception e) {
@@ -138,8 +141,8 @@ public class TransactionIntegrationTest extends AbstractFoxPlatformIntegrationTe
       ProcessInstance processInstance = runtimeService.createProcessInstanceQuery()
         .processInstanceId(id)
         .singleResult();
-      
-      Assert.assertNotNull(processInstance);
+
+      assertThat(processInstance).isNotNull();
      
       utx.commit();
       
@@ -149,8 +152,8 @@ public class TransactionIntegrationTest extends AbstractFoxPlatformIntegrationTe
       processInstance = runtimeService.createProcessInstanceQuery()
         .processInstanceId(id)
         .singleResult();
-      
-      Assert.assertNotNull(processInstance);
+
+      assertThat(processInstance).isNotNull();
       
       utx.commit();
     }catch (Exception e) {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/TransactionListenerTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/TransactionListenerTest.java
@@ -16,14 +16,15 @@
  */
 package org.operaton.bpm.integrationtest.functional.transactions;
 
-import org.junit.Assert;
-
 import org.operaton.bpm.engine.impl.cfg.TransactionListener;
 import org.operaton.bpm.engine.impl.cfg.TransactionState;
 import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
@@ -48,8 +49,8 @@ public class TransactionListenerTest extends AbstractFoxPlatformIntegrationTest 
     
     final TestTransactionListener rolledBackListener = new TestTransactionListener();
     final TestTransactionListener committedListener = new TestTransactionListener();
-    Assert.assertFalse(rolledBackListener.isInvoked());
-    Assert.assertFalse(committedListener.isInvoked());
+    assertThat(rolledBackListener.isInvoked()).isFalse();
+    assertThat(committedListener.isInvoked()).isFalse();
     
     try {
       
@@ -66,11 +67,11 @@ public class TransactionListenerTest extends AbstractFoxPlatformIntegrationTest 
       });
       
     }catch(Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Rollback!"));
+      assertThat(e.getMessage()).contains("Rollback!");
     }
-    
-    Assert.assertTrue(rolledBackListener.isInvoked());
-    Assert.assertFalse(committedListener.isInvoked());
+
+    assertThat(rolledBackListener.isInvoked()).isTrue();
+    assertThat(committedListener.isInvoked()).isFalse();
     
   }
   
@@ -79,9 +80,9 @@ public class TransactionListenerTest extends AbstractFoxPlatformIntegrationTest 
     
     final TestTransactionListener rolledBackListener = new TestTransactionListener();
     final TestTransactionListener committedListener = new TestTransactionListener();
-    
-    Assert.assertFalse(rolledBackListener.isInvoked());
-    Assert.assertFalse(committedListener.isInvoked());
+
+    assertThat(rolledBackListener.isInvoked()).isFalse();
+    assertThat(committedListener.isInvoked()).isFalse();
     
     try {
       
@@ -97,11 +98,11 @@ public class TransactionListenerTest extends AbstractFoxPlatformIntegrationTest 
       });
       
     }catch(Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Rollback!"));
+      assertThat(e.getMessage()).contains("Rollback!");
     }
-    
-    Assert.assertFalse(rolledBackListener.isInvoked());
-    Assert.assertTrue(committedListener.isInvoked());
+
+    assertThat(rolledBackListener.isInvoked()).isFalse();
+    assertThat(committedListener.isInvoked()).isTrue();
     
   }
   

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jboss/TestJobExecutorActivateFalse_JBOSS.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jboss/TestJobExecutorActivateFalse_JBOSS.java
@@ -27,8 +27,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Daniel Meyer
@@ -48,12 +47,12 @@ public class TestJobExecutorActivateFalse_JBOSS extends AbstractFoxPlatformInteg
     ProcessEngine processEngine = processEngineService.getProcessEngine("jobExecutorActivate-FALSE-engine");
     ProcessEngineConfiguration configuration = processEngine.getProcessEngineConfiguration();
     JobExecutor jobExecutor = ((ProcessEngineConfigurationImpl)configuration).getJobExecutor();
-    assertFalse(jobExecutor.isActive());
+    assertThat(jobExecutor.isActive()).isFalse();
 
     processEngine = processEngineService.getProcessEngine("jobExecutorActivate-UNDEFINED-engine");
     configuration = processEngine.getProcessEngineConfiguration();
     jobExecutor = ((ProcessEngineConfigurationImpl)configuration).getJobExecutor();
-    assertTrue(jobExecutor.isActive());
+    assertThat(jobExecutor.isActive()).isTrue();
 
   }
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jboss/TestManagedDomain_JBOSS.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jboss/TestManagedDomain_JBOSS.java
@@ -17,11 +17,14 @@
 package org.operaton.bpm.integrationtest.jboss;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
+import org.assertj.core.api.Assertions;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
@@ -47,18 +50,14 @@ public class TestManagedDomain_JBOSS {
 
   @Test
   public void shouldBeAbleToLookupDefaultProcessEngine() {
-    try {
-      assertThat(InitialContext.doLookup("java:global/operaton-bpm-platform/process-engine/default")).isNotNull();
-    } catch (NamingException e) {
-      fail("Could not lookup default process engine");
-    }
 
-    try {
-      assertThat(InitialContext.doLookup("java:global/operaton-bpm-platform/process-engine/someNonExistingEngine")).isNotNull();
-      fail("Should not be able to lookup someNonExistingEngine process engine");
-    } catch (NamingException e) {
-      // expected
-    }
+    assertThatCode(() -> InitialContext.<Object>doLookup("java:global/operaton-bpm-platform/process-engine/default"))
+      .as("Expected to lookup default process engine")
+      .doesNotThrowAnyException();
+
+    assertThatThrownBy(() -> InitialContext.doLookup("java:global/operaton-bpm-platform/process-engine/someNonExistingEngine"))
+      .as("Expected exception when looking up someNonExistingEngine")
+      .isInstanceOf(NamingException.class);
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jboss/TestManagedDomain_JBOSS.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jboss/TestManagedDomain_JBOSS.java
@@ -16,15 +16,9 @@
  */
 package org.operaton.bpm.integrationtest.jboss;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
-
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
-import org.assertj.core.api.Assertions;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
@@ -32,6 +26,9 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * <p>Ensures subsystem boots in domain mode</p>
@@ -51,7 +48,7 @@ public class TestManagedDomain_JBOSS {
   @Test
   public void shouldBeAbleToLookupDefaultProcessEngine() {
 
-    assertThatCode(() -> InitialContext.<Object>doLookup("java:global/operaton-bpm-platform/process-engine/default"))
+    assertThatCode(() -> InitialContext.doLookup("java:global/operaton-bpm-platform/process-engine/default"))
       .as("Expected to lookup default process engine")
       .doesNotThrowAnyException();
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jboss/TestManagedDomain_JBOSS.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jboss/TestManagedDomain_JBOSS.java
@@ -16,6 +16,9 @@
  */
 package org.operaton.bpm.integrationtest.jboss;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
@@ -24,7 +27,6 @@ import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -46,14 +48,14 @@ public class TestManagedDomain_JBOSS {
   @Test
   public void shouldBeAbleToLookupDefaultProcessEngine() {
     try {
-      Assert.assertNotNull(InitialContext.doLookup("java:global/operaton-bpm-platform/process-engine/default"));
+      assertThat(InitialContext.doLookup("java:global/operaton-bpm-platform/process-engine/default")).isNotNull();
     } catch (NamingException e) {
-      Assert.fail("Could not lookup default process engine");
+      fail("Could not lookup default process engine");
     }
 
     try {
-      Assert.assertNotNull(InitialContext.doLookup("java:global/operaton-bpm-platform/process-engine/someNonExistingEngine"));
-      Assert.fail("Should not be able to lookup someNonExistingEngine process engine");
+      assertThat(InitialContext.doLookup("java:global/operaton-bpm-platform/process-engine/someNonExistingEngine")).isNotNull();
+      fail("Should not be able to lookup someNonExistingEngine process engine");
     } catch (NamingException e) {
       // expected
     }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/IndependentJobExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/IndependentJobExecutionTest.java
@@ -93,13 +93,13 @@ public class IndependentJobExecutionTest extends AbstractFoxPlatformIntegrationT
     List<ProcessApplicationDeploymentInfo> pa1DeploymentInfo = pa1Info.getDeploymentInfo();
 
     Assert.assertEquals(1, pa1DeploymentInfo.size());
-    assertThat(registeredDeploymentsForEngine1).contains(pa1DeploymentInfo.get(0));
+    assertThat(registeredDeploymentsForEngine1).contains(pa1DeploymentInfo.get(0).getDeploymentId());
 
     ProcessApplicationInfo pa2Info = getProcessApplicationDeploymentInfo("pa2");
 
     List<ProcessApplicationDeploymentInfo> pa2DeploymentInfo = pa2Info.getDeploymentInfo();
     Assert.assertEquals(1, pa2DeploymentInfo.size());
-    assertThat(registeredDeploymentsForDefaultEngine).contains(pa2DeploymentInfo.get(0));
+    assertThat(registeredDeploymentsForDefaultEngine).contains(pa2DeploymentInfo.get(0).getDeploymentId());
   }
 
   private ProcessApplicationInfo getProcessApplicationDeploymentInfo(String applicationName) {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/IndependentJobExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/IndependentJobExecutionTest.java
@@ -44,6 +44,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Set;
 
 @RunWith(Arquillian.class)
@@ -91,13 +93,13 @@ public class IndependentJobExecutionTest extends AbstractFoxPlatformIntegrationT
     List<ProcessApplicationDeploymentInfo> pa1DeploymentInfo = pa1Info.getDeploymentInfo();
 
     Assert.assertEquals(1, pa1DeploymentInfo.size());
-    Assert.assertTrue(registeredDeploymentsForEngine1.contains(pa1DeploymentInfo.get(0).getDeploymentId()));
+    assertThat(registeredDeploymentsForEngine1).contains(pa1DeploymentInfo.get(0));
 
     ProcessApplicationInfo pa2Info = getProcessApplicationDeploymentInfo("pa2");
 
     List<ProcessApplicationDeploymentInfo> pa2DeploymentInfo = pa2Info.getDeploymentInfo();
     Assert.assertEquals(1, pa2DeploymentInfo.size());
-    Assert.assertTrue(registeredDeploymentsForDefaultEngine.contains(pa2DeploymentInfo.get(0).getDeploymentId()));
+    assertThat(registeredDeploymentsForDefaultEngine).contains(pa2DeploymentInfo.get(0));
   }
 
   private ProcessApplicationInfo getProcessApplicationDeploymentInfo(String applicationName) {
@@ -126,8 +128,8 @@ public class IndependentJobExecutionTest extends AbstractFoxPlatformIntegrationT
     AcquiredJobs acquiredJobs = commandExecutor.execute(new AcquireJobsCmd(jobExecutor1));
 
     Assert.assertEquals(1, acquiredJobs.size());
-    Assert.assertTrue(acquiredJobs.contains(job1.getId()));
-    Assert.assertFalse(acquiredJobs.contains(job2.getId()));
+    assertThat(acquiredJobs.contains(job1.getId())).isTrue();
+    assertThat(acquiredJobs.contains(job2.getId())).isFalse();
   }
 
   @OperateOnDeployment("pa1")
@@ -148,8 +150,8 @@ public class IndependentJobExecutionTest extends AbstractFoxPlatformIntegrationT
       AcquiredJobs acquiredJobs = commandExecutor.execute(new AcquireJobsCmd(defaultJobExecutor));
 
       Assert.assertEquals(2, acquiredJobs.size());
-      Assert.assertTrue(acquiredJobs.contains(job1.getId()));
-      Assert.assertTrue(acquiredJobs.contains(job2.getId()));
+      assertThat(acquiredJobs.contains(job1.getId())).isTrue();
+      assertThat(acquiredJobs.contains(job2.getId())).isTrue();
     } finally {
       processEngineConfiguration.setJobExecutorDeploymentAware(true);
     }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/JobPrioritizationDuringDeploymentTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/JobPrioritizationDuringDeploymentTest.java
@@ -19,7 +19,11 @@ package org.operaton.bpm.integrationtest.jobexecutor;
 import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.integrationtest.jobexecutor.beans.PriorityBean;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployer;
+
+import static org.assertj.core.api.Assertions.fail;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -66,7 +70,7 @@ public class JobPrioritizationDuringDeploymentTest extends AbstractFoxPlatformIn
 
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.fail("deployment should be successful, i.e. bean for timer start event should get resolved");
+      fail("deployment should be successful, i.e. bean for timer start event should get resolved");
     }
   }
 
@@ -78,7 +82,7 @@ public class JobPrioritizationDuringDeploymentTest extends AbstractFoxPlatformIn
     // then the timer start event job has the priority resolved from the bean
     Job job = managementService.createJobQuery().activityId("timerStart").singleResult();
 
-    Assert.assertNotNull(job);
+    assertThat(job).isNotNull();
     Assert.assertEquals(PriorityBean.PRIORITY, job.getPriority());
   }
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/JobPrioritizationDuringDeploymentTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/JobPrioritizationDuringDeploymentTest.java
@@ -22,6 +22,7 @@ import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 
 import org.jboss.arquillian.container.test.api.Deployer;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/SetVariablesAsyncTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/SetVariablesAsyncTest.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.integrationtest.jobexecutor;
 
-import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.engine.variable.Variables;
@@ -26,6 +25,11 @@ import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Collections;
+import java.util.List;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -36,14 +40,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.ByteArrayOutputStream;
-import java.util.Collections;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.Assert.fail;
 
 @RunWith(Arquillian.class)
 public class SetVariablesAsyncTest extends AbstractFoxPlatformIntegrationTest {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/SetVariablesAsyncTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/SetVariablesAsyncTest.java
@@ -20,6 +20,7 @@ import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.engine.variable.Variables;
+import org.operaton.bpm.engine.variable.value.ObjectValue;
 import org.operaton.bpm.integrationtest.jobexecutor.classes.MyPojo;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.TestContainer;
@@ -39,6 +40,8 @@ import java.io.ByteArrayOutputStream;
 import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assert.fail;
 
@@ -99,15 +102,11 @@ public class SetVariablesAsyncTest extends AbstractFoxPlatformIntegrationTest {
     // when: execute remaining batch jobs
     jobs = managementService.createJobQuery().list();
     for (Job job : jobs) {
-      try {
-        managementService.executeJob(job.getId());
-      } catch (ProcessEngineException ex) {
-        fail("No exception expected: " + ex.getMessage());
-      }
+      assertThatCode(() -> managementService.executeJob(job.getId())).doesNotThrowAnyException();
     }
 
     // then
-    assertThat(runtimeService.getVariableTyped(pi, "foo", false)).isNotNull();
+    assertThat(runtimeService.<ObjectValue>getVariableTyped(pi, "foo", false)).isNotNull();
   }
 
   protected static Asset modelAsAsset(BpmnModelInstance modelInstance) {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/SetVariablesAsyncTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/SetVariablesAsyncTest.java
@@ -32,7 +32,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,6 +39,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.Collections;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assert.fail;
 
 @RunWith(Arquillian.class)
@@ -107,7 +107,7 @@ public class SetVariablesAsyncTest extends AbstractFoxPlatformIntegrationTest {
     }
 
     // then
-    Assert.assertNotNull(runtimeService.getVariableTyped(pi, "foo", false));
+    assertThat(runtimeService.getVariableTyped(pi, "foo", false)).isNotNull();
   }
 
   protected static Asset modelAsAsset(BpmnModelInstance modelInstance) {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/TimeoutTaskListenerExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/TimeoutTaskListenerExecutionTest.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.jobexecutor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.operaton.bpm.engine.runtime.ProcessInstance;
@@ -50,11 +52,11 @@ public class TimeoutTaskListenerExecutionTest extends AbstractFoxPlatformIntegra
     Assert.assertEquals(1, finallyRunningInstances.size());
 
     Task task = taskService.createTaskQuery().processInstanceId(instance.getId()).singleResult();
-    Assert.assertNotNull(task);
+    assertThat(task).isNotNull();
 
     Object variable = taskService.getVariable(task.getId(), "called");
-    Assert.assertNotNull(variable);
+    assertThat(variable).isNotNull();
 
-    Assert.assertTrue((boolean) variable);
+    assertThat((boolean) variable).isTrue();
   }
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/TimerRecalculationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/TimerRecalculationTest.java
@@ -16,8 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.jobexecutor;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -73,7 +73,7 @@ public class TimerRecalculationTest extends AbstractFoxPlatformIntegrationTest {
     // then
     assertEquals(1, jobQuery.count());
     Job jobRecalculated = jobQuery.singleResult();
-    assertNotEquals(oldDueDate, jobRecalculated.getDuedate());
+    assertThat(jobRecalculated.getDuedate()).isNotEqualTo(oldDueDate);
     
     Calendar calendar = Calendar.getInstance();
     calendar.setTime(jobRecalculated.getCreateTime());

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/service/PlatformServicesJndiBindingTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/service/PlatformServicesJndiBindingTest.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.service;
 
+import static org.assertj.core.api.Assertions.fail;
+
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
@@ -24,7 +26,6 @@ import org.operaton.bpm.integrationtest.util.TestConstants;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -43,7 +44,7 @@ public class PlatformServicesJndiBindingTest extends AbstractFoxPlatformIntegrat
     try {
       InitialContext.doLookup(testConstants.getProcessApplicationService());
     } catch (NamingException e) {
-      Assert.fail("Failed to lookup ProcessApplicationService '" + TestConstants.PROCESS_APPLICATION_SERVICE_JNDI_NAME + "'. Reason: " + e);
+      fail("Failed to lookup ProcessApplicationService '" + TestConstants.PROCESS_APPLICATION_SERVICE_JNDI_NAME + "'. Reason: " + e);
     }
   }
 
@@ -52,7 +53,7 @@ public class PlatformServicesJndiBindingTest extends AbstractFoxPlatformIntegrat
     try {
       InitialContext.doLookup(testConstants.getEngineService());
     } catch (NamingException e) {
-      Assert.fail("Failed to lookup ProcessEngineService '" + TestConstants.PROCESS_ENGINE_SERVICE_JNDI_NAME + "'. Reason: " + e);
+      fail("Failed to lookup ProcessEngineService '" + TestConstants.PROCESS_ENGINE_SERVICE_JNDI_NAME + "'. Reason: " + e);
     }
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/service/ProcessApplicationServiceTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/service/ProcessApplicationServiceTest.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Arrays;
 import java.util.Set;
 
@@ -66,9 +68,9 @@ public class ProcessApplicationServiceTest extends AbstractFoxPlatformIntegratio
 
     for (String appName : processApplicationNames) {
       ProcessApplicationInfo processApplicationInfo = processApplicationService.getProcessApplicationInfo(appName);
-      
-      Assert.assertNotNull(processApplicationInfo);
-      Assert.assertNotNull(processApplicationInfo.getName());
+
+      assertThat(processApplicationInfo).isNotNull();
+      assertThat(processApplicationInfo.getName()).isNotNull();
       Assert.assertEquals(1, processApplicationInfo.getDeploymentInfo().size());      
     }
     

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/service/ProcessEngineServiceTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/service/ProcessEngineServiceTest.java
@@ -16,13 +16,14 @@
  */
 package org.operaton.bpm.integrationtest.service;
 
-import org.junit.Assert;
-
 import org.operaton.bpm.BpmPlatform;
 import org.operaton.bpm.ProcessEngineService;
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+
 import org.jboss.arquillian.container.test.api.Deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -46,6 +47,6 @@ public class ProcessEngineServiceTest extends AbstractFoxPlatformIntegrationTest
     
     ProcessEngineService engineService = BpmPlatform.getProcessEngineService();
     ProcessEngine engine = engineService.getProcessEngine("aNonExistingEngineName");
-    Assert.assertNull(engine);
+    assertThat(engine).isNull();
   }
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/service/TestProcessEngineJndiBinding_JBOSS.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/service/TestProcessEngineJndiBinding_JBOSS.java
@@ -16,19 +16,19 @@
  */
 package org.operaton.bpm.integrationtest.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 
 import javax.naming.InitialContext;
 
-import org.operaton.bpm.engine.ProcessEngine;
-import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * <p>Makes sure that the process engine JNDI bindings are created</p>

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/service/TestProcessEngineJndiBinding_JBOSS.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/service/TestProcessEngineJndiBinding_JBOSS.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.integrationtest.service;
 
+import static org.assertj.core.api.Assertions.fail;
+
 import javax.naming.InitialContext;
 
 import org.operaton.bpm.engine.ProcessEngine;
@@ -46,10 +48,10 @@ public class TestProcessEngineJndiBinding_JBOSS extends AbstractFoxPlatformInteg
     
     try {
       ProcessEngine processEngine = InitialContext.doLookup("java:global/operaton-bpm-platform/process-engine/default");
-      Assert.assertNotNull("Process engine must not be null", processEngine);
+      assertThat(processEngine).as("Process engine must not be null").isNotNull();
       
     } catch(Exception e) {
-      Assert.fail("Process Engine not bound in JNDI.");
+      fail("Process Engine not bound in JNDI.");
       
     }
         

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/service/TestProcessEngineJndiBinding_JBOSS.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/service/TestProcessEngineJndiBinding_JBOSS.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.integrationtest.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import javax.naming.InitialContext;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/util/TestHelper.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/util/TestHelper.java
@@ -23,7 +23,6 @@ import org.operaton.bpm.engine.impl.util.IoUtil;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
-import org.junit.Assert;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,7 +30,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 public abstract class TestHelper {
@@ -63,12 +62,12 @@ public abstract class TestHelper {
 
   public static void assertDiagramIsDeployed(boolean deployed, Class<?> clazz, String expectedDiagramResource, String processDefinitionKey) throws IOException {
     ProcessEngine processEngine = ProgrammaticBeanLookup.lookup(ProcessEngine.class);
-    Assert.assertNotNull(processEngine);
+    assertThat(processEngine).isNotNull();
     RepositoryService repositoryService = processEngine.getRepositoryService();
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery()
       .processDefinitionKey(processDefinitionKey)
       .singleResult();
-    assertNotNull(processDefinition);
+    assertThat(processDefinition).isNotNull();
 
     InputStream actualStream = null;
     InputStream expectedStream = null;
@@ -77,16 +76,16 @@ public abstract class TestHelper {
 
       if (deployed) {
         byte[] actualDiagram = IoUtil.readInputStream(actualStream, "actualStream");
-        assertNotNull(actualDiagram);
-        assertTrue(actualDiagram.length > 0);
+        assertThat(actualDiagram).isNotNull();
+        assertThat(actualDiagram.length > 0).isTrue();
 
         expectedStream = clazz.getResourceAsStream(expectedDiagramResource);
         byte[] expectedDiagram = IoUtil.readInputStream(expectedStream, "expectedSteam");
-        assertNotNull(expectedDiagram);
+        assertThat(expectedDiagram).isNotNull();
 
-        assertTrue(isEqual(expectedStream, actualStream));
+        assertThat(isEqual(expectedStream, actualStream)).isTrue();
       } else {
-        assertNull(actualStream);
+        assertThat(actualStream).isNull();
       }
     } finally {
       IoUtil.closeSilently(actualStream);

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.java
@@ -54,7 +54,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 class TransactionIntegrationTest {
@@ -132,7 +131,7 @@ class TransactionIntegrationTest {
         try {
           // when
           userBean.completeTask(taskId);
-          Assertions.fail();
+          fail("");
         } catch (ProcessEngineException ignored) {
           // expected
         } catch (RuntimeException e) {

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.java
@@ -36,7 +36,6 @@ import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -54,6 +53,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 class TransactionIntegrationTest {
@@ -134,8 +134,6 @@ class TransactionIntegrationTest {
           fail("");
         } catch (ProcessEngineException ignored) {
           // expected
-        } catch (RuntimeException e) {
-          fail(e.getMessage());
         }
 
         // then
@@ -279,7 +277,7 @@ class TransactionIntegrationTest {
 
     @Transactional
     @Override
-    public void execute(DelegateExecution execution) throws Exception {
+    public void execute(DelegateExecution execution) {
       beanWithException.doSomething();
     }
 
@@ -343,6 +341,7 @@ class TransactionIntegrationTest {
           }
         }
       } catch (SQLException ignored) {
+        // ignored
       }
 
       if (nrOfRows != 1) {

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/UserTransactionIntegrationTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/UserTransactionIntegrationTest.java
@@ -34,10 +34,7 @@ import jakarta.inject.Named;
 import jakarta.transaction.Status;
 import jakarta.transaction.UserTransaction;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 class UserTransactionIntegrationTest {
 
@@ -68,7 +65,7 @@ class UserTransactionIntegrationTest {
           .processInstanceId(id)
           .singleResult();
 
-      assertNotNull(processInstance);
+      assertThat(processInstance).isNotNull();
 
       userTransactionManager.commit();
 
@@ -77,7 +74,7 @@ class UserTransactionIntegrationTest {
       // the process instance is visible in a new tx:
       processInstance = runtimeService.createProcessInstanceQuery().processInstanceId(id).singleResult();
 
-      assertNotNull(processInstance);
+      assertThat(processInstance).isNotNull();
 
       userTransactionManager.commit();
     } catch (Exception e) {
@@ -146,7 +143,7 @@ class UserTransactionIntegrationTest {
           .processInstanceId(id)
           .singleResult();
 
-      assertNull(processInstance);
+      assertThat(processInstance).isNull();
 
       userTransactionManager.commit();
     } catch (Exception e) {

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/UserTransactionIntegrationTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/UserTransactionIntegrationTest.java
@@ -34,6 +34,7 @@ import jakarta.inject.Named;
 import jakarta.transaction.Status;
 import jakarta.transaction.UserTransaction;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 class UserTransactionIntegrationTest {
@@ -111,7 +112,7 @@ class UserTransactionIntegrationTest {
       assertThat(userTransactionManager.getStatus()).isEqualTo(Status.STATUS_MARKED_ROLLBACK);
 
     } finally {
-      // make sure we always rollback
+      // make sure we always roll back
       userTransactionManager.rollback();
     }
   }

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/dmn/engine/test/junit5/ParameterizedTestExtensionTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/dmn/engine/test/junit5/ParameterizedTestExtensionTest.java
@@ -1,4 +1,4 @@
-/*/*
+/*
  * Copyright and/or licensed under one or more contributor license agreements.
  * See the NOTICE file distributed with this work for additional information regarding
  * copyright ownership. This file is licensed to you under the Apache License,
@@ -47,17 +47,17 @@ public class ParameterizedTestExtensionTest {
 	}
 
 	@BeforeEach
-	public void setup() throws Exception {
+	void setUp() {
 		requestUrl = requestUrl + "processed/";
 	}
 
 	@AfterEach
-	public void teardown() {
+	void tearDown() {
 		requestUrl = null;
 	}
 
 	@TestTemplate
-	public void ensureBeforeEachCanProcessParamaters() throws Exception {
+	void ensureBeforeEachCanProcessParameters() {
 		if (alreadyAuthenticated) {
       assertThat(requestUrl).isEqualTo("/app/cockpit/default/processed/");
 		} else {

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/dmn/engine/test/junit5/ParameterizedTestExtensionTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/dmn/engine/test/junit5/ParameterizedTestExtensionTest.java
@@ -15,7 +15,7 @@
  */
 package org.operaton.bpm.dmn.engine.test.junit5;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -59,9 +59,9 @@ public class ParameterizedTestExtensionTest {
 	@TestTemplate
 	public void ensureBeforeEachCanProcessParamaters() throws Exception {
 		if (alreadyAuthenticated) {
-			assertEquals("/app/cockpit/default/processed/", requestUrl);
+      assertThat(requestUrl).isEqualTo("/app/cockpit/default/processed/");
 		} else {
-			assertEquals("/app/cockpit/engine2/processed/", requestUrl);
+      assertThat(requestUrl).isEqualTo("/app/cockpit/engine2/processed/");
 		}
 	}
 


### PR DESCRIPTION
This change refactors test classes to use AssertJ instead of JUnit 4.

The initial change has been performed with OpenRewrite. Afterwards the changed test classes have been cleaned up from Sonar findings and other warnings that the IDE reveiled.

*JUnit assertions to AssertJ*

- `assertEquals(XXX,YYY)` -> `assertThat(XXX).isEqualTo(YYY)`
- `assertNotNull(XXX)` -> `assertThat(XXX).isNotNull()`
- `assertNull(XXX)` -> `assertThat(XXX).isNull()`
- `assertTrue(XXX)`-> `assertThat(XXX).isTrue()`
- `assertFalse(XXX)`-> `assertThat(XXX).isFalse()`
- `assertTrue(XXX.contains(YYY))` -> `assertThat(XXX).contains(YYY)`
- `assertArrayEquals(XXX, YYY)` -> assertThat(XXX).containsExactly(YYY)`


*Cleanups*
  - remove unnecessary throws declarations
  
  
related to #27  