### PR TITLE
Move internal-dependencies (fixes #533)

### DIFF
--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.operaton.bpm</groupId>
     <artifactId>operaton-parent</artifactId>
-    <relativePath>../parent</relativePath>
+    <relativePath>../../parent/pom.xml</relativePath>
     <version>1.0.0-beta-4-SNAPSHOT</version>
   </parent>
 
@@ -332,13 +332,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-test</artifactId>
-        <version>5.3.39</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
         <groupId>jakarta.ws.rs</groupId>
         <artifactId>jakarta.ws.rs-api</artifactId>
         <version>4.0.0</version>
@@ -363,12 +356,6 @@
         <version>6.2.1</version>
         <scope>test</scope>
       </dependency>-->
-
-      <dependency>
-        <groupId>jakarta.servlet</groupId>
-        <artifactId>jakarta.servlet-api</artifactId>
-        <version>6.1.0</version>
-      </dependency>
 
       <dependency>
         <groupId>jakarta.xml.bind</groupId>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -28,6 +28,7 @@
     <version.db2>${version.db2-11.5}</version.db2>
     <version.postgresql>42.5.5</version.postgresql>
     <version.liquibase>4.8.0</version.liquibase>
+    <version.operaton.dbscheme>7.23.0</version.operaton.dbscheme>
 
     <!-- needed for sql script and backward compatibility checks -->
     <operaton.version.old>7.22.0</operaton.version.old>

--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@
         <module>distro/tomcat</module>
         <module>distro/sql-script</module>
         <module>clients/java</module>
-        <module>internal-dependencies</module>
+        <module>bom/internal-dependencies</module>
         <module>database</module>
         <module>parent</module>
         <module>bom</module>
@@ -393,7 +393,7 @@
         <module>examples</module>
         <module>engine-plugins</module>
         <module>distro/sql-script</module>
-        <module>internal-dependencies</module>
+        <module>bom/internal-dependencies</module>
         <module>database</module>
         <module>parent</module>
         <module>bom</module>
@@ -463,7 +463,7 @@
         <module>engine-spring</module>
         <module>engine-rest</module>
 
-        <module>internal-dependencies</module>
+        <module>bom/internal-dependencies</module>
         <module>database</module>
         <module>parent</module>
         <module>bom</module>
@@ -474,7 +474,7 @@
       <!-- profile for running webapp unit tests in QA -->
       <id>check-webapps</id>
       <modules>
-        <module>internal-dependencies</module>
+        <module>bom/internal-dependencies</module>
         <module>parent</module>
         <module>bom</module>
       </modules>
@@ -511,7 +511,7 @@
         <module>test-utils/archunit</module>
         <module>test-utils/assert</module>
         <module>test-utils/testcontainers</module>
-        <module>internal-dependencies</module>
+        <module>bom/internal-dependencies</module>
         <module>database</module>
         <module>parent</module>
         <module>bom</module>

--- a/webapps/assembly/pom.xml
+++ b/webapps/assembly/pom.xml
@@ -63,7 +63,7 @@
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-core-internal-dependencies</artifactId>
       <version>${project.version}</version>
-      <scope>import</scope>
+      <scope>compile</scope>
       <type>pom</type>
     </dependency>
 

--- a/webapps/assembly/pom.xml
+++ b/webapps/assembly/pom.xml
@@ -59,15 +59,6 @@
       </exclusions>
     </dependency>
 
-    <dependency>
-      <groupId>org.operaton.bpm</groupId>
-      <artifactId>operaton-core-internal-dependencies</artifactId>
-      <version>${project.version}</version>
-      <scope>compile</scope>
-      <type>pom</type>
-    </dependency>
-
-
     <!-- rest api -->
     <dependency>
       <groupId>org.operaton.bpm</groupId>


### PR DESCRIPTION
- moved internal-dependencies BOM to .bom\
- removed duplicate dependency declarations in dependencyManagement
- ensured correct resolution of version.operaton.dbscheme from parent BOM
- fixed duplicate maven-dependency-plugin in integration-test-operaton-run profile"