### PR TITLE
chore: Fix two sonar findings with only one finding in code base.

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/auth/DefaultAuthorizationProvider.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/auth/DefaultAuthorizationProvider.java
@@ -528,10 +528,6 @@ public class DefaultAuthorizationProvider implements ResourceAuthorizationProvid
   }
 
   protected boolean areIdsEqual(String firstId, String secondId) {
-    if (firstId == null || secondId == null) {
-      return Objects.equals(firstId, secondId);
-    }else {
-      return firstId.equals(secondId);
-    }
+    return Objects.equals(firstId, secondId);
   }
 }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
@@ -67,10 +67,10 @@ public class OperatonExtensionsTest {
 
   public void initOperatonExtensionsTest(String namespace, BpmnModelInstance modelInstance) {
     this.originalModelInstance = modelInstance;
-    setUp();
+    initModelElements();
   }
 
-  public void setUp() {
+  private void initModelElements() {
     modelInstance = originalModelInstance.clone();
     process = modelInstance.getModelElementById(PROCESS_ID);
     startEvent = modelInstance.getModelElementById(START_EVENT_ID);


### PR DESCRIPTION
- OperatonExtensionsTest: "Annotate this method with JUnit5 '@org.junit.jupiter.api.BeforeEach' or rename it to avoid confusion."
- DefaultAuthorizationProvider: "Refactor this method to not always return the same value."

relates to #511