### PR TITLE
chore: Log information when timing out.

### DIFF
--- a/clients/java/client/src/main/java/org/operaton/bpm/client/topic/impl/TopicSubscriptionManager.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/topic/impl/TopicSubscriptionManager.java
@@ -232,7 +232,10 @@ public class TopicSubscriptionManager implements Runnable {
       ACQUISITION_MONITOR.lock();
       try {
         if (isRunning.get()) {
-          IS_WAITING.await(waitTime, TimeUnit.MILLISECONDS);
+          boolean wasSignaled = IS_WAITING.await(waitTime, TimeUnit.MILLISECONDS);
+          if (!wasSignaled) {
+              LOG.timeout(waitTime);
+          }
         }
       } catch (InterruptedException e) {
         LOG.exceptionWhileExecutingBackoffStrategyMethod(e);

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/topic/impl/TopicSubscriptionManagerLogger.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/topic/impl/TopicSubscriptionManagerLogger.java
@@ -72,4 +72,10 @@ public class TopicSubscriptionManagerLogger extends ExternalTaskClientLogger {
       String.format("Fetch and lock new external tasks for %d topics", subscriptions.size()));
   }
 
+  protected void timeout(long waitTime) {
+    logDebug(
+      "009",
+      String.format("Timed out after %d ms without a signal.", waitTime));
+  }
+
 }


### PR DESCRIPTION
The 'await' can terminate either by a call from 'signal' or by timing out. Both can happen and are probably ok, but we should at least log the information that a timeout occurred.

relates to: #537