### PR TITLE
chore: Rewriting thread behavior to best practices.

### DIFF
--- a/clients/java/client/src/main/java/org/operaton/bpm/client/topic/impl/TopicSubscriptionManagerLogger.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/topic/impl/TopicSubscriptionManagerLogger.java
@@ -72,4 +72,10 @@ public class TopicSubscriptionManagerLogger extends ExternalTaskClientLogger {
       String.format("Fetch and lock new external tasks for %d topics", subscriptions.size()));
   }
 
+  protected void timeout(long waitTime) {
+    logDebug(
+      "009",
+      String.format("Timed out after %d ms without a signal.", waitTime));
+  }
+
 }

--- a/clients/java/client/src/test/java/org/operaton/bpm/client/impl/TopicSubscriptionManagerTest.java
+++ b/clients/java/client/src/test/java/org/operaton/bpm/client/impl/TopicSubscriptionManagerTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.client.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.operaton.bpm.client.backoff.BackoffStrategy;
+import org.operaton.bpm.client.task.ExternalTask;
+import org.operaton.bpm.client.task.ExternalTaskHandler;
+import org.operaton.bpm.client.task.ExternalTaskService;
+import org.operaton.bpm.client.task.impl.ExternalTaskImpl;
+import org.operaton.bpm.client.topic.TopicSubscription;
+import org.operaton.bpm.client.topic.impl.TopicSubscriptionBuilderImpl;
+import org.operaton.bpm.client.topic.impl.TopicSubscriptionManager;
+import org.operaton.bpm.client.variable.impl.DefaultValueMappers;
+import org.operaton.bpm.client.variable.impl.TypedValueField;
+import org.operaton.bpm.client.variable.impl.TypedValues;
+import org.operaton.bpm.engine.variable.value.PrimitiveValue;
+
+class TopicSubscriptionManagerTest {
+
+	private static final String T0 = "t0";
+	private static final String T1 = "t1";
+
+	TypedValues typedValues;
+	EngineClient engineClient;
+	TopicSubscriptionManagerForTesting topicSubscriptionManager;
+	RecordingExternalTaskHandler t0Handler;
+	RecordingExternalTaskHandler t1Handler;
+	List<ExternalTask> taskList;
+	TopicSubscription subscriptionT0;
+	private TopicSubscription subscriptionT1;
+
+	@BeforeEach
+	void setUp() {
+		typedValues = new TypedValues(new DefaultValueMappers<PrimitiveValue<String>>(""));
+		engineClient = mock(EngineClient.class);
+		topicSubscriptionManager = new TopicSubscriptionManagerForTesting(engineClient, typedValues, 0l);
+		topicSubscriptionManager.setBackoffStrategy(new OneSecondBackOffStrategy());
+		t0Handler = new RecordingExternalTaskHandler();
+		taskList = new ArrayList<ExternalTask>();
+		ExternalTaskImpl externalt0Task = new ExternalTaskImpl();
+		externalt0Task.setTopicName(T0);
+		externalt0Task.setVariables(new HashMap<String, TypedValueField>());
+		taskList.add(externalt0Task);
+		t1Handler = new RecordingExternalTaskHandler();
+		ExternalTaskImpl externalt1Task = new ExternalTaskImpl();
+		externalt1Task.setTopicName(T1);
+		externalt1Task.setVariables(new HashMap<String, TypedValueField>());
+		taskList.add(externalt1Task);
+		when(engineClient.fetchAndLock(anyList())).thenReturn(taskList);
+	}
+
+	@AfterEach
+	void tearDown() {
+		waitForTopicSubscriptionManagerToFinish();
+	}
+
+	@Test
+	void startStopFinishes() {
+		topicSubscriptionManager.start();
+		topicSubscriptionManager.stop();
+	}
+
+	@Test
+	void isRunningAfterStart() {
+		topicSubscriptionManager.start();
+		assertTrue(topicSubscriptionManager.isRunning());
+
+		topicSubscriptionManager.stop();
+	}
+
+	@Test
+	void isNotRunningAfterStop() {
+		topicSubscriptionManager.start();
+		topicSubscriptionManager.stop();
+		assertFalse(topicSubscriptionManager.isRunning());
+	}
+
+	@Test
+	void taskExecutesOnce() {
+		topicSubscriptionManager.start();
+		subscribeTopicT0();
+		waitMillies(500);
+		topicSubscriptionManager.stop();
+
+		assertEquals(1, t0Handler.getExecuteCount());
+	}
+
+	@Test
+	void taskExecutesOnceIfSubscribedBeforeStart() {
+		subscribeTopicT0();
+		topicSubscriptionManager.start();
+		waitMillies(500);
+		topicSubscriptionManager.stop();
+
+		assertEquals(1, t0Handler.getExecuteCount());
+	}
+
+	@Test
+	void subscribeExecutesSecondTimeAfterBackupStrategyTimesOut() {
+		subscribeTopicT0();
+		topicSubscriptionManager.start();
+		waitMillies(1500);
+		topicSubscriptionManager.stop();
+
+		assertEquals(2, t0Handler.getExecuteCount());
+	}
+
+	@Test
+	void twoTasksExecutedOnce() {
+		subscribeTopicT0();
+		subscribeTopicT1();
+		topicSubscriptionManager.start();
+		waitMillies(500);
+		topicSubscriptionManager.stop();
+
+		assertEquals(1, t0Handler.getExecuteCount());
+		assertEquals(1, t1Handler.getExecuteCount());
+	}
+
+	@Test
+	void twoTasksExecutedTwice() {
+		subscribeTopicT0();
+		subscribeTopicT1();
+		topicSubscriptionManager.start();
+		waitMillies(1500);
+		topicSubscriptionManager.stop();
+
+		assertEquals(2, t0Handler.getExecuteCount());
+		assertEquals(2, t1Handler.getExecuteCount());
+	}
+
+	@Test
+	void subscribeDuringRunning() {
+		topicSubscriptionManager.start();
+		waitMillies(1500);
+		subscribeTopicT0();
+		waitMillies(750); // 2000 ... t0 executed once
+		subscribeTopicT1();
+		waitMillies(500); // 3000 ... t0 executed second time, t1 executed once
+		topicSubscriptionManager.stop();
+
+		assertEquals(2, t0Handler.getExecuteCount());
+		assertEquals(1, t1Handler.getExecuteCount());
+	}
+
+	@Test
+	void unsubscribeDuringRunning() {
+		subscribeTopicT0();
+		subscribeTopicT1();
+		topicSubscriptionManager.start();
+		waitMillies(500); // t0 and t1 executed once
+		unsubscribeTopicT1();
+		waitMillies(1000); // t0 executed second time
+		topicSubscriptionManager.stop();
+
+		assertEquals(2, t0Handler.getExecuteCount());
+		assertEquals(1, t1Handler.getExecuteCount());
+	}
+
+	@Test
+	void unsubscribeAllBeforeRunning() {
+		subscribeTopicT0();
+		subscribeTopicT1();
+		unsubscribeTopicT0();
+		unsubscribeTopicT1();
+		topicSubscriptionManager.start();
+		waitMillies(500);
+		topicSubscriptionManager.stop();
+
+		assertEquals(0, t0Handler.getExecuteCount());
+		assertEquals(0, t1Handler.getExecuteCount());
+	}
+
+	@Test
+	void interruptIsWaiting() {
+		subscribeTopicT0();
+		subscribeTopicT1();
+		topicSubscriptionManager.start();
+		waitMillies(500); // t0 and t1 executed once
+		topicSubscriptionManager.getThread().interrupt();
+		waitMillies(250); // t0 and t1 executed second time because timer restart
+		topicSubscriptionManager.stop();
+
+		assertEquals(2, t0Handler.getExecuteCount());
+		assertEquals(2, t1Handler.getExecuteCount());
+	}
+
+	private void waitMillies(int millies) {
+		try {
+			Thread.sleep(millies);
+		} catch (InterruptedException e) {
+			fail(e);
+		}
+	}
+
+	private void waitForTopicSubscriptionManagerToFinish() {
+		try {
+			topicSubscriptionManager.getThread().join();
+		} catch (InterruptedException e) {
+			fail(e);
+		}
+	}
+
+	private void subscribeTopicT0() {
+		subscriptionT0 = new TopicSubscriptionBuilderImpl(T0, topicSubscriptionManager).handler(t0Handler).open();
+	}
+
+	private void subscribeTopicT1() {
+		subscriptionT1 = new TopicSubscriptionBuilderImpl(T1, topicSubscriptionManager).handler(t1Handler).open();
+	}
+
+	private void unsubscribeTopicT0() {
+		subscriptionT0.close();
+	}
+
+	private void unsubscribeTopicT1() {
+		subscriptionT1.close();
+	}
+
+}
+
+// Testing class modifying visibility of fields and methods of TopicSubscriptionManager to ease testing
+class TopicSubscriptionManagerForTesting extends TopicSubscriptionManager {
+	public TopicSubscriptionManagerForTesting(EngineClient engineClient, TypedValues typedValues,
+			long clientLockDuration) {
+		super(engineClient, typedValues, clientLockDuration);
+	}
+
+	public Thread getThread() {
+		return thread;
+	}
+}
+
+// Testing class to count the numbers of "execute" calls for a specific task
+class RecordingExternalTaskHandler implements ExternalTaskHandler {
+	private int executeCount = 0;
+
+	@Override
+	public void execute(ExternalTask externalTask, ExternalTaskService externalTaskService) {
+		executeCount++;
+	}
+
+	public int getExecuteCount() {
+		return executeCount;
+	}
+}
+
+// Backup strategy that waits one second to make thread testing reliable
+class OneSecondBackOffStrategy implements BackoffStrategy {
+	@Override
+	public void reconfigure(List<ExternalTask> externalTasks) {
+	}
+
+	@Override
+	public long calculateBackoffTime() {
+		return 1000L;
+	}
+}


### PR DESCRIPTION
We call 'await' in a loop until we run out of time or receive the signal. We exit immediately when receiving the signal and calculate if there is remaining time otherwise.

The 'await' can terminate either by a call from 'signal' or by timing out. Both can happen and are probably ok, but we should at least log the information that a timeout occurred while thread is still running.

If the thread is interrupted we catch the exception and signal the thread to exit gracefully.

relates to: #537