### PR TITLE
chore(test): Migrate first tests in engine from JUnit4 to JUnit5.

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/application/impl/context/ProcessApplicationContextTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/context/ProcessApplicationContextTest.java
@@ -16,49 +16,52 @@
  */
 package org.operaton.bpm.application.impl.context;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.operaton.bpm.application.ProcessApplicationContext.withProcessApplicationContext;
 
 import java.util.concurrent.Callable;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.operaton.bpm.application.InvocationContext;
 import org.operaton.bpm.application.ProcessApplicationContext;
 import org.operaton.bpm.application.ProcessApplicationReference;
 import org.operaton.bpm.application.ProcessApplicationUnavailableException;
 import org.operaton.bpm.application.impl.embedded.TestApplicationWithoutEngine;
+import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.delegate.BaseDelegateExecution;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.context.Context;
-import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
-import static org.operaton.bpm.application.ProcessApplicationContext.withProcessApplicationContext;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 
 /**
  * @author Thorben Lindhauer
  *
  */
-public class ProcessApplicationContextTest extends PluggableProcessEngineTest {
+@ExtendWith(ProcessEngineExtension.class)
+public class ProcessApplicationContextTest {
 
+  protected ProcessEngine processEngine;
   protected TestApplicationWithoutEngine pa;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     pa = new TestApplicationWithoutEngine();
     pa.deploy();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     pa.undeploy();
   }
@@ -153,7 +156,7 @@ public class ProcessApplicationContextTest extends PluggableProcessEngineTest {
         fail("should not succeed");
 
       } catch (ProcessEngineException e) {
-        testRule.assertTextPresent("A process application with name '" + nonExistingName + "' is not registered", e.getMessage());
+        assertThat(e.getMessage()).contains("A process application with name '" + nonExistingName + "' is not registered");
       }
 
     } finally {

--- a/engine/src/test/java/org/operaton/bpm/application/impl/deployment/DeploymentRegistrationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/deployment/DeploymentRegistrationTest.java
@@ -16,26 +16,36 @@
  */
 package org.operaton.bpm.application.impl.deployment;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.operaton.bpm.engine.ManagementService;
+import org.operaton.bpm.engine.RepositoryService;
+import org.operaton.bpm.engine.RuntimeService;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.repository.Deployment;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
-import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-
-import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Roman Smirnov
  *
  */
-public class DeploymentRegistrationTest extends PluggableProcessEngineTest {
+@ExtendWith(ProcessEngineExtension.class)
+public class DeploymentRegistrationTest {
 
   protected static final String DEPLOYMENT_NAME = "my-deployment";
 
   protected static final String PROCESS_KEY = "process-1";
   protected static final String BPMN_RESOURCE = "path/to/my/process1.bpmn";
+
+  protected ProcessEngineConfigurationImpl processEngineConfiguration;
+  protected RuntimeService runtimeService;
+  protected RepositoryService repositoryService;
+  protected ManagementService managementService;
 
   @Test
   public void testNoRegistrationCheckIfNoProcessApplicationIsDeployed() {

--- a/engine/src/test/java/org/operaton/bpm/application/impl/deployment/EmptyProcessesXmlTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/deployment/EmptyProcessesXmlTest.java
@@ -20,10 +20,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.application.impl.metadata.spi.ProcessArchiveXml;
 import org.operaton.bpm.application.impl.metadata.spi.ProcessesXml;
 import org.operaton.bpm.engine.repository.ResumePreviousBy;
-import org.junit.Test;
 
 /**
  * <p>Testcase verifying the default properties in the empty processes.xml</p>

--- a/engine/src/test/java/org/operaton/bpm/application/impl/deployment/RedeploymentRegistrationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/deployment/RedeploymentRegistrationTest.java
@@ -21,8 +21,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.operaton.bpm.application.ProcessApplicationReference;
 import org.operaton.bpm.application.impl.EmbeddedProcessApplication;
+import org.operaton.bpm.engine.ManagementService;
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.engine.impl.application.ProcessApplicationManager;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -34,20 +39,13 @@ import org.operaton.bpm.engine.impl.interceptor.Command;
 import org.operaton.bpm.engine.impl.persistence.deploy.cache.DeploymentCache;
 import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.operaton.bpm.engine.repository.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.util.ProcessEngineTestRule;
-import org.operaton.bpm.engine.test.util.ProvidedProcessEngineRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameter;
+import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameterized;
+import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameters;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 
-@RunWith(Parameterized.class)
+@Parameterized
+@ExtendWith(ProcessEngineExtension.class)
 public class RedeploymentRegistrationTest {
 
   protected static final String DEPLOYMENT_NAME = "my-deployment";
@@ -66,13 +64,8 @@ public class RedeploymentRegistrationTest {
 
   protected EmbeddedProcessApplication processApplication;
 
-  protected ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
-  protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);
-
-  @Rule
-  public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(testRule);
-
   protected RepositoryService repositoryService;
+  protected ManagementService managementService;
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
 
   @Parameter(0)
@@ -90,7 +83,7 @@ public class RedeploymentRegistrationTest {
   @Parameter(4)
   public TestProvider testProvider;
 
-  @Parameters(name = "scenario {index}")
+  @Parameters
   public static Collection<Object[]> scenarios() {
     return Arrays.asList(new Object[][] {
       { BPMN_RESOURCE_1, BPMN_RESOURCE_2, "processOne", "processTwo", processDefinitionTestProvider() },
@@ -100,15 +93,12 @@ public class RedeploymentRegistrationTest {
     });
   }
 
-  @Before
+  @BeforeEach
   public void init() {
-    repositoryService = engineRule.getRepositoryService();
-    processEngineConfiguration = engineRule.getProcessEngineConfiguration();
-
     processApplication = new EmbeddedProcessApplication();
   }
 
-  @Test
+  @TestTemplate
 	public void registrationNotFoundByDeploymentId() {
     // given
     ProcessApplicationReference reference = processApplication.getReference();
@@ -132,7 +122,7 @@ public class RedeploymentRegistrationTest {
     assertThat(getProcessApplicationForDeployment(deployment2.getId())).isNull();
   }
 
-  @Test
+  @TestTemplate
 	public void registrationNotFoundByDefinition() {
     // given
 
@@ -163,7 +153,7 @@ public class RedeploymentRegistrationTest {
     assertThat(getProcessApplicationForDefinition(definitionId)).isNull();
   }
 
-  @Test
+  @TestTemplate
 	public void registrationFoundByDeploymentId() {
     // given
     ProcessApplicationReference reference1 = processApplication.getReference();
@@ -189,7 +179,7 @@ public class RedeploymentRegistrationTest {
     assertThat(getProcessApplicationForDeployment(deployment2.getId())).isEqualTo(reference2);
   }
 
-  @Test
+  @TestTemplate
 	public void registrationFoundFromPreviousDefinition() {
     // given
     ProcessApplicationReference reference = processApplication.getReference();
@@ -215,7 +205,7 @@ public class RedeploymentRegistrationTest {
     assertThat(getProcessApplicationForDeployment(deployment2.getId())).isNull();
   }
 
-  @Test
+  @TestTemplate
 	public void registrationFoundFromLatestDeployment() {
     // given
     ProcessApplicationReference reference1 = processApplication.getReference();
@@ -240,7 +230,7 @@ public class RedeploymentRegistrationTest {
     assertThat(getProcessApplicationForDeployment(deployment2.getId())).isEqualTo(reference2);
   }
 
-  @Test
+  @TestTemplate
 	public void registrationFoundOnlyForOneProcessDefinition() {
     // given
 
@@ -275,7 +265,7 @@ public class RedeploymentRegistrationTest {
     assertThat(getProcessApplicationForDefinition(secondDefinitionId)).isNull();
   }
 
-  @Test
+  @TestTemplate
 	public void registrationFoundFromDifferentDeployment() {
     // given
 
@@ -311,7 +301,7 @@ public class RedeploymentRegistrationTest {
     assertThat(getProcessApplicationForDefinition(secondDefinitionId)).isEqualTo(reference1);
   }
 
-  @Test
+  @TestTemplate
 	public void registrationFoundFromSameDeployment() {
     // given
 
@@ -352,7 +342,7 @@ public class RedeploymentRegistrationTest {
     assertThat(getProcessApplicationForDefinition(secondDefinitionId)).isEqualTo(reference1);
   }
 
-  @Test
+  @TestTemplate
 	public void registrationFoundFromDifferentDeployments() {
     // given
 
@@ -387,7 +377,7 @@ public class RedeploymentRegistrationTest {
     assertThat(getProcessApplicationForDefinition(secondDefinitionId)).isEqualTo(reference2);
   }
 
-  @Test
+  @TestTemplate
 	public void registrationNotFoundWhenDeletingDeployment() {
     // given
 
@@ -426,7 +416,7 @@ public class RedeploymentRegistrationTest {
     assertThat(getProcessApplicationForDefinition(firstDefinitionId)).isNull();
   }
 
-  @Test
+  @TestTemplate
 	public void registrationFoundAfterDiscardingDeploymentCache() {
     // given
 
@@ -467,7 +457,7 @@ public class RedeploymentRegistrationTest {
 
   // helper ///////////////////////////////////////////
 
-  @After
+  @AfterEach
   public void cleanUp() {
     for (Deployment deployment : repositoryService.createDeploymentQuery().list()) {
       deleteDeployment(deployment);
@@ -476,7 +466,7 @@ public class RedeploymentRegistrationTest {
 
   protected void deleteDeployment(Deployment deployment) {
     repositoryService.deleteDeployment(deployment.getId(), true);
-    engineRule.getManagementService().unregisterProcessApplication(deployment.getId(), false);
+    managementService.unregisterProcessApplication(deployment.getId(), false);
   }
 
   protected ProcessApplicationReference getProcessApplicationForDeployment(String deploymentId) {

--- a/test-utils/junit5-extension/src/main/java/org/operaton/bpm/engine/test/junit5/ParameterizedTestExtension.java
+++ b/test-utils/junit5-extension/src/main/java/org/operaton/bpm/engine/test/junit5/ParameterizedTestExtension.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.TestInstanceFactory;
 import org.junit.jupiter.api.extension.TestInstanceFactoryContext;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
 import org.junit.jupiter.api.extension.TestInstantiationException;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
@@ -65,6 +67,7 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
  *    import org.junit.jupiter.api.*;
  *    import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameterized;
  *    import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameters;
+ *    import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameter;
  *    
  * 3. Replace the class @RunWith(Parameterized.class) annotation with @Parameterized
  * 
@@ -76,6 +79,12 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
  * 
  */
 public class ParameterizedTestExtension implements TestTemplateInvocationContextProvider {
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.FIELD)
+	public @interface Parameter {
+		int value();
+	}
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(ElementType.METHOD)
@@ -97,8 +106,7 @@ public class ParameterizedTestExtension implements TestTemplateInvocationContext
 	@Override
 	public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
 		Class<?> testClass = context.getRequiredTestClass();
-		// Look for a static method annotated with
-		// @org.junit.runners.Parameterized.Parameters
+		// Look for a static method annotated with @Parameters
 		Method parametersMethod = Arrays.stream(testClass.getDeclaredMethods())
 				.filter(m -> m.isAnnotationPresent(Parameters.class) && Modifier.isStatic(m.getModifiers())).findFirst()
 				.orElseThrow(() -> new ExtensionConfigurationException(
@@ -137,7 +145,7 @@ public class ParameterizedTestExtension implements TestTemplateInvocationContext
 		@Override
 		public List<Extension> getAdditionalExtensions() {
 			return asList(
-					// A ParameterResolver that will resolve constructor (or method) parameters.
+					// ParameterResolver for method/constructor parameters
 					new ParameterResolver() {
 						@Override
 						public boolean supportsParameter(ParameterContext parameterContext,
@@ -158,20 +166,40 @@ public class ParameterizedTestExtension implements TestTemplateInvocationContext
 							return parameters[index];
 						}
 					},
-					// A TestInstanceFactory that uses our parameters to create a new instance.
+					// TestInstanceFactory to create a new test instance using the parameters
 					new TestInstanceFactory() {
 						@Override
 						public Object createTestInstance(TestInstanceFactoryContext factoryContext,
 								ExtensionContext extensionContext) throws TestInstantiationException {
 							try {
 								Class<?> testClass = extensionContext.getRequiredTestClass();
-								// we assume the test class has a single constructor.
+								// assume the test class has a single constructor.
 								Constructor<?> constructor = testClass.getDeclaredConstructors()[0];
 								constructor.setAccessible(true);
-								// Use the parameters provided by our invocation context.
 								return constructor.newInstance(parameters);
 							} catch (Exception e) {
 								throw new TestInstantiationException("Could not create test instance", e);
+							}
+						}
+					},
+					// TestInstancePostProcessor for field injection using @Parameter(X)
+					new TestInstancePostProcessor() {
+						@Override
+						public void postProcessTestInstance(Object testInstance, ExtensionContext context)
+								throws Exception {
+							// Iterate over declared fields and inject values for those annotated with
+							// @Parameter
+							for (Field field : testInstance.getClass().getDeclaredFields()) {
+								Parameter parameterAnnotation = field.getAnnotation(Parameter.class);
+								if (parameterAnnotation != null) {
+									int index = parameterAnnotation.value();
+									if (index < 0 || index >= parameters.length) {
+										throw new ExtensionConfigurationException("Index " + index
+												+ " is out of bounds for the provided parameters array.");
+									}
+									field.setAccessible(true);
+									field.set(testInstance, parameters[index]);
+								}
 							}
 						}
 					});

--- a/test-utils/junit5-extension/src/main/java/org/operaton/bpm/engine/test/junit5/ParameterizedTestExtension.java
+++ b/test-utils/junit5-extension/src/main/java/org/operaton/bpm/engine/test/junit5/ParameterizedTestExtension.java
@@ -45,37 +45,51 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 
 /**
- * This JUnit 5 extension is intended to make the conversion from JUnit 4 Tests like ContainerAuthenticationFilterTest
- * as easy as possible. The issue is, that these tests are run with @RunWith(org.junit.runners.Parameterized.class)
- * and use a static method annotated with @org.junit.runners.Parameterized.Parameters to inject parameters into
- * the constructor of the test class. This extension implements the same mechanism for JUnit 5.
+ * This JUnit 5 extension is intended to make the conversion from JUnit 4 Tests
+ * like ContainerAuthenticationFilterTest as easy as possible. The issue is,
+ * that these tests are run with @RunWith(org.junit.runners.Parameterized.class)
+ * and use a static method annotated
+ * with @org.junit.runners.Parameterized.Parameters to inject parameters into
+ * the constructor of the test class or by using field injection
+ * with @Paramater(0), @Parameter(1). This extension implements the same
+ * mechanism for JUnit 5.
  * 
  * To migrate the tests you can follow the following recipe:
  * 
- * 1. Remove the junit 4 imports
+ * <ol>
+ * <li>Remove the junit 4 imports
  * 
- *    import org.junit.After;
- *    import org.junit.Assert;
- *    import org.junit.Before;
- *    import org.junit.Test;
- *    import org.junit.runner.RunWith;
- *    import org.junit.runners.Parameterized;
- *    import org.junit.runners.Parameterized.Parameters;
- *    
- * 2. Add the imports for junit 5 and this class
+ * <pre>
+ * import org.junit.After;
+ * import org.junit.Assert;
+ * import org.junit.Before;
+ * import org.junit.Test;
+ * import org.junit.runner.RunWith;
+ * import org.junit.runners.Parameterized;
+ * import org.junit.runners.Parameterized.Parameters;
+ * </pre>
  * 
- *    import org.junit.jupiter.api.*;
- *    import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameterized;
- *    import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameters;
- *    import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameter;
- *    
- * 3. Replace the class @RunWith(Parameterized.class) annotation with @Parameterized
+ * </li>
  * 
- * 4. Replace @Before with @BeforeEach and @After with @AfterEach
+ * <li>Add the imports for junit 5 and this class
  * 
- * 5. Replace each @Test with @TestTemplate
+ * <pre>
+ * import org.junit.jupiter.api.*;
+ * import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameterized;
+ * import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameters;
+ * import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameter;
+ * </pre>
  * 
- * 6. Use assertion methods from Assertions instead from Assert
+ * </li>
+ * <li>Replace the class @RunWith(Parameterized.class) annotation
+ * with @Parameterized</li>
+ * 
+ * <li>Replace @Before with @BeforeEach and @After with @AfterEach</li>
+ * 
+ * <li>Replace each @Test with @TestTemplate</li>
+ * 
+ * <li>Use assertion methods from Assertions instead from Assert</li>
+ * </ol>
  * 
  */
 public class ParameterizedTestExtension implements TestTemplateInvocationContextProvider {

--- a/test-utils/junit5-extension/src/test/java/org/operaton/bpm/dmn/engine/test/junit5/ParameterizedTestExtensionFieldInjectionTest.java
+++ b/test-utils/junit5-extension/src/test/java/org/operaton/bpm/dmn/engine/test/junit5/ParameterizedTestExtensionFieldInjectionTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright and/or licensed under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. This file is licensed to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.dmn.engine.test.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameter;
+import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameterized;
+import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameters;
+
+/**
+ * This test uses the ParameterizedTestExtension and demonstrates that the
+ * passed parameters are actually available in the @BeforeEach method.
+ */
+@Parameterized
+public class ParameterizedTestExtensionFieldInjectionTest {
+
+	@Parameter(0)
+	protected String requestUrl;
+	@Parameter(1)
+	protected boolean alreadyAuthenticated;
+
+	@Parameters
+	public static Collection<Object[]> getRequestUrls() {
+		return Arrays.asList(new Object[][] { { "/app/cockpit/default/", true }, { "/app/cockpit/engine2/", false }, });
+	}
+
+	@BeforeEach
+	void setUp() {
+		requestUrl = requestUrl + "processed/";
+	}
+
+	@AfterEach
+	void tearDown() {
+		requestUrl = null;
+	}
+
+	@TestTemplate
+	void ensureBeforeEachCanProcessParameters() {
+		if (alreadyAuthenticated) {
+      assertThat(requestUrl).isEqualTo("/app/cockpit/default/processed/");
+		} else {
+      assertThat(requestUrl).isEqualTo("/app/cockpit/engine2/processed/");
+		}
+	}
+
+}


### PR DESCRIPTION
- Extended ParameteriedTestExtension to support `@Parameter(X)` on fields.
- Added unit test to cover new functionality.
- Migrated first four tests in engine project to JUnit5.

reöates to #566