### PR TITLE
JUnit 5 migration: Module assert-core

### DIFF
--- a/test-utils/assert/core/pom.xml
+++ b/test-utils/assert/core/pom.xml
@@ -42,6 +42,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.operaton.bpm</groupId>
+      <artifactId>operaton-engine</artifactId>
+      <classifier>junit5</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>test</scope>

--- a/test-utils/assert/core/pom.xml
+++ b/test-utils/assert/core/pom.xml
@@ -28,6 +28,10 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -48,20 +52,24 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <version>${version.mockito}</version>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/AbstractProcessAssertTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/AbstractProcessAssertTest.java
@@ -26,13 +26,13 @@ import java.util.Arrays;
 import java.util.Iterator;
 
 import org.operaton.bpm.engine.ProcessEngine;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 @SuppressWarnings("unchecked")
-public class AbstractProcessAssertTest {
+class AbstractProcessAssertTest {
 
   ProcessEngine processEngine;
   Class<AbstractProcessAssert<?, ?>> anAssertClass;
@@ -41,8 +41,8 @@ public class AbstractProcessAssertTest {
 
   Iterator<Class<AbstractProcessAssert<?, ?>>> allAsserts;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     processEngine = Mockito.mock(ProcessEngine.class);
     AbstractAssertions.init(processEngine);
     allAsserts = Arrays.asList((Class<AbstractProcessAssert<?, ?>>[]) new Class[] {
@@ -53,13 +53,13 @@ public class AbstractProcessAssertTest {
     }).iterator();
   }
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
     AbstractAssertions.reset();
   }
 
   @Test
-  public void testConstructorPattern() {
+  void constructorPattern() {
     while(allAsserts.hasNext()) {
       mockActual(allAsserts.next());
       AbstractProcessAssert<?, ?> newInstanceFromExpectedConstructor = newInstanceFromExpectedConstructor();
@@ -68,7 +68,7 @@ public class AbstractProcessAssertTest {
   }
 
   @Test
-  public void testFactoryMethodPattern() {
+  void factoryMethodPattern() {
     while(allAsserts.hasNext()) {
       mockActual(allAsserts.next());
       AbstractProcessAssert<?, ?> newInstanceFromExpectedFactoryMethod = newInstanceFromExpectedFactoryMethod();
@@ -77,7 +77,7 @@ public class AbstractProcessAssertTest {
   }
 
   @Test
-  public void testLastAssert_BeforeFirstAssert() {
+  void lastAssertBeforeFirstAssert() {
     while(allAsserts.hasNext()) {
       mockActual(allAsserts.next());
       assertThat(AbstractProcessAssert.getLastAssert(anAssertClass)).isNull();
@@ -85,7 +85,7 @@ public class AbstractProcessAssertTest {
   }
 
   @Test
-  public void testLastAssert_AfterFirstAssert() {
+  void lastAssertAfterFirstAssert() {
     while(allAsserts.hasNext()) {
       mockActual(allAsserts.next());
       AbstractProcessAssert<?, ?> assertInstance = newInstanceFromExpectedFactoryMethod();
@@ -95,7 +95,7 @@ public class AbstractProcessAssertTest {
   }
 
   @Test
-  public void testLastAssert_AfterSecondAssert() {
+  void lastAssertAfterSecondAssert() {
     while(allAsserts.hasNext()) {
       mockActual(allAsserts.next());
       AbstractProcessAssert<?, ?> assertInstance1 = newInstanceFromExpectedFactoryMethod();

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ExternalTaskAssertHasActivityIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ExternalTaskAssertHasActivityIdTest.java
@@ -19,12 +19,11 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.externalTaskQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ExternalTaskAssertHasActivityIdTest extends ProcessAssertTestCase {
 
@@ -32,8 +31,8 @@ public class ExternalTaskAssertHasActivityIdTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "bpmn/ExternalTaskAssert-hasActivityId.bpmn" })
-  public void testHasActivityId_Success() {
+  @Deployment(resources = {"bpmn/ExternalTaskAssert-hasActivityId.bpmn"})
+  void hasActivityIdSuccess() {
     // When
     runtimeService().startProcessInstanceByKey("ExternalTaskAssert-hasActivityId");
     // Then
@@ -43,8 +42,8 @@ public class ExternalTaskAssertHasActivityIdTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ExternalTaskAssert-hasActivityId.bpmn" })
-  public void testHasActivityId_Failure() {
+  @Deployment(resources = {"bpmn/ExternalTaskAssert-hasActivityId.bpmn"})
+  void hasActivityIdFailure() {
     // When
     runtimeService().startProcessInstanceByKey("ExternalTaskAssert-hasActivityId");
     // Then
@@ -54,8 +53,8 @@ public class ExternalTaskAssertHasActivityIdTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ExternalTaskAssert-hasActivityId.bpmn" })
-  public void testHasActivityId_Error_Null() {
+  @Deployment(resources = {"bpmn/ExternalTaskAssert-hasActivityId.bpmn"})
+  void hasActivityIdErrorNull() {
     // When
     runtimeService().startProcessInstanceByKey("ExternalTaskAssert-hasActivityId");
     // Then

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ExternalTaskAssertHasActivityIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ExternalTaskAssertHasActivityIdTest.java
@@ -16,19 +16,18 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.externalTaskQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ProcessEngineExtension.class)
 public class ExternalTaskAssertHasActivityIdTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ExternalTaskAssert-hasActivityId.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ExternalTaskAssertHasActivityIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ExternalTaskAssertHasActivityIdTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ProcessEngineExtension.class)
-public class ExternalTaskAssertHasActivityIdTest extends ProcessAssertTestCase {
+class ExternalTaskAssertHasActivityIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ExternalTaskAssert-hasActivityId.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ExternalTaskAssertHasTopicNameTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ExternalTaskAssertHasTopicNameTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class ExternalTaskAssertHasTopicNameTest extends ProcessAssertTestCase {
+class ExternalTaskAssertHasTopicNameTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ExternalTaskAssert-hasTopicName.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ExternalTaskAssertHasTopicNameTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ExternalTaskAssertHasTopicNameTest.java
@@ -19,12 +19,11 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.externalTaskQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ExternalTaskAssertHasTopicNameTest extends ProcessAssertTestCase {
 
@@ -32,8 +31,8 @@ public class ExternalTaskAssertHasTopicNameTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "bpmn/ExternalTaskAssert-hasTopicName.bpmn" })
-  public void testHasTopicName_Success() {
+  @Deployment(resources = {"bpmn/ExternalTaskAssert-hasTopicName.bpmn"})
+  void hasTopicNameSuccess() {
     // When
     runtimeService().startProcessInstanceByKey("ExternalTaskAssert-hasTopicName");
     // Then
@@ -43,8 +42,8 @@ public class ExternalTaskAssertHasTopicNameTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ExternalTaskAssert-hasTopicName.bpmn" })
-  public void testHasTopicName_Failure() {
+  @Deployment(resources = {"bpmn/ExternalTaskAssert-hasTopicName.bpmn"})
+  void hasTopicNameFailure() {
     // When
     runtimeService().startProcessInstanceByKey("ExternalTaskAssert-hasTopicName");
     // Then
@@ -54,8 +53,8 @@ public class ExternalTaskAssertHasTopicNameTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ExternalTaskAssert-hasTopicName.bpmn" })
-  public void testHasTopicName_Error_Null() {
+  @Deployment(resources = {"bpmn/ExternalTaskAssert-hasTopicName.bpmn"})
+  void hasTopicNameErrorNull() {
     // When
     runtimeService().startProcessInstanceByKey("ExternalTaskAssert-hasTopicName");
     // Then

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ExternalTaskAssertHasTopicNameTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ExternalTaskAssertHasTopicNameTest.java
@@ -16,19 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.externalTaskQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class ExternalTaskAssertHasTopicNameTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ExternalTaskAssert-hasTopicName.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasActivityIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasActivityIdTest.java
@@ -25,7 +25,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class JobAssertHasActivityIdTest extends ProcessAssertTestCase {
+class JobAssertHasActivityIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasActivityId.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasActivityIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasActivityIdTest.java
@@ -16,20 +16,16 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.job;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class JobAssertHasActivityIdTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasActivityId.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasActivityIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasActivityIdTest.java
@@ -19,13 +19,12 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.job;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class JobAssertHasActivityIdTest extends ProcessAssertTestCase {
 
@@ -35,7 +34,7 @@ public class JobAssertHasActivityIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasActivityId.bpmn"
   })
-  public void testHasActivityId_Success() {
+  void hasActivityIdSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "JobAssert-hasActivityId"
@@ -51,7 +50,7 @@ public class JobAssertHasActivityIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasActivityId.bpmn"
   })
-  public void testHasActivityId_Failure() {
+  void hasActivityIdFailure() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "JobAssert-hasActivityId"
@@ -67,7 +66,7 @@ public class JobAssertHasActivityIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasActivityId.bpmn"
   })
-  public void testHasActivityId_Error_Null() {
+  void hasActivityIdErrorNull() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "JobAssert-hasActivityId"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasDeploymentIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasDeploymentIdTest.java
@@ -22,7 +22,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class JobAssertHasDeploymentIdTest extends ProcessAssertTestCase {
+class JobAssertHasDeploymentIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasDeploymentId.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasDeploymentIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasDeploymentIdTest.java
@@ -16,21 +16,13 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processDefinitionQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processInstanceQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class JobAssertHasDeploymentIdTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasDeploymentId.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasDeploymentIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasDeploymentIdTest.java
@@ -21,12 +21,11 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQue
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processDefinitionQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processInstanceQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class JobAssertHasDeploymentIdTest extends ProcessAssertTestCase {
 
@@ -36,7 +35,7 @@ public class JobAssertHasDeploymentIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasDeploymentId.bpmn"
   })
-  public void testHasDeploymentId_Success() {
+  void hasDeploymentIdSuccess() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasDeploymentId"
@@ -50,7 +49,7 @@ public class JobAssertHasDeploymentIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasDeploymentId.bpmn"
   })
-  public void testHasDeploymentId_Failure() {
+  void hasDeploymentIdFailure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasDeploymentId"
@@ -64,7 +63,7 @@ public class JobAssertHasDeploymentIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasDeploymentId.bpmn"
   })
-  public void testHasDeploymentId_Error_Null() {
+  void hasDeploymentIdErrorNull() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasDeploymentId"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasDueDateTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasDueDateTest.java
@@ -16,20 +16,16 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
+import org.operaton.bpm.engine.impl.calendar.DateTimeUtil;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.impl.calendar.DateTimeUtil;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class JobAssertHasDueDateTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasDueDate.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasDueDateTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasDueDateTest.java
@@ -25,7 +25,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class JobAssertHasDueDateTest extends ProcessAssertTestCase {
+class JobAssertHasDueDateTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasDueDate.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasDueDateTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasDueDateTest.java
@@ -19,13 +19,12 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.impl.calendar.DateTimeUtil;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class JobAssertHasDueDateTest extends ProcessAssertTestCase {
 
@@ -35,7 +34,7 @@ public class JobAssertHasDueDateTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasDueDate.bpmn"
   })
-  public void testHasDueDate_Success() {
+  void hasDueDateSuccess() {
     // When
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasDueDate"
@@ -49,7 +48,7 @@ public class JobAssertHasDueDateTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasDueDate.bpmn"
   })
-  public void testHasDueDate_Failure() {
+  void hasDueDateFailure() {
     // When
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasDueDate"
@@ -63,7 +62,7 @@ public class JobAssertHasDueDateTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasDueDate.bpmn"
   })
-  public void testHasDueDate_Error_Null() {
+  void hasDueDateErrorNull() {
     // When
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasDueDate"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasExceptionMessageTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasExceptionMessageTest.java
@@ -16,22 +16,16 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.assertj.core.api.Assertions.fail;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.managementService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.fail;
 
 public class JobAssertHasExceptionMessageTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasExceptionMessage.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasExceptionMessageTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasExceptionMessageTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.fail;
 
-public class JobAssertHasExceptionMessageTest extends ProcessAssertTestCase {
+class JobAssertHasExceptionMessageTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasExceptionMessage.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasExceptionMessageTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasExceptionMessageTest.java
@@ -21,13 +21,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.managementService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class JobAssertHasExceptionMessageTest extends ProcessAssertTestCase {
 
@@ -37,7 +36,7 @@ public class JobAssertHasExceptionMessageTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasExceptionMessage.bpmn"
   })
-  public void testHasExceptionMessage_Success() {
+  void hasExceptionMessageSuccess() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasExceptionMessage"
@@ -58,7 +57,7 @@ public class JobAssertHasExceptionMessageTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasExceptionMessage.bpmn"
   })
-  public void testHasExceptionMessage_Failure() {
+  void hasExceptionMessageFailure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasExceptionMessage"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasExecutionIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasExecutionIdTest.java
@@ -16,19 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class JobAssertHasExecutionIdTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasExecutionId.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasExecutionIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasExecutionIdTest.java
@@ -19,12 +19,11 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class JobAssertHasExecutionIdTest extends ProcessAssertTestCase {
 
@@ -34,7 +33,7 @@ public class JobAssertHasExecutionIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasExecutionId.bpmn"
   })
-  public void testHasExecutionId_Success() {
+  void hasExecutionIdSuccess() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasExecutionId"
@@ -48,7 +47,7 @@ public class JobAssertHasExecutionIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasExecutionId.bpmn"
   })
-  public void testHasExecutionId_Failure() {
+  void hasExecutionIdFailure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasExecutionId"
@@ -62,7 +61,7 @@ public class JobAssertHasExecutionIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasExecutionId.bpmn"
   })
-  public void testHasExecutionId_Error_Null() {
+  void hasExecutionIdErrorNull() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasExecutionId"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasExecutionIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasExecutionIdTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class JobAssertHasExecutionIdTest extends ProcessAssertTestCase {
+class JobAssertHasExecutionIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasExecutionId.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasIdTest.java
@@ -19,12 +19,11 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class JobAssertHasIdTest extends ProcessAssertTestCase {
 
@@ -34,7 +33,7 @@ public class JobAssertHasIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasId.bpmn"
   })
-  public void testHasId_Success() {
+  void hasIdSuccess() {
     // When
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasId"
@@ -48,7 +47,7 @@ public class JobAssertHasIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasId.bpmn"
   })
-  public void testHasId_Failure() {
+  void hasIdFailure() {
     // When
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasId"
@@ -62,7 +61,7 @@ public class JobAssertHasIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasId.bpmn"
   })
-  public void testHasId_Error_Null() {
+  void hasIdErrorNull() {
     // When
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasId"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasIdTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class JobAssertHasIdTest extends ProcessAssertTestCase {
+class JobAssertHasIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasId.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasIdTest.java
@@ -16,19 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class JobAssertHasIdTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasId.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasProcessInstanceIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasProcessInstanceIdTest.java
@@ -25,7 +25,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class JobAssertHasProcessInstanceIdTest extends ProcessAssertTestCase {
+class JobAssertHasProcessInstanceIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasProcessInstanceId.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasProcessInstanceIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasProcessInstanceIdTest.java
@@ -16,20 +16,16 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class JobAssertHasProcessInstanceIdTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasProcessInstanceId.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasProcessInstanceIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasProcessInstanceIdTest.java
@@ -19,13 +19,12 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class JobAssertHasProcessInstanceIdTest extends ProcessAssertTestCase {
 
@@ -35,7 +34,7 @@ public class JobAssertHasProcessInstanceIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasProcessInstanceId.bpmn"
   })
-  public void testHasProcessInstanceId_Success() {
+  void hasProcessInstanceIdSuccess() {
     // When
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "JobAssert-hasProcessInstanceId"
@@ -49,7 +48,7 @@ public class JobAssertHasProcessInstanceIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasProcessInstanceId.bpmn"
   })
-  public void testHasProcessInstanceId_Failure() {
+  void hasProcessInstanceIdFailure() {
     // When
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasProcessInstanceId"
@@ -63,7 +62,7 @@ public class JobAssertHasProcessInstanceIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasProcessInstanceId.bpmn"
   })
-  public void testHasProcessInstanceId_Error_Null() {
+  void hasProcessInstanceIdErrorNull() {
     // When
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasProcessInstanceId"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasRetriesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasRetriesTest.java
@@ -16,19 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class JobAssertHasRetriesTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasRetries.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasRetriesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasRetriesTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class JobAssertHasRetriesTest extends ProcessAssertTestCase {
+class JobAssertHasRetriesTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasRetries.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasRetriesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/JobAssertHasRetriesTest.java
@@ -19,12 +19,11 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class JobAssertHasRetriesTest extends ProcessAssertTestCase {
 
@@ -34,7 +33,7 @@ public class JobAssertHasRetriesTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasRetries.bpmn"
   })
-  public void testHasRetries_Success() {
+  void hasRetriesSuccess() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasRetries"
@@ -48,7 +47,7 @@ public class JobAssertHasRetriesTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/JobAssert-hasRetries.bpmn"
   })
-  public void testHasRetries_Failure() {
+  void hasRetriesFailure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "JobAssert-hasRetries"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessDefinitionAssertHasActiveInstancesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessDefinitionAssertHasActiveInstancesTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessDefinitionAssertHasActiveInstancesTest extends ProcessAssertTestCase {
+class ProcessDefinitionAssertHasActiveInstancesTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessDefinitionAssert-hasActiveInstances.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessDefinitionAssertHasActiveInstancesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessDefinitionAssertHasActiveInstancesTest.java
@@ -21,14 +21,13 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.comple
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processDefinitionQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessDefinitionAssertHasActiveInstancesTest extends ProcessAssertTestCase {
 
@@ -38,7 +37,7 @@ public class ProcessDefinitionAssertHasActiveInstancesTest extends ProcessAssert
   @Test
   @Deployment(resources = {"bpmn/ProcessDefinitionAssert-hasActiveInstances.bpmn"
   })
-  public void testHasActiveInstances_One_Started_Success() {
+  void hasActiveInstancesOneStartedSuccess() {
     // Given
     final ProcessDefinition processDefinition =
       processDefinitionQuery().processDefinitionKey("ProcessDefinitionAssert-hasActiveInstances").singleResult();
@@ -53,7 +52,7 @@ public class ProcessDefinitionAssertHasActiveInstancesTest extends ProcessAssert
   @Test
   @Deployment(resources = {"bpmn/ProcessDefinitionAssert-hasActiveInstances.bpmn"
   })
-  public void testHasActiveInstances_One_Started_Failure() {
+  void hasActiveInstancesOneStartedFailure() {
     // Given
     final ProcessDefinition processDefinition =
       processDefinitionQuery().processDefinitionKey("ProcessDefinitionAssert-hasActiveInstances").singleResult();
@@ -70,7 +69,7 @@ public class ProcessDefinitionAssertHasActiveInstancesTest extends ProcessAssert
   @Test
   @Deployment(resources = {"bpmn/ProcessDefinitionAssert-hasActiveInstances.bpmn"
   })
-  public void testHasActiveInstances_Two_Started_Success() {
+  void hasActiveInstancesTwoStartedSuccess() {
     // Given
     final ProcessDefinition processDefinition =
       processDefinitionQuery().processDefinitionKey("ProcessDefinitionAssert-hasActiveInstances").singleResult();
@@ -89,7 +88,7 @@ public class ProcessDefinitionAssertHasActiveInstancesTest extends ProcessAssert
   @Test
   @Deployment(resources = {"bpmn/ProcessDefinitionAssert-hasActiveInstances.bpmn"
   })
-  public void testHasActiveInstances_Two_Started_Failure() {
+  void hasActiveInstancesTwoStartedFailure() {
     // Given
     final ProcessDefinition processDefinition =
       processDefinitionQuery().processDefinitionKey("ProcessDefinitionAssert-hasActiveInstances").singleResult();
@@ -112,7 +111,7 @@ public class ProcessDefinitionAssertHasActiveInstancesTest extends ProcessAssert
   @Test
   @Deployment(resources = {"bpmn/ProcessDefinitionAssert-hasActiveInstances.bpmn"
   })
-  public void testHasActiveInstances_Two_Started_One_Ended_Success() {
+  void hasActiveInstancesTwoStartedOneEndedSuccess() {
     // Given
     final ProcessDefinition processDefinition =
       processDefinitionQuery().processDefinitionKey("ProcessDefinitionAssert-hasActiveInstances").singleResult();
@@ -133,7 +132,7 @@ public class ProcessDefinitionAssertHasActiveInstancesTest extends ProcessAssert
   @Test
   @Deployment(resources = {"bpmn/ProcessDefinitionAssert-hasActiveInstances.bpmn"
   })
-  public void testHasActiveInstances_Two_Started_One_Ended_Failure() {
+  void hasActiveInstancesTwoStartedOneEndedFailure() {
     // Given
     final ProcessDefinition processDefinition =
       processDefinitionQuery().processDefinitionKey("ProcessDefinitionAssert-hasActiveInstances").singleResult();

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessDefinitionAssertHasActiveInstancesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessDefinitionAssertHasActiveInstancesTest.java
@@ -16,23 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processDefinitionQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessDefinitionAssertHasActiveInstancesTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessDefinitionAssert-hasActiveInstances.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCalledProcessInstanceTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCalledProcessInstanceTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.fail;
 
-public class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTestCase {
+class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess2.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCalledProcessInstanceTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCalledProcessInstanceTest.java
@@ -16,20 +16,19 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
+import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.calledProcessInstance;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processInstanceQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import static org.junit.Assert.fail;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTestCase {
 
@@ -39,7 +38,7 @@ public class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstanceNoArgs_CalledTooEarly_Failure() {
+  void calledProcessInstanceNoArgsCalledTooEarlyFailure() {
     // Given
     final String processDefinitionKey = "ProcessEngineTests-calledProcessInstance-superProcess1";
     runtimeService().startProcessInstanceByKey(processDefinitionKey);
@@ -50,7 +49,7 @@ public class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstanceArgProcessInstance_CalledTooEarly_Success() {
+  void calledProcessInstanceArgProcessInstanceCalledTooEarlySuccess() {
     // Given
     final String processDefinitionKey = "ProcessEngineTests-calledProcessInstance-superProcess1";
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(processDefinitionKey);
@@ -61,7 +60,7 @@ public class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstanceArgProcessInstanceQuery_CalledTooEarly_Failure() {
+  void calledProcessInstanceArgProcessInstanceQueryCalledTooEarlyFailure() {
     // Given
     final String processDefinitionKey = "ProcessEngineTests-calledProcessInstance-superProcess1";
     runtimeService().startProcessInstanceByKey(processDefinitionKey);
@@ -72,7 +71,7 @@ public class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstanceArgProcessDefinitionKey_CalledTooEarly_Failure() {
+  void calledProcessInstanceArgProcessDefinitionKeyCalledTooEarlyFailure() {
     // Given
     final String processDefinitionKey = "ProcessEngineTests-calledProcessInstance-superProcess1";
     runtimeService().startProcessInstanceByKey(processDefinitionKey);
@@ -83,7 +82,7 @@ public class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstanceArgProcessDefinitionKeyAndProcessInstance_CalledTooEarly_Success() {
+  void calledProcessInstanceArgProcessDefinitionKeyAndProcessInstanceCalledTooEarlySuccess() {
     // Given
     final String processDefinitionKey = "ProcessEngineTests-calledProcessInstance-superProcess1";
     final String subProcessDefinitionKey = "ProcessEngineTests-calledProcessInstance-subProcess1";
@@ -95,7 +94,7 @@ public class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstanceArgProcessInstanceQueryAndProcessInstance_CalledTooEarly_Success() {
+  void calledProcessInstanceArgProcessInstanceQueryAndProcessInstanceCalledTooEarlySuccess() {
     // Given
     final String processDefinitionKey = "ProcessEngineTests-calledProcessInstance-superProcess1";
     final String subProcessDefinitionKey = "ProcessEngineTests-calledProcessInstance-subProcess1";
@@ -117,7 +116,7 @@ public class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstance_FirstOfTwoSequential_Success() {
+  void calledProcessInstanceFirstOfTwoSequentialSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-calledProcessInstance-superProcess1"
@@ -154,7 +153,7 @@ public class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstance_SecondOfTwoSequential_Success() {
+  void calledProcessInstanceSecondOfTwoSequentialSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-calledProcessInstance-superProcess1"
@@ -193,7 +192,7 @@ public class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstance_SecondOfTwoSequential_Failure() {
+  void calledProcessInstanceSecondOfTwoSequentialFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-calledProcessInstance-superProcess1"
@@ -226,7 +225,7 @@ public class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-calledProcessInstance-superProcess2.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstance_TwoOfTwoParallel_Success() {
+  void calledProcessInstanceTwoOfTwoParallelSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-calledProcessInstance-superProcess2"
@@ -248,7 +247,7 @@ public class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-calledProcessInstance-superProcess2.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstance_TwoOfTwoParallel_Failure() {
+  void calledProcessInstanceTwoOfTwoParallelFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-calledProcessInstance-superProcess2"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCalledProcessInstanceTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCalledProcessInstanceTest.java
@@ -16,24 +16,16 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.assertj.core.api.Assertions.fail;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.calledProcessInstance;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processInstanceQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.fail;
 
 public class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessEngineTests-calledProcessInstance-subProcess2.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsClaimTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsClaimTest.java
@@ -16,21 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.claim;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessEngineTestsClaimTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-claim.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsClaimTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsClaimTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessEngineTestsClaimTest extends ProcessAssertTestCase {
+class ProcessEngineTestsClaimTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-claim.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsClaimTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsClaimTest.java
@@ -20,13 +20,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.claim;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessEngineTestsClaimTest extends ProcessAssertTestCase {
 
@@ -36,7 +35,7 @@ public class ProcessEngineTestsClaimTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-claim.bpmn"
   })
-  public void testClaim_Success() {
+  void claimSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-claim"
@@ -50,7 +49,7 @@ public class ProcessEngineTestsClaimTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-claim.bpmn"
   })
-  public void testClaimNoTask_Failure() {
+  void claimNoTaskFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-claim"
@@ -62,7 +61,7 @@ public class ProcessEngineTestsClaimTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-claim.bpmn"
   })
-  public void testClaimNoUser_Failure() {
+  void claimNoUserFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-claim"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCompleteExternalTaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCompleteExternalTaskTest.java
@@ -16,7 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.operaton.bpm.engine.ProcessEngineException;
+import org.operaton.bpm.engine.exception.NotFoundException;
+import org.operaton.bpm.engine.externaltask.ExternalTask;
+import org.operaton.bpm.engine.externaltask.LockedExternalTask;
+import org.operaton.bpm.engine.history.HistoricExternalTaskLog;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.DEFAULT_WORKER_EXTERNAL_TASK;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
@@ -29,22 +36,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVa
 
 import java.util.Collections;
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.exception.NotFoundException;
-import org.operaton.bpm.engine.externaltask.ExternalTask;
-import org.operaton.bpm.engine.externaltask.LockedExternalTask;
-import org.operaton.bpm.engine.history.HistoricExternalTaskLog;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCompleteExternalTaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCompleteExternalTaskTest.java
@@ -29,7 +29,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVa
 
 import java.util.Collections;
 import java.util.List;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.exception.NotFoundException;
 import org.operaton.bpm.engine.externaltask.ExternalTask;
@@ -40,7 +40,6 @@ import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTestCase {
 
@@ -48,8 +47,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-completeExternalTask.bpmn" })
-  public void testComplete_TaskOnly_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})
+  void completeTaskOnlySuccess() {
     // Given
     ProcessInstance processInstance = getProcessInstanceStarted();
     assertThat(processInstance).hasNotPassed("ExternalTask_1");
@@ -63,8 +62,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-completeExternalTask.bpmn" })
-  public void testComplete_TaskOnly_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})
+  void completeTaskOnlyFailure() {
     // Given
     final ProcessInstance processInstance = getProcessInstanceStarted();
     // And
@@ -76,8 +75,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-completeExternalTask.bpmn" })
-  public void testComplete_NullTaskOnly_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})
+  void completeNullTaskOnlyFailure() {
     // Given
     getProcessInstanceStarted();
     // Then
@@ -85,8 +84,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-completeExternalTask.bpmn" })
-  public void testComplete_TaskOnlyMultiplePerTopic_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})
+  void completeTaskOnlyMultiplePerTopicFailure() {
     // Given
     final ProcessInstance processInstance = getProcessInstanceStarted();
     getProcessInstanceStarted();
@@ -101,8 +100,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-completeExternalTask.bpmn" })
-  public void testComplete_WithVariables_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})
+  void completeWithVariablesSuccess() {
     // Given
     ProcessInstance processInstance = getProcessInstanceStarted();
     // When
@@ -114,8 +113,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-completeExternalTask.bpmn" })
-  public void testComplete_WithVariables_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})
+  void completeWithVariablesFailure() {
     // Given
     final ProcessInstance processInstance = getProcessInstanceStarted();
     // And
@@ -127,8 +126,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-completeExternalTask.bpmn" })
-  public void testComplete_WithVariablesNullTask_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})
+  void completeWithVariablesNullTaskFailure() {
     // Given
     getProcessInstanceStarted();
     // Then
@@ -136,8 +135,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-completeExternalTask.bpmn" })
-  public void testComplete_WithNullVariables_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})
+  void completeWithNullVariablesFailure() {
     // Given
     final ProcessInstance processInstance = getProcessInstanceStarted();
     // And
@@ -147,8 +146,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-completeExternalTask.bpmn" })
-  public void testComplete_LockedTask_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})
+  void completeLockedTaskSuccess() {
     // Given
     ProcessInstance processInstance = getProcessInstanceStarted();
     assertThat(processInstance).hasNotPassed("ExternalTask_1");
@@ -165,8 +164,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-completeExternalTask.bpmn" })
-  public void testComplete_LockedTask_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})
+  void completeLockedTaskFailure() {
     // Given
     final ProcessInstance processInstance = getProcessInstanceStarted();
     // And
@@ -180,8 +179,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-completeExternalTask.bpmn" })
-  public void testComplete_NullLockedTask_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})
+  void completeNullLockedTaskFailure() {
     // Given
     getProcessInstanceStarted();
     // Then
@@ -189,8 +188,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-completeExternalTask.bpmn" })
-  public void testComplete_LockedTaskWithVariables_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})
+  void completeLockedTaskWithVariablesSuccess() {
     // Given
     ProcessInstance processInstance = getProcessInstanceStarted();
     assertThat(processInstance).hasNotPassed("ExternalTask_1");
@@ -207,8 +206,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-completeExternalTask.bpmn" })
-  public void testComplete_LockedTaskWithVariables_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})
+  void completeLockedTaskWithVariablesFailure() {
     // Given
     final ProcessInstance processInstance = getProcessInstanceStarted();
     // And
@@ -222,8 +221,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-completeExternalTask.bpmn" })
-  public void testComplete_NullLockedTaskWithVariables_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})
+  void completeNullLockedTaskWithVariablesFailure() {
     // Given
     getProcessInstanceStarted();
     // Then
@@ -231,8 +230,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-completeExternalTask.bpmn" })
-  public void testComplete_LockedTaskWithNullVariables_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})
+  void completeLockedTaskWithNullVariablesFailure() {
     // Given
     ProcessInstance processInstance = getProcessInstanceStarted();
     // And
@@ -245,8 +244,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ExternalTaskAssert-localVariables.bpmn" })
-  public void testComplete_LockedTaskWithLocalVariables_Success() {
+  @Deployment(resources = {"bpmn/ExternalTaskAssert-localVariables.bpmn"})
+  void completeLockedTaskWithLocalVariablesSuccess() {
     // Given
     ProcessInstance pi = runtimeService().startProcessInstanceByKey("ExternalTaskAssert-localVariables");
 
@@ -271,8 +270,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ExternalTaskAssert-localVariables.bpmn" })
-  public void testComplete_LockedTaskWithLocalVariables_Failure() {
+  @Deployment(resources = {"bpmn/ExternalTaskAssert-localVariables.bpmn"})
+  void completeLockedTaskWithLocalVariablesFailure() {
     // Given
     runtimeService().startProcessInstanceByKey("ExternalTaskAssert-localVariables");
 
@@ -288,8 +287,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ExternalTaskAssert-localVariables.bpmn" })
-  public void testCompleteTaskWithLocalVariables_Success() {
+  @Deployment(resources = {"bpmn/ExternalTaskAssert-localVariables.bpmn"})
+  void completeTaskWithLocalVariablesSuccess() {
     // Given
     ProcessInstance pi = runtimeService().startProcessInstanceByKey("ExternalTaskAssert-localVariables");
 
@@ -311,8 +310,8 @@ public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTes
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ExternalTaskAssert-localVariables.bpmn" })
-  public void testCompleteTaskWithoutLocalVariables_Failure() {
+  @Deployment(resources = {"bpmn/ExternalTaskAssert-localVariables.bpmn"})
+  void completeTaskWithoutLocalVariablesFailure() {
     // Given
     runtimeService().startProcessInstanceByKey("ExternalTaskAssert-localVariables");
 

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCompleteExternalTaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCompleteExternalTaskTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTestCase {
+class ProcessEngineTestsCompleteExternalTaskTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-completeExternalTask.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCompleteTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCompleteTest.java
@@ -21,7 +21,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.comple
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVariables;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
@@ -29,7 +29,6 @@ import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessEngineTestsCompleteTest extends ProcessAssertTestCase {
 
@@ -39,7 +38,7 @@ public class ProcessEngineTestsCompleteTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-complete.bpmn"
   })
-  public void testComplete_Success() {
+  void completeSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-complete"
@@ -53,7 +52,7 @@ public class ProcessEngineTestsCompleteTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-complete.bpmn"
   })
-  public void testComplete_Failure() {
+  void completeFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-complete"
@@ -69,7 +68,7 @@ public class ProcessEngineTestsCompleteTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-complete.bpmn"
   })
-  public void testComplete_WithVariables_Success() {
+  void completeWithVariablesSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-complete"
@@ -83,7 +82,7 @@ public class ProcessEngineTestsCompleteTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-complete.bpmn"
   })
-  public void testComplete_WithVariables_Failure() {
+  void completeWithVariablesFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-complete"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCompleteTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCompleteTest.java
@@ -28,7 +28,7 @@ import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 
-public class ProcessEngineTestsCompleteTest extends ProcessAssertTestCase {
+class ProcessEngineTestsCompleteTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-complete.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCompleteTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCompleteTest.java
@@ -26,14 +26,9 @@ import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class ProcessEngineTestsCompleteTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-complete.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsExecuteTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsExecuteTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.execute;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.job;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessEngineTestsExecuteTest extends ProcessAssertTestCase {
 
@@ -37,7 +36,7 @@ public class ProcessEngineTestsExecuteTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-execute.bpmn"
   })
-  public void testExecute_Success() {
+  void executeSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-execute"
@@ -57,7 +56,7 @@ public class ProcessEngineTestsExecuteTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-execute.bpmn"
   })
-  public void testExecute_Failure() {
+  void executeFailure() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-execute"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsExecuteTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsExecuteTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessEngineTestsExecuteTest extends ProcessAssertTestCase {
+class ProcessEngineTestsExecuteTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-execute.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsExecuteTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsExecuteTest.java
@@ -16,22 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.execute;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.job;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessEngineTestsExecuteTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-execute.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsExternalTaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsExternalTaskTest.java
@@ -22,14 +22,13 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.extern
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.externalTaskQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
 
@@ -40,8 +39,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_OnlyActivity_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // And
@@ -53,8 +52,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_OnlyActivity_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskOnlyActivityFailure() {
     // Given
     runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // Then
@@ -62,8 +61,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_TwoActivities_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskTwoActivitiesSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // When
@@ -75,8 +74,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_TwoActivities_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskTwoActivitiesFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // And
@@ -90,8 +89,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_ActivityId_OnlyActivity_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskActivityIdOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // And
@@ -103,8 +102,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_ActivityId_OnlyActivity_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskActivityIdOnlyActivityFailure() {
     // Given
     runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // Then
@@ -112,8 +111,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_ActivityId_TwoActivities_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskActivityIdTwoActivitiesSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // And
@@ -128,8 +127,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_taskQuery_OnlyActivity_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskTaskQueryOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // And
@@ -141,8 +140,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_taskQuery_OnlyActivity_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskTaskQueryOnlyActivityFailure() {
     // Given
     runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // Then
@@ -150,8 +149,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_taskQuery_TwoActivities_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskTaskQueryTwoActivitiesSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // And
@@ -166,8 +165,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_taskQuery_TwoActivities_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskTaskQueryTwoActivitiesFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // And
@@ -181,8 +180,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_processInstance_OnlyActivity_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskProcessInstanceOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // And
@@ -192,8 +191,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_processInstance_TwoActivities_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskProcessInstanceTwoActivitiesFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // And
@@ -205,8 +204,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_ActivityId_processInstance_OnlyActivity_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskActivityIdProcessInstanceOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // And
@@ -216,8 +215,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_ActivityId_processInstance_TwoActivities_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskActivityIdProcessInstanceTwoActivitiesSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // And
@@ -231,8 +230,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_taskQuery_processInstance_OnlyActivity_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskTaskQueryProcessInstanceOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // And
@@ -242,8 +241,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_taskQuery_processInstance_TwoActivities_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskTaskQueryProcessInstanceTwoActivitiesSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // And
@@ -257,8 +256,8 @@ public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-externalTask.bpmn" })
-  public void testTask_taskQuery_processInstance_TwoActivities_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})
+  void taskTaskQueryProcessInstanceTwoActivitiesFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("ProcessEngineTests-externalTask");
     // And

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsExternalTaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsExternalTaskTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
+class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
 
   private static final String EXTERNAL_TASK_3 = "ExternalTask_3";
   private static final String EXTERNAL_TASK_2 = "ExternalTask_2";

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsExternalTaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsExternalTaskTest.java
@@ -16,27 +16,19 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.externalTask;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.externalTaskQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessEngineTestsExternalTaskTest extends ProcessAssertTestCase {
 
   private static final String EXTERNAL_TASK_3 = "ExternalTask_3";
   private static final String EXTERNAL_TASK_2 = "ExternalTask_2";
   private static final String EXTERNAL_TASK_1 = "ExternalTask_1";
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-externalTask.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsFetchAndLockTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsFetchAndLockTest.java
@@ -22,14 +22,13 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.fetchA
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 
 import java.util.List;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.externaltask.LockedExternalTask;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessEngineTestsFetchAndLockTest extends ProcessAssertTestCase {
 
@@ -37,8 +36,8 @@ public class ProcessEngineTestsFetchAndLockTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-fetchAndLock.bpmn" })
-  public void testFetchAndLock_Success() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-fetchAndLock.bpmn"})
+  void fetchAndLockSuccess() {
     // Given
     getProcessInstanceStarted();
     // When
@@ -50,8 +49,8 @@ public class ProcessEngineTestsFetchAndLockTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-fetchAndLock.bpmn" })
-  public void testFetchAndLock_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-fetchAndLock.bpmn"})
+  void fetchAndLockFailure() {
     // Given
     getProcessInstanceStarted();
     // When
@@ -61,8 +60,8 @@ public class ProcessEngineTestsFetchAndLockTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-fetchAndLock.bpmn" })
-  public void testFetchAndLock_NullTopic_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-fetchAndLock.bpmn"})
+  void fetchAndLockNullTopicFailure() {
     // Given
     getProcessInstanceStarted();
     // Then
@@ -70,8 +69,8 @@ public class ProcessEngineTestsFetchAndLockTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessEngineTests-fetchAndLock.bpmn" })
-  public void testFetchAndLock_NullWorker_Failure() {
+  @Deployment(resources = {"bpmn/ProcessEngineTests-fetchAndLock.bpmn"})
+  void fetchAndLockNullWorkerFailure() {
     // Given
     getProcessInstanceStarted();
     // Then

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsFetchAndLockTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsFetchAndLockTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProcessEngineTestsFetchAndLockTest extends ProcessAssertTestCase {
+class ProcessEngineTestsFetchAndLockTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-fetchAndLock.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsFetchAndLockTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsFetchAndLockTest.java
@@ -16,24 +16,21 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.operaton.bpm.engine.externaltask.LockedExternalTask;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.DEFAULT_WORKER_EXTERNAL_TASK;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.fetchAndLock;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.externaltask.LockedExternalTask;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProcessEngineTestsFetchAndLockTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-fetchAndLock.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsFindIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsFindIdTest.java
@@ -16,18 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.findId;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.findId;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = "bpmn/ProcessEngineTests-findTest.bpmn")

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsFindIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsFindIdTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
+class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = "bpmn/ProcessEngineTests-findTest.bpmn")

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsFindIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsFindIdTest.java
@@ -18,12 +18,11 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.findId;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
 
@@ -32,7 +31,7 @@ public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = "bpmn/ProcessEngineTests-findTest.bpmn")
-  public void testFindPlainTaskByName() {
+  void findPlainTaskByName() {
     // Given
     // Process model deployed
     // When
@@ -43,7 +42,7 @@ public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = "bpmn/ProcessEngineTests-findTest.bpmn")
-  public void testFindEndEventByName() {
+  void findEndEventByName() {
     // Given
     // Process model deployed
     // When
@@ -54,7 +53,7 @@ public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = "bpmn/ProcessEngineTests-findTest.bpmn")
-  public void testFindAttachedEventByName() {
+  void findAttachedEventByName() {
     // Given
     // Process model deployed
     // When
@@ -65,7 +64,7 @@ public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = "bpmn/ProcessEngineTests-findTest.bpmn")
-  public void testFindGatewayByName() {
+  void findGatewayByName() {
     // Given
     // process model deployed
     // When
@@ -76,7 +75,7 @@ public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = "bpmn/ProcessEngineTests-findTest.bpmn")
-  public void testNameNotFound() {
+  void nameNotFound() {
     // Given
     // Process model deployed
     // When
@@ -87,7 +86,7 @@ public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = "bpmn/ProcessEngineTests-findTest.bpmn")
-  public void testNameNull() {
+  void nameNull() {
     // Given
     // Process model deployed
     // When
@@ -98,7 +97,7 @@ public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = "bpmn/ProcessEngineTests-findTest.bpmn")
-  public void testFindAllElements() {
+  void findAllElements() {
     // Given
     // Process model deployed
     // When
@@ -123,7 +122,7 @@ public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = "bpmn/ProcessEngineTests-findInTwoPools.bpmn")
-  public void testFindInTwoPoolsInPool1() {
+  void findInTwoPoolsInPool1() {
     // Given
     // Process model with two pools deployed
     // When
@@ -134,7 +133,7 @@ public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = "bpmn/ProcessEngineTests-findInTwoPools.bpmn")
-  public void testFindTwoPoolsInPool2() {
+  void findTwoPoolsInPool2() {
     // Given
     // Process model with two pools deployed
     // When
@@ -145,7 +144,7 @@ public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-findTest.bpmn", "bpmn/ProcessEngineTests-findInTwoPools.bpmn"})
-  public void testFindOneInEachOfTwoDiagrams() {
+  void findOneInEachOfTwoDiagrams() {
     // Given
     // Two process models deployed
     // When
@@ -164,7 +163,7 @@ public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = "bpmn/ProcessEngineTests-findDuplicateNames.bpmn")
-  public void testProcessWithDuplicateNames() {
+  void processWithDuplicateNames() {
     // Given
     // Process model with duplicate task names deployed
     // When
@@ -179,7 +178,7 @@ public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = "bpmn/ProcessEngineTests-findDuplicateNamesOnTaskAndGateway.bpmn")
-  public void testProcessWithDuplicateNamesOnDifferentElementsTypes() {
+  void processWithDuplicateNamesOnDifferentElementsTypes() {
     // Given
     // Process model with same name on task and gateway deployed
     // When
@@ -190,7 +189,7 @@ public class ProcessEngineTestsFindIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = "bpmn/ProcessEngineTests-findDuplicateNamesOnTaskAndGateway.bpmn")
-  public void testProcessWithDuplicateNamesBindTheUniqueOnly() {
+  void processWithDuplicateNamesBindTheUniqueOnly() {
     // Given
     // Process model with two pools and a mix of duplicate and unique names deployed
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsJobTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsJobTest.java
@@ -16,24 +16,16 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.execute;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.job;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.operaton.bpm.engine.test.mock.Mocks;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsJobTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsJobTest.java
@@ -25,7 +25,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
+class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsJobTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsJobTest.java
@@ -21,7 +21,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.execut
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.job;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
@@ -29,7 +29,6 @@ import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.operaton.bpm.engine.test.mock.Mocks;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
 
@@ -39,7 +38,7 @@ public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"
   })
-  public void testJob_OnlyActivity_Success() {
+  void jobOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-job"
@@ -57,7 +56,7 @@ public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"
   })
-  public void testJob_OnlyActivity_Failure() {
+  void jobOnlyActivityFailure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-job"
@@ -73,7 +72,7 @@ public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"
   })
-  public void testJob_TwoActivities_Failure() {
+  void jobTwoActivitiesFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-job"
@@ -95,7 +94,7 @@ public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"
   })
-  public void testJob_activityId_OnlyActivity_Success() {
+  void jobActivityIdOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-job"
@@ -113,7 +112,7 @@ public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"
   })
-  public void testJob_activityId_TwoActivities_Success() {
+  void jobActivityIdTwoActivitiesSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-job"
@@ -137,7 +136,7 @@ public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"
   })
-  public void testJob_activityId_OnlyActivity_Failure() {
+  void jobActivityIdOnlyActivityFailure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-job"
@@ -153,7 +152,7 @@ public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"
   })
-  public void testJob_jobQuery_OnlyActivity_Success() {
+  void jobJobQueryOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-job"
@@ -171,7 +170,7 @@ public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"
   })
-  public void testJob_jobQuery_OnlyActivity_Failure() {
+  void jobJobQueryOnlyActivityFailure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-job"
@@ -187,7 +186,7 @@ public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"
   })
-  public void testJob_jobQuery_TwoActivities_Failure() {
+  void jobJobQueryTwoActivitiesFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-job"
@@ -209,7 +208,7 @@ public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"
   })
-  public void testJob_processInstance_OnlyActivity_Success() {
+  void jobProcessInstanceOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-job"
@@ -225,7 +224,7 @@ public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"
   })
-  public void testJob_TwoActivities_processInstance_Failure() {
+  void jobTwoActivitiesProcessInstanceFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-job"
@@ -245,7 +244,7 @@ public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"
   })
-  public void testJob_jobDefinitionKey_processInstance_OnlyActivity_Success() {
+  void jobJobDefinitionKeyProcessInstanceOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-job"
@@ -261,7 +260,7 @@ public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"
   })
-  public void testJob_jobDefinitionKey_processInstance_TwoActivities_Success() {
+  void jobJobDefinitionKeyProcessInstanceTwoActivitiesSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-job"
@@ -283,7 +282,7 @@ public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"
   })
-  public void testJob_jobQuery_processInstance_OnlyActivity_Success() {
+  void jobJobQueryProcessInstanceOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-job"
@@ -299,7 +298,7 @@ public class ProcessEngineTestsJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-job.bpmn"
   })
-  public void testJob_jobQuery_processInstance_TwoActivities_Failure() {
+  void jobJobQueryProcessInstanceTwoActivitiesFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-job"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsProcessDefinitionTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsProcessDefinitionTest.java
@@ -23,14 +23,13 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.proces
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processDefinitionQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessEngineTestsProcessDefinitionTest extends ProcessAssertTestCase {
 
@@ -38,13 +37,13 @@ public class ProcessEngineTestsProcessDefinitionTest extends ProcessAssertTestCa
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  public void testProcessDefinition_No_Definition() {
+  void processDefinitionNoDefinition() {
     // Then
     expect(BpmnAwareTests::processDefinition, IllegalStateException.class);
   }
 
   @Test
-  public void testProcessDefinition_No_Definition_Via_ProcessDefinitionKey() {
+  void processDefinitionNoDefinitionViaProcessDefinitionKey() {
     // Then
     assertThat(processDefinition("nonExistingKey")).isNull();
   }
@@ -52,7 +51,7 @@ public class ProcessEngineTestsProcessDefinitionTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-processDefinition.bpmn"
   })
-  public void testProcessDefinition_One_Definition() {
+  void processDefinitionOneDefinition() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-processDefinition"
@@ -71,7 +70,7 @@ public class ProcessEngineTestsProcessDefinitionTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-processDefinition.bpmn"
   })
-  public void testProcessDefinition_One_Definition_Via_ProcessInstance() {
+  void processDefinitionOneDefinitionViaProcessInstance() {
     // When
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-processDefinition"
@@ -86,7 +85,7 @@ public class ProcessEngineTestsProcessDefinitionTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-processDefinition.bpmn"
   })
-  public void testProcessDefinition_One_Definition_Via_ProcessDefinitionKey() {
+  void processDefinitionOneDefinitionViaProcessDefinitionKey() {
     // When
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-processDefinition"
@@ -103,7 +102,7 @@ public class ProcessEngineTestsProcessDefinitionTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-processDefinition.bpmn"
   })
-  public void testProcessDefinition_One_Definition_Via_ProcessDefinitionQuery() {
+  void processDefinitionOneDefinitionViaProcessDefinitionQuery() {
     // When
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-processDefinition"
@@ -120,7 +119,7 @@ public class ProcessEngineTestsProcessDefinitionTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-processDefinition.bpmn"
   })
-  public void testProcessDefinition_One_Definition_Instance_Ended() {
+  void processDefinitionOneDefinitionInstanceEnded() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-processDefinition"
@@ -139,7 +138,7 @@ public class ProcessEngineTestsProcessDefinitionTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-processDefinition.bpmn", "bpmn/ProcessEngineTests-processDefinition2.bpmn"
   })
-  public void testProcessDefinition_Two_Definitions() {
+  void processDefinitionTwoDefinitions() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-processDefinition2"
@@ -159,7 +158,7 @@ public class ProcessEngineTestsProcessDefinitionTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-processDefinition.bpmn", "bpmn/ProcessEngineTests-processDefinition2.bpmn"
   })
-  public void testProcessDefinition_Two_Definitions_Via_ProcessInstance() {
+  void processDefinitionTwoDefinitionsViaProcessInstance() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-processDefinition"
@@ -183,7 +182,7 @@ public class ProcessEngineTestsProcessDefinitionTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-processDefinition.bpmn", "bpmn/ProcessEngineTests-processDefinition2.bpmn"
   })
-  public void testProcessDefinition_Two_Definitions_Via_ProcessDefinitionKey() {
+  void processDefinitionTwoDefinitionsViaProcessDefinitionKey() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-processDefinition"
@@ -209,7 +208,7 @@ public class ProcessEngineTestsProcessDefinitionTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-processDefinition.bpmn", "bpmn/ProcessEngineTests-processDefinition2.bpmn"
   })
-  public void testProcessDefinition_Two_Definitions_Via_ProcessDefinitionQuery() {
+  void processDefinitionTwoDefinitionsViaProcessDefinitionQuery() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-processDefinition"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsProcessDefinitionTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsProcessDefinitionTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProcessEngineTestsProcessDefinitionTest extends ProcessAssertTestCase {
+class ProcessEngineTestsProcessDefinitionTest extends ProcessAssertTestCase {
 
   @Test
   void processDefinitionNoDefinition() {

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsProcessDefinitionTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsProcessDefinitionTest.java
@@ -16,25 +16,22 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.operaton.bpm.engine.ProcessEngineException;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processDefinition;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processDefinitionQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProcessEngineTestsProcessDefinitionTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   void processDefinitionNoDefinition() {

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsTaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsTaskTest.java
@@ -16,23 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsTaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsTaskTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
+class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsTaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsTaskTest.java
@@ -21,14 +21,13 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.comple
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
 
@@ -38,7 +37,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_OnlyActivity_Success() {
+  void taskOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -56,7 +55,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_OnlyActivity_Failure() {
+  void taskOnlyActivityFailure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -72,7 +71,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_TwoActivities_Failure() {
+  void taskTwoActivitiesFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -92,7 +91,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_taskDefinitionKey_OnlyActivity_Success() {
+  void taskTaskDefinitionKeyOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -110,7 +109,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_taskDefinitionKey_TwoActivities_Success() {
+  void taskTaskDefinitionKeyTwoActivitiesSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -131,7 +130,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_taskDefinitionKey_OnlyActivity_Failure() {
+  void taskTaskDefinitionKeyOnlyActivityFailure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -147,7 +146,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_taskQuery_OnlyActivity_Success() {
+  void taskTaskQueryOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -165,7 +164,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_taskQuery_OnlyActivity_Failure() {
+  void taskTaskQueryOnlyActivityFailure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -181,7 +180,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_taskQuery_TwoActivities_Success() {
+  void taskTaskQueryTwoActivitiesSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -202,7 +201,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_taskQuery_TwoActivities_Failure() {
+  void taskTaskQueryTwoActivitiesFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -222,7 +221,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_processInstance_OnlyActivity_Success() {
+  void taskProcessInstanceOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -238,7 +237,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_TwoActivities_processInstance_Failure() {
+  void taskTwoActivitiesProcessInstanceFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -256,7 +255,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_taskDefinitionKey_processInstance_OnlyActivity_Success() {
+  void taskTaskDefinitionKeyProcessInstanceOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -272,7 +271,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_taskDefinitionKey_processInstance_TwoActivities_Success() {
+  void taskTaskDefinitionKeyProcessInstanceTwoActivitiesSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -292,7 +291,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_taskQuery_processInstance_OnlyActivity_Success() {
+  void taskTaskQueryProcessInstanceOnlyActivitySuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -308,7 +307,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_taskQuery_processInstance_TwoActivities_Success() {
+  void taskTaskQueryProcessInstanceTwoActivitiesSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"
@@ -328,7 +327,7 @@ public class ProcessEngineTestsTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-task.bpmn"
   })
-  public void testTask_taskQuery_processInstance_TwoActivities_Failure() {
+  void taskTaskQueryProcessInstanceTwoActivitiesFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-task"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.test.assertions.bpmn.AbstractAssertions.init;
 import static org.operaton.bpm.engine.test.assertions.bpmn.AbstractAssertions.processEngine;
 import static org.operaton.bpm.engine.test.assertions.bpmn.AbstractAssertions.reset;
@@ -35,7 +36,6 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
 import java.util.Map;
-
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.operaton.bpm.engine.AuthorizationService;
 import org.operaton.bpm.engine.FormService;
 import org.operaton.bpm.engine.HistoryService;
@@ -72,35 +72,34 @@ import org.operaton.bpm.engine.task.TaskQuery;
 import org.operaton.bpm.engine.test.assertions.cmmn.CaseDefinitionAssert;
 import org.operaton.bpm.engine.test.assertions.cmmn.CaseExecutionAssert;
 import org.operaton.bpm.engine.test.assertions.cmmn.CaseInstanceAssert;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ProcessEngineTestsTest {
+@ExtendWith(MockitoExtension.class)
+class ProcessEngineTestsTest {
 
   ProcessEngine processEngine;
   MockedStatic<ProcessEngines> processEnginesMockedStatic;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     processEngine = mock(ProcessEngine.class);
     processEnginesMockedStatic = mockStatic(ProcessEngines.class, CALLS_REAL_METHODS);
     init(processEngine);
   }
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
     reset();
     processEnginesMockedStatic.close();
   }
 
   @Test
-  public void testProcessEngine() {
+  void testProcessEngine() {
     // When
     ProcessEngine returnedEngine = processEngine();
     // Then
@@ -108,7 +107,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testNoProcessEngine_Failure() {
+  void noProcessEngineFailure() {
     // Given
     processEnginesMockedStatic.when(ProcessEngines::getProcessEngines).thenReturn(new HashMap<String,ProcessEngine>());
     reset();
@@ -123,7 +122,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testMultipleProcessEngine_Failure() {
+  void multipleProcessEngineFailure() {
     // Given
     Map<String,ProcessEngine> multipleEnginesMap = new HashMap<>();
     multipleEnginesMap.put("test1", mock(ProcessEngine.class));
@@ -141,7 +140,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testInit() {
+  void testInit() {
     // Given
     reset();
     // When
@@ -151,7 +150,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testReset() {
+  void testReset() {
     // When
     reset();
     // Then
@@ -159,7 +158,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testAssertThat_ProcessDefinition() {
+  void assertThatProcessDefinition() {
     // Given
     ProcessDefinition processDefinition = Mockito.mock(ProcessDefinition.class);
     // When
@@ -171,7 +170,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testAssertThat_ProcessInstance() {
+  void assertThatProcessInstance() {
     // Given
     ProcessInstance processInstance = Mockito.mock(ProcessInstance.class);
     // When
@@ -183,7 +182,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testAssertThat_Task() {
+  void assertThatTask() {
     // Given
     Task task = Mockito.mock(Task.class);
     // When
@@ -195,7 +194,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testAssertThat_Job() {
+  void assertThatJob() {
     // Given
     Job job = Mockito.mock(Job.class);
     // When
@@ -207,7 +206,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testAssertThat_CaseInstance() {
+  void assertThatCaseInstance() {
     //Given
     CaseInstance caseInstance = Mockito.mock(CaseInstance.class);
     // When
@@ -217,7 +216,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testAssertThat_CaseExecution() {
+  void assertThatCaseExecution() {
     //Given
     CaseExecution caseExecution = Mockito.mock(CaseExecution.class);
     // When
@@ -227,7 +226,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testAssertThat_CaseDefinition() {
+  void assertThatCaseDefinition() {
     //Given
     CaseDefinition caseDefinition = Mockito.mock(CaseDefinition.class);
     // When
@@ -237,7 +236,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testRuntimeService() {
+  void testRuntimeService() {
     // Given
     RuntimeService runtimeService = mock(RuntimeService.class);
     when(processEngine.getRuntimeService()).thenReturn(runtimeService);
@@ -250,7 +249,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testAuthorizationService() {
+  void testAuthorizationService() {
     // Given
     AuthorizationService authorizationService = mock(AuthorizationService.class);
     when(processEngine.getAuthorizationService()).thenReturn(authorizationService);
@@ -263,7 +262,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testFormService() {
+  void testFormService() {
     // Given
     FormService formService = mock(FormService.class);
     when(processEngine.getFormService()).thenReturn(formService);
@@ -276,7 +275,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testHistoryService() {
+  void testHistoryService() {
     // Given
     HistoryService historyService = mock(HistoryService.class);
     when(processEngine.getHistoryService()).thenReturn(historyService);
@@ -289,7 +288,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testIdentityService() {
+  void testIdentityService() {
     // Given
     IdentityService identityService = mock(IdentityService.class);
     when(processEngine.getIdentityService()).thenReturn(identityService);
@@ -302,7 +301,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testManagementService() {
+  void testManagementService() {
     // Given
     ManagementService managementService = mock(ManagementService.class);
     when(processEngine.getManagementService()).thenReturn(managementService);
@@ -315,7 +314,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testRepositoryService() {
+  void testRepositoryService() {
     // Given
     RepositoryService repositoryService = mock(RepositoryService.class);
     when(processEngine.getRepositoryService()).thenReturn(repositoryService);
@@ -328,7 +327,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testTaskService() {
+  void testTaskService() {
     // Given
     TaskService taskService = mock(TaskService.class);
     when(processEngine.getTaskService()).thenReturn(taskService);
@@ -341,7 +340,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testTaskQuery() {
+  void testTaskQuery() {
     // Given
     TaskService taskService = mock(TaskService.class);
     TaskQuery taskQuery = mock(TaskQuery.class);
@@ -356,7 +355,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testJobQuery() {
+  void testJobQuery() {
     // Given
     ManagementService managementService = mock(ManagementService.class);
     JobQuery jobQuery = mock(JobQuery.class);
@@ -371,7 +370,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testProcessInstanceQuery() {
+  void testProcessInstanceQuery() {
     // Given
     RuntimeService runtimeService = mock(RuntimeService.class);
     ProcessInstanceQuery processInstanceQuery = mock(ProcessInstanceQuery.class);
@@ -386,7 +385,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testProcessDefinitionQuery() {
+  void testProcessDefinitionQuery() {
     // Given
     RepositoryService repositoryService = mock(RepositoryService.class);
     ProcessDefinitionQuery processDefinitionQuery = mock(ProcessDefinitionQuery.class);
@@ -401,7 +400,7 @@ public class ProcessEngineTestsTest {
   }
 
   @Test
-  public void testExecutionQuery() {
+  void testExecutionQuery() {
     // Given
     RuntimeService runtimeService = mock(RuntimeService.class);
     ExecutionQuery executionQuery = mock(ExecutionQuery.class);

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsUnclaimTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsUnclaimTest.java
@@ -16,21 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.unclaim;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessEngineTestsUnclaimTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-unclaim.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsUnclaimTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsUnclaimTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessEngineTestsUnclaimTest extends ProcessAssertTestCase {
+class ProcessEngineTestsUnclaimTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-unclaim.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsUnclaimTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsUnclaimTest.java
@@ -20,13 +20,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.unclaim;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessEngineTestsUnclaimTest extends ProcessAssertTestCase {
 
@@ -36,7 +35,7 @@ public class ProcessEngineTestsUnclaimTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-unclaim.bpmn"
   })
-  public void testUnclaim_Success() {
+  void unclaimSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-unclaim"
@@ -51,7 +50,7 @@ public class ProcessEngineTestsUnclaimTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-unclaim.bpmn"
   })
-  public void testUnclaim_Failure() {
+  void unclaimFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-unclaim"
@@ -63,7 +62,7 @@ public class ProcessEngineTestsUnclaimTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessEngineTests-unclaim.bpmn"
   })
-  public void testUnclaim_AlreadyUnclaimed() {
+  void unclaimAlreadyUnclaimed() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessEngineTests-unclaim"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsWithVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsWithVariablesTest.java
@@ -27,18 +27,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(value = Parameterized.class)
 public class ProcessEngineTestsWithVariablesTest {
 
   List<Object> keys;
   List<Object> values;
   Map<String, Object> expectedMap;
 
-  public ProcessEngineTestsWithVariablesTest(String key1, Object value1, String key2, Object value2, String key3, Object value3) {
+  public void initProcessEngineTestsWithVariablesTest(String key1, Object value1, String key2, Object value2, String key3, Object value3) {
 
     expectedMap = new HashMap<>();
     if (key1 != null)
@@ -66,7 +64,6 @@ public class ProcessEngineTestsWithVariablesTest {
 
   }
 
-  @Parameterized.Parameters
   public static Collection<Object[]> data() {
     Object[][] data = new Object[][] {
       { "key1", 1   , null  , null, null  , null },
@@ -77,16 +74,20 @@ public class ProcessEngineTestsWithVariablesTest {
     return Arrays.asList(data);
   }
 
-  @Test
-  public void testWithVariables() {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void withVariables(String key1, Object value1, String key2, Object value2, String key3, Object value3) {
+    initProcessEngineTestsWithVariablesTest(key1, value1, key2, value2, key3, value3);
     // When we simply constuct the map with the given data
     Map<String, Object> returnedMap = returnedMap(keys, values);
     // Then we expect to find the expected Map
     assertThat(returnedMap).isEqualTo(expectedMap);
   }
 
-  @Test
-  public void testWithVariables_NoStringKeys() {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void withVariablesNoStringKeys(String key1, Object value1, String key2, Object value2, String key3, Object value3) {
+    initProcessEngineTestsWithVariablesTest(key1, value1, key2, value2, key3, value3);
     // Given we replace the last key with its integer value
     keys.set(keys.size() - 1, values.get(values.size() - 1));
     // When we construct the variables map
@@ -100,8 +101,10 @@ public class ProcessEngineTestsWithVariablesTest {
     fail("IllegalArgumentException or AssertionError expected!");
   }
 
-  @Test
-  public void testWithVariables_NullKeys() {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void withVariablesNullKeys(String key1, Object value1, String key2, Object value2, String key3, Object value3) {
+    initProcessEngineTestsWithVariablesTest(key1, value1, key2, value2, key3, value3);
     // Given we replace the last key with a null pointer
     keys.set(keys.size() - 1, null);
     // When we construct the variables map
@@ -115,8 +118,10 @@ public class ProcessEngineTestsWithVariablesTest {
     fail("IllegalArgumentException expected!");
   }
 
-  @Test
-  public void testWithVariables_NullValues() {
+  @MethodSource("data")
+  @ParameterizedTest
+  public void withVariablesNullValues(String key1, Object value1, String key2, Object value2, String key3, Object value3) {
+    initProcessEngineTestsWithVariablesTest(key1, value1, key2, value2, key3, value3);
     // Given we replace all values with a null pointer
     int idx = values.size();
     while (idx > 0)

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsWithVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsWithVariablesTest.java
@@ -16,19 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVariables;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class ProcessEngineTestsWithVariablesTest {
 
@@ -48,37 +44,37 @@ public class ProcessEngineTestsWithVariablesTest {
 
     keys = new ArrayList<>();
     if (key1 != null)
-    keys.add(key1);
+      keys.add(key1);
     if (key2 != null)
-    keys.add(key2);
+      keys.add(key2);
     if (key3 != null)
-    keys.add(key3);
+      keys.add(key3);
 
     values = new ArrayList<>();
     if (key1 != null)
-    values.add(value1);
+      values.add(value1);
     if (key2 != null)
-    values.add(value2);
+      values.add(value2);
     if (key3 != null)
-    values.add(value3);
+      values.add(value3);
 
   }
 
   public static Collection<Object[]> data() {
-    Object[][] data = new Object[][] {
-      { "key1", 1   , null  , null, null  , null },
-      { "key1", 1   , "key2", 2   , null  , null },
-      { null  , null, "key2", 2   , null  , null },
-      { "key1", 1   , "key2", 2   , "key3", 3    }
+    Object[][] data = new Object[][]{
+      {"key1", 1, null, null, null, null},
+      {"key1", 1, "key2", 2, null, null},
+      {null, null, "key2", 2, null, null},
+      {"key1", 1, "key2", 2, "key3", 3}
     };
     return Arrays.asList(data);
   }
 
   @MethodSource("data")
   @ParameterizedTest
-  public void withVariables(String key1, Object value1, String key2, Object value2, String key3, Object value3) {
+  void testWithVariables(String key1, Object value1, String key2, Object value2, String key3, Object value3) {
     initProcessEngineTestsWithVariablesTest(key1, value1, key2, value2, key3, value3);
-    // When we simply constuct the map with the given data
+    // When we simply construct the map with the given data
     Map<String, Object> returnedMap = returnedMap(keys, values);
     // Then we expect to find the expected Map
     assertThat(returnedMap).isEqualTo(expectedMap);
@@ -86,14 +82,14 @@ public class ProcessEngineTestsWithVariablesTest {
 
   @MethodSource("data")
   @ParameterizedTest
-  public void withVariablesNoStringKeys(String key1, Object value1, String key2, Object value2, String key3, Object value3) {
+  void withVariablesNoStringKeys(String key1, Object value1, String key2, Object value2, String key3, Object value3) {
     initProcessEngineTestsWithVariablesTest(key1, value1, key2, value2, key3, value3);
     // Given we replace the last key with its integer value
     keys.set(keys.size() - 1, values.get(values.size() - 1));
     // When we construct the variables map
     try {
       returnedMap(keys, values);
-    // Then we expect an exception to be thrown
+      // Then we expect an exception to be thrown
     } catch (Throwable t) {
       assertThat(t).isInstanceOfAny(ClassCastException.class, IllegalArgumentException.class, AssertionError.class);
       return;
@@ -103,14 +99,14 @@ public class ProcessEngineTestsWithVariablesTest {
 
   @MethodSource("data")
   @ParameterizedTest
-  public void withVariablesNullKeys(String key1, Object value1, String key2, Object value2, String key3, Object value3) {
+  void withVariablesNullKeys(String key1, Object value1, String key2, Object value2, String key3, Object value3) {
     initProcessEngineTestsWithVariablesTest(key1, value1, key2, value2, key3, value3);
     // Given we replace the last key with a null pointer
     keys.set(keys.size() - 1, null);
     // When we construct the variables map
     try {
       returnedMap(keys, values);
-    // Then we expect an exception to be thrown
+      // Then we expect an exception to be thrown
     } catch (Throwable t) {
       assertThat(t).isInstanceOfAny(IllegalArgumentException.class, AssertionError.class);
       return;
@@ -120,7 +116,7 @@ public class ProcessEngineTestsWithVariablesTest {
 
   @MethodSource("data")
   @ParameterizedTest
-  public void withVariablesNullValues(String key1, Object value1, String key2, Object value2, String key3, Object value3) {
+  void withVariablesNullValues(String key1, Object value1, String key2, Object value2, String key3, Object value3) {
     initProcessEngineTestsWithVariablesTest(key1, value1, key2, value2, key3, value3);
     // Given we replace all values with a null pointer
     int idx = values.size();

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertCalledProcessInstanceTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertCalledProcessInstanceTest.java
@@ -16,25 +16,22 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.runtime.ProcessInstanceQuery;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.calledProcessInstance;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processInstanceQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.runtime.ProcessInstanceQuery;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProcessInstanceAssertCalledProcessInstanceTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess2.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertCalledProcessInstanceTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertCalledProcessInstanceTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProcessInstanceAssertCalledProcessInstanceTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertCalledProcessInstanceTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess2.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertCalledProcessInstanceTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertCalledProcessInstanceTest.java
@@ -23,14 +23,13 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.comple
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processInstanceQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstanceQuery;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertCalledProcessInstanceTest extends ProcessAssertTestCase {
 
@@ -40,7 +39,7 @@ public class ProcessInstanceAssertCalledProcessInstanceTest extends ProcessAsser
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstance_FirstOfTwoSequential_Success() {
+  void calledProcessInstanceFirstOfTwoSequentialSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-calledProcessInstance-superProcess1"
@@ -66,7 +65,7 @@ public class ProcessInstanceAssertCalledProcessInstanceTest extends ProcessAsser
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstance_SecondOfTwoSequential_Success() {
+  void calledProcessInstanceSecondOfTwoSequentialSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-calledProcessInstance-superProcess1"
@@ -94,7 +93,7 @@ public class ProcessInstanceAssertCalledProcessInstanceTest extends ProcessAsser
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-calledProcessInstance-superProcess1.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstance_SecondOfTwoSequential_Failure() {
+  void calledProcessInstanceSecondOfTwoSequentialFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-calledProcessInstance-superProcess1"
@@ -117,7 +116,7 @@ public class ProcessInstanceAssertCalledProcessInstanceTest extends ProcessAsser
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-calledProcessInstance-superProcess2.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstance_TwoOfTwoParallel_Success() {
+  void calledProcessInstanceTwoOfTwoParallelSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-calledProcessInstance-superProcess2"
@@ -143,7 +142,7 @@ public class ProcessInstanceAssertCalledProcessInstanceTest extends ProcessAsser
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-calledProcessInstance-superProcess2.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstance_TwoOfTwoParallel_Failure() {
+  void calledProcessInstanceTwoOfTwoParallelFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-calledProcessInstance-superProcess2"
@@ -157,7 +156,7 @@ public class ProcessInstanceAssertCalledProcessInstanceTest extends ProcessAsser
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-calledProcessInstance-superProcess2.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess1.bpmn", "bpmn/ProcessInstanceAssert-calledProcessInstance-subProcess2.bpmn"
   })
-  public void testCalledProcessInstance_NullQuery_Failure() {
+  void calledProcessInstanceNullQueryFailure() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
         "ProcessInstanceAssert-calledProcessInstance-superProcess2"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertExternalTaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertExternalTaskTest.java
@@ -22,7 +22,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.comple
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.externalTask;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.externalTaskQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.externaltask.ExternalTaskQuery;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
@@ -30,7 +30,6 @@ import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase {
 
@@ -43,8 +42,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testNoArgsForSingleTask_Success() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void noArgsForSingleTaskSuccess() {
     // When
     final ProcessInstance processInstance = startProcess();
     // Then
@@ -52,8 +51,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testNoArgsForMultipleTasks_Failure() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void noArgsForMultipleTasksFailure() {
     // Given
     final ProcessInstance processInstance = startProcess();
     assertThat(processInstance).externalTask().isNotNull();
@@ -69,8 +68,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testNullQuery_Failure() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void nullQueryFailure() {
     // Given
     final ProcessInstance processInstance = startProcess();
     assertThat(processInstance).externalTask().isNotNull();
@@ -85,8 +84,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testEmptyQueryForSingleTask_Success() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void emptyQueryForSingleTaskSuccess() {
     // When
     final ProcessInstance processInstance = startProcess();
     // Then
@@ -94,8 +93,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testEmptyQueryForMultipleTasks_Failure() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void emptyQueryForMultipleTasksFailure() {
     // Given
     final ProcessInstance processInstance = startProcess();
     assertThat(processInstance).externalTask().isNotNull();
@@ -111,8 +110,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testNarrowedQuery_Success() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void narrowedQuerySuccess() {
     // Given
     final ProcessInstance processInstance = startProcess();
     assertThat(processInstance).externalTask().isNotNull();
@@ -125,8 +124,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testNarrowedQuery_Failure() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void narrowedQueryFailure() {
     // Given
     final ProcessInstance processInstance = startProcess();
     assertThat(processInstance).externalTask().isNotNull();
@@ -142,8 +141,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testNotYetQuery_Failure() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void notYetQueryFailure() {
     // Given
     final ProcessInstance processInstance = startProcess();
     assertThat(processInstance).externalTask().isNotNull();
@@ -152,8 +151,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testAlreadyPassedQuery_Failure() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void alreadyPassedQueryFailure() {
     // Given
     final ProcessInstance processInstance = startProcess();
     assertThat(processInstance).externalTask(externalTaskQuery().activityId(TASK1)).isNotNull();
@@ -163,8 +162,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testNullId_Failure() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void nullIdFailure() {
     // Given
     final ProcessInstance processInstance = startProcess();
     assertThat(processInstance).externalTask().isNotNull();
@@ -179,8 +178,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testIdForSingleTask_Success() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void idForSingleTaskSuccess() {
     // When
     final ProcessInstance processInstance = startProcess();
     // Then
@@ -188,8 +187,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testIdForSingleTask_Failure() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void idForSingleTaskFailure() {
     // Given
     final ProcessInstance processInstance = startProcess();
     try {
@@ -203,8 +202,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testIdForMultipleTasks_Success() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void idForMultipleTasksSuccess() {
     // Given
     final ProcessInstance processInstance = startProcess();
     assertThat(processInstance).externalTask().isNotNull();
@@ -217,8 +216,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testIdForMultipleTasks_Failure() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void idForMultipleTasksFailure() {
     // Given
     final ProcessInstance processInstance = startProcess();
     assertThat(processInstance).externalTask().isNotNull();
@@ -228,8 +227,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testNotYetId_Failure() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void notYetIdFailure() {
     // Given
     final ProcessInstance processInstance = startProcess();
     assertThat(processInstance).externalTask().isNotNull();
@@ -238,8 +237,8 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   }
 
   @Test
-  @Deployment(resources = { "bpmn/ProcessInstanceAssert-externalTask.bpmn" })
-  public void testAlreadyPassedId_Failure() {
+  @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})
+  void alreadyPassedIdFailure() {
     // Given
     final ProcessInstance processInstance = startProcess();
     assertThat(processInstance).externalTask(externalTaskQuery().activityId(TASK1)).isNotNull();

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertExternalTaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertExternalTaskTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase {
 
   private static final String TASK1 = "ExternalTask_1";
   private static final String TASK2 = "ExternalTask_2";

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertExternalTaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertExternalTaskTest.java
@@ -16,20 +16,20 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.operaton.bpm.engine.ProcessEngineException;
+import org.operaton.bpm.engine.externaltask.ExternalTaskQuery;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.externalTask;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.externalTaskQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.externaltask.ExternalTaskQuery;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase {
 
@@ -37,9 +37,6 @@ public class ProcessInstanceAssertExternalTaskTest extends ProcessAssertTestCase
   private static final String TASK2 = "ExternalTask_2";
   private static final String TASK3 = "ExternalTask_3";
   private static final String TASK4 = "ExternalTask_4";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-externalTask.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasBusinessKeyTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasBusinessKeyTest.java
@@ -18,13 +18,12 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertHasBusinessKeyTest extends ProcessAssertTestCase {
 
@@ -33,7 +32,7 @@ public class ProcessInstanceAssertHasBusinessKeyTest extends ProcessAssertTestCa
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasBusinessKey.bpmn"})
-  public void testHasBusinessKey_Success_With_String() {
+  void hasBusinessKeySuccessWithString() {
     // When
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasBusinessKey",
@@ -45,7 +44,7 @@ public class ProcessInstanceAssertHasBusinessKeyTest extends ProcessAssertTestCa
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasBusinessKey.bpmn"})
-  public void testHasBusinessKey_Success_With_Null() {
+  void hasBusinessKeySuccessWithNull() {
     // When
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasBusinessKey"
@@ -56,7 +55,7 @@ public class ProcessInstanceAssertHasBusinessKeyTest extends ProcessAssertTestCa
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasBusinessKey.bpmn"})
-  public void testHasBusinessKey_Failure() {
+  void hasBusinessKeyFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasBusinessKey",

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasBusinessKeyTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasBusinessKeyTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertHasBusinessKeyTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertHasBusinessKeyTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasBusinessKey.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasBusinessKeyTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasBusinessKeyTest.java
@@ -16,19 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertHasBusinessKeyTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasBusinessKey.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasNoVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasNoVariablesTest.java
@@ -21,13 +21,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.comple
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVariables;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertHasNoVariablesTest extends ProcessAssertTestCase {
 
@@ -37,7 +36,7 @@ public class ProcessInstanceAssertHasNoVariablesTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasNoVariables.bpmn"
   })
-  public void testHasNoVariables_None_Success() {
+  void hasNoVariablesNoneSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasNoVariables"
@@ -53,7 +52,7 @@ public class ProcessInstanceAssertHasNoVariablesTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasNoVariables.bpmn"
   })
-  public void testHasNoVariables_One_Failure() {
+  void hasNoVariablesOneFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasNoVariables", withVariables("aVariable", "aValue")
@@ -69,7 +68,7 @@ public class ProcessInstanceAssertHasNoVariablesTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasNoVariables.bpmn"
   })
-  public void testHasNoVariables_Two_Failure() {
+  void hasNoVariablesTwoFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasNoVariables", withVariables("firstVariable", "firstValue", "secondVariable", "secondValue")

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasNoVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasNoVariablesTest.java
@@ -16,22 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVariables;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertHasNoVariablesTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasNoVariables.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasNoVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasNoVariablesTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertHasNoVariablesTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertHasNoVariablesTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasNoVariables.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasNotPassedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasNotPassedTest.java
@@ -21,13 +21,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.comple
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVariables;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertHasNotPassedTest extends ProcessAssertTestCase {
 
@@ -37,7 +36,7 @@ public class ProcessInstanceAssertHasNotPassedTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasNotPassed.bpmn"
   })
-  public void testHasNotPassed_OnlyActivity_RunningInstance_Failure() {
+  void hasNotPassedOnlyActivityRunningInstanceFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasNotPassed"
@@ -51,7 +50,7 @@ public class ProcessInstanceAssertHasNotPassedTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasNotPassed.bpmn"
   })
-  public void testHasNotPassed_OnlyActivity_RunningInstance_Success() {
+  void hasNotPassedOnlyActivityRunningInstanceSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasNotPassed"
@@ -65,7 +64,7 @@ public class ProcessInstanceAssertHasNotPassedTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasNotPassed.bpmn"
   })
-  public void testHasNotPassed_ParallelActivities_RunningInstance_Success() {
+  void hasNotPassedParallelActivitiesRunningInstanceSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasNotPassed"
@@ -83,7 +82,7 @@ public class ProcessInstanceAssertHasNotPassedTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasNotPassed.bpmn"
   })
-  public void testHasNotPassed_ParallelActivities_RunningInstance_Failure() {
+  void hasNotPassedParallelActivitiesRunningInstanceFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasNotPassed"
@@ -99,7 +98,7 @@ public class ProcessInstanceAssertHasNotPassedTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasNotPassed.bpmn"
   })
-  public void testHasNotPassed_SeveralActivities_RunningInstance_Success() {
+  void hasNotPassedSeveralActivitiesRunningInstanceSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasNotPassed"
@@ -117,7 +116,7 @@ public class ProcessInstanceAssertHasNotPassedTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasNotPassed.bpmn"
   })
-  public void testHasNotPassed_SeveralActivities_HistoricInstance_Success() {
+  void hasNotPassedSeveralActivitiesHistoricInstanceSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasNotPassed"
@@ -137,7 +136,7 @@ public class ProcessInstanceAssertHasNotPassedTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasNotPassed.bpmn"
   })
-  public void testHasNotPassed_SeveralActivities_HistoricInstance_Failure() {
+  void hasNotPassedSeveralActivitiesHistoricInstanceFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasNotPassed"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasNotPassedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasNotPassedTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertHasNotPassedTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertHasNotPassedTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasNotPassed.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasNotPassedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasNotPassedTest.java
@@ -16,22 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVariables;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertHasNotPassedTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasNotPassed.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedInOrderLoopTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedInOrderLoopTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertHasPassedInOrderLoopTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertHasPassedInOrderLoopTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassedInOrder-loop.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedInOrderLoopTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedInOrderLoopTest.java
@@ -16,22 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVariables;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertHasPassedInOrderLoopTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassedInOrder-loop.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedInOrderLoopTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedInOrderLoopTest.java
@@ -21,13 +21,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.comple
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVariables;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertHasPassedInOrderLoopTest extends ProcessAssertTestCase {
 
@@ -37,7 +36,7 @@ public class ProcessInstanceAssertHasPassedInOrderLoopTest extends ProcessAssert
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassedInOrder-loop.bpmn"
   })
-  public void testHasPassedInOrder_SeveralActivities_HistoricInstance() {
+  void hasPassedInOrderSeveralActivitiesHistoricInstance() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassedInOrder-loop",

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedInOrderTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedInOrderTest.java
@@ -20,13 +20,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertHasPassedInOrderTest extends ProcessAssertTestCase {
 
@@ -36,7 +35,7 @@ public class ProcessInstanceAssertHasPassedInOrderTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassedInOrder.bpmn"
   })
-  public void testHasPassedInOrder_OnlyActivity_RunningInstance_Success() {
+  void hasPassedInOrderOnlyActivityRunningInstanceSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassedInOrder"
@@ -50,7 +49,7 @@ public class ProcessInstanceAssertHasPassedInOrderTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassedInOrder.bpmn"
   })
-  public void testHasPassedInOrder_OnlyActivity_RunningInstance_Failure() {
+  void hasPassedInOrderOnlyActivityRunningInstanceFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassedInOrder"
@@ -62,7 +61,7 @@ public class ProcessInstanceAssertHasPassedInOrderTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassedInOrder.bpmn"
   })
-  public void testHasPassedInOrder_ParallelActivities_RunningInstance_Success() {
+  void hasPassedInOrderParallelActivitiesRunningInstanceSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassedInOrder"
@@ -82,7 +81,7 @@ public class ProcessInstanceAssertHasPassedInOrderTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassedInOrder.bpmn"
   })
-  public void testHasPassedInOrder_ParallelActivities_RunningInstance_Failure() {
+  void hasPassedInOrderParallelActivitiesRunningInstanceFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassedInOrder"
@@ -104,7 +103,7 @@ public class ProcessInstanceAssertHasPassedInOrderTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassedInOrder.bpmn"
   })
-  public void testHasPassedInOrder_SeveralActivities_RunningInstance_Success() {
+  void hasPassedInOrderSeveralActivitiesRunningInstanceSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassedInOrder"
@@ -138,7 +137,7 @@ public class ProcessInstanceAssertHasPassedInOrderTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassedInOrder.bpmn"
   })
-  public void testHasPassedInOrder_SeveralActivities_RunningInstance_Failure() {
+  void hasPassedInOrderSeveralActivitiesRunningInstanceFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassedInOrder"
@@ -160,7 +159,7 @@ public class ProcessInstanceAssertHasPassedInOrderTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassedInOrder.bpmn"
   })
-  public void testHasPassedInOrder_SeveralActivities_HistoricInstance_Success() {
+  void hasPassedInOrderSeveralActivitiesHistoricInstanceSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassedInOrder"
@@ -190,7 +189,7 @@ public class ProcessInstanceAssertHasPassedInOrderTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassedInOrder.bpmn"
   })
-  public void testHasPassedInOrder_SeveralActivities_HistoricInstance_Failure() {
+  void hasPassedInOrderSeveralActivitiesHistoricInstanceFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassedInOrder"
@@ -216,7 +215,7 @@ public class ProcessInstanceAssertHasPassedInOrderTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"
   })
-  public void testHasPassedInOrder_Null_Error() {
+  void hasPassedInOrderNullError() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingAt"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedInOrderTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedInOrderTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertHasPassedInOrderTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertHasPassedInOrderTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassedInOrder.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedInOrderTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedInOrderTest.java
@@ -16,21 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertHasPassedInOrderTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassedInOrder.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedTest.java
@@ -20,13 +20,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertHasPassedTest extends ProcessAssertTestCase {
 
@@ -36,7 +35,7 @@ public class ProcessInstanceAssertHasPassedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassed.bpmn"
   })
-  public void testHasPassed_OnlyActivity_RunningInstance_Success() {
+  void hasPassedOnlyActivityRunningInstanceSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassed"
@@ -50,7 +49,7 @@ public class ProcessInstanceAssertHasPassedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassed.bpmn"
   })
-  public void testHasPassed_OnlyActivity_RunningInstance_Failure() {
+  void hasPassedOnlyActivityRunningInstanceFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassed"
@@ -62,7 +61,7 @@ public class ProcessInstanceAssertHasPassedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassed.bpmn"
   })
-  public void testHasPassed_ParallelActivities_RunningInstance_Success() {
+  void hasPassedParallelActivitiesRunningInstanceSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassed"
@@ -82,7 +81,7 @@ public class ProcessInstanceAssertHasPassedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassed.bpmn"
   })
-  public void testHasPassed_ParallelActivities_RunningInstance_Failure() {
+  void hasPassedParallelActivitiesRunningInstanceFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassed"
@@ -99,7 +98,7 @@ public class ProcessInstanceAssertHasPassedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassed.bpmn"
   })
-  public void testHasPassed_SeveralActivities_RunningInstance_Success() {
+  void hasPassedSeveralActivitiesRunningInstanceSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassed"
@@ -123,7 +122,7 @@ public class ProcessInstanceAssertHasPassedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassed.bpmn"
   })
-  public void testHasPassed_SeveralActivities_RunningInstance_Failure() {
+  void hasPassedSeveralActivitiesRunningInstanceFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassed"
@@ -141,7 +140,7 @@ public class ProcessInstanceAssertHasPassedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassed.bpmn"
   })
-  public void testHasPassed_SeveralActivities_HistoricInstance_Success() {
+  void hasPassedSeveralActivitiesHistoricInstanceSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassed"
@@ -169,7 +168,7 @@ public class ProcessInstanceAssertHasPassedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassed.bpmn"
   })
-  public void testHasPassed_SeveralActivities_HistoricInstance_Failure() {
+  void hasPassedSeveralActivitiesHistoricInstanceFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasPassed"
@@ -189,7 +188,7 @@ public class ProcessInstanceAssertHasPassedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"
   })
-  public void testHasPassed_Null_Error() {
+  void hasPassedNullError() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingAt"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertHasPassedTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertHasPassedTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassed.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasPassedTest.java
@@ -16,21 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertHasPassedTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasPassed.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasProcessDefinitionKeyTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasProcessDefinitionKeyTest.java
@@ -16,19 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertHasProcessDefinitionKeyTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasProcessDefinitionKey-1.bpmn", "bpmn/ProcessInstanceAssert-hasProcessDefinitionKey-2.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasProcessDefinitionKeyTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasProcessDefinitionKeyTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertHasProcessDefinitionKeyTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertHasProcessDefinitionKeyTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasProcessDefinitionKey-1.bpmn", "bpmn/ProcessInstanceAssert-hasProcessDefinitionKey-2.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasProcessDefinitionKeyTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasProcessDefinitionKeyTest.java
@@ -18,13 +18,12 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertHasProcessDefinitionKeyTest extends ProcessAssertTestCase {
 
@@ -34,7 +33,7 @@ public class ProcessInstanceAssertHasProcessDefinitionKeyTest extends ProcessAss
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasProcessDefinitionKey-1.bpmn", "bpmn/ProcessInstanceAssert-hasProcessDefinitionKey-2.bpmn"
   })
-  public void testHasProcessDefinitionKey_Success() {
+  void hasProcessDefinitionKeySuccess() {
     // When
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasProcessDefinitionKey-1"
@@ -46,7 +45,7 @@ public class ProcessInstanceAssertHasProcessDefinitionKeyTest extends ProcessAss
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasProcessDefinitionKey-1.bpmn", "bpmn/ProcessInstanceAssert-hasProcessDefinitionKey-2.bpmn"
   })
-  public void testHasProcessDefinitionKey_Failure() {
+  void hasProcessDefinitionKeyFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasProcessDefinitionKey-2"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasVariablesTest.java
@@ -21,13 +21,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.comple
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVariables;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertHasVariablesTest extends ProcessAssertTestCase {
 
@@ -37,7 +36,7 @@ public class ProcessInstanceAssertHasVariablesTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasVariables.bpmn"
   })
-  public void testHasVariables_One_Success() {
+  void hasVariablesOneSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasVariables", withVariables("aVariable", "aValue")
@@ -57,7 +56,7 @@ public class ProcessInstanceAssertHasVariablesTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasVariables.bpmn"
   })
-  public void testHasVariables_One_Failure() {
+  void hasVariablesOneFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasVariables", withVariables("aVariable", "aValue")
@@ -77,7 +76,7 @@ public class ProcessInstanceAssertHasVariablesTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasVariables.bpmn"
   })
-  public void testHasVariables_Two_Success() {
+  void hasVariablesTwoSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasVariables", withVariables("firstVariable", "firstValue", "secondVariable", "secondValue")
@@ -109,7 +108,7 @@ public class ProcessInstanceAssertHasVariablesTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasVariables.bpmn"
   })
-  public void testHasVariables_Two_Failure() {
+  void hasVariablesTwoFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasVariables", withVariables("firstVariable", "firstValue", "secondVariable", "secondValue")
@@ -137,7 +136,7 @@ public class ProcessInstanceAssertHasVariablesTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasVariables.bpmn"
   })
-  public void testHasVariables_None_Failure() {
+  void hasVariablesNoneFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-hasVariables"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasVariablesTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertHasVariablesTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertHasVariablesTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasVariables.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertHasVariablesTest.java
@@ -16,22 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVariables;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertHasVariablesTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-hasVariables.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsActiveTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsActiveTest.java
@@ -18,13 +18,12 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertIsActiveTest extends ProcessAssertTestCase {
 
@@ -34,7 +33,7 @@ public class ProcessInstanceAssertIsActiveTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isActive.bpmn"
   })
-  public void testIsActive_Success() {
+  void isActiveSuccess() {
     // When
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isActive"
@@ -46,7 +45,7 @@ public class ProcessInstanceAssertIsActiveTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isActive.bpmn"
   })
-  public void testIsActive_AfterActivation_Success() {
+  void isActiveAfterActivationSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isActive"
@@ -62,7 +61,7 @@ public class ProcessInstanceAssertIsActiveTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isActive.bpmn"
   })
-  public void testIsActive_Failure() {
+  void isActiveFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isActive"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsActiveTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsActiveTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertIsActiveTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertIsActiveTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isActive.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsActiveTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsActiveTest.java
@@ -16,19 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertIsActiveTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isActive.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsEndedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsEndedTest.java
@@ -20,13 +20,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertIsEndedTest extends ProcessAssertTestCase {
 
@@ -36,7 +35,7 @@ public class ProcessInstanceAssertIsEndedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isEnded.bpmn"
   })
-  public void testIsEnded_Success() {
+  void isEndedSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isEnded"
@@ -50,7 +49,7 @@ public class ProcessInstanceAssertIsEndedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isEnded.bpmn"
   })
-  public void testIsEnded_Failure() {
+  void isEndedFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isEnded"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsEndedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsEndedTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertIsEndedTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertIsEndedTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isEnded.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsEndedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsEndedTest.java
@@ -16,21 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertIsEndedTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isEnded.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotEndedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotEndedTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertIsNotEndedTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertIsNotEndedTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isEnded.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotEndedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotEndedTest.java
@@ -20,13 +20,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertIsNotEndedTest extends ProcessAssertTestCase {
 
@@ -36,7 +35,7 @@ public class ProcessInstanceAssertIsNotEndedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isEnded.bpmn"
   })
-  public void testIsNotEnded_Success() {
+  void isNotEndedSuccess() {
     // When
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isEnded"
@@ -48,7 +47,7 @@ public class ProcessInstanceAssertIsNotEndedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isEnded.bpmn"
   })
-  public void testIsNotEnded_Failure() {
+  void isNotEndedFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isEnded"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotEndedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotEndedTest.java
@@ -16,21 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertIsNotEndedTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isEnded.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotWaitingAtTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotWaitingAtTest.java
@@ -20,13 +20,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertIsNotWaitingAtTest extends ProcessAssertTestCase {
 
@@ -36,7 +35,7 @@ public class ProcessInstanceAssertIsNotWaitingAtTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingAt.bpmn"
   })
-  public void testIsNotWaitingAt_Only_Activity_Success() {
+  void isNotWaitingAtOnlyActivitySuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isNotWaitingAt"
@@ -48,7 +47,7 @@ public class ProcessInstanceAssertIsNotWaitingAtTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingAt.bpmn"
   })
-  public void testIsNotWaitingAt_Only_Activity_Failure() {
+  void isNotWaitingAtOnlyActivityFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isNotWaitingAt"
@@ -60,7 +59,7 @@ public class ProcessInstanceAssertIsNotWaitingAtTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingAt.bpmn"
   })
-  public void testIsNotWaitingAt_Non_Existing_Activity_Success() {
+  void isNotWaitingAtNonExistingActivitySuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isNotWaitingAt"
@@ -72,7 +71,7 @@ public class ProcessInstanceAssertIsNotWaitingAtTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingAt.bpmn"
   })
-  public void testIsNotWaitingAt_One_Of_Two_Activities_Success() {
+  void isNotWaitingAtOneOfTwoActivitiesSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isNotWaitingAt"
@@ -86,7 +85,7 @@ public class ProcessInstanceAssertIsNotWaitingAtTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingAt.bpmn"
   })
-  public void testIsNotWaitingAt_One_Of_Two_Activities_Failure() {
+  void isNotWaitingAtOneOfTwoActivitiesFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isNotWaitingAt"
@@ -104,7 +103,7 @@ public class ProcessInstanceAssertIsNotWaitingAtTest extends ProcessAssertTestCa
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingAt.bpmn"
   })
-  public void testIsNotWaitingAt_Null_Error() {
+  void isNotWaitingAtNullError() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isNotWaitingAt"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotWaitingAtTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotWaitingAtTest.java
@@ -16,21 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertIsNotWaitingAtTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingAt.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotWaitingAtTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotWaitingAtTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertIsNotWaitingAtTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertIsNotWaitingAtTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingAt.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotWaitingForTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotWaitingForTest.java
@@ -18,13 +18,12 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertIsNotWaitingForTest extends ProcessAssertTestCase {
 
@@ -34,7 +33,7 @@ public class ProcessInstanceAssertIsNotWaitingForTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingFor.bpmn"
   })
-  public void testIsNotWaitingFor_One_Message_Success() {
+  void isNotWaitingForOneMessageSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isNotWaitingFor"
@@ -48,7 +47,7 @@ public class ProcessInstanceAssertIsNotWaitingForTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingFor-2.bpmn"
   })
-  public void testIsNotWaitingFor_Two_Messages_Success() {
+  void isNotWaitingForTwoMessagesSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isNotWaitingFor-2"
@@ -64,7 +63,7 @@ public class ProcessInstanceAssertIsNotWaitingForTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingFor-2.bpmn"
   })
-  public void testIsNotWaitingFor_One_Of_Two_Messages_Success() {
+  void isNotWaitingForOneOfTwoMessagesSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isNotWaitingFor-2"
@@ -80,7 +79,7 @@ public class ProcessInstanceAssertIsNotWaitingForTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingFor.bpmn"
   })
-  public void testIsNotWaitingFor_One_Message_Failure() {
+  void isNotWaitingForOneMessageFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isNotWaitingFor"
@@ -92,7 +91,7 @@ public class ProcessInstanceAssertIsNotWaitingForTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingFor.bpmn"
   })
-  public void testIsNotWaitingFor_Not_Waiting_For_One_Of_One_Success() {
+  void isNotWaitingForNotWaitingForOneOfOneSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isNotWaitingFor"
@@ -104,7 +103,7 @@ public class ProcessInstanceAssertIsNotWaitingForTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingFor.bpmn"
   })
-  public void testIsNotWaitingFor_Not_Waiting_For_One_Of_Two_Failure() {
+  void isNotWaitingForNotWaitingForOneOfTwoFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isNotWaitingFor"
@@ -116,7 +115,7 @@ public class ProcessInstanceAssertIsNotWaitingForTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingFor.bpmn"
   })
-  public void testIsNotWaitingFor_Null_Error() {
+  void isNotWaitingForNullError() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isNotWaitingFor"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotWaitingForTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotWaitingForTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertIsNotWaitingForTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertIsNotWaitingForTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingFor.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotWaitingForTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsNotWaitingForTest.java
@@ -16,19 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertIsNotWaitingForTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isNotWaitingFor.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsStartedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsStartedTest.java
@@ -16,23 +16,17 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ProcessInstanceAssertIsStartedTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isStarted.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsStartedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsStartedTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ProcessInstanceAssertIsStartedTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertIsStartedTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isStarted.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsStartedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsStartedTest.java
@@ -22,13 +22,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertIsStartedTest extends ProcessAssertTestCase {
 
@@ -38,7 +37,7 @@ public class ProcessInstanceAssertIsStartedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isStarted.bpmn"
   })
-  public void testIsStarted_AndActive_Success() {
+  void isStartedAndActiveSuccess() {
     // When
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isStarted"
@@ -50,7 +49,7 @@ public class ProcessInstanceAssertIsStartedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isStarted.bpmn"
   })
-  public void testIsStarted_AndEnded_Success() {
+  void isStartedAndEndedSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isStarted"
@@ -64,7 +63,7 @@ public class ProcessInstanceAssertIsStartedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isStarted.bpmn"
   })
-  public void testIsStarted_Failure() {
+  void isStartedFailure() {
     // When
     final ProcessInstance processInstance = mock(ProcessInstance.class);
     // And

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsSuspendedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsSuspendedTest.java
@@ -18,13 +18,12 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertIsSuspendedTest extends ProcessAssertTestCase {
 
@@ -34,7 +33,7 @@ public class ProcessInstanceAssertIsSuspendedTest extends ProcessAssertTestCase 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isSuspended.bpmn"
   })
-  public void testIsSuspended_Success() {
+  void isSuspendedSuccess() {
     // Given
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isSuspended"
@@ -48,7 +47,7 @@ public class ProcessInstanceAssertIsSuspendedTest extends ProcessAssertTestCase 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isSuspended.bpmn"
   })
-  public void testIsSuspended_AfterStart_Failure() {
+  void isSuspendedAfterStartFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isSuspended"
@@ -60,7 +59,7 @@ public class ProcessInstanceAssertIsSuspendedTest extends ProcessAssertTestCase 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isSuspended.bpmn"
   })
-  public void testIsSuspended_AfterActivation_Failure() {
+  void isSuspendedAfterActivationFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isSuspended"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsSuspendedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsSuspendedTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertIsSuspendedTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertIsSuspendedTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isSuspended.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsSuspendedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsSuspendedTest.java
@@ -16,19 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertIsSuspendedTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isSuspended.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtActivityTreeTests.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtActivityTreeTests.java
@@ -16,23 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.execute;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.job;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertIsWaitingAtActivityTreeTests extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt-ActivityTreeTests.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtActivityTreeTests.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtActivityTreeTests.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertIsWaitingAtActivityTreeTests extends ProcessAssertTestCase {
+class ProcessInstanceAssertIsWaitingAtActivityTreeTests extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt-ActivityTreeTests.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtActivityTreeTests.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtActivityTreeTests.java
@@ -22,13 +22,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.execut
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.job;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertIsWaitingAtActivityTreeTests extends ProcessAssertTestCase {
 
@@ -38,7 +37,7 @@ public class ProcessInstanceAssertIsWaitingAtActivityTreeTests extends ProcessAs
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt-ActivityTreeTests.bpmn"
   })
-  public void testIsWaitingAt_AsyncBefore() {
+  void isWaitingAtAsyncBefore() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingAt-ActivityTreeTests"
@@ -49,7 +48,7 @@ public class ProcessInstanceAssertIsWaitingAtActivityTreeTests extends ProcessAs
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt-ActivityTreeTests.bpmn"})
-  public void testIsWaitingAt_Subprocess() {
+  void isWaitingAtSubprocess() {
     // When
     final ProcessInstance processInstance = runtimeService()
         .createProcessInstanceByKey("ProcessInstanceAssert-isWaitingAt-ActivityTreeTests")
@@ -61,7 +60,7 @@ public class ProcessInstanceAssertIsWaitingAtActivityTreeTests extends ProcessAs
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt-Subprocesses.bpmn"})
-  public void testIsWaitingAtNestedUserTask() {
+  void isWaitingAtNestedUserTask() {
     // When
     final ProcessInstance processInstance = runtimeService()
         .startProcessInstanceByKey("ProcessInstanceAssert-isWaitingAt-Subprocesses");
@@ -72,7 +71,7 @@ public class ProcessInstanceAssertIsWaitingAtActivityTreeTests extends ProcessAs
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt-AsyncUserTask.bpmn"})
-  public void testIsWaitingAtAsyncUserTask() {
+  void isWaitingAtAsyncUserTask() {
     // When
     ProcessInstance processInstance = runtimeService()
         .startProcessInstanceByKey("ProcessInstanceAssert-isWaitingAt-AsyncUserTask");

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtExactlyTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtExactlyTest.java
@@ -16,21 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertIsWaitingAtExactlyTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtExactlyTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtExactlyTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertIsWaitingAtExactlyTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertIsWaitingAtExactlyTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtExactlyTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtExactlyTest.java
@@ -20,13 +20,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertIsWaitingAtExactlyTest extends ProcessAssertTestCase {
 
@@ -36,7 +35,7 @@ public class ProcessInstanceAssertIsWaitingAtExactlyTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"
   })
-  public void testIsWaitingAtExactly_Only_Activity_Success() {
+  void isWaitingAtExactlyOnlyActivitySuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingAt"
@@ -48,7 +47,7 @@ public class ProcessInstanceAssertIsWaitingAtExactlyTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"
   })
-  public void testIsWaitingAtExactly_Only_Activity_Failure() {
+  void isWaitingAtExactlyOnlyActivityFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingAt"
@@ -60,7 +59,7 @@ public class ProcessInstanceAssertIsWaitingAtExactlyTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"
   })
-  public void testIsWaitingAtExactly_Non_Existing_Activity_Failure() {
+  void isWaitingAtExactlyNonExistingActivityFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingAt"
@@ -72,7 +71,7 @@ public class ProcessInstanceAssertIsWaitingAtExactlyTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"
   })
-  public void testIsWaitingAtExactly_Two_Activities_Success() {
+  void isWaitingAtExactlyTwoActivitiesSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingAt"
@@ -88,7 +87,7 @@ public class ProcessInstanceAssertIsWaitingAtExactlyTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"
   })
-  public void testIsWaitingAtExactly_Two_Activities_Failure() {
+  void isWaitingAtExactlyTwoActivitiesFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingAt"
@@ -104,7 +103,7 @@ public class ProcessInstanceAssertIsWaitingAtExactlyTest extends ProcessAssertTe
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"
   })
-  public void testIsWaitingAtExactly_Null_Error() {
+  void isWaitingAtExactlyNullError() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingAt"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertIsWaitingAtTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertIsWaitingAtTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtTest.java
@@ -20,13 +20,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertIsWaitingAtTest extends ProcessAssertTestCase {
 
@@ -36,7 +35,7 @@ public class ProcessInstanceAssertIsWaitingAtTest extends ProcessAssertTestCase 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"
   })
-  public void testIsWaitingAt_Only_Activity_Success() {
+  void isWaitingAtOnlyActivitySuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingAt"
@@ -48,7 +47,7 @@ public class ProcessInstanceAssertIsWaitingAtTest extends ProcessAssertTestCase 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"
   })
-  public void testIsWaitingAt_Only_Activity_Failure() {
+  void isWaitingAtOnlyActivityFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingAt"
@@ -60,7 +59,7 @@ public class ProcessInstanceAssertIsWaitingAtTest extends ProcessAssertTestCase 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"
   })
-  public void testIsWaitingAt_Non_Existing_Activity_Failure() {
+  void isWaitingAtNonExistingActivityFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingAt"
@@ -72,7 +71,7 @@ public class ProcessInstanceAssertIsWaitingAtTest extends ProcessAssertTestCase 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"
   })
-  public void testIsWaitingAt_One_Of_Two_Activities_Success() {
+  void isWaitingAtOneOfTwoActivitiesSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingAt"
@@ -90,7 +89,7 @@ public class ProcessInstanceAssertIsWaitingAtTest extends ProcessAssertTestCase 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"
   })
-  public void testIsWaitingAt_One_Of_Two_Activities_Failure() {
+  void isWaitingAtOneOfTwoActivitiesFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingAt"
@@ -104,7 +103,7 @@ public class ProcessInstanceAssertIsWaitingAtTest extends ProcessAssertTestCase 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"
   })
-  public void testIsWaitingAt_Null_Error() {
+  void isWaitingAtNullError() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingAt"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingAtTest.java
@@ -16,21 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertIsWaitingAtTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingAt.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingForJoinTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingForJoinTest.java
@@ -16,21 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertIsWaitingForJoinTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = "bpmn/ProcessInstanceAssert-isWaitingForJoinAt.bpmn")

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingForJoinTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingForJoinTest.java
@@ -20,13 +20,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertIsWaitingForJoinTest extends ProcessAssertTestCase {
 
@@ -35,7 +34,7 @@ public class ProcessInstanceAssertIsWaitingForJoinTest extends ProcessAssertTest
 
   @Test
   @Deployment(resources = "bpmn/ProcessInstanceAssert-isWaitingForJoinAt.bpmn")
-  public void testIsWaitingForJoinAt() {
+  void isWaitingForJoinAt() {
     // given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingForJoinAt"
@@ -51,7 +50,7 @@ public class ProcessInstanceAssertIsWaitingForJoinTest extends ProcessAssertTest
 
   @Test
   @Deployment(resources = "bpmn/ProcessInstanceAssert-isWaitingForJoinAt.bpmn")
-  public void testIsNotWaitingForJoin() {
+  void isNotWaitingForJoin() {
     // when
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingForJoinAt"
@@ -63,7 +62,7 @@ public class ProcessInstanceAssertIsWaitingForJoinTest extends ProcessAssertTest
 
   @Test
   @Deployment(resources = "bpmn/ProcessInstanceAssert-isWaitingForJoinAt2.bpmn")
-  public void testNestedJoinGateways() {
+  void nestedJoinGateways() {
     // given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingForJoinAt2"
@@ -88,7 +87,7 @@ public class ProcessInstanceAssertIsWaitingForJoinTest extends ProcessAssertTest
 
   @Test
   @Deployment(resources = "bpmn/ProcessInstanceAssert-isWaitingForJoinAt3.bpmn")
-  public void testNestedInclusiveGatewaysAll() {
+  void nestedInclusiveGatewaysAll() {
     // given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingForJoinAt3"
@@ -110,7 +109,7 @@ public class ProcessInstanceAssertIsWaitingForJoinTest extends ProcessAssertTest
 
   @Test
   @Deployment(resources = "bpmn/ProcessInstanceAssert-isWaitingForJoinAt.bpmn")
-  public void testIsNotWaitingForJoinFails() {
+  void isNotWaitingForJoinFails() {
     // given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingForJoinAt"
@@ -124,7 +123,7 @@ public class ProcessInstanceAssertIsWaitingForJoinTest extends ProcessAssertTest
 
   @Test
   @Deployment(resources = "bpmn/ProcessInstanceAssert-isWaitingForJoinAt.bpmn")
-  public void testIsWaitingForJoinAtNull() {
+  void isWaitingForJoinAtNull() {
     // given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingForJoinAt");
@@ -135,7 +134,7 @@ public class ProcessInstanceAssertIsWaitingForJoinTest extends ProcessAssertTest
 
   @Test
   @Deployment(resources = "bpmn/ProcessInstanceAssert-isWaitingForJoinAt.bpmn")
-  public void testIsWaitingForJoinAtWrongActivityId() {
+  void isWaitingForJoinAtWrongActivityId() {
     // given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingForJoinAt"
@@ -150,7 +149,7 @@ public class ProcessInstanceAssertIsWaitingForJoinTest extends ProcessAssertTest
 
   @Test
   @Deployment(resources = "bpmn/ProcessInstanceAssert-isWaitingForJoinAt.bpmn")
-  public void testProcessWithJoinInCompletedProcessInstance() {
+  void processWithJoinInCompletedProcessInstance() {
     // given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingForJoinAt"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingForJoinTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingForJoinTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertIsWaitingForJoinTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertIsWaitingForJoinTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = "bpmn/ProcessInstanceAssert-isWaitingForJoinAt.bpmn")

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingForTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingForTest.java
@@ -16,19 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertIsWaitingForTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingFor.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingForTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingForTest.java
@@ -18,13 +18,12 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertIsWaitingForTest extends ProcessAssertTestCase {
 
@@ -34,7 +33,7 @@ public class ProcessInstanceAssertIsWaitingForTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingFor.bpmn"
   })
-  public void testIsWaitingFor_One_Message_Success() {
+  void isWaitingForOneMessageSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingFor"
@@ -46,7 +45,7 @@ public class ProcessInstanceAssertIsWaitingForTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingFor-2.bpmn"
   })
-  public void testIsWaitingFor_Two_Messages_Success() {
+  void isWaitingForTwoMessagesSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingFor-2"
@@ -58,7 +57,7 @@ public class ProcessInstanceAssertIsWaitingForTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingFor-2.bpmn"
   })
-  public void testIsWaitingFor_One_Of_Two_Messages_Success() {
+  void isWaitingForOneOfTwoMessagesSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingFor-2"
@@ -74,7 +73,7 @@ public class ProcessInstanceAssertIsWaitingForTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingFor.bpmn"
   })
-  public void testIsWaitingFor_One_Message_Failure() {
+  void isWaitingForOneMessageFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingFor"
@@ -88,7 +87,7 @@ public class ProcessInstanceAssertIsWaitingForTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingFor.bpmn"
   })
-  public void testIsWaitingFor_Not_Waiting_For_One_Of_One_Failure() {
+  void isWaitingForNotWaitingForOneOfOneFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingFor"
@@ -100,7 +99,7 @@ public class ProcessInstanceAssertIsWaitingForTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingFor.bpmn"
   })
-  public void testIsWaitingFor_Not_Waiting_For_One_Of_Two_Failure() {
+  void isWaitingForNotWaitingForOneOfTwoFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingFor"
@@ -112,7 +111,7 @@ public class ProcessInstanceAssertIsWaitingForTest extends ProcessAssertTestCase
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingFor.bpmn"
   })
-  public void testIsWaitingFor_Null_Error() {
+  void isWaitingForNullError() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-isWaitingFor"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingForTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertIsWaitingForTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertIsWaitingForTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertIsWaitingForTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-isWaitingFor.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertJobTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertJobTest.java
@@ -16,25 +16,22 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.execute;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.runtime.JobQuery;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.operaton.bpm.engine.test.mock.Mocks;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.execute;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-job.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertJobTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertJobTest.java
@@ -21,7 +21,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.execute;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.jobQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.runtime.JobQuery;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
@@ -30,7 +30,6 @@ import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.operaton.bpm.engine.test.mock.Mocks;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
 
@@ -40,7 +39,7 @@ public class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-job.bpmn"
   })
-  public void testJob_Single_Success() {
+  void jobSingleSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-job"
@@ -52,7 +51,7 @@ public class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-job.bpmn"
   })
-  public void testJob_NullQuery_Failure() {
+  void jobNullQueryFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-job"
@@ -69,7 +68,7 @@ public class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-job.bpmn"
   })
-  public void testJob_SingleWithQuery_Success() {
+  void jobSingleWithQuerySuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-job"
@@ -81,7 +80,7 @@ public class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-job.bpmn"
   })
-  public void testJob_MultipleWithQuery_Success() {
+  void jobMultipleWithQuerySuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-job"
@@ -101,7 +100,7 @@ public class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-job.bpmn"
   })
-  public void testJob_NotYet_Failure() {
+  void jobNotYetFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-job"
@@ -113,7 +112,7 @@ public class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-job.bpmn"
   })
-  public void testJob_Passed_Failure() {
+  void jobPassedFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-job"
@@ -129,7 +128,7 @@ public class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-job.bpmn"
   })
-  public void testJob_MultipleWithQuery_Failure() {
+  void jobMultipleWithQueryFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-job"
@@ -144,7 +143,7 @@ public class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-job.bpmn"
   })
-  public void testJob_MultipleWithTaskDefinitionKey_Success() {
+  void jobMultipleWithTaskDefinitionKeySuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-job"
@@ -161,7 +160,7 @@ public class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-job.bpmn"
   })
-  public void testJob_MultipleWithTaskDefinitionKey_Failure() {
+  void jobMultipleWithTaskDefinitionKeyFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-job"
@@ -181,7 +180,7 @@ public class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-jobEventSubprocess.bpmn"})
-  public void testJob_MultipleAsyncAndEventSubprocessTimerStartWithActivityId_Success() {
+  void jobMultipleAsyncAndEventSubprocessTimerStartWithActivityIdSuccess() {
     // When
     ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
         "ProcessInstanceAssert-jobEventSubprocess"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertJobTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertJobTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertJobTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-job.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertTaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertTaskTest.java
@@ -21,7 +21,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.TaskQuery;
@@ -29,7 +29,6 @@ import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertTaskTest extends ProcessAssertTestCase {
 
@@ -39,7 +38,7 @@ public class ProcessInstanceAssertTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-task.bpmn"
   })
-  public void testTask_Single_Success() {
+  void taskSingleSuccess() {
     // When
     final ProcessInstance processInstance = startProcess();
     // Then
@@ -49,7 +48,7 @@ public class ProcessInstanceAssertTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-task.bpmn"
   })
-  public void testTask_NullQuery_Failure() {
+  void taskNullQueryFailure() {
     // Given
     final ProcessInstance processInstance = startProcess();
     try {
@@ -64,7 +63,7 @@ public class ProcessInstanceAssertTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-task.bpmn"
   })
-  public void testTask_SingleWithQuery_Success() {
+  void taskSingleWithQuerySuccess() {
     // When
     final ProcessInstance processInstance = startProcess();
     // Then
@@ -74,7 +73,7 @@ public class ProcessInstanceAssertTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-task.bpmn"
   })
-  public void testTask_MultipleWithQuery_Success() {
+  void taskMultipleWithQuerySuccess() {
     // When
     final ProcessInstance processInstance = startProcess();
     // And
@@ -88,7 +87,7 @@ public class ProcessInstanceAssertTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-task.bpmn"
   })
-  public void testTask_NotYet_Failure() {
+  void taskNotYetFailure() {
     // When
     final ProcessInstance processInstance = startProcess();
     // Then
@@ -98,7 +97,7 @@ public class ProcessInstanceAssertTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-task.bpmn"
   })
-  public void testTask_Passed_Failure() {
+  void taskPassedFailure() {
     // Given
     final ProcessInstance processInstance = startProcess();
     // When
@@ -110,7 +109,7 @@ public class ProcessInstanceAssertTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-task.bpmn"
   })
-  public void testTask_MultipleWithQuery_Failure() {
+  void taskMultipleWithQueryFailure() {
     // When
     final ProcessInstance processInstance = startProcess();
     // And
@@ -126,7 +125,7 @@ public class ProcessInstanceAssertTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-task.bpmn"
   })
-  public void testTask_MultipleWithTaskDefinitionKey_Success() {
+  void taskMultipleWithTaskDefinitionKeySuccess() {
     // When
     final ProcessInstance processInstance = startProcess();
     // And
@@ -140,7 +139,7 @@ public class ProcessInstanceAssertTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-task.bpmn"
   })
-  public void testTask_MultipleWithTaskDefinitionKey_Failure() {
+  void taskMultipleWithTaskDefinitionKeyFailure() {
     // When
     final ProcessInstance processInstance = startProcess();
     // And
@@ -157,7 +156,7 @@ public class ProcessInstanceAssertTaskTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-task.bpmn"
   })
-  public void testTask_notWaitingAtTaskDefinitionKey() {
+  void taskNotWaitingAtTaskDefinitionKey() {
     final ProcessInstance processInstance = startProcess();
     expect(() -> assertThat(processInstance).task("UserTask_2").isNotNull());
   }

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertTaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertTaskTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProcessInstanceAssertTaskTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertTaskTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-task.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertTaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertTaskTest.java
@@ -16,24 +16,21 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.TaskQuery;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProcessInstanceAssertTaskTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-task.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertVariablesTest.java
@@ -21,13 +21,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.comple
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVariables;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessInstanceAssertVariablesTest extends ProcessAssertTestCase {
 
@@ -37,7 +36,7 @@ public class ProcessInstanceAssertVariablesTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-variables.bpmn"
   })
-  public void testVariables_One_Success() {
+  void variablesOneSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-variables", withVariables("aVariable", "aValue")
@@ -53,7 +52,7 @@ public class ProcessInstanceAssertVariablesTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-variables.bpmn"
   })
-  public void testVariables_One_Changed_Success() {
+  void variablesOneChangedSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-variables", withVariables("aVariable", "aValue")
@@ -71,7 +70,7 @@ public class ProcessInstanceAssertVariablesTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-variables.bpmn"
   })
-  public void testVariables_One_Failure() {
+  void variablesOneFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-variables", withVariables("aVariable", "aValue")
@@ -91,7 +90,7 @@ public class ProcessInstanceAssertVariablesTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-variables.bpmn"
   })
-  public void testVariables_Two_Success() {
+  void variablesTwoSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-variables", withVariables("firstVariable", "firstValue", "secondVariable", "secondValue")
@@ -119,7 +118,7 @@ public class ProcessInstanceAssertVariablesTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-variables.bpmn"
   })
-  public void testVariables_Two_Failure() {
+  void variablesTwoFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-variables", withVariables("firstVariable", "firstValue", "secondVariable", "secondValue")
@@ -147,7 +146,7 @@ public class ProcessInstanceAssertVariablesTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-variables.bpmn"
   })
-  public void testVariables_None_Success() {
+  void variablesNoneSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-variables"
@@ -163,7 +162,7 @@ public class ProcessInstanceAssertVariablesTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-variables.bpmn"
   })
-  public void testVariables_None_Failure() {
+  void variablesNoneFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "ProcessInstanceAssert-variables"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertVariablesTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class ProcessInstanceAssertVariablesTest extends ProcessAssertTestCase {
+class ProcessInstanceAssertVariablesTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-variables.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessInstanceAssertVariablesTest.java
@@ -16,22 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVariables;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceAssertVariablesTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/ProcessInstanceAssert-variables.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateGroupAssociatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateGroupAssociatedTest.java
@@ -16,28 +16,18 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.claim;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTestCase {
 
   private static final String CANDIDATE_GROUP = "candidateGroup";
   private static final String ASSIGNEE = "assignee";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroupAssociated.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateGroupAssociatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateGroupAssociatedTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTestCase {
+class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTestCase {
 
   private static final String CANDIDATE_GROUP = "candidateGroup";
   private static final String ASSIGNEE = "assignee";

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateGroupAssociatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateGroupAssociatedTest.java
@@ -23,14 +23,13 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTestCase {
 
@@ -43,7 +42,7 @@ public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroupAssociated.bpmn"
   })
-  public void testHasCandidateGroupAssociated_PreDefined_Success() {
+  void hasCandidateGroupAssociatedPreDefinedSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroupAssociated"
@@ -55,7 +54,7 @@ public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroupAssociated.bpmn"
   })
-  public void testHasCandidateGroupAssociated_PreDefined_Failure() {
+  void hasCandidateGroupAssociatedPreDefinedFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroupAssociated"
@@ -69,7 +68,7 @@ public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroupAssociated.bpmn"
   })
-  public void testHasCandidateGroupAssociated_Predefined_Removed_Failure() {
+  void hasCandidateGroupAssociatedPredefinedRemovedFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroupAssociated"
@@ -83,7 +82,7 @@ public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroupAssociated.bpmn"
   })
-  public void testHasCandidateGroupAssociated_PreDefined_Other_Failure() {
+  void hasCandidateGroupAssociatedPreDefinedOtherFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroupAssociated"
@@ -97,7 +96,7 @@ public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroupAssociated.bpmn"
   })
-  public void testHasCandidateGroupAssociated_ExplicitlySet_Success() {
+  void hasCandidateGroupAssociatedExplicitlySetSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroupAssociated"
@@ -113,7 +112,7 @@ public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroupAssociated.bpmn"
   })
-  public void testHasCandidateGroupAssociated_ExplicitlySet_Failure() {
+  void hasCandidateGroupAssociatedExplicitlySetFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroupAssociated"
@@ -127,7 +126,7 @@ public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroupAssociated.bpmn"
   })
-  public void testHasCandidateGroupAssociated_ExplicitlySet_Removed_Failure() {
+  void hasCandidateGroupAssociatedExplicitlySetRemovedFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroupAssociated"
@@ -145,7 +144,7 @@ public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroupAssociated.bpmn"
   })
-  public void testHasCandidateGroupAssociated_ExplicitlySet_Other_Failure() {
+  void hasCandidateGroupAssociatedExplicitlySetOtherFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroupAssociated"
@@ -162,7 +161,7 @@ public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroupAssociated.bpmn"
   })
-  public void testHasCandidateGroupAssociated_MoreThanOne_Success() {
+  void hasCandidateGroupAssociatedMoreThanOneSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroupAssociated"
@@ -178,7 +177,7 @@ public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroupAssociated.bpmn"
   })
-  public void testHasCandidateGroupAssociated_MoreThanOne_Failure() {
+  void hasCandidateGroupAssociatedMoreThanOneFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroupAssociated"
@@ -192,7 +191,7 @@ public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroupAssociated.bpmn"
   })
-  public void testHasCandidateGroupAssociated_Null_Failure() {
+  void hasCandidateGroupAssociatedNullFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroupAssociated"
@@ -204,7 +203,7 @@ public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroupAssociated.bpmn"
   })
-  public void testHasCandidateGroupAssociated_NonExistingTask_Failure() {
+  void hasCandidateGroupAssociatedNonExistingTaskFailure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroupAssociated"
@@ -219,7 +218,7 @@ public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroupAssociated.bpmn"
   })
-  public void testHasCandidateGroupAssociated_Assigned_Success() {
+  void hasCandidateGroupAssociatedAssignedSuccess() {
     // Given
     final ProcessInstance pi = runtimeService().startProcessInstanceByKey(
         "TaskAssert-hasCandidateGroupAssociated"
@@ -233,7 +232,7 @@ public class TaskAssertHasCandidateGroupAssociatedTest extends ProcessAssertTest
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroupAssociated.bpmn"
   })
-  public void testHasCandidateGroupAssociated_Assigned_Failure() {
+  void hasCandidateGroupAssociatedAssignedFailure() {
     // Given
     final ProcessInstance pi = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroupAssociated"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateGroupTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateGroupTest.java
@@ -23,14 +23,13 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
 
@@ -43,7 +42,7 @@ public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroup.bpmn"
   })
-  public void testHasCandidateGroup_PreDefined_Success() {
+  void hasCandidateGroupPreDefinedSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroup"
@@ -55,7 +54,7 @@ public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroup.bpmn"
   })
-  public void testHasCandidateGroup_PreDefined_Failure() {
+  void hasCandidateGroupPreDefinedFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroup"
@@ -69,7 +68,7 @@ public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroup.bpmn"
   })
-  public void testHasCandidateGroup_Predefined_Removed_Failure() {
+  void hasCandidateGroupPredefinedRemovedFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroup"
@@ -83,7 +82,7 @@ public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroup.bpmn"
   })
-  public void testHasCandidateGroup_PreDefined_Other_Failure() {
+  void hasCandidateGroupPreDefinedOtherFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroup"
@@ -97,7 +96,7 @@ public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroup.bpmn"
   })
-  public void testHasCandidateGroup_ExplicitlySet_Success() {
+  void hasCandidateGroupExplicitlySetSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroup"
@@ -113,7 +112,7 @@ public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroup.bpmn"
   })
-  public void testHasCandidateGroup_ExplicitlySet_Failure() {
+  void hasCandidateGroupExplicitlySetFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroup"
@@ -127,7 +126,7 @@ public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroup.bpmn"
   })
-  public void testHasCandidateGroup_ExplicitlySet_Removed_Failure() {
+  void hasCandidateGroupExplicitlySetRemovedFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroup"
@@ -145,7 +144,7 @@ public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroup.bpmn"
   })
-  public void testHasCandidateGroup_ExplicitlySet_Other_Failure() {
+  void hasCandidateGroupExplicitlySetOtherFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroup"
@@ -162,7 +161,7 @@ public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroup.bpmn"
   })
-  public void testHasCandidateGroup_MoreThanOne_Success() {
+  void hasCandidateGroupMoreThanOneSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroup"
@@ -178,7 +177,7 @@ public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroup.bpmn"
   })
-  public void testHasCandidateGroup_MoreThanOne_Failure() {
+  void hasCandidateGroupMoreThanOneFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroup"
@@ -192,7 +191,7 @@ public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroup.bpmn"
   })
-  public void testHasCandidateGroup_Null_Failure() {
+  void hasCandidateGroupNullFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroup"
@@ -204,7 +203,7 @@ public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroup.bpmn"
   })
-  public void testHasCandidateGroup_NonExistingTask_Failure() {
+  void hasCandidateGroupNonExistingTaskFailure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateGroup"
@@ -219,7 +218,7 @@ public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroup.bpmn"
   })
-  public void testHasCandidateGroup_Assigned_Failure() {
+  void hasCandidateGroupAssignedFailure() {
     // Given
     final ProcessInstance pi = runtimeService().startProcessInstanceByKey(
         "TaskAssert-hasCandidateGroup"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateGroupTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateGroupTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
+class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
 
   private static final String CANDIDATE_GROUP = "candidateGroup";
   private static final String ASSIGNEE = "assignee";

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateGroupTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateGroupTest.java
@@ -16,28 +16,18 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.claim;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class TaskAssertHasCandidateGroupTest extends ProcessAssertTestCase {
 
   private static final String CANDIDATE_GROUP = "candidateGroup";
   private static final String ASSIGNEE = "assignee";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateGroup.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateUserAssociatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateUserAssociatedTest.java
@@ -21,14 +21,13 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.comple
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestCase {
 
@@ -41,7 +40,7 @@ public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUserAssociated.bpmn"
   })
-  public void hasCandidateUserAssociatedPreDefined_Success() {
+  void hasCandidateUserAssociatedPreDefined_Success() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUserAssociated"
@@ -53,7 +52,7 @@ public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUserAssociated.bpmn"
   })
-  public void hasCandidateUserAssociated_PreDefined_Failure() {
+  void hasCandidateUserAssociated_PreDefined_Failure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUserAssociated"
@@ -67,7 +66,7 @@ public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUserAssociated.bpmn"
   })
-  public void hasCandidateUserAssociated_Predefined_Removed_Failure() {
+  void hasCandidateUserAssociated_Predefined_Removed_Failure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUserAssociated"
@@ -81,7 +80,7 @@ public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUserAssociated.bpmn"
   })
-  public void hasCandidateUserAssociated_PreDefined_Other_Failure() {
+  void hasCandidateUserAssociated_PreDefined_Other_Failure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUserAssociated"
@@ -95,7 +94,7 @@ public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUserAssociated.bpmn"
   })
-  public void hasCandidateUserAssociated_ExplicitlySet_Success() {
+  void hasCandidateUserAssociated_ExplicitlySet_Success() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUserAssociated"
@@ -111,7 +110,7 @@ public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUserAssociated.bpmn"
   })
-  public void hasCandidateUserAssociated_ExplicitlySet_Failure() {
+  void hasCandidateUserAssociated_ExplicitlySet_Failure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUserAssociated"
@@ -125,7 +124,7 @@ public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUserAssociated.bpmn"
   })
-  public void hasCandidateUserAssociated_ExplicitlySet_Removed_Failure() {
+  void hasCandidateUserAssociated_ExplicitlySet_Removed_Failure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUserAssociated"
@@ -143,7 +142,7 @@ public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUserAssociated.bpmn"
   })
-  public void hasCandidateUserAssociated_ExplicitlySet_Other_Failure() {
+  void hasCandidateUserAssociated_ExplicitlySet_Other_Failure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUserAssociated"
@@ -160,7 +159,7 @@ public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUserAssociated.bpmn"
   })
-  public void hasCandidateUserAssociated_MoreThanOne_Success() {
+  void hasCandidateUserAssociated_MoreThanOne_Success() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUserAssociated"
@@ -176,7 +175,7 @@ public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUserAssociated.bpmn"
   })
-  public void hasCandidateUserAssociated_MoreThanOne_Failure() {
+  void hasCandidateUserAssociated_MoreThanOne_Failure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUserAssociated"
@@ -190,7 +189,7 @@ public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUserAssociated.bpmn"
   })
-  public void hasCandidateUserAssociated_Null_Failure() {
+  void hasCandidateUserAssociated_Null_Failure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUserAssociated"
@@ -202,7 +201,7 @@ public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUserAssociated.bpmn"
   })
-  public void hasCandidateUserAssociated_NonExistingTask_Failure() {
+  void hasCandidateUserAssociated_NonExistingTask_Failure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUserAssociated"
@@ -217,7 +216,7 @@ public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUserAssociated.bpmn"
   })
-  public void hasCandidateUserAssociated_Assigned_Success() {
+  void hasCandidateUserAssociated_Assigned_Success() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUserAssociated"
@@ -232,7 +231,7 @@ public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestC
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUserAssociated.bpmn"
   })
-  public void hasCandidateUserAssociated_Assigned_Failure() {
+  void hasCandidateUserAssociated_Assigned_Failure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUserAssociated"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateUserAssociatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateUserAssociatedTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestCase {
+class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestCase {
 
   private static final String CANDIDATE_USER = "candidateUser";
   private static final String ASSIGNEE = "assignee";

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateUserAssociatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateUserAssociatedTest.java
@@ -16,26 +16,18 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class TaskAssertHasCandidateUserAssociatedTest extends ProcessAssertTestCase {
 
   private static final String CANDIDATE_USER = "candidateUser";
   private static final String ASSIGNEE = "assignee";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUserAssociated.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateUserTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateUserTest.java
@@ -21,14 +21,13 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.comple
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
 
@@ -41,7 +40,7 @@ public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUser.bpmn"
   })
-  public void testHasCandidateUserPreDefined_Success() {
+  void hasCandidateUserPreDefinedSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUser"
@@ -53,7 +52,7 @@ public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUser.bpmn"
   })
-  public void testHasCandidateUser_PreDefined_Failure() {
+  void hasCandidateUserPreDefinedFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUser"
@@ -67,7 +66,7 @@ public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUser.bpmn"
   })
-  public void testHasCandidateUser_Predefined_Removed_Failure() {
+  void hasCandidateUserPredefinedRemovedFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUser"
@@ -81,7 +80,7 @@ public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUser.bpmn"
   })
-  public void testHasCandidateUser_PreDefined_Other_Failure() {
+  void hasCandidateUserPreDefinedOtherFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUser"
@@ -95,7 +94,7 @@ public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUser.bpmn"
   })
-  public void testHasCandidateUser_ExplicitlySet_Success() {
+  void hasCandidateUserExplicitlySetSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUser"
@@ -111,7 +110,7 @@ public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUser.bpmn"
   })
-  public void testHasCandidateUser_ExplicitlySet_Failure() {
+  void hasCandidateUserExplicitlySetFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUser"
@@ -125,7 +124,7 @@ public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUser.bpmn"
   })
-  public void testHasCandidateUser_ExplicitlySet_Removed_Failure() {
+  void hasCandidateUserExplicitlySetRemovedFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUser"
@@ -143,7 +142,7 @@ public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUser.bpmn"
   })
-  public void testHasCandidateUser_ExplicitlySet_Other_Failure() {
+  void hasCandidateUserExplicitlySetOtherFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUser"
@@ -160,7 +159,7 @@ public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUser.bpmn"
   })
-  public void testHasCandidateUser_MoreThanOne_Success() {
+  void hasCandidateUserMoreThanOneSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUser"
@@ -176,7 +175,7 @@ public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUser.bpmn"
   })
-  public void testHasCandidateUser_MoreThanOne_Failure() {
+  void hasCandidateUserMoreThanOneFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUser"
@@ -190,7 +189,7 @@ public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUser.bpmn"
   })
-  public void testHasCandidateUser_Null_Failure() {
+  void hasCandidateUserNullFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUser"
@@ -202,7 +201,7 @@ public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUser.bpmn"
   })
-  public void testHasCandidateUser_NonExistingTask_Failure() {
+  void hasCandidateUserNonExistingTaskFailure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUser"
@@ -217,7 +216,7 @@ public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUser.bpmn"
   })
-  public void testHasCandidateUser_Assigned_Failure() {
+  void hasCandidateUserAssignedFailure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasCandidateUser"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateUserTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateUserTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
+class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
 
   private static final String CANDIDATE_USER = "candidateUser";
   private static final String ASSIGNEE = "assignee";

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateUserTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasCandidateUserTest.java
@@ -16,26 +16,18 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class TaskAssertHasCandidateUserTest extends ProcessAssertTestCase {
 
   private static final String CANDIDATE_USER = "candidateUser";
   private static final String ASSIGNEE = "assignee";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasCandidateUser.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDefinitionKeyTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDefinitionKeyTest.java
@@ -16,19 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
+import org.junit.jupiter.api.Test;
 
 public class TaskAssertHasDefinitionKeyTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasDefinitionKey.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDefinitionKeyTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDefinitionKeyTest.java
@@ -18,13 +18,12 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskAssertHasDefinitionKeyTest extends ProcessAssertTestCase {
 
@@ -34,7 +33,7 @@ public class TaskAssertHasDefinitionKeyTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasDefinitionKey.bpmn"
   })
-  public void testHasDefinitionKey_Success() {
+  void hasDefinitionKeySuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasDefinitionKey"
@@ -46,7 +45,7 @@ public class TaskAssertHasDefinitionKeyTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasDefinitionKey.bpmn"
   })
-  public void testHasDefinitionKey_Failure() {
+  void hasDefinitionKeyFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasDefinitionKey"
@@ -58,7 +57,7 @@ public class TaskAssertHasDefinitionKeyTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasDefinitionKey.bpmn"
   })
-  public void testHasDefinitionKey_Null_Failure() {
+  void hasDefinitionKeyNullFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasDefinitionKey"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDefinitionKeyTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDefinitionKeyTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class TaskAssertHasDefinitionKeyTest extends ProcessAssertTestCase {
+class TaskAssertHasDefinitionKeyTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasDefinitionKey.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDescriptionTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDescriptionTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class TaskAssertHasDescriptionTest extends ProcessAssertTestCase {
+class TaskAssertHasDescriptionTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasDescription.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDescriptionTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDescriptionTest.java
@@ -16,19 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
+import org.junit.jupiter.api.Test;
 
 public class TaskAssertHasDescriptionTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasDescription.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDescriptionTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDescriptionTest.java
@@ -18,13 +18,12 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskAssertHasDescriptionTest extends ProcessAssertTestCase {
 
@@ -34,7 +33,7 @@ public class TaskAssertHasDescriptionTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasDescription.bpmn"
   })
-  public void testHasDescription_Success() {
+  void hasDescriptionSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasDescription"
@@ -46,7 +45,7 @@ public class TaskAssertHasDescriptionTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasDescription.bpmn"
   })
-  public void testHasDescription_Failure() {
+  void hasDescriptionFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasDescription"
@@ -58,7 +57,7 @@ public class TaskAssertHasDescriptionTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasDescription.bpmn"
   })
-  public void testHasDescription_Null_Failure() {
+  void hasDescriptionNullFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasDescription"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDueDateTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDueDateTest.java
@@ -26,7 +26,7 @@ import java.util.Date;
 
 import org.junit.jupiter.api.Test;
 
-public class TaskAssertHasDueDateTest extends ProcessAssertTestCase {
+class TaskAssertHasDueDateTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasDueDate.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDueDateTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDueDateTest.java
@@ -16,24 +16,17 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskService;
-
-import java.util.Date;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
 
 public class TaskAssertHasDueDateTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasDueDate.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDueDateTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasDueDateTest.java
@@ -22,14 +22,13 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQu
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskService;
 
 import java.util.Date;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskAssertHasDueDateTest extends ProcessAssertTestCase {
 
@@ -39,7 +38,7 @@ public class TaskAssertHasDueDateTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasDueDate.bpmn"
   })
-  public void testHasDueDate_Success() {
+  void hasDueDateSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasDueDate"
@@ -55,7 +54,7 @@ public class TaskAssertHasDueDateTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasDueDate.bpmn"
   })
-  public void testHasDueDate_Failure() {
+  void hasDueDateFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasDueDate"
@@ -69,7 +68,7 @@ public class TaskAssertHasDueDateTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasDueDate.bpmn"
   })
-  public void testHasDueDate_Null_Failure() {
+  void hasDueDateNullFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasDueDate"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasFormKeyTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasFormKeyTest.java
@@ -18,13 +18,12 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskAssertHasFormKeyTest extends ProcessAssertTestCase {
 
@@ -34,7 +33,7 @@ public class TaskAssertHasFormKeyTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasFormKey.bpmn"
   })
-  public void testHasFormKey_Success() {
+  void hasFormKeySuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasFormKey"
@@ -46,7 +45,7 @@ public class TaskAssertHasFormKeyTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasFormKey.bpmn"
   })
-  public void testHasFormKey_Failure() {
+  void hasFormKeyFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasFormKey"
@@ -58,7 +57,7 @@ public class TaskAssertHasFormKeyTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasFormKey.bpmn"
   })
-  public void testHasFormKey_Null_Failure() {
+  void hasFormKeyNullFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasFormKey"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasFormKeyTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasFormKeyTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class TaskAssertHasFormKeyTest extends ProcessAssertTestCase {
+class TaskAssertHasFormKeyTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasFormKey.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasFormKeyTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasFormKeyTest.java
@@ -16,19 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
+import org.junit.jupiter.api.Test;
 
 public class TaskAssertHasFormKeyTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasFormKey.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasIdTest.java
@@ -19,13 +19,12 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskAssertHasIdTest extends ProcessAssertTestCase {
 
@@ -35,7 +34,7 @@ public class TaskAssertHasIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasId.bpmn"
   })
-  public void testHasId_Success() {
+  void hasIdSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasId"
@@ -47,7 +46,7 @@ public class TaskAssertHasIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasId.bpmn"
   })
-  public void testHasId_Failure() {
+  void hasIdFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasId"
@@ -59,7 +58,7 @@ public class TaskAssertHasIdTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasId.bpmn"
   })
-  public void testHasId_Null_Failure() {
+  void hasIdNullFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasId"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasIdTest.java
@@ -25,7 +25,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQu
 
 import org.junit.jupiter.api.Test;
 
-public class TaskAssertHasIdTest extends ProcessAssertTestCase {
+class TaskAssertHasIdTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasId.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasIdTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasIdTest.java
@@ -16,20 +16,16 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class TaskAssertHasIdTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasId.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasNameTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasNameTest.java
@@ -16,19 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
+
+import org.junit.jupiter.api.Test;
 
 public class TaskAssertHasNameTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasName.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasNameTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasNameTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtim
 
 import org.junit.jupiter.api.Test;
 
-public class TaskAssertHasNameTest extends ProcessAssertTestCase {
+class TaskAssertHasNameTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasName.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasNameTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertHasNameTest.java
@@ -18,13 +18,12 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskAssertHasNameTest extends ProcessAssertTestCase {
 
@@ -34,7 +33,7 @@ public class TaskAssertHasNameTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasName.bpmn"
   })
-  public void testHasName_Success() {
+  void hasNameSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasName"
@@ -46,7 +45,7 @@ public class TaskAssertHasNameTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasName.bpmn"
   })
-  public void testHasName_Failure() {
+  void hasNameFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasName"
@@ -58,7 +57,7 @@ public class TaskAssertHasNameTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-hasName.bpmn"
   })
-  public void testHasName_Null_Failure() {
+  void hasNameNullFailure() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-hasName"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertIsAssignedToTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertIsAssignedToTest.java
@@ -16,23 +16,15 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.claim;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class TaskAssertIsAssignedToTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-isAssignedTo.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertIsAssignedToTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertIsAssignedToTest.java
@@ -21,14 +21,13 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.claim;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskAssertIsAssignedToTest extends ProcessAssertTestCase {
 
@@ -38,7 +37,7 @@ public class TaskAssertIsAssignedToTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-isAssignedTo.bpmn"
   })
-  public void testIsAssignedTo_Success() {
+  void isAssignedToSuccess() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-isAssignedTo"
@@ -52,7 +51,7 @@ public class TaskAssertIsAssignedToTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-isAssignedTo.bpmn"
   })
-  public void testIsAssignedTo_NotAssigned_Failure() {
+  void isAssignedToNotAssignedFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-isAssignedTo"
@@ -64,7 +63,7 @@ public class TaskAssertIsAssignedToTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-isAssignedTo.bpmn"
   })
-  public void testIsAssignedTo_OtherAssignee_Failure() {
+  void isAssignedToOtherAssigneeFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-isAssignedTo"
@@ -78,7 +77,7 @@ public class TaskAssertIsAssignedToTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-isAssignedTo.bpmn"
   })
-  public void testIsAssignedTo_Null_Failure() {
+  void isAssignedToNullFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-isAssignedTo"
@@ -92,7 +91,7 @@ public class TaskAssertIsAssignedToTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-isAssignedTo.bpmn"
   })
-  public void testIsAssignedTo_NonExistingTask_Failure() {
+  void isAssignedToNonExistingTaskFailure() {
     // Given
     runtimeService().startProcessInstanceByKey(
       "TaskAssert-isAssignedTo"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertIsAssignedToTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertIsAssignedToTest.java
@@ -24,7 +24,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class TaskAssertIsAssignedToTest extends ProcessAssertTestCase {
+class TaskAssertIsAssignedToTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-isAssignedTo.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertIsNotAssignedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertIsNotAssignedTest.java
@@ -16,21 +16,14 @@
  */
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.claim;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class TaskAssertIsNotAssignedTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-isNotAssigned.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertIsNotAssignedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertIsNotAssignedTest.java
@@ -20,13 +20,12 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.claim;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.runtimeService;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.taskQuery;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskAssertIsNotAssignedTest extends ProcessAssertTestCase {
 
@@ -36,7 +35,7 @@ public class TaskAssertIsNotAssignedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-isNotAssigned.bpmn"
   })
-  public void testIsNotAssigned_Success() {
+  void isNotAssignedSuccess() {
     // When
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-isNotAssigned"
@@ -48,7 +47,7 @@ public class TaskAssertIsNotAssignedTest extends ProcessAssertTestCase {
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-isNotAssigned.bpmn"
   })
-  public void testIsNotAssigned_Failure() {
+  void isNotAssignedFailure() {
     // Given
     final ProcessInstance processInstance = runtimeService().startProcessInstanceByKey(
       "TaskAssert-isNotAssigned"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertIsNotAssignedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/TaskAssertIsNotAssignedTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
 
-public class TaskAssertIsNotAssignedTest extends ProcessAssertTestCase {
+class TaskAssertIsNotAssignedTest extends ProcessAssertTestCase {
 
   @Test
   @Deployment(resources = {"bpmn/TaskAssert-isNotAssigned.bpmn"

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsActiveTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsActiveTest.java
@@ -16,17 +16,13 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class CaseInstanceAssertIsActiveTest extends ProcessAssertTestCase {
 
@@ -34,9 +30,6 @@ public class CaseInstanceAssertIsActiveTest extends ProcessAssertTestCase {
   public static final String TASK_B = "PI_TaskB";
   public static final String CASE_KEY = "Case_CaseTaskAssertIsActiveTest";
   public static final String CASE_KEY_B = "Case_CaseTaskAssertIsActiveTest_CaseB";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/CaseTaskAssertIsActiveTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsActiveTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsActiveTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class CaseInstanceAssertIsActiveTest extends ProcessAssertTestCase {
 
@@ -40,8 +39,8 @@ public class CaseInstanceAssertIsActiveTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsActiveTest.cmmn" })
-  public void testIsActive_Success() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsActiveTest.cmmn"})
+  void isActiveSuccess() {
     // Given
     // case model is deployed
     // When
@@ -51,8 +50,8 @@ public class CaseInstanceAssertIsActiveTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsActiveTest.cmmn" })
-  public void testIsActive_Failure() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsActiveTest.cmmn"})
+  void isActiveFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     CaseInstance caseInstanceB = caseService().createCaseInstanceQuery().caseDefinitionKey(CASE_KEY_B).singleResult();

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsClosedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsClosedTest.java
@@ -18,14 +18,13 @@ package org.operaton.bpm.engine.test.assertions.cmmn;
 
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class CaseInstanceAssertIsClosedTest extends ProcessAssertTestCase {
 
@@ -36,8 +35,8 @@ public class CaseInstanceAssertIsClosedTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsTerminatedTest.cmmn" })
-  public void testIsClosed_Success() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsTerminatedTest.cmmn"})
+  void isClosedSuccess() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     // When
@@ -49,8 +48,8 @@ public class CaseInstanceAssertIsClosedTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsTerminatedTest.cmmn" })
-  public void testIsClosed_Failure() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsTerminatedTest.cmmn"})
+  void isClosedFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsClosedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsClosedTest.java
@@ -16,23 +16,19 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
+
+import org.junit.jupiter.api.Test;
 
 public class CaseInstanceAssertIsClosedTest extends ProcessAssertTestCase {
 
   public static final String TASK_B = "PI_TaskB";
   public static final String CASE_KEY = "Case_CaseTaskAssertIsTerminatedTest";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/CaseTaskAssertIsTerminatedTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsCompletedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsCompletedTest.java
@@ -16,17 +16,13 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class CaseInstanceAssertIsCompletedTest extends ProcessAssertTestCase {
 
@@ -34,9 +30,6 @@ public class CaseInstanceAssertIsCompletedTest extends ProcessAssertTestCase {
   public static final String TASK_B = "PI_TaskB";
   public static final String CASE_KEY = "Case_CaseTaskAssertIsCompletedTest";
   public static final String CASE_KEY_B = "Case_CaseTaskAssertIsCompletedTest_CaseB";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/CaseTaskAssertIsCompletedTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsCompletedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsCompletedTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class CaseInstanceAssertIsCompletedTest extends ProcessAssertTestCase {
 
@@ -40,8 +39,8 @@ public class CaseInstanceAssertIsCompletedTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsCompletedTest.cmmn" })
-  public void testIsCompleted_Success() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsCompletedTest.cmmn"})
+  void isCompletedSuccess() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreated();
     CaseInstance caseInstanceB = caseService().createCaseInstanceQuery().caseDefinitionKey(CASE_KEY_B).singleResult();
@@ -52,8 +51,8 @@ public class CaseInstanceAssertIsCompletedTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsCompletedTest.cmmn" })
-  public void testIsCompleted_Failure() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsCompletedTest.cmmn"})
+  void isCompletedFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsTerminatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsTerminatedTest.java
@@ -21,14 +21,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseEx
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.manuallyStart;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class CaseInstanceAssertIsTerminatedTest extends ProcessAssertTestCase {
 
@@ -42,8 +41,8 @@ public class CaseInstanceAssertIsTerminatedTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsTerminatedTest.cmmn" })
-  public void testIsTerminated_Success() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsTerminatedTest.cmmn"})
+  void isTerminatedSuccess() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     CaseInstance caseInstanceB = caseService().createCaseInstanceQuery().caseDefinitionKey(CASE_KEY_B).singleResult();
@@ -56,8 +55,8 @@ public class CaseInstanceAssertIsTerminatedTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsTerminatedTest.cmmn" })
-  public void testIsTerminated_Failure() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsTerminatedTest.cmmn"})
+  void isTerminatedFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsTerminatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertIsTerminatedTest.java
@@ -16,18 +16,13 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.manuallyStart;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class CaseInstanceAssertIsTerminatedTest extends ProcessAssertTestCase {
 
@@ -36,9 +31,6 @@ public class CaseInstanceAssertIsTerminatedTest extends ProcessAssertTestCase {
   public static final String HTASK_B = "PI_TaskB_HT";
   public static final String CASE_KEY = "Case_CaseTaskAssertIsTerminatedTest";
   public static final String CASE_KEY_B = "Case_CaseTaskAssertIsTerminatedTest_CaseB";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/CaseTaskAssertIsTerminatedTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertTest.java
@@ -16,26 +16,18 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecutionQuery;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CaseInstanceAssertTest extends ProcessAssertTestCase {
 
 	public static final String TASK_A = "PI_TaskA";
-
-	@Rule
-	public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/TaskTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseInstanceAssertTest.java
@@ -22,13 +22,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseEx
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class CaseInstanceAssertTest extends ProcessAssertTestCase {
 
@@ -37,9 +37,9 @@ public class CaseInstanceAssertTest extends ProcessAssertTestCase {
 	@Rule
 	public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
-	@Test
-	@Deployment(resources = { "cmmn/TaskTest.cmmn" })
-	public void testReturnsCaseTaskAssertForCompletedTasks() {
+  @Test
+  @Deployment(resources = {"cmmn/TaskTest.cmmn"})
+  void returnsCaseTaskAssertForCompletedTasks() {
 		// Given
 		CaseInstance caseInstance = aStartedCase();
 		CaseExecution taskA = caseExecution(TASK_A, caseInstance);
@@ -51,9 +51,9 @@ public class CaseInstanceAssertTest extends ProcessAssertTestCase {
 		assertThat(caseInstance).isCompleted();
 	}
 
-	@Test
-	@Deployment(resources = { "cmmn/TaskTest.cmmn" })
-	public void testReturnsHumanTaskAssertForGivenActivityId() {
+  @Test
+  @Deployment(resources = {"cmmn/TaskTest.cmmn"})
+  void returnsHumanTaskAssertForGivenActivityId() {
 		// Given
 		CaseInstance caseInstance = aStartedCase();
 		CaseExecution pi_taskA = caseService()
@@ -73,9 +73,9 @@ public class CaseInstanceAssertTest extends ProcessAssertTestCase {
 				.isEqualToComparingOnlyGivenFields(pi_taskA, "id");
 	}
 
-	@Test
-  @Deployment(resources = { "cmmn/TaskTest.cmmn" })
-  public void testIsCaseInstance() {
+  @Test
+  @Deployment(resources = {"cmmn/TaskTest.cmmn"})
+  void isCaseInstance() {
     // Given
     CaseInstance caseInstance = aStartedCase();
     // Then

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsActiveTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsActiveTest.java
@@ -16,17 +16,13 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class CaseTaskAssertIsActiveTest extends ProcessAssertTestCase {
 
@@ -34,9 +30,6 @@ public class CaseTaskAssertIsActiveTest extends ProcessAssertTestCase {
   public static final String TASK_B = "PI_TaskB";
   public static final String CASE_KEY = "Case_CaseTaskAssertIsActiveTest";
   public static final String CASE_KEY_B = "Case_CaseTaskAssertIsActiveTest_CaseB";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/CaseTaskAssertIsActiveTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsActiveTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsActiveTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class CaseTaskAssertIsActiveTest extends ProcessAssertTestCase {
 
@@ -40,8 +39,8 @@ public class CaseTaskAssertIsActiveTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsActiveTest.cmmn" })
-  public void testIsActive_Success() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsActiveTest.cmmn"})
+  void isActiveSuccess() {
     // Given
     // case model is deployed
     // When
@@ -51,8 +50,8 @@ public class CaseTaskAssertIsActiveTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsActiveTest.cmmn" })
-  public void testIsActive_Failure() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsActiveTest.cmmn"})
+  void isActiveFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     CaseInstance caseInstanceB = caseService().createCaseInstanceQuery().caseDefinitionKey(CASE_KEY_B).singleResult();

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsAvailableTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsAvailableTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class CaseTaskAssertIsAvailableTest extends ProcessAssertTestCase {
 
@@ -41,8 +40,8 @@ public class CaseTaskAssertIsAvailableTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsAvailableTest.cmmn" })
-  public void testIsAvailable_Success() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsAvailableTest.cmmn"})
+  void isAvailableSuccess() {
     // Given
     // case model is deployed
     // When
@@ -52,8 +51,8 @@ public class CaseTaskAssertIsAvailableTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsAvailableTest.cmmn" })
-  public void testIsAvailable_Failure() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsAvailableTest.cmmn"})
+  void isAvailableFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     CaseInstance caseInstanceB = caseService().createCaseInstanceQuery().caseDefinitionKey(CASE_KEY_B).singleResult();

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsAvailableTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsAvailableTest.java
@@ -16,17 +16,13 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class CaseTaskAssertIsAvailableTest extends ProcessAssertTestCase {
 
@@ -35,9 +31,6 @@ public class CaseTaskAssertIsAvailableTest extends ProcessAssertTestCase {
   public static final String HTASK_B = "PI_TaskB_HT";
   public static final String CASE_KEY = "Case_CaseTaskAssertIsAvailableTest";
   public static final String CASE_KEY_B = "Case_CaseTaskAssertIsAvailableTest_CaseB";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/CaseTaskAssertIsAvailableTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsCompletedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsCompletedTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class CaseTaskAssertIsCompletedTest extends ProcessAssertTestCase {
 
@@ -40,8 +39,8 @@ public class CaseTaskAssertIsCompletedTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsCompletedTest.cmmn" })
-  public void testIsCompleted_Success() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsCompletedTest.cmmn"})
+  void isCompletedSuccess() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreated();
     CaseInstance caseInstanceB = caseService().createCaseInstanceQuery().caseDefinitionKey(CASE_KEY_B).singleResult();
@@ -53,8 +52,8 @@ public class CaseTaskAssertIsCompletedTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsCompletedTest.cmmn" })
-  public void testIsCompleted_Failure() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsCompletedTest.cmmn"})
+  void isCompletedFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsCompletedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsCompletedTest.java
@@ -16,17 +16,13 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class CaseTaskAssertIsCompletedTest extends ProcessAssertTestCase {
 
@@ -34,9 +30,6 @@ public class CaseTaskAssertIsCompletedTest extends ProcessAssertTestCase {
   public static final String TASK_B = "PI_TaskB";
   public static final String CASE_KEY = "Case_CaseTaskAssertIsCompletedTest";
   public static final String CASE_KEY_B = "Case_CaseTaskAssertIsCompletedTest_CaseB";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/CaseTaskAssertIsCompletedTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsDisabledTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsDisabledTest.java
@@ -16,17 +16,13 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.disable;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class CaseTaskAssertIsDisabledTest extends ProcessAssertTestCase {
 
@@ -34,9 +30,6 @@ public class CaseTaskAssertIsDisabledTest extends ProcessAssertTestCase {
   public static final String TASK_B = "PI_TaskB";
   public static final String CASE_KEY = "Case_CaseTaskAssertIsDisabledTest";
   public static final String CASE_KEY_B = "Case_CaseTaskAssertIsDisabledTest_CaseB";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/CaseTaskAssertIsDisabledTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsDisabledTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsDisabledTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.disable;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class CaseTaskAssertIsDisabledTest extends ProcessAssertTestCase {
 
@@ -40,8 +39,8 @@ public class CaseTaskAssertIsDisabledTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsDisabledTest.cmmn" })
-  public void testIsDisabled_Success() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsDisabledTest.cmmn"})
+  void isDisabledSuccess() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     // When
@@ -52,8 +51,8 @@ public class CaseTaskAssertIsDisabledTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsDisabledTest.cmmn" })
-  public void testIsDisabled_Failure() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsDisabledTest.cmmn"})
+  void isDisabledFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsEnabledTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsEnabledTest.java
@@ -16,18 +16,13 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.disable;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class CaseTaskAssertIsEnabledTest extends ProcessAssertTestCase {
 
@@ -36,9 +31,6 @@ public class CaseTaskAssertIsEnabledTest extends ProcessAssertTestCase {
   public static final String HTASK_B = "PI_TaskB_HT";
   public static final String CASE_KEY = "Case_CaseTaskAssertIsEnabledTest";
   public static final String CASE_KEY_B = "Case_CaseTaskAssertIsEnabledTest_CaseB";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/CaseTaskAssertIsEnabledTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsEnabledTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsEnabledTest.java
@@ -21,14 +21,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseEx
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.disable;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class CaseTaskAssertIsEnabledTest extends ProcessAssertTestCase {
 
@@ -42,8 +41,8 @@ public class CaseTaskAssertIsEnabledTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsEnabledTest.cmmn" })
-  public void testIsEnabled_Success() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsEnabledTest.cmmn"})
+  void isEnabledSuccess() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreated();
     CaseInstance caseInstanceB = caseService().createCaseInstanceQuery().caseDefinitionKey(CASE_KEY_B).singleResult();
@@ -54,8 +53,8 @@ public class CaseTaskAssertIsEnabledTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsEnabledTest.cmmn" })
-  public void testIsEnabled_Failure() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsEnabledTest.cmmn"})
+  void isEnabledFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     CaseInstance caseInstanceB = caseService().createCaseInstanceQuery().caseDefinitionKey(CASE_KEY_B).singleResult();

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsTerminatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsTerminatedTest.java
@@ -16,18 +16,13 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.manuallyStart;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class CaseTaskAssertIsTerminatedTest extends ProcessAssertTestCase {
 
@@ -36,9 +31,6 @@ public class CaseTaskAssertIsTerminatedTest extends ProcessAssertTestCase {
   public static final String HTASK_B = "PI_TaskB_HT";
   public static final String CASE_KEY = "Case_CaseTaskAssertIsTerminatedTest";
   public static final String CASE_KEY_B = "Case_CaseTaskAssertIsTerminatedTest_CaseB";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/CaseTaskAssertIsTerminatedTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsTerminatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertIsTerminatedTest.java
@@ -21,14 +21,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseEx
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.manuallyStart;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class CaseTaskAssertIsTerminatedTest extends ProcessAssertTestCase {
 
@@ -42,8 +41,8 @@ public class CaseTaskAssertIsTerminatedTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsTerminatedTest.cmmn" })
-  public void testIsTerminated_Success() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsTerminatedTest.cmmn"})
+  void isTerminatedSuccess() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     CaseInstance caseInstanceB = caseService().createCaseInstanceQuery().caseDefinitionKey(CASE_KEY_B).singleResult();
@@ -57,8 +56,8 @@ public class CaseTaskAssertIsTerminatedTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssertIsTerminatedTest.cmmn" })
-  public void testIsTerminated_Failure() {
+  @Deployment(resources = {"cmmn/CaseTaskAssertIsTerminatedTest.cmmn"})
+  void isTerminatedFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertVariablesTest.java
@@ -18,7 +18,7 @@ package org.operaton.bpm.engine.test.assertions.cmmn;
 
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseExecutionCommandBuilder;
 import org.operaton.bpm.engine.runtime.CaseInstance;
@@ -27,7 +27,6 @@ import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class CaseTaskAssertVariablesTest extends ProcessAssertTestCase {
 
@@ -39,8 +38,8 @@ public class CaseTaskAssertVariablesTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssert-variables.cmmn" })
-  public void testVariables_Success() {
+  @Deployment(resources = {"cmmn/CaseTaskAssert-variables.cmmn"})
+  void variablesSuccess() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -68,8 +67,8 @@ public class CaseTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssert-variables.cmmn" })
-  public void testVariables_Success_No_Variables() {
+  @Deployment(resources = {"cmmn/CaseTaskAssert-variables.cmmn"})
+  void variablesSuccessNoVariables() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -82,8 +81,8 @@ public class CaseTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssert-variables.cmmn" })
-  public void testVariables_Failure_CaseTask_Completed() {
+  @Deployment(resources = {"cmmn/CaseTaskAssert-variables.cmmn"})
+  void variablesFailureCaseTaskCompleted() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -100,8 +99,8 @@ public class CaseTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssert-variables.cmmn" })
-  public void testHasVariables_Success() {
+  @Deployment(resources = {"cmmn/CaseTaskAssert-variables.cmmn"})
+  void hasVariablesSuccess() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -119,8 +118,8 @@ public class CaseTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssert-variables.cmmn" })
-  public void testHasVariables_Failure() {
+  @Deployment(resources = {"cmmn/CaseTaskAssert-variables.cmmn"})
+  void hasVariablesFailure() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -136,8 +135,8 @@ public class CaseTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssert-variables.cmmn" })
-  public void testHasNoVariables_Success() {
+  @Deployment(resources = {"cmmn/CaseTaskAssert-variables.cmmn"})
+  void hasNoVariablesSuccess() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -148,8 +147,8 @@ public class CaseTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssert-variables.cmmn" })
-  public void testHasNoVariables_Failure() {
+  @Deployment(resources = {"cmmn/CaseTaskAssert-variables.cmmn"})
+  void hasNoVariablesFailure() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -166,8 +165,8 @@ public class CaseTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssert-variables.cmmn" })
-  public void testVariables_Success_NoCaseTaskVariables() {
+  @Deployment(resources = {"cmmn/CaseTaskAssert-variables.cmmn"})
+  void variablesSuccessNoCaseTaskVariables() {
     // Given
     final CaseInstance caseInstance = createCaseInstanceWithVariable();
 
@@ -178,8 +177,8 @@ public class CaseTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssert-variables.cmmn" })
-  public void testVariables_Failure_NoCaseTaskVariables() {
+  @Deployment(resources = {"cmmn/CaseTaskAssert-variables.cmmn"})
+  void variablesFailureNoCaseTaskVariables() {
     // Given
     final CaseInstance caseInstance = createCaseInstanceWithVariable();
 
@@ -195,8 +194,8 @@ public class CaseTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssert-variables.cmmn" })
-  public void testHasNoVariables_Success_NoCaseTaskVariables() {
+  @Deployment(resources = {"cmmn/CaseTaskAssert-variables.cmmn"})
+  void hasNoVariablesSuccessNoCaseTaskVariables() {
     // Given
     final CaseInstance caseInstance = createCaseInstanceWithVariable();
 
@@ -207,8 +206,8 @@ public class CaseTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/CaseTaskAssert-variables.cmmn" })
-  public void testHasVariables_Failure_NoCaseTaskVariables() {
+  @Deployment(resources = {"cmmn/CaseTaskAssert-variables.cmmn"})
+  void hasVariablesFailureNoCaseTaskVariables() {
     // Given
     final CaseInstance caseInstance = createCaseInstanceWithVariable();
 

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CaseTaskAssertVariablesTest.java
@@ -16,26 +16,22 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseExecutionCommandBuilder;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
+
+import org.junit.jupiter.api.Test;
 
 public class CaseTaskAssertVariablesTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_TaskA";
   public static final String CASE_KEY = "Case_CaseTaskAssert-variables";
   public static final String TASK_B = "PI_TaskB";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/CaseTaskAssert-variables.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CmmnAwareTestsTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CmmnAwareTestsTest.java
@@ -20,12 +20,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVa
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import org.assertj.core.api.Assertions;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -85,10 +80,10 @@ public class CmmnAwareTestsTest {
     cmmnAwareTestsMockedStatic = mockStatic(CmmnAwareTests.class, CALLS_REAL_METHODS);
     abstractAssertionsMockedStatic = mockStatic(AbstractAssertions.class);
     abstractAssertionsMockedStatic.when(AbstractAssertions::processEngine).thenReturn(processEngine);
-    when(processEngine.getCaseService()).thenReturn(caseService);
+    lenient().when(processEngine.getCaseService()).thenReturn(caseService);
 
     caseExecutionQuery = mock(CaseExecutionQuery.class, new CaseExecutionQueryFluentAnswer());
-    when(caseService.createCaseExecutionQuery()).thenReturn(caseExecutionQuery);
+    lenient().when(caseService.createCaseExecutionQuery()).thenReturn(caseExecutionQuery);
   }
 
   @AfterEach

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CmmnAwareTestsTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/CmmnAwareTestsTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVariables;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
@@ -27,6 +28,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import org.assertj.core.api.Assertions;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.operaton.bpm.engine.CaseService;
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.RepositoryService;
@@ -39,16 +41,13 @@ import org.operaton.bpm.engine.runtime.CaseInstanceQuery;
 import org.operaton.bpm.engine.test.assertions.bpmn.AbstractAssertions;
 import org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests;
 import org.operaton.bpm.engine.test.assertions.helpers.CaseExecutionQueryFluentAnswer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * You will notice that this test class does not cover all methods.
@@ -56,13 +55,10 @@ import org.mockito.junit.MockitoJUnitRunner;
  * That code is so simplistic, it is not expected to break easily.
  *
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CmmnAwareTestsTest {
 
   public static final String ACTIVITY_ID = "FOO";
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Mock
   private CaseInstance caseInstance;
@@ -84,8 +80,8 @@ public class CmmnAwareTestsTest {
   private MockedStatic<CmmnAwareTests> cmmnAwareTestsMockedStatic;
   private MockedStatic<AbstractAssertions> abstractAssertionsMockedStatic;
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  void setUp() {
     cmmnAwareTestsMockedStatic = mockStatic(CmmnAwareTests.class, CALLS_REAL_METHODS);
     abstractAssertionsMockedStatic = mockStatic(AbstractAssertions.class);
     abstractAssertionsMockedStatic.when(AbstractAssertions::processEngine).thenReturn(processEngine);
@@ -95,14 +91,14 @@ public class CmmnAwareTestsTest {
     when(caseService.createCaseExecutionQuery()).thenReturn(caseExecutionQuery);
   }
 
-  @After
-  public void tearDown() {
+  @AfterEach
+  void tearDown() {
     cmmnAwareTestsMockedStatic.close();
     abstractAssertionsMockedStatic.close();
   }
 
   @Test
-  public void assertThatCaseDefinition_should_delegate_to_CmmnAwareAssertions() {
+  void assertThatCaseDefinition_should_delegate_to_CmmnAwareAssertions() {
 
     //prepare and mock static methods
     //because we need control over the CaseDefinitionAssert created
@@ -122,7 +118,7 @@ public class CmmnAwareTestsTest {
   }
 
   @Test
-  public void assertThatCaseExecution_should_delegate_to_CmmnAwareAssertions() {
+  void assertThatCaseExecution_should_delegate_to_CmmnAwareAssertions() {
 
     //prepare and mock static methods
     //because we need control over the CaseExecutionAssert created
@@ -142,7 +138,7 @@ public class CmmnAwareTestsTest {
   }
 
   @Test
-  public void assertThatCaseInstance_should_delegate_to_CmmnAwareAssertions() {
+  void assertThatCaseInstance_should_delegate_to_CmmnAwareAssertions() {
 
     //prepare and mock static methods
     //because we need control over the CaseInstanceAssert created
@@ -162,7 +158,7 @@ public class CmmnAwareTestsTest {
   }
 
   @Test
-  public void caseDefinitionQuery_should_create_vanilla_query() {
+  void caseDefinitionQuery_should_create_vanilla_query() {
 
     //prepare and mock static methods
     //because we need control over the CaseDefinitionQuery created
@@ -187,7 +183,7 @@ public class CmmnAwareTestsTest {
   }
 
   @Test
-  public void caseExecutionCaseExecutionQueryCaseInstance_should_delegate_to_assertThatCaseInstance() {
+  void caseExecutionCaseExecutionQueryCaseInstance_should_delegate_to_assertThatCaseInstance() {
     final MockedStatic<CaseInstanceAssert> caseInstanceAssertMockedStatic = mockStatic(CaseInstanceAssert.class);
     CaseInstanceAssert caseInstanceAssert = mock(CaseInstanceAssert.class);
     when(caseInstanceAssert.isNotNull()).thenReturn(caseInstanceAssert);
@@ -212,7 +208,7 @@ public class CmmnAwareTestsTest {
   }
 
   @Test
-  public void caseExecutionQuery_should_create_vanilla_query() {
+  void caseExecutionQuery_should_create_vanilla_query() {
     when(caseService.createCaseExecutionQuery()).thenReturn(caseExecutionQuery);
 
     //when getting a CaseExecutionQuery
@@ -227,7 +223,7 @@ public class CmmnAwareTestsTest {
   }
 
   @Test
-  public void caseExecutionStringCaseInstance_should_delegate_to_its_query_variant() {
+  void caseExecutionStringCaseInstance_should_delegate_to_its_query_variant() {
     final MockedStatic<CaseInstanceAssert> caseInstanceAssertMockedStatic = mockStatic(CaseInstanceAssert.class);
     final CaseInstanceAssert caseInstanceAssert = mock(CaseInstanceAssert.class);
     caseInstanceAssertMockedStatic.when(() -> CaseInstanceAssert.assertThat(any(), eq(caseInstance))).thenReturn(caseInstanceAssert);
@@ -250,7 +246,7 @@ public class CmmnAwareTestsTest {
   }
 
   @Test
-  public void caseInstanceQuery_should_create_vanilla_query() {
+  void caseInstanceQuery_should_create_vanilla_query() {
     CaseInstanceQuery caseInstanceQuery = mock(CaseInstanceQuery.class);
     when(caseService.createCaseInstanceQuery()).thenReturn(caseInstanceQuery);
 
@@ -266,7 +262,7 @@ public class CmmnAwareTestsTest {
   }
 
   @Test
-  public void caseService_should_return_the_processEngines_caseService() {
+  void caseService_should_return_the_processEngines_caseService() {
     //when getting a CaseInstanceQuery
     CaseService actualCaseService = CmmnAwareTests.caseService();
 
@@ -275,7 +271,7 @@ public class CmmnAwareTestsTest {
   }
 
   @Test
-  public void completeCaseExecution_should_delegate_to_caseService() {
+  void completeCaseExecution_should_delegate_to_caseService() {
     when(caseExecution.getId()).thenReturn("baz");
 
     CmmnAwareTests.complete(caseExecution);
@@ -284,14 +280,14 @@ public class CmmnAwareTestsTest {
   }
 
   @Test
-  public void completeCaseExecution_should_throw_IAE_for_null_arg() {
-    thrown.expect(IllegalArgumentException.class);
+  void completeCaseExecution_should_throw_IAE_for_null_arg() {
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
 
-    CmmnAwareTests.complete((CaseExecution) null);
+      CmmnAwareTests.complete((CaseExecution) null));
   }
 
   @Test
-  public void disableCaseExecution_should_delegate_to_caseService() {
+  void disableCaseExecution_should_delegate_to_caseService() {
     when(caseExecution.getId()).thenReturn("baz");
 
     CmmnAwareTests.disable(caseExecution);
@@ -300,14 +296,14 @@ public class CmmnAwareTestsTest {
   }
 
   @Test
-  public void disableCaseExecution_should_throw_IAE_for_null_arg() {
-    thrown.expect(IllegalArgumentException.class);
+  void disableCaseExecution_should_throw_IAE_for_null_arg() {
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
 
-    CmmnAwareTests.disable((CaseExecution) null);
+      CmmnAwareTests.disable((CaseExecution) null));
   }
 
   @Test
-  public void manuallyStartCaseExecution_should_delegate_to_caseService() {
+  void manuallyStartCaseExecution_should_delegate_to_caseService() {
     when(caseExecution.getId()).thenReturn("baz");
 
     CmmnAwareTests.manuallyStart(caseExecution);
@@ -316,14 +312,14 @@ public class CmmnAwareTestsTest {
   }
 
   @Test
-  public void manuallyStartCaseExecution_should_throw_IAE_for_null_arg() {
-    thrown.expect(IllegalArgumentException.class);
+  void manuallyStartCaseExecution_should_throw_IAE_for_null_arg() {
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
 
-    CmmnAwareTests.manuallyStart((CaseExecution) null);
+      CmmnAwareTests.manuallyStart((CaseExecution) null));
   }
 
   @Test
-  public void completeCaseExecutionWithVariables_should_delegate_to_caseService() {
+  void completeCaseExecutionWithVariables_should_delegate_to_caseService() {
     when(caseExecution.getId()).thenReturn("baz");
 
     CmmnAwareTests.complete(caseExecution, withVariables("aVariable", "aValue"));
@@ -332,17 +328,17 @@ public class CmmnAwareTestsTest {
   }
 
   @Test
-  public void completeCaseExecutionWithVariables_should_throw_IAE_for_null_arg_caseExecution() {
-    thrown.expect(IllegalArgumentException.class);
+  void completeCaseExecutionWithVariables_should_throw_IAE_for_null_arg_caseExecution() {
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
 
-    CmmnAwareTests.complete((CaseExecution) null, withVariables("aVariable", "aValue"));
+      CmmnAwareTests.complete((CaseExecution) null, withVariables("aVariable", "aValue")));
   }
 
   @Test
-  public void completeCaseExecutionWithVariables_should_throw_IAE_for_null_arg_valriables() {
-    thrown.expect(IllegalArgumentException.class);
+  void completeCaseExecutionWithVariables_should_throw_IAE_for_null_arg_valriables() {
+    assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
 
-    CmmnAwareTests.complete(caseExecution, null);
+      CmmnAwareTests.complete(caseExecution, null));
   }
 
 }

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsActiveTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsActiveTest.java
@@ -16,25 +16,18 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class HumanTaskAssertIsActiveTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_TaskA";
   public static final String CASE_KEY = "Case_HumanTaskAssertIsActiveTest";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/HumanTaskAssertIsActiveTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsActiveTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsActiveTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class HumanTaskAssertIsActiveTest extends ProcessAssertTestCase {
 
@@ -38,8 +37,8 @@ public class HumanTaskAssertIsActiveTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssertIsActiveTest.cmmn" })
-  public void testIsActive_Success() {
+  @Deployment(resources = {"cmmn/HumanTaskAssertIsActiveTest.cmmn"})
+  void isActiveSuccess() {
     // Given
     // case model is deployed
     // When
@@ -49,8 +48,8 @@ public class HumanTaskAssertIsActiveTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssertIsActiveTest.cmmn" })
-  public void testIsActive_Failure() {
+  @Deployment(resources = {"cmmn/HumanTaskAssertIsActiveTest.cmmn"})
+  void isActiveFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsAvailableTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsAvailableTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class HumanTaskAssertIsAvailableTest extends ProcessAssertTestCase {
 
@@ -39,8 +38,8 @@ public class HumanTaskAssertIsAvailableTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssertIsAvailableTest.cmmn" })
-  public void testIsAvailable_Success() {
+  @Deployment(resources = {"cmmn/HumanTaskAssertIsAvailableTest.cmmn"})
+  void isAvailableSuccess() {
     // Given
     // case model is deployed
     // When
@@ -50,8 +49,8 @@ public class HumanTaskAssertIsAvailableTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssertIsAvailableTest.cmmn" })
-  public void testIsAvailable_Failure() {
+  @Deployment(resources = {"cmmn/HumanTaskAssertIsAvailableTest.cmmn"})
+  void isAvailableFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsAvailableTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsAvailableTest.java
@@ -16,26 +16,19 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class HumanTaskAssertIsAvailableTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_TaskA";
   public static final String TASK_B = "PI_TaskB";
   public static final String CASE_KEY = "Case_HumanTaskAssertIsAvailableTest";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/HumanTaskAssertIsAvailableTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsCompletedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsCompletedTest.java
@@ -16,25 +16,18 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class HumanTaskAssertIsCompletedTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_TaskA";
   public static final String CASE_KEY = "Case_HumanTaskAssertIsCompletedTest";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/HumanTaskAssertIsCompletedTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsCompletedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsCompletedTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class HumanTaskAssertIsCompletedTest extends ProcessAssertTestCase {
 
@@ -38,8 +37,8 @@ public class HumanTaskAssertIsCompletedTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssertIsCompletedTest.cmmn" })
-  public void testIsCompleted_Success() {
+  @Deployment(resources = {"cmmn/HumanTaskAssertIsCompletedTest.cmmn"})
+  void isCompletedSuccess() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     HumanTaskAssert humanTask = assertThat(caseInstance).humanTask(TASK_A);
@@ -50,8 +49,8 @@ public class HumanTaskAssertIsCompletedTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssertIsCompletedTest.cmmn" })
-  public void testIsCompleted_Failure() {
+  @Deployment(resources = {"cmmn/HumanTaskAssertIsCompletedTest.cmmn"})
+  void isCompletedFailure() {
     // Given
     // case model is deployed
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsDisabledTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsDisabledTest.java
@@ -16,25 +16,18 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.disable;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class HumanTaskAssertIsDisabledTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_TaskA";
   public static final String CASE_KEY = "Case_HumanTaskAssertIsDisabledTest";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/HumanTaskAssertIsDisabledTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsDisabledTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsDisabledTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.disable;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class HumanTaskAssertIsDisabledTest extends ProcessAssertTestCase {
 
@@ -38,8 +37,8 @@ public class HumanTaskAssertIsDisabledTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssertIsDisabledTest.cmmn" })
-  public void testIsDisabled_Success() {
+  @Deployment(resources = {"cmmn/HumanTaskAssertIsDisabledTest.cmmn"})
+  void isDisabledSuccess() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     HumanTaskAssert humanTask = assertThat(caseInstance).humanTask(TASK_A);
@@ -50,8 +49,8 @@ public class HumanTaskAssertIsDisabledTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssertIsDisabledTest.cmmn" })
-  public void testIsDisabled_Failure() {
+  @Deployment(resources = {"cmmn/HumanTaskAssertIsDisabledTest.cmmn"})
+  void isDisabledFailure() {
     // Given
     // When
     final CaseInstance caseInstance = givenCaseIsCreated();

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsEnabledTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsEnabledTest.java
@@ -16,27 +16,19 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.disable;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class HumanTaskAssertIsEnabledTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_TaskA";
   public static final String TASK_B = "PI_TaskB";
   public static final String CASE_KEY = "Case_HumanTaskAssertIsEnabledTest";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/HumanTaskAssertIsEnabledTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsEnabledTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsEnabledTest.java
@@ -21,14 +21,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseEx
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.disable;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class HumanTaskAssertIsEnabledTest extends ProcessAssertTestCase {
 
@@ -40,8 +39,8 @@ public class HumanTaskAssertIsEnabledTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssertIsEnabledTest.cmmn" })
-  public void testIsEnabled_Success() {
+  @Deployment(resources = {"cmmn/HumanTaskAssertIsEnabledTest.cmmn"})
+  void isEnabledSuccess() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreated();
     // When
@@ -51,8 +50,8 @@ public class HumanTaskAssertIsEnabledTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssertIsEnabledTest.cmmn" })
-  public void testIsEnabled_Failure() {
+  @Deployment(resources = {"cmmn/HumanTaskAssertIsEnabledTest.cmmn"})
+  void isEnabledFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsTerminatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsTerminatedTest.java
@@ -16,26 +16,19 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class HumanTaskAssertIsTerminatedTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_TaskA";
   public static final String TASK_B = "PI_TaskB";
   public static final String CASE_KEY = "Case_HumanTaskAssertIsTerminatedTest";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/HumanTaskAssertIsTerminatedTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsTerminatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertIsTerminatedTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class HumanTaskAssertIsTerminatedTest extends ProcessAssertTestCase {
 
@@ -39,8 +38,8 @@ public class HumanTaskAssertIsTerminatedTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssertIsTerminatedTest.cmmn" })
-  public void testIsTerminated_Success() {
+  @Deployment(resources = {"cmmn/HumanTaskAssertIsTerminatedTest.cmmn"})
+  void isTerminatedSuccess() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     HumanTaskAssert humanTask = assertThat(caseInstance).humanTask(TASK_B);
@@ -51,8 +50,8 @@ public class HumanTaskAssertIsTerminatedTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssertIsTerminatedTest.cmmn" })
-  public void testIsTerminated_Failure() {
+  @Deployment(resources = {"cmmn/HumanTaskAssertIsTerminatedTest.cmmn"})
+  void isTerminatedFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertVariablesTest.java
@@ -16,24 +16,20 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecutionCommandBuilder;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
+
+import org.junit.jupiter.api.Test;
 
 public class HumanTaskAssertVariablesTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_TaskA";
   public static final String CASE_KEY = "Case_HumanTaskAssert-variables";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/HumanTaskAssert-variables.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/HumanTaskAssertVariablesTest.java
@@ -18,7 +18,7 @@ package org.operaton.bpm.engine.test.assertions.cmmn;
 
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecutionCommandBuilder;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
@@ -26,7 +26,6 @@ import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class HumanTaskAssertVariablesTest extends ProcessAssertTestCase {
 
@@ -37,8 +36,8 @@ public class HumanTaskAssertVariablesTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssert-variables.cmmn" })
-  public void testVariables_Success() {
+  @Deployment(resources = {"cmmn/HumanTaskAssert-variables.cmmn"})
+  void variablesSuccess() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -66,8 +65,8 @@ public class HumanTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssert-variables.cmmn" })
-  public void testVariables_Success_No_Variables() {
+  @Deployment(resources = {"cmmn/HumanTaskAssert-variables.cmmn"})
+  void variablesSuccessNoVariables() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -80,8 +79,8 @@ public class HumanTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssert-variables.cmmn" })
-  public void testVariables_Failure_HumanTask_Completed() {
+  @Deployment(resources = {"cmmn/HumanTaskAssert-variables.cmmn"})
+  void variablesFailureHumanTaskCompleted() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -98,8 +97,8 @@ public class HumanTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssert-variables.cmmn" })
-  public void testHasVariables_Success() {
+  @Deployment(resources = {"cmmn/HumanTaskAssert-variables.cmmn"})
+  void hasVariablesSuccess() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -117,8 +116,8 @@ public class HumanTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssert-variables.cmmn" })
-  public void testHasVariables_Failure() {
+  @Deployment(resources = {"cmmn/HumanTaskAssert-variables.cmmn"})
+  void hasVariablesFailure() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -134,8 +133,8 @@ public class HumanTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssert-variables.cmmn" })
-  public void testHasNoVariables_Success() {
+  @Deployment(resources = {"cmmn/HumanTaskAssert-variables.cmmn"})
+  void hasNoVariablesSuccess() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -146,8 +145,8 @@ public class HumanTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssert-variables.cmmn" })
-  public void testHasNoVariables_Failure() {
+  @Deployment(resources = {"cmmn/HumanTaskAssert-variables.cmmn"})
+  void hasNoVariablesFailure() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -164,8 +163,8 @@ public class HumanTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssert-variables.cmmn" })
-  public void testVariables_Success_NoHumanTaskVariables() {
+  @Deployment(resources = {"cmmn/HumanTaskAssert-variables.cmmn"})
+  void variablesSuccessNoHumanTaskVariables() {
     // Given
     final CaseInstance caseInstance = createCaseInstanceWithVariable();
 
@@ -176,8 +175,8 @@ public class HumanTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssert-variables.cmmn" })
-  public void testVariables_Failure_NoHumanTaskVariables() {
+  @Deployment(resources = {"cmmn/HumanTaskAssert-variables.cmmn"})
+  void variablesFailureNoHumanTaskVariables() {
     // Given
     final CaseInstance caseInstance = createCaseInstanceWithVariable();
 
@@ -193,8 +192,8 @@ public class HumanTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssert-variables.cmmn" })
-  public void testHasNoVariables_Success_NoHumanTaskVariables() {
+  @Deployment(resources = {"cmmn/HumanTaskAssert-variables.cmmn"})
+  void hasNoVariablesSuccessNoHumanTaskVariables() {
     // Given
     final CaseInstance caseInstance = createCaseInstanceWithVariable();
 
@@ -205,8 +204,8 @@ public class HumanTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/HumanTaskAssert-variables.cmmn" })
-  public void testHasVariables_Failure_NoHumanTaskVariables() {
+  @Deployment(resources = {"cmmn/HumanTaskAssert-variables.cmmn"})
+  void hasVariablesFailureNoHumanTaskVariables() {
     // Given
     final CaseInstance caseInstance = createCaseInstanceWithVariable();
 

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsAvailableTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsAvailableTest.java
@@ -25,7 +25,7 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
 import org.junit.jupiter.api.Test;
 
 @Deployment(resources = "cmmn/MilestoneAssertIsAvailableTest.cmmn")
-public class MilestoneAssertIsAvailableTest extends ProcessAssertTestCase {
+class MilestoneAssertIsAvailableTest extends ProcessAssertTestCase {
 
   @Test
   void is_available_success() {

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsAvailableTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsAvailableTest.java
@@ -16,23 +16,16 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 @Deployment(resources = "cmmn/MilestoneAssertIsAvailableTest.cmmn")
 public class MilestoneAssertIsAvailableTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   void is_available_success() {

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsAvailableTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsAvailableTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 @Deployment(resources = "cmmn/MilestoneAssertIsAvailableTest.cmmn")
 public class MilestoneAssertIsAvailableTest extends ProcessAssertTestCase {
@@ -36,14 +35,14 @@ public class MilestoneAssertIsAvailableTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  public void test_isAvailable_Success() {
+  void is_available_success() {
     CaseInstance caseInstance = caseService().createCaseInstanceByKey("MilestoneAssertIsAvailableTest");
 
     assertThat(caseInstance).milestone("Milestone").isAvailable();
   }
 
   @Test
-  public void test_isAvailable_Fail() {
+  void is_available_fail() {
     final CaseInstance caseInstance = caseService().createCaseInstanceByKey("MilestoneAssertIsAvailableTest");
 
     complete(caseExecution("PI_TaskA", caseInstance));

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsCompletedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsCompletedTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 @Deployment(resources = "cmmn/MilestoneAssertIsCompletedTest.cmmn")
 public class MilestoneAssertIsCompletedTest extends ProcessAssertTestCase {
@@ -36,7 +35,7 @@ public class MilestoneAssertIsCompletedTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  public void test_IsCompleted_Success() {
+  void is_completed_success() {
     CaseInstance caseInstance = caseService().createCaseInstanceByKey("MilestoneAssertIsCompletedTest");
     MilestoneAssert milestoneAssert = assertThat(caseInstance).milestone("Milestone");
 
@@ -46,7 +45,7 @@ public class MilestoneAssertIsCompletedTest extends ProcessAssertTestCase {
   }
 
   @Test
-  public void test_IsCompleted_Fail() {
+  void is_completed_fail() {
     final CaseInstance caseInstance = caseService().createCaseInstanceByKey("MilestoneAssertIsCompletedTest");
 
     expect(new Failure() {

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsCompletedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsCompletedTest.java
@@ -16,23 +16,16 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 @Deployment(resources = "cmmn/MilestoneAssertIsCompletedTest.cmmn")
 public class MilestoneAssertIsCompletedTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   void is_completed_success() {

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsCompletedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsCompletedTest.java
@@ -25,7 +25,7 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
 import org.junit.jupiter.api.Test;
 
 @Deployment(resources = "cmmn/MilestoneAssertIsCompletedTest.cmmn")
-public class MilestoneAssertIsCompletedTest extends ProcessAssertTestCase {
+class MilestoneAssertIsCompletedTest extends ProcessAssertTestCase {
 
   @Test
   void is_completed_success() {

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsTerminatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsTerminatedTest.java
@@ -25,7 +25,7 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
 import org.junit.jupiter.api.Test;
 
 @Deployment(resources = "cmmn/MilestoneAssertIsTerminatedTest.cmmn")
-public class MilestoneAssertIsTerminatedTest extends ProcessAssertTestCase {
+class MilestoneAssertIsTerminatedTest extends ProcessAssertTestCase {
 
   @Test
   void is_terminated_success() {

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsTerminatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsTerminatedTest.java
@@ -16,23 +16,16 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 @Deployment(resources = "cmmn/MilestoneAssertIsTerminatedTest.cmmn")
 public class MilestoneAssertIsTerminatedTest extends ProcessAssertTestCase {
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   void is_terminated_success() {

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsTerminatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/MilestoneAssertIsTerminatedTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 @Deployment(resources = "cmmn/MilestoneAssertIsTerminatedTest.cmmn")
 public class MilestoneAssertIsTerminatedTest extends ProcessAssertTestCase {
@@ -36,7 +35,7 @@ public class MilestoneAssertIsTerminatedTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  public void test_IsTerminated_Success() {
+  void is_terminated_success() {
     CaseInstance caseInstance = caseService().createCaseInstanceByKey("MilestoneAssertIsTerminatedTest");
     MilestoneAssert milestoneAssert = assertThat(caseInstance).stage("Stage").milestone("Milestone");
 
@@ -46,7 +45,7 @@ public class MilestoneAssertIsTerminatedTest extends ProcessAssertTestCase {
   }
 
   @Test
-  public void test_IsTerminated_Fail() {
+  void is_terminated_fail() {
     final CaseInstance caseInstance = caseService().createCaseInstanceByKey("MilestoneAssertIsTerminatedTest");
 
     expect(new Failure() {

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsActiveTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsActiveTest.java
@@ -16,28 +16,24 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
+import org.operaton.bpm.engine.runtime.CaseInstance;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.Failure;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processInstanceQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.Failure;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class ProcessTaskAssertIsActiveTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_TaskA";
   public static final String USER_TASK = "UserTask_1";
   public static final String CASE_KEY = "Case_ProcessTaskAssertIsActiveTest";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/ProcessTaskAssertIsActiveTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsActiveTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsActiveTest.java
@@ -21,7 +21,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
@@ -29,7 +29,6 @@ import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessTaskAssertIsActiveTest extends ProcessAssertTestCase {
 
@@ -41,8 +40,8 @@ public class ProcessTaskAssertIsActiveTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssertIsActiveTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testIsActive_Success() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssertIsActiveTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void isActiveSuccess() {
     // Given
     // case model is deployed
     // When
@@ -52,8 +51,8 @@ public class ProcessTaskAssertIsActiveTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssertIsActiveTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testIsActive_Failure() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssertIsActiveTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void isActiveFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsAvailableTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsAvailableTest.java
@@ -21,7 +21,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.proces
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
@@ -29,7 +29,6 @@ import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessTaskAssertIsAvailableTest extends ProcessAssertTestCase {
 
@@ -42,8 +41,8 @@ public class ProcessTaskAssertIsAvailableTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssertIsAvailableTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testIsAvailable_Success() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssertIsAvailableTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void isAvailableSuccess() {
     // Given
     // case model is deployed
     // When
@@ -53,8 +52,8 @@ public class ProcessTaskAssertIsAvailableTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssertIsAvailableTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testIsAvailable_Failure() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssertIsAvailableTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void isAvailableFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsAvailableTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsAvailableTest.java
@@ -16,19 +16,18 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
+import org.operaton.bpm.engine.runtime.CaseInstance;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.Failure;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processInstanceQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.Failure;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class ProcessTaskAssertIsAvailableTest extends ProcessAssertTestCase {
 
@@ -36,9 +35,6 @@ public class ProcessTaskAssertIsAvailableTest extends ProcessAssertTestCase {
   public static final String TASK_B = "PI_TaskB";
   public static final String USER_TASK = "UserTask_1";
   public static final String CASE_KEY = "Case_ProcessTaskAssertIsAvailableTest";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/ProcessTaskAssertIsAvailableTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsCompletedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsCompletedTest.java
@@ -16,28 +16,24 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
+import org.operaton.bpm.engine.runtime.CaseInstance;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.Failure;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processInstanceQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.Failure;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class ProcessTaskAssertIsCompletedTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_TaskA";
   public static final String USER_TASK = "UserTask_1";
   public static final String CASE_KEY = "Case_ProcessTaskAssertIsCompletedTest";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/ProcessTaskAssertIsCompletedTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsCompletedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsCompletedTest.java
@@ -21,7 +21,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.proces
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
@@ -29,7 +29,6 @@ import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessTaskAssertIsCompletedTest extends ProcessAssertTestCase {
 
@@ -41,8 +40,8 @@ public class ProcessTaskAssertIsCompletedTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssertIsCompletedTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testIsCompleted_Success() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssertIsCompletedTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void isCompletedSuccess() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     ProcessTaskAssert processTask = assertThat(caseInstance).processTask(TASK_A);
@@ -53,8 +52,8 @@ public class ProcessTaskAssertIsCompletedTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssertIsCompletedTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testIsCompleted_Failure() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssertIsCompletedTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void isCompletedFailure() {
     // Given
     // case model is deployed
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsDisabledTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsDisabledTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.disable;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessTaskAssertIsDisabledTest extends ProcessAssertTestCase {
 
@@ -38,8 +37,8 @@ public class ProcessTaskAssertIsDisabledTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssertIsDisabledTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testIsDisabled_Success() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssertIsDisabledTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void isDisabledSuccess() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     ProcessTaskAssert processTask = assertThat(caseInstance).processTask(TASK_A);
@@ -50,8 +49,8 @@ public class ProcessTaskAssertIsDisabledTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssertIsDisabledTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testIsDisabled_Failure() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssertIsDisabledTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void isDisabledFailure() {
     // Given
     // When
     final CaseInstance caseInstance = givenCaseIsCreated();

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsDisabledTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsDisabledTest.java
@@ -16,25 +16,18 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.disable;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessTaskAssertIsDisabledTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_TaskA";
   public static final String CASE_KEY = "Case_ProcessTaskAssertIsDisabledTest";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/ProcessTaskAssertIsDisabledTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsEnabledTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsEnabledTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.disable;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
@@ -31,7 +31,6 @@ import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessTaskAssertIsEnabledTest extends ProcessAssertTestCase {
 
@@ -44,8 +43,8 @@ public class ProcessTaskAssertIsEnabledTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssertIsEnabledTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testIsEnabled_Success() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssertIsEnabledTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void isEnabledSuccess() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreated();
     // When
@@ -55,8 +54,8 @@ public class ProcessTaskAssertIsEnabledTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssertIsEnabledTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testIsEnabled_Failure() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssertIsEnabledTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void isEnabledFailure() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsEnabledTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsEnabledTest.java
@@ -16,21 +16,17 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processInstanceQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.disable;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processInstanceQuery;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessTaskAssertIsEnabledTest extends ProcessAssertTestCase {
 
@@ -38,9 +34,6 @@ public class ProcessTaskAssertIsEnabledTest extends ProcessAssertTestCase {
   public static final String TASK_B = "PI_TaskB";
   public static final String USER_TASK = "UserTask_1";
   public static final String CASE_KEY = "Case_ProcessTaskAssertIsEnabledTest";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/ProcessTaskAssertIsEnabledTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsTerminatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsTerminatedTest.java
@@ -23,7 +23,7 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.manuallyStart;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
@@ -31,7 +31,6 @@ import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessTaskAssertIsTerminatedTest extends ProcessAssertTestCase {
 
@@ -44,8 +43,8 @@ public class ProcessTaskAssertIsTerminatedTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssertIsTerminatedTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testIsTerminated_Success() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssertIsTerminatedTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void isTerminatedSuccess() {
     // Given
     final CaseInstance caseInstance = givenCaseIsCreated();
     ProcessTaskAssert processTask = assertThat(caseInstance).processTask(TASK_B);
@@ -58,8 +57,8 @@ public class ProcessTaskAssertIsTerminatedTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssertIsTerminatedTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testIsTerminated_Failure() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssertIsTerminatedTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void isTerminatedFailure() {
     // Given
     // When
     final CaseInstance caseInstance = givenCaseIsCreated();

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsTerminatedTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertIsTerminatedTest.java
@@ -16,21 +16,17 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processInstanceQuery;
-import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.manuallyStart;
-import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processInstanceQuery;
+import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
+import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.*;
+
+import org.junit.jupiter.api.Test;
 
 public class ProcessTaskAssertIsTerminatedTest extends ProcessAssertTestCase {
 
@@ -38,9 +34,6 @@ public class ProcessTaskAssertIsTerminatedTest extends ProcessAssertTestCase {
   public static final String TASK_B = "PI_TaskB";
   public static final String USER_TASK = "UserTask_1";
   public static final String CASE_KEY = "Case_ProcessTaskAssertIsTerminatedTest";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/ProcessTaskAssertIsTerminatedTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertVariablesTest.java
@@ -16,29 +16,25 @@
  */
 package org.operaton.bpm.engine.test.assertions.cmmn;
 
+import org.operaton.bpm.engine.runtime.CaseExecutionCommandBuilder;
+import org.operaton.bpm.engine.runtime.CaseInstance;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.assertions.helpers.Failure;
+import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.processInstanceQuery;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
+
 import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.runtime.CaseExecutionCommandBuilder;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
-import org.operaton.bpm.engine.test.assertions.helpers.Failure;
-import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class ProcessTaskAssertVariablesTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_TaskA";
   public static final String USER_TASK = "UserTask_1";
   public static final String CASE_KEY = "Case_ProcessTaskAssert-variables";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/ProcessTaskAssertVariablesTest.java
@@ -21,7 +21,7 @@ import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.proces
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.task;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecutionCommandBuilder;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
@@ -30,7 +30,6 @@ import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.Failure;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class ProcessTaskAssertVariablesTest extends ProcessAssertTestCase {
 
@@ -42,8 +41,8 @@ public class ProcessTaskAssertVariablesTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testVariables_Success() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void variablesSuccess() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -71,8 +70,8 @@ public class ProcessTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testVariables_Success_No_Variables() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void variablesSuccessNoVariables() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -85,8 +84,8 @@ public class ProcessTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testVariables_Failure_ProcessTask_Completed() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void variablesFailureProcessTaskCompleted() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -103,8 +102,8 @@ public class ProcessTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testHasVariables_Success() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void hasVariablesSuccess() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -122,8 +121,8 @@ public class ProcessTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testHasVariables_Failure() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void hasVariablesFailure() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -139,8 +138,8 @@ public class ProcessTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testHasNoVariables_Success() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void hasNoVariablesSuccess() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -151,8 +150,8 @@ public class ProcessTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testHasNoVariables_Failure() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void hasNoVariablesFailure() {
     // Given
     final CaseInstance caseInstance = createCaseInstance();
 
@@ -169,8 +168,8 @@ public class ProcessTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testVariables_Success_NoProcessTaskVariables() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void variablesSuccessNoProcessTaskVariables() {
     // Given
     final CaseInstance caseInstance = createCaseInstanceWithVariable();
 
@@ -181,8 +180,8 @@ public class ProcessTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testVariables_Failure_NoProcessTaskVariables() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void variablesFailureNoProcessTaskVariables() {
     // Given
     final CaseInstance caseInstance = createCaseInstanceWithVariable();
 
@@ -198,8 +197,8 @@ public class ProcessTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testHasNoVariables_Success_NoProcessTaskVariables() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void hasNoVariablesSuccessNoProcessTaskVariables() {
     // Given
     final CaseInstance caseInstance = createCaseInstanceWithVariable();
 
@@ -210,8 +209,8 @@ public class ProcessTaskAssertVariablesTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testHasVariables_Failure_NoProcessTaskVariables() {
+  @Deployment(resources = {"cmmn/ProcessTaskAssert-variables.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void hasVariablesFailureNoProcessTaskVariables() {
     // Given
     final CaseInstance caseInstance = createCaseInstanceWithVariable();
 

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageTest.java
@@ -26,7 +26,7 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseSe
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.disable;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.manuallyStart;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
@@ -34,7 +34,6 @@ import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class StageTest extends ProcessAssertTestCase {
 
@@ -50,8 +49,8 @@ public class StageTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/StageTest.cmmn" })
-  public void testCaseIsActiveAndStageIsEnabled() {
+  @Deployment(resources = {"cmmn/StageTest.cmmn"})
+  void caseIsActiveAndStageIsEnabled() {
     // Given
     // case model is deployed
     // When
@@ -61,8 +60,8 @@ public class StageTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/StageTest.cmmn" })
-  public void testStageIsActiveAndTaskIsEnabled() {
+  @Deployment(resources = {"cmmn/StageTest.cmmn"})
+  void stageIsActiveAndTaskIsEnabled() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreated();
     // When
@@ -72,8 +71,8 @@ public class StageTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/StageTest.cmmn" })
-  public void testStageAndTaskAreActive() {
+  @Deployment(resources = {"cmmn/StageTest.cmmn"})
+  void stageAndTaskAreActive() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreatedAndStageSActive();
     // When
@@ -83,8 +82,8 @@ public class StageTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/StageTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn" })
-  public void testCaseIsCompletedWhenTasksAreCompleted() {
+  @Deployment(resources = {"cmmn/StageTest.cmmn", "cmmn/ProcessTaskAssert-calledProcess.bpmn"})
+  void caseIsCompletedWhenTasksAreCompleted() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreatedAndStageSActiveAndTaskAActive();
     StageAssert stage = assertThat(caseInstance).stage(STAGE_S);
@@ -108,8 +107,8 @@ public class StageTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/StageTest.cmmn" })
-  public void testStageAndTaskAreDisabled() {
+  @Deployment(resources = {"cmmn/StageTest.cmmn"})
+  void stageAndTaskAreDisabled() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreated();
     StageAssert stage = assertThat(caseInstance).stage(STAGE_S);
@@ -123,8 +122,8 @@ public class StageTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/StageTest.cmmn" })
-  public void testStageIsTerminated() {
+  @Deployment(resources = {"cmmn/StageTest.cmmn"})
+  void stageIsTerminated() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreatedAndStageSActive();
     StageAssert stage = assertThat(caseInstance).stage(STAGE_S);

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageTest.java
@@ -31,9 +31,7 @@ import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class StageTest extends ProcessAssertTestCase {
 
@@ -44,9 +42,6 @@ public class StageTest extends ProcessAssertTestCase {
   public static final String STAGE_S2  = "PI_S_S2";
   public static final String STAGE_S3  = "PI_S_S3";
   public static final String USER_TASK = "UserTask_1";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/StageTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageWithSentryExitCriteriaTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageWithSentryExitCriteriaTest.java
@@ -21,14 +21,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.manuallyStart;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class StageWithSentryExitCriteriaTest extends ProcessAssertTestCase {
 
@@ -43,8 +42,8 @@ public class StageWithSentryExitCriteriaTest extends ProcessAssertTestCase {
    * Introduces:
    */
   @Test
-  @Deployment(resources = { "cmmn/StageWithSentryTestExitCriteria.cmmn" })
-  public void case_is_active_and_task_a_and_task_b_should_be_enabled() {
+  @Deployment(resources = {"cmmn/StageWithSentryTestExitCriteria.cmmn"})
+  void case_is_active_and_task_a_and_task_b_should_be_enabled() {
     // Given
     // case model is deployed
     // When
@@ -58,8 +57,8 @@ public class StageWithSentryExitCriteriaTest extends ProcessAssertTestCase {
    * Introduces:
    */
   @Test
-  @Deployment(resources = { "cmmn/StageWithSentryTestExitCriteria.cmmn" })
-  public void case_is_active_and_stage_s_should_be_active_and_task_a_and_task_b_enabled() {
+  @Deployment(resources = {"cmmn/StageWithSentryTestExitCriteria.cmmn"})
+  void case_is_active_and_stage_s_should_be_active_and_task_a_and_task_b_enabled() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreated();
     // When
@@ -73,8 +72,8 @@ public class StageWithSentryExitCriteriaTest extends ProcessAssertTestCase {
    * Introduces:
    */
   @Test
-  @Deployment(resources = { "cmmn/StageWithSentryTestExitCriteria.cmmn" })
-  public void case_is_active_and_stage_s_and_task_a_should_be_active_and_task_b_enabled() {
+  @Deployment(resources = {"cmmn/StageWithSentryTestExitCriteria.cmmn"})
+  void case_is_active_and_stage_s_and_task_a_should_be_active_and_task_b_enabled() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreatedAndStageSActive();
     // When
@@ -88,8 +87,8 @@ public class StageWithSentryExitCriteriaTest extends ProcessAssertTestCase {
    * Introduces: stage.isTerminated()
    */
   @Test
-  @Deployment(resources = { "cmmn/StageWithSentryTestExitCriteria.cmmn" })
-  public void case_is_active_and_stage_s_and_task_a_should_be_terminated_and_task_b_active() {
+  @Deployment(resources = {"cmmn/StageWithSentryTestExitCriteria.cmmn"})
+  void case_is_active_and_stage_s_and_task_a_should_be_terminated_and_task_b_active() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreatedAndStageSActiveAndTaskAActive();
     CaseExecution taskA = caseExecution(TASK_A, caseInstance);

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageWithSentryExitCriteriaTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageWithSentryExitCriteriaTest.java
@@ -25,18 +25,13 @@ import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class StageWithSentryExitCriteriaTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_HT_A";
   public static final String TASK_B = "PI_HT_B";
   public static final String STAGE_S = "PI_StageS";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   /**
    * Introduces:

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageWithSentryTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageWithSentryTest.java
@@ -21,14 +21,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseEx
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.manuallyStart;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class StageWithSentryTest extends ProcessAssertTestCase {
 
@@ -42,8 +41,8 @@ public class StageWithSentryTest extends ProcessAssertTestCase {
    * Introduces: stage.isAvailable()
    */
   @Test
-  @Deployment(resources = { "cmmn/StageWithSentryTest.cmmn" })
-  public void stage_t_should_be_available() {
+  @Deployment(resources = {"cmmn/StageWithSentryTest.cmmn"})
+  void stage_t_should_be_available() {
     // Given
     // When
     CaseInstance caseInstance = givenCaseIsCreated();
@@ -56,8 +55,8 @@ public class StageWithSentryTest extends ProcessAssertTestCase {
    * Introduces:
    */
   @Test
-  @Deployment(resources = { "cmmn/StageWithSentryTest.cmmn" })
-  public void stage_t_should_be_enabled() {
+  @Deployment(resources = {"cmmn/StageWithSentryTest.cmmn"})
+  void stage_t_should_be_enabled() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageWithSentryTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/StageWithSentryTest.java
@@ -25,17 +25,12 @@ import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class StageWithSentryTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_HT_A";
   public static final String STAGE_S = "PI_StageS";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   /**
    * Introduces: stage.isAvailable()

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.complete;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskTest extends ProcessAssertTestCase {
 
@@ -37,8 +36,6 @@ public class TaskTest extends ProcessAssertTestCase {
   @Rule
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
-  @Test
-  @Deployment(resources = { "cmmn/TaskTest.cmmn" })
   /**
    * Introduces:
    * assertThat(CaseInstance)
@@ -46,7 +43,9 @@ public class TaskTest extends ProcessAssertTestCase {
    * caseInstance.activity(id)
    * task.isActive()
    */
-  public void case_and_task_should_be_active() {
+  @Test
+  @Deployment(resources = {"cmmn/TaskTest.cmmn"})
+  void case_and_task_should_be_active() {
     // Given
     // case model is deployed
     // When
@@ -55,8 +54,6 @@ public class TaskTest extends ProcessAssertTestCase {
     assertThat(caseInstance).isActive().humanTask(TASK_A).isActive();
   }
 
-  @Test
-  @Deployment(resources = { "cmmn/TaskTest.cmmn" })
   /**
    * Introduces:
    * caseExecution(id, caseInstance)
@@ -64,7 +61,9 @@ public class TaskTest extends ProcessAssertTestCase {
    * caseInstance.isCompleted()
    * task.isCompleted()
    */
-  public void case_should_complete_when_task_is_completed() {
+  @Test
+  @Deployment(resources = {"cmmn/TaskTest.cmmn"})
+  void case_should_complete_when_task_is_completed() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskTest.java
@@ -24,17 +24,12 @@ import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class TaskTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_TaskA";
   public static final String CASE_KEY = "Case_TaskTests";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   /**
    * Introduces:

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskWithManualActivationTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskWithManualActivationTest.java
@@ -25,17 +25,12 @@ import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class TaskWithManualActivationTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_TaskA";
   public static final String CASE_KEY = "Case_TaskTests";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/TaskWithManualActivationTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskWithManualActivationTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskWithManualActivationTest.java
@@ -21,14 +21,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseEx
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.disable;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.manuallyStart;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskWithManualActivationTest extends ProcessAssertTestCase {
 
@@ -39,8 +38,8 @@ public class TaskWithManualActivationTest extends ProcessAssertTestCase {
   public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
-  @Deployment(resources = { "cmmn/TaskWithManualActivationTest.cmmn" })
-  public void task_should_be_enabled() {
+  @Deployment(resources = {"cmmn/TaskWithManualActivationTest.cmmn"})
+  void task_should_be_enabled() {
     // Given
     CaseInstance caseInstance = caseService().createCaseInstanceByKey(CASE_KEY);
     // Then
@@ -48,8 +47,8 @@ public class TaskWithManualActivationTest extends ProcessAssertTestCase {
   }
 
   @Test
-  @Deployment(resources = { "cmmn/TaskWithManualActivationTest.cmmn" })
-  public void task_should_be_active_when_manually_started() {
+  @Deployment(resources = {"cmmn/TaskWithManualActivationTest.cmmn"})
+  void task_should_be_active_when_manually_started() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreated();
     // When
@@ -64,8 +63,8 @@ public class TaskWithManualActivationTest extends ProcessAssertTestCase {
    * task.isDisabled()
    */
   @Test
-  @Deployment(resources = { "cmmn/TaskWithManualActivationTest.cmmn" })
-  public void task_should_be_disabed() {
+  @Deployment(resources = {"cmmn/TaskWithManualActivationTest.cmmn"})
+  void task_should_be_disabed() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreated();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskWithSentryExitCriteriaTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskWithSentryExitCriteriaTest.java
@@ -24,17 +24,12 @@ import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class TaskWithSentryExitCriteriaTest extends ProcessAssertTestCase {
 
   public static final String TASK_A = "PI_HT_A";
   public static final String TASK_B = "PI_HT_B";
-
-  @Rule
-  public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   /**
    * Introduces:

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskWithSentryExitCriteriaTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskWithSentryExitCriteriaTest.java
@@ -20,14 +20,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assert
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.manuallyStart;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskWithSentryExitCriteriaTest extends ProcessAssertTestCase {
 
@@ -41,8 +40,8 @@ public class TaskWithSentryExitCriteriaTest extends ProcessAssertTestCase {
    * Introduces:
    */
   @Test
-  @Deployment(resources = { "cmmn/TaskWithSentryTestExitCriteria.cmmn" })
-  public void case_is_active_and_task_a_and_task_b_should_be_enabled() {
+  @Deployment(resources = {"cmmn/TaskWithSentryTestExitCriteria.cmmn"})
+  void case_is_active_and_task_a_and_task_b_should_be_enabled() {
     // Given
     // case model is deployed
     // When
@@ -57,8 +56,8 @@ public class TaskWithSentryExitCriteriaTest extends ProcessAssertTestCase {
    * task.isTerminated()
    */
   @Test
-  @Deployment(resources = { "cmmn/TaskWithSentryTestExitCriteria.cmmn" })
-  public void case_is_active_and_task_a_should_be_terminated_and_task_b_active() {
+  @Deployment(resources = {"cmmn/TaskWithSentryTestExitCriteria.cmmn"})
+  void case_is_active_and_task_a_should_be_terminated_and_task_b_active() {
     // Given
     CaseInstance caseInstance = givenCaseIsCreatedAndTaskAActive();
     // When

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskWithSentryTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskWithSentryTest.java
@@ -19,13 +19,12 @@ package org.operaton.bpm.engine.test.assertions.cmmn;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.assertThat;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseExecution;
 import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseService;
-
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
 import org.junit.Rule;
-import org.junit.Test;
 
 public class TaskWithSentryTest extends ProcessAssertTestCase {
 
@@ -36,9 +35,9 @@ public class TaskWithSentryTest extends ProcessAssertTestCase {
 	@Rule
 	public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
-	@Test
-	@Deployment(resources = { "cmmn/TaskWithSentryTest.cmmn" })
-	public void task_b_should_be_available() {
+  @Test
+  @Deployment(resources = {"cmmn/TaskWithSentryTest.cmmn"})
+  void task_b_should_be_available() {
 		// Given
 		CaseInstance caseInstance = caseService().createCaseInstanceByKey(CASE_KEY);
 		// Then

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskWithSentryTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/cmmn/TaskWithSentryTest.java
@@ -22,18 +22,13 @@ import static org.operaton.bpm.engine.test.assertions.cmmn.CmmnAwareTests.caseSe
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.ProcessEngineRule;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
-import org.junit.Rule;
 
 public class TaskWithSentryTest extends ProcessAssertTestCase {
 
 	public static final String TASK_A = "PI_HT_A";
 	public static final String TASK_B = "PI_HT_B";
 	public static final String CASE_KEY = "Case_TaskWithSentryTests";
-
-	@Rule
-	public ProcessEngineRule processEngineRule = new ProcessEngineRule();
 
   @Test
   @Deployment(resources = {"cmmn/TaskWithSentryTest.cmmn"})

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/helpers/ProcessAssertTestCase.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/helpers/ProcessAssertTestCase.java
@@ -17,12 +17,18 @@
 package org.operaton.bpm.engine.test.assertions.helpers;
 
 
+import org.operaton.bpm.engine.test.junit5.DeploymentExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+
 import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.test.assertions.bpmn.AbstractAssertions.reset;
 
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+@ExtendWith(ProcessEngineExtension.class)
+@ExtendWith(DeploymentExtension.class)
 public abstract class ProcessAssertTestCase {
 
   @AfterEach

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/helpers/ProcessAssertTestCase.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/helpers/ProcessAssertTestCase.java
@@ -21,11 +21,11 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.test.assertions.bpmn.AbstractAssertions.reset;
 
 import org.assertj.core.util.Lists;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 
 public abstract class ProcessAssertTestCase {
 
-  @After
+  @AfterEach
   public void tearDown() {
     reset();
   }


### PR DESCRIPTION
This change migrates the module /test-utils/assert/core to JUnit 5 & AssertJ.

related to #27 