### PR TITLE
Issue  #398: Tests must not rely on port 8080

### DIFF
--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
@@ -34,6 +34,8 @@ import org.openapitools.client.api.ProcessInstanceApi;
 import org.openapitools.client.model.ProcessInstanceDto;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
 
 public class BasicAuthenticationTest {
 

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
@@ -44,8 +44,8 @@ public class BasicAuthenticationTest {
 
   ProcessInstanceApi api;
 
-  @Rule
-  public WireMockRule wireMockRule = new WireMockRule(8080);
+ @Rule
+public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
 
   @Before
   public void clientWithValidCredentials() {

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
@@ -33,6 +33,7 @@ import org.openapitools.client.api.DeploymentApi;
 import org.openapitools.client.model.DeploymentWithDefinitionsDto;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 public class DeploymentTest {
 

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
@@ -41,7 +41,7 @@ public class DeploymentTest {
   final DeploymentApi api = new DeploymentApi();
 
   @Rule
-  public WireMockRule wireMockRule = new WireMockRule(8080);
+public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
 
   @Test
   public void shouldCreateDeployment() throws ApiException {

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
@@ -44,8 +44,8 @@ public class ProcessInstanceTest {
 
   final ProcessInstanceApi api = new ProcessInstanceApi();
 
-  @Rule
-  public WireMockRule wireMockRule = new WireMockRule(8080);
+ @Rule
+public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
 
   @Test
   public void shouldQueryProcessInstancesCount() throws ApiException {

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
@@ -37,6 +37,7 @@ import org.openapitools.client.model.ProcessInstanceQueryDto;
 import org.openapitools.client.model.SuspensionStateDto;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 public class ProcessInstanceTest {
 


### PR DESCRIPTION
Change the port number of the test to dynamic port