### PR TITLE
chore(test): Porting AuthorizationTest and all subclasses to JUnit5.

### DIFF
--- a/engine/src/main/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtension.java
+++ b/engine/src/main/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineExtension.java
@@ -213,25 +213,43 @@ public class ProcessEngineExtension implements TestWatcher,
     final Method testMethod = context.getTestMethod().orElseThrow(illegalStateException("testMethod not set"));
     final Class<?> testClass = context.getTestClass().orElseThrow(illegalStateException("testClass not set"));
 
-    deploymentId = TestHelper.annotationDeploymentSetUp(processEngine, testClass, testMethod.getName(), null, testMethod.getParameterTypes());
-    boolean hasRequiredHistoryLevel = TestHelper.annotationRequiredHistoryLevelCheck(processEngine, testClass, testMethod.getName(), testMethod.getParameterTypes());
-    boolean hasRequiredDatabase = TestHelper.annotationRequiredDatabaseCheck(processEngine, testClass, testMethod.getName(), testMethod.getParameterTypes());
-
-    Assumptions.assumeTrue(hasRequiredHistoryLevel, "ignored because the current history level is too low");
-    Assumptions.assumeTrue(hasRequiredDatabase, "ignored because the database doesn't match the required ones");
+    // we disable the authorization check when deploying before the test starts
+    boolean oldValue = processEngineConfiguration.isAuthorizationEnabled();
+    try {
+      processEngineConfiguration.setAuthorizationEnabled(false);
+      deploymentId = TestHelper.annotationDeploymentSetUp(processEngine, testClass, testMethod.getName(), null, testMethod.getParameterTypes());
+      boolean hasRequiredHistoryLevel = TestHelper.annotationRequiredHistoryLevelCheck(processEngine, testClass, testMethod.getName(), testMethod.getParameterTypes());
+      boolean hasRequiredDatabase = TestHelper.annotationRequiredDatabaseCheck(processEngine, testClass, testMethod.getName(), testMethod.getParameterTypes());
+      Assumptions.assumeTrue(hasRequiredHistoryLevel, "ignored because the current history level is too low");
+      Assumptions.assumeTrue(hasRequiredDatabase, "ignored because the database doesn't match the required ones");
+    } finally {
+      // after the initialization we restore authorization to the state defined by the test
+      processEngineConfiguration.setAuthorizationEnabled(oldValue);
+    }
+    
   }
 
   @Override
   public void afterTestExecution(ExtensionContext context) {
+    identityService.clearAuthentication();
+
     final String testMethod = context.getTestMethod().orElseThrow(illegalStateException("testMethod not set")).getName();
     final Class<?> testClass = context.getTestClass().orElseThrow(illegalStateException("testClass not set"));
 
-   TestHelper.annotationDeploymentTearDown(processEngine, deploymentId, testClass, testMethod);
-   deploymentId = null;
-   for (String additionalDeployment : additionalDeployments) {
-     TestHelper.deleteDeployment(processEngine, additionalDeployment);
-   }
-   additionalDeployments.clear();
+    // we disable the tenant check when undeploying after the test ends
+    boolean tenantCheckEnabled = processEngineConfiguration.isTenantCheckEnabled();
+    try {
+      processEngineConfiguration.setTenantCheckEnabled(false);
+      TestHelper.annotationDeploymentTearDown(processEngine, deploymentId, testClass, testMethod);
+      deploymentId = null;
+      for (String additionalDeployment : additionalDeployments) {
+        TestHelper.deleteDeployment(processEngine, additionalDeployment);
+      }
+      additionalDeployments.clear();
+    } finally {
+      // restore tenant check to the state defined by the test
+      processEngineConfiguration.setTenantCheckEnabled(tenantCheckEnabled);
+    }
 
    TestHelper.resetIdGenerator(processEngineConfiguration);
    ClockUtil.reset();
@@ -245,7 +263,7 @@ public class ProcessEngineExtension implements TestWatcher,
 
   @Override
   public void afterAll(ExtensionContext context) {
-    deleteHistoryCleanupJob();
+	  deleteHistoryCleanupJob();
   }
 
   private void deleteHistoryCleanupJob() {
@@ -273,6 +291,7 @@ public class ProcessEngineExtension implements TestWatcher,
       // allow other extensions to access the engine instance created by this extension
       context.getStore(ExtensionContext.Namespace.create("Operaton")).put(ProcessEngine.class, processEngine);
     }
+    initializeServices();
     getAllFields(testInstance.getClass())
             .filter(field -> field.getType() == ProcessEngine.class)
             .forEach(field -> inject(testInstance, field, processEngine));

--- a/engine/src/main/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineTestExtension.java
+++ b/engine/src/main/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineTestExtension.java
@@ -1,0 +1,470 @@
+package org.operaton.bpm.engine.test.junit5;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+import org.opentest4j.AssertionFailedError;
+import org.operaton.bpm.engine.AuthorizationService;
+import org.operaton.bpm.engine.HistoryService;
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.TaskService;
+import org.operaton.bpm.engine.authorization.Authorization;
+import org.operaton.bpm.engine.authorization.Permission;
+import org.operaton.bpm.engine.authorization.Resource;
+import org.operaton.bpm.engine.delegate.Expression;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.operaton.bpm.engine.impl.cmmn.behavior.CaseControlRuleImpl;
+import org.operaton.bpm.engine.impl.el.FixedValue;
+import org.operaton.bpm.engine.impl.history.HistoryLevel;
+import org.operaton.bpm.engine.impl.interceptor.Command;
+import org.operaton.bpm.engine.impl.jobexecutor.JobExecutor;
+import org.operaton.bpm.engine.impl.persistence.entity.JobEntity;
+import org.operaton.bpm.engine.impl.persistence.entity.JobManager;
+import org.operaton.bpm.engine.impl.util.ClockUtil;
+import org.operaton.bpm.engine.repository.Deployment;
+import org.operaton.bpm.engine.repository.DeploymentBuilder;
+import org.operaton.bpm.engine.repository.DeploymentWithDefinitions;
+import org.operaton.bpm.engine.repository.ProcessDefinition;
+import org.operaton.bpm.engine.runtime.CaseInstance;
+import org.operaton.bpm.engine.runtime.Job;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.task.Task;
+import org.operaton.bpm.engine.variable.VariableMap;
+import org.operaton.bpm.model.bpmn.BpmnModelInstance;
+
+/**
+ * JUnit 5 Extension for managing a ProcessEngine during tests.
+ * <p>
+ * This extension provides many of the utility methods from your former JUnit 4
+ * rule. It now has a default no-args constructor that creates a ProcessEngine
+ * using the default configuration. This allows you to register it via:
+ * 
+ * <pre>
+ * &#64;RegisterExtension
+ * protected ProcessEngineTestExtension testRule = new ProcessEngineTestExtension();
+ * </pre>
+ * </p>
+ */
+public class ProcessEngineTestExtension
+		implements BeforeEachCallback, AfterEachCallback, TestInstancePostProcessor {
+
+  public static final String DEFAULT_BPMN_RESOURCE_NAME = "process.bpmn20.xml";
+
+  private ProcessEngineExtension processEngineRule;
+  private ProcessEngine processEngine;
+
+  public ProcessEngineTestExtension(ProcessEngineExtension processEngineExtension) {
+    this.processEngineRule = processEngineExtension;
+  }
+
+  public ProcessEngine getProcessEngine() {
+    return processEngineRule.getProcessEngine();
+  }
+
+  @Override
+  public void postProcessTestInstance(Object testInstance, ExtensionContext context) throws Exception {
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) throws Exception {
+    this.processEngine = processEngineRule.getProcessEngine();
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) throws Exception {
+    this.processEngine = null;
+  }
+
+  public void assertProcessEnded(String processInstanceId) {
+    ProcessInstance processInstance = processEngine
+      .getRuntimeService()
+      .createProcessInstanceQuery()
+      .processInstanceId(processInstanceId)
+      .singleResult();
+
+    assertThat(processInstance).describedAs("Process instance with id " + processInstanceId + " is not finished").isNull();
+  }
+
+  public void assertProcessNotEnded(final String processInstanceId) {
+    ProcessInstance processInstance = processEngine
+      .getRuntimeService()
+      .createProcessInstanceQuery()
+      .processInstanceId(processInstanceId)
+      .singleResult();
+
+    if (processInstance==null) {
+      throw new AssertionFailedError("Expected process instance '"+processInstanceId+"' to be still active but it was not in the db");
+    }
+  }
+
+
+  public void assertCaseEnded(String caseInstanceId) {
+    CaseInstance caseInstance = processEngine
+      .getCaseService()
+      .createCaseInstanceQuery()
+      .caseInstanceId(caseInstanceId)
+      .singleResult();
+
+    assertThat(caseInstance).describedAs("Case instance with id " + caseInstanceId + " is not finished").isNull();
+  }
+
+  public DeploymentWithDefinitions deploy(BpmnModelInstance... bpmnModelInstances) {
+    return deploy(createDeploymentBuilder(), Arrays.asList(bpmnModelInstances), Collections.<String> emptyList());
+  }
+
+  public DeploymentWithDefinitions deploy(String... resources) {
+    return deploy(createDeploymentBuilder(), Collections.<BpmnModelInstance> emptyList(), Arrays.asList(resources));
+  }
+
+  public <T extends DeploymentWithDefinitions> T deploy(DeploymentBuilder deploymentBuilder) {
+    T deployment = (T) deploymentBuilder.deployWithResult();
+
+    processEngineRule.manageDeployment(deployment);
+
+    return deployment;
+  }
+
+  public Deployment deploy(BpmnModelInstance bpmnModelInstance, String resource) {
+    return deploy(createDeploymentBuilder(), Collections.singletonList(bpmnModelInstance), Collections.singletonList(resource));
+  }
+
+  public Deployment deployForTenant(String tenantId, BpmnModelInstance... bpmnModelInstances) {
+    return deploy(createDeploymentBuilder().tenantId(tenantId), Arrays.asList(bpmnModelInstances), Collections.<String> emptyList());
+  }
+
+  public Deployment deployForTenant(String tenantId, String... resources) {
+    return deploy(createDeploymentBuilder().tenantId(tenantId), Collections.<BpmnModelInstance> emptyList(), Arrays.asList(resources));
+  }
+
+  public Deployment deployForTenant(String tenant, BpmnModelInstance bpmnModelInstance, String resource) {
+    return deploy(createDeploymentBuilder().tenantId(tenant), Collections.singletonList(bpmnModelInstance), Collections.singletonList(resource));
+  }
+
+  public ProcessDefinition deployAndGetDefinition(BpmnModelInstance bpmnModel) {
+    return deployForTenantAndGetDefinition(null, bpmnModel);
+  }
+
+  public ProcessDefinition deployAndGetDefinition(String classpathResource) {
+    return deployForTenantAndGetDefinition(null, classpathResource);
+  }
+
+  public ProcessDefinition deployForTenantAndGetDefinition(String tenant, String classpathResource) {
+    Deployment deployment = deploy(createDeploymentBuilder().tenantId(tenant), Collections.<BpmnModelInstance>emptyList(), Collections.singletonList(classpathResource));
+
+    return processEngineRule.getRepositoryService()
+      .createProcessDefinitionQuery()
+      .deploymentId(deployment.getId())
+      .singleResult();
+  }
+
+  public ProcessDefinition deployForTenantAndGetDefinition(String tenant, BpmnModelInstance bpmnModel) {
+    Deployment deployment = deploy(createDeploymentBuilder().tenantId(tenant), Collections.singletonList(bpmnModel), Collections.<String>emptyList());
+
+    return processEngineRule.getRepositoryService()
+      .createProcessDefinitionQuery()
+      .deploymentId(deployment.getId())
+      .singleResult();
+  }
+
+  protected DeploymentWithDefinitions deploy(DeploymentBuilder deploymentBuilder, List<BpmnModelInstance> bpmnModelInstances, List<String> resources) {
+    int i = 0;
+    for (BpmnModelInstance bpmnModelInstance : bpmnModelInstances) {
+      deploymentBuilder.addModelInstance(i + "_" + DEFAULT_BPMN_RESOURCE_NAME, bpmnModelInstance);
+      i++;
+    }
+
+    for (String resource : resources) {
+      deploymentBuilder.addClasspathResource(resource);
+    }
+
+    return deploy(deploymentBuilder);
+  }
+
+  protected DeploymentBuilder createDeploymentBuilder() {
+    return processEngine.getRepositoryService().createDeployment();
+  }
+
+  public void waitForJobExecutorToProcessAllJobs() {
+    waitForJobExecutorToProcessAllJobs(0);
+  }
+
+  public void waitForJobExecutorToProcessAllJobs(long maxMillisToWait) {
+    ProcessEngineConfigurationImpl processEngineConfiguration = (ProcessEngineConfigurationImpl) processEngine.getProcessEngineConfiguration();
+    JobExecutor jobExecutor = processEngineConfiguration.getJobExecutor();
+    jobExecutor.start();
+    long intervalMillis = 1000;
+
+    int jobExecutorWaitTime = jobExecutor.getWaitTimeInMillis() * 2;
+    if(maxMillisToWait < jobExecutorWaitTime) {
+      maxMillisToWait = jobExecutorWaitTime;
+    }
+
+    try {
+      Timer timer = new Timer();
+      InterruptTask task = new InterruptTask(Thread.currentThread());
+      timer.schedule(task, maxMillisToWait);
+      boolean areJobsAvailable = true;
+      try {
+        while (areJobsAvailable && !task.isTimeLimitExceeded()) {
+          Thread.sleep(intervalMillis);
+          try {
+            areJobsAvailable = areJobsAvailable();
+          } catch(Throwable t) {
+            // Ignore, possible that exception occurs due to locking/updating of table on MSSQL when
+            // isolation level doesn't allow READ of the table
+          }
+        }
+      } catch (InterruptedException e) {
+      } finally {
+        timer.cancel();
+      }
+      if (areJobsAvailable) {
+        throw new AssertionError("time limit of " + maxMillisToWait + " was exceeded");
+      }
+
+    } finally {
+      jobExecutor.shutdown();
+    }
+  }
+
+  protected boolean areJobsAvailable() {
+    List<Job> list = processEngine.getManagementService().createJobQuery().list();
+    for (Job job : list) {
+      if (!job.isSuspended() && job.getRetries() > 0 && (job.getDuedate() == null || ClockUtil.getCurrentTime().after(job.getDuedate()))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Execute all available jobs recursively till no more jobs found.
+   */
+  public void executeAvailableJobs() {
+    executeAvailableJobs(0, Integer.MAX_VALUE, true);
+  }
+
+  public void executeAvailableJobs(Boolean recursive) {
+    executeAvailableJobs(0, Integer.MAX_VALUE, recursive);
+  }
+
+  /**
+   * Execute all available jobs recursively till no more jobs found or the number of executions is higher than expected.
+   *
+   * @param expectedExecutions number of expected job executions
+   *
+   * @throws AssertionFailedError when execute less or more jobs than expected
+   *
+   * @see #executeAvailableJobs()
+   */
+  public void executeAvailableJobs(int expectedExecutions) {
+    executeAvailableJobs(0, expectedExecutions, true);
+  }
+
+  public void executeAvailableJobs(int expectedExecutions, Boolean recursive) {
+    executeAvailableJobs(0, expectedExecutions, recursive);
+  }
+
+  private void executeAvailableJobs(int jobsExecuted, int expectedExecutions, Boolean recursive) {
+    List<Job> jobs = processEngine.getManagementService().createJobQuery().withRetriesLeft().list();
+
+    if (jobs.isEmpty()) {
+      if (expectedExecutions != Integer.MAX_VALUE) {
+        assertThat(jobsExecuted).describedAs("executed less jobs than expected.").isEqualTo(expectedExecutions);
+      }
+      return;
+    }
+
+    for (Job job : jobs) {
+      try {
+        processEngine.getManagementService().executeJob(job.getId());
+        jobsExecuted += 1;
+      } catch (Exception e) {}
+    }
+
+    assertThat(jobsExecuted).describedAs("executed more jobs than expected.").isLessThanOrEqualTo(expectedExecutions);
+
+    if (recursive) {
+      executeAvailableJobs(jobsExecuted, expectedExecutions, recursive);
+    }
+  }
+
+  public void completeTask(String taskKey) {
+    TaskService taskService = processEngine.getTaskService();
+    Task task = taskService.createTaskQuery().taskDefinitionKey(taskKey).singleResult();
+    assertThat(task).as("Expected a task with key '" + taskKey + "' to exist").isNotNull();
+    taskService.complete(task.getId());
+  }
+
+  public void completeAnyTask(String taskKey) {
+    TaskService taskService = processEngine.getTaskService();
+    List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey(taskKey).list();
+    assertThat(!tasks.isEmpty()).isTrue();
+    taskService.complete(tasks.get(0).getId());
+  }
+
+  public void setAnyVariable(String executionId) {
+    setVariable(executionId, "any", "any");
+  }
+
+  public void setVariable(String executionId, String varName, Object varValue) {
+    processEngine.getRuntimeService().setVariable(executionId, varName, varValue);
+  }
+
+  public void correlateMessage(String messageName) {
+    processEngine.getRuntimeService().createMessageCorrelation(messageName).correlate();
+  }
+
+  public void sendSignal(String signalName) {
+    processEngine.getRuntimeService().signalEventReceived(signalName);
+  }
+
+  public boolean isHistoryLevelNone() {
+    HistoryLevel historyLevel = processEngineRule.getProcessEngineConfiguration().getHistoryLevel();
+    return HistoryLevel.HISTORY_LEVEL_NONE.equals(historyLevel);
+  }
+
+  public boolean isHistoryLevelActivity() {
+    HistoryLevel historyLevel = processEngineRule.getProcessEngineConfiguration().getHistoryLevel();
+    return HistoryLevel.HISTORY_LEVEL_ACTIVITY.equals(historyLevel);
+  }
+
+  public boolean isHistoryLevelAudit() {
+    HistoryLevel historyLevel = processEngineRule.getProcessEngineConfiguration().getHistoryLevel();
+    return HistoryLevel.HISTORY_LEVEL_AUDIT.equals(historyLevel);
+  }
+
+  public boolean isHistoryLevelFull() {
+    HistoryLevel historyLevel = processEngineRule.getProcessEngineConfiguration().getHistoryLevel();
+    return HistoryLevel.HISTORY_LEVEL_FULL.equals(historyLevel);
+  }
+
+  /**
+   * Asserts if the provided text is part of some text.
+   */
+  public void assertTextPresent(String expected, String actual) {
+    if ( (actual==null)
+      || (actual.indexOf(expected)==-1)
+      ) {
+      throw new AssertionFailedError("expected presence of ["+expected+"], but was ["+actual+"]");
+    }
+  }
+
+  /**
+   * Asserts if the provided text is part of some text, ignoring any uppercase characters
+   */
+  public void assertTextPresentIgnoreCase(String expected, String actual) {
+    assertTextPresent(expected.toLowerCase(), actual.toLowerCase());
+  }
+
+  public Object defaultManualActivation() {
+    Expression expression = new FixedValue(true);
+    return new CaseControlRuleImpl(expression);
+  }
+
+
+  public void deleteHistoryCleanupJobs() {
+    HistoryService historyService = processEngine.getHistoryService();
+    final List<Job> jobs = historyService.findHistoryCleanupJobs();
+    for (final Job job : jobs) {
+      final String jobId = job.getId();
+
+      processEngineRule
+        .getProcessEngineConfiguration()
+        .getCommandExecutorTxRequired()
+        .execute((Command<Void>) commandContext -> {
+          JobManager jobManager = commandContext.getJobManager();
+
+          JobEntity jobEntity = jobManager.findJobById(jobId);
+
+          jobEntity.delete();
+          commandContext.getHistoricJobLogManager().deleteHistoricJobLogByJobId(job.getId());
+          return null;
+        });
+    }
+  }
+
+  public CaseInstance createCaseInstanceByKey(String caseDefinitionKey) {
+    return createCaseInstanceByKey(caseDefinitionKey, null, null);
+  }
+
+  public CaseInstance createCaseInstanceByKey(String caseDefinitionKey, String businessKey) {
+    return createCaseInstanceByKey(caseDefinitionKey, businessKey, null);
+  }
+
+  public CaseInstance createCaseInstanceByKey(String caseDefinitionKey, VariableMap variables) {
+    return createCaseInstanceByKey(caseDefinitionKey, null, variables);
+  }
+
+  public CaseInstance createCaseInstanceByKey(String caseDefinitionKey, String businessKey, VariableMap variables) {
+    return processEngine.getCaseService()
+        .withCaseDefinitionByKey(caseDefinitionKey)
+        .businessKey(businessKey)
+        .setVariables(variables)
+        .create();
+  }
+
+  public String getDatabaseType() {
+    return processEngineRule.getProcessEngineConfiguration()
+        .getDbSqlSessionFactory()
+        .getDatabaseType();
+  }
+
+  public void deleteAllAuthorizations() {
+    AuthorizationService authorizationService = processEngine.getAuthorizationService();
+
+    authorizationService.createAuthorizationQuery()
+      .list()
+      .stream()
+      .map(Authorization::getId)
+      .forEach(authorizationService::deleteAuthorization);
+  }
+
+
+  public void deleteAllStandaloneTasks() {
+    TaskService taskService = processEngine.getTaskService();
+
+    taskService.createTaskQuery()
+      .list()
+      .stream()
+      .filter(t -> t.getProcessInstanceId() == null && t.getCaseInstanceId() == null)
+      .forEach(t -> taskService.deleteTask(t.getId(), true));
+  }
+
+  public void createGrantAuthorization(String userId, Resource resource, String resourceId, Permission... permissions) {
+    AuthorizationService authorizationService = processEngine.getAuthorizationService();
+
+    Authorization processInstanceAuthorization = authorizationService.createNewAuthorization(Authorization.AUTH_TYPE_GRANT);
+    processInstanceAuthorization.setResource(resource);
+    processInstanceAuthorization.setResourceId(resourceId);
+    processInstanceAuthorization.setPermissions(permissions);
+    processInstanceAuthorization.setUserId(userId);
+    authorizationService.saveAuthorization(processInstanceAuthorization);
+  }
+
+  protected static class InterruptTask extends TimerTask {
+    protected boolean timeLimitExceeded = false;
+    protected Thread thread;
+    public InterruptTask(Thread thread) {
+      this.thread = thread;
+    }
+    public boolean isTimeLimitExceeded() {
+      return timeLimitExceeded;
+    }
+    @Override
+    public void run() {
+      timeLimitExceeded = true;
+      thread.interrupt();
+    }
+  }
+
+}

--- a/engine/src/main/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineTestExtension.java
+++ b/engine/src/main/junit5/org/operaton/bpm/engine/test/junit5/ProcessEngineTestExtension.java
@@ -1,12 +1,19 @@
+/*
+ * Copyright and/or licensed under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. This file is licensed to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.operaton.bpm.engine.test.junit5;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
 
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -40,6 +47,14 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * JUnit 5 Extension for managing a ProcessEngine during tests.

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ActivityStatisticsAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ActivityStatisticsAuthorizationTest.java
@@ -37,7 +37,7 @@ import org.operaton.bpm.engine.management.IncidentStatistics;
  * @author Roman Smirnov
  *
  */
-public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
+class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
 
   protected static final String ONE_INCIDENT_PROCESS_KEY = "process";
 
@@ -54,7 +54,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   // without any authorization
 
   @Test
-  public void testQueryWithoutAuthorizations() {
+  void testQueryWithoutAuthorizations() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -71,7 +71,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   // including instances //////////////////////////////////////////////////////////////
 
   @Test
-  public void testQueryIncludingInstancesWithoutAuthorizationOnProcessInstance() {
+  void testQueryIncludingInstancesWithoutAuthorizationOnProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -85,7 +85,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingInstancesWithReadPermissionOnOneProcessInstance() {
+  void testQueryIncludingInstancesWithReadPermissionOnOneProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -108,7 +108,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingInstancesWithMany() {
+  void testQueryIncludingInstancesWithMany() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -132,7 +132,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingInstancesWithReadPermissionOnAnyProcessInstance() {
+  void testQueryIncludingInstancesWithReadPermissionOnAnyProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -151,7 +151,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingInstancesWithReadInstancePermissionOnProcessDefinition() {
+  void testQueryIncludingInstancesWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -169,7 +169,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindStatisticsWithRevokedReadInstancePermissionOnProcessDefinition() {
+  void shouldNotFindStatisticsWithRevokedReadInstancePermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -186,7 +186,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   // including failed jobs //////////////////////////////////////////////////////////////
 
   @Test
-  public void testQueryIncludingFailedJobsWithoutAuthorizationOnProcessInstance() {
+  void testQueryIncludingFailedJobsWithoutAuthorizationOnProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -203,7 +203,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingFailedJobsWithReadPermissionOnOneProcessInstance() {
+  void testQueryIncludingFailedJobsWithReadPermissionOnOneProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -229,7 +229,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingFailedJobsWithReadPermissionOnAnyProcessInstance() {
+  void testQueryIncludingFailedJobsWithReadPermissionOnAnyProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -251,7 +251,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingFailedJobsWithReadInstancePermissionOnProcessDefinition() {
+  void testQueryIncludingFailedJobsWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -274,7 +274,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   // including incidents //////////////////////////////////////////////////////////////
 
   @Test
-  public void testQueryIncludingIncidentsWithoutAuthorizationOnProcessInstance() {
+  void testQueryIncludingIncidentsWithoutAuthorizationOnProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -291,7 +291,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingIncidentsWithReadPermissionOnOneProcessInstance() {
+  void testQueryIncludingIncidentsWithReadPermissionOnOneProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -319,7 +319,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingIncidentsWithReadPermissionOnAnyProcessInstance() {
+  void testQueryIncludingIncidentsWithReadPermissionOnAnyProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -343,7 +343,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingIncidentsWithReadInstancePermissionOnProcessDefinition() {
+  void testQueryIncludingIncidentsWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -368,7 +368,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   // including incidents and failed jobs //////////////////////////////////////////////////////////
 
   @Test
-  public void testQueryIncludingIncidentsAndFailedJobsWithoutAuthorizationOnProcessInstance() {
+  void testQueryIncludingIncidentsAndFailedJobsWithoutAuthorizationOnProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -386,7 +386,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingIncidentsAndFailedJobsWithReadPermissionOnOneProcessInstance() {
+  void testQueryIncludingIncidentsAndFailedJobsWithReadPermissionOnOneProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -415,7 +415,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingIncidentsAndFailedJobsWithReadPermissionOnAnyProcessInstance() {
+  void testQueryIncludingIncidentsAndFailedJobsWithReadPermissionOnAnyProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -440,7 +440,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingIncidentsAndFailedJobsWithReadInstancePermissionOnProcessDefinition() {
+  void testQueryIncludingIncidentsAndFailedJobsWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
@@ -464,7 +464,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testManyAuthorizationsActivityStatisticsQueryIncludingFailedJobsAndIncidents() {
+  void testManyAuthorizationsActivityStatisticsQueryIncludingFailedJobsAndIncidents() {
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
     createGrantAuthorization(PROCESS_DEFINITION, ONE_INCIDENT_PROCESS_KEY, userId, READ, READ_INSTANCE);
@@ -489,7 +489,7 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testManyAuthorizationsActivityStatisticsQuery() {
+  void testManyAuthorizationsActivityStatisticsQuery() {
     String processDefinitionId = selectProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY).getId();
 
     createGrantAuthorization(PROCESS_DEFINITION, ONE_INCIDENT_PROCESS_KEY, userId, READ, READ_INSTANCE);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ActivityStatisticsAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ActivityStatisticsAuthorizationTest.java
@@ -16,22 +16,22 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
-import static org.operaton.bpm.engine.authorization.Authorization.ANY;
-import static org.operaton.bpm.engine.authorization.Permissions.READ;
-import static org.operaton.bpm.engine.authorization.Permissions.READ_INSTANCE;
-import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
-import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.management.ActivityStatistics;
 import org.operaton.bpm.engine.management.ActivityStatisticsQuery;
 import org.operaton.bpm.engine.management.IncidentStatistics;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.operaton.bpm.engine.authorization.Authorization.ANY;
+import static org.operaton.bpm.engine.authorization.Permissions.READ;
+import static org.operaton.bpm.engine.authorization.Permissions.READ_INSTANCE;
+import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
+import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 
 /**
  * @author Roman Smirnov
@@ -44,7 +44,7 @@ class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   @Override
   @BeforeEach
   public void setUp() {
-	testRule.deploy("org/operaton/bpm/engine/test/api/authorization/oneIncidentProcess.bpmn20.xml");
+    testRule.deploy("org/operaton/bpm/engine/test/api/authorization/oneIncidentProcess.bpmn20.xml");
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ActivityStatisticsAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ActivityStatisticsAuthorizationTest.java
@@ -25,12 +25,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.management.ActivityStatistics;
 import org.operaton.bpm.engine.management.ActivityStatisticsQuery;
 import org.operaton.bpm.engine.management.IncidentStatistics;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -41,9 +42,9 @@ public class ActivityStatisticsAuthorizationTest extends AuthorizationTest {
   protected static final String ONE_INCIDENT_PROCESS_KEY = "process";
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
-    testRule.deploy("org/operaton/bpm/engine/test/api/authorization/oneIncidentProcess.bpmn20.xml");
+	testRule.deploy("org/operaton/bpm/engine/test/api/authorization/oneIncidentProcess.bpmn20.xml");
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/AuthorizationRevokeModeAlwaysTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/AuthorizationRevokeModeAlwaysTest.java
@@ -45,17 +45,17 @@ public class AuthorizationRevokeModeAlwaysTest extends AuthorizationTest {
       .watch(LOGGING_CONTEXT, Level.DEBUG);
 
   @BeforeEach
-  public void storeRevokeMode() {
+  void storeRevokeMode() {
     defaultRevokeMode = processEngineConfiguration.getAuthorizationCheckRevokes();
   }
 
   @AfterEach
-  public void resetRevokeMode() {
+  void resetRevokeMode() {
     processEngineConfiguration.setAuthorizationCheckRevokes(defaultRevokeMode);
   }
 
   @Test
-  public void shouldCreateEqualQueriesForModesAlwaysAndAutoWhenRevokeExists() {
+  void shouldCreateEqualQueriesForModesAlwaysAndAutoWhenRevokeExists() {
     // given
     disableAuthorization();
     testRule.deploy("org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml");
@@ -83,7 +83,7 @@ public class AuthorizationRevokeModeAlwaysTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldCreateUnequalQueriesForModesAlwaysAndAutoWhenNoRevokeExists() {
+  void shouldCreateUnequalQueriesForModesAlwaysAndAutoWhenNoRevokeExists() {
     // given
     disableAuthorization();
     testRule.deploy("org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/AuthorizationRevokeModeAlwaysTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/AuthorizationRevokeModeAlwaysTest.java
@@ -25,12 +25,14 @@ import static org.operaton.bpm.engine.authorization.Resources.TASK;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineLoggingExtension;
 import org.operaton.commons.testing.ProcessEngineLoggingRule;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
 
 public class AuthorizationRevokeModeAlwaysTest extends AuthorizationTest {
 
@@ -38,16 +40,16 @@ public class AuthorizationRevokeModeAlwaysTest extends AuthorizationTest {
 
   protected String defaultRevokeMode;
 
-  @Rule
-  public ProcessEngineLoggingRule loggingRule = new ProcessEngineLoggingRule()
+  @RegisterExtension
+  public ProcessEngineLoggingExtension loggingRule = new ProcessEngineLoggingExtension()
       .watch(LOGGING_CONTEXT, Level.DEBUG);
 
-  @Before
+  @BeforeEach
   public void storeRevokeMode() {
     defaultRevokeMode = processEngineConfiguration.getAuthorizationCheckRevokes();
   }
 
-  @After
+  @AfterEach
   public void resetRevokeMode() {
     processEngineConfiguration.setAuthorizationCheckRevokes(defaultRevokeMode);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/AuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/AuthorizationTest.java
@@ -16,28 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
-import org.operaton.bpm.engine.ProcessEngineException;
-import org.operaton.bpm.engine.authorization.Authorization;
-import org.operaton.bpm.engine.authorization.Permission;
-import org.operaton.bpm.engine.authorization.Permissions;
-import org.operaton.bpm.engine.authorization.Resource;
-import org.operaton.bpm.engine.identity.Group;
-import org.operaton.bpm.engine.identity.User;
-import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.operaton.bpm.engine.impl.identity.Authentication;
-import org.operaton.bpm.engine.query.Query;
-import org.operaton.bpm.engine.repository.DecisionDefinition;
-import org.operaton.bpm.engine.repository.Deployment;
-import org.operaton.bpm.engine.repository.DeploymentBuilder;
-import org.operaton.bpm.engine.repository.ProcessDefinition;
-import org.operaton.bpm.engine.runtime.CaseInstance;
-import org.operaton.bpm.engine.runtime.Job;
-import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.task.Comment;
-import org.operaton.bpm.engine.task.Task;
-import org.operaton.bpm.engine.test.util.PluggableProcessEngineTest;
-import org.operaton.bpm.engine.variable.VariableMap;
-import org.operaton.bpm.engine.variable.Variables;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Authorization.AUTH_TYPE_GLOBAL;
@@ -53,15 +32,55 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import org.junit.After;
-import org.junit.Before;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.operaton.bpm.engine.AuthorizationService;
+import org.operaton.bpm.engine.CaseService;
+import org.operaton.bpm.engine.DecisionService;
+import org.operaton.bpm.engine.ExternalTaskService;
+import org.operaton.bpm.engine.FormService;
+import org.operaton.bpm.engine.HistoryService;
+import org.operaton.bpm.engine.IdentityService;
+import org.operaton.bpm.engine.ManagementService;
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.ProcessEngineException;
+import org.operaton.bpm.engine.RepositoryService;
+import org.operaton.bpm.engine.RuntimeService;
+import org.operaton.bpm.engine.TaskService;
+import org.operaton.bpm.engine.authorization.Authorization;
+import org.operaton.bpm.engine.authorization.Permission;
+import org.operaton.bpm.engine.authorization.Permissions;
+import org.operaton.bpm.engine.authorization.Resource;
+import org.operaton.bpm.engine.history.UserOperationLogEntry;
+import org.operaton.bpm.engine.identity.Group;
+import org.operaton.bpm.engine.identity.User;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.operaton.bpm.engine.impl.identity.Authentication;
+import org.operaton.bpm.engine.query.Query;
+import org.operaton.bpm.engine.repository.DecisionDefinition;
+import org.operaton.bpm.engine.repository.Deployment;
+import org.operaton.bpm.engine.repository.DeploymentBuilder;
+import org.operaton.bpm.engine.repository.ProcessDefinition;
+import org.operaton.bpm.engine.runtime.CaseInstance;
+import org.operaton.bpm.engine.runtime.Job;
+import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.task.Comment;
+import org.operaton.bpm.engine.task.Task;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.variable.VariableMap;
+import org.operaton.bpm.engine.variable.Variables;
 
 /**
  * @author Roman Smirnov
  */
-public abstract class AuthorizationTest extends PluggableProcessEngineTest {
+public abstract class AuthorizationTest {
+
+  @RegisterExtension
+  protected static ProcessEngineExtension processEngineExtension = ProcessEngineExtension.builder().build();
+  @RegisterExtension
+  protected static ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(processEngineExtension);
 
   protected String userId = "test";
   protected String groupId = "accounting";
@@ -71,35 +90,53 @@ public abstract class AuthorizationTest extends PluggableProcessEngineTest {
   protected static final String VARIABLE_NAME = "aVariableName";
   protected static final String VARIABLE_VALUE = "aVariableValue";
   protected static final String TASK_ID = "myTask";
+  
+  protected ProcessEngine processEngine;
+  protected ProcessEngineConfigurationImpl processEngineConfiguration;
+  protected IdentityService identityService;
+  protected AuthorizationService authorizationService;
+  protected RuntimeService runtimeService;
+  protected TaskService taskService;
+  protected ManagementService managementService;
+  protected RepositoryService repositoryService;
+  protected CaseService caseService;
+  protected FormService formService;
+  protected ExternalTaskService externalTaskService;
+  protected HistoryService historyService;
+  protected DecisionService decisionService;
 
   protected List<String> deploymentIds = new ArrayList<>();
 
-  @Before
+  @BeforeEach
   public void setUp() {
+    processEngineConfiguration.setAuthorizationEnabled(false);
     testUser = createUser(userId);
     testGroup = createGroup(groupId);
-
     identityService.createMembership(userId, groupId);
-
     identityService.setAuthentication(userId, Arrays.asList(groupId));
     processEngineConfiguration.setAuthorizationEnabled(true);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
-    processEngineConfiguration.setAuthorizationEnabled(false);
-    for (User user : identityService.createUserQuery().list()) {
-      identityService.deleteUser(user.getId());
-    }
-    for (Group group : identityService.createGroupQuery().list()) {
-      identityService.deleteGroup(group.getId());
-    }
-    for (Authorization authorization : authorizationService.createAuthorizationQuery().list()) {
-      authorizationService.deleteAuthorization(authorization.getId());
-    }
-    for (String deploymentId : deploymentIds) {
-      deleteDeployment(deploymentId);
-    }
+    runWithoutAuthorization((Callable<Void>) () -> {
+      for (User user : identityService.createUserQuery().list()) {
+        identityService.deleteUser(user.getId());
+      }
+      for (Group group : identityService.createGroupQuery().list()) {
+        identityService.deleteGroup(group.getId());
+      }
+      for (Authorization authorization : authorizationService.createAuthorizationQuery().list()) {
+        authorizationService.deleteAuthorization(authorization.getId());
+      }
+      for (String deploymentId : deploymentIds) {
+        deleteDeployment(deploymentId);
+      }
+      for (UserOperationLogEntry logEntry : historyService.createUserOperationLogQuery().list()) {
+        historyService.deleteUserOperationLogEntry(logEntry.getId());
+      }
+      return null;
+    });
   }
 
   protected <T> T runWithoutAuthorization(Callable<T> runnable) {
@@ -140,7 +177,7 @@ public abstract class AuthorizationTest extends PluggableProcessEngineTest {
     authorization.setUserId(userId);
     authorization.addPermission(Permissions.ALL);
     saveAuthorization(authorization);
-
+    
     return user;
   }
 
@@ -262,7 +299,7 @@ public abstract class AuthorizationTest extends PluggableProcessEngineTest {
 
   public void executeAvailableJobs() {
     runWithoutAuthorization((Callable<Void>) () -> {
-      testRule.executeAvailableJobs();
+    	testRule.executeAvailableJobs();
       return null;
     });
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/AuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/AuthorizationTest.java
@@ -16,22 +16,6 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.operaton.bpm.engine.authorization.Authorization.ANY;
-import static org.operaton.bpm.engine.authorization.Authorization.AUTH_TYPE_GLOBAL;
-import static org.operaton.bpm.engine.authorization.Authorization.AUTH_TYPE_GRANT;
-import static org.operaton.bpm.engine.authorization.Authorization.AUTH_TYPE_REVOKE;
-import static org.operaton.bpm.engine.authorization.Permissions.ALL;
-import static org.operaton.bpm.engine.authorization.Resources.AUTHORIZATION;
-import static org.operaton.bpm.engine.authorization.Resources.USER;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Callable;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -71,6 +55,22 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.operaton.bpm.engine.authorization.Authorization.ANY;
+import static org.operaton.bpm.engine.authorization.Authorization.AUTH_TYPE_GLOBAL;
+import static org.operaton.bpm.engine.authorization.Authorization.AUTH_TYPE_GRANT;
+import static org.operaton.bpm.engine.authorization.Authorization.AUTH_TYPE_REVOKE;
+import static org.operaton.bpm.engine.authorization.Permissions.ALL;
+import static org.operaton.bpm.engine.authorization.Resources.AUTHORIZATION;
+import static org.operaton.bpm.engine.authorization.Resources.USER;
 
 /**
  * @author Roman Smirnov
@@ -177,7 +177,7 @@ public abstract class AuthorizationTest {
     authorization.setUserId(userId);
     authorization.addPermission(Permissions.ALL);
     saveAuthorization(authorization);
-    
+
     return user;
   }
 
@@ -299,7 +299,7 @@ public abstract class AuthorizationTest {
 
   public void executeAvailableJobs() {
     runWithoutAuthorization((Callable<Void>) () -> {
-    	testRule.executeAvailableJobs();
+      testRule.executeAvailableJobs();
       return null;
     });
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ConditionStartEventAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ConditionStartEventAuthorizationTest.java
@@ -25,12 +25,12 @@ import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 
 import java.util.List;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.runtime.ConditionEvaluationBuilder;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
-import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ConditionStartEventAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ConditionStartEventAuthorizationTest.java
@@ -35,16 +35,16 @@ import org.operaton.bpm.engine.test.Deployment;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class ConditionStartEventAuthorizationTest extends AuthorizationTest {
+class ConditionStartEventAuthorizationTest extends AuthorizationTest {
 
   private static final String SINGLE_CONDITIONAL_XML = "org/operaton/bpm/engine/test/bpmn/event/conditional/ConditionalStartEventTest.testSingleConditionalStartEvent1.bpmn20.xml";
   private static final String TRUE_CONDITIONAL_XML = "org/operaton/bpm/engine/test/bpmn/event/conditional/ConditionalStartEventTest.testStartInstanceWithTrueConditionalStartEvent.bpmn20.xml";
   protected static final String PROCESS_KEY = "conditionalEventProcess";
   protected static final String PROCESS_KEY_TWO = "trueConditionProcess";
 
-  @Deployment(resources = { SINGLE_CONDITIONAL_XML, TRUE_CONDITIONAL_XML })
+  @Deployment(resources = {SINGLE_CONDITIONAL_XML, TRUE_CONDITIONAL_XML})
   @Test
-  public void testWithAllPermissions() {
+  void testWithAllPermissions() {
     // given two deployed processes with conditional start event
 
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY_TWO, userId, CREATE_INSTANCE);
@@ -61,9 +61,9 @@ public class ConditionStartEventAuthorizationTest extends AuthorizationTest {
     assertThat(instances).hasSize(1);
   }
 
-  @Deployment(resources = { SINGLE_CONDITIONAL_XML })
+  @Deployment(resources = {SINGLE_CONDITIONAL_XML})
   @Test
-  public void testWithoutProcessDefinitionPermissions() {
+  void testWithoutProcessDefinitionPermissions() {
     // given deployed process with conditional start event
 
     // user does not have process definition permissions
@@ -78,9 +78,9 @@ public class ConditionStartEventAuthorizationTest extends AuthorizationTest {
         .hasMessageContaining("No subscriptions were found during evaluation of the conditional start events.");
   }
 
-  @Deployment(resources = { SINGLE_CONDITIONAL_XML })
+  @Deployment(resources = {SINGLE_CONDITIONAL_XML})
   @Test
-  public void testWithoutCreateInstancePermissions() {
+  void testWithoutCreateInstancePermissions() {
     // given deployed process with conditional start event
 
     // user does not have process definition CREATE_INSTANCE permissions
@@ -97,9 +97,9 @@ public class ConditionStartEventAuthorizationTest extends AuthorizationTest {
   }
 
   @SuppressWarnings("GrazieInspection")
-  @Deployment(resources = { SINGLE_CONDITIONAL_XML })
+  @Deployment(resources = {SINGLE_CONDITIONAL_XML})
   @Test
-  public void testWithoutProcessInstancePermission() {
+  void testWithoutProcessInstancePermission() {
     // given deployed process with conditional start event
 
     // the user doesn't have CREATE permission for process instances
@@ -114,9 +114,9 @@ public class ConditionStartEventAuthorizationTest extends AuthorizationTest {
         .hasMessageContaining("The user with id 'test' does not have 'CREATE' permission on resource 'ProcessInstance'.");
   }
 
-  @Deployment(resources = { SINGLE_CONDITIONAL_XML })
+  @Deployment(resources = {SINGLE_CONDITIONAL_XML})
   @Test
-  public void testWithRevokeAuthorizations() {
+  void testWithRevokeAuthorizations() {
     // given deployed process with conditional start event
 
     createRevokeAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DefaultUserPermissionsForTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DefaultUserPermissionsForTaskTest.java
@@ -23,12 +23,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.authorization.Permissions;
 import org.operaton.bpm.engine.authorization.Resources;
 import org.operaton.bpm.engine.identity.Group;
 import org.operaton.bpm.engine.identity.User;
-import org.junit.After;
-import org.junit.Test;
 
 /**
  *
@@ -45,7 +45,7 @@ public class DefaultUserPermissionsForTaskTest extends AuthorizationTest {
 
   protected String defaultTaskPermissionValue;
 
-  @After
+  @AfterEach
   @Override
   public void tearDown() {
     // reset default permission

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DefaultUserPermissionsForTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DefaultUserPermissionsForTaskTest.java
@@ -35,7 +35,7 @@ import org.operaton.bpm.engine.identity.User;
  * @author Deivarayan Azhagappan
  *
  */
-public class DefaultUserPermissionsForTaskTest extends AuthorizationTest {
+class DefaultUserPermissionsForTaskTest extends AuthorizationTest {
 
   protected String userId2 = "demo";
   protected User user2;
@@ -54,7 +54,7 @@ public class DefaultUserPermissionsForTaskTest extends AuthorizationTest {
   }
 
   @Test
-  public void testShouldGrantTaskWorkOnAssign() {
+  void testShouldGrantTaskWorkOnAssign() {
 
     // given
     processEngineConfiguration.setDefaultUserPermissionForTask(TASK_WORK);
@@ -75,7 +75,7 @@ public class DefaultUserPermissionsForTaskTest extends AuthorizationTest {
   }
 
   @Test
-  public void testShouldGrantUpdateOnAssign() {
+  void testShouldGrantUpdateOnAssign() {
 
     // given
     processEngineConfiguration.setDefaultUserPermissionForTask(UPDATE);
@@ -95,7 +95,7 @@ public class DefaultUserPermissionsForTaskTest extends AuthorizationTest {
   }
 
   @Test
-  public void testShouldGrantTaskWorkOnSetCandidateUser() {
+  void testShouldGrantTaskWorkOnSetCandidateUser() {
 
     // given
     processEngineConfiguration.setDefaultUserPermissionForTask(TASK_WORK);
@@ -116,7 +116,7 @@ public class DefaultUserPermissionsForTaskTest extends AuthorizationTest {
   }
 
   @Test
-  public void testShouldGrantUpdateOnSetCandidateUser() {
+  void testShouldGrantUpdateOnSetCandidateUser() {
 
     // given
     processEngineConfiguration.setDefaultUserPermissionForTask(UPDATE);
@@ -136,7 +136,7 @@ public class DefaultUserPermissionsForTaskTest extends AuthorizationTest {
   }
 
   @Test
-  public void testShouldGrantTaskWorkOnSetOwner() {
+  void testShouldGrantTaskWorkOnSetOwner() {
 
     // given
     processEngineConfiguration.setDefaultUserPermissionForTask(TASK_WORK);
@@ -157,7 +157,7 @@ public class DefaultUserPermissionsForTaskTest extends AuthorizationTest {
   }
 
   @Test
-  public void testShouldGrantUpdateOnSetOwner() {
+  void testShouldGrantUpdateOnSetOwner() {
 
     // given
     processEngineConfiguration.setDefaultUserPermissionForTask(UPDATE);
@@ -178,7 +178,7 @@ public class DefaultUserPermissionsForTaskTest extends AuthorizationTest {
 
 
   @Test
-  public void testShouldGrantTaskWorkOnSetCandidateGroup() {
+  void testShouldGrantTaskWorkOnSetCandidateGroup() {
 
     // given
     processEngineConfiguration.setDefaultUserPermissionForTask(TASK_WORK);
@@ -199,7 +199,7 @@ public class DefaultUserPermissionsForTaskTest extends AuthorizationTest {
   }
 
   @Test
-  public void testShouldGrantUpdateOnSetCandidateGroup() {
+  void testShouldGrantUpdateOnSetCandidateGroup() {
 
     // given
     processEngineConfiguration.setDefaultUserPermissionForTask(UPDATE);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DelegationAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DelegationAuthorizationTest.java
@@ -68,7 +68,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testJavaDelegateExecutesQueryAfterUserCompletesTask() {
+  void testJavaDelegateExecutesQueryAfterUserCompletesTask() {
     // given
     startProcessInstancesByKey(DEFAULT_PROCESS_KEY, 5);
     String taskId = selectAnyTask().getId();
@@ -86,7 +86,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testJavaDelegateExecutesCommandAfterUserCompletesTask() {
+  void testJavaDelegateExecutesCommandAfterUserCompletesTask() {
     // given
     startProcessInstanceByKey(DEFAULT_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -106,7 +106,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testJavaDelegateExecutesQueryAfterUserCompletesTaskAsDelegateExpression() {
+  void testJavaDelegateExecutesQueryAfterUserCompletesTaskAsDelegateExpression() {
     // given
     processEngineConfiguration.getBeans().put("myDelegate", new ExecuteQueryDelegate());
 
@@ -126,7 +126,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testJavaDelegateExecutesCommandAfterUserCompletesTaskAsDelegateExpression() {
+  void testJavaDelegateExecutesCommandAfterUserCompletesTaskAsDelegateExpression() {
     // given
     processEngineConfiguration.getBeans().put("myDelegate", new ExecuteCommandDelegate());
 
@@ -148,7 +148,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testJavaDelegateExecutesQueryAfterUserCompletesTaskAsExpression() {
+  void testJavaDelegateExecutesQueryAfterUserCompletesTaskAsExpression() {
     // given
     processEngineConfiguration.getBeans().put("myDelegate", new ExecuteQueryDelegate());
 
@@ -168,7 +168,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testJavaDelegateExecutesCommandAfterUserCompletesTaskAsExpression() {
+  void testJavaDelegateExecutesCommandAfterUserCompletesTaskAsExpression() {
     // given
     processEngineConfiguration.getBeans().put("myDelegate", new ExecuteCommandDelegate());
 
@@ -190,7 +190,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testCustomActivityBehaviorExecutesQueryAfterUserCompletesTask() {
+  void testCustomActivityBehaviorExecutesQueryAfterUserCompletesTask() {
     // given
     startProcessInstancesByKey(DEFAULT_PROCESS_KEY, 5);
     String taskId = selectAnyTask().getId();
@@ -208,7 +208,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testCustomActivityBehaviorExecutesCommandAfterUserCompletesTask() {
+  void testCustomActivityBehaviorExecutesCommandAfterUserCompletesTask() {
     // given
     startProcessInstanceByKey(DEFAULT_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -228,7 +228,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testCustomActivityBehaviorExecutesQueryAfterUserCompletesTaskAsDelegateExpression() {
+  void testCustomActivityBehaviorExecutesQueryAfterUserCompletesTaskAsDelegateExpression() {
     // given
     processEngineConfiguration.getBeans().put("myBehavior", new MyServiceTaskActivityBehaviorExecuteQuery());
 
@@ -248,7 +248,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testCustomActivityBehaviorExecutesCommandAfterUserCompletesTaskAsDelegateExpression() {
+  void testCustomActivityBehaviorExecutesCommandAfterUserCompletesTaskAsDelegateExpression() {
     // given
     processEngineConfiguration.getBeans().put("myBehavior", new MyServiceTaskActivityBehaviorExecuteCommand());
 
@@ -270,7 +270,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testSignallableActivityBehaviorAsClass() {
+  void testSignallableActivityBehaviorAsClass() {
     // given
     startProcessInstancesByKey(DEFAULT_PROCESS_KEY, 4);
     String processInstanceId = startProcessInstanceByKey(DEFAULT_PROCESS_KEY).getId();
@@ -288,7 +288,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testSignallableActivityBehaviorAsDelegateExpression() {
+  void testSignallableActivityBehaviorAsDelegateExpression() {
     // given
     processEngineConfiguration.getBeans().put("activityBehavior", new MyServiceTaskActivityBehaviorExecuteQuery());
 
@@ -308,7 +308,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testExecutionListenerExecutesQueryAfterUserCompletesTask() {
+  void testExecutionListenerExecutesQueryAfterUserCompletesTask() {
     // given
     startProcessInstancesByKey(DEFAULT_PROCESS_KEY, 5);
     String taskId = selectAnyTask().getId();
@@ -326,7 +326,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testExecutionListenerExecutesCommandAfterUserCompletesTask() {
+  void testExecutionListenerExecutesCommandAfterUserCompletesTask() {
     // given
     startProcessInstanceByKey(DEFAULT_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -346,7 +346,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testExecutionListenerExecutesQueryAfterUserCompletesTaskAsDelegateExpression() {
+  void testExecutionListenerExecutesQueryAfterUserCompletesTaskAsDelegateExpression() {
     // given
     processEngineConfiguration.getBeans().put("myListener", new ExecuteQueryListener());
 
@@ -366,7 +366,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testExecutionListenerExecutesCommandAfterUserCompletesTaskAsDelegateExpression() {
+  void testExecutionListenerExecutesCommandAfterUserCompletesTaskAsDelegateExpression() {
     // given
     processEngineConfiguration.getBeans().put("myListener", new ExecuteCommandListener());
 
@@ -388,7 +388,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testExecutionListenerExecutesQueryAfterUserCompletesTaskAsExpression() {
+  void testExecutionListenerExecutesQueryAfterUserCompletesTaskAsExpression() {
     // given
     processEngineConfiguration.getBeans().put("myListener", new ExecuteQueryListener());
 
@@ -408,7 +408,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testExecutionListenerExecutesCommandAfterUserCompletesTaskAsExpression() {
+  void testExecutionListenerExecutesCommandAfterUserCompletesTaskAsExpression() {
     // given
     processEngineConfiguration.getBeans().put("myListener", new ExecuteCommandListener());
 
@@ -430,7 +430,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testTaskListenerExecutesQueryAfterUserCompletesTask() {
+  void testTaskListenerExecutesQueryAfterUserCompletesTask() {
     // given
     startProcessInstancesByKey(DEFAULT_PROCESS_KEY, 5);
     String taskId = selectAnyTask().getId();
@@ -448,7 +448,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testTaskListenerExecutesCommandAfterUserCompletesTask() {
+  void testTaskListenerExecutesCommandAfterUserCompletesTask() {
     // given
     startProcessInstanceByKey(DEFAULT_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -468,7 +468,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testTaskListenerExecutesQueryAfterUserCompletesTaskAsDelegateExpression() {
+  void testTaskListenerExecutesQueryAfterUserCompletesTaskAsDelegateExpression() {
     // given
     processEngineConfiguration.getBeans().put("myListener", new ExecuteQueryTaskListener());
 
@@ -488,7 +488,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testTaskListenerExecutesCommandAfterUserCompletesTaskAsDelegateExpression() {
+  void testTaskListenerExecutesCommandAfterUserCompletesTaskAsDelegateExpression() {
     // given
     processEngineConfiguration.getBeans().put("myListener", new ExecuteCommandTaskListener());
 
@@ -510,7 +510,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testTaskListenerExecutesQueryAfterUserCompletesTaskAsExpression() {
+  void testTaskListenerExecutesQueryAfterUserCompletesTaskAsExpression() {
     // given
     processEngineConfiguration.getBeans().put("myListener", new ExecuteQueryTaskListener());
 
@@ -530,7 +530,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testTaskListenerExecutesCommandAfterUserCompletesTaskAsExpression() {
+  void testTaskListenerExecutesCommandAfterUserCompletesTaskAsExpression() {
     // given
     processEngineConfiguration.getBeans().put("myListener", new ExecuteCommandTaskListener());
 
@@ -552,7 +552,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testTaskAssigneeExpression() {
+  void testTaskAssigneeExpression() {
     // given
     processEngineConfiguration.getBeans().put("myTaskService", new MyTaskService());
 
@@ -572,7 +572,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testScriptTaskExecutesQueryAfterUserCompletesTask() {
+  void testScriptTaskExecutesQueryAfterUserCompletesTask() {
     // given
     startProcessInstancesByKey(DEFAULT_PROCESS_KEY, 5);
     Task task = selectAnyTask();
@@ -609,7 +609,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testScriptTaskExecutesCommandAfterUserCompletesTask() {
+  void testScriptTaskExecutesCommandAfterUserCompletesTask() {
     // given
     String processInstanceId = startProcessInstanceByKey(DEFAULT_PROCESS_KEY).getId();
     String taskId = selectSingleTask().getId();
@@ -636,7 +636,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testScriptExecutionListenerExecutesQueryAfterUserCompletesTask() {
+  void testScriptExecutionListenerExecutesQueryAfterUserCompletesTask() {
     // given
     startProcessInstancesByKey(DEFAULT_PROCESS_KEY, 5);
     Task task = selectAnyTask();
@@ -673,7 +673,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testScriptExecutionListenerExecutesCommandAfterUserCompletesTask() {
+  void testScriptExecutionListenerExecutesCommandAfterUserCompletesTask() {
     // given
     String processInstanceId = startProcessInstanceByKey(DEFAULT_PROCESS_KEY).getId();
     String taskId = selectSingleTask().getId();
@@ -700,7 +700,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testScriptTaskListenerExecutesQueryAfterUserCompletesTask() {
+  void testScriptTaskListenerExecutesQueryAfterUserCompletesTask() {
     // given
     startProcessInstancesByKey(DEFAULT_PROCESS_KEY, 5);
     Task task = selectAnyTask();
@@ -737,7 +737,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testScriptTaskListenerExecutesCommandAfterUserCompletesTask() {
+  void testScriptTaskListenerExecutesCommandAfterUserCompletesTask() {
     // given
     String processInstanceId = startProcessInstanceByKey(DEFAULT_PROCESS_KEY).getId();
     String taskId = selectSingleTask().getId();
@@ -764,7 +764,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testScriptConditionExecutesQueryAfterUserCompletesTask() {
+  void testScriptConditionExecutesQueryAfterUserCompletesTask() {
     // given
     startProcessInstancesByKey(DEFAULT_PROCESS_KEY, 5);
     Task task = selectAnyTask();
@@ -801,7 +801,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testScriptConditionExecutesCommandAfterUserCompletesTask() {
+  void testScriptConditionExecutesCommandAfterUserCompletesTask() {
     // given
     String processInstanceId = startProcessInstanceByKey(DEFAULT_PROCESS_KEY).getId();
     String taskId = selectSingleTask().getId();
@@ -828,7 +828,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testScriptIoMappingExecutesQueryAfterUserCompletesTask() {
+  void testScriptIoMappingExecutesQueryAfterUserCompletesTask() {
     // given
     startProcessInstancesByKey(DEFAULT_PROCESS_KEY, 5);
     Task task = selectAnyTask();
@@ -865,7 +865,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testScriptIoMappingExecutesCommandAfterUserCompletesTask() {
+  void testScriptIoMappingExecutesCommandAfterUserCompletesTask() {
     // given
     String processInstanceId = startProcessInstanceByKey(DEFAULT_PROCESS_KEY).getId();
     String taskId = selectSingleTask().getId();
@@ -900,7 +900,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testCustomStartFormHandlerExecutesQuery() {
+  void testCustomStartFormHandlerExecutesQuery() {
     // given
     startProcessInstancesByKey(DEFAULT_PROCESS_KEY, 5);
 
@@ -921,7 +921,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testCustomTaskFormHandlerExecutesQuery() {
+  void testCustomTaskFormHandlerExecutesQuery() {
     // given
     startProcessInstancesByKey(DEFAULT_PROCESS_KEY, 5);
 
@@ -942,7 +942,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/authorization/DelegationAuthorizationTest.testCustomStartFormHandlerExecutesQuery.bpmn20.xml"})
   @Test
-  public void testSubmitCustomStartFormHandlerExecutesQuery() {
+  void testSubmitCustomStartFormHandlerExecutesQuery() {
     // given
     startProcessInstancesByKey(DEFAULT_PROCESS_KEY, 5);
 
@@ -962,7 +962,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/authorization/DelegationAuthorizationTest.testCustomTaskFormHandlerExecutesQuery.bpmn20.xml"})
   @Test
-  public void testSubmitCustomTaskFormHandlerExecutesQuery() {
+  void testSubmitCustomTaskFormHandlerExecutesQuery() {
     // given
     startProcessInstancesByKey(DEFAULT_PROCESS_KEY, 5);
 
@@ -981,7 +981,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testCustomFormFieldValidator() {
+  void testCustomFormFieldValidator() {
     // given
     startProcessInstancesByKey(DEFAULT_PROCESS_KEY, 5);
 
@@ -1000,7 +1000,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testCustomFormFieldValidatorAsDelegateExpression() {
+  void testCustomFormFieldValidatorAsDelegateExpression() {
     // given
     processEngineConfiguration.getBeans().put("myValidator", new MyFormFieldValidator());
 
@@ -1021,7 +1021,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/authorization/DelegationAuthorizationTest.testJavaDelegateExecutesQueryAfterUserCompletesTask.bpmn20.xml"})
   @Test
-  public void testPerformAuthorizationCheckByExecutingQuery() {
+  void testPerformAuthorizationCheckByExecutingQuery() {
     // given
     processEngineConfiguration.setAuthorizationEnabledForCustomCode(true);
 
@@ -1041,7 +1041,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/authorization/DelegationAuthorizationTest.testJavaDelegateExecutesCommandAfterUserCompletesTask.bpmn20.xml"})
   @Test
-  public void testPerformAuthorizationCheckByExecutingCommand() {
+  void testPerformAuthorizationCheckByExecutingCommand() {
     // given
     processEngineConfiguration.setAuthorizationEnabledForCustomCode(true);
 
@@ -1067,7 +1067,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   @Deployment
   @Test
-  public void testTaskListenerOnCreateAssignsTask() {
+  void testTaskListenerOnCreateAssignsTask() {
     // given
     String processInstanceId = startProcessInstanceByKey(DEFAULT_PROCESS_KEY).getId();
     String taskId = selectSingleTask().getId();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DelegationAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DelegationAuthorizationTest.java
@@ -24,6 +24,10 @@ import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 import static org.operaton.bpm.engine.authorization.Resources.TASK;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -45,8 +49,6 @@ import org.operaton.bpm.engine.test.api.authorization.service.MyFormFieldValidat
 import org.operaton.bpm.engine.test.api.authorization.service.MyServiceTaskActivityBehaviorExecuteCommand;
 import org.operaton.bpm.engine.test.api.authorization.service.MyServiceTaskActivityBehaviorExecuteQuery;
 import org.operaton.bpm.engine.test.api.authorization.service.MyTaskService;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -56,7 +58,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
 
   public static final String DEFAULT_PROCESS_KEY = "process";
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() {
     MyDelegationService.clearProperties();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DeploymentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DeploymentAuthorizationTest.java
@@ -48,7 +48,7 @@ import org.operaton.bpm.engine.repository.Resource;
  * @author Roman Smirnov
  *
  */
-public class DeploymentAuthorizationTest extends AuthorizationTest {
+class DeploymentAuthorizationTest extends AuthorizationTest {
 
   protected static final String FIRST_RESOURCE = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml";
   protected static final String SECOND_RESOURCE = "org/operaton/bpm/engine/test/api/authorization/messageBoundaryEventProcess.bpmn20.xml";
@@ -56,7 +56,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   // query ////////////////////////////////////////////////////////////
 
   @Test
-  public void testSimpleDeploymentQueryWithoutAuthorization() {
+  void testSimpleDeploymentQueryWithoutAuthorization() {
     // given
     createDeployment(null);
 
@@ -68,7 +68,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleDeploymentQueryWithReadPermissionOnDeployment() {
+  void testSimpleDeploymentQueryWithReadPermissionOnDeployment() {
     // given
     String deploymentId = createDeployment(null);
     createGrantAuthorization(DEPLOYMENT, deploymentId, userId, READ);
@@ -81,7 +81,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleDeploymentQueryWithReadPermissionOnAnyDeployment() {
+  void testSimpleDeploymentQueryWithReadPermissionOnAnyDeployment() {
     // given
     createDeployment(null);
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
@@ -94,7 +94,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleDeploymentQueryWithMultiple() {
+  void testSimpleDeploymentQueryWithMultiple() {
     // given
     String deploymentId = createDeployment(null);
     createGrantAuthorization(DEPLOYMENT, deploymentId, userId, READ);
@@ -108,7 +108,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeploymentQueryWithoutAuthorization() {
+  void testDeploymentQueryWithoutAuthorization() {
     // given
     createDeployment("first");
     createDeployment("second");
@@ -121,7 +121,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeploymentQueryWithReadPermissionOnDeployment() {
+  void testDeploymentQueryWithReadPermissionOnDeployment() {
     // given
     String deploymentId1 = createDeployment("first");
     createDeployment("second");
@@ -135,7 +135,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeploymentQueryWithReadPermissionOnAnyDeployment() {
+  void testDeploymentQueryWithReadPermissionOnAnyDeployment() {
     // given
     createDeployment("first");
     createDeployment("second");
@@ -149,7 +149,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindDeploymentWithRevokedReadPermissionOnAnyDeployment() {
+  void shouldNotFindDeploymentWithRevokedReadPermissionOnAnyDeployment() {
     // given
     createDeployment("first");
     createDeployment("second");
@@ -166,7 +166,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   // create deployment ///////////////////////////////////////////////
 
   @Test
-  public void testCreateDeploymentWithoutAuthoriatzion() {
+  void testCreateDeploymentWithoutAuthoriatzion() {
     // given
     var deploymentBuilder = repositoryService
         .createDeployment()
@@ -182,7 +182,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCreateDeployment() {
+  void testCreateDeployment() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, CREATE);
 
@@ -205,7 +205,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   // delete deployment //////////////////////////////////////////////
 
   @Test
-  public void testDeleteDeploymentWithoutAuthorization() {
+  void testDeleteDeploymentWithoutAuthorization() {
     // given
     String deploymentId = createDeployment(null);
 
@@ -219,7 +219,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteDeploymentWithDeletePermissionOnDeployment() {
+  void testDeleteDeploymentWithDeletePermissionOnDeployment() {
     // given
     String deploymentId = createDeployment(null);
     createGrantAuthorization(DEPLOYMENT, deploymentId, userId, DELETE);
@@ -235,7 +235,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteDeploymentWithDeletePermissionOnAnyDeployment() {
+  void testDeleteDeploymentWithDeletePermissionOnAnyDeployment() {
     // given
     String deploymentId = createDeployment(null);
     createGrantAuthorization(DEPLOYMENT, ANY, userId, DELETE);
@@ -253,7 +253,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   // get deployment resource names //////////////////////////////////
 
   @Test
-  public void testGetDeploymentResourceNamesWithoutAuthorization() {
+  void testGetDeploymentResourceNamesWithoutAuthorization() {
     // given
     String deploymentId = createDeployment(null);
 
@@ -267,7 +267,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetDeploymentResourceNamesWithReadPermissionOnDeployment() {
+  void testGetDeploymentResourceNamesWithReadPermissionOnDeployment() {
     // given
     String deploymentId = createDeployment(null);
     createGrantAuthorization(DEPLOYMENT, deploymentId, userId, READ);
@@ -284,7 +284,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetDeploymentResourceNamesWithReadPermissionOnAnyDeployment() {
+  void testGetDeploymentResourceNamesWithReadPermissionOnAnyDeployment() {
     // given
     String deploymentId = createDeployment(null);
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
@@ -303,7 +303,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   // get deployment resources //////////////////////////////////
 
   @Test
-  public void testGetDeploymentResourcesWithoutAuthorization() {
+  void testGetDeploymentResourcesWithoutAuthorization() {
     // given
     String deploymentId = createDeployment(null);
 
@@ -316,7 +316,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetDeploymentResourcesWithReadPermissionOnDeployment() {
+  void testGetDeploymentResourcesWithReadPermissionOnDeployment() {
     // given
     String deploymentId = createDeployment(null);
     createGrantAuthorization(DEPLOYMENT, deploymentId, userId, READ);
@@ -331,7 +331,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetDeploymentResourcesWithReadPermissionOnAnyDeployment() {
+  void testGetDeploymentResourcesWithReadPermissionOnAnyDeployment() {
     // given
     String deploymentId = createDeployment(null);
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
@@ -348,7 +348,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   // get resource as stream //////////////////////////////////
 
   @Test
-  public void testGetResourceAsStreamWithoutAuthorization() {
+  void testGetResourceAsStreamWithoutAuthorization() {
     // given
     String deploymentId = createDeployment(null);
 
@@ -360,7 +360,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetResourceAsStreamWithReadPermissionOnDeployment() {
+  void testGetResourceAsStreamWithReadPermissionOnDeployment() {
     // given
     String deploymentId = createDeployment(null);
     createGrantAuthorization(DEPLOYMENT, deploymentId, userId, READ);
@@ -373,7 +373,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetResourceAsStreamWithReadPermissionOnAnyDeployment() {
+  void testGetResourceAsStreamWithReadPermissionOnAnyDeployment() {
     // given
     String deploymentId = createDeployment(null);
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
@@ -388,7 +388,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   // get resource as stream by id//////////////////////////////////
 
   @Test
-  public void testGetResourceAsStreamByIdWithoutAuthorization() {
+  void testGetResourceAsStreamByIdWithoutAuthorization() {
     // given
     String deploymentId = createDeployment(null);
 
@@ -405,7 +405,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetResourceAsStreamByIdWithReadPermissionOnDeployment() {
+  void testGetResourceAsStreamByIdWithReadPermissionOnDeployment() {
     // given
     String deploymentId = createDeployment(null);
     createGrantAuthorization(DEPLOYMENT, deploymentId, userId, READ);
@@ -423,7 +423,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetResourceAsStreamByIdWithReadPermissionOnAnyDeployment() {
+  void testGetResourceAsStreamByIdWithReadPermissionOnAnyDeployment() {
     // given
     String deploymentId = createDeployment(null);
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
@@ -443,7 +443,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   // should create authorization /////////////////////////////////////
 
   @Test
-  public void testCreateAuthorizationOnDeploy() {
+  void testCreateAuthorizationOnDeploy() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, CREATE);
     Deployment deployment = repositoryService
@@ -471,7 +471,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   // clear authorization /////////////////////////////////////
 
   @Test
-  public void testClearAuthorizationOnDeleteDeployment() {
+  void testClearAuthorizationOnDeleteDeployment() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, CREATE);
     Deployment deployment = repositoryService
@@ -499,7 +499,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   // register process application ///////////////////////////////////
 
   @Test
-  public void shouldRegisterProcessApplicationAsOperatonAdmin() {
+  void shouldRegisterProcessApplicationAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -516,7 +516,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldRegisterProcessApplicationWithPermission() {
+  void shouldRegisterProcessApplicationWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.SET);
     EmbeddedProcessApplication processApplication = new EmbeddedProcessApplication();
@@ -532,7 +532,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldRegisterProcessApplicationWithAdminAndPermission() {
+  void shouldRegisterProcessApplicationWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.SET);
@@ -549,7 +549,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotRegisterProcessApplicationWithoutAuthorization() {
+  void shouldNotRegisterProcessApplicationWithoutAuthorization() {
     // given
 
     assertThatThrownBy(() -> {
@@ -562,7 +562,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
 
   // unregister process application ///////////////////////////////////
   @Test
-  public void shouldUnregisterProcessApplicationAsOperatonAdmin() {
+  void shouldUnregisterProcessApplicationAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -579,7 +579,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldUnregisterProcessApplicationWithPermission() {
+  void shouldUnregisterProcessApplicationWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.SET);
 
@@ -596,7 +596,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldUnregisterProcessApplicationWithAdminAndPermission() {
+  void shouldUnregisterProcessApplicationWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.SET);
@@ -614,7 +614,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotUnregisterProcessApplicationWithoutAuthorization() {
+  void shouldNotUnregisterProcessApplicationWithoutAuthorization() {
     // given
 
     assertThatThrownBy(() -> {
@@ -628,7 +628,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   // get process application for deployment ///////////////////////////////////
 
   @Test
-  public void shouldGetProcessApplicationForDeploymentAsOperatonAdmin() {
+  void shouldGetProcessApplicationForDeploymentAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -645,7 +645,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetProcessApplicationForDeploymentWithPermission() {
+  void shouldGetProcessApplicationForDeploymentWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
 
@@ -662,7 +662,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetProcessApplicationForDeploymentWithAdminAndPermission() {
+  void shouldGetProcessApplicationForDeploymentWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
@@ -680,7 +680,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotGetProcessApplicationForDeploymentWithoutAuthorization() {
+  void shouldNotGetProcessApplicationForDeploymentWithoutAuthorization() {
     // given
 
     assertThatThrownBy(() -> {
@@ -694,7 +694,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   // get registered deployments ///////////////////////////////////
 
   @Test
-  public void shouldGetRegisteredDeploymentsAsOperatonAdmin() {
+  void shouldGetRegisteredDeploymentsAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -708,7 +708,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetRegisteredDeploymentsWithPermission() {
+  void shouldGetRegisteredDeploymentsWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
 
@@ -722,7 +722,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetRegisteredDeploymentsWithAdminAndPermission() {
+  void shouldGetRegisteredDeploymentsWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
@@ -737,7 +737,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotGetRegisteredDeploymentsWithoutAuthorization() {
+  void shouldNotGetRegisteredDeploymentsWithoutAuthorization() {
     // given
 
     assertThatThrownBy(() -> {
@@ -751,7 +751,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   // register deployment for job executor ///////////////////////////////////
 
   @Test
-  public void shouldRegisterDeploymentAsOperatonAdmin() {
+  void shouldRegisterDeploymentAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -765,7 +765,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldRegisterDeploymentWithPermission() {
+  void shouldRegisterDeploymentWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.SET);
 
@@ -779,7 +779,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldRegisterDeploymentWithAdminAndPermission() {
+  void shouldRegisterDeploymentWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.SET);
@@ -794,7 +794,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotRegisterDeploymentWithoutAuthorization() {
+  void shouldNotRegisterDeploymentWithoutAuthorization() {
     // given
     disableAuthorization();
     String deploymentId = createDeployment(null, FIRST_RESOURCE).getId();
@@ -811,7 +811,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   // unregister deployment for job executor ///////////////////////////////////
 
   @Test
-  public void shouldUnregisterDeploymentAsOperatonAdmin() {
+  void shouldUnregisterDeploymentAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -825,7 +825,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldUnregisterDeploymentWithPermission() {
+  void shouldUnregisterDeploymentWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.SET);
 
@@ -839,7 +839,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldUnregisterDeploymentWithAdminAndPermission() {
+  void shouldUnregisterDeploymentWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.SET);
@@ -854,7 +854,7 @@ public class DeploymentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotUnregisterDeploymentWithoutAuthorization() {
+  void shouldNotUnregisterDeploymentWithoutAuthorization() {
     // given
 
     assertThatThrownBy(() -> {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DeploymentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DeploymentAuthorizationTest.java
@@ -29,6 +29,8 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.application.ProcessApplicationReference;
 import org.operaton.bpm.application.ProcessApplicationRegistration;
 import org.operaton.bpm.application.impl.EmbeddedProcessApplication;
@@ -41,7 +43,6 @@ import org.operaton.bpm.engine.authorization.SystemPermissions;
 import org.operaton.bpm.engine.repository.Deployment;
 import org.operaton.bpm.engine.repository.DeploymentQuery;
 import org.operaton.bpm.engine.repository.Resource;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DeploymentStatisticsAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DeploymentStatisticsAuthorizationTest.java
@@ -25,12 +25,13 @@ import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.management.DeploymentStatistics;
 import org.operaton.bpm.engine.management.DeploymentStatisticsQuery;
 import org.operaton.bpm.engine.management.IncidentStatistics;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -47,7 +48,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   protected String thirdDeploymentId;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     firstDeploymentId = createDeployment("first", "org/operaton/bpm/engine/test/api/authorization/oneIncidentProcess.bpmn20.xml").getId();
     secondDeploymentId = createDeployment("second", "org/operaton/bpm/engine/test/api/authorization/timerStartEventProcess.bpmn20.xml").getId();
@@ -56,7 +57,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     deleteDeployment(firstDeploymentId);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DeploymentStatisticsAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DeploymentStatisticsAuthorizationTest.java
@@ -37,7 +37,7 @@ import org.operaton.bpm.engine.management.IncidentStatistics;
  * @author Roman Smirnov
  *
  */
-public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
+class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
 
   protected static final String ONE_INCIDENT_PROCESS_KEY = "process";
   protected static final String TIMER_START_PROCESS_KEY = "timerStartProcess";
@@ -68,7 +68,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   // deployment statistics query without process instance authorizations /////////////////////////////////////////////
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
 
     // when
@@ -79,7 +79,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnDeployment() {
+  void testQueryWithReadPermissionOnDeployment() {
     // given
     createGrantAuthorization(DEPLOYMENT, firstDeploymentId, userId, READ);
 
@@ -94,7 +94,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithMultiple() {
+  void testQueryWithMultiple() {
     // given
     createGrantAuthorization(DEPLOYMENT, firstDeploymentId, userId, READ);
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
@@ -107,7 +107,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnAnyDeployment() {
+  void testQueryWithReadPermissionOnAnyDeployment() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -124,7 +124,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindStatisticsWithRevokedReadPermissionOnAnyDeployment() {
+  void shouldNotFindStatisticsWithRevokedReadPermissionOnAnyDeployment() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, ANY, READ);
     createRevokeAuthorization(DEPLOYMENT, ANY, userId, READ);
@@ -139,7 +139,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   // deployment statistics query (including process instances) /////////////////////////////////////////////
 
   @Test
-  public void testQueryWithReadPermissionOnProcessInstance() {
+  void testQueryWithReadPermissionOnProcessInstance() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -177,7 +177,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnAnyProcessInstance() {
+  void testQueryWithReadPermissionOnAnyProcessInstance() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -216,7 +216,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstancePermissionOnProcessDefinition() {
+  void testQueryWithReadInstancePermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -255,7 +255,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testQueryWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -296,7 +296,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   // deployment statistics query (including failed jobs) /////////////////////////////////////////////
 
   @Test
-  public void testQueryIncludingFailedJobsWithReadPermissionOnProcessInstance() {
+  void testQueryIncludingFailedJobsWithReadPermissionOnProcessInstance() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -336,7 +336,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingFailedJobsWithReadPermissionOnAnyProcessInstance() {
+  void testQueryIncludingFailedJobsWithReadPermissionOnAnyProcessInstance() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -377,7 +377,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingFailedJobsWithReadInstancePermissionOnProcessDefinition() {
+  void testQueryIncludingFailedJobsWithReadInstancePermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -418,7 +418,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingFailedJobsWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testQueryIncludingFailedJobsWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -461,7 +461,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   // deployment statistics query (including incidents) /////////////////////////////////////////////
 
   @Test
-  public void testQueryIncludingIncidentsWithReadPermissionOnProcessInstance() {
+  void testQueryIncludingIncidentsWithReadPermissionOnProcessInstance() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -501,7 +501,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingIncidentsWithReadPermissionOnAnyProcessInstance() {
+  void testQueryIncludingIncidentsWithReadPermissionOnAnyProcessInstance() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -542,7 +542,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingIncidentsWithReadInstancePermissionOnProcessDefinition() {
+  void testQueryIncludingIncidentsWithReadInstancePermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -583,7 +583,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingIncidentsWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testQueryIncludingIncidentsWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -626,7 +626,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   // deployment statistics query (including failed jobs and incidents) /////////////////////////////////////////////
 
   @Test
-  public void testQueryIncludingFailedJobsAndIncidentsWithReadPermissionOnProcessInstance() {
+  void testQueryIncludingFailedJobsAndIncidentsWithReadPermissionOnProcessInstance() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -667,7 +667,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingFailedJobsAndIncidentsWithReadPermissionOnAnyProcessInstance() {
+  void testQueryIncludingFailedJobsAndIncidentsWithReadPermissionOnAnyProcessInstance() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -709,7 +709,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingFailedJobsAndIncidentsWithReadInstancePermissionOnProcessDefinition() {
+  void testQueryIncludingFailedJobsAndIncidentsWithReadInstancePermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 
@@ -751,7 +751,7 @@ public class DeploymentStatisticsAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryIncludingFailedJobsAndIncidentsWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testQueryIncludingFailedJobsAndIncidentsWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(DEPLOYMENT, ANY, userId, READ);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/EventSubscriptionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/EventSubscriptionAuthorizationTest.java
@@ -21,13 +21,15 @@ import static org.operaton.bpm.engine.authorization.Permissions.READ;
 import static org.operaton.bpm.engine.authorization.Permissions.READ_INSTANCE;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.operaton.bpm.engine.runtime.EventSubscription;
 import org.operaton.bpm.engine.runtime.EventSubscriptionQuery;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -39,7 +41,7 @@ public class EventSubscriptionAuthorizationTest extends AuthorizationTest {
   protected static final String SIGNAL_BOUNDARY_PROCESS_KEY = "signalBoundaryProcess";
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     testRule.deploy(
         "org/operaton/bpm/engine/test/api/oneMessageBoundaryEventProcess.bpmn20.xml",

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/EventSubscriptionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/EventSubscriptionAuthorizationTest.java
@@ -35,7 +35,7 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
  * @author Roman Smirnov
  *
  */
-public class EventSubscriptionAuthorizationTest extends AuthorizationTest {
+class EventSubscriptionAuthorizationTest extends AuthorizationTest {
 
   protected static final String ONE_TASK_PROCESS_KEY = "oneTaskProcess";
   protected static final String SIGNAL_BOUNDARY_PROCESS_KEY = "signalBoundaryProcess";
@@ -50,7 +50,7 @@ public class EventSubscriptionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithoutAuthorization() {
+  void testSimpleQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -62,7 +62,7 @@ public class EventSubscriptionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadPermissionOnProcessInstance() {
+  void testSimpleQueryWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -79,7 +79,7 @@ public class EventSubscriptionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadPermissionOnAnyProcessInstance() {
+  void testSimpleQueryWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -96,7 +96,7 @@ public class EventSubscriptionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithMultiple() {
+  void testSimpleQueryWithMultiple() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -110,7 +110,7 @@ public class EventSubscriptionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadInstancesPermissionOnOneTaskProcess() {
+  void testSimpleQueryWithReadInstancesPermissionOnOneTaskProcess() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ_INSTANCE);
@@ -127,7 +127,7 @@ public class EventSubscriptionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
+  void testSimpleQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -144,7 +144,7 @@ public class EventSubscriptionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
@@ -163,7 +163,7 @@ public class EventSubscriptionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnProcessInstance() {
+  void testQueryWithReadPermissionOnProcessInstance() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
@@ -188,7 +188,7 @@ public class EventSubscriptionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnAnyProcessInstance() {
+  void testQueryWithReadPermissionOnAnyProcessInstance() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
@@ -209,7 +209,7 @@ public class EventSubscriptionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstancesPermissionOnOneTaskProcess() {
+  void testQueryWithReadInstancesPermissionOnOneTaskProcess() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
@@ -230,7 +230,7 @@ public class EventSubscriptionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
+  void testQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
@@ -251,7 +251,7 @@ public class EventSubscriptionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindSubscriptionWithRevokedReadPermissionOnAnyProcessInstance() {
+  void shouldNotFindSubscriptionWithRevokedReadPermissionOnAnyProcessInstance() {
     // given
     ProcessInstance instance1 = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     ProcessInstance instance2 = startProcessInstanceByKey(SIGNAL_BOUNDARY_PROCESS_KEY);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ExecutionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ExecutionAuthorizationTest.java
@@ -21,13 +21,15 @@ import static org.operaton.bpm.engine.authorization.Permissions.READ;
 import static org.operaton.bpm.engine.authorization.Permissions.READ_INSTANCE;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.operaton.bpm.engine.runtime.Execution;
 import org.operaton.bpm.engine.runtime.ExecutionQuery;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -39,7 +41,7 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
   protected static final String MESSAGE_BOUNDARY_PROCESS_KEY = "messageBoundaryProcess";
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     testRule.deploy(
         "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml",

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ExecutionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ExecutionAuthorizationTest.java
@@ -35,7 +35,7 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
  * @author Roman Smirnov
  *
  */
-public class ExecutionAuthorizationTest extends AuthorizationTest {
+class ExecutionAuthorizationTest extends AuthorizationTest {
 
   protected static final String ONE_TASK_PROCESS_KEY = "oneTaskProcess";
   protected static final String MESSAGE_BOUNDARY_PROCESS_KEY = "messageBoundaryProcess";
@@ -50,7 +50,7 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithoutAuthorization() {
+  void testSimpleQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -62,7 +62,7 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadPermissionOnProcessInstance() {
+  void testSimpleQueryWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -79,7 +79,7 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadPermissionOnAnyProcessInstance() {
+  void testSimpleQueryWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -96,7 +96,7 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithMultiple() {
+  void testSimpleQueryWithMultiple() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -110,7 +110,7 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindExecutionWithRevokedReadPermissionOnProcess() {
+  void shouldNotFindExecutionWithRevokedReadPermissionOnProcess() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, ANY, READ);
@@ -124,7 +124,7 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadInstancesPermissionOnOneTaskProcess() {
+  void testSimpleQueryWithReadInstancesPermissionOnOneTaskProcess() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ_INSTANCE);
@@ -141,7 +141,7 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
+  void testSimpleQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -158,7 +158,7 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
@@ -177,7 +177,7 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnProcessInstance() {
+  void testQueryWithReadPermissionOnProcessInstance() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
@@ -202,7 +202,7 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnAnyProcessInstance() {
+  void testQueryWithReadPermissionOnAnyProcessInstance() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
@@ -223,7 +223,7 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstancesPermissionOnOneTaskProcess() {
+  void testQueryWithReadInstancesPermissionOnOneTaskProcess() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
@@ -244,7 +244,7 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
+  void testQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
@@ -265,7 +265,7 @@ public class ExecutionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryShouldReturnAllExecutions() {
+  void testQueryShouldReturnAllExecutions() {
     // given
     ProcessInstance processInstance = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_INSTANCE, processInstance.getId(), userId, READ);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/FormAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/FormAuthorizationTest.java
@@ -34,6 +34,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 
 import java.io.InputStream;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.exception.NullValueException;
 import org.operaton.bpm.engine.form.StartFormData;
@@ -41,9 +44,6 @@ import org.operaton.bpm.engine.form.TaskFormData;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.variable.VariableMap;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -58,7 +58,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   protected String deploymentId;
   protected boolean ensureSpecificVariablePermission;
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() {
     deploymentId = testRule.deploy(
@@ -71,7 +71,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
     super.setUp();
   }
 
-  @After
+  @AfterEach
   @Override
   public void tearDown() {
     super.tearDown();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/FormAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/FormAuthorizationTest.java
@@ -49,7 +49,7 @@ import org.operaton.bpm.engine.variable.VariableMap;
  * @author Roman Smirnov
  *
  */
-public class FormAuthorizationTest extends AuthorizationTest {
+class FormAuthorizationTest extends AuthorizationTest {
 
   protected static final String FORM_PROCESS_KEY = "FormsProcess";
   protected static final String RENDERED_FORM_PROCESS_KEY = "renderedFormProcess";
@@ -81,7 +81,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get start form data ///////////////////////////////////////////
 
   @Test
-  public void testGetStartFormDataWithoutAuthorizations() {
+  void testGetStartFormDataWithoutAuthorizations() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
 
@@ -100,7 +100,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetStartFormData() {
+  void testGetStartFormData() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, FORM_PROCESS_KEY, userId, READ);
@@ -116,7 +116,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get rendered start form /////////////////////////////////////
 
   @Test
-  public void testGetRenderedStartFormWithoutAuthorization() {
+  void testGetRenderedStartFormWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(RENDERED_FORM_PROCESS_KEY).getId();
 
@@ -135,7 +135,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetRenderedStartForm() {
+  void testGetRenderedStartForm() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(RENDERED_FORM_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, RENDERED_FORM_PROCESS_KEY, userId, READ);
@@ -150,7 +150,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get start form variables //////////////////////////////////
 
   @Test
-  public void testGetStartFormVariablesWithoutAuthorization() {
+  void testGetStartFormVariablesWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(RENDERED_FORM_PROCESS_KEY).getId();
 
@@ -169,7 +169,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetStartFormVariables() {
+  void testGetStartFormVariables() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(RENDERED_FORM_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, RENDERED_FORM_PROCESS_KEY, userId, READ);
@@ -186,7 +186,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // submit start form /////////////////////////////////////////
 
   @Test
-  public void testSubmitStartFormWithoutAuthorization() {
+  void testSubmitStartFormWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
 
@@ -204,7 +204,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSubmitStartFormWithCreatePermissionOnProcessInstance() {
+  void testSubmitStartFormWithCreatePermissionOnProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
@@ -224,7 +224,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSubmitStartFormWithCreateInstancePermissionOnProcessDefinition() {
+  void testSubmitStartFormWithCreateInstancePermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, FORM_PROCESS_KEY, userId, CREATE_INSTANCE);
@@ -243,7 +243,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSubmitStartForm() {
+  void testSubmitStartForm() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, FORM_PROCESS_KEY, userId, CREATE_INSTANCE);
@@ -259,7 +259,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get task form data (standalone task) /////////////////////////////////
 
   @Test
-  public void testStandaloneTaskGetTaskFormDataWithoutAuthorization() {
+  void testStandaloneTaskGetTaskFormDataWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -297,7 +297,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskGetTaskFormData() {
+  void testStandaloneTaskGetTaskFormData() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -314,7 +314,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskGetTaskFormDataWithReadVariablePermission() {
+  void testStandaloneTaskGetTaskFormDataWithReadVariablePermission() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String taskId = "myTask";
@@ -334,7 +334,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get task form data (process task) /////////////////////////////////
 
   @Test
-  public void testProcessTaskGetTaskFormDataWithoutAuthorization() {
+  void testProcessTaskGetTaskFormDataWithoutAuthorization() {
     // given
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -376,7 +376,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetTaskFormDataWithReadPermissionOnTask() {
+  void testProcessTaskGetTaskFormDataWithReadPermissionOnTask() {
     // given
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -390,7 +390,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetTaskFormDataWithReadTaskPermissionOnProcessDefinition() {
+  void testProcessTaskGetTaskFormDataWithReadTaskPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -404,7 +404,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetTaskFormDataWithReadVariablePermissionOnTask() {
+  void testProcessTaskGetTaskFormDataWithReadVariablePermissionOnTask() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     startProcessInstanceByKey(FORM_PROCESS_KEY);
@@ -419,7 +419,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetTaskFormDataWithReadTaskVariablePermissionOnProcessDefinition() {
+  void testProcessTaskGetTaskFormDataWithReadTaskVariablePermissionOnProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     startProcessInstanceByKey(FORM_PROCESS_KEY);
@@ -434,7 +434,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetTaskFormData() {
+  void testProcessTaskGetTaskFormData() {
     // given
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -451,7 +451,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get task form data (case task) /////////////////////////////////
 
   @Test
-  public void testCaseTaskGetTaskFormData() {
+  void testCaseTaskGetTaskFormData() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -466,7 +466,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get rendered task form (standalone task) //////////////////
 
   @Test
-  public void testStandaloneTaskGetTaskRenderedFormWithoutAuthorization() {
+  void testStandaloneTaskGetTaskRenderedFormWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -505,7 +505,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskGetTaskRenderedForm() {
+  void testStandaloneTaskGetTaskRenderedForm() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -519,7 +519,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskGetTaskRenderedFormWithReadVariablePermission() {
+  void testStandaloneTaskGetTaskRenderedFormWithReadVariablePermission() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String taskId = "myTask";
@@ -536,7 +536,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get rendered task form (process task) /////////////////////////////////
 
   @Test
-  public void testProcessTaskGetRenderedTaskFormWithoutAuthorization() {
+  void testProcessTaskGetRenderedTaskFormWithoutAuthorization() {
     // given
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -578,7 +578,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetRenderedTaskFormWithReadPermissionOnTask() {
+  void testProcessTaskGetRenderedTaskFormWithReadPermissionOnTask() {
     // given
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -592,7 +592,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetRenderedTaskFormWithReadTaskPermissionOnProcessDefinition() {
+  void testProcessTaskGetRenderedTaskFormWithReadTaskPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -606,7 +606,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetRenderedTaskFormWithReadTaskVariablesPermissionOnProcessDefinition() {
+  void testProcessTaskGetRenderedTaskFormWithReadTaskVariablesPermissionOnProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
@@ -621,7 +621,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetRenderedTaskFormWithReadVariablePermissionOnTask() {
+  void testProcessTaskGetRenderedTaskFormWithReadVariablePermissionOnTask() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
@@ -636,7 +636,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetRenderedTaskForm() {
+  void testProcessTaskGetRenderedTaskForm() {
     // given
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -653,7 +653,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get rendered task form (case task) /////////////////////////////////
 
   @Test
-  public void testCaseTaskGetRenderedTaskForm() {
+  void testCaseTaskGetRenderedTaskForm() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -668,7 +668,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get task form variables (standalone task) ////////////////////////
 
   @Test
-  public void testStandaloneTaskGetTaskFormVariablesWithoutAuthorization() {
+  void testStandaloneTaskGetTaskFormVariablesWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -706,7 +706,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskGetTaskFormVariables() {
+  void testStandaloneTaskGetTaskFormVariables() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -722,7 +722,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskGetTaskFormVariablesWithReadVariablePermission() {
+  void testStandaloneTaskGetTaskFormVariablesWithReadVariablePermission() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String taskId = "myTask";
@@ -741,7 +741,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get task form variables (process task) /////////////////////////////////
 
   @Test
-  public void testProcessTaskGetTaskFormVariablesWithoutAuthorization() {
+  void testProcessTaskGetTaskFormVariablesWithoutAuthorization() {
     // given
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -783,7 +783,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetTaskFormVariablesWithReadPermissionOnTask() {
+  void testProcessTaskGetTaskFormVariablesWithReadPermissionOnTask() {
     // given
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -799,7 +799,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetTaskFormVariablesWithReadTaskPermissionOnProcessDefinition() {
+  void testProcessTaskGetTaskFormVariablesWithReadTaskPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -815,7 +815,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetTaskFormVariables() {
+  void testProcessTaskGetTaskFormVariables() {
     // given
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -832,7 +832,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetTaskFormVariablesWithReadVariablePermissionOnTask() {
+  void testProcessTaskGetTaskFormVariablesWithReadVariablePermissionOnTask() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
@@ -849,7 +849,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetTaskFormVariablesWithReadTaskVariablePermissionOnProcessDefinition() {
+  void testProcessTaskGetTaskFormVariablesWithReadTaskVariablePermissionOnProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
@@ -868,7 +868,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get task form variables (case task) /////////////////////////////////
 
   @Test
-  public void testCaseTaskGetTaskFormVariables() {
+  void testCaseTaskGetTaskFormVariables() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -883,7 +883,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // submit task form (standalone task) ////////////////////////////////
 
   @Test
-  public void testStandaloneTaskSubmitTaskFormWithoutAuthorization() {
+  void testStandaloneTaskSubmitTaskFormWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -905,7 +905,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskSubmitTaskForm() {
+  void testStandaloneTaskSubmitTaskForm() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -924,7 +924,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // submit task form (process task) ////////////////////////////////
 
   @Test
-  public void testProcessTaskSubmitTaskFormWithoutAuthorization() {
+  void testProcessTaskSubmitTaskFormWithoutAuthorization() {
     // given
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -947,7 +947,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSubmitTaskFormWithUpdatePermissionOnTask() {
+  void testProcessTaskSubmitTaskFormWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -963,7 +963,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSubmitTaskFormWithUpdateTaskPermissionOnProcessDefinition() {
+  void testProcessTaskSubmitTaskFormWithUpdateTaskPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -979,7 +979,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSubmitTaskForm() {
+  void testProcessTaskSubmitTaskForm() {
     // given
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -997,7 +997,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // submit task form (case task) ////////////////////////////////
 
   @Test
-  public void testCaseTaskSubmitTaskForm() {
+  void testCaseTaskSubmitTaskForm() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -1013,7 +1013,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get start form key ////////////////////////////////////////
 
   @Test
-  public void testGetStartFormKeyWithoutAuthorizations() {
+  void testGetStartFormKeyWithoutAuthorizations() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
 
@@ -1032,7 +1032,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetStartFormKey() {
+  void testGetStartFormKey() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, FORM_PROCESS_KEY, userId, READ);
@@ -1047,7 +1047,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get task form key ////////////////////////////////////////
 
   @Test
-  public void testGetTaskFormKeyWithoutAuthorizations() {
+  void testGetTaskFormKeyWithoutAuthorizations() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
 
@@ -1066,7 +1066,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetTaskFormKey() {
+  void testGetTaskFormKey() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, FORM_PROCESS_KEY, userId, READ);
@@ -1081,7 +1081,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get deployed start form////////////////////////////////////////
 
   @Test
-  public void testGetDeployedStartForm() {
+  void testGetDeployedStartForm() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, FORM_PROCESS_KEY, userId, READ);
@@ -1092,7 +1092,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetDeployedStartFormWithoutAuthorization() {
+  void testGetDeployedStartFormWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
 
@@ -1113,7 +1113,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   // get deployed task form////////////////////////////////////////
 
   @Test
-  public void testGetDeployedTaskForm() {
+  void testGetDeployedTaskForm() {
     // given
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1125,7 +1125,7 @@ public class FormAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetDeployedTaskFormWithoutAuthorization() {
+  void testGetDeployedTaskFormWithoutAuthorization() {
     // given
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/GroupAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/GroupAuthorizationTest.java
@@ -67,7 +67,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
 
 
   @Test
-  public void testTaskQueryWithoutGroupAuthorizations() {
+  void testTaskQueryWithoutGroupAuthorizations() {
     processEngineConfiguration.getCommandExecutorTxRequired().execute(commandContext -> {
       AuthorizationManager authorizationManager = spyOnSession(commandContext, AuthorizationManager.class);
 
@@ -85,7 +85,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testTaskQueryWithOneGroupAuthorization() {
+  void testTaskQueryWithOneGroupAuthorization() {
     createGroupGrantAuthorization(Resources.TASK, Authorization.ANY, TEST_GROUP_IDS.get(0));
 
     processEngineConfiguration.getCommandExecutorTxRequired().execute(commandContext -> {
@@ -105,7 +105,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testTaskQueryWithGroupAuthorization() {
+  void testTaskQueryWithGroupAuthorization() {
     for (String testGroupId : TEST_GROUP_IDS) {
       createGroupGrantAuthorization(Resources.TASK, Authorization.ANY, testGroupId);
     }
@@ -126,7 +126,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testTaskQueryWithUserWithoutGroups() {
+  void testTaskQueryWithUserWithoutGroups() {
     identityService.setAuthentication(TEST_USER_ID, null);
 
     processEngineConfiguration.getCommandExecutorTxRequired().execute(commandContext -> {
@@ -146,7 +146,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckAuthorizationWithoutGroupAuthorizations() {
+  void testCheckAuthorizationWithoutGroupAuthorizations() {
     processEngineConfiguration.getCommandExecutorTxRequired().execute(commandContext -> {
       AuthorizationManager authorizationManager = spyOnSession(commandContext, AuthorizationManager.class);
       DbEntityManager dbEntityManager = spyOnSession(commandContext, DbEntityManager.class);
@@ -166,7 +166,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckAuthorizationWithOneGroupAuthorizations() {
+  void testCheckAuthorizationWithOneGroupAuthorizations() {
     createGroupGrantAuthorization(Resources.TASK, Authorization.ANY, TEST_GROUP_IDS.get(0));
 
     processEngineConfiguration.getCommandExecutorTxRequired().execute(commandContext -> {
@@ -188,7 +188,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckAuthorizationWithGroupAuthorizations() {
+  void testCheckAuthorizationWithGroupAuthorizations() {
     for (String testGroupId : TEST_GROUP_IDS) {
       createGroupGrantAuthorization(Resources.TASK, Authorization.ANY, testGroupId);
     }
@@ -212,7 +212,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckAuthorizationWithUserWithoutGroups() {
+  void testCheckAuthorizationWithUserWithoutGroups() {
     processEngineConfiguration.getCommandExecutorTxRequired().execute(commandContext -> {
       AuthorizationManager authorizationManager = spyOnSession(commandContext, AuthorizationManager.class);
       DbEntityManager dbEntityManager = spyOnSession(commandContext, DbEntityManager.class);
@@ -232,7 +232,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckAuthorizationForNullHostileListOfGroups() {
+  void testCheckAuthorizationForNullHostileListOfGroups() {
     // given
     identityService.clearAuthentication();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/GroupAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/GroupAuthorizationTest.java
@@ -29,8 +29,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.operaton.bpm.engine.authorization.Authorization;
 import org.operaton.bpm.engine.authorization.Permission;
@@ -52,7 +53,7 @@ public class GroupAuthorizationTest extends AuthorizationTest {
   public static final String TEST_USER_ID = "testUser";
   public static final List<String> TEST_GROUP_IDS = Arrays.asList("testGroup1", "testGroup2", "testGroup3");
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() {
     createUser(TEST_USER_ID);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/IncidentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/IncidentAuthorizationTest.java
@@ -46,7 +46,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Roman Smirnov
  *
  */
-public class IncidentAuthorizationTest extends AuthorizationTest {
+class IncidentAuthorizationTest extends AuthorizationTest {
 
   protected static final String TIMER_START_PROCESS_KEY = "timerStartProcess";
   protected static final String ONE_INCIDENT_PROCESS_KEY = "process";
@@ -63,7 +63,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryForStandaloneIncidents() {
+  void testQueryForStandaloneIncidents() {
     // given
     String jobId = createStandaloneIncident();
 
@@ -78,7 +78,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartTimerJobIncidentQueryWithoutAuthorization() {
+  void testStartTimerJobIncidentQueryWithoutAuthorization() {
     // given
     disableAuthorization();
     String jobId = managementService.createJobQuery().singleResult().getId();
@@ -93,7 +93,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartTimerJobIncidentQueryWithReadPermissionOnAnyProcessInstance() {
+  void testStartTimerJobIncidentQueryWithReadPermissionOnAnyProcessInstance() {
     // given
     disableAuthorization();
     String jobId = managementService.createJobQuery().singleResult().getId();
@@ -110,7 +110,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartTimerJobIncidentQueryWithReadInstancePermissionOnProcessDefinition() {
+  void testStartTimerJobIncidentQueryWithReadInstancePermissionOnProcessDefinition() {
     // given
     disableAuthorization();
     String jobId = managementService.createJobQuery().singleResult().getId();
@@ -127,7 +127,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartTimerJobIncidentQueryWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testStartTimerJobIncidentQueryWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     disableAuthorization();
     String jobId = managementService.createJobQuery().singleResult().getId();
@@ -144,7 +144,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithoutAuthorization() {
+  void testSimpleQueryWithoutAuthorization() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
 
@@ -156,7 +156,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadPermissionOnProcessInstance() {
+  void testSimpleQueryWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -173,7 +173,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadPermissionOnAnyProcessInstance() {
+  void testSimpleQueryWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -190,7 +190,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithMultiple() {
+  void testSimpleQueryWithMultiple() {
     // given
     String processInstanceId = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -208,7 +208,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadInstancesPermissionOnOneTaskProcess() {
+  void testSimpleQueryWithReadInstancesPermissionOnOneTaskProcess() {
     // given
     String processInstanceId = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_INCIDENT_PROCESS_KEY, userId, READ_INSTANCE);
@@ -225,7 +225,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
+  void testSimpleQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -242,7 +242,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindIncidentWithRevokedReadPermissionOnProcessInstance() {
+  void shouldNotFindIncidentWithRevokedReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -256,7 +256,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -275,7 +275,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnProcessInstance() {
+  void testQueryWithReadPermissionOnProcessInstance() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -300,7 +300,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnAnyProcessInstance() {
+  void testQueryWithReadPermissionOnAnyProcessInstance() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -321,7 +321,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstancesPermissionOnOneTaskProcess() {
+  void testQueryWithReadInstancesPermissionOnOneTaskProcess() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -342,7 +342,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
+  void testQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -364,7 +364,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
 
 
   @Test
-  public void shouldDenySetAnnotationWithoutAuthorization() {
+  void shouldDenySetAnnotationWithoutAuthorization() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     disableAuthorization();
@@ -380,7 +380,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldAllowSetAnnotationWithUpdatePermissionOnAnyInstance() {
+  void shouldAllowSetAnnotationWithUpdatePermissionOnAnyInstance() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     disableAuthorization();
@@ -395,7 +395,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldAllowSetAnnotationWithUpdatePermissionOnInstance() {
+  void shouldAllowSetAnnotationWithUpdatePermissionOnInstance() {
     // given
     ProcessInstance instance = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     disableAuthorization();
@@ -410,7 +410,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldAllowSetAnnotationWithUpdateInstancePermissionOnAnyDefinition() {
+  void shouldAllowSetAnnotationWithUpdateInstancePermissionOnAnyDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     disableAuthorization();
@@ -425,7 +425,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldAllowSetAnnotationWithUpdateInstancePermissionOnOneTaskDefinition() {
+  void shouldAllowSetAnnotationWithUpdateInstancePermissionOnOneTaskDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     disableAuthorization();
@@ -440,7 +440,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldDenyClearAnnotationWithoutAuthorization() {
+  void shouldDenyClearAnnotationWithoutAuthorization() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     disableAuthorization();
@@ -456,7 +456,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldAllowClearAnnotationWithUpdatePermissionOnAnyInstance() {
+  void shouldAllowClearAnnotationWithUpdatePermissionOnAnyInstance() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     disableAuthorization();
@@ -471,7 +471,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldAllowClearAnnotationWithUpdatePermissionOnInstance() {
+  void shouldAllowClearAnnotationWithUpdatePermissionOnInstance() {
     // given
     ProcessInstance instance = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     disableAuthorization();
@@ -486,7 +486,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldAllowClearAnnotationWithUpdateInstancePermissionOnAnyDefinition() {
+  void shouldAllowClearAnnotationWithUpdateInstancePermissionOnAnyDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     disableAuthorization();
@@ -501,7 +501,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldAllowClearAnnotationWithUpdateInstancePermissionOnOneTaskDefinition() {
+  void shouldAllowClearAnnotationWithUpdateInstancePermissionOnOneTaskDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     disableAuthorization();
@@ -516,7 +516,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldAllowSetAnnotationOnStandaloneIncidentWithoutAuthorization() {
+  void shouldAllowSetAnnotationOnStandaloneIncidentWithoutAuthorization() {
     // given
     String jobId = createStandaloneIncident();
     disableAuthorization();
@@ -531,7 +531,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldAllowClearAnnotationOnStandaloneIncidentWithoutAuthorization() {
+  void shouldAllowClearAnnotationOnStandaloneIncidentWithoutAuthorization() {
     // given
     String jobId = createStandaloneIncident();
     disableAuthorization();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/IncidentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/IncidentAuthorizationTest.java
@@ -29,18 +29,21 @@ import org.operaton.bpm.engine.runtime.Incident;
 import org.operaton.bpm.engine.runtime.IncidentQuery;
 import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
-import static org.operaton.bpm.engine.authorization.Authorization.ANY;
-import static org.operaton.bpm.engine.authorization.Permissions.*;
-import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
-import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.operaton.bpm.engine.authorization.Authorization.ANY;
+import static org.operaton.bpm.engine.authorization.Permissions.READ;
+import static org.operaton.bpm.engine.authorization.Permissions.READ_INSTANCE;
+import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
+import static org.operaton.bpm.engine.authorization.Permissions.UPDATE_INSTANCE;
+import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
+import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 
 /**
  * @author Roman Smirnov
@@ -539,12 +542,11 @@ class IncidentAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     // when
-    assertAll(() -> {
-    	// then no error is thrown
-    	runtimeService.clearAnnotationForIncidentById(incident.getId());
-    	// cleanup
-    	cleanupStandalonIncident(jobId);
-    });
+    // then no error is thrown
+    assertAll(() -> runtimeService.clearAnnotationForIncidentById(incident.getId()));
+
+    // cleanup
+    cleanupStandalonIncident(jobId);
   }
 
   protected String createStandaloneIncident() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/IncidentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/IncidentAuthorizationTest.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.history.HistoricIncident;
 import org.operaton.bpm.engine.impl.context.Context;
@@ -31,14 +33,11 @@ import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.*;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.Date;
 import java.util.List;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.Test.None;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -54,7 +53,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
   protected static final String ANOTHER_ONE_INCIDENT_PROCESS_KEY = "anotherOneIncidentProcess";
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     testRule.deploy(
         "org/operaton/bpm/engine/test/api/authorization/timerStartEventProcess.bpmn20.xml",
@@ -380,7 +379,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
       .hasMessageMatching(getMissingPermissionMessageRegex(UPDATE_INSTANCE, PROCESS_DEFINITION));
   }
 
-  @Test(expected = None.class)
+  @Test
   public void shouldAllowSetAnnotationWithUpdatePermissionOnAnyInstance() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -391,12 +390,11 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
 
     // when
-    runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation");
-
+    assertAll(() -> runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation"));
     // then no error is thrown
   }
 
-  @Test(expected = None.class)
+  @Test
   public void shouldAllowSetAnnotationWithUpdatePermissionOnInstance() {
     // given
     ProcessInstance instance = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -407,12 +405,11 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_INSTANCE, instance.getId(), userId, UPDATE);
 
     // when
-    runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation");
-
+    assertAll(() -> runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation"));
     // then no error is thrown
   }
 
-  @Test(expected = None.class)
+  @Test
   public void shouldAllowSetAnnotationWithUpdateInstancePermissionOnAnyDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -423,12 +420,11 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
 
     // when
-    runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation");
-
+    assertAll(() -> runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation"));
     // then no error is thrown
   }
 
-  @Test(expected = None.class)
+  @Test
   public void shouldAllowSetAnnotationWithUpdateInstancePermissionOnOneTaskDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -439,8 +435,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, ONE_INCIDENT_PROCESS_KEY, userId, UPDATE_INSTANCE);
 
     // when
-    runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation");
-
+    assertAll(() -> runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation"));
     // then no error is thrown
   }
 
@@ -460,7 +455,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
       .hasMessageMatching(getMissingPermissionMessageRegex(UPDATE_INSTANCE, PROCESS_DEFINITION));
   }
 
-  @Test(expected = None.class)
+  @Test
   public void shouldAllowClearAnnotationWithUpdatePermissionOnAnyInstance() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -471,12 +466,11 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
 
     // when
-    runtimeService.clearAnnotationForIncidentById(incident.getId());
-
+    assertAll(() -> runtimeService.clearAnnotationForIncidentById(incident.getId()));
     // then no error is thrown
   }
 
-  @Test(expected = None.class)
+  @Test
   public void shouldAllowClearAnnotationWithUpdatePermissionOnInstance() {
     // given
     ProcessInstance instance = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -487,12 +481,11 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_INSTANCE, instance.getId(), userId, UPDATE);
 
     // when
-    runtimeService.clearAnnotationForIncidentById(incident.getId());
-
+    assertAll(() -> runtimeService.clearAnnotationForIncidentById(incident.getId()));
     // then no error is thrown
   }
 
-  @Test(expected = None.class)
+  @Test
   public void shouldAllowClearAnnotationWithUpdateInstancePermissionOnAnyDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -503,12 +496,11 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
 
     // when
-    runtimeService.clearAnnotationForIncidentById(incident.getId());
-
+    assertAll(() -> runtimeService.clearAnnotationForIncidentById(incident.getId()));
     // then no error is thrown
   }
 
-  @Test(expected = None.class)
+  @Test
   public void shouldAllowClearAnnotationWithUpdateInstancePermissionOnOneTaskDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -519,8 +511,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, ONE_INCIDENT_PROCESS_KEY, userId, UPDATE_INSTANCE);
 
     // when
-    runtimeService.clearAnnotationForIncidentById(incident.getId());
-
+    assertAll(() -> runtimeService.clearAnnotationForIncidentById(incident.getId()));
     // then no error is thrown
   }
 
@@ -539,7 +530,7 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     cleanupStandalonIncident(jobId);
   }
 
-  @Test(expected = None.class)
+  @Test
   public void shouldAllowClearAnnotationOnStandaloneIncidentWithoutAuthorization() {
     // given
     String jobId = createStandaloneIncident();
@@ -548,12 +539,12 @@ public class IncidentAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     // when
-    runtimeService.clearAnnotationForIncidentById(incident.getId());
-
-    // then no error is thrown
-
-    // cleanup
-    cleanupStandalonIncident(jobId);
+    assertAll(() -> {
+    	// then no error is thrown
+    	runtimeService.clearAnnotationForIncidentById(incident.getId());
+    	// cleanup
+    	cleanupStandalonIncident(jobId);
+    });
   }
 
   protected String createStandaloneIncident() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobAuthorizationTest.java
@@ -27,6 +27,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Date;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.impl.interceptor.CommandExecutor;
 import org.operaton.bpm.engine.impl.jobexecutor.TimerSuspendJobDefinitionHandler;
@@ -34,9 +38,6 @@ import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.engine.management.JobDefinition;
 import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.engine.runtime.JobQuery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -49,7 +50,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   protected static final String ONE_INCIDENT_PROCESS_KEY = "process";
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     testRule.deploy(
         "org/operaton/bpm/engine/test/api/authorization/timerStartEventProcess.bpmn20.xml",
@@ -59,7 +60,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     CommandExecutor commandExecutor = processEngineConfiguration.getCommandExecutorTxRequired();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobAuthorizationTest.java
@@ -43,7 +43,7 @@ import org.operaton.bpm.engine.runtime.JobQuery;
  * @author Roman Smirnov
  *
  */
-public class JobAuthorizationTest extends AuthorizationTest {
+class JobAuthorizationTest extends AuthorizationTest {
 
   protected static final String TIMER_START_PROCESS_KEY = "timerStartProcess";
   protected static final String TIMER_BOUNDARY_PROCESS_KEY = "timerBoundaryProcess";
@@ -73,7 +73,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   // job query (jobs associated to a process) //////////////////////////////////////////////////
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
 
@@ -85,7 +85,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnProcessInstance() {
+  void testQueryWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -98,7 +98,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnAnyProcessInstance() {
+  void testQueryWithReadPermissionOnAnyProcessInstance() {
     // given
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -111,7 +111,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithMultiple() {
+  void testQueryWithMultiple() {
     // given
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -125,7 +125,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindJobWithRevokedReadPermissionOnProcessInstance() {
+  void shouldNotFindJobWithRevokedReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, ANY, ALL);
@@ -139,7 +139,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstancePermissionOnTimerStartProcessDefinition() {
+  void testQueryWithReadInstancePermissionOnTimerStartProcessDefinition() {
     // given
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
 
@@ -157,7 +157,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstancePermissionOnTimerBoundaryProcessDefinition() {
+  void testQueryWithReadInstancePermissionOnTimerBoundaryProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, READ_INSTANCE);
@@ -174,7 +174,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testQueryWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
 
@@ -190,7 +190,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   // job query (standalone job) /////////////////////////////////
 
   @Test
-  public void testStandaloneJobQueryWithoutAuthorization() {
+  void testStandaloneJobQueryWithoutAuthorization() {
     // given
     Date startTime = new Date();
     ClockUtil.setCurrentTime(startTime);
@@ -218,7 +218,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   // execute job (standalone job) ////////////////////////////////
 
   @Test
-  public void testExecuteStandaloneJob() {
+  void testExecuteStandaloneJob() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_START_PROCESS_KEY, userId, UPDATE);
 
@@ -244,7 +244,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   // delete standalone job ////////////////////////////////
 
   @Test
-  public void testDeleteStandaloneJob() {
+  void testDeleteStandaloneJob() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_START_PROCESS_KEY, userId, UPDATE);
 
@@ -270,7 +270,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   // set job retries (standalone) ////////////////////////////////
 
   @Test
-  public void testSetStandaloneJobRetries() {
+  void testSetStandaloneJobRetries() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_START_PROCESS_KEY, userId, UPDATE);
 
@@ -298,7 +298,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   // set job retries (standalone) ////////////////////////////////
 
   @Test
-  public void testSetStandaloneJobDueDate() {
+  void testSetStandaloneJobDueDate() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_START_PROCESS_KEY, userId, UPDATE);
 
@@ -326,7 +326,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   // get exception stacktrace ///////////////////////////////////////////
 
   @Test
-  public void testGetExceptionStacktraceWithoutAuthorization() {
+  void testGetExceptionStacktraceWithoutAuthorization() {
     // given
     String processInstanceId = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY).getId();
     disableAuthorization();
@@ -346,7 +346,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetExceptionStacktraceWithReadPermissionOnProcessInstance() {
+  void testGetExceptionStacktraceWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY).getId();
     String jobId = selectJobByProcessInstanceId(processInstanceId).getId();
@@ -360,7 +360,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetExceptionStacktraceReadPermissionOnAnyProcessInstance() {
+  void testGetExceptionStacktraceReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY).getId();
     String jobId = selectJobByProcessInstanceId(processInstanceId).getId();
@@ -375,7 +375,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetExceptionStacktraceWithReadInstancePermissionOnTimerBoundaryProcessDefinition() {
+  void testGetExceptionStacktraceWithReadInstancePermissionOnTimerBoundaryProcessDefinition() {
     // given
     String processInstanceId = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY).getId();
     String jobId = selectJobByProcessInstanceId(processInstanceId).getId();
@@ -390,7 +390,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetExceptionStacktraceWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testGetExceptionStacktraceWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY).getId();
     String jobId = selectJobByProcessInstanceId(processInstanceId).getId();
@@ -407,7 +407,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   // get exception stacktrace (standalone) ////////////////////////////////
 
   @Test
-  public void testStandaloneJobGetExceptionStacktrace() {
+  void testStandaloneJobGetExceptionStacktrace() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_START_PROCESS_KEY, userId, UPDATE);
 
@@ -435,7 +435,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
 
 
   @Test
-  public void testSuspendStandaloneJobById() {
+  void testSuspendStandaloneJobById() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_START_PROCESS_KEY, userId, UPDATE);
 
@@ -464,7 +464,7 @@ public class JobAuthorizationTest extends AuthorizationTest {
   // activate job by id //////////////////////////////////////////
 
   @Test
-  public void testActivateStandaloneJobById() {
+  void testActivateStandaloneJobById() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_START_PROCESS_KEY, userId, UPDATE);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobDefinitionAuthorizationTest.java
@@ -38,7 +38,7 @@ import org.operaton.bpm.engine.runtime.Job;
  * @author Roman Smirnov
  *
  */
-public class JobDefinitionAuthorizationTest extends AuthorizationTest {
+class JobDefinitionAuthorizationTest extends AuthorizationTest {
 
   protected static final String TIMER_START_PROCESS_KEY = "timerStartProcess";
   protected static final String TIMER_BOUNDARY_PROCESS_KEY = "timerBoundaryProcess";
@@ -55,7 +55,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   // job definition query ///////////////////////////////////////
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
 
     // when
@@ -66,7 +66,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnProcessDefinition() {
+  void testQueryWithReadPermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_START_PROCESS_KEY, userId, READ);
 
@@ -78,7 +78,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnAnyProcessDefinition() {
+  void testQueryWithReadPermissionOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ);
 
@@ -90,7 +90,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithMultiple() {
+  void testQueryWithMultiple() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ);
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_START_PROCESS_KEY, userId, READ);
@@ -103,7 +103,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindJobDefinitionWithRevokedReadPermissionOnProcessDefinition() {
+  void shouldNotFindJobDefinitionWithRevokedReadPermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ);
     createRevokeAuthorization(PROCESS_DEFINITION, TIMER_START_PROCESS_KEY, userId, READ);
@@ -118,7 +118,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   // suspend job definition by id ///////////////////////////////
 
   @Test
-  public void testSuspendByIdWithoutAuthorization() {
+  void testSuspendByIdWithoutAuthorization() {
     // given
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
 
@@ -137,7 +137,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendByIdWithUpdatePermissionOnProcessDefinition() {
+  void testSuspendByIdWithUpdatePermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -152,7 +152,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendByIdWithUpdatePermissionOnAnyProcessDefinition() {
+  void testSuspendByIdWithUpdatePermissionOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE);
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -169,7 +169,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   // activate job definition by id ///////////////////////////////
 
   @Test
-  public void testActivateByIdWithoutAuthorization() {
+  void testActivateByIdWithoutAuthorization() {
     // given
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     suspendJobDefinitionById(jobDefinitionId);
@@ -189,7 +189,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateByIdWithUpdatePermissionOnProcessDefinition() {
+  void testActivateByIdWithUpdatePermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -205,7 +205,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateByIdWithUpdatePermissionOnAnyProcessDefinition() {
+  void testActivateByIdWithUpdatePermissionOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE);
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -223,7 +223,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   // suspend job definition by id (including jobs) ///////////////////////////////
 
   @Test
-  public void testSuspendIncludingJobsByIdWithoutAuthorization() {
+  void testSuspendIncludingJobsByIdWithoutAuthorization() {
     // given
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
@@ -246,7 +246,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendIncludingJobsByIdWithUpdatePermissionOnProcessInstance() {
+  void testSuspendIncludingJobsByIdWithUpdatePermissionOnProcessInstance() {
     // given
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -271,7 +271,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendIncludingJobsByIdWithUpdatePermissionOnAnyProcessInstance() {
+  void testSuspendIncludingJobsByIdWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -293,7 +293,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendIncludingJobsByIdWithUpdateInstancePermissionOnProcessDefinition() {
+  void testSuspendIncludingJobsByIdWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -314,7 +314,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendIncludingJobsByIdWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testSuspendIncludingJobsByIdWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -338,7 +338,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   // activate job definition by id (including jobs) ///////////////////////////////
 
   @Test
-  public void testActivateIncludingJobsByIdWithoutAuthorization() {
+  void testActivateIncludingJobsByIdWithoutAuthorization() {
     // given
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
@@ -363,7 +363,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateIncludingJobsByIdWithUpdatePermissionOnProcessInstance() {
+  void testActivateIncludingJobsByIdWithUpdatePermissionOnProcessInstance() {
     // given
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -389,7 +389,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateIncludingJobsByIdWithUpdatePermissionOnAnyProcessInstance() {
+  void testActivateIncludingJobsByIdWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -412,7 +412,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateIncludingJobsByIdWithUpdateInstancePermissionOnProcessDefinition() {
+  void testActivateIncludingJobsByIdWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -434,7 +434,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateIncludingJobsByIdWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testActivateIncludingJobsByIdWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -459,7 +459,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   // suspend job definition by process definition id ///////////////////////////////
 
   @Test
-  public void testSuspendByProcessDefinitionIdWithoutAuthorization() {
+  void testSuspendByProcessDefinitionIdWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
 
@@ -478,7 +478,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendByProcessDefinitionIdWithUpdatePermissionOnProcessDefinition() {
+  void testSuspendByProcessDefinitionIdWithUpdatePermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -493,7 +493,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendByProcessDefinitionIdWithUpdatePermissionOnAnyProcessDefinition() {
+  void testSuspendByProcessDefinitionIdWithUpdatePermissionOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE);
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -510,7 +510,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   // activate job definition by process definition id ///////////////////////////////
 
   @Test
-  public void testActivateByProcessDefinitionIdWithoutAuthorization() {
+  void testActivateByProcessDefinitionIdWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     suspendJobDefinitionByProcessDefinitionId(processDefinitionId);
@@ -530,7 +530,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateByProcessDefinitionIdWithUpdatePermissionOnProcessDefinition() {
+  void testActivateByProcessDefinitionIdWithUpdatePermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -546,7 +546,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateByProcessDefinitionIdWithUpdatePermissionOnAnyProcessDefinition() {
+  void testActivateByProcessDefinitionIdWithUpdatePermissionOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE);
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -564,7 +564,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   // suspend job definition by process definition id (including jobs) ///////////////////////////////
 
   @Test
-  public void testSuspendIncludingJobsByProcessDefinitionIdWithoutAuthorization() {
+  void testSuspendIncludingJobsByProcessDefinitionIdWithoutAuthorization() {
     // given
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -588,7 +588,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendIncludingJobsByProcessDefinitionIdWithUpdatePermissionOnProcessInstance() {
+  void testSuspendIncludingJobsByProcessDefinitionIdWithUpdatePermissionOnProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -613,7 +613,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendIncludingJobsByProcessDefinitionIdWithUpdatePermissionOnAnyProcessInstance() {
+  void testSuspendIncludingJobsByProcessDefinitionIdWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -635,7 +635,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendIncludingJobsByProcessDefinitionIdWithUpdateInstancePermissionOnProcessDefinition() {
+  void testSuspendIncludingJobsByProcessDefinitionIdWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -656,7 +656,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendIncludingJobsByProcessDefinitionIdWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testSuspendIncludingJobsByProcessDefinitionIdWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -680,7 +680,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   // activate job definition by id (including jobs) ///////////////////////////////
 
   @Test
-  public void testActivateIncludingJobsByProcessDefinitionIdWithoutAuthorization() {
+  void testActivateIncludingJobsByProcessDefinitionIdWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
@@ -705,7 +705,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateIncludingJobsByProcessDefinitionIdWithUpdatePermissionOnProcessInstance() {
+  void testActivateIncludingJobsByProcessDefinitionIdWithUpdatePermissionOnProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -731,7 +731,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateIncludingJobsByProcessDefinitionIdWithUpdatePermissionOnAnyProcessInstance() {
+  void testActivateIncludingJobsByProcessDefinitionIdWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -754,7 +754,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateIncludingJobsByProcessDefinitionIdWithUpdateInstancePermissionOnProcessDefinition() {
+  void testActivateIncludingJobsByProcessDefinitionIdWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -776,7 +776,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateIncludingJobsByProcessDefinitionIdWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testActivateIncludingJobsByProcessDefinitionIdWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
@@ -801,7 +801,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   // suspend job definition by process definition key ///////////////////////////////
 
   @Test
-  public void testSuspendByProcessDefinitionKeyWithoutAuthorization() {
+  void testSuspendByProcessDefinitionKeyWithoutAuthorization() {
     // given
 
     try {
@@ -819,7 +819,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendByProcessDefinitionKeyWithUpdatePermissionOnProcessDefinition() {
+  void testSuspendByProcessDefinitionKeyWithUpdatePermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
 
@@ -833,7 +833,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendByProcessDefinitionKeyWithUpdatePermissionOnAnyProcessDefinition() {
+  void testSuspendByProcessDefinitionKeyWithUpdatePermissionOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE);
 
@@ -849,7 +849,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   // activate job definition by process definition key ///////////////////////////////
 
   @Test
-  public void testActivateByProcessDefinitionKeyWithoutAuthorization() {
+  void testActivateByProcessDefinitionKeyWithoutAuthorization() {
     // given
     suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY);
 
@@ -868,7 +868,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateByProcessDefinitionKeyWithUpdatePermissionOnProcessDefinition() {
+  void testActivateByProcessDefinitionKeyWithUpdatePermissionOnProcessDefinition() {
     // given
     suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
@@ -883,7 +883,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateByProcessDefinitionKeyWithUpdatePermissionOnAnyProcessDefinition() {
+  void testActivateByProcessDefinitionKeyWithUpdatePermissionOnAnyProcessDefinition() {
     // given
     suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE);
@@ -900,7 +900,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   // suspend job definition by process definition key (including jobs) ///////////////////////////////
 
   @Test
-  public void testSuspendIncludingJobsByProcessDefinitionKeyWithoutAuthorization() {
+  void testSuspendIncludingJobsByProcessDefinitionKeyWithoutAuthorization() {
     // given
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
 
@@ -923,7 +923,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendIncludingJobsByProcessDefinitionKeyWithUpdatePermissionOnProcessInstance() {
+  void testSuspendIncludingJobsByProcessDefinitionKeyWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
 
@@ -947,7 +947,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendIncludingJobsByProcessDefinitionKeyWithUpdatePermissionOnAnyProcessInstance() {
+  void testSuspendIncludingJobsByProcessDefinitionKeyWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
 
@@ -968,7 +968,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendIncludingJobsByProcessDefinitionKeyWithUpdateInstancePermissionOnProcessDefinition() {
+  void testSuspendIncludingJobsByProcessDefinitionKeyWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
 
@@ -988,7 +988,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendIncludingJobsByProcessDefinitionKeyWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testSuspendIncludingJobsByProcessDefinitionKeyWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
 
@@ -1011,7 +1011,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   // activate job definition by id (including jobs) ///////////////////////////////
 
   @Test
-  public void testActivateIncludingJobsByProcessDefinitionKeyWithoutAuthorization() {
+  void testActivateIncludingJobsByProcessDefinitionKeyWithoutAuthorization() {
     // given
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
     suspendJobDefinitionIncludingJobsByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY);
@@ -1035,7 +1035,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateIncludingJobsByProcessDefinitionKeyWithUpdatePermissionOnProcessInstance() {
+  void testActivateIncludingJobsByProcessDefinitionKeyWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     suspendJobDefinitionIncludingJobsByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY);
@@ -1060,7 +1060,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateIncludingJobsByProcessDefinitionKeyWithUpdatePermissionOnAnyProcessInstance() {
+  void testActivateIncludingJobsByProcessDefinitionKeyWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     suspendJobDefinitionIncludingJobsByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY);
@@ -1082,7 +1082,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateIncludingJobsByProcessDefinitionKeyWithUpdateInstancePermissionOnProcessDefinition() {
+  void testActivateIncludingJobsByProcessDefinitionKeyWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     suspendJobDefinitionIncludingJobsByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY);
@@ -1103,7 +1103,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateIncludingJobsByProcessDefinitionKeyWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testActivateIncludingJobsByProcessDefinitionKeyWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     suspendJobDefinitionIncludingJobsByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobDefinitionAuthorizationTest.java
@@ -22,6 +22,10 @@ import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
 import static org.operaton.bpm.engine.authorization.Permissions.UPDATE_INSTANCE;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -29,8 +33,6 @@ import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.management.JobDefinition;
 import org.operaton.bpm.engine.management.JobDefinitionQuery;
 import org.operaton.bpm.engine.runtime.Job;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -42,7 +44,7 @@ public class JobDefinitionAuthorizationTest extends AuthorizationTest {
   protected static final String TIMER_BOUNDARY_PROCESS_KEY = "timerBoundaryProcess";
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     testRule.deploy(
         "org/operaton/bpm/engine/test/api/authorization/timerStartEventProcess.bpmn20.xml",

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ManagementAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ManagementAuthorizationTest.java
@@ -23,8 +23,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.authorization.Groups;
 import org.operaton.bpm.engine.authorization.Resources;
 import org.operaton.bpm.engine.authorization.SystemPermissions;
@@ -49,7 +50,13 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   protected static final String DUMMY_METRIC = "dummyMetric";
 
   @Override
-  @After
+  @BeforeEach
+  public void setUp() {
+    super.setUp();
+  }
+  
+  @Override
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     managementService.deleteProperty(DUMMY_PROPERTY);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ManagementAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ManagementAuthorizationTest.java
@@ -42,7 +42,7 @@ import org.operaton.bpm.engine.telemetry.TelemetryData;
  * @author Roman Smirnov
  *
  */
-public class ManagementAuthorizationTest extends AuthorizationTest {
+class ManagementAuthorizationTest extends AuthorizationTest {
 
   protected static final String REQUIRED_ADMIN_AUTH_EXCEPTION = "ENGINE-03029 Required admin authenticated group or user.";
   protected static final String DUMMY_PROPERTY = "dummy-property";
@@ -65,7 +65,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   // get table count //////////////////////////////////////////////
 
   @Test
-  public void shouldGetTableCountAsOperatonAdmin() {
+  void shouldGetTableCountAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -77,7 +77,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetTableCountWithPermission() {
+  void shouldGetTableCountWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
 
@@ -89,7 +89,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetTableCountWithAdminAndPermission() {
+  void shouldGetTableCountWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
@@ -102,7 +102,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotGetTableCountWithoutAuthorization() {
+  void shouldNotGetTableCountWithoutAuthorization() {
     // given
 
     assertThatThrownBy(() -> {
@@ -116,7 +116,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   // get table name //////////////////////////////////////////////
 
   @Test
-  public void shouldGetTableNameAsOperatonAdmin() {
+  void shouldGetTableNameAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     String tablePrefix = processEngineConfiguration.getDatabaseTablePrefix();
@@ -129,7 +129,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetTableNameWithPermission() {
+  void shouldGetTableNameWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
     String tablePrefix = processEngineConfiguration.getDatabaseTablePrefix();
@@ -142,7 +142,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetTableNameAdminAndWithPermission() {
+  void shouldGetTableNameAdminAndWithPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
@@ -156,7 +156,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotGetTableNameWithoutAuthorization() {
+  void shouldNotGetTableNameWithoutAuthorization() {
     // given
 
     assertThatThrownBy(() -> {
@@ -170,7 +170,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   // get table meta data //////////////////////////////////////////////
 
   @Test
-  public void shouldGetTableMetaDataAsOperatonAdmin() {
+  void shouldGetTableMetaDataAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -182,7 +182,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetTableMetaDataWithPermission() {
+  void shouldGetTableMetaDataWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
 
@@ -194,7 +194,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetTableMetaDataWithAdminAndPermission() {
+  void shouldGetTableMetaDataWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
@@ -208,7 +208,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
 
 
   @Test
-  public void shouldNotGetTableMetaDataWithoutAuthorization() {
+  void shouldNotGetTableMetaDataWithoutAuthorization() {
     // given
 
     assertThatThrownBy(() -> {
@@ -222,7 +222,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   // table page query //////////////////////////////////
 
   @Test
-  public void shouldNotPerformTablePageQueryWithoutAuthorization() {
+  void shouldNotPerformTablePageQueryWithoutAuthorization() {
     // given
 
     assertThatThrownBy(() -> {
@@ -234,7 +234,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldPerformTablePageQueryAsOperatonAdmin() {
+  void shouldPerformTablePageQueryAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     String tablePrefix = processEngineConfiguration.getDatabaseTablePrefix();
@@ -249,7 +249,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   // get history level /////////////////////////////////
 
   @Test
-  public void shouldGetHistoryLevelAsOperatonAdmin() {
+  void shouldGetHistoryLevelAsOperatonAdmin() {
     //given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -261,7 +261,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetHistoryLevelWithPermission() {
+  void shouldGetHistoryLevelWithPermission() {
     //given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
 
@@ -273,7 +273,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetHistoryLevelAdminAndWithPermission() {
+  void shouldGetHistoryLevelAdminAndWithPermission() {
     //given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
@@ -286,7 +286,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotGetHistoryLevelWithoutAuthorization() {
+  void shouldNotGetHistoryLevelWithoutAuthorization() {
     // given
     assertThatThrownBy(() -> {
       // when
@@ -299,7 +299,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   // database schema upgrade ///////////////////////////
 
   @Test
-  public void shouldNotPerformDataSchemaUpgradeWithoutAuthorization() {
+  void shouldNotPerformDataSchemaUpgradeWithoutAuthorization() {
     // given
 
     assertThatThrownBy(() -> {
@@ -314,7 +314,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
 
 
   @Test
-  public void shouldGetPropertiesAsOperatonAdmin() {
+  void shouldGetPropertiesAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -326,7 +326,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetPropertiesWithPermission() {
+  void shouldGetPropertiesWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
 
@@ -338,7 +338,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetPropertiesWithAdminAndPermission() {
+  void shouldGetPropertiesWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
@@ -351,7 +351,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotGetPropertiesWithWrongPermission() {
+  void shouldNotGetPropertiesWithWrongPermission() {
     // given
     createGrantAuthorization(Resources.TASK, "*", userId, TaskPermissions.DELETE);
 
@@ -364,7 +364,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotGetPropertiesWithoutAuthorization() {
+  void shouldNotGetPropertiesWithoutAuthorization() {
     // given
 
     assertThatThrownBy(() -> {
@@ -378,7 +378,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   // set properties ///////////////////////////
 
   @Test
-  public void shouldSetPropertyAsOperatonAdmin() {
+  void shouldSetPropertyAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -391,7 +391,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldSetPropertyWithPermission() {
+  void shouldSetPropertyWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.SET);
 
@@ -404,7 +404,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldSetPropertyWithAdminAndPermission() {
+  void shouldSetPropertyWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.SET);
@@ -418,7 +418,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotSetPropertyWithoutAuthorization() {
+  void shouldNotSetPropertyWithoutAuthorization() {
     // given
 
     assertThatThrownBy(() -> {
@@ -432,7 +432,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   // delete properties ///////////////////////////
 
   @Test
-  public void shouldDeletePropertyAsOperatonAdmin() {
+  void shouldDeletePropertyAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     managementService.setProperty(DUMMY_VALUE, DUMMY_PROPERTY);
@@ -446,7 +446,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldDeletePropertyWithPermission() {
+  void shouldDeletePropertyWithPermission() {
     // given
     disableAuthorization();
     managementService.setProperty(DUMMY_VALUE, DUMMY_PROPERTY);
@@ -463,7 +463,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldDeletePropertyWithAdminAndPermission() {
+  void shouldDeletePropertyWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.DELETE);
@@ -477,7 +477,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotDeletePropertyWithoutAuthorization() {
+  void shouldNotDeletePropertyWithoutAuthorization() {
     // given
 
     assertThatThrownBy(() -> {
@@ -491,7 +491,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   // configure telemetry /////////////////////////////////////
 
   @Test
-  public void shouldNotThrowExceptionWhenToggleTelemetry() {
+  void shouldNotThrowExceptionWhenToggleTelemetry() {
     // given
 
     // when
@@ -504,7 +504,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   // get telemetry data /////////////////////////////////////
 
   @Test
-  public void shouldGetTelemetryDataAsOperatonAdmin() {
+  void shouldGetTelemetryDataAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -516,7 +516,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetTelemetryDataWithPermission() {
+  void shouldGetTelemetryDataWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
 
@@ -528,7 +528,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldGetTelemetryDataWithAdminAndPermission() {
+  void shouldGetTelemetryDataWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
@@ -542,7 +542,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
 
 
   @Test
-  public void shouldNotGetTelemetryDataWithoutAdminAndPermission() {
+  void shouldNotGetTelemetryDataWithoutAdminAndPermission() {
     // given
 
     assertThatThrownBy(() -> {
@@ -556,7 +556,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   // delete metrics //////////////////////////////////////
 
   @Test
-  public void shouldDeleteMetricsAsOperatonAdmin() {
+  void shouldDeleteMetricsAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -570,7 +570,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldDeleteMetricsWithPermission() {
+  void shouldDeleteMetricsWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.DELETE);
 
@@ -584,7 +584,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldDeleteMetricsWithAdminAndPermission() {
+  void shouldDeleteMetricsWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.DELETE);
@@ -599,7 +599,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotDeleteMetricsWithoutAuthorization() {
+  void shouldNotDeleteMetricsWithoutAuthorization() {
     // given
 
     assertThatThrownBy(() -> {
@@ -613,7 +613,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   // delete task metrics /////////////////////////////////
 
   @Test
-  public void shouldDeleteTaskMetricsAsOperatonAdmin() {
+  void shouldDeleteTaskMetricsAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -626,7 +626,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldDeleteTaskMetricsWithPermission() {
+  void shouldDeleteTaskMetricsWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.DELETE);
 
@@ -639,7 +639,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldDeleteTaskMetricsWithAdminAndPermission() {
+  void shouldDeleteTaskMetricsWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.DELETE);
@@ -653,7 +653,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotDeleteTaskMetricsWithoutAuthorization() {
+  void shouldNotDeleteTaskMetricsWithoutAuthorization() {
     // given
 
     assertThatThrownBy(() -> {
@@ -667,7 +667,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   // query schema log list //////////////////////////////////////////
 
   @Test
-  public void shouldExecuteSchemaLogListAsOperatonAdmin() {
+  void shouldExecuteSchemaLogListAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -679,7 +679,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldExecuteSchemaLogListWithPermission() {
+  void shouldExecuteSchemaLogListWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
 
@@ -691,7 +691,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldExecuteSchemaLogListWithAdminAndPermission() {
+  void shouldExecuteSchemaLogListWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
@@ -704,7 +704,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotExecuteSchemaLogListWithoutAuthorization() {
+  void shouldNotExecuteSchemaLogListWithoutAuthorization() {
     // given
 
     // when
@@ -717,7 +717,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   // query schema log count //////////////////////////////////////////
 
   @Test
-  public void shouldExecuteSchemaLogCountAsOperatonAdmin() {
+  void shouldExecuteSchemaLogCountAsOperatonAdmin() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -729,7 +729,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldExecuteSchemaLogCountWithPermission() {
+  void shouldExecuteSchemaLogCountWithPermission() {
     // given
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
 
@@ -741,7 +741,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldExecuteSchemaLogCountWithAdminAndPermission() {
+  void shouldExecuteSchemaLogCountWithAdminAndPermission() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
     createGrantAuthorization(Resources.SYSTEM, "*", userId, SystemPermissions.READ);
@@ -754,7 +754,7 @@ public class ManagementAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotExecuteSchemaLogCountWithoutAuthorization() {
+  void shouldNotExecuteSchemaLogCountWithoutAuthorization() {
     // given
 
     // when

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ManagementAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ManagementAuthorizationTest.java
@@ -16,15 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.authorization.Groups;
 import org.operaton.bpm.engine.authorization.Resources;
@@ -36,6 +28,13 @@ import org.operaton.bpm.engine.management.SchemaLogEntry;
 import org.operaton.bpm.engine.management.TableMetaData;
 import org.operaton.bpm.engine.management.TablePage;
 import org.operaton.bpm.engine.telemetry.TelemetryData;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 /**
@@ -49,12 +48,6 @@ class ManagementAuthorizationTest extends AuthorizationTest {
   protected static final String DUMMY_VALUE = "aPropertyValue";
   protected static final String DUMMY_METRIC = "dummyMetric";
 
-  @Override
-  @BeforeEach
-  public void setUp() {
-    super.setUp();
-  }
-  
   @Override
   @AfterEach
   public void tearDown() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessDefinitionAuthorizationTest.java
@@ -31,6 +31,9 @@ import static org.assertj.core.api.Assertions.*;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.authorization.Authorization;
 import org.operaton.bpm.engine.authorization.ProcessDefinitionPermissions;
@@ -44,8 +47,6 @@ import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.repository.ProcessDefinitionQuery;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -57,7 +58,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   protected static final String TWO_TASKS_PROCESS_KEY = "twoTasksProcess";
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     testRule.deploy(
         "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml",

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessDefinitionAuthorizationTest.java
@@ -52,7 +52,7 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
  * @author Roman Smirnov
  *
  */
-public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
+class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
 
   protected static final String ONE_TASK_PROCESS_KEY = "oneTaskProcess";
   protected static final String TWO_TASKS_PROCESS_KEY = "twoTasksProcess";
@@ -67,7 +67,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
     // given user is not authorized to read any process definition
 
@@ -79,7 +79,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnAnyProcessDefinition() {
+  void testQueryWithReadPermissionOnAnyProcessDefinition() {
     // given
     // given user gets read permission on any process definition
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ);
@@ -92,7 +92,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithMultiple() {
+  void testQueryWithMultiple() {
     // given
     // given user gets read permission on any process definition
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ);
@@ -106,7 +106,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnOneTaskProcess() {
+  void testQueryWithReadPermissionOnOneTaskProcess() {
     // given
     // given user gets read permission on "oneTaskProcess" process definition
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ);
@@ -123,7 +123,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithRevokedReadPermission() {
+  void testQueryWithRevokedReadPermission() {
     // given
     // given user gets all permissions on any process definition
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, ALL);
@@ -145,7 +145,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithGroupAuthorizationRevokedReadPermission() {
+  void testQueryWithGroupAuthorizationRevokedReadPermission() {
     // given
     // given user gets all permissions on any process definition
     Authorization authorization = createGrantAuthorization(PROCESS_DEFINITION, ANY);
@@ -172,7 +172,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // get process definition /////////////////////////////////////////////////////
 
   @Test
-  public void testGetProcessDefinitionWithoutAuthorizations() {
+  void testGetProcessDefinitionWithoutAuthorizations() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
@@ -188,7 +188,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetProcessDefinition() {
+  void testGetProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ);
@@ -203,7 +203,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // get deployed process definition /////////////////////////////////////////////////////
 
   @Test
-  public void testGetDeployedProcessDefinitionWithoutAuthorizations() {
+  void testGetDeployedProcessDefinitionWithoutAuthorizations() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
@@ -222,7 +222,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetDeployedProcessDefinition() {
+  void testGetDeployedProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ);
@@ -237,7 +237,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // get process diagram /////////////////////////////////////////////////////
 
   @Test
-  public void testGetProcessDiagramWithoutAuthorizations() {
+  void testGetProcessDiagramWithoutAuthorizations() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
@@ -256,7 +256,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetProcessDiagram() {
+  void testGetProcessDiagram() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ);
@@ -272,7 +272,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // get process model /////////////////////////////////////////////////////
 
   @Test
-  public void testGetProcessModelWithoutAuthorizations() {
+  void testGetProcessModelWithoutAuthorizations() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
@@ -291,7 +291,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetProcessModel() {
+  void testGetProcessModel() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ);
@@ -306,7 +306,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // get bpmn model instance /////////////////////////////////////////////////////
 
   @Test
-  public void testGetBpmnModelInstanceWithoutAuthorizations() {
+  void testGetBpmnModelInstanceWithoutAuthorizations() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
@@ -325,7 +325,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetBpmnModelInstance() {
+  void testGetBpmnModelInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ);
@@ -340,7 +340,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // get process diagram layout /////////////////////////////////////////////////
 
   @Test
-  public void testGetProcessDiagramLayoutWithoutAuthorization() {
+  void testGetProcessDiagramLayoutWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
@@ -359,7 +359,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetProcessDiagramLayout() {
+  void testGetProcessDiagramLayout() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ);
@@ -375,7 +375,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // suspend process definition by id ///////////////////////////////////////////
 
   @Test
-  public void testSuspendProcessDefinitionByIdWithoutAuthorization() {
+  void testSuspendProcessDefinitionByIdWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
@@ -395,7 +395,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionById() {
+  void testSuspendProcessDefinitionById() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE);
@@ -409,7 +409,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionByIdWithSuspendPermission() {
+  void testSuspendProcessDefinitionByIdWithSuspendPermission() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, ProcessDefinitionPermissions.SUSPEND);
@@ -425,7 +425,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // activate process definition by id ///////////////////////////////////////////
 
   @Test
-  public void testActivateProcessDefinitionByIdWithoutAuthorization() {
+  void testActivateProcessDefinitionByIdWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     suspendProcessDefinitionById(processDefinitionId);
@@ -446,7 +446,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessDefinitionById() {
+  void testActivateProcessDefinitionById() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     suspendProcessDefinitionById(processDefinitionId);
@@ -462,7 +462,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
 
 
   @Test
-  public void testActivateProcessDefinitionByIdWithSuspendPermission() {
+  void testActivateProcessDefinitionByIdWithSuspendPermission() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     suspendProcessDefinitionById(processDefinitionId);
@@ -479,7 +479,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // suspend process definition by id including instances ///////////////////////////////////////////
 
   @Test
-  public void testSuspendProcessDefinitionByIdIncludingInstancesWithoutAuthorization() {
+  void testSuspendProcessDefinitionByIdIncludingInstancesWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE);
@@ -503,7 +503,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionByIdIncludingInstancesWithUpdatePermissionOnProcessInstance() {
+  void testSuspendProcessDefinitionByIdIncludingInstancesWithUpdatePermissionOnProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE, ProcessDefinitionPermissions.SUSPEND);
@@ -530,7 +530,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionByIdIncludingInstancesWithUpdatePermissionOnAnyProcessInstance() {
+  void testSuspendProcessDefinitionByIdIncludingInstancesWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE);
@@ -550,7 +550,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionByIdIncludingInstancesWithSuspendPermissionOnAnyProcessInstance() {
+  void testSuspendProcessDefinitionByIdIncludingInstancesWithSuspendPermissionOnAnyProcessInstance() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, ProcessDefinitionPermissions.SUSPEND);
@@ -566,7 +566,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionByIdIncludingInstancesWithUpdateInstancePermissionOnProcessDefinition() {
+  void testSuspendProcessDefinitionByIdIncludingInstancesWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE, UPDATE_INSTANCE);
@@ -585,7 +585,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionByIdIncludingInstancesWithUpdateAndSuspendInstancePermissionOnProcessDefinition() {
+  void testSuspendProcessDefinitionByIdIncludingInstancesWithUpdateAndSuspendInstancePermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE, SUSPEND_INSTANCE);
@@ -600,7 +600,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionByIdIncludingInstancesWithSuspendAndSuspendInstancePermissionOnProcessDefinition() {
+  void testSuspendProcessDefinitionByIdIncludingInstancesWithSuspendAndSuspendInstancePermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, ProcessDefinitionPermissions.SUSPEND, SUSPEND_INSTANCE);
@@ -615,7 +615,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionByIdIncludingInstancesWithSuspendAndUpdateInstancePermissionOnProcessDefinition() {
+  void testSuspendProcessDefinitionByIdIncludingInstancesWithSuspendAndUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, ProcessDefinitionPermissions.SUSPEND, UPDATE_INSTANCE);
@@ -632,7 +632,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // activate process definition by id including instances ///////////////////////////////////////////
 
   @Test
-  public void testActivateProcessDefinitionByIdIncludingInstancesWithoutAuthorization() {
+  void testActivateProcessDefinitionByIdIncludingInstancesWithoutAuthorization() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -659,7 +659,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessDefinitionByIdIncludingInstancesWithUpdatePermissionOnProcessInstance() {
+  void testActivateProcessDefinitionByIdIncludingInstancesWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -687,7 +687,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessDefinitionByIdIncludingInstancesWithUpdatePermissionOnAnyProcessInstance() {
+  void testActivateProcessDefinitionByIdIncludingInstancesWithUpdatePermissionOnAnyProcessInstance() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -708,7 +708,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessDefinitionByIdIncludingInstancesWithSuspendPermissionOnAnyProcessInstance() {
+  void testActivateProcessDefinitionByIdIncludingInstancesWithSuspendPermissionOnAnyProcessInstance() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, ProcessInstancePermissions.SUSPEND);
@@ -725,7 +725,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessDefinitionByIdIncludingInstancesWithUpdateInstancePermissionOnProcessDefinition() {
+  void testActivateProcessDefinitionByIdIncludingInstancesWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -745,7 +745,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessDefinitionByIdIncludingInstancesWithSuspendAndSuspendInstancePermissionOnProcessDefinition() {
+  void testActivateProcessDefinitionByIdIncludingInstancesWithSuspendAndSuspendInstancePermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -761,7 +761,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessDefinitionByIdIncludingInstancesWithSuspendAndUpdateInstancePermissionOnProcessDefinition() {
+  void testActivateProcessDefinitionByIdIncludingInstancesWithSuspendAndUpdateInstancePermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -777,7 +777,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessDefinitionByIdIncludingInstancesWithUpdateAndSuspendInstancePermissionOnProcessDefinition() {
+  void testActivateProcessDefinitionByIdIncludingInstancesWithUpdateAndSuspendInstancePermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -795,7 +795,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // suspend process definition by key ///////////////////////////////////////////
 
   @Test
-  public void testSuspendProcessDefinitionByKeyWithoutAuthorization() {
+  void testSuspendProcessDefinitionByKeyWithoutAuthorization() {
     // given
 
     try {
@@ -814,7 +814,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionByKey() {
+  void testSuspendProcessDefinitionByKey() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE);
 
@@ -827,7 +827,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionByKeyWithSuspendPermission() {
+  void testSuspendProcessDefinitionByKeyWithSuspendPermission() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, ProcessDefinitionPermissions.SUSPEND);
 
@@ -842,7 +842,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // activate process definition by id ///////////////////////////////////////////
 
   @Test
-  public void testActivateProcessDefinitionByKeyWithoutAuthorization() {
+  void testActivateProcessDefinitionByKeyWithoutAuthorization() {
     // given
     suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
 
@@ -862,7 +862,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessDefinitionByKey() {
+  void testActivateProcessDefinitionByKey() {
     // given
     suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE);
@@ -876,7 +876,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessDefinitionByKeyWithSuspendPermission() {
+  void testActivateProcessDefinitionByKeyWithSuspendPermission() {
     // given
     suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, ProcessDefinitionPermissions.SUSPEND);
@@ -892,7 +892,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // suspend process definition by key including instances ///////////////////////////////////////////
 
   @Test
-  public void testSuspendProcessDefinitionByKeyIncludingInstancesWithoutAuthorization() {
+  void testSuspendProcessDefinitionByKeyIncludingInstancesWithoutAuthorization() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE, ProcessDefinitionPermissions.SUSPEND);
 
@@ -915,7 +915,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionByKeyIncludingInstancesWithUpdatePermissionOnProcessInstance() {
+  void testSuspendProcessDefinitionByKeyIncludingInstancesWithUpdatePermissionOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE, ProcessDefinitionPermissions.SUSPEND);
 
@@ -941,7 +941,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionByKeyIncludingInstancesWithUpdatePermissionOnAnyProcessInstance() {
+  void testSuspendProcessDefinitionByKeyIncludingInstancesWithUpdatePermissionOnAnyProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE);
 
@@ -960,7 +960,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionByKeyIncludingInstancesWithSuspendPermissionOnAnyProcessInstance() {
+  void testSuspendProcessDefinitionByKeyIncludingInstancesWithSuspendPermissionOnAnyProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, ProcessDefinitionPermissions.SUSPEND);
 
@@ -975,7 +975,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionByKeyIncludingInstancesWithUpdateInstancePermissionOnProcessDefinition() {
+  void testSuspendProcessDefinitionByKeyIncludingInstancesWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE, UPDATE_INSTANCE);
 
@@ -993,7 +993,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessDefinitionByKeyIncludingInstancesWithSuspendAndSuspendInstancePermissionOnProcessDefinition() {
+  void testSuspendProcessDefinitionByKeyIncludingInstancesWithSuspendAndSuspendInstancePermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, ProcessDefinitionPermissions.SUSPEND, SUSPEND_INSTANCE);
 
@@ -1008,7 +1008,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
 
 
   @Test
-  public void testSuspendProcessDefinitionByKeyIncludingInstancesWithSuspendAndUpdateInstancePermissionOnProcessDefinition() {
+  void testSuspendProcessDefinitionByKeyIncludingInstancesWithSuspendAndUpdateInstancePermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, ProcessDefinitionPermissions.SUSPEND, UPDATE_INSTANCE);
 
@@ -1023,7 +1023,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
 
 
   @Test
-  public void testSuspendProcessDefinitionByKeyIncludingInstancesWithUpdateAndSuspendInstancePermissionOnProcessDefinition() {
+  void testSuspendProcessDefinitionByKeyIncludingInstancesWithUpdateAndSuspendInstancePermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE, SUSPEND_INSTANCE);
 
@@ -1039,7 +1039,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // activate process definition by key including instances ///////////////////////////////////////////
 
   @Test
-  public void testActivateProcessDefinitionByKeyIncludingInstancesWithoutAuthorization() {
+  void testActivateProcessDefinitionByKeyIncludingInstancesWithoutAuthorization() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -1065,7 +1065,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessDefinitionByKeyIncludingInstancesWithUpdatePermissionOnProcessInstance() {
+  void testActivateProcessDefinitionByKeyIncludingInstancesWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE, ProcessInstancePermissions.SUSPEND);
@@ -1092,7 +1092,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessDefinitionByKeyIncludingInstancesWithUpdatePermissionOnAnyProcessInstance() {
+  void testActivateProcessDefinitionByKeyIncludingInstancesWithUpdatePermissionOnAnyProcessInstance() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -1112,7 +1112,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessDefinitionByKeyIncludingInstancesWithSuspendPermissionOnAnyProcessInstance() {
+  void testActivateProcessDefinitionByKeyIncludingInstancesWithSuspendPermissionOnAnyProcessInstance() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, ProcessInstancePermissions.SUSPEND);
@@ -1128,7 +1128,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessDefinitionByKeyIncludingInstancesWithUpdateInstancePermissionOnProcessDefinition() {
+  void testActivateProcessDefinitionByKeyIncludingInstancesWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -1147,7 +1147,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessDefinitionByKeyIncludingInstancesWithSuspendAndSuspendInstancePermissionOnProcessDefinition() {
+  void testActivateProcessDefinitionByKeyIncludingInstancesWithSuspendAndSuspendInstancePermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -1163,7 +1163,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
 
 
   @Test
-  public void testActivateProcessDefinitionByKeyIncludingInstancesWithSuspendAndUpdateInstancePermissionOnProcessDefinition() {
+  void testActivateProcessDefinitionByKeyIncludingInstancesWithSuspendAndUpdateInstancePermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -1179,7 +1179,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
 
 
   @Test
-  public void testActivateProcessDefinitionByKeyIncludingInstancesWithUpdateAndSuspendInstancePermissionOnProcessDefinition() {
+  void testActivateProcessDefinitionByKeyIncludingInstancesWithUpdateAndSuspendInstancePermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -1197,7 +1197,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // update history time to live ///////////////////////////////////////////
 
   @Test
-  public void testProcessDefinitionUpdateTimeToLive() {
+  void testProcessDefinitionUpdateTimeToLive() {
 
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE);
@@ -1213,7 +1213,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDecisionDefinitionUpdateTimeToLiveWithoutAuthorizations() {
+  void testDecisionDefinitionUpdateTimeToLiveWithoutAuthorizations() {
     //given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
@@ -1231,7 +1231,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   // startable in tasklist ///////////////////////////////////////////
 
   @Test
-  public void testStartableInTasklist() {
+  void testStartableInTasklist() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ, CREATE_INSTANCE);
     createGrantAuthorization(PROCESS_INSTANCE, "*", userId, CREATE);
@@ -1247,7 +1247,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartableInTasklistReadAllProcessDefinition() {
+  void testStartableInTasklistReadAllProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, "*", userId, READ);
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, CREATE_INSTANCE);
@@ -1264,7 +1264,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartableInTasklistWithoutCreateInstancePerm() {
+  void testStartableInTasklistWithoutCreateInstancePerm() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ);
     createGrantAuthorization(PROCESS_INSTANCE, "*", userId, CREATE);
@@ -1277,7 +1277,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartableInTasklistWithoutReadDefPerm() {
+  void testStartableInTasklistWithoutReadDefPerm() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, CREATE_INSTANCE);
     createGrantAuthorization(PROCESS_INSTANCE, "*", userId, CREATE);
@@ -1290,7 +1290,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartableInTasklistWithoutCreatePerm() {
+  void testStartableInTasklistWithoutCreatePerm() {
     // given
     selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
 
@@ -1301,7 +1301,7 @@ public class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotResolveUnauthorizedCalledProcessDefinitions() {
+  void shouldNotResolveUnauthorizedCalledProcessDefinitions() {
     Deployment deployment = createDeployment("test",
       "org/operaton/bpm/engine/test/api/repository/call-activities-with-references.bpmn",
       "org/operaton/bpm/engine/test/api/repository/first-process.bpmn20.xml");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessDefinitionStatisticsAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessDefinitionStatisticsAuthorizationTest.java
@@ -23,11 +23,12 @@ import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.management.IncidentStatistics;
 import org.operaton.bpm.engine.management.ProcessDefinitionStatistics;
 import org.operaton.bpm.engine.management.ProcessDefinitionStatisticsQuery;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -39,7 +40,7 @@ public class ProcessDefinitionStatisticsAuthorizationTest extends AuthorizationT
   protected static final String ONE_INCIDENT_PROCESS_KEY = "process";
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     testRule.deploy(
         "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml",

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessDefinitionStatisticsAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessDefinitionStatisticsAuthorizationTest.java
@@ -34,7 +34,7 @@ import org.operaton.bpm.engine.management.ProcessDefinitionStatisticsQuery;
  * @author Roman Smirnov
  *
  */
-public class ProcessDefinitionStatisticsAuthorizationTest extends AuthorizationTest {
+class ProcessDefinitionStatisticsAuthorizationTest extends AuthorizationTest {
 
   protected static final String ONE_TASK_PROCESS_KEY = "oneTaskProcess";
   protected static final String ONE_INCIDENT_PROCESS_KEY = "process";
@@ -51,7 +51,7 @@ public class ProcessDefinitionStatisticsAuthorizationTest extends AuthorizationT
   // without running instances //////////////////////////////////////////////////////////
 
   @Test
-  public void testQueryWithoutAuthorizations() {
+  void testQueryWithoutAuthorizations() {
     // given
 
     // when
@@ -62,7 +62,7 @@ public class ProcessDefinitionStatisticsAuthorizationTest extends AuthorizationT
   }
 
   @Test
-  public void testQueryWithReadPermissionOnOneTaskProcess() {
+  void testQueryWithReadPermissionOnOneTaskProcess() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ);
 
@@ -80,7 +80,7 @@ public class ProcessDefinitionStatisticsAuthorizationTest extends AuthorizationT
   }
 
   @Test
-  public void testQueryWithMultiple() {
+  void testQueryWithMultiple() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ);
@@ -93,7 +93,7 @@ public class ProcessDefinitionStatisticsAuthorizationTest extends AuthorizationT
   }
 
   @Test
-  public void testQueryWithReadPermissionOnAnyProcessDefinition() {
+  void testQueryWithReadPermissionOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ);
 
@@ -110,7 +110,7 @@ public class ProcessDefinitionStatisticsAuthorizationTest extends AuthorizationT
   }
 
   @Test
-  public void shouldNotFindStatisticsWithRevokedReadPermissionOnAnyProcessDefinition() {
+  void shouldNotFindStatisticsWithRevokedReadPermissionOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, "*", ALL);
     createRevokeAuthorization(PROCESS_DEFINITION, ANY, userId, READ);
@@ -125,7 +125,7 @@ public class ProcessDefinitionStatisticsAuthorizationTest extends AuthorizationT
   // including instances //////////////////////////////////////////////////////////////
 
   @Test
-  public void testQueryIncludingInstancesWithoutProcessInstanceAuthorizations() {
+  void testQueryIncludingInstancesWithoutProcessInstanceAuthorizations() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
@@ -152,7 +152,7 @@ public class ProcessDefinitionStatisticsAuthorizationTest extends AuthorizationT
   // including failed jobs ////////////////////////////////////////////////////////////
 
   @Test
-  public void testQueryIncludingFailedJobsWithoutProcessInstanceAuthorizations() {
+  void testQueryIncludingFailedJobsWithoutProcessInstanceAuthorizations() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
@@ -182,7 +182,7 @@ public class ProcessDefinitionStatisticsAuthorizationTest extends AuthorizationT
   // including incidents //////////////////////////////////////////////////////////////////////////
 
   @Test
-  public void testQueryIncludingIncidentsWithoutProcessInstanceAuthorizations() {
+  void testQueryIncludingIncidentsWithoutProcessInstanceAuthorizations() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
@@ -212,7 +212,7 @@ public class ProcessDefinitionStatisticsAuthorizationTest extends AuthorizationT
   // including incidents and failed jobs ///////////////////////////////////////////////////////////////
 
   @Test
-  public void testQueryIncludingIncidentsAndFailedJobsWithoutProcessInstanceAuthorizations() {
+  void testQueryIncludingIncidentsAndFailedJobsWithoutProcessInstanceAuthorizations() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceAuthorizationTest.java
@@ -16,6 +16,9 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.authorization.Authorization;
 import org.operaton.bpm.engine.impl.RuntimeServiceImpl;
@@ -37,10 +40,6 @@ import static org.operaton.bpm.engine.authorization.Resources.TASK;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -60,7 +59,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   protected boolean ensureSpecificVariablePermission;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     testRule.deploy(
       "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml",
@@ -76,7 +75,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     processEngineConfiguration.setEnforceSpecificVariablePermission(ensureSpecificVariablePermission);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceAuthorizationTest.java
@@ -84,7 +84,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // process instance query //////////////////////////////////////////////////////////
 
   @Test
-  public void testSimpleQueryWithoutAuthorization() {
+  void testSimpleQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
 
@@ -96,7 +96,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadPermissionOnProcessInstance() {
+  void testSimpleQueryWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -113,7 +113,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithMultiple() {
+  void testSimpleQueryWithMultiple() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -127,7 +127,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadPermissionOnAnyProcessInstance() {
+  void testSimpleQueryWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -144,7 +144,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadInstancesPermissionOnOneTaskProcess() {
+  void testSimpleQueryWithReadInstancesPermissionOnOneTaskProcess() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -161,7 +161,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
+  void testSimpleQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -178,7 +178,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindProcessInstanceWithRevokedReadPermissionOnProcessDefinition() {
+  void shouldNotFindProcessInstanceWithRevokedReadPermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, ALL);
@@ -194,7 +194,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // process instance query (multiple process instances) ////////////////////////
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -213,7 +213,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnProcessInstance() {
+  void testQueryWithReadPermissionOnProcessInstance() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -238,7 +238,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnAnyProcessInstance() {
+  void testQueryWithReadPermissionOnAnyProcessInstance() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -259,7 +259,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstancesPermissionOnOneTaskProcess() {
+  void testQueryWithReadInstancesPermissionOnOneTaskProcess() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -280,7 +280,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
+  void testQueryWithReadInstancesPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -303,7 +303,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // start process instance by key //////////////////////////////////////////////
 
   @Test
-  public void testStartProcessInstanceByKeyWithoutAuthorization() {
+  void testStartProcessInstanceByKeyWithoutAuthorization() {
     // given
     // no authorization to start a process instance
 
@@ -315,7 +315,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceByKeyWithCreatePermissionOnProcessInstance() {
+  void testStartProcessInstanceByKeyWithCreatePermissionOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
 
@@ -327,7 +327,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceByKeyWithCreateInstancesPermissionOnProcessDefinition() {
+  void testStartProcessInstanceByKeyWithCreateInstancesPermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, CREATE_INSTANCE);
 
@@ -340,7 +340,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceByKey() {
+  void testStartProcessInstanceByKey() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, CREATE_INSTANCE);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
@@ -358,7 +358,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // start process instance by id //////////////////////////////////////////////
 
   @Test
-  public void testStartProcessInstanceByIdWithoutAuthorization() {
+  void testStartProcessInstanceByIdWithoutAuthorization() {
     // given
     // no authorization to start a process instance
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
@@ -372,7 +372,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceByIdWithCreatePermissionOnProcessInstance() {
+  void testStartProcessInstanceByIdWithCreatePermissionOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
@@ -386,7 +386,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceByIdWithCreateInstancesPermissionOnProcessDefinition() {
+  void testStartProcessInstanceByIdWithCreateInstancesPermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, CREATE_INSTANCE);
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
@@ -400,7 +400,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceById() {
+  void testStartProcessInstanceById() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, CREATE_INSTANCE);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
@@ -418,7 +418,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceAtActivitiesByKey() {
+  void testStartProcessInstanceAtActivitiesByKey() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, CREATE_INSTANCE);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
@@ -434,7 +434,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceAtActivitiesByKeyWithoutAuthorization() {
+  void testStartProcessInstanceAtActivitiesByKeyWithoutAuthorization() {
     // given
     // no authorization to start a process instance
     var processInstantiationBuilder = runtimeService.createProcessInstanceByKey(PROCESS_KEY).startBeforeActivity("theTask");
@@ -448,7 +448,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceAtActivitiesByKeyWithCreatePermissionOnProcessInstance() {
+  void testStartProcessInstanceAtActivitiesByKeyWithCreatePermissionOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
     ProcessInstantiationBuilder builder = runtimeService.createProcessInstanceByKey(PROCESS_KEY).startBeforeActivity("theTask");
@@ -462,7 +462,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceAtActivitiesByKeyWithCreateInstancesPermissionOnProcessDefinition() {
+  void testStartProcessInstanceAtActivitiesByKeyWithCreateInstancesPermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, CREATE_INSTANCE);
     ProcessInstantiationBuilder builder = runtimeService.createProcessInstanceByKey(PROCESS_KEY).startBeforeActivity("theTask");
@@ -476,7 +476,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceAtActivitiesById() {
+  void testStartProcessInstanceAtActivitiesById() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, CREATE_INSTANCE);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
@@ -494,7 +494,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceAtActivitiesByIdWithoutAuthorization() {
+  void testStartProcessInstanceAtActivitiesByIdWithoutAuthorization() {
     // given
     // no authorization to start a process instance
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
@@ -509,7 +509,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceAtActivitiesByIdWithCreatePermissionOnProcessInstance() {
+  void testStartProcessInstanceAtActivitiesByIdWithCreatePermissionOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
@@ -524,7 +524,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceAtActivitiesByIdWithCreateInstancesPermissionOnProcessDefinition() {
+  void testStartProcessInstanceAtActivitiesByIdWithCreateInstancesPermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, CREATE_INSTANCE);
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
@@ -541,7 +541,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // start process instance by message //////////////////////////////////////////////
 
   @Test
-  public void testStartProcessInstanceByMessageWithoutAuthorization() {
+  void testStartProcessInstanceByMessageWithoutAuthorization() {
     // given
     // no authorization to start a process instance
 
@@ -554,7 +554,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceByMessageWithCreatePermissionOnProcessInstance() {
+  void testStartProcessInstanceByMessageWithCreatePermissionOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
 
@@ -567,7 +567,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceByMessageWithCreateInstancesPermissionOnProcessDefinition() {
+  void testStartProcessInstanceByMessageWithCreateInstancesPermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_START_PROCESS_KEY, userId, CREATE_INSTANCE);
 
@@ -580,7 +580,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceByMessage() {
+  void testStartProcessInstanceByMessage() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_START_PROCESS_KEY, userId, CREATE_INSTANCE);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
@@ -598,7 +598,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // start process instance by message and process definition id /////////////////////////////
 
   @Test
-  public void testStartProcessInstanceByMessageAndProcDefIdWithoutAuthorization() {
+  void testStartProcessInstanceByMessageAndProcDefIdWithoutAuthorization() {
     // given
     // no authorization to start a process instance
 
@@ -613,7 +613,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceByMessageAndProcDefIdWithCreatePermissionOnProcessInstance() {
+  void testStartProcessInstanceByMessageAndProcDefIdWithCreatePermissionOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
 
@@ -628,7 +628,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceByMessageAndProcDefIdWithCreateInstancesPermissionOnProcessDefinition() {
+  void testStartProcessInstanceByMessageAndProcDefIdWithCreateInstancesPermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_START_PROCESS_KEY, userId, CREATE_INSTANCE);
 
@@ -643,7 +643,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceByMessageAndProcDefId() {
+  void testStartProcessInstanceByMessageAndProcDefId() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_START_PROCESS_KEY, userId, CREATE_INSTANCE);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
@@ -663,7 +663,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // delete process instance /////////////////////////////
 
   @Test
-  public void testDeleteProcessInstanceWithoutAuthorization() {
+  void testDeleteProcessInstanceWithoutAuthorization() {
     // given
     // no authorization to delete a process instance
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
@@ -683,7 +683,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteProcessInstanceWithDeletePermissionOnProcessInstance() {
+  void testDeleteProcessInstanceWithDeletePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, DELETE);
@@ -698,7 +698,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteProcessInstanceWithDeletePermissionOnAnyProcessInstance() {
+  void testDeleteProcessInstanceWithDeletePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, DELETE);
@@ -713,7 +713,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteProcessInstanceWithDeleteInstancesPermissionOnProcessDefinition() {
+  void testDeleteProcessInstanceWithDeleteInstancesPermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, DELETE_INSTANCE);
@@ -728,7 +728,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteProcessInstance() {
+  void testDeleteProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, DELETE);
@@ -746,7 +746,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // get active activity ids ///////////////////////////////////
 
   @Test
-  public void testGetActiveActivityIdsWithoutAuthorization() {
+  void testGetActiveActivityIdsWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
 
@@ -762,7 +762,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetActiveActivityIdsWithReadPermissionOnProcessInstance() {
+  void testGetActiveActivityIdsWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -777,7 +777,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetActiveActivityIdsWithReadPermissionOnAnyProcessInstance() {
+  void testGetActiveActivityIdsWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -792,7 +792,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetActiveActivityIdsWithReadInstancesPermissionOnProcessDefinition() {
+  void testGetActiveActivityIdsWithReadInstancesPermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -807,7 +807,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetActiveActivityIds() {
+  void testGetActiveActivityIds() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -825,7 +825,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // get activity instance ///////////////////////////////////////////
 
   @Test
-  public void testGetActivityInstanceWithoutAuthorization() {
+  void testGetActivityInstanceWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
 
@@ -844,7 +844,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetActivityInstanceWithReadPermissionOnProcessInstance() {
+  void testGetActivityInstanceWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -857,7 +857,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetActivityInstanceWithReadPermissionOnAnyProcessInstance() {
+  void testGetActivityInstanceWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -870,7 +870,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetActivityInstanceWithReadInstancesPermissionOnProcessDefinition() {
+  void testGetActivityInstanceWithReadInstancesPermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -883,7 +883,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetActivityInstanceIds() {
+  void testGetActivityInstanceIds() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -899,7 +899,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // signal execution ///////////////////////////////////////////
 
   @Test
-  public void testSignalWithoutAuthorization() {
+  void testSignalWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
 
@@ -918,7 +918,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSignalWithUpdatePermissionOnProcessInstance() {
+  void testSignalWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -931,7 +931,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSignalWithUpdatePermissionOnAnyProcessInstance() {
+  void testSignalWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -944,7 +944,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSignalWithUpdateInstancesPermissionOnProcessDefinition() {
+  void testSignalWithUpdateInstancesPermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -957,7 +957,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSignal() {
+  void testSignal() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -973,7 +973,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // signal event received //////////////////////////////////////
 
   @Test
-  public void testSignalEventReceivedWithoutAuthorization() {
+  void testSignalEventReceivedWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(SIGNAL_BOUNDARY_PROCESS_KEY).getId();
 
@@ -992,7 +992,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSignalEventReceivedWithUpdatePermissionOnProcessInstance() {
+  void testSignalEventReceivedWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(SIGNAL_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -1007,7 +1007,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSignalEventReceivedWithUpdatePermissionOnAnyProcessInstance() {
+  void testSignalEventReceivedWithUpdatePermissionOnAnyProcessInstance() {
     // given
     startProcessInstanceByKey(SIGNAL_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -1022,7 +1022,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSignalEventReceivedWithUpdateInstancesPermissionOnProcessDefinition() {
+  void testSignalEventReceivedWithUpdateInstancesPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(SIGNAL_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, SIGNAL_BOUNDARY_PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -1037,7 +1037,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSignalEventReceived() {
+  void testSignalEventReceived() {
     // given
     String processInstanceId = startProcessInstanceByKey(SIGNAL_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -1053,7 +1053,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSignalEventReceivedTwoExecutionsShouldFail() {
+  void testSignalEventReceivedTwoExecutionsShouldFail() {
     // given
     String firstProcessInstanceId = startProcessInstanceByKey(SIGNAL_BOUNDARY_PROCESS_KEY).getId();
     String secondProcessInstanceId = startProcessInstanceByKey(SIGNAL_BOUNDARY_PROCESS_KEY).getId();
@@ -1075,7 +1075,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSignalEventReceivedTwoExecutionsShouldSuccess() {
+  void testSignalEventReceivedTwoExecutionsShouldSuccess() {
     // given
     String firstProcessInstanceId = startProcessInstanceByKey(SIGNAL_BOUNDARY_PROCESS_KEY).getId();
     String secondProcessInstanceId = startProcessInstanceByKey(SIGNAL_BOUNDARY_PROCESS_KEY).getId();
@@ -1099,7 +1099,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // signal event received by execution id //////////////////////////////////////
 
   @Test
-  public void testSignalEventReceivedByExecutionIdWithoutAuthorization() {
+  void testSignalEventReceivedByExecutionIdWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(SIGNAL_BOUNDARY_PROCESS_KEY).getId();
     String executionId = selectSingleTask().getExecutionId();
@@ -1119,7 +1119,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSignalEventReceivedByExecutionIdWithUpdatePermissionOnProcessInstance() {
+  void testSignalEventReceivedByExecutionIdWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(SIGNAL_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -1136,7 +1136,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSignalEventReceivedByExecutionIdWithUpdatePermissionOnAnyProcessInstance() {
+  void testSignalEventReceivedByExecutionIdWithUpdatePermissionOnAnyProcessInstance() {
     // given
     startProcessInstanceByKey(SIGNAL_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -1153,7 +1153,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSignalEventReceivedByExecutionIdWithUpdateInstancesPermissionOnProcessDefinition() {
+  void testSignalEventReceivedByExecutionIdWithUpdateInstancesPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(SIGNAL_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, SIGNAL_BOUNDARY_PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -1170,7 +1170,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSignalEventReceivedByExecutionId() {
+  void testSignalEventReceivedByExecutionId() {
     // given
     String processInstanceId = startProcessInstanceByKey(SIGNAL_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -1188,7 +1188,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceBySignalEventReceivedWithoutAuthorization() {
+  void testStartProcessInstanceBySignalEventReceivedWithoutAuthorization() {
     // given
     // no authorization to start a process instance
 
@@ -1200,7 +1200,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceBySignalEventReceivedWithCreatePermissionOnProcessInstance() {
+  void testStartProcessInstanceBySignalEventReceivedWithCreatePermissionOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
 
@@ -1212,7 +1212,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceBySignalEventReceived() {
+  void testStartProcessInstanceBySignalEventReceived() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
     createGrantAuthorization(PROCESS_DEFINITION, SIGNAL_START_PROCESS_KEY, userId, CREATE_INSTANCE);
@@ -1242,7 +1242,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartProcessInstanceByThrowSignalEvent() {
+  void testStartProcessInstanceByThrowSignalEvent() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
     createGrantAuthorization(PROCESS_DEFINITION, SIGNAL_START_PROCESS_KEY, userId, CREATE_INSTANCE);
@@ -1281,7 +1281,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testThrowSignalEvent() {
+  void testThrowSignalEvent() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
     createGrantAuthorization(PROCESS_DEFINITION, THROW_ALERT_SIGNAL_PROCESS_KEY, userId, CREATE_INSTANCE);
@@ -1303,7 +1303,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // message event received /////////////////////////////////////
 
   @Test
-  public void testMessageEventReceivedWithoutAuthorization() {
+  void testMessageEventReceivedWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     String executionId = selectSingleTask().getExecutionId();
@@ -1323,7 +1323,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testMessageEventReceivedByExecutionIdWithUpdatePermissionOnProcessInstance() {
+  void testMessageEventReceivedByExecutionIdWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -1340,7 +1340,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testMessageEventReceivedByExecutionIdWithUpdatePermissionOnAnyProcessInstance() {
+  void testMessageEventReceivedByExecutionIdWithUpdatePermissionOnAnyProcessInstance() {
     // given
     startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -1357,7 +1357,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testMessageEventReceivedByExecutionIdWithUpdateInstancesPermissionOnProcessDefinition() {
+  void testMessageEventReceivedByExecutionIdWithUpdateInstancesPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_BOUNDARY_PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -1374,7 +1374,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testMessageEventReceivedByExecutionId() {
+  void testMessageEventReceivedByExecutionId() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -1394,7 +1394,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // correlate message (correlates to an execution) /////////////
 
   @Test
-  public void testCorrelateMessageExecutionWithoutAuthorization() {
+  void testCorrelateMessageExecutionWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
 
@@ -1413,7 +1413,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateMessageExecutionWithUpdatePermissionOnProcessInstance() {
+  void testCorrelateMessageExecutionWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -1428,7 +1428,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateMessageExecutionWithUpdatePermissionOnAnyProcessInstance() {
+  void testCorrelateMessageExecutionWithUpdatePermissionOnAnyProcessInstance() {
     // given
     startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -1443,7 +1443,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateMessageExecutionWithUpdateInstancesPermissionOnProcessDefinition() {
+  void testCorrelateMessageExecutionWithUpdateInstancesPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_BOUNDARY_PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -1458,7 +1458,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateMessageExecution() {
+  void testCorrelateMessageExecution() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -1476,7 +1476,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // correlate message (correlates to a process definition) /////////////
 
   @Test
-  public void testCorrelateMessageProcessDefinitionWithoutAuthorization() {
+  void testCorrelateMessageProcessDefinitionWithoutAuthorization() {
     // given
 
     // when
@@ -1488,7 +1488,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateMessageProcessDefinitionWithCreatePermissionOnProcessInstance() {
+  void testCorrelateMessageProcessDefinitionWithCreatePermissionOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
 
@@ -1501,7 +1501,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateMessageProcessDefinitionWithCreateInstancesPermissionOnProcessDefinition() {
+  void testCorrelateMessageProcessDefinitionWithCreateInstancesPermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_START_PROCESS_KEY, userId, CREATE_INSTANCE);
 
@@ -1514,7 +1514,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateMessageProcessDefinition() {
+  void testCorrelateMessageProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
     createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_START_PROCESS_KEY, userId, CREATE_INSTANCE);
@@ -1531,7 +1531,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // correlate all (correlates to executions) ///////////////////
 
   @Test
-  public void testCorrelateAllExecutionWithoutAuthorization() {
+  void testCorrelateAllExecutionWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     MessageCorrelationBuilder builder = runtimeService.createMessageCorrelation("boundaryInvoiceMessage");
@@ -1551,7 +1551,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateAllExecutionWithUpdatePermissionOnProcessInstance() {
+  void testCorrelateAllExecutionWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -1568,7 +1568,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateAllExecutionWithUpdatePermissionOnAnyProcessInstance() {
+  void testCorrelateAllExecutionWithUpdatePermissionOnAnyProcessInstance() {
     // given
     startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -1585,7 +1585,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateAllExecutionWithUpdateInstancesPermissionOnProcessDefinition() {
+  void testCorrelateAllExecutionWithUpdateInstancesPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_BOUNDARY_PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -1602,7 +1602,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateAllExecution() {
+  void testCorrelateAllExecution() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -1620,7 +1620,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateAllTwoExecutionsShouldFail() {
+  void testCorrelateAllTwoExecutionsShouldFail() {
     // given
     String firstProcessInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     String secondProcessInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
@@ -1644,7 +1644,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateAllTwoExecutionsShouldSuccess() {
+  void testCorrelateAllTwoExecutionsShouldSuccess() {
     // given
     String firstProcessInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     String secondProcessInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
@@ -1670,7 +1670,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // correlate all (correlates to a process definition) /////////////
 
   @Test
-  public void testCorrelateAllProcessDefinitionWithoutAuthorization() {
+  void testCorrelateAllProcessDefinitionWithoutAuthorization() {
     // given
     MessageCorrelationBuilder builder = runtimeService.createMessageCorrelation("startInvoiceMessage");
 
@@ -1683,7 +1683,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateAllProcessDefinitionWithCreatePermissionOnProcessInstance() {
+  void testCorrelateAllProcessDefinitionWithCreatePermissionOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
     MessageCorrelationBuilder builder = runtimeService.createMessageCorrelation("startInvoiceMessage");
@@ -1697,7 +1697,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateAllProcessDefinitionWithCreateInstancesPermissionOnProcessDefinition() {
+  void testCorrelateAllProcessDefinitionWithCreateInstancesPermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_START_PROCESS_KEY, userId, CREATE_INSTANCE);
     MessageCorrelationBuilder builder = runtimeService.createMessageCorrelation("startInvoiceMessage");
@@ -1711,7 +1711,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCorrelateAllProcessDefinition() {
+  void testCorrelateAllProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
     createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_START_PROCESS_KEY, userId, CREATE_INSTANCE);
@@ -1730,7 +1730,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // suspend process instance by id /////////////////////////////
 
   @Test
-  public void testSuspendProcessInstanceByIdWithoutAuthorization() {
+  void testSuspendProcessInstanceByIdWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
 
@@ -1751,7 +1751,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByIdWithUpdatePermissionOnProcessInstance() {
+  void testSuspendProcessInstanceByIdWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -1765,7 +1765,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByIdWithUpdatePermissionOnAnyProcessInstance() {
+  void testSuspendProcessInstanceByIdWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -1779,7 +1779,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByIdWithUpdateInstancesPermissionOnProcessDefinition() {
+  void testSuspendProcessInstanceByIdWithUpdateInstancesPermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -1793,7 +1793,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceById() {
+  void testSuspendProcessInstanceById() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE, SUSPEND);
@@ -1808,7 +1808,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByIdWithSuspendPermissionOnProcessInstance() {
+  void testSuspendProcessInstanceByIdWithSuspendPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, SUSPEND);
@@ -1822,7 +1822,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByIdWithSuspendPermissionOnAnyProcessInstance() {
+  void testSuspendProcessInstanceByIdWithSuspendPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, SUSPEND);
@@ -1836,7 +1836,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByIdWithSuspendInstancesPermissionOnProcessDefinition() {
+  void testSuspendProcessInstanceByIdWithSuspendInstancesPermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, SUSPEND_INSTANCE);
@@ -1852,7 +1852,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // activate process instance by id /////////////////////////////
 
   @Test
-  public void testActivateProcessInstanceByIdWithoutAuthorization() {
+  void testActivateProcessInstanceByIdWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     suspendProcessInstanceById(processInstanceId);
@@ -1874,7 +1874,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByIdWithUpdatePermissionOnProcessInstance() {
+  void testActivateProcessInstanceByIdWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     suspendProcessInstanceById(processInstanceId);
@@ -1889,7 +1889,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByIdWithUpdatePermissionOnAnyProcessInstance() {
+  void testActivateProcessInstanceByIdWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     suspendProcessInstanceById(processInstanceId);
@@ -1904,7 +1904,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByIdWithUpdateInstancesPermissionOnProcessDefinition() {
+  void testActivateProcessInstanceByIdWithUpdateInstancesPermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     suspendProcessInstanceById(processInstanceId);
@@ -1919,7 +1919,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceById() {
+  void testActivateProcessInstanceById() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     suspendProcessInstanceById(processInstanceId);
@@ -1935,7 +1935,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByIdWithSuspendPermissionOnProcessInstance() {
+  void testActivateProcessInstanceByIdWithSuspendPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     suspendProcessInstanceById(processInstanceId);
@@ -1950,7 +1950,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByIdWithSuspendPermissionOnAnyProcessInstance() {
+  void testActivateProcessInstanceByIdWithSuspendPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     suspendProcessInstanceById(processInstanceId);
@@ -1965,7 +1965,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByIdWithSuspendInstancesPermissionOnProcessDefinition() {
+  void testActivateProcessInstanceByIdWithSuspendInstancesPermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     suspendProcessInstanceById(processInstanceId);
@@ -1982,7 +1982,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // suspend process instance by process definition id /////////////////////////////
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionIdWithoutAuthorization() {
+  void testSuspendProcessInstanceByProcessDefinitionIdWithoutAuthorization() {
     // given
     String processDefinitionId = startProcessInstanceByKey(PROCESS_KEY).getProcessDefinitionId();
 
@@ -2002,7 +2002,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionIdWithUpdatePermissionOnProcessInstance() {
+  void testSuspendProcessInstanceByProcessDefinitionIdWithUpdatePermissionOnProcessInstance() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2024,7 +2024,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionIdWithUpdatePermissionOnAnyProcessInstance() {
+  void testSuspendProcessInstanceByProcessDefinitionIdWithUpdatePermissionOnAnyProcessInstance() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processDefinitionId = instance.getProcessDefinitionId();
@@ -2039,7 +2039,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionIdWithUpdateInstancesPermissionOnProcessDefinition() {
+  void testSuspendProcessInstanceByProcessDefinitionIdWithUpdateInstancesPermissionOnProcessDefinition() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processDefinitionId = instance.getProcessDefinitionId();
@@ -2054,7 +2054,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionId() {
+  void testSuspendProcessInstanceByProcessDefinitionId() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2072,7 +2072,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionIdWithSuspendPermissionOnProcessInstance() {
+  void testSuspendProcessInstanceByProcessDefinitionIdWithSuspendPermissionOnProcessInstance() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2094,7 +2094,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionIdWithSuspendPermissionOnAnyProcessInstance() {
+  void testSuspendProcessInstanceByProcessDefinitionIdWithSuspendPermissionOnAnyProcessInstance() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processDefinitionId = instance.getProcessDefinitionId();
@@ -2109,7 +2109,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionIdWithSuspendInstancesPermissionOnProcessDefinition() {
+  void testSuspendProcessInstanceByProcessDefinitionIdWithSuspendInstancesPermissionOnProcessDefinition() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processDefinitionId = instance.getProcessDefinitionId();
@@ -2127,7 +2127,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // activate process instance by process definition id /////////////////////////////
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionIdWithoutAuthorization() {
+  void testActivateProcessInstanceByProcessDefinitionIdWithoutAuthorization() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2150,7 +2150,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionIdWithUpdatePermissionOnProcessInstance() {
+  void testActivateProcessInstanceByProcessDefinitionIdWithUpdatePermissionOnProcessInstance() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2174,7 +2174,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionIdWithUpdatePermissionOnAnyProcessInstance() {
+  void testActivateProcessInstanceByProcessDefinitionIdWithUpdatePermissionOnAnyProcessInstance() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2192,7 +2192,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionIdWithUpdateInstancesPermissionOnProcessDefinition() {
+  void testActivateProcessInstanceByProcessDefinitionIdWithUpdateInstancesPermissionOnProcessDefinition() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2210,7 +2210,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionId() {
+  void testActivateProcessInstanceByProcessDefinitionId() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2229,7 +2229,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionIdWithSuspendPermissionOnProcessInstance() {
+  void testActivateProcessInstanceByProcessDefinitionIdWithSuspendPermissionOnProcessInstance() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2253,7 +2253,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionIdWithSuspendPermissionOnAnyProcessInstance() {
+  void testActivateProcessInstanceByProcessDefinitionIdWithSuspendPermissionOnAnyProcessInstance() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2271,7 +2271,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionIdWithSuspendInstancesPermissionOnProcessDefinition() {
+  void testActivateProcessInstanceByProcessDefinitionIdWithSuspendInstancesPermissionOnProcessDefinition() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2291,7 +2291,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // suspend process instance by process definition key /////////////////////////////
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionKeyWithoutAuthorization() {
+  void testSuspendProcessInstanceByProcessDefinitionKeyWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
 
@@ -2311,7 +2311,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionKeyWithUpdatePermissionOnProcessInstance() {
+  void testSuspendProcessInstanceByProcessDefinitionKeyWithUpdatePermissionOnProcessInstance() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2332,7 +2332,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionKeyWithUpdatePermissionOnAnyProcessInstance() {
+  void testSuspendProcessInstanceByProcessDefinitionKeyWithUpdatePermissionOnAnyProcessInstance() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -2346,7 +2346,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionKeyWithUpdateInstancesPermissionOnProcessDefinition() {
+  void testSuspendProcessInstanceByProcessDefinitionKeyWithUpdateInstancesPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -2360,7 +2360,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionKey() {
+  void testSuspendProcessInstanceByProcessDefinitionKey() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2377,7 +2377,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionKeyWithSuspendPermissionOnProcessInstance() {
+  void testSuspendProcessInstanceByProcessDefinitionKeyWithSuspendPermissionOnProcessInstance() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2398,7 +2398,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionKeyWithSuspendPermissionOnAnyProcessInstance() {
+  void testSuspendProcessInstanceByProcessDefinitionKeyWithSuspendPermissionOnAnyProcessInstance() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, SUSPEND);
@@ -2412,7 +2412,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSuspendProcessInstanceByProcessDefinitionKeyWithSuspendInstancesPermissionOnProcessDefinition() {
+  void testSuspendProcessInstanceByProcessDefinitionKeyWithSuspendInstancesPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, SUSPEND_INSTANCE);
@@ -2428,7 +2428,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // activate process instance by process definition key /////////////////////////////
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionKeyWithoutAuthorization() {
+  void testActivateProcessInstanceByProcessDefinitionKeyWithoutAuthorization() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2450,7 +2450,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionKeyWithUpdatePermissionOnProcessInstance() {
+  void testActivateProcessInstanceByProcessDefinitionKeyWithUpdatePermissionOnProcessInstance() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2473,7 +2473,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionKeyWithUpdatePermissionOnAnyProcessInstance() {
+  void testActivateProcessInstanceByProcessDefinitionKeyWithUpdatePermissionOnAnyProcessInstance() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2490,7 +2490,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionKeyWithUpdateInstancesPermissionOnProcessDefinition() {
+  void testActivateProcessInstanceByProcessDefinitionKeyWithUpdateInstancesPermissionOnProcessDefinition() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2507,7 +2507,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionKey() {
+  void testActivateProcessInstanceByProcessDefinitionKey() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2525,7 +2525,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionKeyWithSuspendPermissionOnProcessInstance() {
+  void testActivateProcessInstanceByProcessDefinitionKeyWithSuspendPermissionOnProcessInstance() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2548,7 +2548,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionKeyWithSuspendPermissionOnAnyProcessInstance() {
+  void testActivateProcessInstanceByProcessDefinitionKeyWithSuspendPermissionOnAnyProcessInstance() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2565,7 +2565,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testActivateProcessInstanceByProcessDefinitionKeyWithSuspendInstancesPermissionOnProcessDefinition() {
+  void testActivateProcessInstanceByProcessDefinitionKeyWithSuspendInstancesPermissionOnProcessDefinition() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY);
     String processInstanceId = instance.getId();
@@ -2584,7 +2584,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // modify process instance /////////////////////////////////////
 
   @Test
-  public void testModifyProcessInstanceWithoutAuthorization() {
+  void testModifyProcessInstanceWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     var processInstanceModificationInstantiationBuilder = runtimeService
@@ -2604,7 +2604,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testModifyProcessInstanceWithUpdatePermissionOnProcessInstance() {
+  void testModifyProcessInstanceWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -2625,7 +2625,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testModifyProcessInstanceWithUpdatePermissionOnAnyProcessInstance() {
+  void testModifyProcessInstanceWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -2646,7 +2646,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testModifyProcessInstanceWithUpdateInstancePermissionOnProcessDefinition() {
+  void testModifyProcessInstanceWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_BOUNDARY_PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -2667,7 +2667,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testModifyProcessInstance() {
+  void testModifyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -2689,7 +2689,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteProcessInstanceByModifyingWithoutDeleteAuthorization() {
+  void testDeleteProcessInstanceByModifyingWithoutDeleteAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_BOUNDARY_PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -2710,7 +2710,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteProcessInstanceByModifyingWithoutDeletePermissionOnProcessInstance() {
+  void testDeleteProcessInstanceByModifyingWithoutDeletePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_BOUNDARY_PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -2726,7 +2726,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteProcessInstanceByModifyingWithoutDeletePermissionOnAnyProcessInstance() {
+  void testDeleteProcessInstanceByModifyingWithoutDeletePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_BOUNDARY_PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -2742,7 +2742,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteProcessInstanceByModifyingWithoutDeleteInstancePermissionOnProcessDefinition() {
+  void testDeleteProcessInstanceByModifyingWithoutDeleteInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(MESSAGE_BOUNDARY_PROCESS_KEY).getId();
     Authorization authorization = createGrantAuthorization(PROCESS_DEFINITION, MESSAGE_BOUNDARY_PROCESS_KEY);
@@ -2763,7 +2763,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // clear process instance authorization ////////////////////////
 
   @Test
-  public void testClearProcessInstanceAuthorization() {
+  void testClearProcessInstanceAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, ALL);
@@ -2794,7 +2794,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteProcessInstanceClearAuthorization() {
+  void testDeleteProcessInstanceClearAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, ALL);
@@ -2824,7 +2824,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#getVariable() ////////////////////////////////////////////
 
   @Test
-  public void testGetVariableWithoutAuthorization() {
+  void testGetVariableWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
 
@@ -2853,7 +2853,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableWithReadPermissionOnProcessInstance() {
+  void testGetVariableWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -2866,7 +2866,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableWithReadPermissionOnAnyProcessInstance() {
+  void testGetVariableWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -2879,7 +2879,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableWithReadInstancePermissionOnProcessDefinition() {
+  void testGetVariableWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -2892,7 +2892,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testGetVariableWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -2905,7 +2905,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableWithReadInstanceVariablePermissionOnProcessDefinition() {
+  void testGetVariableWithReadInstanceVariablePermissionOnProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -2919,7 +2919,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testGetVariableWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -2935,7 +2935,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#getVariableLocal() ////////////////////////////////////////////
 
   @Test
-  public void testGetVariableLocalWithoutAuthorization() {
+  void testGetVariableLocalWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
 
@@ -2967,7 +2967,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableLocalWithReadPermissionOnProcessInstance() {
+  void testGetVariableLocalWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -2980,7 +2980,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableLocalWithReadPermissionOnAnyProcessInstance() {
+  void testGetVariableLocalWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -2993,7 +2993,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableLocalWithReadInstancePermissionOnProcessDefinition() {
+  void testGetVariableLocalWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -3006,7 +3006,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableLocalWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testGetVariableLocalWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -3019,7 +3019,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableLocalWithReadInstanceVariablePermissionOnProcessDefinition() {
+  void testGetVariableLocalWithReadInstanceVariablePermissionOnProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3033,7 +3033,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableLocalWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testGetVariableLocalWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3049,7 +3049,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#getVariableTyped() ////////////////////////////////////////////
 
   @Test
-  public void testGetVariableTypedWithoutAuthorization() {
+  void testGetVariableTypedWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
 
@@ -3081,7 +3081,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableTypedWithReadPermissionOnProcessInstance() {
+  void testGetVariableTypedWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -3095,7 +3095,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableTypedWithReadPermissionOnAnyProcessInstance() {
+  void testGetVariableTypedWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -3109,7 +3109,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableTypedWithReadInstancePermissionOnProcessDefinition() {
+  void testGetVariableTypedWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -3123,7 +3123,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableTypedWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testGetVariableTypedWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -3137,7 +3137,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableTypedWithReadInstanceVariablePermissionOnProcessDefinition() {
+  void testGetVariableTypedWithReadInstanceVariablePermissionOnProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3152,7 +3152,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableTypedWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testGetVariableTypedWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3169,7 +3169,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#getVariableLocalTyped() ////////////////////////////////////////////
 
   @Test
-  public void testGetVariableLocalTypedWithoutAuthorization() {
+  void testGetVariableLocalTypedWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
 
@@ -3201,7 +3201,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableLocalTypedWithReadPermissionOnProcessInstance() {
+  void testGetVariableLocalTypedWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -3215,7 +3215,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableLocalTypedWithReadPermissionOnAnyProcessInstance() {
+  void testGetVariableLocalTypedWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -3229,7 +3229,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableLocalTypedWithReadInstancePermissionOnProcessDefinition() {
+  void testGetVariableLocalTypedWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -3243,7 +3243,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableLocalTypedWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testGetVariableLocalTypedWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -3257,7 +3257,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableLocalTypedWithReadInstanceVariablePermissionOnProcessDefinition() {
+  void testGetVariableLocalTypedWithReadInstanceVariablePermissionOnProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3272,7 +3272,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariableLocalTypedWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testGetVariableLocalTypedWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3289,7 +3289,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#getVariables() ////////////////////////////////////////////
 
   @Test
-  public void testGetVariablesWithoutAuthorization() {
+  void testGetVariablesWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
 
@@ -3321,7 +3321,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesWithReadPermissionOnProcessInstance() {
+  void testGetVariablesWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -3337,7 +3337,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesWithReadPermissionOnAnyProcessInstance() {
+  void testGetVariablesWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -3353,7 +3353,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesWithReadInstancePermissionOnProcessDefinition() {
+  void testGetVariablesWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -3369,7 +3369,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testGetVariablesWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -3382,7 +3382,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesWithReadInstanceVariablePermissionOnProcessDefinition() {
+  void testGetVariablesWithReadInstanceVariablePermissionOnProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3396,7 +3396,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testGetVariablesWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3414,7 +3414,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#getVariablesLocal() ////////////////////////////////////////////
 
   @Test
-  public void testGetVariablesLocalWithoutAuthorization() {
+  void testGetVariablesLocalWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
 
@@ -3446,7 +3446,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalWithReadPermissionOnProcessInstance() {
+  void testGetVariablesLocalWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -3459,7 +3459,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalWithReadPermissionOnAnyProcessInstance() {
+  void testGetVariablesLocalWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -3472,7 +3472,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalWithReadInstancePermissionOnProcessDefinition() {
+  void testGetVariablesLocalWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -3485,7 +3485,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testGetVariablesLocalWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -3498,7 +3498,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalWithReadInstanceVariablePermissionOnProcessDefinition() {
+  void testGetVariablesLocalWithReadInstanceVariablePermissionOnProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3512,7 +3512,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testGetVariablesLocalWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3530,7 +3530,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#getVariablesTyped() ////////////////////////////////////////////
 
   @Test
-  public void testGetVariablesTypedWithoutAuthorization() {
+  void testGetVariablesTypedWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
 
@@ -3562,7 +3562,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesTypedWithReadPermissionOnProcessInstance() {
+  void testGetVariablesTypedWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -3575,7 +3575,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesTypedWithReadPermissionOnAnyProcessInstance() {
+  void testGetVariablesTypedWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -3588,7 +3588,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesTypedWithReadInstancePermissionOnProcessDefinition() {
+  void testGetVariablesTypedWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -3601,7 +3601,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesTypedWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testGetVariablesTypedWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -3614,7 +3614,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesTypedWithReadInstanceVariablePermissionOnProcessDefinition() {
+  void testGetVariablesTypedWithReadInstanceVariablePermissionOnProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3628,7 +3628,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesTypedWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testGetVariablesTypedWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3646,7 +3646,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#getVariablesLocalTyped() ////////////////////////////////////////////
 
   @Test
-  public void testGetVariablesLocalTypedWithoutAuthorization() {
+  void testGetVariablesLocalTypedWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
 
@@ -3678,7 +3678,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalTypedWithReadPermissionOnProcessInstance() {
+  void testGetVariablesLocalTypedWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -3691,7 +3691,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalTypedWithReadPermissionOnAnyProcessInstance() {
+  void testGetVariablesLocalTypedWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -3704,7 +3704,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalTypedWithReadInstancePermissionOnProcessDefinition() {
+  void testGetVariablesLocalTypedWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -3717,7 +3717,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalTypedWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testGetVariablesLocalTypedWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -3730,7 +3730,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalTypedWithReadInstanceVariablePermissionOnProcessDefinition() {
+  void testGetVariablesLocalTypedWithReadInstanceVariablePermissionOnProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3744,7 +3744,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalTypedWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testGetVariablesLocalTypedWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3760,7 +3760,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#getVariables() ////////////////////////////////////////////
 
   @Test
-  public void testGetVariablesByNameWithoutAuthorization() {
+  void testGetVariablesByNameWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     List<String> variableNames = List.of(VARIABLE_NAME);
@@ -3793,7 +3793,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesByNameWithReadPermissionOnProcessInstance() {
+  void testGetVariablesByNameWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -3806,7 +3806,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesByNameWithReadPermissionOnAnyProcessInstance() {
+  void testGetVariablesByNameWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -3819,7 +3819,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesByNameWithReadInstancePermissionOnProcessDefinition() {
+  void testGetVariablesByNameWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -3832,7 +3832,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesByNameWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testGetVariablesByNameWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -3845,7 +3845,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesByNameWithReadInstanceVariablePermissionOnProcessDefinition() {
+  void testGetVariablesByNameWithReadInstanceVariablePermissionOnProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3859,7 +3859,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesByNameWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testGetVariablesByNameWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3875,7 +3875,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#getVariablesLocal() ////////////////////////////////////////////
 
   @Test
-  public void testGetVariablesLocalByNameWithoutAuthorization() {
+  void testGetVariablesLocalByNameWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     List<String> variableNames = List.of(VARIABLE_NAME);
@@ -3908,7 +3908,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalByNameWithReadPermissionOnProcessInstance() {
+  void testGetVariablesLocalByNameWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -3921,7 +3921,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalByNameWithReadPermissionOnAnyProcessInstance() {
+  void testGetVariablesLocalByNameWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -3934,7 +3934,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalByNameWithReadInstancePermissionOnProcessDefinition() {
+  void testGetVariablesLocalByNameWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -3947,7 +3947,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalByNameWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testGetVariablesLocalByNameWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -3960,7 +3960,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalByNameWithReadInstanceVariablePermissionOnProcessDefinition() {
+  void testGetVariablesLocalByNameWithReadInstanceVariablePermissionOnProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3974,7 +3974,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalByNameWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testGetVariablesLocalByNameWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -3990,7 +3990,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#getVariablesTyped() ////////////////////////////////////////////
 
   @Test
-  public void testGetVariablesTypedByNameWithoutAuthorization() {
+  void testGetVariablesTypedByNameWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     List<String> variableNames = List.of(VARIABLE_NAME);
@@ -4023,7 +4023,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesTypedByNameWithReadPermissionOnProcessInstance() {
+  void testGetVariablesTypedByNameWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -4036,7 +4036,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesTypedByNameWithReadPermissionOnAnyProcessInstance() {
+  void testGetVariablesTypedByNameWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -4049,7 +4049,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesTypedByNameWithReadInstancePermissionOnProcessDefinition() {
+  void testGetVariablesTypedByNameWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -4062,7 +4062,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesTypedByNameWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testGetVariablesTypedByNameWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -4075,7 +4075,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesTypedByNameWithReadInstanceVariablePermissionOnProcessDefinition() {
+  void testGetVariablesTypedByNameWithReadInstanceVariablePermissionOnProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -4089,7 +4089,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesTypedByNameWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testGetVariablesTypedByNameWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -4105,7 +4105,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#getVariablesLocalTyped() ////////////////////////////////////////////
 
   @Test
-  public void testGetVariablesLocalTypedByNameWithoutAuthorization() {
+  void testGetVariablesLocalTypedByNameWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     List<String> variableNames = List.of(VARIABLE_NAME);
@@ -4138,7 +4138,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalTypedByNameWithReadPermissionOnProcessInstance() {
+  void testGetVariablesLocalTypedByNameWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -4151,7 +4151,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalTypedByNameWithReadPermissionOnAnyProcessInstance() {
+  void testGetVariablesLocalTypedByNameWithReadPermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
@@ -4164,7 +4164,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalTypedByNameWithReadInstancePermissionOnProcessDefinition() {
+  void testGetVariablesLocalTypedByNameWithReadInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -4177,7 +4177,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalTypedByNameWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testGetVariablesLocalTypedByNameWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
@@ -4190,7 +4190,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalTypedByNameWithReadInstanceVariablePermissionOnProcessDefinition() {
+  void testGetVariablesLocalTypedByNameWithReadInstanceVariablePermissionOnProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -4204,7 +4204,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetVariablesLocalTypedByNameWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testGetVariablesLocalTypedByNameWithReadInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -4220,7 +4220,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#setVariable() ////////////////////////////////////////////
 
   @Test
-  public void testSetVariableWithoutAuthorization() {
+  void testSetVariableWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
 
@@ -4233,7 +4233,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableWithUpdatePermissionOnProcessInstance() {
+  void testSetVariableWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -4242,7 +4242,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableWithUpdatePermissionOnAnyProcessInstance() {
+  void testSetVariableWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -4251,7 +4251,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableWithUpdateInstanceInstancePermissionOnProcessDefinition() {
+  void testSetVariableWithUpdateInstanceInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -4267,7 +4267,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testSetVariableWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
@@ -4276,7 +4276,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableWithUpdateVariablePermissionOnProcessInstance() {
+  void testSetVariableWithUpdateVariablePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE_VARIABLE);
@@ -4285,7 +4285,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableWithUpdateVariablePermissionOnAnyProcessInstance() {
+  void testSetVariableWithUpdateVariablePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE_VARIABLE);
@@ -4294,7 +4294,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableWithUpdateInstanceVariablePermissionOnProcessDefinition() {
+  void testSetVariableWithUpdateInstanceVariablePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4303,7 +4303,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testSetVariableWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4314,7 +4314,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#setVariableLocal() ////////////////////////////////////////////
 
   @Test
-  public void testSetVariableLocalWithoutAuthorization() {
+  void testSetVariableLocalWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
 
@@ -4327,7 +4327,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableLocalWithUpdatePermissionOnProcessInstance() {
+  void testSetVariableLocalWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -4336,7 +4336,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableLocalWithUpdatePermissionOnAnyProcessInstance() {
+  void testSetVariableLocalWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -4345,7 +4345,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableLocalWithUpdateInstancePermissionOnProcessDefinition() {
+  void testSetVariableLocalWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -4354,7 +4354,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableLocalWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testSetVariableLocalWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
@@ -4370,7 +4370,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableLocalWithUpdateVariablePermissionOnProcessInstance() {
+  void testSetVariableLocalWithUpdateVariablePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE_VARIABLE);
@@ -4379,7 +4379,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableLocalWithUpdateVariablePermissionOnAnyProcessInstance() {
+  void testSetVariableLocalWithUpdateVariablePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE_VARIABLE);
@@ -4388,7 +4388,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableLocalWithUpdateInstanceVariablePermissionOnProcessDefinition() {
+  void testSetVariableLocalWithUpdateInstanceVariablePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4397,7 +4397,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariableLocalWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testSetVariableLocalWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4408,7 +4408,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#setVariables() ////////////////////////////////////////////
 
   @Test
-  public void testSetVariablesWithoutAuthorization() {
+  void testSetVariablesWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     var variableMap = getVariables();
@@ -4422,7 +4422,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesWithUpdatePermissionOnProcessInstance() {
+  void testSetVariablesWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -4431,7 +4431,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesWithUpdatePermissionOnAnyProcessInstance() {
+  void testSetVariablesWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -4440,7 +4440,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesWithUpdateInstancePermissionOnProcessDefinition() {
+  void testSetVariablesWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -4449,7 +4449,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testSetVariablesWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
@@ -4458,7 +4458,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesWithUpdateVariablePermissionOnProcessInstance() {
+  void testSetVariablesWithUpdateVariablePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -4467,7 +4467,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesWithUpdateVariablePermissionOnAnyProcessInstance() {
+  void testSetVariablesWithUpdateVariablePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE_VARIABLE);
@@ -4476,7 +4476,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesWithUpdateInstanceVariablePermissionOnProcessDefinition() {
+  void testSetVariablesWithUpdateInstanceVariablePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4485,7 +4485,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testSetVariablesWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4496,7 +4496,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#setVariablesLocal() ////////////////////////////////////////////
 
   @Test
-  public void testSetVariablesLocalWithoutAuthorization() {
+  void testSetVariablesLocalWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     var variableMap = getVariables();
@@ -4510,7 +4510,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesLocalWithUpdatePermissionOnProcessInstance() {
+  void testSetVariablesLocalWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -4519,7 +4519,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesLocalWithUpdatePermissionOnAnyProcessInstance() {
+  void testSetVariablesLocalWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -4528,7 +4528,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesLocalWithUpdateInstancePermissionOnProcessDefinition() {
+  void testSetVariablesLocalWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -4537,7 +4537,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesLocalWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testSetVariablesLocalWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
@@ -4546,7 +4546,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesLocalWithUpdateVariablePermissionOnProcessInstance() {
+  void testSetVariablesLocalWithUpdateVariablePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE_VARIABLE);
@@ -4555,7 +4555,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesLocalWithUpdateVariablePermissionOnAnyProcessInstance() {
+  void testSetVariablesLocalWithUpdateVariablePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE_VARIABLE);
@@ -4564,7 +4564,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesLocalWithUpdateInstanceVariablePermissionOnProcessDefinition() {
+  void testSetVariablesLocalWithUpdateInstanceVariablePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4573,7 +4573,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSetVariablesLocalWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testSetVariablesLocalWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4584,7 +4584,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#removeVariable() ////////////////////////////////////////////
 
   @Test
-  public void testRemoveVariableWithoutAuthorization() {
+  void testRemoveVariableWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
 
@@ -4597,7 +4597,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableWithUpdatePermissionOnProcessInstance() {
+  void testRemoveVariableWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -4606,7 +4606,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableWithUpdatePermissionOnAnyProcessInstance() {
+  void testRemoveVariableWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -4615,7 +4615,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableWithUpdateInstancePermissionOnProcessDefinition() {
+  void testRemoveVariableWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -4624,7 +4624,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testRemoveVariableWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
@@ -4633,7 +4633,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableWithUpdateVariablePermissionOnProcessInstance() {
+  void testRemoveVariableWithUpdateVariablePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE_VARIABLE);
@@ -4642,7 +4642,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableWithUpdateVariablePermissionOnAnyProcessInstance() {
+  void testRemoveVariableWithUpdateVariablePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE_VARIABLE);
@@ -4651,7 +4651,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableWithUpdateInstanceVariablePermissionOnProcessDefinition() {
+  void testRemoveVariableWithUpdateInstanceVariablePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4660,7 +4660,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testRemoveVariableWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4671,7 +4671,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#removeVariableLocal() ////////////////////////////////////////////
 
   @Test
-  public void testRemoveVariableLocalWithoutAuthorization() {
+  void testRemoveVariableLocalWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
 
@@ -4684,7 +4684,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableLocalWithUpdatePermissionOnProcessInstance() {
+  void testRemoveVariableLocalWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -4693,7 +4693,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableLocalWithUpdatePermissionOnAnyProcessInstance() {
+  void testRemoveVariableLocalWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -4702,7 +4702,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableLocalWithUpdateInstancePermissionOnProcessDefinition() {
+  void testRemoveVariableLocalWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -4711,7 +4711,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableLocalWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testRemoveVariableLocalWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
@@ -4720,7 +4720,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableLocalWithUpdateVariablePermissionOnProcessInstance() {
+  void testRemoveVariableLocalWithUpdateVariablePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE_VARIABLE);
@@ -4729,7 +4729,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableLocalWithUpdateVariablePermissionOnAnyProcessInstance() {
+  void testRemoveVariableLocalWithUpdateVariablePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE_VARIABLE);
@@ -4738,7 +4738,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableLocalWithUpdateInstanceVariablePermissionOnProcessDefinition() {
+  void testRemoveVariableLocalWithUpdateInstanceVariablePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4747,7 +4747,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariableLocalWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testRemoveVariableLocalWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4758,7 +4758,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#removeVariables() ////////////////////////////////////////////
 
   @Test
-  public void testRemoveVariablesWithoutAuthorization() {
+  void testRemoveVariablesWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     List<String> variableNames = List.of(VARIABLE_NAME);
@@ -4772,7 +4772,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesWithUpdatePermissionOnProcessInstance() {
+  void testRemoveVariablesWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -4781,7 +4781,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesWithUpdatePermissionOnAnyProcessInstance() {
+  void testRemoveVariablesWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -4790,7 +4790,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesWithUpdateInstancePermissionOnProcessDefinition() {
+  void testRemoveVariablesWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -4799,7 +4799,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testRemoveVariablesWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
@@ -4808,7 +4808,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesWithUpdateVariablePermissionOnProcessInstance() {
+  void testRemoveVariablesWithUpdateVariablePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE_VARIABLE);
@@ -4817,7 +4817,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesWithUpdateVariablePermissionOnAnyProcessInstance() {
+  void testRemoveVariablesWithUpdateVariablePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE_VARIABLE);
@@ -4826,7 +4826,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesWithUpdateInstanceVariablePermissionOnProcessDefinition() {
+  void testRemoveVariablesWithUpdateInstanceVariablePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4835,7 +4835,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testRemoveVariablesWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4846,7 +4846,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeService#removeVariablesLocal() ////////////////////////////////////////////
 
   @Test
-  public void testRemoveVariablesLocalWithoutAuthorization() {
+  void testRemoveVariablesLocalWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     List<String> variableNames = List.of(VARIABLE_NAME);
@@ -4860,7 +4860,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesLocalWithUpdatePermissionOnProcessInstance() {
+  void testRemoveVariablesLocalWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -4869,7 +4869,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesLocalWithUpdatePermissionOnAnyProcessInstance() {
+  void testRemoveVariablesLocalWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -4878,7 +4878,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesLocalWithUpdateInstancePermissionOnProcessDefinition() {
+  void testRemoveVariablesLocalWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -4887,7 +4887,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesLocalWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testRemoveVariablesLocalWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
@@ -4896,7 +4896,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesLocalWithUpdateVariablePermissionOnProcessInstance() {
+  void testRemoveVariablesLocalWithUpdateVariablePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE_VARIABLE);
@@ -4905,7 +4905,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesLocalWithUpdateVariablePermissionOnAnyProcessInstance() {
+  void testRemoveVariablesLocalWithUpdateVariablePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE_VARIABLE);
@@ -4914,7 +4914,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesLocalWithUpdateInstanceVariablePermissionOnProcessDefinition() {
+  void testRemoveVariablesLocalWithUpdateInstanceVariablePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4923,7 +4923,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testRemoveVariablesLocalWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testRemoveVariablesLocalWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -4934,7 +4934,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeServiceImpl#updateVariables() ////////////////////////////////////////////
 
   @Test
-  public void testUpdateVariablesWithoutAuthorization() {
+  void testUpdateVariablesWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     var variableMap = getVariables();
@@ -4964,7 +4964,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesWithUpdatePermissionOnProcessInstance() {
+  void testUpdateVariablesWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -4973,7 +4973,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesWithUpdatePermissionOnAnyProcessInstance() {
+  void testUpdateVariablesWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -4982,7 +4982,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesWithUpdateInstancePermissionOnProcessDefinition() {
+  void testUpdateVariablesWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -4991,7 +4991,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testUpdateVariablesWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
@@ -5000,7 +5000,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesWithUpdateVariablePermissionOnProcessInstance() {
+  void testUpdateVariablesWithUpdateVariablePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE_VARIABLE);
@@ -5009,7 +5009,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesWithUpdateVariablePermissionOnAnyProcessInstance() {
+  void testUpdateVariablesWithUpdateVariablePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE_VARIABLE);
@@ -5018,7 +5018,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesWithUpdateInstanceVariablePermissionOnProcessDefinition() {
+  void testUpdateVariablesWithUpdateInstanceVariablePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -5027,7 +5027,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testUpdateVariablesWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -5038,7 +5038,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   // RuntimeServiceImpl#updateVariablesLocal() ////////////////////////////////////////////
 
   @Test
-  public void testUpdateVariablesLocalWithoutAuthorization() {
+  void testUpdateVariablesLocalWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     RuntimeServiceImpl runtimeServiceImpl = (RuntimeServiceImpl) runtimeService;
@@ -5068,7 +5068,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesLocalWithUpdatePermissionOnProcessInstance() {
+  void testUpdateVariablesLocalWithUpdatePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
@@ -5077,7 +5077,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesLocalWithUpdatePermissionOnAnyProcessInstance() {
+  void testUpdateVariablesLocalWithUpdatePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
@@ -5086,7 +5086,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesLocalWithUpdateInstancePermissionOnProcessDefinition() {
+  void testUpdateVariablesLocalWithUpdateInstancePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE);
@@ -5095,7 +5095,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesLocalWithUpdateInstancePermissionOnAnyProcessDefinition() {
+  void testUpdateVariablesLocalWithUpdateInstancePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
@@ -5104,7 +5104,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesLocalWithUpdateVariablePermissionOnProcessInstance() {
+  void testUpdateVariablesLocalWithUpdateVariablePermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE_VARIABLE);
@@ -5113,7 +5113,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesLocalWithUpdateVariablePermissionOnAnyProcessInstance() {
+  void testUpdateVariablesLocalWithUpdateVariablePermissionOnAnyProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE_VARIABLE);
@@ -5122,7 +5122,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesLocalWithUpdateInstanceVariablePermissionOnProcessDefinition() {
+  void testUpdateVariablesLocalWithUpdateInstanceVariablePermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, UPDATE_INSTANCE_VARIABLE);
@@ -5131,7 +5131,7 @@ public class ProcessInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateVariablesLocalWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
+  void testUpdateVariablesLocalWithUpdateInstanceVariablePermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE_VARIABLE);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceCommentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceCommentAuthorizationTest.java
@@ -21,10 +21,11 @@ import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 
 import java.util.Collections;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.task.Comment;
 import org.operaton.bpm.engine.test.Deployment;
-import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceCommentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceCommentAuthorizationTest.java
@@ -30,12 +30,12 @@ import org.operaton.bpm.engine.test.Deployment;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
+class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
   protected static final String ONE_TASK_PROCESS_KEY = "oneTaskProcess";
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
   @Test
-  public void testDeleteProcessInstanceTaskCommentWithoutAuthorization() {
+  void testDeleteProcessInstanceTaskCommentWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createTask(TASK_ID);
@@ -55,7 +55,7 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
   @Test
-  public void testDeleteProcessInstanceTaskComment() {
+  void testDeleteProcessInstanceTaskComment() {
     // given
     createTask(TASK_ID);
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
@@ -75,7 +75,7 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
   @Test
-  public void testDeleteProcessInstanceTaskCommentsWithoutAuthorization() {
+  void testDeleteProcessInstanceTaskCommentsWithoutAuthorization() {
     // given
     createTask(TASK_ID);
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
@@ -97,7 +97,7 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
   @Test
-  public void testDeleteProcessInstanceTaskComments() {
+  void testDeleteProcessInstanceTaskComments() {
     // given
     createTask(TASK_ID);
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
@@ -119,7 +119,7 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
   @Test
-  public void testUpdateProcessInstanceTaskCommentWithoutAuthorization() {
+  void testUpdateProcessInstanceTaskCommentWithoutAuthorization() {
     // given
     createTask(TASK_ID);
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
@@ -137,7 +137,7 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
   @Test
-  public void testUpdateProcessInstanceTaskComment() {
+  void testUpdateProcessInstanceTaskComment() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -162,7 +162,7 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
   @Test
-  public void testDeleteProcessInstanceCommentWithoutAuthorization() {
+  void testDeleteProcessInstanceCommentWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     String createdCommentId = createComment(null, processInstanceId, "aComment").getId();
@@ -177,7 +177,7 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
   @Test
-  public void testDeleteProcessInstanceComment() {
+  void testDeleteProcessInstanceComment() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     Comment createdComment = taskService.createComment(null, processInstanceId, "aComment");
@@ -193,7 +193,7 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
   @Test
-  public void testDeleteProcessInstanceCommentsWithoutAuthorization() {
+  void testDeleteProcessInstanceCommentsWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createComment(null, processInstanceId, "aComment");
@@ -211,7 +211,7 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
   @Test
-  public void testDeleteProcessInstanceComments() {
+  void testDeleteProcessInstanceComments() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     taskService.createComment(null, processInstanceId, "aCommentOne");
@@ -229,7 +229,7 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
   @Test
-  public void testUpdateProcessInstanceCommentWithoutAuthorization() {
+  void testUpdateProcessInstanceCommentWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     String createdCommentId = createComment(null, processInstanceId, "originalComment").getId();
@@ -244,7 +244,7 @@ public class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
   @Test
-  public void testUpdateProcessInstanceComment() {
+  void testUpdateProcessInstanceComment() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SchemaLogQueryAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SchemaLogQueryAuthorizationTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.authorization.Groups;
 
 import java.util.Collections;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SchemaLogQueryAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SchemaLogQueryAuthorizationTest.java
@@ -27,10 +27,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Miklas Boskamp
  *
  */
-public class SchemaLogQueryAuthorizationTest extends AuthorizationTest {
+class SchemaLogQueryAuthorizationTest extends AuthorizationTest {
 
   @Test
-  public void testSimpleQueryWithoutAuthorization() {
+  void testSimpleQueryWithoutAuthorization() {
     // given
 
     // then
@@ -38,7 +38,7 @@ public class SchemaLogQueryAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCountQueryWithAuthorization() {
+  void testCountQueryWithAuthorization() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 
@@ -47,7 +47,7 @@ public class SchemaLogQueryAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithAuthorization() {
+  void testQueryWithAuthorization() {
     // given
     identityService.setAuthentication(userId, Collections.singletonList(Groups.OPERATON_ADMIN));
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SetTaskPropertyAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SetTaskPropertyAuthorizationTest.java
@@ -17,10 +17,7 @@
 
 package org.operaton.bpm.engine.test.api.authorization;
 
-import org.operaton.bpm.engine.AuthorizationException;
-import org.operaton.bpm.engine.TaskService;
-import org.operaton.bpm.engine.task.Task;
-import org.operaton.bpm.engine.test.util.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.TASK_ASSIGN;
@@ -33,24 +30,22 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.operaton.bpm.engine.AuthorizationException;
+import org.operaton.bpm.engine.TaskService;
+import org.operaton.bpm.engine.task.Task;
+import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameter;
+import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameterized;
+import org.operaton.bpm.engine.test.junit5.ParameterizedTestExtension.Parameters;
+import org.operaton.bpm.engine.test.util.ClockTestUtil;
+import org.operaton.bpm.engine.test.util.ObjectProperty;
+import org.operaton.bpm.engine.test.util.TriConsumer;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-@RunWith(Parameterized.class)
-@SuppressWarnings("java:S1117")
+@Parameterized
 public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
 
   protected static final String PROCESS_KEY = "oneTaskProcess";
-
-  @Rule
-  public EntityRemoveRule entityRemoveRule = EntityRemoveRule.of(testRule);
 
   @Parameter(0)
   public String operationName;
@@ -71,7 +66,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
    * setValue: The value to use to set property to
    * taskQueryBuilderMethodName: The corresponding taskQuery builder method name to use for assertion purposes
    */
-  @Parameters(name = "{0}")
+  @Parameters
   public static List<Object[]> data() {
     TriConsumer<TaskService, String, Object> setPriority = (taskService, taskId, value) -> taskService.setPriority(taskId, (int) value);
     TriConsumer<TaskService, String, Object> setName = (taskService, taskId, value) -> taskService.setName(taskId, (String) value);
@@ -89,14 +84,13 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
   }
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     testRule.deploy("org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml");
     super.setUp();
   }
 
-  @Test
-  @RemoveAfter
+  @TestTemplate
   public void shouldSetOperationStandaloneWithoutAuthorization() {
     // given
     createTask(taskId);
@@ -111,10 +105,10 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
           "The user with id '" + userId + "' does not have one of the following permissions: 'TASK_ASSIGN'",
           e.getMessage());
     }
+    deleteTask(taskId, true);
   }
 
-  @Test
-  @RemoveAfter
+  @TestTemplate
   public void shouldSetOperationStandalone() {
     // given
     createTask(taskId);
@@ -128,10 +122,11 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
 
     assertThat(task).isNotNull();
     assertHasPropertyValue(task, operationName, value);
+    
+    deleteTask(taskId, true);
   }
 
-  @Test
-  @RemoveAfter
+  @TestTemplate
   public void shouldSetOperationStandaloneWithTaskAssignPermission() {
     // given
     createTask(taskId);
@@ -145,9 +140,11 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
 
     assertThat(task).isNotNull();
     assertHasPropertyValue(task, operationName, value);
+    
+    deleteTask(taskId, true);
   }
 
-  @Test
+  @TestTemplate
   public void shouldSetOperationOnProcessWithTaskAssignPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
@@ -165,7 +162,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
     assertHasPropertyValue(task, operationName, value);
   }
 
-  @Test
+  @TestTemplate
   public void shouldSetOperationOnProcessWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
@@ -187,7 +184,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
     }
   }
 
-  @Test
+  @TestTemplate
   public void shouldSetOperationOnProcessWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
@@ -205,7 +202,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
     assertHasPropertyValue(task, operationName, value);
   }
 
-  @Test
+  @TestTemplate
   public void shouldSetOperationOnProcessWithTaskAssignPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
@@ -223,7 +220,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
     assertHasPropertyValue(task, operationName, value);
   }
 
-  @Test
+  @TestTemplate
   public void shouldSetOperationOnProcessWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
@@ -241,7 +238,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
     assertHasPropertyValue(task, operationName, value);
   }
 
-  @Test
+  @TestTemplate
   public void shouldSetOperationOnProcessWithTaskAssignPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
@@ -259,7 +256,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
     assertHasPropertyValue(task, operationName, value);
   }
 
-  @Test
+  @TestTemplate
   public void shouldSetOperationOnProcessTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
@@ -278,7 +275,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
     assertHasPropertyValue(task, operationName, value);
   }
 
-  @Test
+  @TestTemplate
   public void shouldSetOperationOnProcessWithTaskAssignPermission() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SingleProcessInstanceModificationAsyncAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SingleProcessInstanceModificationAsyncAuthorizationTest.java
@@ -43,8 +43,8 @@ import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.util.ExecutionTree;
 
 import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -53,7 +53,7 @@ public class SingleProcessInstanceModificationAsyncAuthorizationTest extends Aut
 
   protected static final String PARALLEL_GATEWAY_PROCESS = "org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationTest.parallelGateway.bpmn20.xml";
 
-  @After
+  @AfterEach
   @Override
   public void tearDown() {
     disableAuthorization();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SingleProcessInstanceModificationAsyncAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SingleProcessInstanceModificationAsyncAuthorizationTest.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class SingleProcessInstanceModificationAsyncAuthorizationTest extends AuthorizationTest {
+class SingleProcessInstanceModificationAsyncAuthorizationTest extends AuthorizationTest {
 
   protected static final String PARALLEL_GATEWAY_PROCESS = "org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationTest.parallelGateway.bpmn20.xml";
 
@@ -72,7 +72,7 @@ public class SingleProcessInstanceModificationAsyncAuthorizationTest extends Aut
 
   @Deployment(resources = PARALLEL_GATEWAY_PROCESS)
   @Test
-  public void testModificationWithAllPermissions() {
+  void testModificationWithAllPermissions() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, "parallelGateway", userId, CREATE_INSTANCE, READ_INSTANCE, UPDATE_INSTANCE);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
@@ -121,7 +121,7 @@ public class SingleProcessInstanceModificationAsyncAuthorizationTest extends Aut
 
   @Deployment(resources = PARALLEL_GATEWAY_PROCESS)
   @Test
-  public void testModificationWithoutBatchPermissions() {
+  void testModificationWithoutBatchPermissions() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, "parallelGateway", userId, CREATE_INSTANCE, READ_INSTANCE, UPDATE_INSTANCE);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
@@ -144,7 +144,7 @@ public class SingleProcessInstanceModificationAsyncAuthorizationTest extends Aut
 
   @Deployment(resources = PARALLEL_GATEWAY_PROCESS)
   @Test
-  public void testModificationRevoke() {
+  void testModificationRevoke() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, "parallelGateway", userId, CREATE_INSTANCE, READ_INSTANCE, UPDATE_INSTANCE);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskAuthorizationTest.java
@@ -37,6 +37,10 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.authorization.Authorization;
@@ -55,9 +59,6 @@ import org.operaton.bpm.engine.task.TaskQuery;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.value.TypedValue;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -73,7 +74,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   protected static final String INVALID_PERMISSION = "invalidPermission";
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     testRule.deploy(
         "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml",
@@ -85,7 +86,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskAuthorizationTest.java
@@ -64,7 +64,7 @@ import org.operaton.bpm.engine.variable.value.TypedValue;
  * @author Roman Smirnov
  *
  */
-public class TaskAuthorizationTest extends AuthorizationTest {
+class TaskAuthorizationTest extends AuthorizationTest {
 
   protected static final String PROCESS_KEY = "oneTaskProcess";
   protected static final String CASE_KEY = "oneTaskCase";
@@ -103,7 +103,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // task query ///////////////////////////////////////////////////////
 
   @Test
-  public void testSimpleQueryWithTaskInsideProcessWithoutAuthorization() {
+  void testSimpleQueryWithTaskInsideProcessWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
 
@@ -115,7 +115,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithTaskInsideProcessWithReadPermissionOnTask() {
+  void testSimpleQueryWithTaskInsideProcessWithReadPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -129,7 +129,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithTaskInsideProcessWithReadPermissionOnAnyTask() {
+  void testSimpleQueryWithTaskInsideProcessWithReadPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(TASK, ANY, userId, READ);
@@ -142,7 +142,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithTaskInsideProcessWithReadPermissionOnOneTaskProcess() {
+  void testSimpleQueryWithTaskInsideProcessWithReadPermissionOnOneTaskProcess() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_TASK);
@@ -155,7 +155,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithTaskInsideProcessWithReadPermissionOnAnyProcessDefinition() {
+  void testSimpleQueryWithTaskInsideProcessWithReadPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_TASK);
@@ -168,7 +168,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithMultiple() {
+  void testSimpleQueryWithMultiple() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -185,7 +185,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindTaskWithRevokedReadPermissionOnTask() {
+  void shouldNotFindTaskWithRevokedReadPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -201,7 +201,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindTaskWithRevokedReadTaskPermissionOnDefinition() {
+  void shouldNotFindTaskWithRevokedReadTaskPermissionOnDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, ALL);
@@ -216,7 +216,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithTaskInsideProcessWithoutAuthorization() {
+  void testQueryWithTaskInsideProcessWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -235,7 +235,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithTaskInsideProcessWithReadPermissionOnTask() {
+  void testQueryWithTaskInsideProcessWithReadPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -260,7 +260,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithTaskInsideProcessWithReadPermissionOnAnyTask() {
+  void testQueryWithTaskInsideProcessWithReadPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -281,7 +281,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithTaskInsideProcessWithReadPermissionOnOneTaskProcess() {
+  void testQueryWithTaskInsideProcessWithReadPermissionOnOneTaskProcess() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -302,7 +302,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithTaskInsideProcessWithReadPermissionOnAnyProcessDefinition() {
+  void testQueryWithTaskInsideProcessWithReadPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -323,7 +323,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithTaskInsideCaseWithoutAuthorization() {
+  void testQueryWithTaskInsideCaseWithoutAuthorization() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
 
@@ -335,7 +335,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithStandaloneTaskWithoutAuthorization() {
+  void testQueryWithStandaloneTaskWithoutAuthorization() {
     // given
     String taskId = "newTask";
     createTask(taskId);
@@ -350,7 +350,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithStandaloneTaskWithReadPermissionOnTask() {
+  void testQueryWithStandaloneTaskWithReadPermissionOnTask() {
     // given
     String taskId = "newTask";
     createTask(taskId);
@@ -371,7 +371,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
    * both are used.
    */
   @Test
-  public void testQueryWithProcessDefinitionFilter() {
+  void testQueryWithProcessDefinitionFilter() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -389,7 +389,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // new task /////////////////////////////////////////////////////////////
 
   @Test
-  public void testNewTaskWithoutAuthorization() {
+  void testNewTaskWithoutAuthorization() {
     assertThatThrownBy(() -> taskService.newTask())
       .withFailMessage("Exception expected: It should not be possible to create a new task.")
       .isInstanceOf(AuthorizationException.class)
@@ -397,7 +397,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testNewTask() {
+  void testNewTask() {
     // given
     createGrantAuthorization(TASK, ANY, userId, CREATE);
 
@@ -411,7 +411,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // save task (insert) //////////////////////////////////////////////////////////
 
   @Test
-  public void testSaveTaskInsertWithoutAuthorization() {
+  void testSaveTaskInsertWithoutAuthorization() {
     // given
     TaskEntity task = new TaskEntity();
 
@@ -424,7 +424,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSaveTaskInsert() {
+  void testSaveTaskInsert() {
     // given
     TaskEntity task = new TaskEntity();
     task.setAssignee("demo");
@@ -444,7 +444,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSaveAndUpdateTaskWithTaskAssignPermission() {
+  void testSaveAndUpdateTaskWithTaskAssignPermission() {
     // given
     TaskEntity task = new TaskEntity();
     task.setAssignee("demo");
@@ -470,7 +470,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // save (standalone) task (update) //////////////////////////////////////////////////////////
 
   @Test
-  public void testSaveStandaloneTaskUpdateWithoutAuthorization() {
+  void testSaveStandaloneTaskUpdateWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -488,7 +488,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSaveStandaloneTaskUpdate() {
+  void testSaveStandaloneTaskUpdate() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -512,7 +512,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // save (process) task (update) //////////////////////////////////////////////////////////
 
   @Test
-  public void testSaveProcessTaskUpdateWithoutAuthorization() {
+  void testSaveProcessTaskUpdateWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     Task task = selectSingleTask();
@@ -531,7 +531,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSaveProcessTaskUpdateWithUpdatePermissionOnTask() {
+  void testSaveProcessTaskUpdateWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     Task task = selectSingleTask();
@@ -549,7 +549,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSaveProcessTaskUpdateWithTaskAssignPermissionOnTask() {
+  void testSaveProcessTaskUpdateWithTaskAssignPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     Task task = selectSingleTask();
@@ -567,7 +567,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSaveProcessTaskUpdateWithUpdatePermissionOnAnyTask() {
+  void testSaveProcessTaskUpdateWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     Task task = selectSingleTask();
@@ -585,7 +585,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSaveProcessTaskUpdateWithTaskAssignPermissionOnAnyTask() {
+  void testSaveProcessTaskUpdateWithTaskAssignPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     Task task = selectSingleTask();
@@ -603,7 +603,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSaveProcessTaskUpdateWithUpdateTasksPermissionOnProcessDefinition() {
+  void testSaveProcessTaskUpdateWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     Task task = selectSingleTask();
@@ -621,7 +621,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSaveProcessTaskUpdateWithTaskAssignPermissionOnProcessDefinition() {
+  void testSaveProcessTaskUpdateWithTaskAssignPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     Task task = selectSingleTask();
@@ -641,7 +641,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // save (case) task (update) //////////////////////////////////////////////////////////
 
   @Test
-  public void testSaveCaseTaskUpdate() {
+  void testSaveCaseTaskUpdate() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     Task task = selectSingleTask();
@@ -659,7 +659,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delete task ///////////////////////////////////////////////////////////////////////
 
   @Test
-  public void testDeleteTaskWithoutAuthorization() {
+  void testDeleteTaskWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -675,7 +675,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteTask() {
+  void testDeleteTask() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -696,7 +696,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delete tasks ///////////////////////////////////////////////////////////////////////
 
   @Test
-  public void testDeleteTasksWithoutAuthorization() {
+  void testDeleteTasksWithoutAuthorization() {
     // given
     String firstTaskId = "myTask1";
     createTask(firstTaskId);
@@ -715,7 +715,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteTasksWithDeletePermissionOnFirstTask() {
+  void testDeleteTasksWithDeletePermissionOnFirstTask() {
     // given
     String firstTaskId = "myTask1";
     createTask(firstTaskId);
@@ -736,7 +736,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteTasks() {
+  void testDeleteTasks() {
     // given
     String firstTaskId = "myTask1";
     createTask(firstTaskId);
@@ -760,7 +760,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // set assignee on standalone task /////////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskSetAssigneeWithoutAuthorization() {
+  void testStandaloneTaskSetAssigneeWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -776,7 +776,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskSetAssignee() {
+  void testStandaloneTaskSetAssignee() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -795,7 +795,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskSetAssigneeWithTaskAssignPermission() {
+  void testStandaloneTaskSetAssigneeWithTaskAssignPermission() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -816,7 +816,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // set assignee on process task /////////////////////////////////////////////
 
   @Test
-  public void testProcessTaskSetAssigneeWithoutAuthorization() {
+  void testProcessTaskSetAssigneeWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -835,7 +835,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetAssigneeWithUpdatePermissionOnTask() {
+  void testProcessTaskSetAssigneeWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -852,7 +852,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetAssigneeWithTaskAssignPermissionOnTask() {
+  void testProcessTaskSetAssigneeWithTaskAssignPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -869,7 +869,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetAssigneeWithUpdatePermissionOnAnyTask() {
+  void testProcessTaskSetAssigneeWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -886,7 +886,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetAssigneeWithTaskAssignPermissionOnAnyTask() {
+  void testProcessTaskSetAssigneeWithTaskAssignPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -903,7 +903,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetAssigneeWithUpdateTasksPermissionOnProcessDefinition() {
+  void testProcessTaskSetAssigneeWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -920,7 +920,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetAssigneeWithTaskAssignPermissionOnProcessDefinition() {
+  void testProcessTaskSetAssigneeWithTaskAssignPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -937,7 +937,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetAssignee() {
+  void testProcessTaskSetAssignee() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -957,7 +957,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // set assignee on case task /////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskSetAssignee() {
+  void testCaseTaskSetAssignee() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -974,7 +974,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // set owner on standalone task /////////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskSetOwnerWithoutAuthorization() {
+  void testStandaloneTaskSetOwnerWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -990,7 +990,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskSetOwner() {
+  void testStandaloneTaskSetOwner() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -1009,7 +1009,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskSetOwnerWithTaskAssignPermission() {
+  void testStandaloneTaskSetOwnerWithTaskAssignPermission() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -1030,7 +1030,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // set owner on process task /////////////////////////////////////////////
 
   @Test
-  public void testProcessTaskSetOwnerWithoutAuthorization() {
+  void testProcessTaskSetOwnerWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1049,7 +1049,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetOwnerWithUpdatePermissionOnTask() {
+  void testProcessTaskSetOwnerWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1066,7 +1066,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetOwnerWithTaskAssignPermissionOnTask() {
+  void testProcessTaskSetOwnerWithTaskAssignPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1083,7 +1083,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetOwnerWithUpdatePermissionOnAnyTask() {
+  void testProcessTaskSetOwnerWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1100,7 +1100,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetOwnerWithTaskAssignPermissionOnAnyTask() {
+  void testProcessTaskSetOwnerWithTaskAssignPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1117,7 +1117,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetOwnerWithUpdateTasksPermissionOnProcessDefinition() {
+  void testProcessTaskSetOwnerWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1134,7 +1134,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetOwnerWithTaskAssignPermissionOnProcessDefinition() {
+  void testProcessTaskSetOwnerWithTaskAssignPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1151,7 +1151,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetOwner() {
+  void testProcessTaskSetOwner() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1169,7 +1169,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetOwnerWithTaskAssignPermission() {
+  void testProcessTaskSetOwnerWithTaskAssignPermission() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1189,7 +1189,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // set owner on case task /////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskSetOwner() {
+  void testCaseTaskSetOwner() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -1206,7 +1206,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add candidate user ((standalone) task) /////////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskAddCandidateUserWithoutAuthorization() {
+  void testStandaloneTaskAddCandidateUserWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -1222,7 +1222,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskAddCandidateUser() {
+  void testStandaloneTaskAddCandidateUser() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -1253,7 +1253,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add candidate user ((process) task) /////////////////////////////////////////////
 
   @Test
-  public void testProcessTaskAddCandidateUserWithoutAuthorization() {
+  void testProcessTaskAddCandidateUserWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1272,7 +1272,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateUserWithUpdatePermissionOnTask() {
+  void testProcessTaskAddCandidateUserWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1299,7 +1299,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateUserWithTaskAssignPermissionRevokeOnTask() {
+  void testProcessTaskAddCandidateUserWithTaskAssignPermissionRevokeOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1316,7 +1316,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateUserWithTaskAssignPermissionOnTask() {
+  void testProcessTaskAddCandidateUserWithTaskAssignPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1343,7 +1343,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateUserWithGrantTaskAssignAndRevokeUpdatePermissionOnTask() {
+  void testProcessTaskAddCandidateUserWithGrantTaskAssignAndRevokeUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1371,7 +1371,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateUserWithUpdatePermissionOnAnyTask() {
+  void testProcessTaskAddCandidateUserWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1398,7 +1398,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateUserWithTaskAssignPermissionOnAnyTask() {
+  void testProcessTaskAddCandidateUserWithTaskAssignPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1425,7 +1425,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateUserWithUpdateTasksPermissionOnProcessDefinition() {
+  void testProcessTaskAddCandidateUserWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1452,7 +1452,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateUserWithTaskAssignPermissionOnProcessDefinition() {
+  void testProcessTaskAddCandidateUserWithTaskAssignPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1479,7 +1479,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateUser() {
+  void testProcessTaskAddCandidateUser() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1509,7 +1509,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add candidate user ((case) task) /////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskAddCandidateUser() {
+  void testCaseTaskAddCandidateUser() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -1536,7 +1536,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add candidate group ((standalone) task) /////////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskAddCandidateGroupWithoutAuthorization() {
+  void testStandaloneTaskAddCandidateGroupWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -1552,7 +1552,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskAddCandidateGroup() {
+  void testStandaloneTaskAddCandidateGroup() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -1581,7 +1581,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskAddCandidateGroupWithTaskAssignPermission() {
+  void testStandaloneTaskAddCandidateGroupWithTaskAssignPermission() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -1612,7 +1612,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add candidate group ((process) task) /////////////////////////////////////////////
 
   @Test
-  public void testProcessTaskAddCandidateGroupWithoutAuthorization() {
+  void testProcessTaskAddCandidateGroupWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1631,7 +1631,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateGroupWithUpdatePermissionOnTask() {
+  void testProcessTaskAddCandidateGroupWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1658,7 +1658,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateGroupWithTaskAssignPermissionOnTask() {
+  void testProcessTaskAddCandidateGroupWithTaskAssignPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1685,7 +1685,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateGroupWithUpdatePermissionOnAnyTask() {
+  void testProcessTaskAddCandidateGroupWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1712,7 +1712,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateGroupWithTaskAssignPermissionOnAnyTask() {
+  void testProcessTaskAddCandidateGroupWithTaskAssignPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1739,7 +1739,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateGroupWithUpdateTasksPermissionOnProcessDefinition() {
+  void testProcessTaskAddCandidateGroupWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1766,7 +1766,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateGroupWithTaskAssignPermissionOnProcessDefinition() {
+  void testProcessTaskAddCandidateGroupWithTaskAssignPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1793,7 +1793,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateGroup() {
+  void testProcessTaskAddCandidateGroup() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1821,7 +1821,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateGroupWithTaskAssignPermission() {
+  void testProcessTaskAddCandidateGroupWithTaskAssignPermission() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1849,7 +1849,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateGroupWithTaskAssignPermissionRevoked() {
+  void testProcessTaskAddCandidateGroupWithTaskAssignPermissionRevoked() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1879,7 +1879,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add candidate group ((case) task) /////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskAddCandidateGroup() {
+  void testCaseTaskAddCandidateGroup() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -1906,7 +1906,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add user identity link ((standalone) task) /////////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskAddUserIdentityLinkWithoutAuthorization() {
+  void testStandaloneTaskAddUserIdentityLinkWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -1922,7 +1922,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskAddUserIdentityLink() {
+  void testStandaloneTaskAddUserIdentityLink() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -1951,7 +1951,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskAddUserIdentityLinkWithTaskAssignPermission() {
+  void testStandaloneTaskAddUserIdentityLinkWithTaskAssignPermission() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -1981,7 +1981,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add user identity link ((process) task) /////////////////////////////////////////////
 
   @Test
-  public void testProcessTaskAddUserIdentityLinkWithoutAuthorization() {
+  void testProcessTaskAddUserIdentityLinkWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2000,7 +2000,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddUserIdentityLinkWithUpdatePermissionOnTask() {
+  void testProcessTaskAddUserIdentityLinkWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2027,7 +2027,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddUserIdentityLinkWithTaskAssignPermissionOnTask() {
+  void testProcessTaskAddUserIdentityLinkWithTaskAssignPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2054,7 +2054,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddUserIdentityLinkWithUpdatePermissionOnAnyTask() {
+  void testProcessTaskAddUserIdentityLinkWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2081,7 +2081,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddUserIdentityLinkWithTaskAssignPermissionOnAnyTask() {
+  void testProcessTaskAddUserIdentityLinkWithTaskAssignPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2108,7 +2108,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddUserIdentityLinkWithUpdateTasksPermissionOnProcessDefinition() {
+  void testProcessTaskAddUserIdentityLinkWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2135,7 +2135,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddUserIdentityLinkWithTaskAssignPermissionOnProcessDefinition() {
+  void testProcessTaskAddUserIdentityLinkWithTaskAssignPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2162,7 +2162,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddUserIdentityLink() {
+  void testProcessTaskAddUserIdentityLink() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2192,7 +2192,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add user identity link ((case) task) /////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskAddUserIdentityLink() {
+  void testCaseTaskAddUserIdentityLink() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -2219,7 +2219,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add group identity link ((standalone) task) /////////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskAddGroupIdentityLinkWithoutAuthorization() {
+  void testStandaloneTaskAddGroupIdentityLinkWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -2235,7 +2235,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskAddGroupIdentityLink() {
+  void testStandaloneTaskAddGroupIdentityLink() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -2266,7 +2266,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add group identity link ((process) task) /////////////////////////////////////////////
 
   @Test
-  public void testProcessTaskAddGroupIdentityLinkWithoutAuthorization() {
+  void testProcessTaskAddGroupIdentityLinkWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2285,7 +2285,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddGroupIdentityLinkWithUpdatePermissionOnTask() {
+  void testProcessTaskAddGroupIdentityLinkWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2312,7 +2312,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddGroupIdentityLinkWithUpdatePermissionOnAnyTask() {
+  void testProcessTaskAddGroupIdentityLinkWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2339,7 +2339,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddGroupIdentityLinkWithUpdateTasksPermissionOnProcessDefinition() {
+  void testProcessTaskAddGroupIdentityLinkWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2366,7 +2366,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddGroupIdentityLink() {
+  void testProcessTaskAddGroupIdentityLink() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2396,7 +2396,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add group identity link ((case) task) /////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskAddGroupIdentityLink() {
+  void testCaseTaskAddGroupIdentityLink() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -2423,7 +2423,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delete candidate user ((standalone) task) /////////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskDeleteCandidateUserWithoutAuthorization() {
+  void testStandaloneTaskDeleteCandidateUserWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -2440,7 +2440,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskDeleteCandidateUser() {
+  void testStandaloneTaskDeleteCandidateUser() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -2462,7 +2462,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskDeleteCandidateUserWithTaskAssignPermission() {
+  void testStandaloneTaskDeleteCandidateUserWithTaskAssignPermission() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -2486,7 +2486,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delete candidate user ((process) task) /////////////////////////////////////////////
 
   @Test
-  public void testProcessTaskDeleteCandidateUserWithoutAuthorization() {
+  void testProcessTaskDeleteCandidateUserWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2506,7 +2506,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteCandidateUserWithUpdatePermissionOnTask() {
+  void testProcessTaskDeleteCandidateUserWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2526,7 +2526,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteCandidateUserWithTaskAssignPermissionOnTask() {
+  void testProcessTaskDeleteCandidateUserWithTaskAssignPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2546,7 +2546,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteCandidateUserWithUpdatePermissionOnAnyTask() {
+  void testProcessTaskDeleteCandidateUserWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2566,7 +2566,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteCandidateUserWithTaskAssignPermissionOnAnyTask() {
+  void testProcessTaskDeleteCandidateUserWithTaskAssignPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2586,7 +2586,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteCandidateUserWithUpdateTasksPermissionOnProcessDefinition() {
+  void testProcessTaskDeleteCandidateUserWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2606,7 +2606,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteCandidateUserWithTaskAssignPermissionOnProcessDefinition() {
+  void testProcessTaskDeleteCandidateUserWithTaskAssignPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2626,7 +2626,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteCandidateUser() {
+  void testProcessTaskDeleteCandidateUser() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2649,7 +2649,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delete candidate user ((case) task) /////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskDeleteCandidateUser() {
+  void testCaseTaskDeleteCandidateUser() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -2669,7 +2669,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delete candidate group ((standalone) task) /////////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskDeleteCandidateGroupWithoutAuthorization() {
+  void testStandaloneTaskDeleteCandidateGroupWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -2686,7 +2686,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskDeleteCandidateGroup() {
+  void testStandaloneTaskDeleteCandidateGroup() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -2708,7 +2708,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskDeleteCandidateGroupWithTaskAssignPermission() {
+  void testStandaloneTaskDeleteCandidateGroupWithTaskAssignPermission() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -2732,7 +2732,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delete candidate group ((process) task) /////////////////////////////////////////////
 
   @Test
-  public void testProcessTaskDeleteCandidateGroupWithoutAuthorization() {
+  void testProcessTaskDeleteCandidateGroupWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2752,7 +2752,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteCandidateGroupWithUpdatePermissionOnTask() {
+  void testProcessTaskDeleteCandidateGroupWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2772,7 +2772,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteCandidateGroupWithTaskAssignPermissionOnTask() {
+  void testProcessTaskDeleteCandidateGroupWithTaskAssignPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2792,7 +2792,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteCandidateGroupWithUpdatePermissionOnAnyTask() {
+  void testProcessTaskDeleteCandidateGroupWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2812,7 +2812,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteCandidateGroupWithTaskAssignPermissionOnAnyTask() {
+  void testProcessTaskDeleteCandidateGroupWithTaskAssignPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2832,7 +2832,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteCandidateGroupWithUpdateTasksPermissionOnProcessDefinition() {
+  void testProcessTaskDeleteCandidateGroupWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2852,7 +2852,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteCandidateGroupWithTaskAssignPermissionOnProcessDefinition() {
+  void testProcessTaskDeleteCandidateGroupWithTaskAssignPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2872,7 +2872,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteCandidateGroup() {
+  void testProcessTaskDeleteCandidateGroup() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2895,7 +2895,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delete candidate group ((case) task) /////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskDeleteCandidateGroup() {
+  void testCaseTaskDeleteCandidateGroup() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -2915,7 +2915,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delete user identity link ((standalone) task) /////////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskDeleteUserIdentityLinkWithoutAuthorization() {
+  void testStandaloneTaskDeleteUserIdentityLinkWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -2932,7 +2932,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskDeleteUserIdentityLink() {
+  void testStandaloneTaskDeleteUserIdentityLink() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -2954,7 +2954,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskDeleteUserIdentityLinkWithTaskAssignPermission() {
+  void testStandaloneTaskDeleteUserIdentityLinkWithTaskAssignPermission() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -2978,7 +2978,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delete user identity link ((process) task) /////////////////////////////////////////////
 
   @Test
-  public void testProcessTaskDeleteUserIdentityLinkWithoutAuthorization() {
+  void testProcessTaskDeleteUserIdentityLinkWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -2998,7 +2998,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteUserIdentityLinkWithUpdatePermissionOnTask() {
+  void testProcessTaskDeleteUserIdentityLinkWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3018,7 +3018,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteUserIdentityLinkWithTaskAssignPermissionOnTask() {
+  void testProcessTaskDeleteUserIdentityLinkWithTaskAssignPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3038,7 +3038,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteUserIdentityLinkWithUpdatePermissionOnAnyTask() {
+  void testProcessTaskDeleteUserIdentityLinkWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3058,7 +3058,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteUserIdentityLinkWithTaskAssignPermissionOnAnyTask() {
+  void testProcessTaskDeleteUserIdentityLinkWithTaskAssignPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3078,7 +3078,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteUserIdentityLinkWithUpdateTasksPermissionOnProcessDefinition() {
+  void testProcessTaskDeleteUserIdentityLinkWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3098,7 +3098,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteUserIdentityLinkWithTaskAssignPermissionOnProcessDefinition() {
+  void testProcessTaskDeleteUserIdentityLinkWithTaskAssignPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3118,7 +3118,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteUserIdentityLink() {
+  void testProcessTaskDeleteUserIdentityLink() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3139,7 +3139,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteUserIdentityLinkWithTaskAssignPermission() {
+  void testProcessTaskDeleteUserIdentityLinkWithTaskAssignPermission() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3162,7 +3162,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delete user identity link ((case) task) /////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskDeleteUserIdentityLink() {
+  void testCaseTaskDeleteUserIdentityLink() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -3182,7 +3182,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delete group identity link ((standalone) task) /////////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskDeleteGroupIdentityLinkWithoutAuthorization() {
+  void testStandaloneTaskDeleteGroupIdentityLinkWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -3199,7 +3199,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskDeleteGroupIdentityLink() {
+  void testStandaloneTaskDeleteGroupIdentityLink() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -3223,7 +3223,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delete group identity link ((process) task) /////////////////////////////////////////////
 
   @Test
-  public void testProcessTaskDeleteGroupIdentityLinkWithoutAuthorization() {
+  void testProcessTaskDeleteGroupIdentityLinkWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3243,7 +3243,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteGroupIdentityLinkWithUpdatePermissionOnTask() {
+  void testProcessTaskDeleteGroupIdentityLinkWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3263,7 +3263,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteGroupIdentityLinkWithUpdatePermissionOnAnyTask() {
+  void testProcessTaskDeleteGroupIdentityLinkWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3283,7 +3283,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteGroupIdentityLinkWithUpdateTasksPermissionOnProcessDefinition() {
+  void testProcessTaskDeleteGroupIdentityLinkWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3303,7 +3303,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDeleteGroupIdentityLink() {
+  void testProcessTaskDeleteGroupIdentityLink() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3326,7 +3326,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delete group identity link ((case) task) /////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskDeleteGroupIdentityLink() {
+  void testCaseTaskDeleteGroupIdentityLink() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -3346,7 +3346,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // get identity links ((standalone) task) ////////////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskGetIdentityLinksWithoutAuthorization() {
+  void testStandaloneTaskGetIdentityLinksWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -3363,7 +3363,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskGetIdentityLinks() {
+  void testStandaloneTaskGetIdentityLinks() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -3385,7 +3385,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // get identity links ((process) task) ////////////////////////////////////////////////
 
   @Test
-  public void testProcessTaskGetIdentityLinksWithoutAuthorization() {
+  void testProcessTaskGetIdentityLinksWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3405,7 +3405,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetIdentityLinksWithReadPermissionOnTask() {
+  void testProcessTaskGetIdentityLinksWithReadPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3423,7 +3423,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetIdentityLinksWithReadPermissionOnAnyTask() {
+  void testProcessTaskGetIdentityLinksWithReadPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3441,7 +3441,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetIdentityLinksWithReadTasksPermissionOnProcessDefinition() {
+  void testProcessTaskGetIdentityLinksWithReadTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3459,7 +3459,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetIdentityLinks() {
+  void testProcessTaskGetIdentityLinks() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3480,7 +3480,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // get identity links ((case) task) ////////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskGetIdentityLinks() {
+  void testCaseTaskGetIdentityLinks() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -3498,7 +3498,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // claim (standalone) task ////////////////////////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskClaimTaskWithoutAuthorization() {
+  void testStandaloneTaskClaimTaskWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -3514,7 +3514,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskClaimTask() {
+  void testStandaloneTaskClaimTask() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -3533,7 +3533,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskClaimTaskWithTaskWorkPermission() {
+  void testStandaloneTaskClaimTaskWithTaskWorkPermission() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -3552,7 +3552,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskClaimTaskWithRevokeTaskWorkPermission() {
+  void testStandaloneTaskClaimTaskWithRevokeTaskWorkPermission() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -3573,7 +3573,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // claim (process) task ////////////////////////////////////////////////////////////
 
   @Test
-  public void testProcessTaskClaimTaskWithoutAuthorization() {
+  void testProcessTaskClaimTaskWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3592,7 +3592,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskClaimTaskWithUpdatePermissionOnTask() {
+  void testProcessTaskClaimTaskWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3609,7 +3609,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskClaimTaskWithTaskWorkPermissionOnTask() {
+  void testProcessTaskClaimTaskWithTaskWorkPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3626,7 +3626,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskClaimTaskWithGrantTaskWorkAndRevokeUpdatePermissionsOnTask() {
+  void testProcessTaskClaimTaskWithGrantTaskWorkAndRevokeUpdatePermissionsOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3644,7 +3644,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskClaimTaskWithRevokeTaskWorkPermissionOnTask() {
+  void testProcessTaskClaimTaskWithRevokeTaskWorkPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3661,7 +3661,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskClaimTaskWithUpdatePermissionOnAnyTask() {
+  void testProcessTaskClaimTaskWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3678,7 +3678,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskClaimTaskWithTaskWorkPermissionOnAnyTask() {
+  void testProcessTaskClaimTaskWithTaskWorkPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3695,7 +3695,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskClaimTaskWithUpdateTasksPermissionOnProcessDefinition() {
+  void testProcessTaskClaimTaskWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3712,7 +3712,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskClaimTaskWithTaskWorkPermissionOnProcessDefinition() {
+  void testProcessTaskClaimTaskWithTaskWorkPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3730,7 +3730,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskClaimTaskWithRevokeTaskWorkPermissionOnProcessDefinition() {
+  void testProcessTaskClaimTaskWithRevokeTaskWorkPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3748,7 +3748,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskClaimTask() {
+  void testProcessTaskClaimTask() {
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
 
@@ -3767,7 +3767,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // claim (case) task ////////////////////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskClaimTask() {
+  void testCaseTaskClaimTask() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -3784,7 +3784,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // complete (standalone) task ////////////////////////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskCompleteTaskWithoutAuthorization() {
+  void testStandaloneTaskCompleteTaskWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -3800,7 +3800,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskCompleteTask() {
+  void testStandaloneTaskCompleteTask() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -3820,7 +3820,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskCompleteWithTaskWorkPermission() {
+  void testStandaloneTaskCompleteWithTaskWorkPermission() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -3842,7 +3842,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // complete (process) task ////////////////////////////////////////////////////////////
 
   @Test
-  public void testProcessTaskCompleteTaskWithoutAuthorization() {
+  void testProcessTaskCompleteTaskWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3861,7 +3861,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskCompleteTaskWithUpdatePermissionOnTask() {
+  void testProcessTaskCompleteTaskWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3877,7 +3877,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskCompleteTaskWithTaskWorkPermissionOnTask() {
+  void testProcessTaskCompleteTaskWithTaskWorkPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3893,7 +3893,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskCompleteTaskWithUpdatePermissionOnAnyTask() {
+  void testProcessTaskCompleteTaskWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3909,7 +3909,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskCompleteTaskWithUpdateTasksPermissionOnProcessDefinition() {
+  void testProcessTaskCompleteTaskWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3925,7 +3925,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskCompleteTaskWithTaskWorkPermissionOnProcessDefinition() {
+  void testProcessTaskCompleteTaskWithTaskWorkPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3941,7 +3941,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskCompleteTask() {
+  void testProcessTaskCompleteTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -3960,7 +3960,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // complete (case) task ////////////////////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskCompleteTask() {
+  void testCaseTaskCompleteTask() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -3976,7 +3976,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delegate (standalone) task ///////////////////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskDelegateTaskWithoutAuthorization() {
+  void testStandaloneTaskDelegateTaskWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -3992,7 +3992,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskDelegateTask() {
+  void testStandaloneTaskDelegateTask() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -4011,7 +4011,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskDelegateTaskWithTaskAssignPermission() {
+  void testStandaloneTaskDelegateTaskWithTaskAssignPermission() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -4032,7 +4032,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delegate (process) task ///////////////////////////////////////////////////////////
 
   @Test
-  public void testProcessTaskDelegateTaskWithoutAuthorization() {
+  void testProcessTaskDelegateTaskWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4051,7 +4051,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDelegateTaskWithUpdatePermissionOnTask() {
+  void testProcessTaskDelegateTaskWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4068,7 +4068,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDelegateTaskWithTaskAssignPermissionOnTask() {
+  void testProcessTaskDelegateTaskWithTaskAssignPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4085,7 +4085,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDelegateTaskWithUpdatePermissionOnAnyTask() {
+  void testProcessTaskDelegateTaskWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4102,7 +4102,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDelegateTaskWithTaskAssignPermissionOnAnyTask() {
+  void testProcessTaskDelegateTaskWithTaskAssignPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4119,7 +4119,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDelegateTaskWithUpdateTasksPermissionOnProcessDefinition() {
+  void testProcessTaskDelegateTaskWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4136,7 +4136,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDelegateTaskWithTaskAssignPermissionOnProcessDefinition() {
+  void testProcessTaskDelegateTaskWithTaskAssignPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4153,7 +4153,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDelegateTask() {
+  void testProcessTaskDelegateTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4171,7 +4171,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskDelegateTaskWithTaskAssignPermission() {
+  void testProcessTaskDelegateTaskWithTaskAssignPermission() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4191,7 +4191,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delegate (case) task /////////////////////////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskDelegateTask() {
+  void testCaseTaskDelegateTask() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -4208,7 +4208,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // resolve (standalone) task ///////////////////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskResolveTaskWithoutAuthorization() {
+  void testStandaloneTaskResolveTaskWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -4224,7 +4224,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskResolveTask() {
+  void testStandaloneTaskResolveTask() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -4247,7 +4247,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delegate (process) task ///////////////////////////////////////////////////////////
 
   @Test
-  public void testProcessTaskResolveTaskWithoutAuthorization() {
+  void testProcessTaskResolveTaskWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4266,7 +4266,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskResolveTaskWithUpdatePermissionOnTask() {
+  void testProcessTaskResolveTaskWithUpdatePermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4285,7 +4285,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskResolveTaskWithUpdatePermissionOnAnyTask() {
+  void testProcessTaskResolveTaskWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4304,7 +4304,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskResolveTaskWithUpdateTasksPermissionOnProcessDefinition() {
+  void testProcessTaskResolveTaskWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4323,7 +4323,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskResolveTask() {
+  void testProcessTaskResolveTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4345,7 +4345,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // delegate (case) task /////////////////////////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskResolveTask() {
+  void testCaseTaskResolveTask() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -4362,7 +4362,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCaseTaskSetPriority() {
+  void testCaseTaskSetPriority() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -4379,7 +4379,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // get sub tasks ((standalone) task) ////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskGetSubTasksWithoutAuthorization() {
+  void testStandaloneTaskGetSubTasksWithoutAuthorization() {
     // given
     String parentTaskId = "parentTaskId";
     createTask(parentTaskId);
@@ -4404,7 +4404,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskGetSubTasksWithReadPermissionOnSub1() {
+  void testStandaloneTaskGetSubTasksWithReadPermissionOnSub1() {
     // given
     String parentTaskId = "parentTaskId";
     createTask(parentTaskId);
@@ -4435,7 +4435,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskGetSubTasks() {
+  void testStandaloneTaskGetSubTasks() {
     // given
     String parentTaskId = "parentTaskId";
     createTask(parentTaskId);
@@ -4466,7 +4466,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // get sub tasks ((process) task) ////////////////////////////////////
 
   @Test
-  public void testProcessTaskGetSubTasksWithoutAuthorization() {
+  void testProcessTaskGetSubTasksWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String parentTaskId = selectSingleTask().getId();
@@ -4489,7 +4489,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetSubTasksWithReadPermissionOnSub1() {
+  void testProcessTaskGetSubTasksWithReadPermissionOnSub1() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String parentTaskId = selectSingleTask().getId();
@@ -4518,7 +4518,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskGetSubTasks() {
+  void testProcessTaskGetSubTasks() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String parentTaskId = selectSingleTask().getId();
@@ -4547,7 +4547,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // get sub tasks ((case) task) ////////////////////////////////////
 
   @Test
-  public void testCaseTaskGetSubTasksWithoutAuthorization() {
+  void testCaseTaskGetSubTasksWithoutAuthorization() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String parentTaskId = selectSingleTask().getId();
@@ -4570,7 +4570,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCaseTaskGetSubTasksWithReadPermissionOnSub1() {
+  void testCaseTaskGetSubTasksWithReadPermissionOnSub1() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String parentTaskId = selectSingleTask().getId();
@@ -4599,7 +4599,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCaseTaskGetSubTasks() {
+  void testCaseTaskGetSubTasks() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String parentTaskId = selectSingleTask().getId();
@@ -4628,7 +4628,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // clear authorization ((standalone) task) ////////////////////////
 
   @Test
-  public void testStandaloneTaskClearAuthorization() {
+  void testStandaloneTaskClearAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -4661,7 +4661,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // clear authorization ((process) task) ////////////////////////
 
   @Test
-  public void testProcessTaskClearAuthorization() {
+  void testProcessTaskClearAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4692,7 +4692,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // set assignee -> an authorization is available (standalone task) /////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskSetAssigneeCreateNewAuthorization() {
+  void testStandaloneTaskSetAssigneeCreateNewAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -4720,7 +4720,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskSetAssigneeUpdateAuthorization() {
+  void testStandaloneTaskSetAssigneeUpdateAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -4749,7 +4749,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskSetAssigneeToNullAuthorizationStillAvailable() {
+  void testStandaloneTaskSetAssigneeToNullAuthorizationStillAvailable() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -4780,7 +4780,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryStandaloneTaskSetAssignee() {
+  void testQueryStandaloneTaskSetAssignee() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -4805,7 +4805,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskSetAssigneeOutsideCommandContextInsert() {
+  void testStandaloneTaskSetAssigneeOutsideCommandContextInsert() {
     // given
     String taskId = "myTask";
     createGrantAuthorization(TASK, ANY, userId, CREATE);
@@ -4834,7 +4834,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskSetAssigneeOutsideCommandContextSave() {
+  void testStandaloneTaskSetAssigneeOutsideCommandContextSave() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -4867,7 +4867,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // set assignee -> an authorization is available (process task) /////////////////////////////////////////
 
   @Test
-  public void testProcessTaskSetAssigneeCreateNewAuthorization() {
+  void testProcessTaskSetAssigneeCreateNewAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4893,7 +4893,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetAssigneeUpdateAuthorization() {
+  void testProcessTaskSetAssigneeUpdateAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4920,7 +4920,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetAssigneeToNullAuthorizationStillAvailable() {
+  void testProcessTaskSetAssigneeToNullAuthorizationStillAvailable() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4949,7 +4949,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryProcessTaskSetAssignee() {
+  void testQueryProcessTaskSetAssignee() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -4973,7 +4973,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAssignee() {
+  void testProcessTaskAssignee() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, DEMO_ASSIGNEE_PROCESS_KEY, userId, CREATE_INSTANCE);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
@@ -5013,7 +5013,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // set assignee -> should not create an authorization (case task) /////////////////////////////////////////
 
   @Test
-  public void testCaseTaskSetAssigneeNoAuthorization() {
+  void testCaseTaskSetAssigneeNoAuthorization() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -5036,7 +5036,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // set owner -> an authorization is available (standalone task) /////////////////////////////////////////
 
   @Test
-  public void testStandaloneTaskSetOwnerCreateNewAuthorization() {
+  void testStandaloneTaskSetOwnerCreateNewAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -5064,7 +5064,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskSetOwnerUpdateAuthorization() {
+  void testStandaloneTaskSetOwnerUpdateAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -5093,7 +5093,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryStandaloneTaskSetOwner() {
+  void testQueryStandaloneTaskSetOwner() {
     String taskId = "myTask";
     createTask(taskId);
     createGrantAuthorization(TASK, taskId, userId, UPDATE);
@@ -5117,7 +5117,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskSetOwnerOutsideCommandContextInsert() {
+  void testStandaloneTaskSetOwnerOutsideCommandContextInsert() {
     // given
     String taskId = "myTask";
     createGrantAuthorization(TASK, ANY, userId, CREATE);
@@ -5147,7 +5147,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskSetOwnerOutsideCommandContextSave() {
+  void testStandaloneTaskSetOwnerOutsideCommandContextSave() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -5180,7 +5180,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // set owner -> an authorization is available (process task) /////////////////////////////////////////
 
   @Test
-  public void testProcessTaskSetOwnerCreateNewAuthorization() {
+  void testProcessTaskSetOwnerCreateNewAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -5206,7 +5206,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskSetOwnerUpdateAuthorization() {
+  void testProcessTaskSetOwnerUpdateAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -5233,7 +5233,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryProcessTaskSetOwner() {
+  void testQueryProcessTaskSetOwner() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -5259,7 +5259,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // set owner -> should not create an authorization  (case task) /////////////////////////////////
 
   @Test
-  public void testCaseTaskSetOwnerNoAuthorization() {
+  void testCaseTaskSetOwnerNoAuthorization() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -5282,7 +5282,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add candidate user -> an authorization is available (standalone task) /////////////////
 
   @Test
-  public void testStandaloneTaskAddCandidateUserCreateNewAuthorization() {
+  void testStandaloneTaskAddCandidateUserCreateNewAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -5309,7 +5309,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskAddCandidateUserUpdateAuthorization() {
+  void testStandaloneTaskAddCandidateUserUpdateAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -5338,7 +5338,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryStandaloneTaskAddCandidateUser() {
+  void testQueryStandaloneTaskAddCandidateUser() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -5364,7 +5364,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryStandaloneTaskAddCandidateUserWithTaskAssignPermission() {
+  void testQueryStandaloneTaskAddCandidateUserWithTaskAssignPermission() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -5392,7 +5392,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add candidate user -> an authorization is available (process task) ////////////////////
 
   @Test
-  public void testProcessTaskAddCandidateUserCreateNewAuthorization() {
+  void testProcessTaskAddCandidateUserCreateNewAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -5417,7 +5417,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateUserUpdateAuthorization() {
+  void testProcessTaskAddCandidateUserUpdateAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -5444,7 +5444,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryProcessTaskAddCandidateUser() {
+  void testQueryProcessTaskAddCandidateUser() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -5468,7 +5468,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskCandidateUsers() {
+  void testProcessTaskCandidateUsers() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, CANDIDATE_USERS_PROCESS_KEY, userId, CREATE_INSTANCE);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
@@ -5529,7 +5529,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add candidate user -> should not create an authorization  (case task) /////////////////////////////////
 
   @Test
-  public void testCaseTaskAddCandidateUserNoAuthorization() {
+  void testCaseTaskAddCandidateUserNoAuthorization() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -5552,7 +5552,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add candidate group -> an authorization is available (standalone task) /////////////////
 
   @Test
-  public void testStandaloneTaskAddCandidateGroupCreateNewAuthorization() {
+  void testStandaloneTaskAddCandidateGroupCreateNewAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -5579,7 +5579,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskAddCandidateGroupUpdateAuthorization() {
+  void testStandaloneTaskAddCandidateGroupUpdateAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -5608,7 +5608,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryStandaloneTaskAddCandidateGroup() {
+  void testQueryStandaloneTaskAddCandidateGroup() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -5636,7 +5636,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add candidate group -> an authorization is available (process task) ////////////////////
 
   @Test
-  public void testProcessTaskAddCandidateGroupCreateNewAuthorization() {
+  void testProcessTaskAddCandidateGroupCreateNewAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -5661,7 +5661,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskAddCandidateGroupUpdateAuthorization() {
+  void testProcessTaskAddCandidateGroupUpdateAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -5688,7 +5688,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryProcessTaskAddCandidateGroup() {
+  void testQueryProcessTaskAddCandidateGroup() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -5712,7 +5712,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskCandidateGroups() {
+  void testProcessTaskCandidateGroups() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, CANDIDATE_GROUPS_PROCESS_KEY, userId, CREATE_INSTANCE);
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
@@ -5772,7 +5772,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // add candidate group -> should not create an authorization (case task) /////////////////////////////////
 
   @Test
-  public void testCaseTaskAddCandidateGroupNoAuthorization() {
+  void testCaseTaskAddCandidateGroupNoAuthorization() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -5795,7 +5795,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // TaskService#getVariable() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskGetVariable() {
+  void testCaseTaskGetVariable() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY, getVariables());
     String taskId = selectSingleTask().getId();
@@ -5810,7 +5810,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // TaskService#getVariableLocal() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskGetVariableLocal() {
+  void testCaseTaskGetVariableLocal() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY, getVariables());
     String taskId = selectSingleTask().getId();
@@ -5829,7 +5829,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // TaskService#getVariableTyped() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskGetVariableTyped() {
+  void testCaseTaskGetVariableTyped() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY, getVariables());
     String taskId = selectSingleTask().getId();
@@ -5845,7 +5845,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // TaskService#getVariableLocalTyped() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskGetVariableLocalTyped() {
+  void testCaseTaskGetVariableLocalTyped() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY, getVariables());
     String taskId = selectSingleTask().getId();
@@ -5865,7 +5865,7 @@ public class TaskAuthorizationTest extends AuthorizationTest {
   // TaskService#getVariables() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskGetVariables() {
+  void testCaseTaskGetVariables() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY, getVariables());
     String taskId = selectSingleTask().getId();
@@ -5879,7 +5879,7 @@ verifyGetVariables(variables);  }
   // TaskService#getVariablesLocal() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskGetVariablesLocal() {
+  void testCaseTaskGetVariablesLocal() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -5897,7 +5897,7 @@ verifyGetVariables(variables);  }
   // TaskService#getVariablesTyped() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskGetVariablesTyped() {
+  void testCaseTaskGetVariablesTyped() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY, getVariables());
     String taskId = selectSingleTask().getId();
@@ -5911,7 +5911,7 @@ verifyGetVariables(variables);  }
   // TaskService#getVariablesLocalTyped() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskGetVariablesLocalTyped() {
+  void testCaseTaskGetVariablesLocalTyped() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -5929,7 +5929,7 @@ verifyGetVariables(variables);  }
   // TaskService#getVariables() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskGetVariablesByName() {
+  void testCaseTaskGetVariablesByName() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY, getVariables());
     String taskId = selectSingleTask().getId();
@@ -5943,7 +5943,7 @@ verifyGetVariables(variables);  }
   // TaskService#getVariablesLocal() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskGetVariablesLocalByName() {
+  void testCaseTaskGetVariablesLocalByName() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -5961,7 +5961,7 @@ verifyGetVariables(variables);  }
   // TaskService#getVariables() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskGetVariablesTypedByName() {
+  void testCaseTaskGetVariablesTypedByName() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY, getVariables());
     String taskId = selectSingleTask().getId();
@@ -5975,7 +5975,7 @@ verifyGetVariables(variables);  }
   // TaskService#getVariablesLocal() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskGetVariablesLocalTypedByName() {
+  void testCaseTaskGetVariablesLocalTypedByName() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -5993,7 +5993,7 @@ verifyGetVariables(variables);  }
   // TaskService#setVariable() (case task) /////////////////////////////////////
 
   @Test
-  public void testCaseTaskSetVariable() {
+  void testCaseTaskSetVariable() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -6004,7 +6004,7 @@ verifyGetVariables(variables);  }
   // TaskService#setVariableLocal() (case task) /////////////////////////////////////
 
   @Test
-  public void testCaseTaskSetVariableLocal() {
+  void testCaseTaskSetVariableLocal() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -6015,7 +6015,7 @@ verifyGetVariables(variables);  }
   // TaskService#setVariables() (case task) /////////////////////////////////////
 
   @Test
-  public void testCaseTaskSetVariables() {
+  void testCaseTaskSetVariables() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -6026,7 +6026,7 @@ verifyGetVariables(variables);  }
   // TaskService#setVariablesLocal() (case task) /////////////////////////////////////
 
   @Test
-  public void testCaseTaskSetVariablesLocal() {
+  void testCaseTaskSetVariablesLocal() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -6037,7 +6037,7 @@ verifyGetVariables(variables);  }
   // TaskService#removeVariable() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskRemoveVariable() {
+  void testCaseTaskRemoveVariable() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY, getVariables());
     String taskId = selectSingleTask().getId();
@@ -6048,7 +6048,7 @@ verifyGetVariables(variables);  }
   // TaskService#removeVariableLocal() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskRemoveVariableLocal() {
+  void testCaseTaskRemoveVariableLocal() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -6063,7 +6063,7 @@ verifyGetVariables(variables);  }
   // TaskService#removeVariables() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskRemoveVariables() {
+  void testCaseTaskRemoveVariables() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY, getVariables());
     String taskId = selectSingleTask().getId();
@@ -6074,7 +6074,7 @@ verifyGetVariables(variables);  }
   // TaskService#removeVariablesLocal() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskRemoveVariablesLocal() {
+  void testCaseTaskRemoveVariablesLocal() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -6089,7 +6089,7 @@ verifyGetVariables(variables);  }
   // TaskServiceImpl#updateVariablesLocal() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskUpdateVariablesLocal() {
+  void testCaseTaskUpdateVariablesLocal() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -6100,7 +6100,7 @@ verifyGetVariables(variables);  }
   // TaskServiceImpl#updateVariablesLocal() (case task) ////////////////////////////////////////////
 
   @Test
-  public void testCaseTaskUpdateVariables() {
+  void testCaseTaskUpdateVariables() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -6109,7 +6109,7 @@ verifyGetVariables(variables);  }
   }
 
   @Test
-  public void testStandaloneTaskSaveWithGenericResourceIdOwner() {
+  void testStandaloneTaskSaveWithGenericResourceIdOwner() {
     createGrantAuthorization(TASK, ANY, userId, CREATE);
 
     Task task = taskService.newTask();
@@ -6124,7 +6124,7 @@ verifyGetVariables(variables);  }
   }
 
   @Test
-  public void testStandaloneTaskSaveWithGenericResourceIdOwnerTaskServiceApi() {
+  void testStandaloneTaskSaveWithGenericResourceIdOwnerTaskServiceApi() {
     createGrantAuthorization(TASK, ANY, userId, CREATE, UPDATE);
 
     Task task = taskService.newTask();
@@ -6141,7 +6141,7 @@ verifyGetVariables(variables);  }
   }
 
   @Test
-  public void testStandaloneTaskSaveWithGenericResourceIdAssignee() {
+  void testStandaloneTaskSaveWithGenericResourceIdAssignee() {
     createGrantAuthorization(TASK, ANY, userId, CREATE);
 
     Task task = taskService.newTask();
@@ -6156,7 +6156,7 @@ verifyGetVariables(variables);  }
   }
 
   @Test
-  public void testStandaloneTaskSaveWithGenericResourceIdAssigneeTaskServiceApi() {
+  void testStandaloneTaskSaveWithGenericResourceIdAssigneeTaskServiceApi() {
     createGrantAuthorization(TASK, ANY, userId, CREATE, UPDATE);
 
     Task task = taskService.newTask();
@@ -6173,7 +6173,7 @@ verifyGetVariables(variables);  }
   }
 
   @Test
-  public void testStandaloneTaskSaveIdentityLinkWithGenericUserId() {
+  void testStandaloneTaskSaveIdentityLinkWithGenericUserId() {
     // given
     createGrantAuthorization(TASK, ANY, userId, CREATE, UPDATE);
 
@@ -6191,7 +6191,7 @@ verifyGetVariables(variables);  }
   }
 
   @Test
-  public void testStandaloneTaskSaveIdentityLinkWithGenericGroupId() {
+  void testStandaloneTaskSaveIdentityLinkWithGenericGroupId() {
     // given
     createGrantAuthorization(TASK, ANY, userId, CREATE, UPDATE);
 
@@ -6209,7 +6209,7 @@ verifyGetVariables(variables);  }
   }
 
   @Test
-  public void testStandaloneTaskSaveIdentityLinkWithGenericGroupIdAndTaskAssignPermission() {
+  void testStandaloneTaskSaveIdentityLinkWithGenericGroupIdAndTaskAssignPermission() {
     // given
     createGrantAuthorization(TASK, ANY, userId, CREATE, TASK_ASSIGN);
 
@@ -6227,7 +6227,7 @@ verifyGetVariables(variables);  }
   }
 
   @Test
-  public void testStandaloneTaskSaveIdentityLinkWithGenericTaskId() {
+  void testStandaloneTaskSaveIdentityLinkWithGenericTaskId() {
     createGrantAuthorization(TASK, ANY, userId, CREATE, UPDATE);
 
     Task task = taskService.newTask();
@@ -6249,7 +6249,7 @@ verifyGetVariables(variables);  }
   }
 
   @Test
-  public void testStandaloneTaskSaveIdentityLinkWithGenericTaskIdAndTaskAssignPermission() {
+  void testStandaloneTaskSaveIdentityLinkWithGenericTaskIdAndTaskAssignPermission() {
     createGrantAuthorization(TASK, ANY, userId, CREATE, TASK_ASSIGN);
 
     Task task = taskService.newTask();
@@ -6272,7 +6272,7 @@ verifyGetVariables(variables);  }
 
   @Deployment
   @Test
-  public void testSetGenericResourceIdAssignee() {
+  void testSetGenericResourceIdAssignee() {
     // given
     createGrantAuthorization(Resources.PROCESS_DEFINITION, Authorization.ANY, userId, CREATE_INSTANCE);
     createGrantAuthorization(Resources.PROCESS_INSTANCE, Authorization.ANY, userId, CREATE);
@@ -6285,7 +6285,7 @@ verifyGetVariables(variables);  }
   }
 
   @Test
-  public void testAssignSameAssigneeAndOwnerToTask() {
+  void testAssignSameAssigneeAndOwnerToTask() {
     // given
     createGrantAuthorization(Resources.TASK, Authorization.ANY, userId, Permissions.ALL);
 
@@ -6304,7 +6304,7 @@ verifyGetVariables(variables);  }
   }
 
   @Test
-  public void testPermissionsOnAssignSameAssigneeAndOwnerToTask() {
+  void testPermissionsOnAssignSameAssigneeAndOwnerToTask() {
 
     try {
       // given
@@ -6332,7 +6332,7 @@ verifyGetVariables(variables);  }
 
   @Deployment
   @Test
-  public void testAssignSameAssigneeAndOwnerToProcess() {
+  void testAssignSameAssigneeAndOwnerToProcess() {
     //given
     createGrantAuthorization(Resources.PROCESS_DEFINITION, Authorization.ANY, userId, Permissions.ALL);
     createGrantAuthorization(Resources.PROCESS_INSTANCE, Authorization.ANY, userId, Permissions.ALL);
@@ -6347,7 +6347,7 @@ verifyGetVariables(variables);  }
 
   @Deployment
   @Test
-  public void testAssignSameUserToProcessTwice() {
+  void testAssignSameUserToProcessTwice() {
     //given
     createGrantAuthorization(Resources.PROCESS_DEFINITION, Authorization.ANY, userId, Permissions.ALL);
     createGrantAuthorization(Resources.PROCESS_INSTANCE, Authorization.ANY, userId, Permissions.ALL);
@@ -6362,7 +6362,7 @@ verifyGetVariables(variables);  }
 
   @Deployment
   @Test
-  public void testAssignSameGroupToProcessTwice() {
+  void testAssignSameGroupToProcessTwice() {
     //given
     createGrantAuthorization(Resources.PROCESS_DEFINITION, Authorization.ANY, userId, Permissions.ALL);
     createGrantAuthorization(Resources.PROCESS_INSTANCE, Authorization.ANY, userId, Permissions.ALL);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskCommentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskCommentAuthorizationTest.java
@@ -16,19 +16,20 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
-import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
-import static org.operaton.bpm.engine.authorization.Resources.TASK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
+import static org.operaton.bpm.engine.authorization.Resources.TASK;
 
 import java.util.Collections;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Comment;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-import org.junit.Test;
 
 public class TaskCommentAuthorizationTest extends AuthorizationTest {
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskCommentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskCommentAuthorizationTest.java
@@ -31,12 +31,12 @@ import org.operaton.bpm.engine.task.Comment;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
 
-public class TaskCommentAuthorizationTest extends AuthorizationTest {
+class TaskCommentAuthorizationTest extends AuthorizationTest {
 
   protected static final String PROCESS_KEY = "oneTaskProcess";
 
   @Test
-  public void testDeleteTaskCommentWithoutAuthorization() {
+  void testDeleteTaskCommentWithoutAuthorization() {
     // given
     createTask(TASK_ID);
     Comment createdComment = createComment(TASK_ID, null, "aComment");
@@ -58,7 +58,7 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteTaskComment() {
+  void testDeleteTaskComment() {
     // given
     createTask(TASK_ID);
     Comment createdComment = taskService.createComment(TASK_ID, null, "aComment");
@@ -76,7 +76,7 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteTaskCommentsWithoutAuthorization() {
+  void testDeleteTaskCommentsWithoutAuthorization() {
     // given
     createTask(TASK_ID);
     createComment(TASK_ID, null, "aComment");
@@ -97,7 +97,7 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteTaskComments() {
+  void testDeleteTaskComments() {
     // given
     createTask(TASK_ID);
     taskService.createComment(TASK_ID, null, "aCommentOne");
@@ -117,7 +117,7 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateTaskCommentWithoutAuthorization() {
+  void testUpdateTaskCommentWithoutAuthorization() {
     // given
     createTask(TASK_ID);
     Comment createdComment = createComment(TASK_ID, null, "originalComment");
@@ -139,7 +139,7 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateTaskComment() {
+  void testUpdateTaskComment() {
     // given
     createTask(TASK_ID);
     String commentMessage = "OriginalCommentMessage";
@@ -161,7 +161,7 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
 
   @Test
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
-  public void testDeleteProcessTaskCommentWithoutAuthorization() {
+  void testDeleteProcessTaskCommentWithoutAuthorization() {
     // given
     ProcessInstance processInstance = startProcessInstanceByKey(PROCESS_KEY);
     var taskId = selectSingleTask().getId();
@@ -181,7 +181,7 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
 
   @Test
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
-  public void testDeleteProcessTaskComment() {
+  void testDeleteProcessTaskComment() {
     // given
     ProcessInstance processInstance = startProcessInstanceByKey(PROCESS_KEY);
     Task task = selectSingleTask();
@@ -199,7 +199,7 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
 
   @Test
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
-  public void testDeleteProcessTaskCommentsWithoutAuthorization() {
+  void testDeleteProcessTaskCommentsWithoutAuthorization() {
     // given
     ProcessInstance processInstance = startProcessInstanceByKey(PROCESS_KEY);
     Task task = selectSingleTask();
@@ -220,7 +220,7 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
 
   @Test
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
-  public void testDeleteProcessTaskComments() {
+  void testDeleteProcessTaskComments() {
     // given
     ProcessInstance processInstance = startProcessInstanceByKey(PROCESS_KEY);
     Task task = selectSingleTask();
@@ -239,7 +239,7 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
 
   @Test
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
-  public void testUpdateProcessTaskCommentWithoutAuthorization() {
+  void testUpdateProcessTaskCommentWithoutAuthorization() {
     // given
     ProcessInstance processInstance = startProcessInstanceByKey(PROCESS_KEY);
     var taskId = selectSingleTask().getId();
@@ -259,7 +259,7 @@ public class TaskCommentAuthorizationTest extends AuthorizationTest {
 
   @Test
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")
-  public void testUpdateProcessTaskComment() {
+  void testUpdateProcessTaskComment() {
     // given
     ProcessInstance processInstance = startProcessInstanceByKey(PROCESS_KEY);
     Task task = selectSingleTask();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/VariableInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/VariableInstanceAuthorizationTest.java
@@ -28,11 +28,12 @@ import static org.operaton.bpm.engine.authorization.TaskPermissions.READ_VARIABL
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.runtime.VariableInstance;
 import org.operaton.bpm.engine.runtime.VariableInstanceQuery;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -47,7 +48,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   protected boolean ensureSpecificVariablePermission;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     deploymentId = testRule.deploy(
         "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml",
@@ -57,7 +58,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     deleteDeployment(deploymentId);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/VariableInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/VariableInstanceAuthorizationTest.java
@@ -66,7 +66,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessVariableQueryWithoutAuthorization() {
+  void testProcessVariableQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
 
@@ -78,7 +78,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCaseVariableQueryWithoutAuthorization () {
+  void testCaseVariableQueryWithoutAuthorization() {
     // given
     createCaseInstanceByKey(CASE_KEY, getVariables());
 
@@ -90,7 +90,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessLocalTaskVariableQueryWithoutAuthorization () {
+  void testProcessLocalTaskVariableQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -104,7 +104,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCaseLocalTaskVariableQueryWithoutAuthorization () {
+  void testCaseLocalTaskVariableQueryWithoutAuthorization() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -118,7 +118,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskVariableQueryWithoutAuthorization() {
+  void testStandaloneTaskVariableQueryWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -134,7 +134,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessVariableQueryWithReadPermissionOnProcessInstance() {
+  void testProcessVariableQueryWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, READ);
@@ -151,7 +151,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessVariableQueryWithReadInstancesPermissionOnOneTaskProcess() {
+  void testProcessVariableQueryWithReadInstancesPermissionOnOneTaskProcess() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -168,7 +168,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessVariableQueryWithReadInstanceVariablePermission() {
+  void testProcessVariableQueryWithReadInstanceVariablePermission() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -200,7 +200,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessVariableQueryWithReadProcessInstanceWhenReadVariableIsEnabled() {
+  void testProcessVariableQueryWithReadProcessInstanceWhenReadVariableIsEnabled() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -214,7 +214,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessVariableQueryWithReadTaskWhenReadVariableIsEnabled() {
+  void testProcessVariableQueryWithReadTaskWhenReadVariableIsEnabled() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
@@ -228,7 +228,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessLocalTaskVariableQueryWithReadPermissionOnTask() {
+  void testProcessLocalTaskVariableQueryWithReadPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -243,9 +243,8 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
 
-
   @Test
-  public void testProcessLocalTaskVariableQueryWithMultiple() {
+  void testProcessLocalTaskVariableQueryWithMultiple() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -261,7 +260,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessLocalTaskVariableQueryWithReadPermissionOnProcessInstance() {
+  void testProcessLocalTaskVariableQueryWithReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     String taskId = selectSingleTask().getId();
@@ -280,7 +279,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessLocalTaskVariableQueryWithReadPermissionOnOneProcessTask() {
+  void testProcessLocalTaskVariableQueryWithReadPermissionOnOneProcessTask() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     String taskId = selectSingleTask().getId();
@@ -299,7 +298,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessLocalTaskVariableQueryWithReadInstanceVariablePermission() {
+  void testProcessLocalTaskVariableQueryWithReadInstanceVariablePermission() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
@@ -319,7 +318,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessLocalTaskVariableQueryWithReadVariablePermission() {
+  void testProcessLocalTaskVariableQueryWithReadVariablePermission() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
@@ -339,7 +338,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessLocalTaskVariableQueryWithReadProcessInstanceWhenReadVariableIsEnabled() {
+  void testProcessLocalTaskVariableQueryWithReadProcessInstanceWhenReadVariableIsEnabled() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
@@ -355,7 +354,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessLocalTaskVariableQueryWithReadTaskWhenReadVariableIsEnabled() {
+  void testProcessLocalTaskVariableQueryWithReadTaskWhenReadVariableIsEnabled() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     startProcessInstanceByKey(PROCESS_KEY);
@@ -371,7 +370,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskVariableQueryWithReadPermissionOnTask() {
+  void testStandaloneTaskVariableQueryWithReadPermissionOnTask() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -388,7 +387,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskVariableQueryWithReadVariablePermissionOnTask() {
+  void testStandaloneTaskVariableQueryWithReadVariablePermissionOnTask() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String taskId = "myTask";
@@ -406,7 +405,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testMixedVariables() {
+  void testMixedVariables() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -438,7 +437,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testMixedVariablesWhenReadVariableIsEnabled() {
+  void testMixedVariablesWhenReadVariableIsEnabled() {
     // given
     setReadVariableAsDefaultReadVariablePermission();
     String taskId = "myTask";
@@ -474,7 +473,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
    * CAM-10864: Tests that the query itself works if authorization is used and a value matcher
    */
   @Test
-  public void testQueryWithVariableValueFilter() {
+  void testQueryWithVariableValueFilter() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_INSTANCE);
@@ -492,7 +491,7 @@ public class VariableInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindProcessVariableWithRevokedReadPermissionOnProcessInstance() {
+  void shouldNotFindProcessVariableWithRevokedReadPermissionOnProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, ANY, ALL);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/dmn/DecisionDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/dmn/DecisionDefinitionAuthorizationTest.java
@@ -36,7 +36,7 @@ import org.operaton.bpm.model.dmn.DmnModelInstance;
 /**
  * @author Philipp Ossler
  */
-public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
+class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
 
   protected static final String PROCESS_KEY = "testProcess";
   protected static final String DECISION_DEFINITION_KEY = "sampleDecision";
@@ -51,7 +51,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given user is not authorized to read any decision definition
 
     // when
@@ -62,7 +62,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnAnyDecisionDefinition() {
+  void testQueryWithReadPermissionOnAnyDecisionDefinition() {
     // given user gets read permission on any decision definition
     createGrantAuthorization(DECISION_DEFINITION, ANY, userId, READ);
 
@@ -74,7 +74,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadPermissionOnOneDecisionDefinition() {
+  void testQueryWithReadPermissionOnOneDecisionDefinition() {
     // given user gets read permission on the decision definition
     createGrantAuthorization(DECISION_DEFINITION, DECISION_DEFINITION_KEY, userId, READ);
 
@@ -90,7 +90,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithMultiple() {
+  void testQueryWithMultiple() {
     createGrantAuthorization(DECISION_DEFINITION, DECISION_DEFINITION_KEY, userId, READ);
     createGrantAuthorization(DECISION_DEFINITION, ANY, userId, READ);
 
@@ -102,7 +102,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindDefinitionWithRevokedReadPermissionOnDefinition() {
+  void shouldNotFindDefinitionWithRevokedReadPermissionOnDefinition() {
     createGrantAuthorization(DECISION_DEFINITION, ANY, ANY, READ);
     createRevokeAuthorization(DECISION_DEFINITION, ANY, userId, READ);
 
@@ -114,7 +114,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetDecisionDefinitionWithoutAuthorizations() {
+  void testGetDecisionDefinitionWithoutAuthorizations() {
     // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
 
@@ -134,7 +134,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetDecisionDefinition() {
+  void testGetDecisionDefinition() {
     // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
     createGrantAuthorization(DECISION_DEFINITION, DECISION_DEFINITION_KEY, userId, READ);
@@ -147,7 +147,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetDecisionDiagramWithoutAuthorizations() {
+  void testGetDecisionDiagramWithoutAuthorizations() {
     // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
 
@@ -167,7 +167,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetDecisionDiagram() {
+  void testGetDecisionDiagram() {
     // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
     createGrantAuthorization(DECISION_DEFINITION, DECISION_DEFINITION_KEY, userId, READ);
@@ -181,7 +181,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetDecisionModelWithoutAuthorizations() {
+  void testGetDecisionModelWithoutAuthorizations() {
     // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
 
@@ -201,7 +201,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetDecisionModel() {
+  void testGetDecisionModel() {
     // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
     createGrantAuthorization(DECISION_DEFINITION, DECISION_DEFINITION_KEY, userId, READ);
@@ -214,7 +214,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetDmnModelInstanceWithoutAuthorizations() {
+  void testGetDmnModelInstanceWithoutAuthorizations() {
     // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
 
@@ -234,7 +234,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetDmnModelInstance() {
+  void testGetDmnModelInstance() {
     // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
     createGrantAuthorization(DECISION_DEFINITION, DECISION_DEFINITION_KEY, userId, READ);
@@ -247,7 +247,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDecisionDefinitionUpdateTimeToLive() {
+  void testDecisionDefinitionUpdateTimeToLive() {
     //given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
     createGrantAuthorization(DECISION_DEFINITION, DECISION_DEFINITION_KEY, userId, UPDATE);
@@ -261,7 +261,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDecisionDefinitionUpdateTimeToLiveWithoutAuthorizations() {
+  void testDecisionDefinitionUpdateTimeToLiveWithoutAuthorizations() {
     //given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
     try {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/dmn/DecisionDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/dmn/DecisionDefinitionAuthorizationTest.java
@@ -24,13 +24,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.io.InputStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.repository.DecisionDefinition;
 import org.operaton.bpm.engine.repository.DecisionDefinitionQuery;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
 import org.operaton.bpm.model.dmn.DmnModelInstance;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Philipp Ossler
@@ -41,7 +42,7 @@ public class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   protected static final String DECISION_DEFINITION_KEY = "sampleDecision";
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     testRule.deploy(
         "org/operaton/bpm/engine/test/api/authorization/singleDecision.dmn11.xml",

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/ExternalTaskQueryAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/ExternalTaskQueryAuthorizationTest.java
@@ -63,7 +63,7 @@ public class ExternalTaskQueryAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // when
     ExternalTaskQuery query = externalTaskService.createExternalTaskQuery();
 
@@ -72,7 +72,7 @@ public class ExternalTaskQueryAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadOnProcessInstance() {
+  void testQueryWithReadOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, instance1Id, userId, READ);
 
@@ -85,7 +85,7 @@ public class ExternalTaskQueryAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadOnAnyProcessInstance() {
+  void testQueryWithReadOnAnyProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
 
@@ -97,7 +97,7 @@ public class ExternalTaskQueryAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstanceOnProcessDefinition() {
+  void testQueryWithReadInstanceOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, "oneExternalTaskProcess", userId, READ_INSTANCE);
 
@@ -110,7 +110,7 @@ public class ExternalTaskQueryAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstanceOnAnyProcessDefinition() {
+  void testQueryWithReadInstanceOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
 
@@ -122,7 +122,7 @@ public class ExternalTaskQueryAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadInstanceWithMultiple() {
+  void testQueryWithReadInstanceWithMultiple() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
     createGrantAuthorization(PROCESS_DEFINITION, "oneExternalTaskProcess", userId, READ_INSTANCE);
@@ -136,7 +136,7 @@ public class ExternalTaskQueryAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindTaskWithRevokedReadOnProcessInstance() {
+  void shouldNotFindTaskWithRevokedReadOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
     createRevokeAuthorization(PROCESS_INSTANCE, instance1Id, userId, READ);
@@ -149,7 +149,7 @@ public class ExternalTaskQueryAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldFetchAndLockWhenUserAuthorized() {
+  void shouldFetchAndLockWhenUserAuthorized() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, ALL);
 
@@ -165,7 +165,7 @@ public class ExternalTaskQueryAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldFetchAndLockWhenGroupAuthorized() {
+  void shouldFetchAndLockWhenGroupAuthorized() {
     // given
     createGrantAuthorizationGroup(PROCESS_DEFINITION, ANY, groupId, ALL);
 
@@ -181,7 +181,7 @@ public class ExternalTaskQueryAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFetchAndLockWhenUnauthorized() {
+  void shouldNotFetchAndLockWhenUnauthorized() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
     createGrantAuthorizationGroup(PROCESS_DEFINITION, ANY, groupId, READ_INSTANCE);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/ExternalTaskQueryAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/ExternalTaskQueryAuthorizationTest.java
@@ -25,13 +25,15 @@ import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 
 import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.operaton.bpm.engine.externaltask.ExternalTaskQuery;
 import org.operaton.bpm.engine.externaltask.LockedExternalTask;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineLoggingExtension;
 import org.operaton.commons.testing.ProcessEngineLoggingRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
 
 /**
  * @author Thorben Lindhauer
@@ -45,11 +47,11 @@ public class ExternalTaskQueryAuthorizationTest extends AuthorizationTest {
   protected String instance1Id;
   protected String instance2Id;
 
-  @Rule
-  public ProcessEngineLoggingRule loggingRule = new ProcessEngineLoggingRule();
+  @RegisterExtension
+  public ProcessEngineLoggingExtension loggingRule = new ProcessEngineLoggingExtension();
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     deploymentId = testRule.deploy(
         "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml",

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/ExternalTaskQueryAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/ExternalTaskQueryAuthorizationTest.java
@@ -16,16 +16,6 @@
  */
 package org.operaton.bpm.engine.test.api.authorization.externaltask;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.authorization.Authorization.ANY;
-import static org.operaton.bpm.engine.authorization.Permissions.ALL;
-import static org.operaton.bpm.engine.authorization.Permissions.READ;
-import static org.operaton.bpm.engine.authorization.Permissions.READ_INSTANCE;
-import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
-import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
-
-import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -33,7 +23,16 @@ import org.operaton.bpm.engine.externaltask.ExternalTaskQuery;
 import org.operaton.bpm.engine.externaltask.LockedExternalTask;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineLoggingExtension;
-import org.operaton.commons.testing.ProcessEngineLoggingRule;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.engine.authorization.Authorization.ANY;
+import static org.operaton.bpm.engine.authorization.Permissions.ALL;
+import static org.operaton.bpm.engine.authorization.Permissions.READ;
+import static org.operaton.bpm.engine.authorization.Permissions.READ_INSTANCE;
+import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
+import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 
 /**
  * @author Thorben Lindhauer

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/FetchExternalTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/FetchExternalTaskAuthorizationTest.java
@@ -64,7 +64,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testFetchWithoutAuthorization() {
+  void testFetchWithoutAuthorization() {
     // when
     List<LockedExternalTask> tasks = externalTaskService.fetchAndLock(5, WORKER_ID)
       .topic("externalTaskTopic", LOCK_TIME)
@@ -75,7 +75,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testFetchWithReadOnProcessInstance() {
+  void testFetchWithReadOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, instance1Id, userId, READ);
 
@@ -89,7 +89,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testFetchWithUpdateOnProcessInstance() {
+  void testFetchWithUpdateOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, instance1Id, userId, READ);
 
@@ -103,7 +103,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testFetchWithReadAndUpdateOnProcessInstance() {
+  void testFetchWithReadAndUpdateOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, instance1Id, userId, READ, UPDATE);
 
@@ -118,7 +118,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testFetchWithReadInstanceOnProcessDefinition() {
+  void testFetchWithReadInstanceOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, "oneExternalTaskProcess", userId, READ_INSTANCE);
 
@@ -132,7 +132,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testFetchWithUpdateInstanceOnProcessDefinition() {
+  void testFetchWithUpdateInstanceOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, "oneExternalTaskProcess", userId, UPDATE_INSTANCE);
 
@@ -146,7 +146,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testFetchWithReadAndUpdateInstanceOnProcessDefinition() {
+  void testFetchWithReadAndUpdateInstanceOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, "oneExternalTaskProcess", userId, READ_INSTANCE, UPDATE_INSTANCE);
 
@@ -161,7 +161,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testFetchWithReadOnProcessInstanceAndUpdateInstanceOnProcessDefinition() {
+  void testFetchWithReadOnProcessInstanceAndUpdateInstanceOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, instance1Id, userId, READ);
     createGrantAuthorization(PROCESS_DEFINITION, "oneExternalTaskProcess", userId, UPDATE_INSTANCE);
@@ -177,7 +177,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testFetchWithUpdateOnProcessInstanceAndReadInstanceOnProcessDefinition() {
+  void testFetchWithUpdateOnProcessInstanceAndReadInstanceOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, instance1Id, userId, UPDATE);
     createGrantAuthorization(PROCESS_DEFINITION, "oneExternalTaskProcess", userId, READ_INSTANCE);
@@ -193,7 +193,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testFetchWithReadAndUpdateOnAnyProcessInstance() {
+  void testFetchWithReadAndUpdateOnAnyProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ, UPDATE);
 
@@ -207,7 +207,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testFetchWithMultipleMatchingAuthorizations() {
+  void testFetchWithMultipleMatchingAuthorizations() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ, UPDATE);
     createGrantAuthorization(PROCESS_INSTANCE, instance1Id, userId, READ, UPDATE);
@@ -222,7 +222,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadAndUpdateInstanceOnAnyProcessDefinition() {
+  void testQueryWithReadAndUpdateInstanceOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE, UPDATE_INSTANCE);
 
@@ -236,7 +236,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadProcessInstanceAndUpdateInstanceOnAnyProcessDefinition() {
+  void testQueryWithReadProcessInstanceAndUpdateInstanceOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
     createGrantAuthorization(PROCESS_INSTANCE, instance1Id, userId, READ);
@@ -252,7 +252,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldLockNoTaskForProcessDefinitionWithRevokedUpdateInstancePermission() {
+  void shouldLockNoTaskForProcessDefinitionWithRevokedUpdateInstancePermission() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE, UPDATE_INSTANCE);
     createRevokeAuthorization(PROCESS_DEFINITION, "oneExternalTaskProcess", userId, UPDATE_INSTANCE);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/FetchExternalTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/FetchExternalTaskAuthorizationTest.java
@@ -16,6 +16,14 @@
  */
 package org.operaton.bpm.engine.test.api.authorization.externaltask;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.operaton.bpm.engine.externaltask.LockedExternalTask;
+import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.READ;
 import static org.operaton.bpm.engine.authorization.Permissions.READ_INSTANCE;
@@ -23,15 +31,6 @@ import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
 import static org.operaton.bpm.engine.authorization.Permissions.UPDATE_INSTANCE;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.List;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.operaton.bpm.engine.externaltask.LockedExternalTask;
-import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
 
 /**
  * @author Thorben Lindhauer
@@ -55,12 +54,6 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
     instance1Id = startProcessInstanceByKey("oneExternalTaskProcess").getId();
     instance2Id = startProcessInstanceByKey("twoExternalTaskProcess").getId();
     super.setUp();
-  }
-  
-  @Override
-  @AfterEach
-  public void tearDown() {
-    super.tearDown();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/FetchExternalTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/FetchExternalTaskAuthorizationTest.java
@@ -26,10 +26,12 @@ import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.externaltask.LockedExternalTask;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Thorben Lindhauer
@@ -44,7 +46,7 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
   protected String instance2Id;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     testRule.deploy(
         "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml",
@@ -53,6 +55,12 @@ public class FetchExternalTaskAuthorizationTest extends AuthorizationTest {
     instance1Id = startProcessInstanceByKey("oneExternalTaskProcess").getId();
     instance2Id = startProcessInstanceByKey("twoExternalTaskProcess").getId();
     super.setUp();
+  }
+  
+  @Override
+  @AfterEach
+  public void tearDown() {
+    super.tearDown();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/GetTopicNamesAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/GetTopicNamesAuthorizationTest.java
@@ -25,16 +25,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
-import org.junit.Before;
-import org.junit.Test;
 
 public class GetTopicNamesAuthorizationTest extends AuthorizationTest {
 
   protected String instance1Id;
   protected String instance2Id;
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() {
     testRule.deploy(

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/GetTopicNamesAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/GetTopicNamesAuthorizationTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
 
-public class GetTopicNamesAuthorizationTest extends AuthorizationTest {
+class GetTopicNamesAuthorizationTest extends AuthorizationTest {
 
   protected String instance1Id;
   protected String instance2Id;
@@ -47,7 +47,7 @@ public class GetTopicNamesAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetTopicNamesWithoutAuthorization() {
+  void testGetTopicNamesWithoutAuthorization() {
     // when
     List<String> result = externalTaskService.getTopicNames();
 
@@ -56,7 +56,7 @@ public class GetTopicNamesAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetTopicNamesWithReadOnProcessInstance() {
+  void testGetTopicNamesWithReadOnProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, instance1Id, userId, READ);
 
@@ -69,7 +69,7 @@ public class GetTopicNamesAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetTopicNamesWithReadOnAnyProcessInstance() {
+  void testGetTopicNamesWithReadOnAnyProcessInstance() {
     // given
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, READ);
 
@@ -81,7 +81,7 @@ public class GetTopicNamesAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetTopicNamesWithReadInstanceOnAnyProcessDefinition() {
+  void testGetTopicNamesWithReadInstanceOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
 
@@ -93,7 +93,7 @@ public class GetTopicNamesAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetTopicNamesWithReadDefinitionWithMultiple() {
+  void testGetTopicNamesWithReadDefinitionWithMultiple() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, "oneExternalTaskProcess", userId, READ_INSTANCE);
 
@@ -106,7 +106,7 @@ public class GetTopicNamesAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetTopicNamesWithReadInstanceWithMultiple() {
+  void testGetTopicNamesWithReadInstanceWithMultiple() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_INSTANCE);
     createGrantAuthorization(PROCESS_DEFINITION, "oneExternalTaskProcess", userId, READ_INSTANCE);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/AuthorizationUserOperationLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/AuthorizationUserOperationLogTest.java
@@ -47,10 +47,10 @@ import org.operaton.bpm.engine.test.api.identity.TestResource;
  *
  */
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
-public class AuthorizationUserOperationLogTest extends AuthorizationTest {
+class AuthorizationUserOperationLogTest extends AuthorizationTest {
 
   @Test
-  public void testLogCreatedOnAuthorizationCreation() {
+  void testLogCreatedOnAuthorizationCreation() {
     // given
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, CATEGORY_ADMIN, userId, READ);
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
@@ -100,7 +100,7 @@ public class AuthorizationUserOperationLogTest extends AuthorizationTest {
   }
 
   @Test
-  public void testLogCreatedOnAuthorizationUpdate() {
+  void testLogCreatedOnAuthorizationUpdate() {
     // given
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
     Authorization authorization = createGrantAuthorizationWithoutAuthentication(Resources.PROCESS_DEFINITION, Authorization.ANY, "testUserId",
@@ -170,7 +170,7 @@ public class AuthorizationUserOperationLogTest extends AuthorizationTest {
   }
 
   @Test
-  public void testLogCreatedOnAuthorizationDeletion() {
+  void testLogCreatedOnAuthorizationDeletion() {
     // given
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
     Authorization authorization = createGrantAuthorizationWithoutAuthentication(Resources.PROCESS_DEFINITION, Authorization.ANY, "testUserId",
@@ -222,7 +222,7 @@ public class AuthorizationUserOperationLogTest extends AuthorizationTest {
   }
 
   @Test
-  public void testLogCreatedOnAuthorizationCreationWithExceedingPermissionStringList() {
+  void testLogCreatedOnAuthorizationCreationWithExceedingPermissionStringList() {
     // given
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, CATEGORY_ADMIN, userId, READ);
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
@@ -245,7 +245,7 @@ public class AuthorizationUserOperationLogTest extends AuthorizationTest {
   }
 
   @Test
-  public void testLogCreatedOnAuthorizationCreationWithAllPermission() {
+  void testLogCreatedOnAuthorizationCreationWithAllPermission() {
     // given
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, CATEGORY_ADMIN, userId, READ);
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
@@ -268,7 +268,7 @@ public class AuthorizationUserOperationLogTest extends AuthorizationTest {
   }
 
   @Test
-  public void testLogCreatedOnAuthorizationCreationWithNonePermission() {
+  void testLogCreatedOnAuthorizationCreationWithNonePermission() {
     // given
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, CATEGORY_ADMIN, userId, READ);
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
@@ -291,7 +291,7 @@ public class AuthorizationUserOperationLogTest extends AuthorizationTest {
   }
 
   @Test
-  public void testLogCreatedOnAuthorizationCreationWithoutAuthorization() {
+  void testLogCreatedOnAuthorizationCreationWithoutAuthorization() {
     // given
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
     assertThat(query.count()).isZero();
@@ -304,7 +304,7 @@ public class AuthorizationUserOperationLogTest extends AuthorizationTest {
   }
 
   @Test
-  public void testLogCreatedOnAuthorizationCreationWithReadPermissionOnAnyCategoryPermission() {
+  void testLogCreatedOnAuthorizationCreationWithReadPermissionOnAnyCategoryPermission() {
     // given
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, Authorization.ANY, userId, READ);
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
@@ -321,7 +321,7 @@ public class AuthorizationUserOperationLogTest extends AuthorizationTest {
   }
 
   @Test
-  public void testLogCreatedOnAuthorizationCreationWithReadPermissionOnWrongCategory() {
+  void testLogCreatedOnAuthorizationCreationWithReadPermissionOnWrongCategory() {
     // given
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, CATEGORY_OPERATOR, userId, READ);
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/AuthorizationUserOperationLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/AuthorizationUserOperationLogTest.java
@@ -16,13 +16,14 @@
  */
 package org.operaton.bpm.engine.test.api.authorization.history;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.authorization.Resources.OPERATION_LOG_CATEGORY;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.operaton.bpm.engine.authorization.UserOperationLogCategoryPermissions.READ;
 import static org.operaton.bpm.engine.history.UserOperationLogEntry.CATEGORY_ADMIN;
 import static org.operaton.bpm.engine.history.UserOperationLogEntry.CATEGORY_OPERATOR;
-import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.EntityTypes;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.authorization.Authorization;
@@ -40,7 +41,6 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
 import org.operaton.bpm.engine.test.api.identity.TestPermissions;
 import org.operaton.bpm.engine.test.api.identity.TestResource;
-import org.junit.Test;
 
 /**
  * @author Tobias Metzke
@@ -308,6 +308,9 @@ public class AuthorizationUserOperationLogTest extends AuthorizationTest {
     // given
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, Authorization.ANY, userId, READ);
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
+    for (UserOperationLogEntry logEntry : query.list()) {
+		System.out.println(logEntry);
+	}
     assertThat(query.count()).isZero();
 
     // when

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/AuthorizationUserOperationLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/AuthorizationUserOperationLogTest.java
@@ -16,13 +16,6 @@
  */
 package org.operaton.bpm.engine.test.api.authorization.history;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.operaton.bpm.engine.authorization.Resources.OPERATION_LOG_CATEGORY;
-import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
-import static org.operaton.bpm.engine.authorization.UserOperationLogCategoryPermissions.READ;
-import static org.operaton.bpm.engine.history.UserOperationLogEntry.CATEGORY_ADMIN;
-import static org.operaton.bpm.engine.history.UserOperationLogEntry.CATEGORY_OPERATOR;
-
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.EntityTypes;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
@@ -41,6 +34,13 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
 import org.operaton.bpm.engine.test.api.identity.TestPermissions;
 import org.operaton.bpm.engine.test.api.identity.TestResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.engine.authorization.Resources.OPERATION_LOG_CATEGORY;
+import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
+import static org.operaton.bpm.engine.authorization.UserOperationLogCategoryPermissions.READ;
+import static org.operaton.bpm.engine.history.UserOperationLogEntry.CATEGORY_ADMIN;
+import static org.operaton.bpm.engine.history.UserOperationLogEntry.CATEGORY_OPERATOR;
 
 /**
  * @author Tobias Metzke
@@ -308,9 +308,6 @@ class AuthorizationUserOperationLogTest extends AuthorizationTest {
     // given
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, Authorization.ANY, userId, READ);
     UserOperationLogQuery query = historyService.createUserOperationLogQuery();
-    for (UserOperationLogEntry logEntry : query.list()) {
-		System.out.println(logEntry);
-	}
     assertThat(query.count()).isZero();
 
     // when

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricActivityInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricActivityInstanceAuthorizationTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
  *
  */
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_AUDIT)
-public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest {
+class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest {
 
   protected static final String PROCESS_KEY = "oneTaskProcess";
   protected static final String MESSAGE_START_PROCESS_KEY = "messageStartProcess";
@@ -68,7 +68,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   // historic activity instance query /////////////////////////////////
 
   @Test
-  public void testSimpleQueryWithoutAuthorization() {
+  void testSimpleQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
 
@@ -80,7 +80,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testSimpleQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testSimpleQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
@@ -93,7 +93,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testSimpleQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testSimpleQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -106,7 +106,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testSimpleQueryMultiple() {
+  void testSimpleQueryMultiple() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -120,7 +120,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void shouldNotFindInstanceWithRevokedReadHistoryPermissionOnAnyProcessDefinition() {
+  void shouldNotFindInstanceWithRevokedReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_HISTORY);
@@ -136,7 +136,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   // historic activity instance query (multiple process instances) ////////////////////////
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -155,7 +155,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -176,7 +176,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -199,7 +199,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   // delete deployment (cascade = false)
 
   @Test
-  public void testQueryAfterDeletingDeployment() {
+  void testQueryAfterDeletingDeployment() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -232,7 +232,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricProcessInstance() {
+  void testCheckNonePermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -250,7 +250,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricProcessInstance() {
+  void testCheckReadPermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -270,7 +270,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckReadPermissionOnCompletedHistoricProcessInstance() {
+  void testCheckReadPermissionOnCompletedHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -294,7 +294,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
+  void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -319,7 +319,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
+  void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -345,7 +345,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testHistoricProcessInstancePermissionsAuthorizationDisabled() {
+  void testHistoricProcessInstancePermissionsAuthorizationDisabled() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricActivityInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricActivityInstanceAuthorizationTest.java
@@ -31,9 +31,9 @@ import org.operaton.bpm.engine.history.HistoricProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Roman Smirnov
@@ -48,7 +48,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   protected String deploymentId;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     deploymentId = createDeployment(null,
         "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml",
@@ -58,7 +58,7 @@ public class HistoricActivityInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     processEngineConfiguration.setEnableHistoricInstancePermissions(false);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricActivityStatisticsAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricActivityStatisticsAuthorizationTest.java
@@ -37,7 +37,7 @@ import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
  *
  */
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_AUDIT)
-public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTest {
+class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTest {
 
   protected static final String PROCESS_KEY = "oneTaskProcess";
 
@@ -52,7 +52,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   // historic activity statistics query //////////////////////////////////
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -68,7 +68,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   }
 
   @Test
-  public void testQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -87,7 +87,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   }
 
   @Test
-  public void testQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -106,7 +106,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   }
 
   @Test
-  public void testQueryMultiple() {
+  void testQueryMultiple() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -126,7 +126,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   }
 
   @Test
-  public void shouldNotFindStatisticsWithRevokedReadHistoryPermissionOnAnyProcessDefinition() {
+  void shouldNotFindStatisticsWithRevokedReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -147,7 +147,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   // historic activity statistics query (including finished) //////////////////////////////////
 
   @Test
-  public void testQueryIncludingFinishedWithoutAuthorization() {
+  void testQueryIncludingFinishedWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -170,7 +170,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   }
 
   @Test
-  public void testQueryIncludingFinishedWithReadHistoryPermissionOnProcessDefinition() {
+  void testQueryIncludingFinishedWithReadHistoryPermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -205,7 +205,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   }
 
   @Test
-  public void testQueryIncludingFinishedWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQueryIncludingFinishedWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -242,7 +242,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   // historic activity statistics query (including canceled) //////////////////////////////////
 
   @Test
-  public void testQueryIncludingCanceledWithoutAuthorization() {
+  void testQueryIncludingCanceledWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -264,7 +264,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   }
 
   @Test
-  public void testQueryIncludingCanceledWithReadHistoryPermissionOnProcessDefinition() {
+  void testQueryIncludingCanceledWithReadHistoryPermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -292,7 +292,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   }
 
   @Test
-  public void testQueryIncludingCanceledWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQueryIncludingCanceledWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -322,7 +322,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   // historic activity statistics query (including complete scope) //////////////////////////////////
 
   @Test
-  public void testQueryIncludingCompleteScopeWithoutAuthorization() {
+  void testQueryIncludingCompleteScopeWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -345,7 +345,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   }
 
   @Test
-  public void testQueryIncludingCompleteScopeWithReadHistoryPermissionOnProcessDefinition() {
+  void testQueryIncludingCompleteScopeWithReadHistoryPermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -377,7 +377,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   }
 
   @Test
-  public void testQueryIncludingCompleteScopeWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQueryIncludingCompleteScopeWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -411,7 +411,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   // historic activity statistics query (including all) //////////////////////////////////
 
   @Test
-  public void testQueryIncludingAllWithoutAuthorization() {
+  void testQueryIncludingAllWithoutAuthorization() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -440,7 +440,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   }
 
   @Test
-  public void testQueryIncludingAllWithReadHistoryPermissionOnProcessDefinition() {
+  void testQueryIncludingAllWithReadHistoryPermissionOnProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 
@@ -481,7 +481,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   }
 
   @Test
-  public void testQueryIncludingAllWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQueryIncludingAllWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(PROCESS_KEY).getId();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricActivityStatisticsAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricActivityStatisticsAuthorizationTest.java
@@ -22,14 +22,15 @@ import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.history.HistoricActivityStatistics;
 import org.operaton.bpm.engine.history.HistoricActivityStatisticsQuery;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -41,7 +42,7 @@ public class HistoricActivityStatisticsAuthorizationTest extends AuthorizationTe
   protected static final String PROCESS_KEY = "oneTaskProcess";
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     testRule.deploy(
         "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDecisionInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDecisionInstanceAuthorizationTest.java
@@ -50,7 +50,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Philipp Ossler
  */
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
-public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest {
+class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest {
 
   protected static final String PROCESS_KEY = "testProcess";
   protected static final String DECISION_DEFINITION_KEY = "testDecision";
@@ -84,7 +84,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
     startProcessInstanceAndEvaluateDecision();
 
@@ -96,7 +96,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testQueryWithReadPermissionOnDecisionDefinition() {
+  void testQueryWithReadPermissionOnDecisionDefinition() {
     // given
     startProcessInstanceAndEvaluateDecision();
     createGrantAuthorization(DECISION_DEFINITION, DECISION_DEFINITION_KEY, userId, READ_HISTORY);
@@ -109,7 +109,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testQueryWithReadPermissionOnAnyDecisionDefinition() {
+  void testQueryWithReadPermissionOnAnyDecisionDefinition() {
     // given
     startProcessInstanceAndEvaluateDecision();
     createGrantAuthorization(DECISION_DEFINITION, ANY, userId, READ_HISTORY);
@@ -122,7 +122,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testQueryWithMultiple() {
+  void testQueryWithMultiple() {
     // given
     startProcessInstanceAndEvaluateDecision();
     createGrantAuthorization(DECISION_DEFINITION, ANY, userId, READ_HISTORY);
@@ -136,7 +136,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void shouldNotFindDecisionInstanceWithRevokedReadPermissionOnAnyDecisionDefinition() {
+  void shouldNotFindDecisionInstanceWithRevokedReadPermissionOnAnyDecisionDefinition() {
     // given
     startProcessInstanceAndEvaluateDecision();
     createGrantAuthorization(DECISION_DEFINITION, ANY, ANY, READ_HISTORY);
@@ -150,7 +150,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testDeleteHistoricDecisionInstanceWithoutAuthorization(){
+  void testDeleteHistoricDecisionInstanceWithoutAuthorization(){
     // given
     startProcessInstanceAndEvaluateDecision();
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
@@ -161,7 +161,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testDeleteHistoricDecisionInstanceWithDeleteHistoryPermissionOnDecisionDefinition() {
+  void testDeleteHistoricDecisionInstanceWithDeleteHistoryPermissionOnDecisionDefinition() {
     // given
     startProcessInstanceAndEvaluateDecision();
     createGrantAuthorization(DECISION_DEFINITION, ANY, userId, DELETE_HISTORY);
@@ -178,7 +178,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
 }
 
   @Test
-  public void testDeleteHistoricDecisionInstanceWithDeleteHistoryPermissionOnAnyDecisionDefinition() {
+  void testDeleteHistoricDecisionInstanceWithDeleteHistoryPermissionOnAnyDecisionDefinition() {
     // given
     startProcessInstanceAndEvaluateDecision();
     createGrantAuthorization(DECISION_DEFINITION, DECISION_DEFINITION_KEY, userId, DELETE_HISTORY);
@@ -194,7 +194,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testDeleteHistoricDecisionInstanceByInstanceIdWithoutAuthorization() {
+  void testDeleteHistoricDecisionInstanceByInstanceIdWithoutAuthorization() {
 
     // given
     createGrantAuthorization(DECISION_DEFINITION, DECISION_DEFINITION_KEY, userId, READ_HISTORY);
@@ -209,7 +209,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testDeleteHistoricDecisionInstanceByInstanceIdWithDeleteHistoryPermissionOnDecisionDefinition() {
+  void testDeleteHistoricDecisionInstanceByInstanceIdWithDeleteHistoryPermissionOnDecisionDefinition() {
 
     // given
     createGrantAuthorization(DECISION_DEFINITION, DECISION_DEFINITION_KEY, userId, DELETE_HISTORY, READ_HISTORY);
@@ -227,7 +227,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testHistoryCleanupReportWithoutAuthorization() {
+  void testHistoryCleanupReportWithoutAuthorization() {
     // given
     prepareDecisionInstances(DECISION_DEFINITION_KEY, -6, 5, 10);
 
@@ -239,7 +239,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testHistoryCleanupReportWithAuthorization() {
+  void testHistoryCleanupReportWithAuthorization() {
     // given
     prepareDecisionInstances(DECISION_DEFINITION_KEY, -6, 5, 10);
 
@@ -256,7 +256,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testHistoryCleanupReportWithReadPermissionOnly() {
+  void testHistoryCleanupReportWithReadPermissionOnly() {
     // given
     prepareDecisionInstances(DECISION_DEFINITION_KEY, -6, 5, 10);
 
@@ -270,7 +270,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testHistoryCleanupReportWithReadHistoryPermissionOnly() {
+  void testHistoryCleanupReportWithReadHistoryPermissionOnly() {
     // given
     prepareDecisionInstances(DECISION_DEFINITION_KEY, -6, 5, 10);
 
@@ -284,7 +284,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void shouldNotFindCleanupReportWithRevokedReadHistoryPermissionOnDecisionDefinition() {
+  void shouldNotFindCleanupReportWithRevokedReadHistoryPermissionOnDecisionDefinition() {
     // given
     prepareDecisionInstances(DECISION_DEFINITION_KEY, -6, 5, 10);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDecisionInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDecisionInstanceAuthorizationTest.java
@@ -27,6 +27,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.time.DateUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
@@ -40,9 +43,6 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
 import org.operaton.bpm.engine.test.util.ResetDmnConfigUtil;
 import org.operaton.bpm.engine.variable.Variables;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -56,7 +56,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   protected static final String DECISION_DEFINITION_KEY = "testDecision";
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     testRule.deploy("org/operaton/bpm/engine/test/history/HistoricDecisionInstanceTest.processWithBusinessRuleTask.bpmn20.xml",
         "org/operaton/bpm/engine/test/history/HistoricDecisionInstanceTest.decisionSingleOutput.dmn11.xml");
@@ -71,7 +71,7 @@ public class HistoricDecisionInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDetailAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDetailAuthorizationTest.java
@@ -24,6 +24,10 @@ import static org.operaton.bpm.engine.authorization.Resources.HISTORIC_TASK;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 
 import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.authorization.HistoricProcessInstancePermissions;
 import org.operaton.bpm.engine.authorization.HistoricTaskPermissions;
@@ -34,9 +38,6 @@ import org.operaton.bpm.engine.history.HistoricProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -52,7 +53,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   protected String deploymentId;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     deploymentId = testRule.deploy(
         "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml",
@@ -63,7 +64,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     processEngineConfiguration.setEnableHistoricInstancePermissions(false);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDetailAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDetailAuthorizationTest.java
@@ -44,7 +44,7 @@ import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
  *
  */
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
-public class HistoricDetailAuthorizationTest extends AuthorizationTest {
+class HistoricDetailAuthorizationTest extends AuthorizationTest {
 
   protected static final String PROCESS_KEY = "oneTaskProcess";
   protected static final String MESSAGE_START_PROCESS_KEY = "messageStartProcess";
@@ -74,7 +74,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   // historic variable update query (standalone task) /////////////////////////////////////////////
 
   @Test
-  public void testQueryAfterStandaloneTaskVariableUpdates() {
+  void testQueryAfterStandaloneTaskVariableUpdates() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -95,7 +95,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   // historic variable update query (process task) /////////////////////////////////////////////
 
   @Test
-  public void testSimpleVariableUpdateQueryWithoutAuthorization() {
+  void testSimpleVariableUpdateQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
 
@@ -107,7 +107,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleVariableUpdateQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testSimpleVariableUpdateQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
@@ -120,7 +120,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleVariableUpdateQueryMultiple() {
+  void testSimpleVariableUpdateQueryMultiple() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
@@ -134,7 +134,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleVariableUpdateQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testSimpleVariableUpdateQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -147,7 +147,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindDetailWithRevokedReadHistoryPermissionOnProcessDefinition() {
+  void shouldNotFindDetailWithRevokedReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -163,7 +163,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   // historic variable update query (multiple process instances) ///////////////////////////////////////////
 
   @Test
-  public void testVariableUpdateQueryWithoutAuthorization() {
+  void testVariableUpdateQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
@@ -182,7 +182,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testVariableUpdateQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testVariableUpdateQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
@@ -203,7 +203,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testVariableUpdateQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testVariableUpdateQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
@@ -226,7 +226,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   // historic variable update query (case variables) /////////////////////////////////////////////
 
   @Test
-  public void testQueryAfterCaseVariables() {
+  void testQueryAfterCaseVariables() {
     // given
     createCaseInstanceByKey(CASE_KEY, getVariables());
 
@@ -240,7 +240,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   // historic variable update query (mixed) ////////////////////////////////////
 
   @Test
-  public void testMixedQueryWithoutAuthorization() {
+  void testMixedQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
@@ -282,7 +282,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testMixedQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testMixedQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
@@ -326,7 +326,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testMixedQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testMixedQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
@@ -372,7 +372,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   // historic form field query //////////////////////////////////////////////////////
 
   @Test
-  public void testSimpleFormFieldQueryWithoutAuthorization() {
+  void testSimpleFormFieldQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -389,7 +389,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleFormFieldQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testSimpleFormFieldQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -407,7 +407,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleFormFieldQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testSimpleFormFieldQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     String taskId = selectSingleTask().getId();
@@ -427,7 +427,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   // historic variable update query (multiple process instances) ///////////////////////////////////////////
 
   @Test
-  public void testFormFieldQueryWithoutAuthorization() {
+  void testFormFieldQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
@@ -446,7 +446,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testFormFieldQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testFormFieldQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -500,7 +500,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testFormFieldQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testFormFieldQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -556,7 +556,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   // historic detail query (variable update + form field) //////////
 
   @Test
-  public void testDetailQueryWithoutAuthorization() {
+  void testDetailQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -582,7 +582,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDetailQueryWithReadHistoryOnProcessDefinition() {
+  void testDetailQueryWithReadHistoryOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -610,7 +610,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDetailQueryWithReadHistoryOnAnyProcessDefinition() {
+  void testDetailQueryWithReadHistoryOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -640,7 +640,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   // delete deployment (cascade = false)
 
   @Test
-  public void testQueryAfterDeletingDeployment() {
+  void testQueryAfterDeletingDeployment() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -686,7 +686,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricTask() {
+  void testCheckNonePermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -707,7 +707,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricTask() {
+  void testCheckReadPermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -728,7 +728,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnStandaloneHistoricTask() {
+  void testCheckReadPermissionOnStandaloneHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -752,7 +752,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNonePermissionOnStandaloneHistoricTask() {
+  void testCheckNonePermissionOnStandaloneHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -776,7 +776,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnCompletedHistoricTask() {
+  void testCheckReadPermissionOnCompletedHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -798,7 +798,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricTaskAndReadHistoryPermissionOnProcessDefinition() {
+  void testCheckNonePermissionOnHistoricTaskAndReadHistoryPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -821,7 +821,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricTaskAndNonePermissionOnProcessDefinition() {
+  void testCheckReadPermissionOnHistoricTaskAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -845,7 +845,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadVariablePermissionOnHistoricTask() {
+  void testCheckReadVariablePermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
@@ -863,7 +863,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testOnlyReadPermissionOnHistoricTask() {
+  void testOnlyReadPermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
@@ -881,7 +881,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testIgnoreReadVariablePermissionOnHistoricTask() {
+  void testIgnoreReadVariablePermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     processEngineConfiguration.setEnforceSpecificVariablePermission(false);
@@ -899,7 +899,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadVariablePermissionOnStandaloneHistoricTask() {
+  void testCheckReadVariablePermissionOnStandaloneHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
@@ -923,7 +923,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadVariablePermissionOnCompletedHistoricTask() {
+  void testCheckReadVariablePermissionOnCompletedHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
@@ -944,7 +944,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadVariablePermissionOnHistoricTaskAndNonePermissionOnProcessDefinition() {
+  void testCheckReadVariablePermissionOnHistoricTaskAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
@@ -967,7 +967,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricTaskAndReadHistoryVariablePermissionOnProcessDefinition() {
+  void testCheckNonePermissionOnHistoricTaskAndReadHistoryVariablePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
@@ -990,7 +990,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadHistoryVariablePermissionOnProcessDefinition() {
+  void testCheckReadHistoryVariablePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
 
@@ -1007,7 +1007,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testOnlyReadPermissionOnProcessDefinition() {
+  void testOnlyReadPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
 
@@ -1024,7 +1024,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testIgnoreReadHistoryVariablePermissionOnProcessDefinition() {
+  void testIgnoreReadHistoryVariablePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnforceSpecificVariablePermission(false);
 
@@ -1041,7 +1041,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricTaskPermissionsAuthorizationDisabled() {
+  void testHistoricTaskPermissionsAuthorizationDisabled() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1060,7 +1060,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricProcessInstance() {
+  void testCheckNonePermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1081,7 +1081,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricProcessInstance_GlobalVariable() {
+  void testCheckReadPermissionOnHistoricProcessInstance_GlobalVariable() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1103,7 +1103,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricProcessInstance_LocalVariable() {
+  void testCheckReadPermissionOnHistoricProcessInstance_LocalVariable() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1126,7 +1126,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnCompletedHistoricProcessInstance() {
+  void testCheckReadPermissionOnCompletedHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1150,7 +1150,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
+  void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1175,7 +1175,7 @@ public class HistoricDetailAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
+  void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricExternalTaskLogAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricExternalTaskLogAuthorizationTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
-public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest {
+class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest {
 
   protected static final String WORKER_ID = "aWorkerId";
   protected static final long LOCK_DURATION = 5 * 60L * 1000L;
@@ -67,7 +67,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testSimpleQueryWithoutAuthorization() {
+  void testSimpleQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(DEFAULT_PROCESS_KEY);
 
@@ -79,7 +79,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testSimpleQueryWithHistoryReadPermissionOnProcessDefinition() {
+  void testSimpleQueryWithHistoryReadPermissionOnProcessDefinition() {
 
     // given
     startProcessInstanceByKey(DEFAULT_PROCESS_KEY);
@@ -93,7 +93,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testSimpleQueryWithHistoryReadPermissionOnAnyProcessDefinition() {
+  void testSimpleQueryWithHistoryReadPermissionOnAnyProcessDefinition() {
 
     // given
     startProcessInstanceByKey(DEFAULT_PROCESS_KEY);
@@ -107,7 +107,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testSimpleQueryWithMultipleAuthorizations() {
+  void testSimpleQueryWithMultipleAuthorizations() {
     // given
     startProcessInstanceByKey(DEFAULT_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -121,7 +121,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
     startThreeProcessInstancesDeleteOneAndCompleteTwoWithFailure();
 
@@ -133,7 +133,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testQueryWithHistoryReadPermissionOnOneProcessDefinition() {
+  void testQueryWithHistoryReadPermissionOnOneProcessDefinition() {
     // given
     startThreeProcessInstancesDeleteOneAndCompleteTwoWithFailure();
     createGrantAuthorization(PROCESS_DEFINITION, DEFAULT_PROCESS_KEY, userId, READ_HISTORY);
@@ -146,7 +146,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testQueryWithHistoryReadPermissionOnAnyProcessDefinition() {
+  void testQueryWithHistoryReadPermissionOnAnyProcessDefinition() {
     // given
     startThreeProcessInstancesDeleteOneAndCompleteTwoWithFailure();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -159,7 +159,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void shouldNotFindLogsWithRevokedHistoryReadPermissionOnAnyProcessDefinition() {
+  void shouldNotFindLogsWithRevokedHistoryReadPermissionOnAnyProcessDefinition() {
     // given
     startThreeProcessInstancesDeleteOneAndCompleteTwoWithFailure();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_HISTORY);
@@ -173,7 +173,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testGetErrorDetailsWithoutAuthorization() {
+  void testGetErrorDetailsWithoutAuthorization() {
     // given
     startThreeProcessInstancesDeleteOneAndCompleteTwoWithFailure();
 
@@ -201,7 +201,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testGetErrorDetailsWithHistoryReadPermissionOnProcessDefinition() {
+  void testGetErrorDetailsWithHistoryReadPermissionOnProcessDefinition() {
 
     // given
     startThreeProcessInstancesDeleteOneAndCompleteTwoWithFailure();
@@ -222,7 +222,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testGetErrorDetailsWithHistoryReadPermissionOnProcessAnyDefinition() {
+  void testGetErrorDetailsWithHistoryReadPermissionOnProcessAnyDefinition() {
 
     // given
     startThreeProcessInstancesDeleteOneAndCompleteTwoWithFailure();
@@ -243,7 +243,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricProcessInstance() {
+  void testCheckNonePermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -261,7 +261,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricProcessInstance() {
+  void testCheckReadPermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -281,7 +281,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
+  void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -303,7 +303,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
+  void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -325,7 +325,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testHistoricProcessInstancePermissionsAuthorizationDisabled() {
+  void testHistoricProcessInstancePermissionsAuthorizationDisabled() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricExternalTaskLogAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricExternalTaskLogAuthorizationTest.java
@@ -38,9 +38,9 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest {
@@ -51,7 +51,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   protected static final String ANOTHER_PROCESS_KEY = "AnotherProcess";
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     BpmnModelInstance defaultModel = createDefaultExternalTaskModel().build();
     BpmnModelInstance modifiedModel = createDefaultExternalTaskModel().processKey(ANOTHER_PROCESS_KEY).build();
@@ -60,7 +60,7 @@ public class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     processEngineConfiguration.setEnableHistoricInstancePermissions(false);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricIdentityLinkLogAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricIdentityLinkLogAuthorizationTest.java
@@ -24,6 +24,10 @@ import static org.operaton.bpm.engine.authorization.Resources.HISTORIC_TASK;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 
 import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.authorization.HistoricProcessInstancePermissions;
 import org.operaton.bpm.engine.authorization.HistoricTaskPermissions;
@@ -33,9 +37,6 @@ import org.operaton.bpm.engine.history.HistoricIdentityLinkLogQuery;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest {
@@ -44,7 +45,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   protected static final String CASE_KEY = "oneTaskCase";
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     testRule.deploy( "org/operaton/bpm/engine/test/api/authorization/oneTaskProcess.bpmn20.xml",
     "org/operaton/bpm/engine/test/api/authorization/oneTaskCase.cmmn");
@@ -52,7 +53,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     processEngineConfiguration.setEnableHistoricInstancePermissions(false);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricIdentityLinkLogAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricIdentityLinkLogAuthorizationTest.java
@@ -62,7 +62,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   // historic identity link query (standalone task) - Authorization
 
   @Test
-  public void testQueryForStandaloneTaskHistoricIdentityLinkWithoutAuthorization() {
+  void testQueryForStandaloneTaskHistoricIdentityLinkWithoutAuthorization() {
     // given
     disableAuthorization();
 
@@ -84,7 +84,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testQueryForTaskHistoricIdentityLinkWithoutUserPermission() {
+  void testQueryForTaskHistoricIdentityLinkWithoutUserPermission() {
     // given
     disableAuthorization();
     startProcessInstanceByKey(ONE_PROCESS_KEY);
@@ -104,7 +104,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testQueryForTaskHistoricIdentityLinkWithUserPermission() {
+  void testQueryForTaskHistoricIdentityLinkWithUserPermission() {
     // given
     disableAuthorization();
     startProcessInstanceByKey(ONE_PROCESS_KEY);
@@ -121,7 +121,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testQueryWithMultiple() {
+  void testQueryWithMultiple() {
     // given
     disableAuthorization();
     startProcessInstanceByKey(ONE_PROCESS_KEY);
@@ -139,7 +139,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void shouldNotFindLinkWithRevokedReadHistoryPermissionOnAnyProcessDefinition() {
+  void shouldNotFindLinkWithRevokedReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     disableAuthorization();
     startProcessInstanceByKey(ONE_PROCESS_KEY);
@@ -157,7 +157,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testQueryCaseTask() {
+  void testQueryCaseTask() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -175,7 +175,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testMixedQuery() {
+  void testMixedQuery() {
 
     disableAuthorization();
     // given
@@ -224,7 +224,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricTask() {
+  void testCheckNonePermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -242,7 +242,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricTask() {
+  void testCheckReadPermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -260,7 +260,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckReadPermissionOnStandaloneHistoricTask() {
+  void testCheckReadPermissionOnStandaloneHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -285,7 +285,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckNonePermissionOnStandaloneHistoricTask() {
+  void testCheckNonePermissionOnStandaloneHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -309,7 +309,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckReadPermissionOnCompletedHistoricTask() {
+  void testCheckReadPermissionOnCompletedHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -330,7 +330,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricTaskAndReadHistoryPermissionOnProcessDefinition() {
+  void testCheckNonePermissionOnHistoricTaskAndReadHistoryPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -352,7 +352,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricTaskAndNonePermissionOnProcessDefinition() {
+  void testCheckReadPermissionOnHistoricTaskAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -375,7 +375,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testHistoricTaskPermissionsAuthorizationDisabled() {
+  void testHistoricTaskPermissionsAuthorizationDisabled() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -394,7 +394,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricProcessInstance() {
+  void testCheckNonePermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -411,7 +411,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricProcessInstance() {
+  void testCheckReadPermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -430,7 +430,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckReadPermissionOnCompletedHistoricProcessInstance() {
+  void testCheckReadPermissionOnCompletedHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -453,7 +453,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
+  void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -477,7 +477,7 @@ public class HistoricIdentityLinkLogAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
+  void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricIncidentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricIncidentAuthorizationTest.java
@@ -16,6 +16,9 @@
  */
 package org.operaton.bpm.engine.test.api.authorization.history;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.authorization.HistoricProcessInstancePermissions;
 import org.operaton.bpm.engine.authorization.ProcessDefinitionPermissions;
@@ -36,10 +39,6 @@ import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION
 import java.util.Date;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -56,7 +55,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   protected String deploymentId;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     deploymentId = testRule.deploy(
         "org/operaton/bpm/engine/test/api/authorization/timerStartEventProcess.bpmn20.xml",
@@ -66,7 +65,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     processEngineConfiguration.setEnableHistoricInstancePermissions(false);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricIncidentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricIncidentAuthorizationTest.java
@@ -46,7 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  */
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
-public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
+class HistoricIncidentAuthorizationTest extends AuthorizationTest {
 
   protected static final String TIMER_START_PROCESS_KEY = "timerStartProcess";
   protected static final String ONE_INCIDENT_PROCESS_KEY = "process";
@@ -74,7 +74,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   // historic incident query (standalone) //////////////////////////////
 
   @Test
-  public void testQueryForStandaloneHistoricIncidents() {
+  void testQueryForStandaloneHistoricIncidents() {
     // given
     disableAuthorization();
     repositoryService.suspendProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY, true, new Date());
@@ -105,7 +105,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   // historic incident query (start timer job incident) //////////////////////////////
 
   @Test
-  public void testStartTimerJobIncidentQueryWithoutAuthorization() {
+  void testStartTimerJobIncidentQueryWithoutAuthorization() {
     // given
     disableAuthorization();
     String jobId = managementService.createJobQuery().singleResult().getId();
@@ -120,7 +120,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartTimerJobIncidentQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testStartTimerJobIncidentQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     disableAuthorization();
     String jobId = managementService.createJobQuery().singleResult().getId();
@@ -137,7 +137,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartTimerJobIncidentQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testStartTimerJobIncidentQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     disableAuthorization();
     String jobId = managementService.createJobQuery().singleResult().getId();
@@ -154,7 +154,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartTimerJobIncidentQueryWithReadInstancePermissionOnAnyProcessDefinition() {
+  void testStartTimerJobIncidentQueryWithReadInstancePermissionOnAnyProcessDefinition() {
     // given
     disableAuthorization();
     String jobId = managementService.createJobQuery().singleResult().getId();
@@ -173,7 +173,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   // historic incident query ///////////////////////////////////////////
 
   @Test
-  public void testSimpleQueryWithoutAuthorization() {
+  void testSimpleQueryWithoutAuthorization() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
 
@@ -185,7 +185,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testSimpleQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ONE_INCIDENT_PROCESS_KEY, userId, READ_HISTORY);
@@ -198,7 +198,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testSimpleQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -211,7 +211,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithMultiple() {
+  void testSimpleQueryWithMultiple() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ONE_INCIDENT_PROCESS_KEY, userId, READ_HISTORY);
@@ -225,7 +225,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricProcessInstance() {
+  void testCheckNonePermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -243,7 +243,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricProcessInstance() {
+  void testCheckReadPermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -263,7 +263,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
+  void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -285,7 +285,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
+  void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -307,7 +307,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricProcessInstancePermissionsAuthorizationDisabled() {
+  void testHistoricProcessInstancePermissionsAuthorizationDisabled() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -327,7 +327,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindIncidentWithRevokedReadHistoryPermissionOnAnyProcessDefinition() {
+  void shouldNotFindIncidentWithRevokedReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_HISTORY);
@@ -343,7 +343,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   // historic incident query (multiple incidents ) ///////////////////////////////////////////
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -360,7 +360,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -379,7 +379,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -400,7 +400,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   // historic job log (mixed) //////////////////////////////////////////
 
   @Test
-  public void testMixedQueryWithoutAuthorization() {
+  void testMixedQueryWithoutAuthorization() {
     // given
     disableAuthorization();
     repositoryService.suspendProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY, true, new Date());
@@ -448,7 +448,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testMixedQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testMixedQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     disableAuthorization();
     repositoryService.suspendProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY, true, new Date());
@@ -498,7 +498,7 @@ public class HistoricIncidentAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testMixedQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testMixedQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     disableAuthorization();
     repositoryService.suspendProcessDefinitionByKey(ONE_INCIDENT_PROCESS_KEY, true, new Date());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricJobLogAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricJobLogAuthorizationTest.java
@@ -46,7 +46,7 @@ import static org.assertj.core.api.Assertions.*;
  *
  */
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
-public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
+class HistoricJobLogAuthorizationTest extends AuthorizationTest {
 
   protected static final String TIMER_START_PROCESS_KEY = "timerStartProcess";
   protected static final String TIMER_BOUNDARY_PROCESS_KEY = "timerBoundaryProcess";
@@ -86,7 +86,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   // historic job log query (start timer job) ////////////////////////////////
 
   @Test
-  public void testStartTimerJobLogQueryWithoutAuthorization() {
+  void testStartTimerJobLogQueryWithoutAuthorization() {
     // given
 
     // when
@@ -98,7 +98,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartTimerJobLogQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testStartTimerJobLogQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_START_PROCESS_KEY, userId, READ_HISTORY);
 
@@ -110,7 +110,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStartTimerJobLogQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testStartTimerJobLogQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
 
@@ -124,7 +124,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   // historic job log query ////////////////////////////////////////////////
 
   @Test
-  public void testSimpleQueryWithoutAuthorization() {
+  void testSimpleQueryWithoutAuthorization() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
 
@@ -136,7 +136,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithHistoryReadPermissionOnProcessDefinition() {
+  void testSimpleQueryWithHistoryReadPermissionOnProcessDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ONE_INCIDENT_PROCESS_KEY, userId, READ_HISTORY);
@@ -149,7 +149,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithHistoryReadPermissionOnAnyProcessDefinition() {
+  void testSimpleQueryWithHistoryReadPermissionOnAnyProcessDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -162,7 +162,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithMultiple() {
+  void testSimpleQueryWithMultiple() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -176,7 +176,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindJobLogWithRevokedHistoryReadPermissionOnAnyProcessDefinition() {
+  void shouldNotFindJobLogWithRevokedHistoryReadPermissionOnAnyProcessDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_HISTORY);
@@ -192,7 +192,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   // historic job log query (multiple process instance) ////////////////////////////////////////////////
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -213,7 +213,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithHistoryReadPermissionOnProcessDefinition() {
+  void testQueryWithHistoryReadPermissionOnProcessDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -236,7 +236,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithHistoryReadPermissionOnAnyProcessDefinition() {
+  void testQueryWithHistoryReadPermissionOnAnyProcessDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
@@ -261,7 +261,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   // historic job log query (standalone job) ///////////////////////
 
   @Test
-  public void testQueryAfterStandaloneJob() {
+  void testQueryAfterStandaloneJob() {
     // given
     disableAuthorization();
     repositoryService.suspendProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY, true, new Date());
@@ -287,7 +287,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   // delete deployment (cascade = false)
 
   @Test
-  public void testQueryAfterDeletingDeployment() {
+  void testQueryAfterDeletingDeployment() {
     // given
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
@@ -322,7 +322,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   // get historic job log exception stacktrace (standalone) /////////////////////
 
   @Test
-  public void testGetHistoricStandaloneJobLogExceptionStacktrace() {
+  void testGetHistoricStandaloneJobLogExceptionStacktrace() {
     // given
     disableAuthorization();
     repositoryService.suspendProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY, true, new Date());
@@ -346,7 +346,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   // get historic job log exception stacktrace /////////////////////
 
   @Test
-  public void testGetHistoricJobLogExceptionStacktraceWithoutAuthorization() {
+  void testGetHistoricJobLogExceptionStacktraceWithoutAuthorization() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
 
@@ -369,7 +369,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetHistoricJobLogExceptionStacktraceWithReadHistoryPermissionOnProcessDefinition() {
+  void testGetHistoricJobLogExceptionStacktraceWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
 
@@ -387,7 +387,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testGetHistoricJobLogExceptionStacktraceWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testGetHistoricJobLogExceptionStacktraceWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY);
 
@@ -405,7 +405,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricProcessInstance() {
+  void testCheckNonePermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -423,7 +423,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricProcessInstance() {
+  void testCheckReadPermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -448,7 +448,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
+  void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -474,7 +474,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
+  void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -501,7 +501,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricProcessInstancePermissionsAuthorizationDisabled() {
+  void testHistoricProcessInstancePermissionsAuthorizationDisabled() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -526,7 +526,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSkipAuthOnNonProcessJob() {
+  void testSkipAuthOnNonProcessJob() {
     // given
     String processInstanceId = startProcessAndExecuteJob(ONE_INCIDENT_PROCESS_KEY)
         .getProcessInstanceId();
@@ -547,7 +547,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSkipAuthOnNonProcessJob_HistoricInstancePermissionsEnabled() {
+  void testSkipAuthOnNonProcessJob_HistoricInstancePermissionsEnabled() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricJobLogAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricJobLogAuthorizationTest.java
@@ -16,6 +16,9 @@
  */
 package org.operaton.bpm.engine.test.api.authorization.history;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.authorization.HistoricProcessInstancePermissions;
@@ -36,10 +39,6 @@ import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION
 import java.util.Date;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.assertj.core.api.Assertions.*;
 
 /**
@@ -57,7 +56,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   protected String deploymentId;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     deploymentId = testRule.deploy(
         "org/operaton/bpm/engine/test/api/authorization/timerStartEventProcess.bpmn20.xml",
@@ -68,7 +67,7 @@ public class HistoricJobLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     CommandExecutor commandExecutor = processEngineConfiguration.getCommandExecutorTxRequired();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricProcessInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricProcessInstanceAuthorizationTest.java
@@ -48,7 +48,7 @@ import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
  *
  */
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_ACTIVITY)
-public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest {
+class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest {
 
   protected static final String PROCESS_KEY = "oneTaskProcess";
   protected static final String MESSAGE_START_PROCESS_KEY = "messageStartProcess";
@@ -75,7 +75,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   // historic process instance query //////////////////////////////////////////////////////////
 
   @Test
-  public void testSimpleQueryWithoutAuthorization() {
+  void testSimpleQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
 
@@ -87,7 +87,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testSimpleQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testSimpleQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
@@ -104,7 +104,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testSimpleQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testSimpleQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -121,7 +121,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testSimpleQueryWithMultiple() {
+  void testSimpleQueryWithMultiple() {
     // given
     startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -135,7 +135,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void shouldNotFindInstanceWithRevokedReadHistoryPermissionOnAnyProcessDefinition() {
+  void shouldNotFindInstanceWithRevokedReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_HISTORY);
@@ -151,7 +151,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   // historic process instance query (multiple process instances) ////////////////////////
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -170,7 +170,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -191,7 +191,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -214,7 +214,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   // delete deployment (cascade = false)
 
   @Test
-  public void testQueryAfterDeletingDeployment() {
+  void testQueryAfterDeletingDeployment() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -249,7 +249,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   // delete historic process instance //////////////////////////////
 
   @Test
-  public void testDeleteHistoricProcessInstanceWithoutAuthorization() {
+  void testDeleteHistoricProcessInstanceWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     String taskId = selectSingleTask().getId();
@@ -272,7 +272,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testDeleteHistoricProcessInstanceWithDeleteHistoryPermissionOnProcessDefinition() {
+  void testDeleteHistoricProcessInstanceWithDeleteHistoryPermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     String taskId = selectSingleTask().getId();
@@ -296,7 +296,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testDeleteHistoricProcessInstanceWithDeleteHistoryPermissionOnAnyProcessDefinition() {
+  void testDeleteHistoricProcessInstanceWithDeleteHistoryPermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     String taskId = selectSingleTask().getId();
@@ -320,7 +320,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testDeleteHistoricProcessInstanceAfterDeletingDeployment() {
+  void testDeleteHistoricProcessInstanceAfterDeletingDeployment() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     String taskId = selectSingleTask().getId();
@@ -350,7 +350,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   // create historic process instance report
 
   @Test
-  public void testHistoricProcessInstanceReportWithoutAuthorization() {
+  void testHistoricProcessInstanceReportWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -374,7 +374,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testHistoricProcessInstanceReportWithHistoryReadPermissionOnAny() {
+  void testHistoricProcessInstanceReportWithHistoryReadPermissionOnAny() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -394,7 +394,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testReportWithoutQueryCriteriaAndAnyReadHistoryPermission() {
+  void testReportWithoutQueryCriteriaAndAnyReadHistoryPermission() {
     // given
     ProcessInstance processInstance1 = startProcessInstanceByKey(PROCESS_KEY);
     ProcessInstance processInstance2 = startProcessInstanceByKey(MESSAGE_START_PROCESS_KEY);
@@ -415,7 +415,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testReportWithoutQueryCriteriaAndNoReadHistoryPermission() {
+  void testReportWithoutQueryCriteriaAndNoReadHistoryPermission() {
     // given
     ProcessInstance processInstance1 = startProcessInstanceByKey(PROCESS_KEY);
     ProcessInstance processInstance2 = startProcessInstanceByKey(MESSAGE_START_PROCESS_KEY);
@@ -434,7 +434,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testReportWithQueryCriterionProcessDefinitionKeyInAndReadHistoryPermission() {
+  void testReportWithQueryCriterionProcessDefinitionKeyInAndReadHistoryPermission() {
     // given
     ProcessInstance processInstance1 = startProcessInstanceByKey(PROCESS_KEY);
     ProcessInstance processInstance2 = startProcessInstanceByKey(MESSAGE_START_PROCESS_KEY);
@@ -457,7 +457,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testReportWithQueryCriterionProcessDefinitionKeyInAndMissingReadHistoryPermission() {
+  void testReportWithQueryCriterionProcessDefinitionKeyInAndMissingReadHistoryPermission() {
     // given
     ProcessInstance processInstance1 = startProcessInstanceByKey(PROCESS_KEY);
     ProcessInstance processInstance2 = startProcessInstanceByKey(MESSAGE_START_PROCESS_KEY);
@@ -478,7 +478,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testReportWithQueryCriterionProcessDefinitionIdInAndReadHistoryPermission() {
+  void testReportWithQueryCriterionProcessDefinitionIdInAndReadHistoryPermission() {
     // given
     ProcessInstance processInstance1 = startProcessInstanceByKey(PROCESS_KEY);
     ProcessInstance processInstance2 = startProcessInstanceByKey(MESSAGE_START_PROCESS_KEY);
@@ -501,7 +501,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testReportWithQueryCriterionProcessDefinitionIdInAndMissingReadHistoryPermission() {
+  void testReportWithQueryCriterionProcessDefinitionIdInAndMissingReadHistoryPermission() {
     // given
     ProcessInstance processInstance1 = startProcessInstanceByKey(PROCESS_KEY);
     ProcessInstance processInstance2 = startProcessInstanceByKey(MESSAGE_START_PROCESS_KEY);
@@ -527,7 +527,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testReportWithMixedQueryCriteriaAndReadHistoryPermission() {
+  void testReportWithMixedQueryCriteriaAndReadHistoryPermission() {
     // given
     ProcessInstance processInstance1 = startProcessInstanceByKey(PROCESS_KEY);
     ProcessInstance processInstance2 = startProcessInstanceByKey(MESSAGE_START_PROCESS_KEY);
@@ -551,7 +551,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testReportWithMixedQueryCriteriaAndMissingReadHistoryPermission() {
+  void testReportWithMixedQueryCriteriaAndMissingReadHistoryPermission() {
     // given
     ProcessInstance processInstance1 = startProcessInstanceByKey(PROCESS_KEY);
     ProcessInstance processInstance2 = startProcessInstanceByKey(MESSAGE_START_PROCESS_KEY);
@@ -574,7 +574,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testReportWithQueryCriterionProcessInstanceIdInWrongProcessDefinitionId() {
+  void testReportWithQueryCriterionProcessInstanceIdInWrongProcessDefinitionId() {
     // when
     List<DurationReportResult> result = historyService
       .createHistoricProcessInstanceReport()
@@ -586,7 +586,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testHistoryCleanupReportWithPermissions() {
+  void testHistoryCleanupReportWithPermissions() {
     // given
     prepareProcessInstances(PROCESS_KEY, -6, 5, 10);
 
@@ -602,7 +602,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testHistoryCleanupReportWithReadPermissionOnly() {
+  void testHistoryCleanupReportWithReadPermissionOnly() {
     // given
     prepareProcessInstances(PROCESS_KEY, -6, 5, 10);
 
@@ -616,7 +616,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testHistoryCleanupReportWithReadHistoryPermissionOnly() {
+  void testHistoryCleanupReportWithReadHistoryPermissionOnly() {
     // given
     prepareProcessInstances(PROCESS_KEY, -6, 5, 10);
 
@@ -630,7 +630,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testHistoryCleanupReportWithoutPermissions() {
+  void testHistoryCleanupReportWithoutPermissions() {
     // given
     prepareProcessInstances(PROCESS_KEY, -6, 5, 10);
 
@@ -642,7 +642,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void shouldNotFindCleanupReportWithRevokedReadHistoryPermissionOnProcessDefinition() {
+  void shouldNotFindCleanupReportWithRevokedReadHistoryPermissionOnProcessDefinition() {
     // given
     prepareProcessInstances(PROCESS_KEY, -6, 5, 10);
 
@@ -659,7 +659,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckAllHistoricProcessInstancePermissions() {
+  void testCheckAllHistoricProcessInstancePermissions() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -679,7 +679,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckReadHistoricProcessInstancePermissions() {
+  void testCheckReadHistoricProcessInstancePermissions() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -699,7 +699,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckNoneHistoricProcessInstancePermission() {
+  void testCheckNoneHistoricProcessInstancePermission() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -719,7 +719,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricProcessInstance() {
+  void testCheckNonePermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -736,7 +736,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricProcessInstance() {
+  void testCheckReadPermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -755,7 +755,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckReadPermissionOnCompletedHistoricProcessInstance() {
+  void testCheckReadPermissionOnCompletedHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -778,7 +778,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
+  void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -802,7 +802,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
+  void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -827,7 +827,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testHistoricProcessInstancePermissionsAuthorizationDisabled() {
+  void testHistoricProcessInstancePermissionsAuthorizationDisabled() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -845,7 +845,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Test
-  public void testDeleteHistoricAuthorizationRelatedToHistoricProcessInstance() {
+  void testDeleteHistoricAuthorizationRelatedToHistoricProcessInstance() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricProcessInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricProcessInstanceAuthorizationTest.java
@@ -28,6 +28,9 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import org.apache.commons.lang3.time.DateUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.authorization.*;
@@ -39,10 +42,6 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -57,7 +56,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   protected String deploymentId;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     deploymentId = testRule.deploy(
         "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml",
@@ -67,7 +66,7 @@ public class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest 
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     processEngineConfiguration.setEnableHistoricInstancePermissions(false);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricTaskInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricTaskInstanceAuthorizationTest.java
@@ -52,7 +52,7 @@ import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
  *
  */
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_ACTIVITY)
-public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
+class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
 
   protected static final String PROCESS_KEY = "oneTaskProcess";
   protected static final String MESSAGE_START_PROCESS_KEY = "messageStartProcess";
@@ -81,7 +81,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   // historic task instance query (standalone task) ///////////////////////////////////////
 
   @Test
-  public void testQueryAfterStandaloneTask() {
+  void testQueryAfterStandaloneTask() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -98,7 +98,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   // historic task instance query (process task) //////////////////////////////////////////
 
   @Test
-  public void testSimpleQueryWithoutAuthorization() {
+  void testSimpleQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
 
@@ -110,7 +110,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testSimpleQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
@@ -123,7 +123,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testSimpleQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -136,7 +136,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testSimpleQueryWithMultiple() {
+  void testSimpleQueryWithMultiple() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -150,7 +150,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void shouldNotFindTaskWithRevokedReadHistoryPermissionOnProcessDefinition() {
+  void shouldNotFindTaskWithRevokedReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ANY, ANY, READ_HISTORY);
@@ -166,7 +166,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   // historic task instance query (multiple process instances) ////////////////////////
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -185,7 +185,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -206,7 +206,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -229,7 +229,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   // historic task instance query (case task) ///////////////////////////////////////
 
   @Test
-  public void testQueryAfterCaseTask() {
+  void testQueryAfterCaseTask() {
     // given
     testRule.createCaseInstanceByKey(CASE_KEY);
 
@@ -243,7 +243,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   // historic task instance query (mixed tasks) ////////////////////////////////////
 
   @Test
-  public void testMixedQueryWithoutAuthorization() {
+  void testMixedQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -277,7 +277,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testMixedQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testMixedQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -313,7 +313,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testMixedQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testMixedQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -351,7 +351,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   // delete deployment (cascade = false)
 
   @Test
-  public void testQueryAfterDeletingDeployment() {
+  void testQueryAfterDeletingDeployment() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     startProcessInstanceByKey(PROCESS_KEY);
@@ -386,7 +386,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   // delete historic task (standalone task) ///////////////////////
 
   @Test
-  public void testDeleteStandaloneTask() {
+  void testDeleteStandaloneTask() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -408,7 +408,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   // delete historic task (process task) ///////////////////////
 
   @Test
-  public void testDeleteProcessTaskWithoutAuthorization() {
+  void testDeleteProcessTaskWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -425,7 +425,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteProcessTaskWithDeleteHistoryPermissionOnProcessDefinition() {
+  void testDeleteProcessTaskWithDeleteHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -445,7 +445,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteProcessTaskWithDeleteHistoryPermissionOnAnyProcessDefinition() {
+  void testDeleteProcessTaskWithDeleteHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -465,7 +465,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteHistoricTaskInstanceAfterDeletingDeployment() {
+  void testDeleteHistoricTaskInstanceAfterDeletingDeployment() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY).getId();
     String taskId = selectSingleTask().getId();
@@ -496,7 +496,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricTaskInstanceDurationReportWithoutAuthorization() {
+  void testHistoricTaskInstanceDurationReportWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -520,7 +520,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricTaskInstanceReportWithHistoryReadPermissionOnAny() {
+  void testHistoricTaskInstanceReportWithHistoryReadPermissionOnAny() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -540,7 +540,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricTaskInstanceCountByProcessDefinitionReportWithoutAuthorization() {
+  void testHistoricTaskInstanceCountByProcessDefinitionReportWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -564,7 +564,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricTaskInstanceReportGroupedByProcessDefinitionKeyWithHistoryReadPermissionOnAny() {
+  void testHistoricTaskInstanceReportGroupedByProcessDefinitionKeyWithHistoryReadPermissionOnAny() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -584,7 +584,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricTaskInstanceGroupedByTaskNameReportWithoutAuthorization() {
+  void testHistoricTaskInstanceGroupedByTaskNameReportWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -608,7 +608,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricTaskInstanceGroupedByTaskNameReportWithHistoryReadPermissionOnAny() {
+  void testHistoricTaskInstanceGroupedByTaskNameReportWithHistoryReadPermissionOnAny() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -628,7 +628,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckAllHistoricTaskPermissions() {
+  void testCheckAllHistoricTaskPermissions() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -650,7 +650,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadHistoricTaskPermissions() {
+  void testCheckReadHistoricTaskPermissions() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -666,7 +666,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNoneHistoricTaskPermission() {
+  void testCheckNoneHistoricTaskPermission() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -679,7 +679,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricTask() {
+  void testCheckNonePermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -696,7 +696,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricTask() {
+  void testCheckReadPermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -713,7 +713,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnStandaloneHistoricTask() {
+  void testCheckReadPermissionOnStandaloneHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -733,7 +733,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNonePermissionOnStandaloneHistoricTask() {
+  void testCheckNonePermissionOnStandaloneHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -753,7 +753,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnCompletedHistoricTask() {
+  void testCheckReadPermissionOnCompletedHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -773,7 +773,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNonePermissionOndHistoricTaskAndReadHistoryPermissionOnProcessDefinition() {
+  void testCheckNonePermissionOndHistoricTaskAndReadHistoryPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -794,7 +794,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOndHistoricTaskAndNonePermissionOnProcessDefinition() {
+  void testCheckReadPermissionOndHistoricTaskAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -816,7 +816,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricTaskPermissionsAuthorizationDisabled() {
+  void testHistoricTaskPermissionsAuthorizationDisabled() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -832,7 +832,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricTaskReadPermissionGrantedWhenAssign() {
+  void testHistoricTaskReadPermissionGrantedWhenAssign() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -853,7 +853,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricTaskReadPermissionGrantedWhenAddingIdentityLinkOnStandaloneTask() {
+  void testHistoricTaskReadPermissionGrantedWhenAddingIdentityLinkOnStandaloneTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -877,7 +877,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricTaskReadPermissionGrantedWhenSettingOwner() {
+  void testHistoricTaskReadPermissionGrantedWhenSettingOwner() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -898,7 +898,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricTaskReadPermissionGrantedWhenSettingCandidateUser() {
+  void testHistoricTaskReadPermissionGrantedWhenSettingCandidateUser() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -919,7 +919,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricTaskReadPermissionGrantedWhenSettingCandidateGroup() {
+  void testHistoricTaskReadPermissionGrantedWhenSettingCandidateGroup() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -940,7 +940,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testStandaloneTaskClearHistoricAuthorization() {
+  void testStandaloneTaskClearHistoricAuthorization() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -975,7 +975,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testProcessTaskClearHistoricAuthorization() {
+  void testProcessTaskClearHistoricAuthorization() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1012,7 +1012,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricProcessInstance() {
+  void testCheckNonePermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1029,7 +1029,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricProcessInstance() {
+  void testCheckReadPermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1048,7 +1048,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnCompletedHHistoricProcessInstance() {
+  void testCheckReadPermissionOnCompletedHHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1071,7 +1071,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
+  void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1095,7 +1095,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
+  void testCheckReadPermissionOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricTaskInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricTaskInstanceAuthorizationTest.java
@@ -29,6 +29,10 @@ import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
 
 import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.authorization.Authorization;
@@ -42,9 +46,6 @@ import org.operaton.bpm.engine.query.PeriodUnit;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -60,7 +61,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   protected String deploymentId;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     deploymentId = testRule.deploy(
         "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml",
@@ -71,7 +72,7 @@ public class HistoricTaskInstanceAuthorizationTest extends AuthorizationTest {
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     processEngineConfiguration.setEnableHistoricInstancePermissions(false);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricVariableInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricVariableInstanceAuthorizationTest.java
@@ -27,6 +27,10 @@ import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.authorization.HistoricProcessInstancePermissions;
@@ -39,9 +43,6 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * @author Roman Smirnov
@@ -58,7 +59,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   protected String deploymentId;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     deploymentId = testRule.deploy(
         "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml",
@@ -71,7 +72,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     processEngineConfiguration.setEnableHistoricInstancePermissions(false);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricVariableInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricVariableInstanceAuthorizationTest.java
@@ -49,7 +49,7 @@ import org.operaton.bpm.engine.test.api.authorization.AuthorizationTest;
  *
  */
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
-public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest {
+class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest {
 
   protected static final String PROCESS_KEY = "oneTaskProcess";
   protected static final String MESSAGE_START_PROCESS_KEY = "messageStartProcess";
@@ -82,7 +82,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   // historic variable instance query (standalone task) /////////////////////////////////////////////
 
   @Test
-  public void testQueryAfterStandaloneTaskVariables() {
+  void testQueryAfterStandaloneTaskVariables() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -103,7 +103,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   // historic variable instance query (process variables) ///////////////////////////////////////////
 
   @Test
-  public void testSimpleQueryWithoutAuthorization() {
+  void testSimpleQueryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
 
@@ -115,7 +115,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testSimpleQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testSimpleQueryWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
@@ -128,7 +128,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testSimpleQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testSimpleQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -141,7 +141,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testSimpleQueryWithMultiple() {
+  void testSimpleQueryWithMultiple() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -155,7 +155,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testSimpleQueryWithReadHistoryVariablePermissionOnProcessDefinition() {
+  void testSimpleQueryWithReadHistoryVariablePermissionOnProcessDefinition() {
     // given
     setReadHistoryVariableAsDefaultReadPermission();
 
@@ -170,7 +170,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testSimpleQueryWithReadHistoryVariablePermissionOnAnyProcessDefinition() {
+  void testSimpleQueryWithReadHistoryVariablePermissionOnAnyProcessDefinition() {
     setReadHistoryVariableAsDefaultReadPermission();
 
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
@@ -184,7 +184,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testSimpleQueryWithMultipleReadHistoryVariable() {
+  void testSimpleQueryWithMultipleReadHistoryVariable() {
     setReadHistoryVariableAsDefaultReadPermission();
 
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
@@ -199,7 +199,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void shouldNotFindVariableWithRevokedReadHistoryVariablePermissionOnProcessDefinition() {
+  void shouldNotFindVariableWithRevokedReadHistoryVariablePermissionOnProcessDefinition() {
     setReadHistoryVariableAsDefaultReadPermission();
 
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
@@ -216,7 +216,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   // historic variable instance query (multiple process instances) ////////////////////////
 
   @Test
-  public void testQueryWithoutAuthorization() {
+  void testQueryWithoutAuthorization() {
     startMultipleProcessInstances();
 
     // when
@@ -227,7 +227,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testQueryWithReadHistoryPermissionOnProcessDefinition() {
     startMultipleProcessInstances();
 
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, READ_HISTORY);
@@ -240,7 +240,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startMultipleProcessInstances();
 
@@ -254,7 +254,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testQueryWithReadHistoryVariablePermissionOnProcessDefinition() {
+  void testQueryWithReadHistoryVariablePermissionOnProcessDefinition() {
     setReadHistoryVariableAsDefaultReadPermission();
 
     startMultipleProcessInstances();
@@ -269,7 +269,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testQueryWithReadHistoryVariablePermissionOnAnyProcessDefinition() {
+  void testQueryWithReadHistoryVariablePermissionOnAnyProcessDefinition() {
     setReadHistoryVariableAsDefaultReadPermission();
 
     startMultipleProcessInstances();
@@ -286,7 +286,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   // historic variable instance query (case variables) /////////////////////////////////////////////
 
   @Test
-  public void testQueryAfterCaseVariables() {
+  void testQueryAfterCaseVariables() {
     // given
     createCaseInstanceByKey(CASE_KEY, getVariables());
 
@@ -300,7 +300,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   // historic variable instance query (mixed variables) ////////////////////////////////////
 
   @Test
-  public void testMixedQueryWithoutAuthorization() {
+  void testMixedQueryWithoutAuthorization() {
     startMultipleProcessInstances();
 
     setupMultipleMixedVariables();
@@ -319,7 +319,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testMixedQueryWithReadHistoryPermissionOnProcessDefinition() {
+  void testMixedQueryWithReadHistoryPermissionOnProcessDefinition() {
     startMultipleProcessInstances();
 
     setupMultipleMixedVariables();
@@ -340,7 +340,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testMixedQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testMixedQueryWithReadHistoryPermissionOnAnyProcessDefinition() {
     startMultipleProcessInstances();
 
     setupMultipleMixedVariables();
@@ -361,7 +361,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testMixedQueryWithReadHistoryVariablePermissionOnProcessDefinition() {
+  void testMixedQueryWithReadHistoryVariablePermissionOnProcessDefinition() {
     setReadHistoryVariableAsDefaultReadPermission();
 
     startMultipleProcessInstances();
@@ -384,7 +384,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testMixedQueryWithReadHistoryVariablePermissionOnAnyProcessDefinition() {
+  void testMixedQueryWithReadHistoryVariablePermissionOnAnyProcessDefinition() {
     setReadHistoryVariableAsDefaultReadPermission();
 
     startMultipleProcessInstances();
@@ -409,7 +409,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   // delete deployment (cascade = false)
 
   @Test
-  public void testQueryAfterDeletingDeployment() {
+  void testQueryAfterDeletingDeployment() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
@@ -437,7 +437,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testQueryAfterDeletingDeploymentWithReadHistoryVariable() {
+  void testQueryAfterDeletingDeploymentWithReadHistoryVariable() {
     setReadHistoryVariableAsDefaultReadPermission();
 
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
@@ -467,7 +467,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
 
   // delete historic variable instance (process variables) /////////////////////////////////////////////
   @Test
-  public void testDeleteHistoricProcessVariableInstanceWithoutAuthorization() {
+  void testDeleteHistoricProcessVariableInstanceWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
 
@@ -486,7 +486,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testDeleteHistoricProcessVariableInstanceWithDeleteHistoryPermissionOnProcessDefinition() {
+  void testDeleteHistoricProcessVariableInstanceWithDeleteHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     createGrantAuthorization(PROCESS_DEFINITION, PROCESS_KEY, userId, DELETE_HISTORY);
@@ -505,7 +505,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
 
   // delete deployment (cascade = false)
   @Test
-  public void testDeleteHistoricProcessVariableInstanceAfterDeletingDeployment() {
+  void testDeleteHistoricProcessVariableInstanceAfterDeletingDeployment() {
     // given
     startProcessInstanceByKey(PROCESS_KEY, getVariables());
     String taskId = selectSingleTask().getId();
@@ -532,7 +532,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
 
   // delete historic variable instance (case variables) /////////////////////////////////////////////
   @Test
-  public void testDeleteHistoricCaseVariableInstance() {
+  void testDeleteHistoricCaseVariableInstance() {
     // given
     createCaseInstanceByKey(CASE_KEY, getVariables());
 
@@ -550,7 +550,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
 
   // delete historic variable instance (task variables) /////////////////////////////////////////////
   @Test
-  public void testDeleteHistoricStandaloneTaskVariableInstance() {
+  void testDeleteHistoricStandaloneTaskVariableInstance() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -573,7 +573,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
 
   // delete historic variable instances (process variables) /////////////////////////////////////////////
   @Test
-  public void testDeleteHistoricProcessVariableInstancesWithoutAuthorization() {
+  void testDeleteHistoricProcessVariableInstancesWithoutAuthorization() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY, getVariables());
     String instanceId = instance.getId();
@@ -590,7 +590,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testDeleteHistoricProcessVariableInstancesWithDeleteHistoryPermissionOnProcessDefinition() {
+  void testDeleteHistoricProcessVariableInstancesWithDeleteHistoryPermissionOnProcessDefinition() {
     // given
     ProcessInstance instance = startProcessInstanceByKey(PROCESS_KEY, getVariables());
     String instanceId = instance.getId();
@@ -607,7 +607,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
 
   // delete deployment (cascade = false)
   @Test
-  public void testDeleteHistoricProcessVariableInstancesAfterDeletingDeployment() {
+  void testDeleteHistoricProcessVariableInstancesAfterDeletingDeployment() {
     // given
     String processInstanceId = startProcessInstanceByKey(PROCESS_KEY, getVariables()).getId();
     String taskId = selectSingleTask().getId();
@@ -687,7 +687,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricTask() {
+  void testCheckNonePermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -708,7 +708,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricTask() {
+  void testCheckReadPermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -729,7 +729,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckReadPermissionOnStandaloneHistoricTask() {
+  void testCheckReadPermissionOnStandaloneHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -753,7 +753,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckNonePermissionOnStandaloneHistoricTask() {
+  void testCheckNonePermissionOnStandaloneHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -777,7 +777,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckReadPermissionOnCompletedHistoricTask() {
+  void testCheckReadPermissionOnCompletedHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -799,7 +799,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricTaskAndReadHistoryPermissionOnProcessDefinition() {
+  void testCheckNonePermissionOnHistoricTaskAndReadHistoryPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -822,7 +822,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricTaskAndNonePermissionOnProcessDefinition() {
+  void testCheckReadPermissionOnHistoricTaskAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -846,7 +846,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckReadVariablePermissionOnHistoricTask() {
+  void testCheckReadVariablePermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
@@ -865,7 +865,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testOnlyReadPermissionOnHistoricTask() {
+  void testOnlyReadPermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
@@ -884,7 +884,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testIgnoreReadVariablePermissionOnHistoricTask() {
+  void testIgnoreReadVariablePermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     processEngineConfiguration.setEnforceSpecificVariablePermission(false);
@@ -903,7 +903,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckReadVariablePermissionOnStandaloneHistoricTask() {
+  void testCheckReadVariablePermissionOnStandaloneHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
@@ -928,7 +928,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckReadVariablePermissionOnCompletedHistoricTask() {
+  void testCheckReadVariablePermissionOnCompletedHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
@@ -950,7 +950,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckReadVariablePermissionOnHistoricTaskAndNonePermissionOnProcessDefinition() {
+  void testCheckReadVariablePermissionOnHistoricTaskAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
@@ -974,7 +974,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricTaskAndReadHistoryVariablePermissionOnProcessDefinition() {
+  void testCheckNonePermissionOnHistoricTaskAndReadHistoryVariablePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
@@ -997,7 +997,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testHistoricTaskPermissionsAuthorizationDisabled() {
+  void testHistoricTaskPermissionsAuthorizationDisabled() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1015,7 +1015,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricProcessInstance() {
+  void testCheckNonePermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1036,7 +1036,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricProcessInstance_GlobalVariable() {
+  void testCheckReadPermissionOnHistoricProcessInstance_GlobalVariable() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1058,7 +1058,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricProcessInstance_LocalVariable() {
+  void testCheckReadPermissionOnHistoricProcessInstance_LocalVariable() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1081,7 +1081,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckReadPermissionOnCompletedHistoricProcessInstance() {
+  void testCheckReadPermissionOnCompletedHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1105,7 +1105,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
+  void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -1130,7 +1130,7 @@ public class HistoricVariableInstanceAuthorizationTest extends AuthorizationTest
   }
 
   @Test
-  public void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
+  void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoryCleanupAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoryCleanupAuthorizationTest.java
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
-public class HistoryCleanupAuthorizationTest extends AuthorizationTest {
+class HistoryCleanupAuthorizationTest extends AuthorizationTest {
 
   @BeforeEach
   @Override
@@ -72,9 +72,9 @@ public class HistoryCleanupAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  @Deployment(resources = { "org/operaton/bpm/engine/test/dmn/businessruletask/DmnBusinessRuleTaskTest.testDecisionRef.bpmn20.xml",
-      "org/operaton/bpm/engine/test/api/history/testDmnWithPojo.dmn11.xml", "org/operaton/bpm/engine/test/api/authorization/oneTaskCase.cmmn" })
-  public void testHistoryCleanupWithAuthorization() {
+  @Deployment(resources = {"org/operaton/bpm/engine/test/dmn/businessruletask/DmnBusinessRuleTaskTest.testDecisionRef.bpmn20.xml",
+      "org/operaton/bpm/engine/test/api/history/testDmnWithPojo.dmn11.xml", "org/operaton/bpm/engine/test/api/authorization/oneTaskCase.cmmn"})
+  void testHistoryCleanupWithAuthorization() {
     // given
     prepareInstances(5, 5, 5);
 
@@ -91,9 +91,9 @@ public class HistoryCleanupAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  @Deployment(resources = { "org/operaton/bpm/engine/test/dmn/businessruletask/DmnBusinessRuleTaskTest.testDecisionRef.bpmn20.xml",
-      "org/operaton/bpm/engine/test/api/history/testDmnWithPojo.dmn11.xml", "org/operaton/bpm/engine/test/api/authorization/oneTaskCase.cmmn" })
-  public void testHistoryCleanupWithoutAuthorization() {
+  @Deployment(resources = {"org/operaton/bpm/engine/test/dmn/businessruletask/DmnBusinessRuleTaskTest.testDecisionRef.bpmn20.xml",
+      "org/operaton/bpm/engine/test/api/history/testDmnWithPojo.dmn11.xml", "org/operaton/bpm/engine/test/api/authorization/oneTaskCase.cmmn"})
+  void testHistoryCleanupWithoutAuthorization() {
     // given
     prepareInstances(5, 5, 5);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoryCleanupAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoryCleanupAuthorizationTest.java
@@ -44,9 +44,9 @@ import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_CLEANUP
 import java.util.*;
 
 import org.apache.commons.lang3.time.DateUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -54,14 +54,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 public class HistoryCleanupAuthorizationTest extends AuthorizationTest {
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() {
     processEngineConfiguration.setHistoryCleanupStrategy(HISTORY_CLEANUP_STRATEGY_END_TIME_BASED);
     super.setUp();
   }
 
-  @After
+  @AfterEach
   @Override
   public void tearDown() {
     processEngineConfiguration.setHistoryCleanupStrategy(HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/UserOperationLogAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/UserOperationLogAuthorizationTest.java
@@ -94,7 +94,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   // standalone task ///////////////////////////////
 
   @Test
-  public void testQueryCreateStandaloneTaskUserOperationLogWithoutAuthorization() {
+  void testQueryCreateStandaloneTaskUserOperationLogWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -109,7 +109,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryCreateStandaloneTaskUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
+  void testQueryCreateStandaloneTaskUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -143,7 +143,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryCreateStandaloneTaskUserOperationLogWithReadPermissionOnCategory() {
+  void testQueryCreateStandaloneTaskUserOperationLogWithReadPermissionOnCategory() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -160,7 +160,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryCreateStandaloneTaskUserOperationLogWithReadPermissionOnAnyCategory() {
+  void testQueryCreateStandaloneTaskUserOperationLogWithReadPermissionOnAnyCategory() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -177,7 +177,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryCreateStandaloneTaskUserOperationLogWithReadPermissionOnAnyCategoryAndRevokeReadHistoryOnProcessDefinition() {
+  void testQueryCreateStandaloneTaskUserOperationLogWithReadPermissionOnAnyCategoryAndRevokeReadHistoryOnProcessDefinition() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -214,7 +214,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetAssigneeStandaloneTaskUserOperationLogWithoutAuthorization() {
+  void testQuerySetAssigneeStandaloneTaskUserOperationLogWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -230,7 +230,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetAssigneeStandaloneTaskUserOperationLogWithReadPermissionOnProcessDefinition() {
+  void testQuerySetAssigneeStandaloneTaskUserOperationLogWithReadPermissionOnProcessDefinition() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -266,7 +266,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetAssigneeStandaloneTaskUserOperationLogWithReadPermissionOnCategory() {
+  void testQuerySetAssigneeStandaloneTaskUserOperationLogWithReadPermissionOnCategory() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -284,7 +284,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetAssigneeStandaloneTaskUserOperationLogWithReadPermissionOnAnyCategory() {
+  void testQuerySetAssigneeStandaloneTaskUserOperationLogWithReadPermissionOnAnyCategory() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -304,7 +304,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   // (process) user task /////////////////////////////
 
   @Test
-  public void testQuerySetAssigneeTaskUserOperationLogWithoutAuthorization() {
+  void testQuerySetAssigneeTaskUserOperationLogWithoutAuthorization() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -318,7 +318,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetAssigneeTaskUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
+  void testQuerySetAssigneeTaskUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -334,7 +334,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetAssigneeTaskUserOperationLogWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQuerySetAssigneeTaskUserOperationLogWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -350,7 +350,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetAssigneeTaskUserOperationLogWithMultiple() {
+  void testQuerySetAssigneeTaskUserOperationLogWithMultiple() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -367,7 +367,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricProcessInstance() {
+  void testCheckNonePermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -388,7 +388,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricProcessInstance() {
+  void testCheckReadPermissionOnHistoricProcessInstance() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -411,7 +411,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
+  void testCheckNoneOnHistoricProcessInstanceAndReadHistoryPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -436,7 +436,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
+  void testCheckReadOnHistoricProcessInstanceAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -461,7 +461,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNoneOnHistoricProcessInstanceAndTaskWorkerCategory() {
+  void testCheckNoneOnHistoricProcessInstanceAndTaskWorkerCategory() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -486,7 +486,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadOnHistoricProcessInstanceAndAdminCategory() {
+  void testCheckReadOnHistoricProcessInstanceAndAdminCategory() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -510,7 +510,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricProcessInstancePermissionsAuthorizationDisabled() {
+  void testHistoricProcessInstancePermissionsAuthorizationDisabled() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -533,7 +533,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricTask() {
+  void testCheckNonePermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -553,7 +553,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricTask() {
+  void testCheckReadPermissionOnHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -574,7 +574,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnStandaloneHistoricTask() {
+  void testCheckReadPermissionOnStandaloneHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -598,7 +598,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNonePermissionOnStandaloneHistoricTask() {
+  void testCheckNonePermissionOnStandaloneHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -619,7 +619,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnCompletedHistoricTask() {
+  void testCheckReadPermissionOnCompletedHistoricTask() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -643,7 +643,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNonePermissionOnHistoricTaskAndReadHistoryPermissionOnProcessDefinition() {
+  void testCheckNonePermissionOnHistoricTaskAndReadHistoryPermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -668,7 +668,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadPermissionOnHistoricTaskAndNonePermissionOnProcessDefinition() {
+  void testCheckReadPermissionOnHistoricTaskAndNonePermissionOnProcessDefinition() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -693,7 +693,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckNoneOnHistoricTaskAndTaskWorkerCategory() {
+  void testCheckNoneOnHistoricTaskAndTaskWorkerCategory() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -717,7 +717,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCheckReadOnHistoricTaskAndAdminCategory() {
+  void testCheckReadOnHistoricTaskAndAdminCategory() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -741,7 +741,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testHistoricTaskPermissionsAuthorizationDisabled() {
+  void testHistoricTaskPermissionsAuthorizationDisabled() {
     // given
     processEngineConfiguration.setEnableHistoricInstancePermissions(true);
 
@@ -761,7 +761,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
 
   @Test
-  public void testQuerySetAssigneeTaskUserOperationLogWithReadPermissionOnCategory() {
+  void testQuerySetAssigneeTaskUserOperationLogWithReadPermissionOnCategory() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -777,7 +777,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetAssigneeTaskUserOperationLogWithReadPermissionOnAnyCategory() {
+  void testQuerySetAssigneeTaskUserOperationLogWithReadPermissionOnAnyCategory() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -793,7 +793,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetAssigneeTaskUserOperationLogWithReadPermissionOnAnyCategoryAndRevokeOnProcessDefinition() {
+  void testQuerySetAssigneeTaskUserOperationLogWithReadPermissionOnAnyCategoryAndRevokeOnProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -810,7 +810,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetAssigneeTaskUserOperationLogWithReadPermissionOnAnyCategoryAndRevokeOnUnrelatedProcessDefinition() {
+  void testQuerySetAssigneeTaskUserOperationLogWithReadPermissionOnAnyCategoryAndRevokeOnUnrelatedProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -827,7 +827,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetAssigneeTaskUserOperationLogWithReadPermissionOnAnyCategoryAndRevokeOnAnyProcessDefinition() {
+  void testQuerySetAssigneeTaskUserOperationLogWithReadPermissionOnAnyCategoryAndRevokeOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -846,7 +846,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   // (case) human task /////////////////////////////
 
   @Test
-  public void testQuerySetAssigneeHumanTaskUserOperationLogWithoutAuthorization() {
+  void testQuerySetAssigneeHumanTaskUserOperationLogWithoutAuthorization() {
     // given
     testRule.createCaseInstanceByKey(ONE_TASK_CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -860,7 +860,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetAssigneeHumanTaskUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
+  void testQuerySetAssigneeHumanTaskUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
     // given
     testRule.createCaseInstanceByKey(ONE_TASK_CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -892,7 +892,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetAssigneeHumanTaskUserOperationLogWithReadPermissionOnCategory() {
+  void testQuerySetAssigneeHumanTaskUserOperationLogWithReadPermissionOnCategory() {
     // given
     testRule.createCaseInstanceByKey(ONE_TASK_CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -908,7 +908,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetAssigneeHumanTaskUserOperationLogWithReadPermissionOnAnyCategory() {
+  void testQuerySetAssigneeHumanTaskUserOperationLogWithReadPermissionOnAnyCategory() {
     // given
     testRule.createCaseInstanceByKey(ONE_TASK_CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -926,7 +926,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   // standalone job ///////////////////////////////
 
   @Test
-  public void testQuerySetStandaloneJobRetriesUserOperationLogWithoutAuthorization() {
+  void testQuerySetStandaloneJobRetriesUserOperationLogWithoutAuthorization() {
     // given
     disableAuthorization();
     repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, new Date());
@@ -951,7 +951,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetStandaloneJobRetriesUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
+  void testQuerySetStandaloneJobRetriesUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
     // given
     disableAuthorization();
     repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, new Date());
@@ -980,7 +980,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetStandaloneJobRetriesUserOperationLogWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQuerySetStandaloneJobRetriesUserOperationLogWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     disableAuthorization();
     identityService.clearAuthentication();
@@ -1009,7 +1009,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetStandaloneJobRetriesUserOperationLogWithReadPermissionOnCategory() {
+  void testQuerySetStandaloneJobRetriesUserOperationLogWithReadPermissionOnCategory() {
     // given
     disableAuthorization();
     repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, new Date());
@@ -1037,7 +1037,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetStandaloneJobRetriesUserOperationLogWithReadPermissionOnAnyCategory() {
+  void testQuerySetStandaloneJobRetriesUserOperationLogWithReadPermissionOnAnyCategory() {
     // given
     disableAuthorization();
     repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, new Date());
@@ -1064,7 +1064,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetStandaloneJobRetriesUserOperationLogWithReadPermissionOnWrongCategory() {
+  void testQuerySetStandaloneJobRetriesUserOperationLogWithReadPermissionOnWrongCategory() {
     // given
     disableAuthorization();
     repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, new Date());
@@ -1093,7 +1093,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   // job ///////////////////////////////
 
   @Test
-  public void testQuerySetJobRetriesUserOperationLogWithoutAuthorization() {
+  void testQuerySetJobRetriesUserOperationLogWithoutAuthorization() {
     // given
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
     String jobId = selectSingleJob().getId();
@@ -1110,7 +1110,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetJobRetriesUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
+  void testQuerySetJobRetriesUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
     String jobId = selectSingleJob().getId();
@@ -1129,7 +1129,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetJobRetriesUserOperationLogWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQuerySetJobRetriesUserOperationLogWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
     String jobId = selectSingleJob().getId();
@@ -1148,7 +1148,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetJobRetriesUserOperationLogWithReadPermissionOnCategory() {
+  void testQuerySetJobRetriesUserOperationLogWithReadPermissionOnCategory() {
     // given
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
     String jobId = selectSingleJob().getId();
@@ -1167,7 +1167,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySetJobRetriesUserOperationLogWithReadPermissionOnAnyCategory() {
+  void testQuerySetJobRetriesUserOperationLogWithReadPermissionOnAnyCategory() {
     // given
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
     String jobId = selectSingleJob().getId();
@@ -1188,7 +1188,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   // process definition ////////////////////////////////////////////
 
   @Test
-  public void testQuerySuspendProcessDefinitionUserOperationLogWithoutAuthorization() {
+  void testQuerySuspendProcessDefinitionUserOperationLogWithoutAuthorization() {
     // given
     suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
 
@@ -1202,7 +1202,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySuspendProcessDefinitionUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
+  void testQuerySuspendProcessDefinitionUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
     // given
     suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, READ_HISTORY);
@@ -1217,7 +1217,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySuspendProcessDefinitionUserOperationLogWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQuerySuspendProcessDefinitionUserOperationLogWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -1232,7 +1232,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySuspendProcessDefinitionUserOperationLogWithReadHPermissionOnCategory() {
+  void testQuerySuspendProcessDefinitionUserOperationLogWithReadHPermissionOnCategory() {
     // given
     suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, CATEGORY_OPERATOR, userId, READ);
@@ -1247,7 +1247,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySuspendProcessDefinitionUserOperationLogWithReadHPermissionOnAnyCategory() {
+  void testQuerySuspendProcessDefinitionUserOperationLogWithReadHPermissionOnAnyCategory() {
     // given
     suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
     createGrantAuthorizationWithoutAuthentication(OPERATION_LOG_CATEGORY, ANY, userId, READ);
@@ -1264,7 +1264,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   // process instance //////////////////////////////////////////////
 
   @Test
-  public void testQuerySuspendProcessInstanceUserOperationLogWithoutAuthorization() {
+  void testQuerySuspendProcessInstanceUserOperationLogWithoutAuthorization() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     suspendProcessInstanceById(processInstanceId);
@@ -1279,7 +1279,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySuspendProcessInstanceUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
+  void testQuerySuspendProcessInstanceUserOperationLogWithReadHistoryPermissionOnProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     suspendProcessInstanceById(processInstanceId);
@@ -1296,7 +1296,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySuspendProcessInstanceUserOperationLogWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQuerySuspendProcessInstanceUserOperationLogWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     suspendProcessInstanceById(processInstanceId);
@@ -1313,7 +1313,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySuspendProcessInstanceUserOperationLogWithReadPermissionOnCategory() {
+  void testQuerySuspendProcessInstanceUserOperationLogWithReadPermissionOnCategory() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     suspendProcessInstanceById(processInstanceId);
@@ -1330,7 +1330,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQuerySuspendProcessInstanceUserOperationLogWithReadPermissionOnAnyCategory() {
+  void testQuerySuspendProcessInstanceUserOperationLogWithReadPermissionOnAnyCategory() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     suspendProcessInstanceById(processInstanceId);
@@ -1349,7 +1349,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   // delete deployment (cascade = false)
 
   @Test
-  public void testQueryAfterDeletingDeploymentWithoutAuthorization() {
+  void testQueryAfterDeletingDeploymentWithoutAuthorization() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1376,7 +1376,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryAfterDeletingDeploymentWithReadHistoryPermissionOnProcessDefinition() {
+  void testQueryAfterDeletingDeploymentWithReadHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1404,7 +1404,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryAfterDeletingDeploymentWithReadHistoryPermissionOnAnyProcessDefinition() {
+  void testQueryAfterDeletingDeploymentWithReadHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1432,7 +1432,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryAfterDeletingDeploymentWithReadPermissionOnCategory() {
+  void testQueryAfterDeletingDeploymentWithReadPermissionOnCategory() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1466,7 +1466,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testQueryAfterDeletingDeploymentWithReadPermissionOnAnyCategory() {
+  void testQueryAfterDeletingDeploymentWithReadPermissionOnAnyCategory() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1496,7 +1496,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   // delete user operation log (standalone) ////////////////////////
 
   @Test
-  public void testDeleteStandaloneEntryWithoutAuthorization() {
+  void testDeleteStandaloneEntryWithoutAuthorization() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -1522,7 +1522,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteStandaloneEntryWithDeleteHistoryPermissionOnProcessDefinition() {
+  void testDeleteStandaloneEntryWithDeleteHistoryPermissionOnProcessDefinition() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -1550,7 +1550,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteStandaloneEntryWithDeleteHistoryPermissionOnAnyProcessDefinition() {
+  void testDeleteStandaloneEntryWithDeleteHistoryPermissionOnAnyProcessDefinition() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -1578,7 +1578,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteStandaloneEntryWithDeletePermissionOnCategory() {
+  void testDeleteStandaloneEntryWithDeletePermissionOnCategory() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -1599,7 +1599,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteStandaloneEntryWithDeletePermissionOnAnyCategory() {
+  void testDeleteStandaloneEntryWithDeletePermissionOnAnyCategory() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -1622,7 +1622,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   // delete user operation log /////////////////////////////////////
 
   @Test
-  public void testDeleteEntryWithoutAuthorization() {
+  void testDeleteEntryWithoutAuthorization() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1650,7 +1650,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteEntryWithDeleteHistoryPermissionOnProcessDefinition() {
+  void testDeleteEntryWithDeleteHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1671,7 +1671,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteEntryWithDeleteHistoryPermissionOnAnyProcessDefinition() {
+  void testDeleteEntryWithDeleteHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1692,7 +1692,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteEntryWithDeletePermissionOnCategory() {
+  void testDeleteEntryWithDeletePermissionOnCategory() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1713,7 +1713,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteEntryWithDeletePermissionOnAnyCategory() {
+  void testDeleteEntryWithDeletePermissionOnAnyCategory() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -1734,7 +1734,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testDeleteEntryAfterDeletingDeployment() {
+  void testDeleteEntryAfterDeletingDeployment() {
     // given
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     String taskId = selectSingleTask().getId();
@@ -1764,7 +1764,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   // delete user operation log (case) //////////////////////////////
 
   @Test
-  public void testCaseDeleteEntryWithoutAuthorization() {
+  void testCaseDeleteEntryWithoutAuthorization() {
     // given
     testRule.createCaseInstanceByKey(ONE_TASK_CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -1789,7 +1789,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCaseDeleteEntryWithDeleteHistoryPermissionOnProcessDefinition() {
+  void testCaseDeleteEntryWithDeleteHistoryPermissionOnProcessDefinition() {
     // given
     testRule.createCaseInstanceByKey(ONE_TASK_CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -1816,7 +1816,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCaseDeleteEntryWithDeleteHistoryPermissionOnAnyProcessDefinition() {
+  void testCaseDeleteEntryWithDeleteHistoryPermissionOnAnyProcessDefinition() {
     // given
     testRule.createCaseInstanceByKey(ONE_TASK_CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -1843,7 +1843,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCaseDeleteEntryWithDeletePermissionOnCategory() {
+  void testCaseDeleteEntryWithDeletePermissionOnCategory() {
     // given
     testRule.createCaseInstanceByKey(ONE_TASK_CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -1863,7 +1863,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testCaseDeleteEntryWithDeletePermissionOnAnyCategory() {
+  void testCaseDeleteEntryWithDeletePermissionOnAnyCategory() {
     // given
     testRule.createCaseInstanceByKey(ONE_TASK_CASE_KEY);
     String taskId = selectSingleTask().getId();
@@ -1885,7 +1885,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   // update user operation log //////////////////////////////
 
   @Test
-  public void testUpdateEntryWithUpdateHistoryPermissionOnProcessDefinition() {
+  void testUpdateEntryWithUpdateHistoryPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -1919,7 +1919,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateEntryWithUpdateHistoryPermissionOnAnyProcessDefinition() {
+  void testUpdateEntryWithUpdateHistoryPermissionOnAnyProcessDefinition() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -1954,7 +1954,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
 
   @Test
-  public void testUpdateEntryWithUpdateHistoryPermissionOnAnyProcessDefinition_Standalone() {
+  void testUpdateEntryWithUpdateHistoryPermissionOnAnyProcessDefinition_Standalone() {
     // given
     createTask("aTaskId");
 
@@ -1988,7 +1988,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateEntryRelatedToProcessDefinitionWithUpdatePermissionOnCategory() {
+  void testUpdateEntryRelatedToProcessDefinitionWithUpdatePermissionOnCategory() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -2022,7 +2022,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateEntryRelatedToProcessDefinitionWithUpdatePermissionOnAnyCategory() {
+  void testUpdateEntryRelatedToProcessDefinitionWithUpdatePermissionOnAnyCategory() {
     // given
     startProcessInstanceByKey(ONE_TASK_PROCESS_KEY);
 
@@ -2056,7 +2056,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateEntryWithoutAuthorization() {
+  void testUpdateEntryWithoutAuthorization() {
     // given
     createTask("aTaskId");
 
@@ -2088,7 +2088,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateEntryWithUpdatePermissionOnCategory() {
+  void testUpdateEntryWithUpdatePermissionOnCategory() {
     // given
     createTask("aTaskId");
 
@@ -2122,7 +2122,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Test
-  public void testUpdateEntryWithUpdatePermissionOnAnyCategory() {
+  void testUpdateEntryWithUpdatePermissionOnAnyCategory() {
     // given
     createTask("aTaskId");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/UserOperationLogAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/UserOperationLogAuthorizationTest.java
@@ -16,6 +16,9 @@
  */
 package org.operaton.bpm.engine.test.api.authorization.history;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.authorization.*;
@@ -47,10 +50,6 @@ import static org.operaton.bpm.engine.history.UserOperationLogEntry.CATEGORY_TAS
 import java.util.Date;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -69,7 +68,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   protected String testTaskId;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUp() {
     deploymentId = testRule.deploy(
         "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml",
@@ -80,7 +79,7 @@ public class UserOperationLogAuthorizationTest extends AuthorizationTest {
   }
 
   @Override
-  @After
+  @AfterEach
   public void tearDown() {
     super.tearDown();
     processEngineConfiguration.setEnableHistoricInstancePermissions(false);


### PR DESCRIPTION
- Abstract AuthorizationTest from JUnit4 to JUnit5
- All subclasses of AuthorizationTest to JUnit5
- Adapting ProcessEngineExtension to disable authentication in BeforeEach and AfterEach methods to avoid false fails

relates to #27