### PR TITLE
chore(dependencies): upgrade JUnit to 5.12.1

### DIFF
--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -20,7 +20,7 @@
   </description>
 
   <properties>
-    <version.junit5>5.11.3</version.junit5>
+    <version.junit5>5.12.0</version.junit5>
     <version.slf4j>2.0.16</version.slf4j>
   </properties>
 

--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -20,7 +20,6 @@
   </description>
 
   <properties>
-    <version.junit5>5.12.0</version.junit5>
     <version.slf4j>2.0.16</version.slf4j>
   </properties>
 
@@ -47,6 +46,13 @@
         <version>${version.spring-boot}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.12.1</version>
+        <type>pom</type>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jboss.arquillian</groupId>
@@ -154,42 +160,6 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${version.junit}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <version>${version.junit5}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${version.junit5}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-params</artifactId>
-        <version>${version.junit5}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <version>${version.junit5}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.platform</groupId>
-        <artifactId>junit-platform-suite</artifactId>
-        <version>1.11.4</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.platform</groupId>
-        <artifactId>junit-platform-testkit</artifactId>
-        <version>1.11.3</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -47,7 +47,7 @@
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpclient5>5.4.1</version.httpclient5>
 
-    <version.junit>5.11.3</version.junit>
+    <version.junit>5.12.0</version.junit>
     <version.junit>4.13.1</version.junit>
     <version.assertj>3.27.3</version.assertj>
     <version.mockito>5.10.0</version.mockito>
@@ -79,7 +79,7 @@
 
     <version.nodejs>22.13.0</version.nodejs>
     <version.npm>11.0.0</version.npm>
-    <version.junit5>5.11.3</version.junit5>
+    <version.junit5>5.12.0</version.junit5>
 
     <jacoco.argLine/>
     <surefire.memArgs>-Xmx1024m -XX:MetaspaceSize=128m</surefire.memArgs>


### PR DESCRIPTION
- Upgrades JUnit to 5.12.1
- Using JUnit BOM for managing all junit related libraries

fixes #574
closes #602 