### PR TITLE
Fix integration test execution

### DIFF
--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -50,7 +50,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.12.1</version>
+        <version>5.11.4</version>
         <type>pom</type>
         <scope>test</scope>
       </dependency>
@@ -159,7 +159,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>${version.junit}</version>
+        <version>4.13.1</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>

--- a/distro/run/qa/integration-tests/pom.xml
+++ b/distro/run/qa/integration-tests/pom.xml
@@ -12,6 +12,18 @@
   <name>Operaton - Run - QA - Integration Tests</name>
   <packaging>jar</packaging>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
+        <version>${project.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
 
     <dependency>
@@ -91,20 +103,24 @@
     </dependency>
 
     <dependency>
-      <groupId>com.sun.jersey.contribs</groupId>
-      <artifactId>jersey-apache-client4</artifactId>
-      <scope>test</scope>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
-      <scope>test</scope>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-client</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/SqlAvailabilityIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/SqlAvailabilityIT.java
@@ -16,7 +16,8 @@
  */
 package org.operaton.bpm.run.qa;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -34,12 +35,12 @@ class SqlAvailabilityIT {
     Path dropDir = sqlDir.resolve("drop");
     Path upgradeDir = sqlDir.resolve("upgrade");
 
-    assertThat(sqlDir).isNotNull();
-    assertThat(createDir).isNotNull();
-    assertThat(dropDir).isNotNull();
-    assertThat(upgradeDir).isNotNull();
-    assertThat(createDir).isNotEmptyDirectory();
-    assertThat(dropDir).isNotEmptyDirectory();
-    assertThat(upgradeDir).isNotEmptyDirectory();
+    assertThat(sqlDir, is(notNullValue()));
+    assertThat(createDir, is(notNullValue()));
+    assertThat(dropDir, is(notNullValue()));
+    assertThat(upgradeDir, is(notNullValue()));
+    assertThat(createDir.toFile().list().length, is(greaterThan(0)));
+    assertThat(dropDir.toFile().list().length, is(greaterThan(0)));
+    assertThat(upgradeDir.toFile().list().length, is(greaterThan(0)));
   }
 }

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebIT.java
@@ -16,20 +16,18 @@
  */
 package org.operaton.bpm.run.qa.webapps;
 
-import com.sun.jersey.api.client.config.ClientConfig;
-import com.sun.jersey.api.json.JSONConfiguration;
-import com.sun.jersey.client.apache4.ApacheHttpClient4;
-import com.sun.jersey.client.apache4.config.DefaultApacheHttpClient4Config;
+import java.util.logging.Logger;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.params.HttpConnectionParams;
-import org.apache.http.params.HttpParams;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.JerseyClient;
+import org.glassfish.jersey.jackson.JacksonFeature;
 import org.junit.jupiter.api.AfterEach;
-import org.operaton.bpm.TestProperties;
-import org.operaton.bpm.util.TestUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.openqa.selenium.chrome.ChromeDriverService;
-
-import java.util.logging.Logger;
+import org.operaton.bpm.TestProperties;
+import org.operaton.bpm.util.TestUtil;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
 
 /**
  * NOTE: copied from
@@ -40,8 +38,8 @@ public abstract class AbstractWebIT {
 
   private static final Logger LOGGER = Logger.getLogger(AbstractWebIT.class.getName());
 
-  protected String TASKLIST_PATH = "app/tasklist/default/";
-  public static final String HOST_NAME = "localhost";
+  protected static final String TASKLIST_PATH = "app/tasklist/default/";
+  protected static final String HOST_NAME = "localhost";
   public String APP_BASE_PATH;
 
   protected String appUrl;
@@ -50,7 +48,7 @@ public abstract class AbstractWebIT {
 
   protected static ChromeDriverService service;
 
-  public ApacheHttpClient4 client;
+  public Client client;
   public DefaultHttpClient defaultHttpClient;
   public String httpPort;
 
@@ -62,23 +60,30 @@ public abstract class AbstractWebIT {
 
   @AfterEach
   public void destroyClient() {
-    client.destroy();
+    client.close();
   }
 
   public void createClient(String ctxPath) throws Exception {
+    // Initialize test properties
     testProperties = new TestProperties();
 
+    // Get the application base path
     APP_BASE_PATH = testProperties.getApplicationPath("/" + ctxPath);
-    LOGGER.info("Connecting to application "+APP_BASE_PATH);
+    LOGGER.info("Connecting to application " + APP_BASE_PATH);
 
-    ClientConfig clientConfig = new DefaultApacheHttpClient4Config();
-    clientConfig.getFeatures().put(JSONConfiguration.FEATURE_POJO_MAPPING, Boolean.TRUE);
-    client = ApacheHttpClient4.create(clientConfig);
+    // Create ClientConfig and register JacksonFeature for POJO mapping
+    ClientConfig clientConfig = new ClientConfig();
+    clientConfig.register(JacksonFeature.class);
 
-    defaultHttpClient = (DefaultHttpClient) client.getClientHandler().getHttpClient();
-    HttpParams params = defaultHttpClient.getParams();
-    HttpConnectionParams.setConnectionTimeout(params, 3 * 60 * 1000);
-    HttpConnectionParams.setSoTimeout(params, 10 * 60 * 1000);
+    // Use JerseyClientBuilder to create the client and configure it with HttpClient
+    client =  ClientBuilder.newBuilder()
+            .withConfig(clientConfig)
+            .build();
+
+    // Set connection timeout and socket timeout
+    // These can be set directly in the HttpClient or via properties in JerseyClient
+    client.property("jersey.config.client.connectTimeout", 3 * 60 * 1000);  // 3 minutes
+    client.property("jersey.config.client.readTimeout", 10 * 60 * 1000);
   }
 
   public void preventRaceConditions() throws InterruptedException {

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/PluginsRootResourceIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/PluginsRootResourceIT.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.run.qa.webapps;
 
+import org.glassfish.jersey.client.JerseyClient;
+import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.operaton.bpm.run.qa.util.SpringBootManagedContainer;
 
 import java.util.Arrays;
@@ -99,7 +101,18 @@ class PluginsRootResourceIT extends AbstractWebIT {
   }
 
   protected Response getAsset(String path) {
-    return client.resource(APP_BASE_PATH + path).get(Response.class);
+    // Ensure the client is properly initialized
+    JerseyClient client = (JerseyClient) JerseyClientBuilder.newClient();
+
+    // Build the target URI using the base path and path parameter
+    String fullPath = APP_BASE_PATH + path;
+
+    // Perform the GET request to fetch the asset
+    Response response = client.target(fullPath)  // Use target() to define the endpoint
+            .request()  // Prepare to send the request
+            .get();  // Execute the GET request
+
+    return response;
   }
 
   protected void assertResponse(String asset, Response response) {
@@ -108,7 +121,7 @@ class PluginsRootResourceIT extends AbstractWebIT {
     } else {
       assertThat(response.getStatus()).isEqualTo(Status.FORBIDDEN.getStatusCode());
       assertThat(response.getMediaType().toString()).startsWith(MediaType.APPLICATION_JSON);
-      String responseEntity = (String)response.getEntity();
+      String responseEntity = response.readEntity(String.class);
       assertThat(responseEntity).contains("\"type\":\"RestException\"");
       assertThat(responseEntity).contains("\"message\":\"Not allowed to load the following file '" + asset + "'.\"");
     }

--- a/distro/run/qa/pom.xml
+++ b/distro/run/qa/pom.xml
@@ -51,15 +51,6 @@
         <version>${version.jersey-json}</version>
       </dependency>
 
-      <!-- using 4.13 in order to have @BeforeParam/@AfterParam for parameterized 
-        tests to correctly start and tear down the Spring Boot container before each 
-        parameter run -->
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${version.junit}</version>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 

--- a/distro/run/qa/pom.xml
+++ b/distro/run/qa/pom.xml
@@ -34,21 +34,9 @@
       </dependency>
 
       <dependency>
-        <groupId>com.sun.jersey.contribs</groupId>
-        <artifactId>jersey-apache-client4</artifactId>
-        <version>${version.jersey-apache-client}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-java</artifactId>
         <version>4.10.0</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.sun.jersey</groupId>
-        <artifactId>jersey-json</artifactId>
-        <version>${version.jersey-json}</version>
       </dependency>
 
     </dependencies>

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -109,19 +109,12 @@
       <version>${version.httpclient}</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>com.sun.jersey.contribs</groupId>
       <artifactId>jersey-apache-client4</artifactId>
+      <version>1.19.4</version>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>

--- a/engine-dmn/engine/pom.xml
+++ b/engine-dmn/engine/pom.xml
@@ -56,16 +56,19 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <scope>compile</scope>
+      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope> 
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -104,21 +104,25 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.junit.vintage</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -47,8 +47,6 @@
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpclient5>5.4.1</version.httpclient5>
 
-    <version.junit>5.12.0</version.junit>
-    <version.junit>4.13.1</version.junit>
     <version.assertj>3.27.3</version.assertj>
     <version.mockito>5.10.0</version.mockito>
     <version.wiremock>3.10.0</version.wiremock>
@@ -79,7 +77,6 @@
 
     <version.nodejs>22.13.0</version.nodejs>
     <version.npm>11.0.0</version.npm>
-    <version.junit5>5.12.0</version.junit5>
 
     <jacoco.argLine/>
     <surefire.memArgs>-Xmx1024m -XX:MetaspaceSize=128m</surefire.memArgs>

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -188,6 +188,10 @@
           <artifactId>spring-beans</artifactId>
           <groupId>org.springframework</groupId>
         </exclusion>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -207,6 +211,10 @@
         <exclusion>
           <groupId>de.odysseus.juel</groupId>
           <artifactId>juel-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -457,7 +465,15 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.maven.surefire</groupId>
+                <artifactId>surefire-junit47</artifactId>
+                <version>3.5.2</version>
+              </dependency>
+            </dependencies>
             <configuration>
+              <failIfNoTests>true</failIfNoTests>
               <excludes>
                 <!-- no EE stuff on tomcat :) -->
                 <exclude>**/ear/**</exclude>

--- a/quarkus-extension/pom.xml
+++ b/quarkus-extension/pom.xml
@@ -19,11 +19,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>${version.junit5}</version>
-        <type>pom</type>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
+        <version>${project.version}</version>
         <scope>import</scope>
+        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>

--- a/spin/dataformat-all/pom.xml
+++ b/spin/dataformat-all/pom.xml
@@ -140,7 +140,7 @@
            <additionalDependency>
              <groupId>junit</groupId>
              <artifactId>junit</artifactId>
-             <version>${version.junit}</version>
+             <version>4.13.1</version>
            </additionalDependency>
           </additionalDependencies>
         </configuration>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -21,17 +21,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>${version.junit5}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <!-- Import dependency management from Spring Boot -->
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
+        <version>${project.version}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/test-utils/assert/pom.xml
+++ b/test-utils/assert/pom.xml
@@ -14,13 +14,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>${version.junit5}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <!-- spring-framework-bom as first element in the list
            ensures to be chosen over spring-boot-dependencies
            to load spring-beans with Spring 5.


### PR DESCRIPTION
This change fixes 2 problems with the integration test execution:
1) distro operaton: Test `PluginsRootResourceIT` had problems with the old jersey client. Upgraded to newer Jersey.
2) Engine integration tests did not find tests, since JUnitPlatformProvider was used, but tests are still JUnit 4 based.
