### PR TITLE
chore: Fix usage of merged modules

### DIFF
--- a/distro/wildfly/assembly/assembly.xml
+++ b/distro/wildfly/assembly/assembly.xml
@@ -39,7 +39,7 @@
     <dependencySet>
       <outputDirectory>lib</outputDirectory>
       <includes>
-        <include>org.operaton.bpm.javaee:operaton-ejb-client-jakarta:jar:${project.version}</include>
+        <include>org.operaton.bpm.jakartaee:operaton-ejb-client:jar:${project.version}</include>
         <include>org.operaton.bpm:*</include>
         <include>org.operaton.bpm.identity:*</include>
         <include>org.operaton.bpm.model:*</include>

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/util/DeploymentHelper.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/util/DeploymentHelper.java
@@ -23,7 +23,7 @@ import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenDependencies;
 
 public class DeploymentHelper extends AbstractDeploymentHelper {
 
-  protected static final String OPERATON_EJB_CLIENT = "org.operaton.bpm.javaee:operaton-ejb-client-jakarta";
+  protected static final String OPERATON_EJB_CLIENT = "org.operaton.bpm.jakartaee:operaton-ejb-client";
   protected static final String OPERATON_ENGINE_CDI = "org.operaton.bpm:operaton-engine-cdi";
   protected static final String OPERATON_ENGINE_SPRING = "org.operaton.bpm:operaton-engine-spring";
   protected static final String OPERATON_ENGINE = "org.operaton.bpm:operaton-engine";

--- a/qa/integration-tests-webapps/shared-engine/pom.xml
+++ b/qa/integration-tests-webapps/shared-engine/pom.xml
@@ -158,7 +158,7 @@
         </dependency>
         <dependency>
           <groupId>org.operaton.bpm.webapp</groupId>
-          <artifactId>operaton-webapp-tomcat-jakarta</artifactId>
+          <artifactId>operaton-webapp-tomcat</artifactId>
           <version>${project.version}</version>
           <type>war</type>
           <scope>test</scope>
@@ -234,7 +234,7 @@
                 </deployable>
                 <deployable>
                   <groupId>org.operaton.bpm.webapp</groupId>
-                  <artifactId>operaton-webapp-tomcat-jakarta</artifactId>
+                  <artifactId>operaton-webapp-tomcat</artifactId>
                   <type>war</type>
                   <pingURL>http://localhost:${tomcat.connector.http.port}/operaton</pingURL>
                   <pingTimeout>${cargo.deploy.timeout}</pingTimeout>


### PR DESCRIPTION
- fix dependency `org.operaton.bpm.javaee:operaton-ejb-client-jakarta` -> `org.operaton.bpm.jakartaee:operaton-ejb-client`
- fix dependency `operaton-webapp-tomcat-jakarta` -> `operaton-webapp-tomcat`