### PR TITLE
Build: Dependency cleanup

### DIFF
--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -394,38 +394,6 @@
         <version>2.0.0</version>
       </dependency>
 
-      <dependency>
-        <groupId>org.jboss.spec</groupId>
-        <artifactId>jboss-javaee-6.0</artifactId>
-        <version>${version.jboss-javaee-spec}</version>
-        <type>pom</type>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jboss.spec</groupId>
-        <artifactId>jboss-javaee-web-6.0</artifactId>
-        <version>${version.jboss-javaee-spec}</version>
-        <type>pom</type>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jboss.spec.javax.servlet</groupId>
-        <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-        <version>1.0.2.Final</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jboss.spec.javax.ws.rs</groupId>
-        <artifactId>jboss-jaxrs-api_1.1_spec</artifactId>
-        <version>1.0.1.Final</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jboss.spec.javax.ws.rs</groupId>
-        <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-        <version>${version.jaxrs.api}</version>
-      </dependency>
-
       <!-- Wildfly -->
       <!-- version 6 depends on jakarta.enterprise.cdi.api version 4.1.0, which is newer than 4.0.1 defined by
       JakartaEE 10.0.0 BOM -->

--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -56,6 +56,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.glassfish.jersey</groupId>
+        <artifactId>jersey-bom</artifactId>
+        <version>3.1.10</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- Test Framework BOMs -->
       <dependency>
         <groupId>org.junit</groupId>
@@ -65,9 +72,9 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.glassfish.jersey</groupId>
-        <artifactId>jersey-bom</artifactId>
-        <version>3.1.10</version>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${version.testcontainers}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -21,6 +21,8 @@
 
   <properties>
     <version.slf4j>2.0.16</version.slf4j>
+    <version.bouncycastle>1.47</version.bouncycastle>
+    <version.jetty>12.0.16</version.jetty>
   </properties>
 
   <dependencyManagement>
@@ -36,7 +38,7 @@
       <dependency>
         <groupId>jakarta.platform</groupId>
         <artifactId>jakarta.jakartaee-bom</artifactId>
-        <version>${version.jakarta-ee-spec}</version>
+        <version>10.0.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -79,14 +81,30 @@
       <dependency>
         <groupId>org.jboss.arquillian.jakarta</groupId>
         <artifactId>arquillian-jakarta-bom</artifactId>
-        <version>${version.arquillian-jakarta}</version>
+        <version>10.0.0.Final</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.shrinkwrap.resolver</groupId>
+        <artifactId>shrinkwrap-resolver-bom</artifactId>
+        <version>3.3.3</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>2.18.3</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-bom</artifactId>
+        <version>5.16.1</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
       <!-- Other dependencies -->
       <dependency>
@@ -142,14 +160,14 @@
         <version>1.5</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.httpcomponents.client5</groupId>
-        <artifactId>httpclient5</artifactId>
-        <version>${version.httpclient5}</version>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>4.5.14</version>
       </dependency>
       <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-xjc</artifactId>
-        <version>2.3.6</version>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>5.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
@@ -231,12 +249,25 @@
         <scope>provided</scope>
       </dependency>
 
-    <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-      <version>3.2.2</version>
-      <scope>test</scope>
-    </dependency>
+      <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>3.2.2</version>
+      </dependency>
+
+      <!-- JNA needed for Managed Container -->
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna</artifactId>
+        <version>5.16.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna-platform</artifactId>
+        <version>5.16.0</version>
+        <scope>test</scope>
+      </dependency>
 
       <!-- EMAIL -->
       <dependency>
@@ -256,11 +287,6 @@
       </dependency>
         <!-- Web service -->
       <dependency>
-        <groupId>org.apache.geronimo.specs</groupId>
-        <artifactId>geronimo-jta_1.1_spec</artifactId>
-        <version>1.1.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.openjpa</groupId>
         <artifactId>openjpa</artifactId>
         <version>${version.openjpa}</version>
@@ -272,11 +298,6 @@
         <artifactId>jetty-bom</artifactId>
         <version>${version.jetty}</version>
         <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-server</artifactId>
-        <version>${version.jetty}</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
@@ -323,18 +344,6 @@
         <groupId>org.mule.tests</groupId>
         <artifactId>mule-tests-functional</artifactId>
         <version>${mule.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>${version.mockito}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-junit-jupiter</artifactId>
-        <version>${version.mockito}</version>
-        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.osgi</groupId>
@@ -498,7 +507,7 @@
       <dependency>
         <groupId>org.wiremock</groupId>
         <artifactId>wiremock</artifactId>
-        <version>${version.wiremock}</version>
+        <version>3.10.0</version>
         <scope>test</scope>
       </dependency>
 
@@ -506,7 +515,7 @@
         <groupId>org.wiremock</groupId>
         <artifactId>wiremock-standalone</artifactId>
         <scope>test</scope>
-        <version>${version.wiremock}</version>
+        <version>3.10.0</version>
       </dependency>
 
       <dependency>
@@ -535,6 +544,7 @@
         <version>1.1.0</version>
         <scope>provided</scope>
       </dependency>
+
 
     </dependencies>
   </dependencyManagement>

--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -426,6 +426,17 @@
         <version>${version.jaxrs.api}</version>
       </dependency>
 
+      <!-- Wildfly -->
+      <!-- version 6 depends on jakarta.enterprise.cdi.api version 4.1.0, which is newer than 4.0.1 defined by
+      JakartaEE 10.0.0 BOM -->
+      <dependency>
+        <groupId>org.jboss.weld</groupId>
+        <artifactId>weld-core-bom</artifactId>
+        <version>5.1.5.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <!-- licensing dependencies -->
       <dependency>
         <groupId>org.bouncycastle</groupId>

--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -41,12 +41,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>${version.httpclient}</version>
-      </dependency>
-
-      <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
         <version>${commons-codec.version}</version>

--- a/distro/run/pom.xml
+++ b/distro/run/pom.xml
@@ -19,9 +19,9 @@
     <dependencies>
 
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
+        <version>${project.version}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/distro/run/qa/integration-tests/pom.xml
+++ b/distro/run/qa/integration-tests/pom.xml
@@ -98,7 +98,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>${version.httpclient}</version>
       <scope>test</scope>
     </dependency>
 

--- a/distro/run/qa/pom.xml
+++ b/distro/run/qa/pom.xml
@@ -16,7 +16,6 @@
     <!-- default os -->
     <os.type>linux64</os.type>
 
-    <version.jersey-json>1.15</version.jersey-json>
     <version.jersey-apache-client>1.15</version.jersey-apache-client>
     <version.httpcomponents>4.5.10</version.httpcomponents>
     <version.chromedriver>112.0.5615.49</version.chromedriver>
@@ -26,26 +25,15 @@
     <dependencies>
 
       <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpcomponents-client</artifactId>
-        <version>${version.httpcomponents}</version>
-        <type>pom</type>
-        <scope>import</scope>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
+        <version>${project.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-java</artifactId>
         <version>4.10.0</version>
-      </dependency>
-
-      <!-- using 4.13 in order to have @BeforeParam/@AfterParam for parameterized
-        tests to correctly start and tear down the Spring Boot container before each 
-        parameter run -->
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${version.junit}</version>
       </dependency>
 
     </dependencies>

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -19,6 +19,18 @@
     <install.skip>true</install.skip>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
+        <version>${project.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
 
     <dependency>
@@ -106,7 +118,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>${version.httpclient}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/engine-cdi/core/pom.xml
+++ b/engine-cdi/core/pom.xml
@@ -26,13 +26,6 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
-      <dependency>
-        <groupId>org.jboss.weld</groupId>
-        <artifactId>weld-core-bom</artifactId>
-        <version>${weld.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/engine-plugins/pom.xml
+++ b/engine-plugins/pom.xml
@@ -28,11 +28,6 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
-      <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-impl</artifactId>
-        <version>${version.xml.jaxb-impl}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/engine-rest/engine-rest-openapi/pom.xml
+++ b/engine-rest/engine-rest-openapi/pom.xml
@@ -21,11 +21,19 @@
     <swagger-core-version>2.1.22</swagger-core-version>
     <okhttp-version>4.12.0</okhttp-version>
     <gson-version>2.8.9</gson-version>
-    <commons-lang3-version>3.9</commons-lang3-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>
-    <junit-version>4.13.1</junit-version>
     <surefire.forkCount>1</surefire.forkCount>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
 
@@ -104,19 +112,17 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>${commons-lang3-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
     <!-- test dependencies -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit-version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -309,11 +309,6 @@
       <id>distro</id>
       <dependencies>
         <dependency>
-          <groupId>org.jboss.spec.javax.ws.rs</groupId>
-          <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-          <scope>provided</scope>
-        </dependency>
-        <dependency>
           <groupId>org.junit.jupiter</groupId>
           <artifactId>junit-jupiter</artifactId>
           <scope>test</scope>
@@ -525,11 +520,6 @@
       </properties>
 
       <dependencies>
-        <dependency>
-          <groupId>org.jboss.spec.javax.ws.rs</groupId>
-          <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
-          <scope>provided</scope>
-        </dependency>
 
         <dependency>
           <groupId>org.jboss.resteasy</groupId>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -14,7 +14,6 @@
     <!-- pin tomcat version for engine-rest -->
     <version.tomcat>10.1.35</version.tomcat>
     <rest.http.port>38080</rest.http.port>
-    <javax.activation.version>1.1.1</javax.activation.version>
     <surefire.memArgs>-Xmx2g</surefire.memArgs>
   </properties>
 
@@ -86,19 +85,6 @@
       <groupId>org.operaton.commons</groupId>
       <artifactId>operaton-commons-logging</artifactId>
       <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
-      <version>${javax.activation.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -181,13 +181,13 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- test dependencies  -->
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>provided</scope>
     </dependency>
-
-    <!-- test dependencies  -->
 
     <dependency>
       <groupId>org.mockito</groupId>

--- a/jakarta-ee/ejb-client/pom.xml
+++ b/jakarta-ee/ejb-client/pom.xml
@@ -16,11 +16,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>jakarta.platform</groupId>
-        <artifactId>jakarta.jakartaee-bom</artifactId>
-        <version>${version.jakarta-ee-spec}</version>
-        <type>pom</type>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
+        <version>${project.version}</version>
         <scope>import</scope>
+        <type>pom</type>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/jakarta-ee/ejb-service/pom.xml
+++ b/jakarta-ee/ejb-service/pom.xml
@@ -23,13 +23,6 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
-      <dependency>
-        <groupId>jakarta.platform</groupId>
-        <artifactId>jakarta.jakartaee-bom</artifactId>
-        <version>${version.jakarta-ee-spec}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -49,9 +49,6 @@
     <version.tomcat>10.1.30</version.tomcat>
 
     <version.arquillian>1.9.3.Final</version.arquillian>
-    <!-- version 6 depends on jakarta.enterprise.cdi.api version 4.1.0, which is newer than 4.0.1 defined by
-    JakartaEE 10.0.0 BOM -->
-    <weld.version>5.1.5.Final</weld.version>
 
     <version.shrinkwrap.resolvers>3.3.3</version.shrinkwrap.resolvers>
     <version.selenium>4.10.0</version.selenium>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -21,49 +21,34 @@
     <version.spring-boot>3.4.4</version.spring-boot>
     <version.resteasy>3.15.6.Final</version.resteasy>
     <version.jersey3>3.1.10</version.jersey3>
-    <version.ejb>3.1</version.ejb>
     <!-- use minimum version of resteasy and jersey -->
     <version.jaxrs.api>2.0.1.Final</version.jaxrs.api>
     <version.groovy>4.0.25</version.groovy>
     <version.graal.js>21.3.12</version.graal.js>
     <version.nashorn>15.4</version.nashorn>
     <version.icu.icu4j>71.1</version.icu.icu4j>
-    <!-- json-smart and accessors-smart are runtime dependencies of json-path -->
-    <version.json-path>2.9.0</version.json-path>
-    <version.json-smart>2.5.2</version.json-smart>
     <version.commons-codec>1.17.2</version.commons-codec>
-    <version.accessors-smart>2.5.2</version.accessors-smart>
     <version.gson>2.8.9</version.gson>
     <version.openjpa>2.4.3</version.openjpa>
     <version.hibernate>6.6.10.Final</version.hibernate>
     <version.hikaricp>4.0.3</version.hikaricp>
     <version.jackson>2.15.2</version.jackson>
-    <version.xml.bind-api>2.3.3</version.xml.bind-api>
-    <version.xml.jaxb-impl>2.3.6</version.xml.jaxb-impl>
-    <version.xml.jaxb-impl4>4.0.5</version.xml.jaxb-impl4>
-    <version.jakarta.xml.bind-api>4.0.2</version.jakarta.xml.bind-api>
-    <version.jakarta.servlet-api>6.1.0</version.jakarta.servlet-api>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpclient5>5.4.1</version.httpclient5>
 
     <version.assertj>3.27.3</version.assertj>
     <version.mockito>5.16.1</version.mockito>
-    <version.wiremock>3.10.0</version.wiremock>
     <version.testcontainers>1.20.6</version.testcontainers>
 
     <version.commonj>1.1.0</version.commonj>
-    <version.bouncycastle>1.47</version.bouncycastle>
 
     <!-- application servers -->
-    <version.jakarta-ee-spec>10.0.0</version.jakarta-ee-spec>
     <version.wildfly>35.0.1.Final</version.wildfly>
     <version.wildfly.core>27.0.1.Final</version.wildfly.core>
 
     <version.tomcat>10.1.30</version.tomcat>
 
     <version.arquillian>1.9.3.Final</version.arquillian>
-    <version.arquillian-jakarta>10.0.0.Final</version.arquillian-jakarta>
-    <version.arquillian.container>4.0.0.Final</version.arquillian.container>
     <!-- version 6 depends on jakarta.enterprise.cdi.api version 4.1.0, which is newer than 4.0.1 defined by
     JakartaEE 10.0.0 BOM -->
     <weld.version>5.1.5.Final</weld.version>
@@ -198,7 +183,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-ejb-plugin</artifactId>
           <configuration>
-            <ejbVersion>${version.ejb}</ejbVersion>
+            <ejbVersion>3.1</ejbVersion>
             <archive>
               <manifest>
                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
     <!-- These properties are used in both the BOM as well as operaton-parent and subprojects -->
     <version.mybatis>3.5.15</version.mybatis>
     <version.joda-time>2.12.5</version.joda-time>
-    <version.jetty>12.0.16</version.jetty>
     <version.uuid-generator>4.3.0</version.uuid-generator>
     <version.feel-scala>1.18.1</version.feel-scala>
     <version.quarkus>3.15.0</version.quarkus>

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -19,7 +19,6 @@
 
     <redirect.test.output>true</redirect.test.output>
 
-    <weld.version>6.0.1.Final</weld.version>
     <install.skip>true</install.skip>
   </properties>
 
@@ -39,14 +38,12 @@
       <dependency>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-bom</artifactId>
-        <version>${weld.version}</version>
       </dependency>
 
       <!-- Deployed programmatically by DeploymentHelper -->
       <dependency>
         <groupId>org.jboss.weld.servlet</groupId>
         <artifactId>weld-servlet-shaded</artifactId>
-        <version>${weld.version}</version>
       </dependency>
 
     </dependencies>

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -35,29 +35,6 @@
         <type>pom</type>
       </dependency>
 
-      <dependency>
-        <groupId>org.jboss.shrinkwrap.resolver</groupId>
-        <artifactId>shrinkwrap-resolver-bom</artifactId>
-        <version>${version.shrinkwrap.resolvers}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jboss.arquillian</groupId>
-        <artifactId>arquillian-bom</artifactId>
-        <version>${version.arquillian}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jboss.arquillian.jakarta</groupId>
-        <artifactId>arquillian-jakarta-bom</artifactId>
-        <version>10.0.0.Final</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
 
       <dependency>
         <groupId>org.jboss.weld</groupId>
@@ -70,22 +47,6 @@
         <groupId>org.jboss.weld.servlet</groupId>
         <artifactId>weld-servlet-shaded</artifactId>
         <version>${weld.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>jakarta.platform</groupId>
-        <artifactId>jakarta.jakartaee-bom</artifactId>
-        <version>${version.jakarta-ee-spec}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>${version.jackson}</version>
-        <scope>import</scope>
-        <type>pom</type>
       </dependency>
 
     </dependencies>

--- a/qa/integration-tests-webapps/pom.xml
+++ b/qa/integration-tests-webapps/pom.xml
@@ -37,6 +37,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
+        <version>${project.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
         <groupId>org.jboss.shrinkwrap.resolver</groupId>
         <artifactId>shrinkwrap-resolver-bom</artifactId>
         <version>${version.shrinkwrap.resolvers}</version>

--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -111,13 +111,6 @@
             <scope>import</scope>
             <type>pom</type>
           </dependency>
-          <dependency>
-            <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-bom</artifactId>
-            <version>${version.jakarta-ee-spec}</version>
-            <type>pom</type>
-            <scope>import</scope>
-          </dependency>
         </dependencies>
       </dependencyManagement>
 
@@ -252,12 +245,6 @@
         <dependency>
           <groupId>jakarta.transaction</groupId>
           <artifactId>jakarta.transaction-api</artifactId>
-          <scope>test</scope>
-        </dependency>
-
-        <dependency>
-          <groupId>org.apache.geronimo.specs</groupId>
-          <artifactId>geronimo-jta_1.1_spec</artifactId>
           <scope>test</scope>
         </dependency>
 

--- a/qa/tomcat-runtime/pom.xml
+++ b/qa/tomcat-runtime/pom.xml
@@ -19,11 +19,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers-bom</artifactId>
-        <version>${version.testcontainers}</version>
-        <type>pom</type>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
+        <version>${project.version}</version>
         <scope>import</scope>
+        <type>pom</type>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/spin/dataformat-json-jackson/pom.xml
+++ b/spin/dataformat-json-jackson/pom.xml
@@ -10,6 +10,16 @@
   <artifactId>operaton-spin-dataformat-json-jackson</artifactId>
   <name>Operaton - Spin - Jackson JSON data format</name>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.operaton.spin</groupId>
@@ -39,6 +49,7 @@
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
+      <version>2.9.0</version>
       <exclusions>
         <exclusion>
           <artifactId>asm</artifactId>

--- a/spin/dataformat-xml-dom/pom.xml
+++ b/spin/dataformat-xml-dom/pom.xml
@@ -45,13 +45,6 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.xml.bind</groupId>
-      <artifactId>jakarta.xml.bind-api</artifactId>
-      <version>${version.jakarta.xml.bind-api}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
       <scope>test</scope>
@@ -112,11 +105,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <profiles>

--- a/spin/pom.xml
+++ b/spin/pom.xml
@@ -48,14 +48,6 @@
       </dependency>
 
       <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>${version.jackson}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-
-      <dependency>
         <groupId>org.apache.groovy</groupId>
         <artifactId>groovy-jsr223</artifactId>
         <version>${version.groovy}</version>
@@ -86,15 +78,8 @@
       </dependency>
 
       <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-impl</artifactId>
-        <version>${version.xml.jaxb-impl}</version>
-      </dependency>
-
-      <dependency>
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path</artifactId>
-        <version>${version.json-path}</version>
       </dependency>
 
     </dependencies>

--- a/spring-boot-starter/starter-qa/integration-test-request-scope/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-request-scope/pom.xml
@@ -17,7 +17,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>${version.spring-boot}</version>
     </dependency>
 
     <dependency>

--- a/spring-boot-starter/starter/pom.xml
+++ b/spring-boot-starter/starter/pom.xml
@@ -13,11 +13,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>jakarta.platform</groupId>
-        <artifactId>jakarta.jakartaee-bom</artifactId>
-        <version>${version.jakarta-ee-spec}</version>
-        <type>pom</type>
+        <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-core-internal-dependencies</artifactId>
+        <version>${project.version}</version>
         <scope>import</scope>
+        <type>pom</type>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -140,7 +140,7 @@
     <dependency>
       <groupId>jakarta.transaction</groupId>
       <artifactId>jakarta.transaction-api</artifactId>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>
@@ -157,12 +157,6 @@
       <artifactId>jakarta.interceptor-api</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <version>${version.xml.jaxb-impl4}</version>
-    </dependency>
-
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-suite</artifactId>

--- a/test-utils/assert/pom.xml
+++ b/test-utils/assert/pom.xml
@@ -14,23 +14,10 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- spring-framework-bom as first element in the list
-           ensures to be chosen over spring-boot-dependencies
-           to load spring-beans with Spring 5.
-           Can be removed if operaton-engine supports Spring 6 -->
       <dependency>
         <groupId>org.operaton.bpm</groupId>
         <artifactId>operaton-core-internal-dependencies</artifactId>
         <version>${project.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-      <!-- spring-boot-dependencies as second element in the list
-           ensures to be chosen over internal-dependencies for assertj -->
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/test-utils/testcontainers/pom.xml
+++ b/test-utils/testcontainers/pom.xml
@@ -21,13 +21,6 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers-bom</artifactId>
-        <version>${version.testcontainers}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/webapps/assembly/pom.xml
+++ b/webapps/assembly/pom.xml
@@ -296,11 +296,6 @@
           <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
-          <groupId>com.sun.xml.bind</groupId>
-          <artifactId>jaxb-impl</artifactId>
-          <version>${version.xml.jaxb-impl}</version>
-        </dependency>
-        <dependency>
           <groupId>org.graalvm.js</groupId>
           <artifactId>js</artifactId>
         </dependency>


### PR DESCRIPTION
- remove version properties from parent POM for dependencies defined by internal-dependencies
- move dependencies to internal-dependencies
- use internal-dependencies in dependency management for more modules
- remove version attributes from dependencies for managed dependencies