### PR TITLE
fix: Fix shading of spin dataformat all artifact

### DIFF
--- a/jakarta-ee/ejb-client/src/main/java/org/operaton/bpm/application/impl/web/ProcessArchiveServletContextListener.java
+++ b/jakarta-ee/ejb-client/src/main/java/org/operaton/bpm/application/impl/web/ProcessArchiveServletContextListener.java
@@ -20,6 +20,7 @@ import jakarta.ejb.EJB;
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 
+import java.util.Objects;
 import org.operaton.bpm.application.ProcessApplicationInfo;
 import org.operaton.bpm.application.ProcessApplicationInterface;
 
@@ -39,6 +40,7 @@ public class ProcessArchiveServletContextListener implements ServletContextListe
   public void contextInitialized(ServletContextEvent contextEvent) {
     String contextPath = contextEvent.getServletContext().getContextPath();
 
+    Objects.requireNonNull(defaultEjbProcessApplication, "Cannot inject ProcessApplicationInterface EJB. Make sure the ProcessApplication is deployed as EJB.");
     defaultEjbProcessApplication.getProperties().put(ProcessApplicationInfo.PROP_SERVLET_CONTEXT_PATH, contextPath);
   }
 

--- a/qa/tomcat-runtime/pom.xml
+++ b/qa/tomcat-runtime/pom.xml
@@ -188,12 +188,6 @@
                       <outputDirectory>target/server/apache-tomcat-${version.tomcat}/lib</outputDirectory>
                     </artifactItem>
                     <artifactItem>
-                      <groupId>jakarta.xml.bind</groupId>
-                      <artifactId>jakarta.xml.bind-api</artifactId>
-                      <version>4.0.2</version>
-                      <outputDirectory>target/server/apache-tomcat-${version.tomcat}/lib</outputDirectory>
-                    </artifactItem>
-                    <artifactItem>
                       <groupId>org.assertj</groupId>
                       <artifactId>assertj-core</artifactId>
                       <version>${version.assertj}</version>

--- a/spin/dataformat-all/pom.xml
+++ b/spin/dataformat-all/pom.xml
@@ -35,6 +35,15 @@
       <artifactId>jakarta.xml.bind-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -54,7 +63,6 @@
               <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <artifactSet>
                 <excludes>
-                  <exclude>jakarta.*:*</exclude>
                   <exclude>org.operaton.commons:*</exclude>
                   <exclude>org.operaton.spin:operaton-spin-core</exclude>
                   <exclude>org.slf4j:*</exclude>
@@ -65,6 +73,14 @@
                 </excludes>
               </artifactSet>
               <relocations>
+                <relocation>
+                  <pattern>jakarta.activation</pattern>
+                  <shadedPattern>spinjar.jakarta.activation</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>jakarta.xml</pattern>
+                  <shadedPattern>spinjar.jakarta.xml</shadedPattern>
+                </relocation>
                 <relocation>
                   <pattern>com.fasterxml</pattern>
                   <shadedPattern>spinjar.com.fasterxml</shadedPattern>

--- a/spin/dataformat-all/pom.xml
+++ b/spin/dataformat-all/pom.xml
@@ -57,6 +57,10 @@
                   <exclude>org.operaton.commons:*</exclude>
                   <exclude>org.operaton.spin:operaton-spin-core</exclude>
                   <exclude>org.slf4j:*</exclude>
+                  <exclude>org.junit.jupiter:*</exclude>
+                  <exclude>org.junit.platform:*</exclude>
+                  <exclude>org.opentest4j:*</exclude>
+                  <exclude>org.apiguardian:*</exclude>
                 </excludes>
               </artifactSet>
               <relocations>
@@ -69,53 +73,41 @@
                   <shadedPattern>spinjar.com.jayway</shadedPattern>
                 </relocation>
                 <relocation>
+                  <pattern>jakarta.xml.bind</pattern>
+                  <shadedPattern>spinjar.jakarta.xml.bind</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>jakarta.activation</pattern>
+                  <shadedPattern>spinjar.jakarta.activation</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>net.minidev</pattern>
                   <shadedPattern>spinjar.com.minidev</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.objectweb</pattern>
-                  <shadedPattern>spinjar.com.objectweb</shadedPattern>
-                </relocation>
-
-                <relocation>
-                  <pattern>com.sun.istack</pattern>
-                  <shadedPattern>spinjar.com.sun.istack</shadedPattern>
+                  <pattern>org.glassfish</pattern>
+                  <shadedPattern>spinjar.org.glassfish</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>com.sun.activation</pattern>
-                  <shadedPattern>spinjar.com.sun.activation</shadedPattern>
+                  <pattern>com.sun</pattern>
+                  <shadedPattern>spinjar.com.sun</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>com.sun.xml.bind</pattern>
-                  <shadedPattern>spinjar.com.sun.xml.bind</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.sun.xml.txw2</pattern>
-                  <shadedPattern>spinjar.com.sun.xml.txw2</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>javax.xml.bind</pattern>
-                  <shadedPattern>spinjar.javax.xml.bind</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>javax.activation</pattern>
-                  <shadedPattern>spinjar.javax.activation</shadedPattern>
+                  <pattern>org.eclipse</pattern>
+                  <shadedPattern>spinjar.org.eclipse</shadedPattern>
                 </relocation>
               </relocations>
               <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
               </transformers>
               <filters>
                 <filter>
-                  <artifact>com.sun.xml.bind:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/services/javax.xml.bind.JAXBContext</exclude>
-                  </excludes>
-                </filter>
-                <filter>
                   <artifact>*:*</artifact>
                   <excludes>
                     <exclude>module-info.class</exclude>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/spin/dataformat-all/pom.xml
+++ b/spin/dataformat-all/pom.xml
@@ -54,6 +54,7 @@
               <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
               <artifactSet>
                 <excludes>
+                  <exclude>jakarta.*:*</exclude>
                   <exclude>org.operaton.commons:*</exclude>
                   <exclude>org.operaton.spin:operaton-spin-core</exclude>
                   <exclude>org.slf4j:*</exclude>
@@ -71,14 +72,6 @@
                 <relocation>
                   <pattern>com.jayway</pattern>
                   <shadedPattern>spinjar.com.jayway</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>jakarta.xml.bind</pattern>
-                  <shadedPattern>spinjar.jakarta.xml.bind</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>jakarta.activation</pattern>
-                  <shadedPattern>spinjar.jakarta.activation</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>net.minidev</pattern>

--- a/spin/dataformat-all/src/main/resources/META-INF/services/jakarta.xml.bind.JAXBContext
+++ b/spin/dataformat-all/src/main/resources/META-INF/services/jakarta.xml.bind.JAXBContext
@@ -1,0 +1,1 @@
+spinjar.org.glassfish.jaxb.runtime.v2.ContextFactory

--- a/spin/dataformat-all/src/main/resources/META-INF/services/jakarta.xml.bind.JAXBContext
+++ b/spin/dataformat-all/src/main/resources/META-INF/services/jakarta.xml.bind.JAXBContext
@@ -1,1 +1,0 @@
-spinjar.org.glassfish.jaxb.runtime.v2.ContextFactory

--- a/spin/dataformat-all/src/main/resources/META-INF/services/spinjar.javax.xml.bind.JAXBContext
+++ b/spin/dataformat-all/src/main/resources/META-INF/services/spinjar.javax.xml.bind.JAXBContext
@@ -1,1 +1,0 @@
-spinjar.com.sun.xml.bind.v2.ContextFactory

--- a/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/DomXmlLogger.java
+++ b/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/DomXmlLogger.java
@@ -155,7 +155,10 @@ public class DomXmlLogger extends SpinLogger {
     return new SpinXmlDataFormatException(exceptionMessage("029", "Cannot create marshaller"), cause);
   }
 
-  public SpinXmlDataFormatException unableToCreateContext(Throwable cause) {
+  public SpinXmlDataFormatException unableToCreateContext(Throwable cause, String additionalInfo) {
+    if (!additionalInfo.isEmpty()) {
+      XML_DOM_LOGGER.logDebug("030", "Unable to create JAXBContext. Additional info: {}", additionalInfo);
+    }
     return new SpinXmlDataFormatException(exceptionMessage("030", "Cannot create context"), cause);
   }
 

--- a/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/impl/xml/dom/format/spi/DefaultJaxBContextProviderTest.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/impl/xml/dom/format/spi/DefaultJaxBContextProviderTest.java
@@ -1,0 +1,49 @@
+package org.operaton.spin.impl.xml.dom.format.spi;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import java.util.Iterator;
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.operaton.spin.xml.SpinXmlDataFormatException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class DefaultJaxBContextProviderTest {
+    @Test
+    void getContext_shouldCreateContext() {
+        // given
+        var contextProvider = new DefaultJaxBContextProvider();
+
+        // when
+        var context = contextProvider.getContext();
+
+        // then
+        assertThat(context).isNotNull();
+    }
+
+    @Test
+    void getContext_throwsAndLog_whenContextCreationFails() {
+        // given
+        var contextProvider = new DefaultJaxBContextProvider();
+
+        try (var mockStaticServiceLoader = mockStatic(ServiceLoader.class)) {
+            var mockServiceLoader = mock(ServiceLoader.class);
+            when(mockServiceLoader.iterator()).thenReturn(mock(Iterator.class));
+            mockStaticServiceLoader.when(() -> ServiceLoader.load(any())).thenReturn(mockServiceLoader);
+            mockStaticServiceLoader.when(() -> ServiceLoader.load(Mockito.<Class>any(), any())).thenReturn(mockServiceLoader);
+            // when + then
+            assertThatThrownBy(() -> contextProvider.getContext(String.class))
+                    .isInstanceOf(SpinXmlDataFormatException.class)
+                    .hasMessage("SPIN/DOM-XML-01030 Cannot create context")
+                    .hasCauseInstanceOf(JAXBException.class);
+        }
+        // when + then
+    }
+}

--- a/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/format/spi/EmptyContextProvider.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/format/spi/EmptyContextProvider.java
@@ -36,7 +36,7 @@ public class EmptyContextProvider implements JaxBContextProvider {
     try {
       return JAXBContext.newInstance();
     } catch (JAXBException e) {
-      throw LOG.unableToCreateContext(e);
+      throw LOG.unableToCreateContext(e, null);
     }
   }
 

--- a/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/format/spi/EmptyContextProvider.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/format/spi/EmptyContextProvider.java
@@ -36,7 +36,7 @@ public class EmptyContextProvider implements JaxBContextProvider {
     try {
       return JAXBContext.newInstance();
     } catch (JAXBException e) {
-      throw LOG.unableToCreateContext(e, null);
+      throw LOG.unableToCreateContext(e, "");
     }
   }
 


### PR DESCRIPTION
This change fixes the shading configuration of the `operaton-spin-dataformat-all` artifact.

It further adds additional debug output when a JAXBContext can't be created due to service loader issues.