### PR TITLE
chore: Disable flaky tests

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionUserOperationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionUserOperationTest.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.test.api.history;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junitpioneer.jupiter.RetryingTest;
@@ -297,7 +298,8 @@ public class BatchHistoricDecisionInstanceDeletionUserOperationTest {
     assertThat(engineRule.getHistoryService().createUserOperationLogQuery().entityType(EntityTypes.DECISION_INSTANCE).count()).isZero();
   }
 
-  @RetryingTest(3)
+  @Test
+  @Disabled("Flaky - see https://github.com/operaton/operaton/issues/671")
   public void testNoCreationOnJobExecutorBatchJobExecutionByIds() {
     // given
     historyService.deleteHistoricDecisionInstancesAsync(decisionInstanceIds, null);
@@ -310,6 +312,7 @@ public class BatchHistoricDecisionInstanceDeletionUserOperationTest {
   }
 
   @Test
+  @Disabled("Flaky - see https://github.com/operaton/operaton/issues/671")
   public void testNoCreationOnJobExecutorBatchJobExecutionByQuery() {
     // given
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery().decisionDefinitionKey(DECISION);
@@ -322,7 +325,8 @@ public class BatchHistoricDecisionInstanceDeletionUserOperationTest {
     assertThat(engineRule.getHistoryService().createUserOperationLogQuery().count()).isZero();
   }
 
-  @RetryingTest(3)
+  @Test
+  @Disabled("Flaky - see https://github.com/operaton/operaton/issues/671")
   public void testNoCreationOnJobExecutorBatchJobExecutionByIdsAndQuery() {
     // given
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery().decisionDefinitionKey(DECISION);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorCmdExceptionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorCmdExceptionTest.java
@@ -18,7 +18,9 @@ package org.operaton.bpm.engine.test.jobexecutor;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
 import org.operaton.bpm.engine.history.HistoricIncident;
 import org.operaton.bpm.engine.history.HistoricJobLog;
 import org.operaton.bpm.engine.impl.cmd.DeleteJobCmd;
@@ -146,6 +148,7 @@ public class JobExecutorCmdExceptionTest extends PluggableProcessEngineTest {
 
   @Deployment(resources="org/operaton/bpm/engine/test/jobexecutor/jobFailingOnFlush.bpmn20.xml")
   @Test
+  @Ignore("Flaky - see https://github.com/operaton/operaton/issues/671")
   public void testJobRetriesDecrementedOnFailedFlush() {
 
     runtimeService.startProcessInstanceByKey("testProcess");
@@ -167,6 +170,7 @@ public class JobExecutorCmdExceptionTest extends PluggableProcessEngineTest {
   }
 
   @Test
+  @Ignore("Flaky - see https://github.com/operaton/operaton/issues/671")
   public void testFailingTransactionListener() {
 
    testRule.deploy(Bpmn.createExecutableProcess("testProcess")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorExceptionLoggingHandlerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorExceptionLoggingHandlerTest.java
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.jobexecutor.ExecuteJobHelper;
 import org.operaton.bpm.engine.test.ProcessEngineRule;
@@ -58,8 +60,9 @@ public class JobExecutorExceptionLoggingHandlerTest {
   }
 
   @Test
+  @Ignore("Flaky - see https://github.com/operaton/operaton/issues/671")
   public void shouldBeAbleToReplaceLoggingHandler() {
- // given
+     // given
     CollectingHandler collectingHandler = new CollectingHandler();
     ExecuteJobHelper.loggingHandler = collectingHandler;
     BpmnModelInstance modelInstance = Bpmn.createExecutableProcess("failingDelegate")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/ReducedJobExceptionLoggingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/ReducedJobExceptionLoggingTest.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.operaton.bpm.engine.ManagementService;
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -67,6 +69,7 @@ public class ReducedJobExceptionLoggingTest {
 
   @Test
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/mgmt/IncidentTest.testShouldCreateOneIncident.bpmn" })
+  @Ignore("Flaky - see https://github.com/operaton/operaton/issues/671")
   public void shouldLogAllFailingJobExceptions() {
     // given
     processEngineConfiguration.setEnableReducedJobExceptionLogging(false);
@@ -85,6 +88,7 @@ public class ReducedJobExceptionLoggingTest {
 
   @Test
   @Deployment(resources = { "org/operaton/bpm/engine/test/api/mgmt/IncidentTest.testShouldCreateOneIncident.bpmn" })
+  @Ignore("Flaky - see https://github.com/operaton/operaton/issues/671")
   public void shouldLogOnlyOneFailingJobException() {
     // given
     processEngineConfiguration.setEnableReducedJobExceptionLogging(true);


### PR DESCRIPTION
waitForJobExecutorToProcessAllJobs() is flaky. Sometimes jobs are still running

related to #671