### PR TITLE
chore: bump Tomcat version to 10.1.39

### DIFF
--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <!-- pin tomcat version for engine-rest -->
-    <version.tomcat>10.1.35</version.tomcat>
+    <version.tomcat>10.1.39</version.tomcat>
     <rest.http.port>38080</rest.http.port>
     <surefire.memArgs>-Xmx2g</surefire.memArgs>
   </properties>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -47,7 +47,7 @@
     <version.wildfly>35.0.1.Final</version.wildfly>
     <version.wildfly.core>27.0.1.Final</version.wildfly.core>
 
-    <version.tomcat>10.1.30</version.tomcat>
+    <version.tomcat>10.1.39</version.tomcat>
 
     <version.arquillian>1.9.3.Final</version.arquillian>
 


### PR DESCRIPTION
Bumping Tomcat version to 10.1.39. We have currently two places where we manage the tomcat version, one is in the engine-rest pom with a comment "pin tomcat version for engine-rest". We need to investigate if this must stay pinned to 10.1.35 (and for what reason and possibly open an issue for it).

I opened the PR to see if the whole test pipelines runs through when we increase the at both places to 10.1.39