### PR TITLE
feat(rest): make LockAndFetchHandler blocking queue's capacity configurable

### DIFF
--- a/engine-rest/assembly/src/main/runtime/jbossas7/webapp/WEB-INF/web.xml
+++ b/engine-rest/assembly/src/main/runtime/jbossas7/webapp/WEB-INF/web.xml
@@ -3,11 +3,19 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee    http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
 
-  <!-- Fetch And Lock Handler (long polling): Unique Worker Request (default value: false) -->
-  <!--
+  <!-- Fetch And Lock Handler (long polling): -->
+
+  <!-- Unique Worker Request (default value: false)
   <context-param>
     <param-name>fetch-and-lock-unique-worker-request</param-name>
     <param-value>true</param-value>
+  </context-param>
+  -->
+
+  <!-- Queue capacity (default value: 200)
+  <context-param>
+    <param-name>fetch-and-lock-queue-capacity</param-name>
+    <param-value>250</param-value>
   </context-param>
   -->
 

--- a/engine-rest/assembly/src/main/runtime/tomcat/webapp/WEB-INF/web.xml
+++ b/engine-rest/assembly/src/main/runtime/tomcat/webapp/WEB-INF/web.xml
@@ -3,11 +3,19 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee    http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
 
-  <!-- Fetch And Lock Handler (long polling): Unique Worker Request (default value: false) -->
-  <!--
+  <!-- Fetch And Lock Handler (long polling): -->
+
+  <!-- Unique Worker Request (default value: false)
   <context-param>
     <param-name>fetch-and-lock-unique-worker-request</param-name>
     <param-value>true</param-value>
+  </context-param>
+  -->
+
+  <!-- Queue capacity (default value: 200)
+  <context-param>
+    <param-name>fetch-and-lock-queue-capacity</param-name>
+    <param-value>250</param-value>
   </context-param>
   -->
 

--- a/engine-rest/assembly/src/main/runtime/was/webapp/WEB-INF/web.xml
+++ b/engine-rest/assembly/src/main/runtime/was/webapp/WEB-INF/web.xml
@@ -5,11 +5,19 @@
 
   <display-name>Operaton REST API</display-name>
 
-  <!-- Fetch And Lock Handler (long polling): Unique Worker Request (default value: false) -->
-  <!--
+  <!-- Fetch And Lock Handler (long polling): -->
+
+  <!-- Unique Worker Request (default value: false)
   <context-param>
     <param-name>fetch-and-lock-unique-worker-request</param-name>
     <param-value>true</param-value>
+  </context-param>
+  -->
+
+  <!-- Queue capacity (default value: 200)
+  <context-param>
+    <param-name>fetch-and-lock-queue-capacity</param-name>
+    <param-value>250</param-value>
   </context-param>
   -->
 

--- a/engine-rest/assembly/src/main/runtime/wildfly/webapp/WEB-INF/web.xml
+++ b/engine-rest/assembly/src/main/runtime/wildfly/webapp/WEB-INF/web.xml
@@ -5,11 +5,19 @@
 
   <display-name>Operaton rest api</display-name>
 
-  <!-- Fetch And Lock Handler (long polling): Unique Worker Request (default value: false) -->
-  <!--
+  <!-- Fetch And Lock Handler (long polling): -->
+
+  <!-- Unique Worker Request (default value: false)
   <context-param>
     <param-name>fetch-and-lock-unique-worker-request</param-name>
     <param-value>true</param-value>
+  </context-param>
+  -->
+
+  <!-- Queue capacity (default value: 200)
+  <context-param>
+    <param-name>fetch-and-lock-queue-capacity</param-name>
+    <param-value>250</param-value>
   </context-param>
   -->
 

--- a/engine-rest/assembly/src/main/runtime/wls/webapp/WEB-INF/web.xml
+++ b/engine-rest/assembly/src/main/runtime/wls/webapp/WEB-INF/web.xml
@@ -5,11 +5,19 @@
 
   <display-name>Operaton rest api</display-name>
 
-  <!-- Fetch And Lock Handler (long polling): Unique Worker Request (default value: false) -->
-  <!--
+  <!-- Fetch And Lock Handler (long polling): -->
+
+  <!-- Unique Worker Request (default value: false)
   <context-param>
     <param-name>fetch-and-lock-unique-worker-request</param-name>
     <param-value>true</param-value>
+  </context-param>
+  -->
+
+  <!-- Queue capacity (default value: 200)
+  <context-param>
+    <param-name>fetch-and-lock-queue-capacity</param-name>
+    <param-value>250</param-value>
   </context-param>
   -->
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerImpl.java
@@ -51,14 +51,16 @@ public class FetchAndLockHandlerImpl implements Runnable, FetchAndLockHandler {
   private static final Logger LOG = Logger.getLogger(FetchAndLockHandlerImpl.class.getName());
 
   protected static final String UNIQUE_WORKER_REQUEST_PARAM_NAME = "fetch-and-lock-unique-worker-request";
+  protected static final String BLOCKING_QUEUE_CAPACITY_PARAM_NAME = "fetch-and-lock-queue-capacity";
 
   protected static final long PENDING_REQUEST_FETCH_INTERVAL = 30L * 1000;
   protected static final long MAX_BACK_OFF_TIME = Long.MAX_VALUE;
   protected static final long MAX_REQUEST_TIMEOUT = 1800000; // 30 minutes
+  protected static final int DEFAULT_BLOCKING_QUEUE_CAPACITY = 200;
 
   protected SingleConsumerCondition condition;
 
-  protected BlockingQueue<FetchAndLockRequest> queue = new ArrayBlockingQueue<>(200);
+  protected BlockingQueue<FetchAndLockRequest> queue;
   protected List<FetchAndLockRequest> pendingRequests = new ArrayList<>();
   protected List<FetchAndLockRequest> newRequests = new ArrayList<>();
 
@@ -180,6 +182,9 @@ public class FetchAndLockHandlerImpl implements Runnable, FetchAndLockHandler {
 
     isRunning = true;
     handlerThread.start();
+    if (queue == null) {
+      initializeQueue(DEFAULT_BLOCKING_QUEUE_CAPACITY);
+    }
 
     ProcessEngineImpl.EXT_TASK_CONDITIONS.addConsumer(condition);
   }
@@ -338,15 +343,19 @@ public class FetchAndLockHandlerImpl implements Runnable, FetchAndLockHandler {
 
   @Override
   public void contextInitialized(ServletContextEvent servletContextEvent) {
-    ServletContext servletContext = null;
+    ServletContext servletContext;
+    int queueCapacity = DEFAULT_BLOCKING_QUEUE_CAPACITY;
 
     if (servletContextEvent != null) {
       servletContext = servletContextEvent.getServletContext();
 
       if (servletContext != null) {
         parseUniqueWorkerRequestParam(servletContext.getInitParameter(UNIQUE_WORKER_REQUEST_PARAM_NAME));
+        queueCapacity = parseBlockingQueueCapacityParam(servletContext.getInitParameter(BLOCKING_QUEUE_CAPACITY_PARAM_NAME));
       }
     }
+
+    initializeQueue(queueCapacity);
   }
 
   protected void parseUniqueWorkerRequestParam(String uniqueWorkerRequestParam) {
@@ -355,6 +364,27 @@ public class FetchAndLockHandlerImpl implements Runnable, FetchAndLockHandler {
     } else {
       isUniqueWorkerRequest = false; // default configuration
     }
+  }
+
+  protected void initializeQueue(int capacity) {
+    LOG.log(Level.FINEST, "Initializing queue with capacity [{0}]", capacity);
+    queue = new ArrayBlockingQueue<>(capacity);
+  }
+
+  private static int parseBlockingQueueCapacityParam(String queueSizeRequestParam) {
+    int capacity = DEFAULT_BLOCKING_QUEUE_CAPACITY;
+    if (queueSizeRequestParam != null) {
+      try {
+        final int parsedCapacity = Integer.parseInt(queueSizeRequestParam);
+        if (parsedCapacity <= 0) {
+          throw new NumberFormatException("Parameter " + BLOCKING_QUEUE_CAPACITY_PARAM_NAME + " has to be greater than zero");
+        }
+        capacity = parsedCapacity;
+      } catch (NumberFormatException e) {
+        LOG.log(Level.WARNING, "Invalid blocking queue capacity parameter: [" + queueSizeRequestParam + "], falling back to default value", e);
+      }
+    }
+    return capacity;
   }
 
   public List<FetchAndLockRequest> getPendingRequests() {

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/FetchAndLockHandlerImpl.java
@@ -377,11 +377,11 @@ public class FetchAndLockHandlerImpl implements Runnable, FetchAndLockHandler {
       try {
         final int parsedCapacity = Integer.parseInt(queueSizeRequestParam);
         if (parsedCapacity <= 0) {
-          throw new NumberFormatException("Parameter " + BLOCKING_QUEUE_CAPACITY_PARAM_NAME + " has to be greater than zero");
+          throw new IllegalArgumentException("Parameter " + BLOCKING_QUEUE_CAPACITY_PARAM_NAME + " has to be greater than zero");
         }
         capacity = parsedCapacity;
-      } catch (NumberFormatException e) {
-        LOG.log(Level.WARNING, "Invalid blocking queue capacity parameter: [" + queueSizeRequestParam + "], falling back to default value", e);
+      } catch (IllegalArgumentException e) {
+        LOG.log(Level.WARNING, e, () -> "Invalid blocking queue capacity parameter: [" + queueSizeRequestParam + "], falling back to default value");
       }
     }
     return capacity;


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/4885

Backported commit 6154d43341 from the camunda-bpm-platform repository.
Original author: Joaquín <joaquin.felici@camunda.com>