### PR TITLE
fix(dependencies): Add org.glassfish.jaxb dep. to jboss-deployment-structure.xml & include into war

### DIFF
--- a/qa/integration-tests-engine/src/test/java-wildfly/org/operaton/bpm/integrationtest/util/TestContainer.java
+++ b/qa/integration-tests-engine/src/test/java-wildfly/org/operaton/bpm/integrationtest/util/TestContainer.java
@@ -34,6 +34,7 @@ public class TestContainer {
   }
 
   public static void addContainerSpecificResourcesWithoutWeld(WebArchive webArchive) {
+    webArchive.addAsManifestResource("jboss-deployment-structure.xml");
     webArchive.addAsLibraries(DeploymentHelper.getEjbClient());
   }
 

--- a/qa/integration-tests-engine/src/test/resources-wildfly/jboss-deployment-structure.xml
+++ b/qa/integration-tests-engine/src/test/resources-wildfly/jboss-deployment-structure.xml
@@ -4,6 +4,7 @@
     <dependencies>
       <module name="org.operaton.bpm.operaton-engine" />
       <module name="org.mybatis.mybatis"/>
+      <module name="org.glassfish.jaxb" services="import"/>
     </dependencies>
   </deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
Resolves the problem that the JAXB implementation of JAXBContextFactory could not be loaded

Fixes #713 