### PR TITLE
Avoid tests running on port 8080

### DIFF
--- a/engine-rest/engine-rest-openapi/pom.xml
+++ b/engine-rest/engine-rest-openapi/pom.xml
@@ -198,7 +198,10 @@
             <configuration>
               <sources>
                 <source>${project.build.directory}/operaton-openapi-client/src/main/java</source>
+<!--                <source>1.8</source>   &lt;!&ndash; Change to 1.8 or 11 based on your Java version &ndash;&gt;-->
               </sources>
+<!--              <target>1.8</target>   &lt;!&ndash; Change to 1.8 or 11 based on your Java version &ndash;&gt;-->
+
             </configuration>
           </execution>
         </executions>

--- a/engine-rest/engine-rest-openapi/pom.xml
+++ b/engine-rest/engine-rest-openapi/pom.xml
@@ -198,10 +198,7 @@
             <configuration>
               <sources>
                 <source>${project.build.directory}/operaton-openapi-client/src/main/java</source>
-<!--                <source>1.8</source>   &lt;!&ndash; Change to 1.8 or 11 based on your Java version &ndash;&gt;-->
               </sources>
-<!--              <target>1.8</target>   &lt;!&ndash; Change to 1.8 or 11 based on your Java version &ndash;&gt;-->
-
             </configuration>
           </execution>
         </executions>

--- a/engine-rest/engine-rest-openapi/pom.xml
+++ b/engine-rest/engine-rest-openapi/pom.xml
@@ -122,11 +122,6 @@
     <!-- test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>

--- a/engine-rest/engine-rest-openapi/pom.xml
+++ b/engine-rest/engine-rest-openapi/pom.xml
@@ -121,11 +121,15 @@
     </dependency>
     <!-- test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.engine.rest.openapi.client;
 
-import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,10 +37,8 @@ public class BasicAuthenticationTest {
 
   ProcessInstanceApi api;
 
-  static int port;
-
   @RegisterExtension
-  static WireMockExtension wireMockExtension = WireMockExtension.newInstance().options(
+  static WireMockExtension wireMock = WireMockExtension.newInstance().options(
           WireMockConfiguration.options().dynamicPort()).build();
 
   @BeforeEach
@@ -51,17 +48,15 @@ public class BasicAuthenticationTest {
     apiClient.setUsername(USERNAME);
     apiClient.setPassword(PASSWORD);
     apiClient.setBasePath(apiClient.getBasePath()
-            .replace("8080", String.valueOf(wireMockExtension.getPort())));
+            .replace("8080", String.valueOf(wireMock.getPort())));
 
     api = new ProcessInstanceApi(apiClient);
-    WireMock.configureFor(wireMockExtension.getPort());
-    port = wireMockExtension.getPort();
   }
 
   @org.junit.jupiter.api.Test
   public void shouldUseBasicAuth() throws ApiException {
     // given
-    stubFor(get(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/1")).willReturn(aResponse().withStatus(
+    wireMock.stubFor(get(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/1")).willReturn(aResponse().withStatus(
             200).withBody("{ \"id\": 1 }")));
 
     // when
@@ -69,7 +64,7 @@ public class BasicAuthenticationTest {
 
     // then
     assertThat(processInstance.getId()).isEqualTo("1");
-    verify(getRequestedFor(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/1")).withHeader("Authorization",
+    wireMock.verify(getRequestedFor(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/1")).withHeader("Authorization",
             equalTo("Basic bWlrZTpzZWNyZXQ=")
     ));
   }

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.rest.openapi.client;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;
@@ -28,7 +29,7 @@ import org.openapitools.client.model.ProcessInstanceDto;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BasicAuthenticationTest {
+class BasicAuthenticationTest {
 
   private static final String ENGINE_REST_PROCESS_INSTANCE = "/engine-rest/process-instance";
 
@@ -38,11 +39,12 @@ public class BasicAuthenticationTest {
   ProcessInstanceApi api;
 
   @RegisterExtension
-  static WireMockExtension wireMock = WireMockExtension.newInstance().options(
-          WireMockConfiguration.options().dynamicPort()).build();
+  static WireMockExtension wireMock = WireMockExtension.newInstance()
+          .options(WireMockConfiguration.options().dynamicPort())
+          .build();
 
   @BeforeEach
-  public void clientWithValidCredentials() {
+  void clientWithValidCredentials() {
     ApiClient apiClient = new ApiClient();
 
     apiClient.setUsername(USERNAME);
@@ -53,8 +55,8 @@ public class BasicAuthenticationTest {
     api = new ProcessInstanceApi(apiClient);
   }
 
-  @org.junit.jupiter.api.Test
-  public void shouldUseBasicAuth() throws ApiException {
+  @Test
+  void shouldUseBasicAuth() throws ApiException {
     // given
     wireMock.stubFor(get(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/1")).willReturn(aResponse().withStatus(
             200).withBody("{ \"id\": 1 }")));

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
@@ -53,10 +53,12 @@ public class BasicAuthenticationTest {
 
     api = new ProcessInstanceApi(apiClient);
     WireMock.configureFor(wireMockExtension.getPort());
+    System.out.printf("%s: Port before: %d%n", getClass(), wireMockExtension.getPort());
   }
 
   @org.junit.jupiter.api.Test
   public void shouldUseBasicAuth() throws ApiException {
+    System.out.printf("%s: Port test: %d%n", getClass(), wireMockExtension.getPort());
     // given
     stubFor(get(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/1")).willReturn(aResponse().withStatus(
             200).withBody("{ \"id\": 1 }")));

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
@@ -60,7 +60,6 @@ public class BasicAuthenticationTest {
 
   @org.junit.jupiter.api.Test
   public void shouldUseBasicAuth() throws ApiException {
-    System.out.printf("%s: Port test: %d%n", getClass(), wireMockExtension.getPort());
     // given
     stubFor(get(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/1")).willReturn(aResponse().withStatus(
             200).withBody("{ \"id\": 1 }")));

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
@@ -16,26 +16,18 @@
  */
 package org.operaton.bpm.engine.rest.openapi.client;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;
 import org.openapitools.client.api.ProcessInstanceApi;
 import org.openapitools.client.model.ProcessInstanceDto;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BasicAuthenticationTest {
 
@@ -46,23 +38,24 @@ public class BasicAuthenticationTest {
 
   ProcessInstanceApi api;
 
-  @Rule
-  public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options()
-          .dynamicPort());
+  @RegisterExtension
+  static WireMockExtension wireMockExtension = WireMockExtension.newInstance().options(
+          WireMockConfiguration.options().dynamicPort()).build();
 
-  @Before
+  @BeforeEach
   public void clientWithValidCredentials() {
     ApiClient apiClient = new ApiClient();
 
     apiClient.setUsername(USERNAME);
     apiClient.setPassword(PASSWORD);
     apiClient.setBasePath(apiClient.getBasePath()
-            .replace("8080", String.valueOf(wireMockRule.port())));
+            .replace("8080", String.valueOf(wireMockExtension.getPort())));
 
     api = new ProcessInstanceApi(apiClient);
+    WireMock.configureFor(wireMockExtension.getPort());
   }
 
-  @Test
+  @org.junit.jupiter.api.Test
   public void shouldUseBasicAuth() throws ApiException {
     // given
     stubFor(get(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/1")).willReturn(aResponse().withStatus(

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
@@ -46,8 +46,9 @@ public class BasicAuthenticationTest {
 
   ProcessInstanceApi api;
 
- @Rule
-public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
+  @Rule
+  public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options()
+          .dynamicPort());
 
   @Before
   public void clientWithValidCredentials() {
@@ -55,7 +56,8 @@ public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.option
 
     apiClient.setUsername(USERNAME);
     apiClient.setPassword(PASSWORD);
-    apiClient.setBasePath(apiClient.getBasePath().replace("8080", String.valueOf(wireMockRule.port())));
+    apiClient.setBasePath(apiClient.getBasePath()
+            .replace("8080", String.valueOf(wireMockRule.port())));
 
     api = new ProcessInstanceApi(apiClient);
   }
@@ -63,8 +65,8 @@ public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.option
   @Test
   public void shouldUseBasicAuth() throws ApiException {
     // given
-    stubFor(get(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/1"))
-        .willReturn(aResponse().withStatus(200).withBody("{ \"id\": 1 }")));
+    stubFor(get(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/1")).willReturn(aResponse().withStatus(
+            200).withBody("{ \"id\": 1 }")));
 
     // when
     ProcessInstanceDto processInstance = api.getProcessInstance("1");
@@ -72,6 +74,7 @@ public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.option
     // then
     assertThat(processInstance.getId()).isEqualTo("1");
     verify(getRequestedFor(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/1")).withHeader("Authorization",
-        equalTo("Basic bWlrZTpzZWNyZXQ=")));
+            equalTo("Basic bWlrZTpzZWNyZXQ=")
+    ));
   }
 }

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
@@ -34,6 +34,8 @@ import org.openapitools.client.api.ProcessInstanceApi;
 import org.openapitools.client.model.ProcessInstanceDto;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
 
 public class BasicAuthenticationTest {
 

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
@@ -44,8 +44,8 @@ public class BasicAuthenticationTest {
 
   ProcessInstanceApi api;
 
-  @Rule
-  public WireMockRule wireMockRule = new WireMockRule(8080);
+ @Rule
+public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
 
   @Before
   public void clientWithValidCredentials() {

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
@@ -38,6 +38,8 @@ public class BasicAuthenticationTest {
 
   ProcessInstanceApi api;
 
+  static int port;
+
   @RegisterExtension
   static WireMockExtension wireMockExtension = WireMockExtension.newInstance().options(
           WireMockConfiguration.options().dynamicPort()).build();
@@ -53,7 +55,7 @@ public class BasicAuthenticationTest {
 
     api = new ProcessInstanceApi(apiClient);
     WireMock.configureFor(wireMockExtension.getPort());
-    System.out.printf("%s: Port before: %d%n", getClass(), wireMockExtension.getPort());
+    port = wireMockExtension.getPort();
   }
 
   @org.junit.jupiter.api.Test

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
@@ -55,6 +55,7 @@ public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.option
 
     apiClient.setUsername(USERNAME);
     apiClient.setPassword(PASSWORD);
+    apiClient.setBasePath(apiClient.getBasePath().replace("8080", String.valueOf(wireMockRule.port())));
 
     api = new ProcessInstanceApi(apiClient);
   }

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
@@ -41,17 +41,13 @@ public class DeploymentTest {
 
   @RegisterExtension
   static WireMockExtension wireMockExtension = WireMockExtension.newInstance().options(
-          WireMockConfiguration.options()
-                  .dynamicPort()
-                  ).build();
+          WireMockConfiguration.options().dynamicPort()).build();
 
   @BeforeEach
   public void setup() {
     api = new DeploymentApi();
-    var apiClient = api.getApiClient();
-    apiClient.setBasePath(apiClient.getBasePath()
+    api.setCustomBaseUrl(api.getApiClient().getBasePath()
             .replace("8080", String.valueOf(wireMockExtension.getPort())));
-
     WireMock.configureFor(wireMockExtension.getPort());
   }
 

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
@@ -33,6 +33,7 @@ import org.openapitools.client.api.DeploymentApi;
 import org.openapitools.client.model.DeploymentWithDefinitionsDto;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 public class DeploymentTest {
 

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openapitools.client.ApiException;
@@ -42,7 +43,13 @@ public class DeploymentTest {
   final DeploymentApi api = new DeploymentApi();
 
   @Rule
-public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
+  public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
+
+  @Before
+  public void before() {
+    var apiClient = api.getApiClient();
+    apiClient.setBasePath(apiClient.getBasePath().replace("8080", String.valueOf(wireMockRule.port())));
+  }
 
   @Test
   public void shouldCreateDeployment() throws ApiException {

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
@@ -38,7 +38,7 @@ public class DeploymentTest {
 
   @RegisterExtension
   static WireMockExtension wireMockExtension = WireMockExtension.newInstance().options(
-          WireMockConfiguration.options().dynamicPort()).build();
+          WireMockConfiguration.options().dynamicPort().disableConnectionReuse(false)).build();
 
   @BeforeEach
   public void setup() {
@@ -94,6 +94,9 @@ public class DeploymentTest {
                     deploymentName,
                     deploymentSource
             ))));
+
+    System.out.println(wireMockExtension.baseUrl());
+    System.out.printf("Wiremock runs on server: %d%n", wireMockExtension.getPort());
 
     // when
     DeploymentWithDefinitionsDto deployment = api.createDeployment(null,

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
@@ -41,7 +41,7 @@ public class DeploymentTest {
   final DeploymentApi api = new DeploymentApi();
 
   @Rule
-  public WireMockRule wireMockRule = new WireMockRule(8080);
+public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
 
   @Test
   public void shouldCreateDeployment() throws ApiException {

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.rest.openapi.client;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;
@@ -30,7 +31,7 @@ import java.io.File;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DeploymentTest {
+class DeploymentTest {
 
   private static final String ENGINE_REST_DEPLOYMENT = "/engine-rest/deployment";
 
@@ -38,18 +39,19 @@ public class DeploymentTest {
   private final DeploymentApi api = new DeploymentApi(new ApiClient());
 
   @RegisterExtension
-  static WireMockExtension wireMock = WireMockExtension.newInstance().options(
-          WireMockConfiguration.options().dynamicPort()).build();
+  static WireMockExtension wireMock = WireMockExtension.newInstance()
+          .options(WireMockConfiguration.options().dynamicPort())
+          .build();
 
   @BeforeEach
-  public void setup() {
+  public void setUp() {
     api.setCustomBaseUrl(api.getApiClient()
             .getBasePath()
             .replace("8080", String.valueOf(wireMock.getPort())));
   }
 
-  @org.junit.jupiter.api.Test
-  public void shouldCreateDeployment() throws ApiException {
+  @Test
+  void shouldCreateDeployment() throws ApiException {
     // given
     String deploymentSource = "test-source";
     String deploymentName = "deployment-test-name";
@@ -103,8 +105,9 @@ public class DeploymentTest {
             deploymentName,
             null,
             new File("src/test/resources/one.bpmn")
-    );// then
+    );
 
+    // then
     assertThat(deployment.getId()).isEqualTo("aDeploymentId");
     assertThat(deployment.getName()).isEqualTo(deploymentName);
     assertThat(deployment.getSource()).isEqualTo(deploymentSource);

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
@@ -54,10 +54,12 @@ public class DeploymentTest {
             .getBasePath()
             .replace("8080", String.valueOf(wireMockExtension.getPort())));
     WireMock.configureFor(wireMockExtension.getPort());
+    System.out.printf("%s: Port before: %d%n", getClass(), wireMockExtension.getPort());
   }
 
   @org.junit.jupiter.api.Test
   public void shouldCreateDeployment() throws ApiException {
+    System.out.printf("%s: Port test: %d%n", getClass(), wireMockExtension.getPort());
     // given
     String deploymentSource = "test-source";
     String deploymentName = "deployment-test-name";

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
@@ -38,7 +38,9 @@ public class DeploymentTest {
 
   @RegisterExtension
   static WireMockExtension wireMockExtension = WireMockExtension.newInstance().options(
-          WireMockConfiguration.options().dynamicPort().disableConnectionReuse(false)).build();
+          WireMockConfiguration.options()
+                  .dynamicPort()
+                  ).build();
 
   @BeforeEach
   public void setup() {
@@ -89,14 +91,10 @@ public class DeploymentTest {
                         "deployedCaseDefinitions": null,
                         "deployedDecisionDefinitions": null,
                         "deployedDecisionRequirementsDefinitions": null
-                    }""".formatted(
-                    wireMockExtension.getPort(),
+                    }""".formatted(wireMockExtension.getPort(),
                     deploymentName,
                     deploymentSource
             ))));
-
-    System.out.println(wireMockExtension.baseUrl());
-    System.out.printf("Wiremock runs on server: %d%n", wireMockExtension.getPort());
 
     // when
     DeploymentWithDefinitionsDto deployment = api.createDeployment(null,

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
@@ -37,7 +37,7 @@ public class DeploymentTest {
   private DeploymentApi api;
 
   @RegisterExtension
-  static WireMockExtension wireMockExtendsion = WireMockExtension.newInstance().options(
+  static WireMockExtension wireMockExtension = WireMockExtension.newInstance().options(
           WireMockConfiguration.options().dynamicPort()).build();
 
   @BeforeEach
@@ -45,9 +45,9 @@ public class DeploymentTest {
     api = new DeploymentApi();
     var apiClient = api.getApiClient();
     apiClient.setBasePath(apiClient.getBasePath()
-            .replace("8080", String.valueOf(wireMockExtendsion.getPort())));
+            .replace("8080", String.valueOf(wireMockExtension.getPort())));
 
-    WireMock.configureFor(wireMockExtendsion.getPort());
+    WireMock.configureFor(wireMockExtension.getPort());
   }
 
   @org.junit.jupiter.api.Test
@@ -55,7 +55,7 @@ public class DeploymentTest {
     // given
     String deploymentSource = "test-source";
     String deploymentName = "deployment-test-name";
-    wireMockExtendsion.stubFor(post(urlEqualTo(ENGINE_REST_DEPLOYMENT + "/create")).willReturn(
+    wireMockExtension.stubFor(post(urlEqualTo(ENGINE_REST_DEPLOYMENT + "/create")).willReturn(
             aResponse().withStatus(200).withBody("""
                         {
                         "links": [
@@ -90,7 +90,7 @@ public class DeploymentTest {
                         "deployedDecisionDefinitions": null,
                         "deployedDecisionRequirementsDefinitions": null
                     }""".formatted(
-                    wireMockExtendsion.getPort(),
+                    wireMockExtension.getPort(),
                     deploymentName,
                     deploymentSource
             ))));

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
@@ -45,67 +45,63 @@ import java.net.URL;
 
 public class ProcessInstanceTest {
 
-    private static final String ENGINE_REST_PROCESS_INSTANCE = "/engine-rest/process-instance";
+  private static final String ENGINE_REST_PROCESS_INSTANCE = "/engine-rest/process-instance";
 
-    final ProcessInstanceApi api = new ProcessInstanceApi();
+  final ProcessInstanceApi api = new ProcessInstanceApi();
 
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options()
-            .dynamicPort());
+  @Rule
+  public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options()
+          .dynamicPort());
 
-
-    @Before
-    public void setUp() {
-        // Dynamically set the basePath for the API to match WireMock's port
-        String currentBasePath = api.getApiClient().getBasePath();
-        try {
-            URL url = new URL(currentBasePath);
-            String newBasePath =
-                    url.getProtocol() + "://" + url.getHost() + ":" + wireMockRule.port() +
-                            url.getPath();
-            api.getApiClient().setBasePath(newBasePath);
-        } catch (MalformedURLException e) {
-            // Fallback if URL parsing fails
-            api.getApiClient().setBasePath("http://localhost:" + wireMockRule.port());
-        }
+  @Before
+  public void setUp() {
+    // Dynamically set the basePath for the API to match WireMock's port
+    String currentBasePath = api.getApiClient().getBasePath();
+    try {
+      URL url = new URL(currentBasePath);
+      String newBasePath =
+              url.getProtocol() + "://" + url.getHost() + ":" + wireMockRule.port() + url.getPath();
+      api.getApiClient().setBasePath(newBasePath);
+    } catch (MalformedURLException e) {
+      // Fallback if URL parsing fails
+      api.getApiClient().setBasePath("http://localhost:" + wireMockRule.port());
     }
+  }
 
-    @Test
-    public void shouldQueryProcessInstancesCount() throws ApiException {
-        // given
-        stubFor(post(urlEqualTo(
-                ENGINE_REST_PROCESS_INSTANCE + "/count")).willReturn(aResponse().withStatus(200)
-                .withBody("{ \"count\": 3 }")));
+  @Test
+  public void shouldQueryProcessInstancesCount() throws ApiException {
+    // given
+    stubFor(post(urlEqualTo(
+            ENGINE_REST_PROCESS_INSTANCE + "/count")).willReturn(aResponse().withStatus(200)
+            .withBody("{ \"count\": 3 }")));
 
-        // when
-        ProcessInstanceQueryDto processInstanceQueryDto = new ProcessInstanceQueryDto();
-        processInstanceQueryDto.setActive(true);
-        CountResultDto count = api.queryProcessInstancesCount(processInstanceQueryDto);
+    // when
+    ProcessInstanceQueryDto processInstanceQueryDto = new ProcessInstanceQueryDto();
+    processInstanceQueryDto.setActive(true);
+    CountResultDto count = api.queryProcessInstancesCount(processInstanceQueryDto);
 
-        // then
-        assertThat(count.getCount()).isEqualTo(3);
-        verify(postRequestedFor(urlEqualTo(
-                ENGINE_REST_PROCESS_INSTANCE + "/count")).withRequestBody(equalToJson(
-                        "{ \"active\": true }"))
-                .withHeader("Content-Type", equalTo("application/json; charset=UTF-8")));
+    // then
+    assertThat(count.getCount()).isEqualTo(3);
+    verify(postRequestedFor(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/count")).withRequestBody(
+                    equalToJson("{ \"active\": true }"))
+            .withHeader("Content-Type", equalTo("application/json; charset=UTF-8")));
+  }
 
-    }
+  @Test
+  public void shouldUpdateSuspensionStateById() throws ApiException {
+    // given
+    String id = "anProcessInstanceId";
+    stubFor(put(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/" + id + "/suspended")).willReturn(
+            aResponse().withStatus(204)));
 
-    @Test
-    public void shouldUpdateSuspensionStateById() throws ApiException {
-        // given
-        String id = "anProcessInstanceId";
-        stubFor(put(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/" + id + "/suspended")).willReturn(
-                aResponse().withStatus(204)));
+    // when
+    SuspensionStateDto dto = new SuspensionStateDto();
+    dto.setSuspended(true);
+    api.updateSuspensionStateById(id, dto);
 
-        // when
-        SuspensionStateDto dto = new SuspensionStateDto();
-        dto.setSuspended(true);
-        api.updateSuspensionStateById(id, dto);
-
-        // then no error
-        verify(putRequestedFor(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/" + id +
-                "/suspended")).withRequestBody(equalToJson("{ \"suspended\": true }")));
-    }
-
+    // then no error
+    verify(putRequestedFor(urlEqualTo(
+            ENGINE_REST_PROCESS_INSTANCE + "/" + id + "/suspended")).withRequestBody(equalToJson(
+            "{ \"suspended\": true }")));
+  }
 }

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
@@ -58,10 +58,12 @@ public class ProcessInstanceTest {
       api.getApiClient().setBasePath("http://localhost:" + wireMockExtension.getPort());
     }
     WireMock.configureFor(wireMockExtension.getPort());
+    System.out.printf("%s: Port before: %d%n", getClass(), wireMockExtension.getPort());
   }
 
   @org.junit.jupiter.api.Test
   public void shouldQueryProcessInstancesCount() throws ApiException {
+    System.out.printf("%s: Port test: %d%n", getClass(), wireMockExtension.getPort());
     // given
     stubFor(post(urlEqualTo(
             ENGINE_REST_PROCESS_INSTANCE + "/count")).willReturn(aResponse().withStatus(200)
@@ -81,6 +83,7 @@ public class ProcessInstanceTest {
 
   @org.junit.jupiter.api.Test
   public void shouldUpdateSuspensionStateById() throws ApiException {
+    System.out.printf("%s: Port test: %d%n", getClass(), wireMockExtension.getPort());
     // given
     String id = "anProcessInstanceId";
     stubFor(put(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/" + id + "/suspended")).willReturn(

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
@@ -44,8 +44,8 @@ public class ProcessInstanceTest {
 
   final ProcessInstanceApi api = new ProcessInstanceApi();
 
-  @Rule
-  public WireMockRule wireMockRule = new WireMockRule(8080);
+ @Rule
+public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
 
   @Test
   public void shouldQueryProcessInstancesCount() throws ApiException {

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
@@ -21,6 +21,7 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;
 import org.openapitools.client.api.ProcessInstanceApi;
 import org.openapitools.client.model.CountResultDto;
@@ -37,12 +38,11 @@ public class ProcessInstanceTest {
 
   private static final String ENGINE_REST_PROCESS_INSTANCE = "/engine-rest/process-instance";
 
-  final ProcessInstanceApi api = new ProcessInstanceApi();
-
-  static int port;
+  //Create new ApiClient for ProcessInstanceApi to avoid the default client.
+  final ProcessInstanceApi api = new ProcessInstanceApi(new ApiClient());
 
   @RegisterExtension
-  static WireMockExtension wireMockExtension = WireMockExtension.newInstance().options(
+  static WireMockExtension wireMock = WireMockExtension.newInstance().options(
           WireMockConfiguration.options().dynamicPort()).build();
 
   @BeforeEach
@@ -52,15 +52,14 @@ public class ProcessInstanceTest {
     try {
       URL url = new URL(currentBasePath);
       String newBasePath =
-              url.getProtocol() + "://" + url.getHost() + ":" + wireMockExtension.getPort() +
+              url.getProtocol() + "://" + url.getHost() + ":" + wireMock.getPort() +
                       url.getPath();
       api.getApiClient().setBasePath(newBasePath);
     } catch (MalformedURLException e) {
       // Fallback if URL parsing fails
-      api.getApiClient().setBasePath("http://localhost:" + wireMockExtension.getPort());
+      api.getApiClient().setBasePath("http://localhost:" + wireMock.getPort());
     }
-    WireMock.configureFor(wireMockExtension.getPort());
-    port = wireMockExtension.getPort();
+    WireMock.configureFor(wireMock.getPort());
   }
 
   @org.junit.jupiter.api.Test

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
@@ -65,7 +65,6 @@ public class ProcessInstanceTest {
 
   @org.junit.jupiter.api.Test
   public void shouldQueryProcessInstancesCount() throws ApiException {
-    System.out.printf("%s: Port test: %d%n", getClass(), wireMockExtension.getPort());
     // given
     stubFor(post(urlEqualTo(
             ENGINE_REST_PROCESS_INSTANCE + "/count")).willReturn(aResponse().withStatus(200)
@@ -85,7 +84,6 @@ public class ProcessInstanceTest {
 
   @org.junit.jupiter.api.Test
   public void shouldUpdateSuspensionStateById() throws ApiException {
-    System.out.printf("%s: Port test: %d%n", getClass(), wireMockExtension.getPort());
     // given
     String id = "anProcessInstanceId";
     stubFor(put(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/" + id + "/suspended")).willReturn(

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
@@ -45,12 +45,13 @@ import java.net.URL;
 
 public class ProcessInstanceTest {
 
-  private static final String ENGINE_REST_PROCESS_INSTANCE = "/engine-rest/process-instance";
+    private static final String ENGINE_REST_PROCESS_INSTANCE = "/engine-rest/process-instance";
 
-  final ProcessInstanceApi api = new ProcessInstanceApi();
+    final ProcessInstanceApi api = new ProcessInstanceApi();
 
- @Rule
-public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options()
+            .dynamicPort());
 
 
     @Before
@@ -59,7 +60,9 @@ public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.option
         String currentBasePath = api.getApiClient().getBasePath();
         try {
             URL url = new URL(currentBasePath);
-            String newBasePath = url.getProtocol() + "://" + url.getHost() + ":" + wireMockRule.port() + url.getPath();
+            String newBasePath =
+                    url.getProtocol() + "://" + url.getHost() + ":" + wireMockRule.port() +
+                            url.getPath();
             api.getApiClient().setBasePath(newBasePath);
         } catch (MalformedURLException e) {
             // Fallback if URL parsing fails
@@ -67,48 +70,42 @@ public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.option
         }
     }
 
-  @Test
-  public void shouldQueryProcessInstancesCount() throws ApiException {
-    // given
-    stubFor(
-        post(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/count"))
-        .willReturn(aResponse()
-            .withStatus(200)
-            .withBody("{ \"count\": 3 }"))
-        );
+    @Test
+    public void shouldQueryProcessInstancesCount() throws ApiException {
+        // given
+        stubFor(post(urlEqualTo(
+                ENGINE_REST_PROCESS_INSTANCE + "/count")).willReturn(aResponse().withStatus(200)
+                .withBody("{ \"count\": 3 }")));
 
-    // when
-    ProcessInstanceQueryDto processInstanceQueryDto = new ProcessInstanceQueryDto();
-    processInstanceQueryDto.setActive(true);
-    CountResultDto count = api.queryProcessInstancesCount(processInstanceQueryDto);
+        // when
+        ProcessInstanceQueryDto processInstanceQueryDto = new ProcessInstanceQueryDto();
+        processInstanceQueryDto.setActive(true);
+        CountResultDto count = api.queryProcessInstancesCount(processInstanceQueryDto);
 
-    // then
-    assertThat(count.getCount()).isEqualTo(3);
-    verify(postRequestedFor(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/count"))
-        .withRequestBody(equalToJson("{ \"active\": true }"))
-        .withHeader("Content-Type",  equalTo("application/json; charset=UTF-8"))
-        );
+        // then
+        assertThat(count.getCount()).isEqualTo(3);
+        verify(postRequestedFor(urlEqualTo(
+                ENGINE_REST_PROCESS_INSTANCE + "/count")).withRequestBody(equalToJson(
+                        "{ \"active\": true }"))
+                .withHeader("Content-Type", equalTo("application/json; charset=UTF-8")));
 
-  }
+    }
 
-  @Test
-  public void shouldUpdateSuspensionStateById() throws ApiException {
-    // given
-    String id = "anProcessInstanceId";
-    stubFor(
-        put(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/" + id + "/suspended"))
-        .willReturn(aResponse().withStatus(204))
-        );
+    @Test
+    public void shouldUpdateSuspensionStateById() throws ApiException {
+        // given
+        String id = "anProcessInstanceId";
+        stubFor(put(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/" + id + "/suspended")).willReturn(
+                aResponse().withStatus(204)));
 
-    // when
-    SuspensionStateDto dto = new SuspensionStateDto();
-    dto.setSuspended(true);
-    api.updateSuspensionStateById(id, dto);
+        // when
+        SuspensionStateDto dto = new SuspensionStateDto();
+        dto.setSuspended(true);
+        api.updateSuspensionStateById(id, dto);
 
-    // then no error
-    verify(putRequestedFor(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/" + id + "/suspended"))
-        .withRequestBody(equalToJson("{ \"suspended\": true }"))
-        );
-  }
+        // then no error
+        verify(putRequestedFor(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/" + id +
+                "/suspended")).withRequestBody(equalToJson("{ \"suspended\": true }")));
+    }
 
 }

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
@@ -37,6 +37,7 @@ import org.openapitools.client.model.ProcessInstanceQueryDto;
 import org.openapitools.client.model.SuspensionStateDto;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 public class ProcessInstanceTest {
 

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
@@ -50,18 +50,15 @@ class ProcessInstanceTest {
 
   @BeforeEach
   void setUp() {
+    api.setCustomBaseUrl(api.getApiClient()
+            .getBasePath()
+            .replace("8080", String.valueOf(wireMock.getPort())));
     // Dynamically set the basePath for the API to match WireMock's port
-    String currentBasePath = api.getApiClient().getBasePath();
-    try {
-      URL url = new URL(currentBasePath);
-      String newBasePath =
-              url.getProtocol() + "://" + url.getHost() + ":" + wireMock.getPort() +
-                      url.getPath();
-      api.getApiClient().setBasePath(newBasePath);
-    } catch (MalformedURLException e) {
-      // Fallback if URL parsing fails
-      api.getApiClient().setBasePath("http://localhost:" + wireMock.getPort());
-    }
+    var basePath = URI.create(api.getApiClient().getBasePath());
+    String newBasePath = String.format("%s://%s:%d%s",
+            basePath.getScheme(), basePath.getHost(), wireMock.getPort(), basePath.getPath());
+    api.getApiClient().setBasePath(newBasePath);
+
     WireMock.configureFor(wireMock.getPort());
   }
 

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
@@ -19,7 +19,9 @@ package org.operaton.bpm.engine.rest.openapi.client;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openapitools.client.ApiClient;
 import org.openapitools.client.ApiException;
@@ -34,19 +36,20 @@ import java.net.URL;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ProcessInstanceTest {
+class ProcessInstanceTest {
 
   private static final String ENGINE_REST_PROCESS_INSTANCE = "/engine-rest/process-instance";
 
-  //Create new ApiClient for ProcessInstanceApi to avoid the default client.
+  // Create new ApiClient for ProcessInstanceApi to avoid the default client.
   final ProcessInstanceApi api = new ProcessInstanceApi(new ApiClient());
 
   @RegisterExtension
-  static WireMockExtension wireMock = WireMockExtension.newInstance().options(
-          WireMockConfiguration.options().dynamicPort()).build();
+  static WireMockExtension wireMock = WireMockExtension.newInstance()
+          .options(WireMockConfiguration.options().dynamicPort())
+          .build();
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     // Dynamically set the basePath for the API to match WireMock's port
     String currentBasePath = api.getApiClient().getBasePath();
     try {
@@ -62,8 +65,8 @@ public class ProcessInstanceTest {
     WireMock.configureFor(wireMock.getPort());
   }
 
-  @org.junit.jupiter.api.Test
-  public void shouldQueryProcessInstancesCount() throws ApiException {
+  @Test
+  void shouldQueryProcessInstancesCount() throws ApiException {
     // given
     stubFor(post(urlEqualTo(
             ENGINE_REST_PROCESS_INSTANCE + "/count")).willReturn(aResponse().withStatus(200)
@@ -81,8 +84,8 @@ public class ProcessInstanceTest {
             .withHeader("Content-Type", equalTo("application/json; charset=UTF-8")));
   }
 
-  @org.junit.jupiter.api.Test
-  public void shouldUpdateSuspensionStateById() throws ApiException {
+  @Test
+  void shouldUpdateSuspensionStateById() throws ApiException {
     // given
     String id = "anProcessInstanceId";
     stubFor(put(urlEqualTo(ENGINE_REST_PROCESS_INSTANCE + "/" + id + "/suspended")).willReturn(

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
@@ -39,6 +39,8 @@ public class ProcessInstanceTest {
 
   final ProcessInstanceApi api = new ProcessInstanceApi();
 
+  static int port;
+
   @RegisterExtension
   static WireMockExtension wireMockExtension = WireMockExtension.newInstance().options(
           WireMockConfiguration.options().dynamicPort()).build();
@@ -58,7 +60,7 @@ public class ProcessInstanceTest {
       api.getApiClient().setBasePath("http://localhost:" + wireMockExtension.getPort());
     }
     WireMock.configureFor(wireMockExtension.getPort());
-    System.out.printf("%s: Port before: %d%n", getClass(), wireMockExtension.getPort());
+    port = wireMockExtension.getPort();
   }
 
   @org.junit.jupiter.api.Test

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
@@ -28,6 +28,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openapitools.client.ApiException;
@@ -39,6 +40,9 @@ import org.openapitools.client.model.SuspensionStateDto;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 public class ProcessInstanceTest {
 
   private static final String ENGINE_REST_PROCESS_INSTANCE = "/engine-rest/process-instance";
@@ -47,6 +51,21 @@ public class ProcessInstanceTest {
 
  @Rule
 public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
+
+
+    @Before
+    public void setUp() {
+        // Dynamically set the basePath for the API to match WireMock's port
+        String currentBasePath = api.getApiClient().getBasePath();
+        try {
+            URL url = new URL(currentBasePath);
+            String newBasePath = url.getProtocol() + "://" + url.getHost() + ":" + wireMockRule.port() + url.getPath();
+            api.getApiClient().setBasePath(newBasePath);
+        } catch (MalformedURLException e) {
+            // Fallback if URL parsing fails
+            api.getApiClient().setBasePath("http://localhost:" + wireMockRule.port());
+        }
+    }
 
   @Test
   public void shouldQueryProcessInstancesCount() throws ApiException {


### PR DESCRIPTION
Start WireMock test on a dynamic port and update to JUnit5

related to #27 
closes #398 