### PR TITLE
Fix Wildfly integration tests

### DIFF
--- a/qa/integration-tests-engine/src/test/java-tomcat/org/operaton/bpm/integrationtest/util/TestContainer.java
+++ b/qa/integration-tests-engine/src/test/java-tomcat/org/operaton/bpm/integrationtest/util/TestContainer.java
@@ -76,6 +76,10 @@ public class TestContainer {
     // nothing to do
   }
 
+  public static void addContainerSpecificResourcesForSpin(WebArchive deployment) {
+    // nothing to do
+  }
+
   public static void addSpinJacksonJsonDataFormat(WebArchive webArchive) {
     webArchive.addAsLibraries(DeploymentHelper.getSpinJacksonJsonDataFormatForServer("tomcat"));
   }

--- a/qa/integration-tests-engine/src/test/java-wildfly-servlet/org/operaton/bpm/integrationtest/util/TestContainer.java
+++ b/qa/integration-tests-engine/src/test/java-wildfly-servlet/org/operaton/bpm/integrationtest/util/TestContainer.java
@@ -50,6 +50,10 @@ public class TestContainer {
     webArchive.addAsManifestResource("jboss-deployment-structure.xml");
   }
 
+  public static void addContainerSpecificResourcesForSpin(WebArchive deployment) {
+    deployment.addAsManifestResource("jboss-deployment-structure-spin.xml", "jboss-deployment-structure.xml");
+  }
+
   public static void addContainerSpecificProcessEngineConfigurationClass(WebArchive deployment) {
     // nothing to do
   }

--- a/qa/integration-tests-engine/src/test/java-wildfly/org/operaton/bpm/integrationtest/util/TestContainer.java
+++ b/qa/integration-tests-engine/src/test/java-wildfly/org/operaton/bpm/integrationtest/util/TestContainer.java
@@ -34,7 +34,6 @@ public class TestContainer {
   }
 
   public static void addContainerSpecificResourcesWithoutWeld(WebArchive webArchive) {
-    webArchive.addAsManifestResource("jboss-deployment-structure.xml");
     webArchive.addAsLibraries(DeploymentHelper.getEjbClient());
   }
 

--- a/qa/integration-tests-engine/src/test/java-wildfly/org/operaton/bpm/integrationtest/util/TestContainer.java
+++ b/qa/integration-tests-engine/src/test/java-wildfly/org/operaton/bpm/integrationtest/util/TestContainer.java
@@ -50,6 +50,10 @@ public class TestContainer {
     webArchive.addAsLibraries(DeploymentHelper.getAssertJ());
   }
 
+  public static void addContainerSpecificResourcesForSpin(WebArchive deployment) {
+    deployment.addAsManifestResource("jboss-deployment-structure-spin.xml", "jboss-deployment-structure.xml");
+  }
+
   public static void addContainerSpecificProcessEngineConfigurationClass(WebArchive deployment) {
     // nothing to do
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/SpinClassloadingTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/SpinClassloadingTest.java
@@ -38,12 +38,12 @@ public class SpinClassloadingTest extends AbstractFoxPlatformIntegrationTest {
   @Deployment(name="pa")
   public static final WebArchive createPaDeployment() {
 
-    return initWebArchiveDeployment()
-      .addAsManifestResource("jboss-deployment-structure-spin.xml","jboss-deployment-structure.xml")
-      .addAsResource("org/operaton/bpm/integrationtest/functional/spin/SpinClassloadingTest.bpmn")
-      .addClass(XmlSerializable.class)
-      .addClass(SpinVariableDelegate.class)
-      .addClass(SpinJsonPathDelegate.class);
+    var webArchive = initWebArchiveDeployment().addAsResource("org/operaton/bpm/integrationtest/functional/spin/SpinClassloadingTest.bpmn")
+            .addClass(XmlSerializable.class)
+            .addClass(SpinVariableDelegate.class)
+            .addClass(SpinJsonPathDelegate.class);
+    TestContainer.addContainerSpecificResourcesForSpin(webArchive);
+    return webArchive;
   }
 
   @Deployment(name="client-app")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/SpinClassloadingTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/SpinClassloadingTest.java
@@ -39,6 +39,7 @@ public class SpinClassloadingTest extends AbstractFoxPlatformIntegrationTest {
   public static final WebArchive createPaDeployment() {
 
     return initWebArchiveDeployment()
+      .addAsManifestResource("jboss-deployment-structure-spin.xml","jboss-deployment-structure.xml")
       .addAsResource("org/operaton/bpm/integrationtest/functional/spin/SpinClassloadingTest.bpmn")
       .addClass(XmlSerializable.class)
       .addClass(SpinVariableDelegate.class)

--- a/qa/integration-tests-engine/src/test/resources-wildfly/arquillian.xml
+++ b/qa/integration-tests-engine/src/test/resources-wildfly/arquillian.xml
@@ -14,8 +14,8 @@
       <property name="managementPort">${jboss.management-http.port}</property>
       <property name="serverConfig">standalone.xml</property>
       <property name="javaVmArguments">-Xmx1024m</property>
+      <!-- <property name="javaVmArguments">-Xmx1024m -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</property> -->
       <property name="startupTimeoutInSeconds">300</property>
-<!--       <property name="javaVmArguments">-Xmx1024m -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</property> -->
     </configuration>
   </container>
 </arquillian>

--- a/qa/integration-tests-engine/src/test/resources-wildfly/jboss-deployment-structure-spin.xml
+++ b/qa/integration-tests-engine/src/test/resources-wildfly/jboss-deployment-structure-spin.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-deployment-structure>
+  <deployment>
+    <exclude-subsystems>
+      <subsystem name="jaxrs" />
+    </exclude-subsystems>
+    <dependencies>
+      <module name="org.operaton.spin.operaton-spin-dataformat-json-jackson" services="import" />
+      <module name="com.fasterxml.jackson.core.jackson-databind" slot="2.15.2" />
+      <module name="org.glassfish.jaxb" services="import"/>
+    </dependencies>
+  </deployment>
+</jboss-deployment-structure>

--- a/qa/integration-tests-engine/src/test/resources/org/operaton/bpm/integrationtest/functional/ejb/local/jboss-deployment-structure.xml
+++ b/qa/integration-tests-engine/src/test/resources/org/operaton/bpm/integrationtest/functional/ejb/local/jboss-deployment-structure.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jboss-deployment-structure>
+<jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
   <deployment>
     <dependencies>
       <module name="deployment.service.war" />

--- a/qa/wildfly-runtime/src/main/wildfly/standalone/configuration/standalone.xml
+++ b/qa/wildfly-runtime/src/main/wildfly/standalone/configuration/standalone.xml
@@ -86,6 +86,9 @@
                 <suffix value=".yyyy-MM-dd"/>
                 <append value="true"/>
             </periodic-rotating-file-handler>
+            <logger category="org.jboss.weld">
+                <level name="INFO"/>
+            </logger>
             <logger category="com.arjuna">
                 <level name="WARN"/>
             </logger>


### PR DESCRIPTION
- revert 3e3dc94
  this has overridden the `jboss-deployment-structure.xml` file that `LocalSFSBInvocationTest` and others needed
- added a spin specific `jboss-deployment-structure.xml` to be used by `SpinClassloadingTest`
