### PR TITLE
Chore/cleanups

### DIFF
--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/rest/WadlDisabledTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/rest/WadlDisabledTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.run.test.config.rest;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 import org.operaton.bpm.run.property.OperatonBpmRunRestProperties;
 import org.operaton.bpm.run.test.AbstractRestTest;
 import org.springframework.http.HttpStatus;
@@ -28,6 +29,7 @@ import org.springframework.test.context.TestPropertySource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @TestPropertySource(properties = {OperatonBpmRunRestProperties.PREFIX + ".disable-wadl=true"})
+@Disabled("application.wadl is not available")
 class WadlDisabledTest extends AbstractRestTest {
 
   @Test

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/rest/WadlEnabledTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/rest/WadlEnabledTest.java
@@ -20,12 +20,14 @@ import org.operaton.bpm.run.property.OperatonBpmRunRestProperties;
 import org.operaton.bpm.run.test.AbstractRestTest;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @TestPropertySource(properties = {OperatonBpmRunRestProperties.PREFIX + ".disable-wadl=false"})
+@Disabled("application.wadl is not available")
 class WadlEnabledTest extends AbstractRestTest {
 
   @Test

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/rest/WadlUnsetTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/rest/WadlUnsetTest.java
@@ -19,10 +19,12 @@ package org.operaton.bpm.run.test.config.rest;
 import org.operaton.bpm.run.test.AbstractRestTest;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 import org.springframework.http.HttpStatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Disabled("application.wadl is not available")
 class WadlUnsetTest extends AbstractRestTest {
 
   @Test

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/el/ElContextDelegate.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/el/ElContextDelegate.java
@@ -32,7 +32,7 @@ public class ElContextDelegate extends ELContext {
 
   protected final ELResolver elResolver;
 
-  public ElContextDelegate(jakarta.el.ELContext delegateContext, ELResolver elResolver) {
+  public ElContextDelegate(ELContext delegateContext, ELResolver elResolver) {
     this.delegateContext = delegateContext;
     this.elResolver = elResolver;
   }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/CaseExecutionRestService.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/CaseExecutionRestService.java
@@ -36,7 +36,7 @@ import java.util.List;
 @Produces(MediaType.APPLICATION_JSON)
 public interface CaseExecutionRestService {
 
-  public static final String PATH = "/case-execution";
+  String PATH = "/case-execution";
 
   @Path("/{id}")
   CaseExecutionResource getCaseExecution(@PathParam("id") String caseExecutionId);

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/CaseExecutionRestService.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/CaseExecutionRestService.java
@@ -36,7 +36,7 @@ import java.util.List;
 @Produces(MediaType.APPLICATION_JSON)
 public interface CaseExecutionRestService {
 
-  String PATH = "/case-execution";
+  static final String PATH = "/case-execution";
 
   @Path("/{id}")
   CaseExecutionResource getCaseExecution(@PathParam("id") String caseExecutionId);

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/TenantRestService.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/TenantRestService.java
@@ -38,7 +38,7 @@ import org.operaton.bpm.engine.rest.sub.identity.TenantResource;
 @Produces(MediaType.APPLICATION_JSON)
 public interface TenantRestService {
 
-  String PATH = "/tenant";
+  static final String PATH = "/tenant";
 
   @Path("/{id}")
   TenantResource getTenant(@PathParam("id") String id);

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/TenantRestService.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/TenantRestService.java
@@ -38,7 +38,7 @@ import org.operaton.bpm.engine.rest.sub.identity.TenantResource;
 @Produces(MediaType.APPLICATION_JSON)
 public interface TenantRestService {
 
-  public static final String PATH = "/tenant";
+  String PATH = "/tenant";
 
   @Path("/{id}")
   TenantResource getTenant(@PathParam("id") String id);

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/JacksonHalJsonProvider.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/JacksonHalJsonProvider.java
@@ -17,8 +17,6 @@
 package org.operaton.bpm.engine.rest.hal;
 
 
-//import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
-
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/authorization/AuthorizationResource.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/authorization/AuthorizationResource.java
@@ -32,16 +32,15 @@ public interface AuthorizationResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  public AuthorizationDto getAuthorization(@Context UriInfo context);
+  AuthorizationDto getAuthorization(@Context UriInfo context);
 
   @DELETE
   @Produces(MediaType.APPLICATION_JSON)
-  public void deleteAuthorization();
+  void deleteAuthorization();
 
   @PUT
   @Consumes(MediaType.APPLICATION_JSON)
-  public void updateAuthorization(AuthorizationDto Authorization);
-
+  void updateAuthorization(AuthorizationDto Authorization);
   @OPTIONS
   @Produces(MediaType.APPLICATION_JSON)
   ResourceOptionsDto availableOperations(@Context UriInfo context);

--- a/engine-rest/engine-rest/src/test/java-jersey2/org/operaton/bpm/engine/rest/util/container/JerseySpecifics.java
+++ b/engine-rest/engine-rest/src/test/java-jersey2/org/operaton/bpm/engine/rest/util/container/JerseySpecifics.java
@@ -38,8 +38,7 @@ public class JerseySpecifics implements ContainerSpecifics {
   protected static final TestRuleFactory DEFAULT_RULE_FACTORY =
       new EmbeddedServerRuleFactory(new JaxrsApplication());
 
-  protected static final Map<Class<?>, TestRuleFactory> TEST_RULE_FACTORIES =
-      new HashMap<>();
+  protected static final Map<Class<?>, TestRuleFactory> TEST_RULE_FACTORIES = new HashMap<>();
 
   static {
     TEST_RULE_FACTORIES.put(ExceptionHandlerTest.class, new EmbeddedServerRuleFactory(new TestCustomResourceApplication()));

--- a/engine/src/test/java/org/operaton/bpm/application/impl/deployment/RedeploymentProcessApplicationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/deployment/RedeploymentProcessApplicationTest.java
@@ -119,7 +119,7 @@ public class RedeploymentProcessApplicationTest {
   }
 
   @TestTemplate
-  public void definitionOnePreviousDeploymentWithPA() {
+  void definitionOnePreviousDeploymentWithPA() {
     // given
 
     MyEmbeddedProcessApplication application = new MyEmbeddedProcessApplication();
@@ -150,7 +150,7 @@ public class RedeploymentProcessApplicationTest {
   }
 
   @TestTemplate
-  public void redeploymentShouldFailOnNullHTTLAndEnforceHistoryTimeToLiveTrue() {
+  void redeploymentShouldFailOnNullHTTLAndEnforceHistoryTimeToLiveTrue() {
     // given
     Deployment deployment1;
     Deployment deployment2 = null;
@@ -195,7 +195,7 @@ public class RedeploymentProcessApplicationTest {
   }
 
   @TestTemplate
-  public void definitionTwoPreviousDeploymentWithPA() {
+  void definitionTwoPreviousDeploymentWithPA() {
     // given
 
     // first deployment
@@ -234,7 +234,7 @@ public class RedeploymentProcessApplicationTest {
   }
 
   @TestTemplate
-  public void definitionTwoPreviousDeploymentFirstDeploymentWithPA() {
+  void definitionTwoPreviousDeploymentFirstDeploymentWithPA() {
     // given
 
     // first deployment
@@ -271,7 +271,7 @@ public class RedeploymentProcessApplicationTest {
   }
 
   @TestTemplate
-  public void definitionTwoPreviousDeploymentDeleteSecondDeployment() {
+  void definitionTwoPreviousDeploymentDeleteSecondDeployment() {
     // given
 
     // first deployment
@@ -311,7 +311,7 @@ public class RedeploymentProcessApplicationTest {
   }
 
   @TestTemplate
-  public void definitionTwoPreviousDeploymentUnregisterSecondPA() {
+  void definitionTwoPreviousDeploymentUnregisterSecondPA() {
     // given
 
     // first deployment
@@ -351,7 +351,7 @@ public class RedeploymentProcessApplicationTest {
   }
 
   @TestTemplate
-  public void definitionTwoDifferentPreviousDeploymentsWithDifferentPA() {
+  void definitionTwoDifferentPreviousDeploymentsWithDifferentPA() {
     // given
 
     // first deployment
@@ -402,7 +402,7 @@ public class RedeploymentProcessApplicationTest {
   }
 
   @TestTemplate
-  public void definitionTwoPreviousDeploymentsWithDifferentPA() {
+  void definitionTwoPreviousDeploymentsWithDifferentPA() {
     // given
 
     // first deployment

--- a/engine/src/test/java/org/operaton/bpm/container/impl/jmx/deployment/util/ClassPathScannerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/jmx/deployment/util/ClassPathScannerTest.java
@@ -71,7 +71,7 @@ public class ClassPathScannerTest {
    * @throws MalformedURLException 
    */
   @TestTemplate
-  public void testScanClassPath() throws MalformedURLException {
+  void testScanClassPath() throws MalformedURLException {
     
     URLClassLoader classLoader = getClassloader();
     
@@ -89,7 +89,7 @@ public class ClassPathScannerTest {
   }
   
   @TestTemplate
-  public void testScanClassPathWithNonExistingRootPath_relativeToPa() throws MalformedURLException {
+  void testScanClassPathWithNonExistingRootPath_relativeToPa() throws MalformedURLException {
 
     URLClassLoader classLoader = getClassloader();
     
@@ -102,7 +102,7 @@ public class ClassPathScannerTest {
   }
   
   @TestTemplate
-  public void testScanClassPathWithNonExistingRootPath_nonRelativeToPa() throws MalformedURLException {
+  void testScanClassPathWithNonExistingRootPath_nonRelativeToPa() throws MalformedURLException {
     
     URLClassLoader classLoader = getClassloader();
     
@@ -115,7 +115,7 @@ public class ClassPathScannerTest {
   }
 
   @TestTemplate
-  public void testScanClassPathWithExistingRootPath_relativeToPa() throws MalformedURLException {
+  void testScanClassPathWithExistingRootPath_relativeToPa() throws MalformedURLException {
 
     URLClassLoader classLoader = getClassloader();
     
@@ -134,7 +134,7 @@ public class ClassPathScannerTest {
   }
   
   @TestTemplate
-  public void testScanClassPathWithExistingRootPath_nonRelativeToPa() throws MalformedURLException {
+  void testScanClassPathWithExistingRootPath_nonRelativeToPa() throws MalformedURLException {
     
     URLClassLoader classLoader = getClassloader();
     
@@ -153,7 +153,7 @@ public class ClassPathScannerTest {
   }
 
   @TestTemplate
-  public void testScanClassPathWithAdditionalResourceSuffixes() throws MalformedURLException {
+  void testScanClassPathWithAdditionalResourceSuffixes() throws MalformedURLException {
     URLClassLoader classLoader = getClassloader();
 
     String[] additionalResourceSuffixes = new String[] {"py", "rb", "groovy"};

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/batch/BatchInvocationsPerJobByBatchTypeConfigTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/batch/BatchInvocationsPerJobByBatchTypeConfigTest.java
@@ -32,7 +32,7 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineLoggingExtension;
 
 import ch.qos.logback.classic.Level;
 
-public class BatchInvocationsPerJobByBatchTypeConfigTest {
+class BatchInvocationsPerJobByBatchTypeConfigTest {
 
   protected static final String PROCESS_ENGINE_CONFIG =
       "operaton.cfg.invocationsPerJobByBatchType.xml";

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/AuthorizationRevokeModeAlwaysTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/AuthorizationRevokeModeAlwaysTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineLoggingExtension;
 
-public class AuthorizationRevokeModeAlwaysTest extends AuthorizationTest {
+class AuthorizationRevokeModeAlwaysTest extends AuthorizationTest {
 
   protected static final String LOGGING_CONTEXT = "org.operaton.bpm.engine.impl.persistence.entity.TaskEntity";
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DeleteProcessDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DeleteProcessDefinitionAuthorizationTest.java
@@ -106,7 +106,7 @@ public class DeleteProcessDefinitionAuthorizationTest {
   }
 
   @TestTemplate
-  public void testDeleteProcessDefinition() {
+  void testDeleteProcessDefinition() {
     testHelper.deploy("org/operaton/bpm/engine/test/repository/twoProcesses.bpmn20.xml");
     List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
 
@@ -125,7 +125,7 @@ public class DeleteProcessDefinitionAuthorizationTest {
 
 
   @TestTemplate
-  public void testDeleteProcessDefinitionCascade() {
+  void testDeleteProcessDefinitionCascade() {
     // given process definition and a process instance
     BpmnModelInstance bpmnModel = Bpmn.createExecutableProcess(PROCESS_DEFINITION_KEY).startEvent().userTask().endEvent().done();
     testHelper.deploy(bpmnModel);
@@ -151,7 +151,7 @@ public class DeleteProcessDefinitionAuthorizationTest {
   }
 
   @TestTemplate
-  public void testDeleteProcessDefinitionsByKey() {
+  void testDeleteProcessDefinitionsByKey() {
     // given
     for (int i = 0; i < 3; i++) {
       deployProcessDefinition();
@@ -174,7 +174,7 @@ public class DeleteProcessDefinitionAuthorizationTest {
   }
 
   @TestTemplate
-  public void testDeleteProcessDefinitionsByKeyCascade() {
+  void testDeleteProcessDefinitionsByKeyCascade() {
     // given
     for (int i = 0; i < 3; i++) {
       deployProcessDefinition();
@@ -205,7 +205,7 @@ public class DeleteProcessDefinitionAuthorizationTest {
   }
 
   @TestTemplate
-  public void testDeleteProcessDefinitionsByIds() {
+  void testDeleteProcessDefinitionsByIds() {
     // given
     for (int i = 0; i < 3; i++) {
       deployProcessDefinition();
@@ -229,7 +229,7 @@ public class DeleteProcessDefinitionAuthorizationTest {
   }
 
   @TestTemplate
-  public void testDeleteProcessDefinitionsByIdsCascade() {
+  void testDeleteProcessDefinitionsByIdsCascade() {
     // given
     for (int i = 0; i < 3; i++) {
       deployProcessDefinition();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SetTaskPropertyAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SetTaskPropertyAuthorizationTest.java
@@ -91,7 +91,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
   }
 
   @TestTemplate
-  public void shouldSetOperationStandaloneWithoutAuthorization() {
+  void shouldSetOperationStandaloneWithoutAuthorization() {
     // given
     createTask(taskId);
 
@@ -109,7 +109,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
   }
 
   @TestTemplate
-  public void shouldSetOperationStandalone() {
+  void shouldSetOperationStandalone() {
     // given
     createTask(taskId);
     createGrantAuthorization(TASK, taskId, userId, UPDATE);
@@ -127,7 +127,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
   }
 
   @TestTemplate
-  public void shouldSetOperationStandaloneWithTaskAssignPermission() {
+  void shouldSetOperationStandaloneWithTaskAssignPermission() {
     // given
     createTask(taskId);
     createGrantAuthorization(TASK, taskId, userId, TASK_ASSIGN);
@@ -145,7 +145,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
   }
 
   @TestTemplate
-  public void shouldSetOperationOnProcessWithTaskAssignPermissionOnTask() {
+  void shouldSetOperationOnProcessWithTaskAssignPermissionOnTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -163,7 +163,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
   }
 
   @TestTemplate
-  public void shouldSetOperationOnProcessWithoutAuthorization() {
+  void shouldSetOperationOnProcessWithoutAuthorization() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -185,7 +185,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
   }
 
   @TestTemplate
-  public void shouldSetOperationOnProcessWithUpdatePermissionOnAnyTask() {
+  void shouldSetOperationOnProcessWithUpdatePermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -203,7 +203,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
   }
 
   @TestTemplate
-  public void shouldSetOperationOnProcessWithTaskAssignPermissionOnAnyTask() {
+  void shouldSetOperationOnProcessWithTaskAssignPermissionOnAnyTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -221,7 +221,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
   }
 
   @TestTemplate
-  public void shouldSetOperationOnProcessWithUpdateTasksPermissionOnProcessDefinition() {
+  void shouldSetOperationOnProcessWithUpdateTasksPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -239,7 +239,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
   }
 
   @TestTemplate
-  public void shouldSetOperationOnProcessWithTaskAssignPermissionOnProcessDefinition() {
+  void shouldSetOperationOnProcessWithTaskAssignPermissionOnProcessDefinition() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -257,7 +257,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
   }
 
   @TestTemplate
-  public void shouldSetOperationOnProcessTask() {
+  void shouldSetOperationOnProcessTask() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
@@ -276,7 +276,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
   }
 
   @TestTemplate
-  public void shouldSetOperationOnProcessWithTaskAssignPermission() {
+  void shouldSetOperationOnProcessWithTaskAssignPermission() {
     // given
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/StandaloneTaskGetVariableAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/StandaloneTaskGetVariableAuthorizationTest.java
@@ -110,7 +110,7 @@ public class StandaloneTaskGetVariableAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariable() {
+  void testGetVariable() {
     // given
     createTask(taskId);
 
@@ -133,7 +133,7 @@ public class StandaloneTaskGetVariableAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariableLocal() {
+  void testGetVariableLocal() {
     // given
     createTask(taskId);
 
@@ -156,7 +156,7 @@ public class StandaloneTaskGetVariableAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariableTyped() {
+  void testGetVariableTyped() {
     // given
     createTask(taskId);
 
@@ -180,7 +180,7 @@ public class StandaloneTaskGetVariableAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariableLocalTyped() {
+  void testGetVariableLocalTyped() {
     // given
     createTask(taskId);
 
@@ -204,7 +204,7 @@ public class StandaloneTaskGetVariableAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariables() {
+  void testGetVariables() {
     // given
     createTask(taskId);
 
@@ -228,7 +228,7 @@ public class StandaloneTaskGetVariableAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesLocal() {
+  void testGetVariablesLocal() {
     // given
     createTask(taskId);
 
@@ -252,7 +252,7 @@ public class StandaloneTaskGetVariableAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesTyped() {
+  void testGetVariablesTyped() {
     createTask(taskId);
 
     taskService.setVariables(taskId, getVariables());
@@ -275,7 +275,7 @@ public class StandaloneTaskGetVariableAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesLocalTyped() {
+  void testGetVariablesLocalTyped() {
     createTask(taskId);
 
     taskService.setVariablesLocal(taskId, getVariables());
@@ -298,7 +298,7 @@ public class StandaloneTaskGetVariableAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesByName() {
+  void testGetVariablesByName() {
     // given
     createTask(taskId);
 
@@ -322,7 +322,7 @@ public class StandaloneTaskGetVariableAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesLocalByName() {
+  void testGetVariablesLocalByName() {
     // given
     createTask(taskId);
 
@@ -346,7 +346,7 @@ public class StandaloneTaskGetVariableAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesTypedByName() {
+  void testGetVariablesTypedByName() {
     createTask(taskId);
 
     taskService.setVariables(taskId, getVariables());
@@ -369,7 +369,7 @@ public class StandaloneTaskGetVariableAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesLocalTypedByName() {
+  void testGetVariablesLocalTypedByName() {
     createTask(taskId);
 
     taskService.setVariablesLocal(taskId, getVariables());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskReadVariablePermissionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskReadVariablePermissionAuthorizationTest.java
@@ -123,7 +123,7 @@ public class TaskReadVariablePermissionAuthorizationTest {
   // TaskService#saveTask() ///////////////////////////////////
 
   @TestTemplate
-  public void testSaveStandaloneTaskAndCheckAssigneePermissions() {
+  void testSaveStandaloneTaskAndCheckAssigneePermissions() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -167,7 +167,7 @@ public class TaskReadVariablePermissionAuthorizationTest {
   // TaskService#setOwner() ///////////////////////////////////
 
   @TestTemplate
-  public void testStandaloneTaskSetOwnerAndCheckOwnerPermissions() {
+  void testStandaloneTaskSetOwnerAndCheckOwnerPermissions() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -208,7 +208,7 @@ public class TaskReadVariablePermissionAuthorizationTest {
   // TaskService#addUserIdentityLink() ///////////////////////////////////
 
   @TestTemplate
-  public void testStandaloneTaskAddUserIdentityLinkAndUserOwnerPermissions() {
+  void testStandaloneTaskAddUserIdentityLinkAndUserOwnerPermissions() {
     // given
     String taskId = "myTask";
     createTask(taskId);
@@ -269,7 +269,7 @@ public class TaskReadVariablePermissionAuthorizationTest {
   // TaskService#addGroupIdentityLink() ///////////////////////////////////
 
   @TestTemplate
-  public void testStandaloneTaskAddGroupIdentityLink() {
+  void testStandaloneTaskAddGroupIdentityLink() {
     // given
     String taskId = "myTask";
     createTask(taskId);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/BatchSuspensionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/BatchSuspensionAuthorizationTest.java
@@ -105,7 +105,7 @@ public class BatchSuspensionAuthorizationTest {
   }
 
   @TestTemplate
-  public void testSuspendBatch() {
+  void testSuspendBatch() {
 
     // given
     ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceById(migrationPlan.getSourceProcessDefinitionId());
@@ -136,7 +136,7 @@ public class BatchSuspensionAuthorizationTest {
   }
 
   @TestTemplate
-  public void testActivateBatch() {
+  void testActivateBatch() {
     // given
     ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceById(migrationPlan.getSourceProcessDefinitionId());
     batch = engineRule

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/DeleteBatchAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/DeleteBatchAuthorizationTest.java
@@ -122,7 +122,7 @@ public class DeleteBatchAuthorizationTest {
   }
 
   @TestTemplate
-  public void testDeleteBatch() {
+  void testDeleteBatch() {
 
     // given
     ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceById(migrationPlan.getSourceProcessDefinitionId());
@@ -164,7 +164,7 @@ public class DeleteBatchAuthorizationTest {
    * Requires no additional DELETE_HISTORY authorization => consistent with deleteDeployment
    */
   @TestTemplate
-  public void testDeleteBatchCascade() {
+  void testDeleteBatchCascade() {
     // given
     ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceById(migrationPlan.getSourceProcessDefinitionId());
     batch = engineRule

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/DeleteHistoricBatchAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/DeleteHistoricBatchAuthorizationTest.java
@@ -111,7 +111,7 @@ public class DeleteHistoricBatchAuthorizationTest {
   }
 
   @TestTemplate
-  public void testDeleteBatch() {
+  void testDeleteBatch() {
 
     // given
     ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceById(migrationPlan.getSourceProcessDefinitionId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/DeleteHistoricProcessInstancesBatchAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/DeleteHistoricProcessInstancesBatchAuthorizationTest.java
@@ -109,7 +109,7 @@ public class DeleteHistoricProcessInstancesBatchAuthorizationTest extends Abstra
   }
 
   @TestTemplate
-  public void testWithTwoInvocationsProcessInstancesList() {
+  void testWithTwoInvocationsProcessInstancesList() {
     engineRule.getProcessEngineConfiguration().setInvocationsPerBatchJob(2);
     setupAndExecuteHistoricProcessInstancesListTest();
 
@@ -120,7 +120,7 @@ public class DeleteHistoricProcessInstancesBatchAuthorizationTest extends Abstra
   }
 
   @TestTemplate
-  public void testProcessInstancesList() {
+  void testProcessInstancesList() {
     setupAndExecuteHistoricProcessInstancesListTest();
     // then
     assertScenario();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/DeleteProcessInstancesBatchAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/DeleteProcessInstancesBatchAuthorizationTest.java
@@ -85,7 +85,7 @@ public class DeleteProcessInstancesBatchAuthorizationTest extends AbstractBatchA
   }
 
   @TestTemplate
-  public void testWithTwoInvocationsProcessInstancesList() {
+  void testWithTwoInvocationsProcessInstancesList() {
     engineRule.getProcessEngineConfiguration().setInvocationsPerBatchJob(2);
     setupAndExecuteProcessInstancesListTest();
 
@@ -94,14 +94,14 @@ public class DeleteProcessInstancesBatchAuthorizationTest extends AbstractBatchA
   }
 
   @TestTemplate
-  public void testProcessInstancesList() {
+  void testProcessInstancesList() {
     setupAndExecuteProcessInstancesListTest();
     // then
     assertScenario();
   }
 
   @TestTemplate
-  public void testWithQuery() {
+  void testWithQuery() {
     //given
     ProcessInstanceQuery processInstanceQuery = runtimeService.createProcessInstanceQuery()
         .processInstanceIds(new HashSet<>(Arrays.asList(processInstance.getId(), processInstance2.getId())));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/SetJobRetriesBatchAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/SetJobRetriesBatchAuthorizationTest.java
@@ -124,7 +124,7 @@ public class SetJobRetriesBatchAuthorizationTest extends AbstractBatchAuthorizat
   }
 
   @TestTemplate
-  public void testWithTwoInvocationsJobsListBased() {
+  void testWithTwoInvocationsJobsListBased() {
     engineRule.getProcessEngineConfiguration().setInvocationsPerBatchJob(2);
     setupAndExecuteJobsListBasedTest();
 
@@ -135,7 +135,7 @@ public class SetJobRetriesBatchAuthorizationTest extends AbstractBatchAuthorizat
   }
 
   @TestTemplate
-  public void testWithTwoInvocationsJobsQueryBased() {
+  void testWithTwoInvocationsJobsQueryBased() {
     engineRule.getProcessEngineConfiguration().setInvocationsPerBatchJob(2);
     setupAndExecuteJobsQueryBasedTest();
 
@@ -146,21 +146,21 @@ public class SetJobRetriesBatchAuthorizationTest extends AbstractBatchAuthorizat
   }
 
   @TestTemplate
-  public void testJobsListBased() {
+  void testJobsListBased() {
     setupAndExecuteJobsListBasedTest();
     // then
     assertScenario();
   }
 
   @TestTemplate
-  public void testJobsListQueryBased() {
+  void testJobsListQueryBased() {
     setupAndExecuteJobsQueryBasedTest();
     // then
     assertScenario();
   }
 
   @TestTemplate
-  public void testWithTwoInvocationsProcessListBased() {
+  void testWithTwoInvocationsProcessListBased() {
     engineRule.getProcessEngineConfiguration().setInvocationsPerBatchJob(2);
     setupAndExecuteProcessListBasedTest();
 
@@ -171,7 +171,7 @@ public class SetJobRetriesBatchAuthorizationTest extends AbstractBatchAuthorizat
   }
 
   @TestTemplate
-  public void testWithTwoInvocationsProcessQueryBased() {
+  void testWithTwoInvocationsProcessQueryBased() {
     engineRule.getProcessEngineConfiguration().setInvocationsPerBatchJob(2);
     setupAndExecuteJobsQueryBasedTest();
 
@@ -200,7 +200,7 @@ public class SetJobRetriesBatchAuthorizationTest extends AbstractBatchAuthorizat
   }
 
   @TestTemplate
-  public void testProcessList() {
+  void testProcessList() {
     setupAndExecuteProcessListBasedTest();
     // then
     assertScenario();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/creation/CorrelateAllMessageBatchAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/creation/CorrelateAllMessageBatchAuthorizationTest.java
@@ -66,7 +66,7 @@ public class CorrelateAllMessageBatchAuthorizationTest extends BatchCreationAuth
   }
 
   @TestTemplate
-  public void shouldAuthorizeSetVariablesBatch() {
+  void shouldAuthorizeSetVariablesBatch() {
     // given
     authRule
         .init(scenario)

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/creation/CreateDeleteProcessInstancesBatchAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/creation/CreateDeleteProcessInstancesBatchAuthorizationTest.java
@@ -56,7 +56,7 @@ public class CreateDeleteProcessInstancesBatchAuthorizationTest extends BatchCre
   }
 
   @TestTemplate
-  public void testBatchProcessInstanceDeletion() {
+  void testBatchProcessInstanceDeletion() {
     //given
     authRule
         .init(scenario)

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/creation/ModificationBatchAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/creation/ModificationBatchAuthorizationTest.java
@@ -62,7 +62,7 @@ public class ModificationBatchAuthorizationTest extends BatchCreationAuthorizati
   }
 
   @TestTemplate
-  public void createBatchModification() {
+  void createBatchModification() {
     //given
     BpmnModelInstance instance = Bpmn.createExecutableProcess("process1").startEvent().userTask("user1").userTask("user2").endEvent().done();
     ProcessDefinition processDefinition = testHelper.deployAndGetDefinition(instance);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/creation/SetJobRetriesBatchAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/creation/SetJobRetriesBatchAuthorizationTest.java
@@ -61,7 +61,7 @@ public class SetJobRetriesBatchAuthorizationTest extends BatchCreationAuthorizat
   }
 
   @TestTemplate
-  public void testBatchSetJobRetriesByJobs() {
+  void testBatchSetJobRetriesByJobs() {
     //given
     List<String> jobIds = setupFailedJobs();
     authRule
@@ -79,7 +79,7 @@ public class SetJobRetriesBatchAuthorizationTest extends BatchCreationAuthorizat
   }
 
   @TestTemplate
-  public void testBatchSetJobRetriesByProcesses() {
+  void testBatchSetJobRetriesByProcesses() {
     //given
     setupFailedJobs();
     List<String> processInstanceIds = Collections.singletonList(processInstance.getId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/creation/SetVariablesBatchAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/batch/creation/SetVariablesBatchAuthorizationTest.java
@@ -67,7 +67,7 @@ public class SetVariablesBatchAuthorizationTest extends BatchCreationAuthorizati
   }
 
   @TestTemplate
-  public void shouldAuthorizeSetVariablesBatch() {
+  void shouldAuthorizeSetVariablesBatch() {
     // given
     authRule
         .init(scenario)

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/deployment/RedeployDeploymentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/deployment/RedeployDeploymentAuthorizationTest.java
@@ -88,7 +88,7 @@ public class RedeployDeploymentAuthorizationTest {
   }
 
   @TestTemplate
-  public void testRedeploy() {
+  void testRedeploy() {
     // given
     RepositoryService repositoryService = engineRule.getRepositoryService();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/dmn/DecisionRequirementsDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/dmn/DecisionRequirementsDefinitionAuthorizationTest.java
@@ -95,7 +95,7 @@ public class DecisionRequirementsDefinitionAuthorizationTest {
 
   @TestTemplate
   @Deployment(resources = { DMN_FILE })
-  public void getDecisionRequirementsDefinition() {
+  void getDecisionRequirementsDefinition() {
 
     String decisionRequirementsDefinitionId = repositoryService
       .createDecisionRequirementsDefinitionQuery()
@@ -114,7 +114,7 @@ public class DecisionRequirementsDefinitionAuthorizationTest {
 
   @TestTemplate
   @Deployment(resources = { DMN_FILE })
-  public void getDecisionRequirementsModel() {
+  void getDecisionRequirementsModel() {
 
     // given
     String decisionRequirementsDefinitionId = repositoryService
@@ -134,7 +134,7 @@ public class DecisionRequirementsDefinitionAuthorizationTest {
 
   @TestTemplate
   @Deployment(resources = { DMN_FILE, DRD_FILE })
-  public void getDecisionRequirementsDiagram() {
+  void getDecisionRequirementsDiagram() {
 
     // given
     String decisionRequirementsDefinitionId = repositoryService

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/dmn/DecisionRequirementsDefinitionQueryAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/dmn/DecisionRequirementsDefinitionQueryAuthorizationTest.java
@@ -106,7 +106,7 @@ public class DecisionRequirementsDefinitionQueryAuthorizationTest {
 
   @TestTemplate
   @Deployment(resources = { DMN_FILE, ANOTHER_DMN })
-  public void queryDecisionRequirementsDefinitions() {
+  void queryDecisionRequirementsDefinitions() {
 
     // when
     authRule.init(scenario).withUser("userId").bindResource("decisionRequirementsDefinitionKey", DEFINITION_KEY).start();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/SetExternalTasksRetriesBatchAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/externaltask/SetExternalTasksRetriesBatchAuthorizationTest.java
@@ -122,7 +122,7 @@ public class SetExternalTasksRetriesBatchAuthorizationTest {
   }
 
   @TestTemplate
-  public void testSetRetriesAsync() {
+  void testSetRetriesAsync() {
 
     // given
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(ExternalTaskModels.ONE_EXTERNAL_TASK_PROCESS);
@@ -159,7 +159,7 @@ public class SetExternalTasksRetriesBatchAuthorizationTest {
   }
 
   @TestTemplate
-  public void testSetRetriesWithQueryAsync() {
+  void testSetRetriesWithQueryAsync() {
 
     // given
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(ExternalTaskModels.ONE_EXTERNAL_TASK_PROCESS);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/DeleteHistoricProcessInstancesAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/DeleteHistoricProcessInstancesAuthorizationTest.java
@@ -126,7 +126,7 @@ public class DeleteHistoricProcessInstancesAuthorizationTest {
   }
 
   @TestTemplate
-  public void testProcessInstancesList() {
+  void testProcessInstancesList() {
     //given
     List<String> processInstanceIds = Arrays.asList(historicProcessInstance.getId(), historicProcessInstance2.getId());
     authRule

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDecisionInstanceStatisticsAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricDecisionInstanceStatisticsAuthorizationTest.java
@@ -102,7 +102,7 @@ public class HistoricDecisionInstanceStatisticsAuthorizationTest {
   }
 
   @TestTemplate
-  public void testCreateStatistics() {
+  void testCreateStatistics() {
     //given
     authRule
         .init(scenario)

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/migration/CreateMigrationPlanAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/migration/CreateMigrationPlanAuthorizationTest.java
@@ -100,7 +100,7 @@ public class CreateMigrationPlanAuthorizationTest {
 
   @TestTemplate
   @Deployment(resources = "org/operaton/bpm/engine/test/api/authorization/oneIncidentProcess.bpmn20.xml")
-  public void testCreate() {
+  void testCreate() {
 
     // given
     ProcessDefinition sourceDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/migration/MigrateProcessInstanceSyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/migration/MigrateProcessInstanceSyncTest.java
@@ -147,7 +147,7 @@ public class MigrateProcessInstanceSyncTest {
   }
 
   @TestTemplate
-  public void testMigrateWithQuery() {
+  void testMigrateWithQuery() {
     // given
     ProcessDefinition sourceDefinition = testHelper.deployAndGetDefinition(ProcessModels.ONE_TASK_PROCESS);
     ProcessDefinition targetDefinition = testHelper.deployAndGetDefinition(modify(ProcessModels.ONE_TASK_PROCESS)

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/optimize/OptimizeServiceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/optimize/OptimizeServiceAuthorizationTest.java
@@ -182,7 +182,7 @@ public class OptimizeServiceAuthorizationTest {
   }
 
   @TestTemplate
-  public void cantGetDataWithoutTenantAuthorization() {
+  void cantGetDataWithoutTenantAuthorization() {
     // given
     identityService.setAuthentication(userId, null, Collections.singletonList(TENANT_ONE));
     authRule.createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -202,7 +202,7 @@ public class OptimizeServiceAuthorizationTest {
   }
 
   @TestTemplate
-  public void cantGetDataWithoutProcessDefinitionAuthorization() {
+  void cantGetDataWithoutProcessDefinitionAuthorization() {
     // given
     identityService.setAuthentication(userId, null, Collections.singletonList(TENANT_ONE));
     authRule.createGrantAuthorization(DECISION_DEFINITION, ANY, userId, READ_HISTORY);
@@ -222,7 +222,7 @@ public class OptimizeServiceAuthorizationTest {
   }
 
   @TestTemplate
-  public void authorizationOnSingleProcessResourceNotEnough() {
+  void authorizationOnSingleProcessResourceNotEnough() {
     // given
     identityService.setAuthentication(userId, null, Collections.singletonList(TENANT_ONE));
     authRule.createGrantAuthorization(PROCESS_DEFINITION, SIMPLE_PROCESS, userId, READ_HISTORY);
@@ -243,7 +243,7 @@ public class OptimizeServiceAuthorizationTest {
   }
 
   @TestTemplate
-  public void cantGetDataWithoutDecisionDefinitionAuthorization() {
+  void cantGetDataWithoutDecisionDefinitionAuthorization() {
     // given
     identityService.setAuthentication(userId, null, Collections.singletonList(TENANT_ONE));
     authRule.createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -263,7 +263,7 @@ public class OptimizeServiceAuthorizationTest {
   }
 
   @TestTemplate
-  public void authorizationOnSingleDecisionResourceNotEnough() {
+  void authorizationOnSingleDecisionResourceNotEnough() {
     // given
     identityService.setAuthentication(userId, null, Collections.singletonList(TENANT_ONE));
     authRule.createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, READ_HISTORY);
@@ -284,7 +284,7 @@ public class OptimizeServiceAuthorizationTest {
   }
 
   @TestTemplate
-  public void canGetDataWithAllAuthorizations() {
+  void canGetDataWithAllAuthorizations() {
     // given
     identityService.setAuthentication(userId, null, Collections.singletonList(TENANT_ONE));
     generateTestData();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/HandleTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/HandleTaskAuthorizationTest.java
@@ -122,7 +122,7 @@ public class HandleTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testHandleTaskBpmnError() {
+  void testHandleTaskBpmnError() {
     // given
     deploymentId = repositoryService.createDeployment().addClasspathResource(ONE_TASK_PROCESS).deployWithResult().getId();
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(PROCESS_KEY);
@@ -146,7 +146,7 @@ public class HandleTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testHandleTaskEscalation() {
+  void testHandleTaskEscalation() {
     // given
     BpmnModelInstance model = Bpmn.createExecutableProcess(PROCESS_KEY)
         .startEvent()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/ProcessTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/ProcessTaskAuthorizationTest.java
@@ -83,7 +83,7 @@ public abstract class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariable() {
+  void testGetVariable() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY, getVariables());
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -104,7 +104,7 @@ public abstract class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariableLocal() {
+  void testGetVariableLocal() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -127,7 +127,7 @@ public abstract class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariableTyped() {
+  void testGetVariableTyped() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY, getVariables());
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -149,7 +149,7 @@ public abstract class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariableLocalTyped() {
+  void testGetVariableLocalTyped() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -173,7 +173,7 @@ public abstract class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariables() {
+  void testGetVariables() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY, getVariables());
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -194,7 +194,7 @@ public abstract class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesLocal() {
+  void testGetVariablesLocal() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -217,7 +217,7 @@ public abstract class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesTyped() {
+  void testGetVariablesTyped() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY, getVariables());
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -238,7 +238,7 @@ public abstract class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesLocalTyped() {
+  void testGetVariablesLocalTyped() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -261,7 +261,7 @@ public abstract class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesByName() {
+  void testGetVariablesByName() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY, getVariables());
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -282,7 +282,7 @@ public abstract class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesLocalByName() {
+  void testGetVariablesLocalByName() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -305,7 +305,7 @@ public abstract class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesTypedByName() {
+  void testGetVariablesTypedByName() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY, getVariables());
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -326,7 +326,7 @@ public abstract class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesLocalTypedByName() {
+  void testGetVariablesLocalTypedByName() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY);
     String taskId = taskService.createTaskQuery().singleResult().getId();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/StandaloneTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/getvariable/StandaloneTaskAuthorizationTest.java
@@ -78,7 +78,7 @@ public abstract class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariable() {
+  void testGetVariable() {
     // given
     createTask(taskId);
 
@@ -100,7 +100,7 @@ public abstract class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariableLocal() {
+  void testGetVariableLocal() {
     // given
     createTask(taskId);
 
@@ -122,7 +122,7 @@ public abstract class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariableTyped() {
+  void testGetVariableTyped() {
     // given
     createTask(taskId);
 
@@ -145,7 +145,7 @@ public abstract class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariableLocalTyped() {
+  void testGetVariableLocalTyped() {
     // given
     createTask(taskId);
 
@@ -168,7 +168,7 @@ public abstract class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariables() {
+  void testGetVariables() {
     // given
     createTask(taskId);
 
@@ -190,7 +190,7 @@ public abstract class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesLocal() {
+  void testGetVariablesLocal() {
     // given
     createTask(taskId);
 
@@ -212,7 +212,7 @@ public abstract class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesTyped() {
+  void testGetVariablesTyped() {
     createTask(taskId);
 
     taskService.setVariables(taskId, getVariables());
@@ -233,7 +233,7 @@ public abstract class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesLocalTyped() {
+  void testGetVariablesLocalTyped() {
     createTask(taskId);
 
     taskService.setVariablesLocal(taskId, getVariables());
@@ -254,7 +254,7 @@ public abstract class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesByName() {
+  void testGetVariablesByName() {
     // given
     createTask(taskId);
 
@@ -276,7 +276,7 @@ public abstract class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesLocalByName() {
+  void testGetVariablesLocalByName() {
     // given
     createTask(taskId);
 
@@ -298,7 +298,7 @@ public abstract class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesTypedByName() {
+  void testGetVariablesTypedByName() {
     createTask(taskId);
 
     taskService.setVariables(taskId, getVariables());
@@ -319,7 +319,7 @@ public abstract class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testGetVariablesLocalTypedByName() {
+  void testGetVariablesLocalTypedByName() {
     createTask(taskId);
 
     taskService.setVariablesLocal(taskId, getVariables());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/updatevariable/ProcessTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/updatevariable/ProcessTaskAuthorizationTest.java
@@ -138,7 +138,7 @@ public class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testSetVariable() {
+  void testSetVariable() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -159,7 +159,7 @@ public class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testSetVariableLocal() {
+  void testSetVariableLocal() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -180,7 +180,7 @@ public class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testSetVariables() {
+  void testSetVariables() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY);
     String taskId = taskService.createTaskQuery().singleResult().getId();
@@ -201,7 +201,7 @@ public class ProcessTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testSetVariablesLocal() {
+  void testSetVariablesLocal() {
     // given
     runtimeService.startProcessInstanceByKey(PROCESS_KEY);
     String taskId = taskService.createTaskQuery().singleResult().getId();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/updatevariable/StandaloneTaskAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/task/updatevariable/StandaloneTaskAuthorizationTest.java
@@ -127,7 +127,7 @@ public class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testSetVariable() {
+  void testSetVariable() {
     // given
     createTask(taskId);
 
@@ -147,7 +147,7 @@ public class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testSetVariableLocal() {
+  void testSetVariableLocal() {
     // given
     createTask(taskId);
 
@@ -167,7 +167,7 @@ public class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testSetVariables() {
+  void testSetVariables() {
     // given
     createTask(taskId);
 
@@ -187,7 +187,7 @@ public class StandaloneTaskAuthorizationTest {
   }
 
   @TestTemplate
-  public void testSetVariablesLocal() {
+  void testSetVariablesLocal() {
     // given
     createTask(taskId);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceMilestoneTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceMilestoneTest.java
@@ -40,8 +40,8 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 @ExtendWith(ProcessEngineTestExtension.class)
 class CaseServiceMilestoneTest {
 
-  protected final String DEFINITION_KEY = "oneMilestoneCase";
-  protected final String MILESTONE_KEY = "PI_Milestone_1";
+  static final String DEFINITION_KEY = "oneMilestoneCase";
+  static final String MILESTONE_KEY = "PI_Milestone_1";
 
   protected TaskService taskService;
   protected CaseService caseService;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceProcessTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceProcessTaskTest.java
@@ -48,8 +48,8 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 @ExtendWith(ProcessEngineTestExtension.class)
 class CaseServiceProcessTaskTest {
 
-  protected final String DEFINITION_KEY = "oneProcessTaskCase";
-  protected final String PROCESS_TASK_KEY = "PI_ProcessTask_1";
+  static final String DEFINITION_KEY = "oneProcessTaskCase";
+  static final String PROCESS_TASK_KEY = "PI_ProcessTask_1";
 
   protected RuntimeService runtimeService;
   protected TaskService taskService;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/encoding/ProcessEngineCharacterEncodingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/encoding/ProcessEngineCharacterEncodingTest.java
@@ -90,7 +90,7 @@ public class ProcessEngineCharacterEncodingTest {
   }
 
   @TestTemplate
-  public void shouldPreserveArabicTaskCommentMessageWithCharset() {
+  void shouldPreserveArabicTaskCommentMessageWithCharset() {
     // given
     String message = "این نمونه است";
     Task task = newTaskWithComment(message);
@@ -104,7 +104,7 @@ public class ProcessEngineCharacterEncodingTest {
   }
 
   @TestTemplate
-  public void shouldPreserveLatinTaskCommentMessageWithCharset() {
+  void shouldPreserveLatinTaskCommentMessageWithCharset() {
     // given
     String message = "This is an example";
     Task task = newTaskWithComment(message);
@@ -118,7 +118,7 @@ public class ProcessEngineCharacterEncodingTest {
   }
 
   @TestTemplate
-  public void shouldPreserveArabicTaskUpdateCommentMessageWithCharset() {
+  void shouldPreserveArabicTaskUpdateCommentMessageWithCharset() {
     // given
     String taskId = newTask().getId();
     Comment comment = createNewComment(taskId, "OriginalMessage");
@@ -135,7 +135,7 @@ public class ProcessEngineCharacterEncodingTest {
   }
 
   @TestTemplate
-  public void shouldPreserveLatinTaskUpdateCommentMessageWithCharset() {
+  void shouldPreserveLatinTaskUpdateCommentMessageWithCharset() {
     // given
     String taskId = newTask().getId();
     Comment comment = createNewComment(taskId, "OriginalMessage");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskServiceTest.java
@@ -87,7 +87,7 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
  * @author Thorben Lindhauer
  *
  */
-public class ExternalTaskServiceTest {
+class ExternalTaskServiceTest {
 
   protected static final String WORKER_ID = "aWorkerId";
   protected static final long LOCK_TIME = 10000L;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskSupportTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskSupportTest.java
@@ -83,7 +83,7 @@ public class ExternalTaskSupportTest {
   }
 
   @TestTemplate
-  public void testExternalTaskSupport() {
+  void testExternalTaskSupport() {
     // given
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
 
@@ -106,7 +106,7 @@ public class ExternalTaskSupportTest {
   }
 
   @TestTemplate
-  public void testExternalTaskProperties() {
+  void testExternalTaskProperties() {
     // given
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
     runtimeService.startProcessInstanceById(processDefinition.getId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/form/HtmlFormEngineTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/form/HtmlFormEngineTest.java
@@ -42,7 +42,7 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
  *
  */
 @ExtendWith(ProcessEngineExtension.class)
-public class HtmlFormEngineTest {
+class HtmlFormEngineTest {
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected RepositoryService repositoryService;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionAuthorizationTest.java
@@ -151,7 +151,7 @@ public class BatchHistoricDecisionInstanceDeletionAuthorizationTest {
   }
 
   @TestTemplate
-  public void executeBatch() {
+  void executeBatch() {
     // given
     authRule.init(scenario)
       .withUser("userId")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionTest.java
@@ -307,7 +307,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
     Batch batch = historyService.deleteHistoricDecisionInstancesAsync(decisionInstanceIds, null);
 
     JobDefinition seedJobDefinition = helper.getSeedJobDefinition(batch);
-    JobDefinition deletionJobDefinition = helper.getExecutionJobDefinition(batch);;
+    JobDefinition deletionJobDefinition = helper.getExecutionJobDefinition(batch);
 
     // when
     helper.executeSeedJob(batch);
@@ -415,7 +415,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
     Batch batch = historyService.deleteHistoricDecisionInstancesAsync(query, null);
 
     JobDefinition seedJobDefinition = helper.getSeedJobDefinition(batch);
-    JobDefinition deletionJobDefinition = helper.getExecutionJobDefinition(batch);;
+    JobDefinition deletionJobDefinition = helper.getExecutionJobDefinition(batch);
 
     // when
     helper.executeSeedJob(batch);
@@ -448,7 +448,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
     Batch batch = historyService.deleteHistoricDecisionInstancesAsync(decisionInstanceIds, query, null);
 
     JobDefinition seedJobDefinition = helper.getSeedJobDefinition(batch);
-    JobDefinition deletionJobDefinition = helper.getExecutionJobDefinition(batch);;
+    JobDefinition deletionJobDefinition = helper.getExecutionJobDefinition(batch);
 
     // when
     helper.executeSeedJob(batch);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BatchHistoricDecisionInstanceDeletionTest.java
@@ -135,7 +135,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void createBatchDeletionByIds() {
+  void createBatchDeletionByIds() {
     // when
     Batch batch = historyService.deleteHistoricDecisionInstancesAsync(decisionInstanceIds, null);
 
@@ -144,14 +144,14 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void createBatchDeletionByInvalidIds() {
+  void createBatchDeletionByInvalidIds() {
     // when/then
     assertThatThrownBy(() -> historyService.deleteHistoricDecisionInstancesAsync((List<String>) null, null))
       .isInstanceOf(BadUserRequestException.class);
   }
 
   @TestTemplate
-  public void createBatchDeletionByQuery() {
+  void createBatchDeletionByQuery() {
     // given
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery().decisionDefinitionKey(DECISION);
 
@@ -163,14 +163,14 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void createBatchDeletionByInvalidQuery() {
+  void createBatchDeletionByInvalidQuery() {
     // when/then
     assertThatThrownBy(() -> historyService.deleteHistoricDecisionInstancesAsync((HistoricDecisionInstanceQuery) null, null))
       .isInstanceOf(BadUserRequestException.class);
   }
 
   @TestTemplate
-  public void createBatchDeletionByInvalidQueryByKey() {
+  void createBatchDeletionByInvalidQueryByKey() {
     // given
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery().decisionDefinitionKey("foo");
 
@@ -180,7 +180,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void createBatchDeletionByIdsAndQuery() {
+  void createBatchDeletionByIdsAndQuery() {
     // given
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery().decisionDefinitionKey(DECISION);
 
@@ -192,7 +192,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void createSeedJobByIds() {
+  void createSeedJobByIds() {
     // when
     Batch batch = historyService.deleteHistoricDecisionInstancesAsync(decisionInstanceIds, null);
 
@@ -226,7 +226,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void createSeedJobByQuery() {
+  void createSeedJobByQuery() {
     // given
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery().decisionDefinitionKey(DECISION);
 
@@ -263,7 +263,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void createSeedJobByIdsAndQuery() {
+  void createSeedJobByIdsAndQuery() {
     // given
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery().decisionDefinitionKey(DECISION);
 
@@ -300,7 +300,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void createDeletionJobsByIds() {
+  void createDeletionJobsByIds() {
     // given
     rule.getProcessEngineConfiguration().setBatchJobsPerSeed(5);
 
@@ -331,7 +331,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void createDeletionJobsByIdsInDifferentDeployments() {
+  void createDeletionJobsByIdsInDifferentDeployments() {
     // given a second deployment and instances
     executeDecisionInstances();
 
@@ -365,7 +365,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void createDeletionJobsByIdsWithDeletedDeployment() {
+  void createDeletionJobsByIdsWithDeletedDeployment() {
     // given a second deployment and instances
     executeDecisionInstances();
 
@@ -406,7 +406,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void createDeletionJobsByQuery() {
+  void createDeletionJobsByQuery() {
     // given
     rule.getProcessEngineConfiguration().setBatchJobsPerSeed(5);
 
@@ -439,7 +439,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void createDeletionJobsByIdsAndQuery() {
+  void createDeletionJobsByIdsAndQuery() {
     // given
     rule.getProcessEngineConfiguration().setBatchJobsPerSeed(5);
 
@@ -472,7 +472,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void createMonitorJobByIds() {
+  void createMonitorJobByIds() {
     // given
     Batch batch = historyService.deleteHistoricDecisionInstancesAsync(decisionInstanceIds, null);
 
@@ -495,7 +495,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void createMonitorJobByQuery() {
+  void createMonitorJobByQuery() {
     // given
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery().decisionDefinitionKey(DECISION);
     Batch batch = historyService.deleteHistoricDecisionInstancesAsync(query, null);
@@ -519,7 +519,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void createMonitorJobByIdsAndQuery() {
+  void createMonitorJobByIdsAndQuery() {
     // given
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery().decisionDefinitionKey(DECISION);
     Batch batch = historyService.deleteHistoricDecisionInstancesAsync(decisionInstanceIds, query, null);
@@ -543,7 +543,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void deleteInstancesByIds() {
+  void deleteInstancesByIds() {
     // given
     Batch batch = historyService.deleteHistoricDecisionInstancesAsync(decisionInstanceIds, null);
 
@@ -561,7 +561,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void deleteInstancesByQuery() {
+  void deleteInstancesByQuery() {
     // given
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery().decisionDefinitionKey(DECISION);
     Batch batch = historyService.deleteHistoricDecisionInstancesAsync(query, null);
@@ -579,7 +579,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void deleteInstancesByIdsAndQuery() {
+  void deleteInstancesByIdsAndQuery() {
     // given
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery().decisionDefinitionKey(DECISION);
     Batch batch = historyService.deleteHistoricDecisionInstancesAsync(decisionInstanceIds, query, null);
@@ -597,7 +597,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void shouldSetInvocationsPerBatchType() {
+  void shouldSetInvocationsPerBatchType() {
     // given
     configuration.getInvocationsPerBatchJobByBatchType()
         .put(Batch.TYPE_HISTORIC_DECISION_INSTANCE_DELETION, 42);
@@ -616,7 +616,7 @@ public class BatchHistoricDecisionInstanceDeletionTest {
   }
 
   @TestTemplate
-  public void shouldSetExecutionStartTimeInBatchAndHistory() {
+  void shouldSetExecutionStartTimeInBatchAndHistory() {
     // given
     ClockUtil.setCurrentTime(TEST_DATE);
     Batch batch = historyService.deleteHistoricDecisionInstancesAsync(decisionInstanceIds, null);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BulkHistoryDeleteDecisionInstancesAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BulkHistoryDeleteDecisionInstancesAuthorizationTest.java
@@ -106,7 +106,7 @@ public class BulkHistoryDeleteDecisionInstancesAuthorizationTest {
   @TestTemplate
   @Deployment(resources = {
       "org/operaton/bpm/engine/test/api/dmn/Example.dmn"})
-  public void testCleanupHistory() {
+  void testCleanupHistory() {
     //given
     final List<String> ids = prepareHistoricDecisions();
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BulkHistoryDeleteProcessInstancesAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BulkHistoryDeleteProcessInstancesAuthorizationTest.java
@@ -102,7 +102,7 @@ public class BulkHistoryDeleteProcessInstancesAuthorizationTest {
   @TestTemplate
   @Deployment(resources = {
       "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
-  public void testCleanupHistory() {
+  void testCleanupHistory() {
     //given
     final List<String> ids = prepareHistoricProcesses();
     runtimeService.deleteProcessInstances(ids, null, true, true);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupBatchWindowForEveryDayTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupBatchWindowForEveryDayTest.java
@@ -136,7 +136,7 @@ public class HistoryCleanupBatchWindowForEveryDayTest {
   }
 
   @TestTemplate
-  public void testScheduleJobForBatchWindow() {
+  void testScheduleJobForBatchWindow() {
     ClockUtil.setCurrentTime(currentDate);
 
     processEngineConfiguration.setHistoryCleanupBatchWindowStartTime(startTime);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupBatchWindowForWeekDaysTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupBatchWindowForWeekDaysTest.java
@@ -144,7 +144,7 @@ public class HistoryCleanupBatchWindowForWeekDaysTest {
   }
 
   @TestTemplate
-  public void testScheduleJobForBatchWindow() {
+  void testScheduleJobForBatchWindow() {
 
     ClockUtil.setCurrentTime(currentDate);
     processEngineConfiguration.initHistoryCleanup();
@@ -168,7 +168,7 @@ public class HistoryCleanupBatchWindowForWeekDaysTest {
   }
 
   @TestTemplate
-  public void testScheduleJobForBatchWindowWithDefaultWindowConfigured() {
+  void testScheduleJobForBatchWindowWithDefaultWindowConfigured() {
     ClockUtil.setCurrentTime(currentDate);
     processEngineConfiguration.setHistoryCleanupBatchWindowStartTime("23:00");
     processEngineConfiguration.setHistoryCleanupBatchWindowEndTime("00:00");
@@ -202,7 +202,7 @@ public class HistoryCleanupBatchWindowForWeekDaysTest {
   }
 
   @TestTemplate
-  public void testScheduleJobForBatchWindowWithShortcutConfiguration() {
+  void testScheduleJobForBatchWindowWithShortcutConfiguration() {
     ClockUtil.setCurrentTime(currentDate);
     processEngineConfiguration.setThursdayHistoryCleanupBatchWindowStartTime("23:00");
     processEngineConfiguration.setThursdayHistoryCleanupBatchWindowEndTime("00:00");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeHierarchicalTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeHierarchicalTest.java
@@ -83,7 +83,7 @@ class BatchSetRemovalTimeHierarchicalTest {
   @RegisterExtension
   protected static BatchSetRemovalTimeExtension testRule = new BatchSetRemovalTimeExtension(engineRule, engineTestRule);
 
-  protected final Date CURRENT_DATE = testRule.CURRENT_DATE;
+  protected final Date currentDate = testRule.CURRENT_DATE;
 
   protected RuntimeService runtimeService;
   protected HistoryService historyService;
@@ -135,9 +135,9 @@ class BatchSetRemovalTimeHierarchicalTest {
     historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -178,7 +178,7 @@ class BatchSetRemovalTimeHierarchicalTest {
       .list();
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -219,7 +219,7 @@ class BatchSetRemovalTimeHierarchicalTest {
       .list();
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -272,8 +272,8 @@ class BatchSetRemovalTimeHierarchicalTest {
     historicDecisionInputInstances = historicDecisionInstance.getInputs();
 
     // then
-    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -320,7 +320,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     historicDecisionInputInstances = historicDecisionInstance.getInputs();
 
     // then
-    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -367,7 +367,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     historicDecisionInputInstances = historicDecisionInstance.getInputs();
 
     // then
-    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -419,7 +419,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
 
     // then
-    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -466,7 +466,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
 
     // then
-    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -513,7 +513,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
 
     // then
-    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -542,8 +542,8 @@ class BatchSetRemovalTimeHierarchicalTest {
     historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
 
     // then
-    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -576,7 +576,7 @@ class BatchSetRemovalTimeHierarchicalTest {
       .singleResult();
 
     // then
-    assertThat(historicActivityInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicActivityInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -605,7 +605,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
 
     // then
-    assertThat(historicTaskInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicTaskInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -644,7 +644,7 @@ class BatchSetRemovalTimeHierarchicalTest {
             .singleResult();
 
     // then
-    assertThat(authorization.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(authorization.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -731,7 +731,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     authQuery = authorizationService.createAuthorizationQuery()
         .resourceType(Resources.HISTORIC_PROCESS_INSTANCE);
 
-    Date removalTime = addDays(CURRENT_DATE, 5);
+    Date removalTime = addDays(currentDate, 5);
     assertThat(authQuery.list())
         .extracting("removalTime", "resourceId", "rootProcessInstanceId")
         .containsExactly(tuple(removalTime, processInstanceId, rootProcessInstanceId));
@@ -819,7 +819,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     historicVariableInstance = historyService.createHistoricVariableInstanceQuery().singleResult();
 
     // then
-    assertThat(historicVariableInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicVariableInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -851,7 +851,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     historicDetail = historyService.createHistoricDetailQuery().singleResult();
 
     // then
-    assertThat(historicDetail.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDetail.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -880,7 +880,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     historicExternalTaskLog = historyService.createHistoricExternalTaskLogQuery().singleResult();
 
     // then
-    assertThat(historicExternalTaskLog.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicExternalTaskLog.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -913,7 +913,7 @@ class BatchSetRemovalTimeHierarchicalTest {
       .singleResult();
 
     // then
-    assertThat(job.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(job.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -955,7 +955,7 @@ class BatchSetRemovalTimeHierarchicalTest {
       .singleResult();
 
     // then
-    assertThat(historicIncident.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicIncident.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -988,7 +988,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // then
-    assertThat(userOperationLog.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(userOperationLog.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1017,7 +1017,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     identityLinkLog = historyService.createHistoricIdentityLinkLogQuery().singleResult();
 
     // then
-    assertThat(identityLinkLog.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(identityLinkLog.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1055,7 +1055,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     comment = taskService.getTaskComments(taskId).get(0);
 
     // then
-    assertThat(comment.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(comment.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1086,7 +1086,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     comment = taskService.getProcessInstanceComments(processInstanceId).get(0);
 
     // then
-    assertThat(comment.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(comment.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1121,7 +1121,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     attachment = taskService.getTaskAttachments(taskId).get(0);
 
     // then
-    assertThat(attachment.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(attachment.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1151,7 +1151,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     attachment = taskService.getProcessInstanceAttachments(processInstanceId).get(0);
 
     // then
-    assertThat(attachment.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(attachment.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1188,7 +1188,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(attachment.getContentId());
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1222,7 +1222,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1260,7 +1260,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1272,8 +1272,9 @@ class BatchSetRemovalTimeHierarchicalTest {
 
     try {
       managementService.executeJob(jobId);
-
-    } catch (Exception ignored) { }
+    } catch (Exception ignored) {
+      // ignored
+    }
 
     HistoricJobLog historicJobLog = historyService.createHistoricJobLogQuery()
       .failureLog()
@@ -1302,7 +1303,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1346,7 +1347,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1395,7 +1396,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1439,7 +1440,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1483,7 +1484,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1532,7 +1533,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1576,7 +1577,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1620,7 +1621,7 @@ class BatchSetRemovalTimeHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeInChunksTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeInChunksTest.java
@@ -93,11 +93,10 @@ class BatchSetRemovalTimeInChunksTest {
   @RegisterExtension
   protected static BatchSetRemovalTimeExtension testRule = new BatchSetRemovalTimeExtension(engineRule, engineTestRule);
 
-  protected final Date REMOVAL_TIME = testRule.REMOVAL_TIME;
+  protected final Date removalTime = testRule.REMOVAL_TIME;
+  protected final Date currentDate = testRule.CURRENT_DATE;
+  protected static final Date CREATE_TIME = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
-  protected final Date CREATE_TIME = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
-
-  protected final Date CURRENT_DATE = testRule.CURRENT_DATE;
 
   protected ProcessEngineConfigurationImpl engineConfiguration;
   protected RuntimeService runtimeService;
@@ -132,7 +131,7 @@ class BatchSetRemovalTimeInChunksTest {
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
 
     Batch batch = historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync();
@@ -155,7 +154,7 @@ class BatchSetRemovalTimeInChunksTest {
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
 
     Batch batch = historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .chunkSize(100) // data updated in one chunk
@@ -179,7 +178,7 @@ class BatchSetRemovalTimeInChunksTest {
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
 
     Batch batch = historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .chunkSize(100) // most data updated in one chunk
@@ -200,7 +199,7 @@ class BatchSetRemovalTimeInChunksTest {
     historicProcessInstance = query.singleResult();
 
     assertThat(testRule.getExecutionJobs(batch)).isEmpty();
-    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -211,7 +210,7 @@ class BatchSetRemovalTimeInChunksTest {
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
 
     Batch batch = historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .hierarchical()
         .updateInChunks()
@@ -234,8 +233,8 @@ class BatchSetRemovalTimeInChunksTest {
     historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
 
     assertThat(testRule.getExecutionJobs(batch)).isEmpty();
-    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -250,7 +249,7 @@ class BatchSetRemovalTimeInChunksTest {
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
 
     Batch batch = historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync();
@@ -369,7 +368,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -378,9 +377,9 @@ class BatchSetRemovalTimeInChunksTest {
     historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -411,7 +410,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -425,8 +424,8 @@ class BatchSetRemovalTimeInChunksTest {
     historicDecisionInputInstances = historicDecisionInstance.getInputs();
 
     // then
-    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -456,7 +455,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -470,7 +469,7 @@ class BatchSetRemovalTimeInChunksTest {
     historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
 
     // then
-    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -488,7 +487,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -497,7 +496,7 @@ class BatchSetRemovalTimeInChunksTest {
     historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
 
     // then
-    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -510,7 +509,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -521,7 +520,7 @@ class BatchSetRemovalTimeInChunksTest {
       .singleResult();
 
     // then
-    assertThat(historicActivityInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicActivityInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -534,7 +533,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -543,7 +542,7 @@ class BatchSetRemovalTimeInChunksTest {
     HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
 
     // then
-    assertThat(historicTaskInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicTaskInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -561,7 +560,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -573,7 +572,7 @@ class BatchSetRemovalTimeInChunksTest {
             .singleResult();
 
     // then
-    assertThat(authorization.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(authorization.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -594,7 +593,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -638,7 +637,7 @@ class BatchSetRemovalTimeInChunksTest {
 
     testRule.syncExec(
         historyService.setRemovalTimeToHistoricProcessInstances()
-            .absoluteRemovalTime(REMOVAL_TIME)
+            .absoluteRemovalTime(removalTime)
             .byQuery(query)
             .updateInChunks()
             .executeAsync()
@@ -650,7 +649,7 @@ class BatchSetRemovalTimeInChunksTest {
 
     assertThat(authQuery.list())
         .extracting("removalTime", "resourceId", "rootProcessInstanceId")
-        .containsExactly(tuple(REMOVAL_TIME, processInstanceId, processInstanceId));
+        .containsExactly(tuple(removalTime, processInstanceId, processInstanceId));
   }
 
   @Test
@@ -682,7 +681,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
         historyService.setRemovalTimeToHistoricProcessInstances()
-            .absoluteRemovalTime(REMOVAL_TIME)
+            .absoluteRemovalTime(removalTime)
             .byQuery(query)
             .updateInChunks()
             .executeAsync()
@@ -710,7 +709,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -719,7 +718,7 @@ class BatchSetRemovalTimeInChunksTest {
     HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery().singleResult();
 
     // then
-    assertThat(historicVariableInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicVariableInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -735,7 +734,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -744,7 +743,7 @@ class BatchSetRemovalTimeInChunksTest {
     HistoricDetail historicDetail = historyService.createHistoricDetailQuery().singleResult();
 
     // then
-    assertThat(historicDetail.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDetail.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -762,7 +761,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -771,7 +770,7 @@ class BatchSetRemovalTimeInChunksTest {
     historicExternalTaskLog = historyService.createHistoricExternalTaskLogQuery().singleResult();
 
     // then
-    assertThat(historicExternalTaskLog.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicExternalTaskLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   /**
@@ -794,7 +793,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -823,7 +822,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -834,7 +833,7 @@ class BatchSetRemovalTimeInChunksTest {
       .singleResult();
 
     // then
-    assertThat(job.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(job.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -856,7 +855,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -865,7 +864,7 @@ class BatchSetRemovalTimeInChunksTest {
     historicIncident = historyService.createHistoricIncidentQuery().singleResult();
 
     // then
-    assertThat(historicIncident.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicIncident.getRemovalTime()).isEqualTo(removalTime);
   }
 
   /**
@@ -892,7 +891,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -923,7 +922,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -932,7 +931,7 @@ class BatchSetRemovalTimeInChunksTest {
     userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // then
-    assertThat(userOperationLog.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(userOperationLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   /**
@@ -959,7 +958,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -986,7 +985,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -995,7 +994,7 @@ class BatchSetRemovalTimeInChunksTest {
     identityLinkLog = historyService.createHistoricIdentityLinkLogQuery().singleResult();
 
     // then
-    assertThat(identityLinkLog.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(identityLinkLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   /**
@@ -1018,7 +1017,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -1043,7 +1042,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query.processInstanceId(instance1))
         .updateInChunks()
         .executeAsync()
@@ -1080,7 +1079,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -1089,7 +1088,7 @@ class BatchSetRemovalTimeInChunksTest {
     comment = taskService.getTaskComments(taskId).get(0);
 
     // then
-    assertThat(comment.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(comment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1109,7 +1108,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -1118,7 +1117,7 @@ class BatchSetRemovalTimeInChunksTest {
     comment = taskService.getProcessInstanceComments(processInstanceId).get(0);
 
     // then
-    assertThat(comment.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(comment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1142,7 +1141,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -1151,7 +1150,7 @@ class BatchSetRemovalTimeInChunksTest {
     attachment = taskService.getTaskAttachments(taskId).get(0);
 
     // then
-    assertThat(attachment.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(attachment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1170,7 +1169,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -1179,7 +1178,7 @@ class BatchSetRemovalTimeInChunksTest {
     attachment = taskService.getProcessInstanceAttachments(processInstanceId).get(0);
 
     // then
-    assertThat(attachment.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(attachment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1205,7 +1204,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -1214,7 +1213,7 @@ class BatchSetRemovalTimeInChunksTest {
     byteArrayEntity = testRule.findByteArrayById(attachment.getContentId());
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1237,7 +1236,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -1246,7 +1245,7 @@ class BatchSetRemovalTimeInChunksTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1273,7 +1272,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -1282,7 +1281,7 @@ class BatchSetRemovalTimeInChunksTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1313,7 +1312,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -1322,7 +1321,7 @@ class BatchSetRemovalTimeInChunksTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1355,7 +1354,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -1364,7 +1363,7 @@ class BatchSetRemovalTimeInChunksTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1396,7 +1395,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -1405,7 +1404,7 @@ class BatchSetRemovalTimeInChunksTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1437,7 +1436,7 @@ class BatchSetRemovalTimeInChunksTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .updateInChunks()
         .executeAsync()
@@ -1446,7 +1445,7 @@ class BatchSetRemovalTimeInChunksTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   // HIERARCHICAL TEST CASES
@@ -1493,9 +1492,9 @@ class BatchSetRemovalTimeInChunksTest {
     historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1549,8 +1548,8 @@ class BatchSetRemovalTimeInChunksTest {
     historicDecisionInputInstances = historicDecisionInstance.getInputs();
 
     // then
-    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1603,7 +1602,7 @@ class BatchSetRemovalTimeInChunksTest {
     historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
 
     // then
-    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1633,8 +1632,8 @@ class BatchSetRemovalTimeInChunksTest {
     historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
 
     // then
-    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1668,7 +1667,7 @@ class BatchSetRemovalTimeInChunksTest {
       .singleResult();
 
     // then
-    assertThat(historicActivityInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicActivityInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1698,7 +1697,7 @@ class BatchSetRemovalTimeInChunksTest {
     historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
 
     // then
-    assertThat(historicTaskInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicTaskInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1738,7 +1737,7 @@ class BatchSetRemovalTimeInChunksTest {
             .singleResult();
 
     // then
-    assertThat(authorization.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(authorization.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1827,10 +1826,10 @@ class BatchSetRemovalTimeInChunksTest {
     authQuery = authorizationService.createAuthorizationQuery()
         .resourceType(Resources.HISTORIC_PROCESS_INSTANCE);
 
-    Date removalTime = addDays(CURRENT_DATE, 5);
+    Date exptectedRemovalTime = addDays(currentDate, 5);
     assertThat(authQuery.list())
         .extracting("removalTime", "resourceId", "rootProcessInstanceId")
-        .containsExactly(tuple(removalTime, processInstanceId, rootProcessInstanceId));
+        .containsExactly(tuple(exptectedRemovalTime, processInstanceId, rootProcessInstanceId));
   }
 
   @Test
@@ -1917,7 +1916,7 @@ class BatchSetRemovalTimeInChunksTest {
     historicVariableInstance = historyService.createHistoricVariableInstanceQuery().singleResult();
 
     // then
-    assertThat(historicVariableInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicVariableInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1950,7 +1949,7 @@ class BatchSetRemovalTimeInChunksTest {
     historicDetail = historyService.createHistoricDetailQuery().singleResult();
 
     // then
-    assertThat(historicDetail.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDetail.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1980,7 +1979,7 @@ class BatchSetRemovalTimeInChunksTest {
     historicExternalTaskLog = historyService.createHistoricExternalTaskLogQuery().singleResult();
 
     // then
-    assertThat(historicExternalTaskLog.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicExternalTaskLog.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2014,7 +2013,7 @@ class BatchSetRemovalTimeInChunksTest {
       .singleResult();
 
     // then
-    assertThat(job.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(job.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2057,7 +2056,7 @@ class BatchSetRemovalTimeInChunksTest {
       .singleResult();
 
     // then
-    assertThat(historicIncident.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicIncident.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2091,7 +2090,7 @@ class BatchSetRemovalTimeInChunksTest {
     userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // then
-    assertThat(userOperationLog.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(userOperationLog.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2121,7 +2120,7 @@ class BatchSetRemovalTimeInChunksTest {
     identityLinkLog = historyService.createHistoricIdentityLinkLogQuery().singleResult();
 
     // then
-    assertThat(identityLinkLog.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(identityLinkLog.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2160,7 +2159,7 @@ class BatchSetRemovalTimeInChunksTest {
     comment = taskService.getTaskComments(taskId).get(0);
 
     // then
-    assertThat(comment.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(comment.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2192,7 +2191,7 @@ class BatchSetRemovalTimeInChunksTest {
     comment = taskService.getProcessInstanceComments(processInstanceId).get(0);
 
     // then
-    assertThat(comment.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(comment.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2228,7 +2227,7 @@ class BatchSetRemovalTimeInChunksTest {
     attachment = taskService.getTaskAttachments(taskId).get(0);
 
     // then
-    assertThat(attachment.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(attachment.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2259,7 +2258,7 @@ class BatchSetRemovalTimeInChunksTest {
     attachment = taskService.getProcessInstanceAttachments(processInstanceId).get(0);
 
     // then
-    assertThat(attachment.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(attachment.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2297,7 +2296,7 @@ class BatchSetRemovalTimeInChunksTest {
     byteArrayEntity = testRule.findByteArrayById(attachment.getContentId());
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2332,7 +2331,7 @@ class BatchSetRemovalTimeInChunksTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2371,7 +2370,7 @@ class BatchSetRemovalTimeInChunksTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2414,7 +2413,7 @@ class BatchSetRemovalTimeInChunksTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2459,7 +2458,7 @@ class BatchSetRemovalTimeInChunksTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2509,7 +2508,7 @@ class BatchSetRemovalTimeInChunksTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2559,6 +2558,6 @@ class BatchSetRemovalTimeInChunksTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeNonHierarchicalTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeNonHierarchicalTest.java
@@ -91,9 +91,9 @@ class BatchSetRemovalTimeNonHierarchicalTest {
   @RegisterExtension
   protected static BatchSetRemovalTimeExtension testRule = new BatchSetRemovalTimeExtension(engineRule, engineTestRule);
 
-  protected final Date REMOVAL_TIME = testRule.REMOVAL_TIME;
+  protected final Date removalTime = testRule.REMOVAL_TIME;
 
-  protected final Date CREATE_TIME = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+  protected static final Date CREATE_TIME = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   protected RuntimeService runtimeService;
   protected DecisionService decisionService;
@@ -128,7 +128,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -136,9 +136,9 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -166,7 +166,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricDecisionInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -174,9 +174,9 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -207,7 +207,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -220,8 +220,8 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     historicDecisionInputInstances = historicDecisionInstance.getInputs();
 
     // then
-    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInputInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -252,7 +252,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricDecisionInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -265,7 +265,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     historicDecisionInputInstances = historicDecisionInstance.getInputs();
 
     // then
-    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionInputInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -295,7 +295,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -308,7 +308,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
 
     // then
-    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -339,7 +339,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricDecisionInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -352,7 +352,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     historicDecisionOutputInstances = historicDecisionInstance.getOutputs();
 
     // then
-    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionOutputInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -370,7 +370,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -378,7 +378,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
 
     // then
-    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -391,7 +391,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -401,7 +401,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
       .singleResult();
 
     // then
-    assertThat(historicActivityInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicActivityInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -414,7 +414,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -422,7 +422,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().singleResult();
 
     // then
-    assertThat(historicTaskInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicTaskInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -440,7 +440,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -451,7 +451,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
             .singleResult();
 
     // then
-    assertThat(authorization.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(authorization.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -472,7 +472,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -515,7 +515,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
 
     testRule.syncExec(
         historyService.setRemovalTimeToHistoricProcessInstances()
-            .absoluteRemovalTime(REMOVAL_TIME)
+            .absoluteRemovalTime(removalTime)
             .byQuery(query)
             .executeAsync()
     );
@@ -526,7 +526,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
 
     assertThat(authQuery.list())
         .extracting("removalTime", "resourceId", "rootProcessInstanceId")
-        .containsExactly(tuple(REMOVAL_TIME, processInstanceId, processInstanceId));
+        .containsExactly(tuple(removalTime, processInstanceId, processInstanceId));
   }
 
   @Test
@@ -558,7 +558,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
         historyService.setRemovalTimeToHistoricProcessInstances()
-            .absoluteRemovalTime(REMOVAL_TIME)
+            .absoluteRemovalTime(removalTime)
             .byQuery(query)
             .executeAsync()
     );
@@ -585,7 +585,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -593,7 +593,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery().singleResult();
 
     // then
-    assertThat(historicVariableInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicVariableInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -609,7 +609,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -617,7 +617,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     HistoricDetail historicDetail = historyService.createHistoricDetailQuery().singleResult();
 
     // then
-    assertThat(historicDetail.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDetail.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -635,7 +635,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -643,7 +643,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     historicExternalTaskLog = historyService.createHistoricExternalTaskLogQuery().singleResult();
 
     // then
-    assertThat(historicExternalTaskLog.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicExternalTaskLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   /**
@@ -666,7 +666,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -694,7 +694,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -704,7 +704,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
       .singleResult();
 
     // then
-    assertThat(job.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(job.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -726,7 +726,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -734,7 +734,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     historicIncident = historyService.createHistoricIncidentQuery().singleResult();
 
     // then
-    assertThat(historicIncident.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicIncident.getRemovalTime()).isEqualTo(removalTime);
   }
 
   /**
@@ -761,7 +761,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -791,7 +791,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -799,7 +799,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     userOperationLog = historyService.createUserOperationLogQuery().singleResult();
 
     // then
-    assertThat(userOperationLog.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(userOperationLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   /**
@@ -826,7 +826,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -852,7 +852,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -860,7 +860,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     identityLinkLog = historyService.createHistoricIdentityLinkLogQuery().singleResult();
 
     // then
-    assertThat(identityLinkLog.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(identityLinkLog.getRemovalTime()).isEqualTo(removalTime);
   }
 
   /**
@@ -883,7 +883,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -907,7 +907,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query.processInstanceId(instance1))
         .executeAsync()
     );
@@ -943,7 +943,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -951,7 +951,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     comment = taskService.getTaskComments(taskId).get(0);
 
     // then
-    assertThat(comment.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(comment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -971,7 +971,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -979,7 +979,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     comment = taskService.getProcessInstanceComments(processInstanceId).get(0);
 
     // then
-    assertThat(comment.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(comment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1003,7 +1003,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1011,7 +1011,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     attachment = taskService.getTaskAttachments(taskId).get(0);
 
     // then
-    assertThat(attachment.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(attachment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1030,7 +1030,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1038,7 +1038,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     attachment = taskService.getProcessInstanceAttachments(processInstanceId).get(0);
 
     // then
-    assertThat(attachment.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(attachment.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1064,7 +1064,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1072,7 +1072,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(attachment.getContentId());
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1095,7 +1095,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1103,7 +1103,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1130,7 +1130,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1138,7 +1138,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1169,7 +1169,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1177,7 +1177,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1210,7 +1210,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1218,7 +1218,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1250,7 +1250,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1258,7 +1258,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1291,7 +1291,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricDecisionInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1299,7 +1299,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1331,7 +1331,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1339,7 +1339,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1372,7 +1372,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricDecisionInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1380,7 +1380,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(byteArrayId);
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1400,7 +1400,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricBatches()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1410,7 +1410,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
       .singleResult();
 
     // then
-    assertThat(historicBatch.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicBatch.getRemovalTime()).isEqualTo(removalTime);
 
     // clear database
     managementService.deleteBatch(batch.getId(), true);
@@ -1435,7 +1435,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricBatches()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1445,7 +1445,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
       .singleResult();
 
     // then
-    assertThat(historicJobLog.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicJobLog.getRemovalTime()).isEqualTo(removalTime);
 
     // clear database
     managementService.deleteBatch(batch.getId(), true);
@@ -1479,7 +1479,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricBatches()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1487,7 +1487,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     byteArrayEntity = testRule.findByteArrayById(historicJobLog.getExceptionByteArrayId());
 
     // then
-    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(byteArrayEntity.getRemovalTime()).isEqualTo(removalTime);
 
     // clear database
     managementService.deleteBatch(batch.getId(), true);
@@ -1513,7 +1513,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricBatches()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1521,7 +1521,7 @@ class BatchSetRemovalTimeNonHierarchicalTest {
     historicIncident = historyService.createHistoricIncidentQuery().singleResult();
 
     // then
-    assertThat(historicIncident.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicIncident.getRemovalTime()).isEqualTo(removalTime);
 
     // clear database
     managementService.deleteBatch(batch.getId(), true);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/BatchSetRemovalTimeTest.java
@@ -80,8 +80,8 @@ class BatchSetRemovalTimeTest {
   protected static BatchSetRemovalTimeExtension testRule = new BatchSetRemovalTimeExtension(engineRule, engineTestRule);
   protected BatchHelper helper = new BatchHelper(engineRule);
 
-  protected final Date CURRENT_DATE = testRule.CURRENT_DATE;
-  protected final Date REMOVAL_TIME = testRule.REMOVAL_TIME;
+  protected final Date currentDate = testRule.CURRENT_DATE;
+  protected final Date removalTime = testRule.REMOVAL_TIME;
 
   protected RuntimeService runtimeService;
   protected DecisionService decisionService;
@@ -123,7 +123,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -210,7 +210,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricDecisionInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -239,7 +239,7 @@ class BatchSetRemovalTimeTest {
 
     // when
     Batch batch = historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(historyService.createHistoricProcessInstanceQuery())
         .executeAsync();
     testRule.executeSeedJobs(batch);
@@ -284,7 +284,7 @@ class BatchSetRemovalTimeTest {
 
     // when
     Batch batch = historyService.setRemovalTimeToHistoricDecisionInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(historyService.createHistoricDecisionInstanceQuery())
         .executeAsync();
     testRule.executeSeedJobs(batch);
@@ -317,7 +317,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -325,8 +325,8 @@ class BatchSetRemovalTimeTest {
     historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
 
     // then
-    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -357,7 +357,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricDecisionInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -365,9 +365,9 @@ class BatchSetRemovalTimeTest {
     historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -395,7 +395,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricBatches()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -405,8 +405,8 @@ class BatchSetRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicBatches.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicBatches.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicBatches.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicBatches.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -429,7 +429,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -437,8 +437,8 @@ class BatchSetRemovalTimeTest {
     historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
 
     // then
-    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -469,7 +469,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricDecisionInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -477,9 +477,9 @@ class BatchSetRemovalTimeTest {
     historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -507,7 +507,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricBatches()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -517,8 +517,8 @@ class BatchSetRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicBatches.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicBatches.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicBatches.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicBatches.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -944,7 +944,7 @@ class BatchSetRemovalTimeTest {
     historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
 
     // then
-    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -988,7 +988,7 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1024,7 +1024,7 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(historicBatch.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicBatch.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1058,8 +1058,8 @@ class BatchSetRemovalTimeTest {
     historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
 
     // then
-    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1104,7 +1104,7 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1340,7 +1340,7 @@ class BatchSetRemovalTimeTest {
     historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
 
     // then
-    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1384,7 +1384,7 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1398,7 +1398,7 @@ class BatchSetRemovalTimeTest {
     String processInstanceId = testRule.process().serviceTask().deploy().start();
     Batch batch = historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
 
-    ClockUtil.setCurrentTime(addDays(CURRENT_DATE, 1));
+    ClockUtil.setCurrentTime(addDays(currentDate, 1));
 
     testRule.syncExec(batch);
 
@@ -1428,7 +1428,7 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(historicBatch.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5+1));
+    assertThat(historicBatch.getRemovalTime()).isEqualTo(addDays(currentDate, 5+1));
   }
 
   @Test
@@ -1462,8 +1462,8 @@ class BatchSetRemovalTimeTest {
     historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
 
     // then
-    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1508,7 +1508,7 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1523,7 +1523,7 @@ class BatchSetRemovalTimeTest {
     HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
 
     // assume
-    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
 
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
 
@@ -1561,7 +1561,7 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
 
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
@@ -1630,8 +1630,8 @@ class BatchSetRemovalTimeTest {
     List<HistoricProcessInstance> historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
 
     // assume
-    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
 
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
 
@@ -1671,7 +1671,7 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
 
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery().rootDecisionInstancesOnly();
 
@@ -1704,14 +1704,14 @@ class BatchSetRemovalTimeTest {
     HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
 
     // assume
-    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
 
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
 
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1719,7 +1719,7 @@ class BatchSetRemovalTimeTest {
     historicProcessInstance = historyService.createHistoricProcessInstanceQuery().singleResult();
 
     // then
-    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicProcessInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1742,14 +1742,14 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
 
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
 
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricDecisionInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1759,7 +1759,7 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1781,7 +1781,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricBatches()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .executeAsync()
     );
@@ -1791,7 +1791,7 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(historicBatch.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicBatch.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1806,15 +1806,15 @@ class BatchSetRemovalTimeTest {
     List<HistoricProcessInstance> historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
 
     // assume
-    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
 
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().rootProcessInstances();
 
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .hierarchical()
         .executeAsync()
@@ -1823,8 +1823,8 @@ class BatchSetRemovalTimeTest {
     historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
 
     // then
-    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1847,14 +1847,14 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // assume
-    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
 
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery().rootDecisionInstancesOnly();
 
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricDecisionInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .hierarchical()
         .executeAsync()
@@ -1865,7 +1865,7 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1876,8 +1876,8 @@ class BatchSetRemovalTimeTest {
     List<HistoricProcessInstance> historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
 
     // assume
-    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
 
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery()
       .superProcessInstanceId(rootProcessInstance);
@@ -1885,7 +1885,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byQuery(query)
         .hierarchical()
         .executeAsync()
@@ -1894,8 +1894,8 @@ class BatchSetRemovalTimeTest {
     historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
 
     // then
-    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
@@ -1935,9 +1935,9 @@ class BatchSetRemovalTimeTest {
     List<HistoricDecisionInstance> historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -1969,15 +1969,15 @@ class BatchSetRemovalTimeTest {
     historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
 
     // then
-    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
   void shouldThrowBadUserRequestException_NotExistingIds() {
     // given
     var setRemovalTimeToHistoricProcessInstancesBuilder = historyService.setRemovalTimeToHistoricProcessInstances()
-      .absoluteRemovalTime(REMOVAL_TIME)
+      .absoluteRemovalTime(removalTime)
       .byIds("aNotExistingId", "anotherNotExistingId");
 
     // when/then
@@ -2024,16 +2024,16 @@ class BatchSetRemovalTimeTest {
     historicDecisionInstances = historyService.createHistoricDecisionInstanceQuery().list();
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicDecisionInstances.get(2).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
   void shouldThrowBadUserRequestExceptionForStandaloneDecision_NotExistingIds() {
     // given
     var setRemovalTimeToHistoricDecisionInstancesBuilder = historyService.setRemovalTimeToHistoricDecisionInstances()
-      .absoluteRemovalTime(REMOVAL_TIME)
+      .absoluteRemovalTime(removalTime)
       .byIds("aNotExistingId", "anotherNotExistingId");
 
     // when/then
@@ -2066,7 +2066,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricBatches()
-        .absoluteRemovalTime(REMOVAL_TIME)
+        .absoluteRemovalTime(removalTime)
         .byIds(ids.toArray(new String[0]))
         .executeAsync()
     );
@@ -2076,15 +2076,15 @@ class BatchSetRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicBatches.get(0).getRemovalTime()).isEqualTo(REMOVAL_TIME);
-    assertThat(historicBatches.get(1).getRemovalTime()).isEqualTo(REMOVAL_TIME);
+    assertThat(historicBatches.get(0).getRemovalTime()).isEqualTo(removalTime);
+    assertThat(historicBatches.get(1).getRemovalTime()).isEqualTo(removalTime);
   }
 
   @Test
   void shouldThrowBadUserRequestExceptionForBatch_NotExistingIds() {
     // given
     var setRemovalTimeToHistoricBatchesBuilder = historyService.setRemovalTimeToHistoricBatches()
-      .absoluteRemovalTime(REMOVAL_TIME)
+      .absoluteRemovalTime(removalTime)
       .byIds("aNotExistingId", "anotherNotExistingId");
 
     // when/then
@@ -2098,7 +2098,7 @@ class BatchSetRemovalTimeTest {
     // given
     HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
     var setRemovalTimeToHistoricProcessInstancesBuilder = historyService.setRemovalTimeToHistoricProcessInstances()
-      .absoluteRemovalTime(REMOVAL_TIME)
+      .absoluteRemovalTime(removalTime)
       .byQuery(query);
 
     // when/then
@@ -2112,7 +2112,7 @@ class BatchSetRemovalTimeTest {
     // given
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
     var setRemovalTimeToHistoricDecisionInstancesBuilder = historyService.setRemovalTimeToHistoricDecisionInstances()
-      .absoluteRemovalTime(REMOVAL_TIME)
+      .absoluteRemovalTime(removalTime)
       .byQuery(query);
 
     // when/then
@@ -2126,7 +2126,7 @@ class BatchSetRemovalTimeTest {
     // given
     HistoricBatchQuery query = historyService.createHistoricBatchQuery();
     var setRemovalTimeToHistoricBatchesBuilder = historyService.setRemovalTimeToHistoricBatches()
-      .absoluteRemovalTime(REMOVAL_TIME)
+      .absoluteRemovalTime(removalTime)
       .byQuery(query);
 
     // when/then
@@ -2154,8 +2154,8 @@ class BatchSetRemovalTimeTest {
 
     // then
     assertThat(historicBatch.getType()).isEqualTo("process-set-removal-time");
-    assertThat(historicBatch.getStartTime()).isEqualTo(CURRENT_DATE);
-    assertThat(historicBatch.getEndTime()).isEqualTo(CURRENT_DATE);
+    assertThat(historicBatch.getStartTime()).isEqualTo(currentDate);
+    assertThat(historicBatch.getEndTime()).isEqualTo(currentDate);
   }
 
   @Test
@@ -2185,8 +2185,8 @@ class BatchSetRemovalTimeTest {
 
     // then
     assertThat(historicBatch.getType()).isEqualTo("decision-set-removal-time");
-    assertThat(historicBatch.getStartTime()).isEqualTo(CURRENT_DATE);
-    assertThat(historicBatch.getEndTime()).isEqualTo(CURRENT_DATE);
+    assertThat(historicBatch.getStartTime()).isEqualTo(currentDate);
+    assertThat(historicBatch.getEndTime()).isEqualTo(currentDate);
   }
 
   @Test
@@ -2212,8 +2212,8 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(historicBatch.getStartTime()).isEqualTo(CURRENT_DATE);
-    assertThat(historicBatch.getEndTime()).isEqualTo(CURRENT_DATE);
+    assertThat(historicBatch.getStartTime()).isEqualTo(currentDate);
+    assertThat(historicBatch.getEndTime()).isEqualTo(currentDate);
   }
 
   @Test
@@ -2325,8 +2325,8 @@ class BatchSetRemovalTimeTest {
     historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
 
     // then
-    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicProcessInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2374,8 +2374,8 @@ class BatchSetRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicDecisionInstances.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2415,8 +2415,8 @@ class BatchSetRemovalTimeTest {
       .list();
 
     // then
-    assertThat(historicBatches.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
-    assertThat(historicBatches.get(1).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicBatches.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
+    assertThat(historicBatches.get(1).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2442,7 +2442,7 @@ class BatchSetRemovalTimeTest {
     historicProcessInstances = historyService.createHistoricProcessInstanceQuery().list();
 
     // then
-    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicProcessInstances.get(0).getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2485,7 +2485,7 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicDecisionInstance.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2518,7 +2518,7 @@ class BatchSetRemovalTimeTest {
       .singleResult();
 
     // then
-    assertThat(historicBatch.getRemovalTime()).isEqualTo(addDays(CURRENT_DATE, 5));
+    assertThat(historicBatch.getRemovalTime()).isEqualTo(addDays(currentDate, 5));
   }
 
   @Test
@@ -2538,10 +2538,10 @@ class BatchSetRemovalTimeTest {
     // given
     SetRemovalTimeSelectModeForHistoricProcessInstancesBuilder builder = historyService.setRemovalTimeToHistoricProcessInstances();
     builder.calculatedRemovalTime();
-    Date removalTime = new Date();
+    Date absoluteRemovalTime = new Date();
 
     // when/then
-    assertThatThrownBy(() -> builder.absoluteRemovalTime(removalTime))
+    assertThatThrownBy(() -> builder.absoluteRemovalTime(absoluteRemovalTime))
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("The removal time modes are mutually exclusive: mode is not null");
   }
@@ -2563,10 +2563,10 @@ class BatchSetRemovalTimeTest {
     // given
     SetRemovalTimeSelectModeForHistoricDecisionInstancesBuilder builder = historyService.setRemovalTimeToHistoricDecisionInstances();
     builder.calculatedRemovalTime();
-    Date removalTime = new Date();
+    Date absoluteRemovalTime = new Date();
 
     // when/then
-    assertThatThrownBy(() -> builder.absoluteRemovalTime(removalTime))
+    assertThatThrownBy(() -> builder.absoluteRemovalTime(absoluteRemovalTime))
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("The removal time modes are mutually exclusive: mode is not null");
   }
@@ -2588,10 +2588,10 @@ class BatchSetRemovalTimeTest {
     // given
     SetRemovalTimeSelectModeForHistoricBatchesBuilder builder = historyService.setRemovalTimeToHistoricBatches();
     builder.calculatedRemovalTime();
-    Date removalTime = new Date();
+    Date absoluteRemovalTime = new Date();
 
     // when/then
-    assertThatThrownBy(() -> builder.absoluteRemovalTime(removalTime))
+    assertThatThrownBy(() -> builder.absoluteRemovalTime(absoluteRemovalTime))
       .isInstanceOf(BadUserRequestException.class)
       .hasMessageContaining("The removal time modes are mutually exclusive: mode is not null");
   }
@@ -2604,7 +2604,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(CURRENT_DATE)
+        .absoluteRemovalTime(currentDate)
         .byIds(processInstanceId)
         .executeAsync()
     );
@@ -2625,7 +2625,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(CURRENT_DATE)
+        .absoluteRemovalTime(currentDate)
         .byIds(processInstanceId)
         .executeAsync()
     );
@@ -2657,7 +2657,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricDecisionInstances()
-        .absoluteRemovalTime(CURRENT_DATE)
+        .absoluteRemovalTime(currentDate)
         .byQuery(query)
         .executeAsync()
     );
@@ -2681,7 +2681,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricBatches()
-        .absoluteRemovalTime(CURRENT_DATE)
+        .absoluteRemovalTime(currentDate)
         .byIds(batchOne.getId())
         .executeAsync()
     );
@@ -2707,7 +2707,7 @@ class BatchSetRemovalTimeTest {
     // when
     testRule.syncExec(
       historyService.setRemovalTimeToHistoricBatches()
-        .absoluteRemovalTime(CURRENT_DATE)
+        .absoluteRemovalTime(currentDate)
         .byIds(batchOne.getId())
         .executeAsync()
     );
@@ -2733,7 +2733,7 @@ class BatchSetRemovalTimeTest {
 
     // when
     Batch batch = historyService.setRemovalTimeToHistoricProcessInstances()
-        .absoluteRemovalTime(CURRENT_DATE)
+        .absoluteRemovalTime(currentDate)
         .byQuery(historyService.createHistoricProcessInstanceQuery())
         .executeAsync();
 
@@ -2760,7 +2760,7 @@ class BatchSetRemovalTimeTest {
 
     // when
     Batch batch = historyService.setRemovalTimeToHistoricDecisionInstances()
-        .absoluteRemovalTime(CURRENT_DATE)
+        .absoluteRemovalTime(currentDate)
         .byQuery(historyService.createHistoricDecisionInstanceQuery())
         .executeAsync();
 
@@ -2782,7 +2782,7 @@ class BatchSetRemovalTimeTest {
 
     // when
     Batch batchTwo = historyService.setRemovalTimeToHistoricBatches()
-        .absoluteRemovalTime(CURRENT_DATE)
+        .absoluteRemovalTime(currentDate)
         .byQuery(historyService.createHistoricBatchQuery())
         .executeAsync();
 
@@ -2793,12 +2793,12 @@ class BatchSetRemovalTimeTest {
   @Test
   void shouldSetExecutionStartTimeInBatchAndHistoryForBatches() {
     // given
-    ClockUtil.setCurrentTime(CURRENT_DATE);
+    ClockUtil.setCurrentTime(currentDate);
     String processInstanceId = testRule.process().serviceTask().deploy().start();
     Batch batchDelete = historyService.deleteHistoricProcessInstancesAsync(Collections.singletonList(processInstanceId), "");
     testRule.syncExec(batchDelete, false);
     Batch batch = historyService.setRemovalTimeToHistoricBatches()
-        .absoluteRemovalTime(CURRENT_DATE)
+        .absoluteRemovalTime(currentDate)
         .byQuery(historyService.createHistoricBatchQuery())
         .executeAsync();
     helper.executeSeedJob(batch);
@@ -2812,15 +2812,15 @@ class BatchSetRemovalTimeTest {
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery().singleResult();
     batch = managementService.createBatchQuery().singleResult();
 
-    assertThat(batch.getExecutionStartTime()).isCloseTo(CURRENT_DATE, 1000);
-    assertThat(historicBatch.getExecutionStartTime()).isCloseTo(CURRENT_DATE, 1000);
+    assertThat(batch.getExecutionStartTime()).isCloseTo(currentDate, 1000);
+    assertThat(historicBatch.getExecutionStartTime()).isCloseTo(currentDate, 1000);
   }
 
   @Test
   @Deployment(resources = "org/operaton/bpm/engine/test/dmn/deployment/drdDish.dmn11.xml")
   void shouldSetExecutionStartTimeInBatchAndHistoryForDecisions() {
     // given
-    ClockUtil.setCurrentTime(CURRENT_DATE);
+    ClockUtil.setCurrentTime(currentDate);
     decisionService.evaluateDecisionByKey("dish-decision")
         .variables(
             Variables.createVariables()
@@ -2828,7 +2828,7 @@ class BatchSetRemovalTimeTest {
                 .putValue("dayType", "Weekend")
         ).evaluate();
     Batch batch = historyService.setRemovalTimeToHistoricDecisionInstances()
-        .absoluteRemovalTime(CURRENT_DATE)
+        .absoluteRemovalTime(currentDate)
         .byQuery(historyService.createHistoricDecisionInstanceQuery())
         .executeAsync();
     helper.executeSeedJob(batch);
@@ -2841,8 +2841,8 @@ class BatchSetRemovalTimeTest {
     HistoricBatch historicBatch = historyService.createHistoricBatchQuery().singleResult();
     batch = managementService.createBatchQuery().singleResult();
 
-    assertThat(batch.getExecutionStartTime()).isCloseTo(CURRENT_DATE, 1000);
-    assertThat(historicBatch.getExecutionStartTime()).isCloseTo(CURRENT_DATE, 1000);
+    assertThat(batch.getExecutionStartTime()).isCloseTo(currentDate, 1000);
+    assertThat(historicBatch.getExecutionStartTime()).isCloseTo(currentDate, 1000);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/helper/BatchSetRemovalTimeExtension.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/helper/BatchSetRemovalTimeExtension.java
@@ -46,8 +46,8 @@ import org.operaton.bpm.model.bpmn.builder.StartEventBuilder;
  */
 public class BatchSetRemovalTimeExtension extends BatchExtension {
 
-  public final Date CURRENT_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
-  public final Date REMOVAL_TIME = new Date(1363609000000L);
+  public static final Date CURRENT_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+  public static final Date REMOVAL_TIME = new Date(1363609000000L);
 
   public BatchSetRemovalTimeExtension(ProcessEngineExtension engineRule, ProcessEngineTestExtension engineTestRule) {
     super(engineRule, engineTestRule);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/helper/BatchSetRemovalTimeRule.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/helper/BatchSetRemovalTimeRule.java
@@ -45,8 +45,8 @@ import org.junit.runner.Description;
  */
 public class BatchSetRemovalTimeRule extends BatchRule {
 
-  public final Date CURRENT_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
-  public final Date REMOVAL_TIME = new Date(1363609000000L);
+  public static final Date CURRENT_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+  public static final Date REMOVAL_TIME = new Date(1363609000000L);
 
   public BatchSetRemovalTimeRule(ProcessEngineRule engineRule, ProcessEngineTestRule engineTestRule) {
     super(engineRule, engineTestRule);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/AbstractHistoryCleanupSchedulerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/AbstractHistoryCleanupSchedulerTest.java
@@ -62,7 +62,7 @@ public abstract class AbstractHistoryCleanupSchedulerTest {
   protected HistoryService historyService;
   protected ManagementService managementService;
 
-  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+  protected static final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   public void initEngineConfiguration(ProcessEngineExtension engineRule, ProcessEngineConfigurationImpl engineConfiguration) {
     AbstractHistoryCleanupSchedulerTest.engineRule = engineRule;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.java
@@ -401,6 +401,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
+  @SuppressWarnings("deprecation")
   void testQueryByDuedateLowerThen() {
     JobQuery query = managementService.createJobQuery().duedateLowerThen(testStartTime);
     verifyQueryResults(query, 0);
@@ -421,6 +422,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
+  @SuppressWarnings("deprecation")
   void testQueryByDuedateLowerThenOrEqual() {
     JobQuery query = managementService.createJobQuery().duedateLowerThenOrEquals(testStartTime);
     verifyQueryResults(query, 0);
@@ -441,6 +443,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
+  @SuppressWarnings("deprecation")
   void testQueryByDuedateHigherThen() {
     int startTimeExpectedCount = ensureJobDueDateSet? 4 : 3;
     int timerOneExpectedCount = ensureJobDueDateSet? 3 : 2;
@@ -466,6 +469,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
+  @SuppressWarnings("deprecation")
   void testQueryByDuedateHigherThenOrEqual() {
     int startTimeExpectedCount = ensureJobDueDateSet? 4 : 3;
     int timerOneExpectedCount = ensureJobDueDateSet? 3 : 2;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.java
@@ -293,7 +293,7 @@ public class JobQueryTest {
 
   @TestTemplate
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.testTimeCycleQueryByProcessDefinitionId.bpmn20.xml"})
-  public void testTimeCycleQueryByProcessDefinitionId() {
+  void testTimeCycleQueryByProcessDefinitionId() {
     String processDefinitionId = repositoryService
         .createProcessDefinitionQuery()
         .processDefinitionKey("process")
@@ -565,7 +565,7 @@ public class JobQueryTest {
 
   @TestTemplate
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml"})
-  public void testQueryByException() {
+  void testQueryByException() {
     JobQuery query = managementService.createJobQuery().withException();
     verifyQueryResults(query, 0);
 
@@ -577,7 +577,7 @@ public class JobQueryTest {
 
   @TestTemplate
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml"})
-  public void testQueryByExceptionMessage() {
+  void testQueryByExceptionMessage() {
     JobQuery query = managementService.createJobQuery().exceptionMessage(EXCEPTION_MESSAGE);
     verifyQueryResults(query, 0);
 
@@ -591,7 +591,7 @@ public class JobQueryTest {
 
   @TestTemplate
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml"})
-  public void testQueryByExceptionMessageEmpty() {
+  void testQueryByExceptionMessageEmpty() {
     JobQuery query = managementService.createJobQuery().exceptionMessage("");
     verifyQueryResults(query, 0);
 
@@ -614,7 +614,7 @@ public class JobQueryTest {
 
   @TestTemplate
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml"})
-  public void testQueryByFailedActivityId(){
+  void testQueryByFailedActivityId(){
     JobQuery query = managementService.createJobQuery().failedActivityId("theScriptTask");
     verifyQueryResults(query, 0);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.java
@@ -178,13 +178,13 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByNoCriteria() {
+  void testQueryByNoCriteria() {
     JobQuery query = managementService.createJobQuery();
     verifyQueryResults(query, 4);
   }
 
   @TestTemplate
-  public void testQueryByActivityId(){
+  void testQueryByActivityId(){
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
 
     JobQuery query = managementService.createJobQuery().activityId(jobDefinition.getActivityId());
@@ -192,7 +192,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByInvalidActivityId(){
+  void testQueryByInvalidActivityId(){
     JobQuery query = managementService.createJobQuery().activityId("invalid");
     verifyQueryResults(query, 0);
     var jobQuery = managementService.createJobQuery();
@@ -206,7 +206,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testByJobDefinitionId() {
+  void testByJobDefinitionId() {
     JobDefinition jobDefinition = managementService.createJobDefinitionQuery().singleResult();
 
     JobQuery query = managementService.createJobQuery().jobDefinitionId(jobDefinition.getId());
@@ -214,7 +214,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testByInvalidJobDefinitionId() {
+  void testByInvalidJobDefinitionId() {
     JobQuery query = managementService.createJobQuery().jobDefinitionId("invalid");
     verifyQueryResults(query, 0);
     var jobQuery = managementService.createJobQuery();
@@ -228,13 +228,13 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByProcessInstanceId() {
+  void testQueryByProcessInstanceId() {
     JobQuery query = managementService.createJobQuery().processInstanceId(processInstanceIdOne);
     verifyQueryResults(query, 1);
   }
 
   @TestTemplate
-  public void testQueryByInvalidProcessInstanceId() {
+  void testQueryByInvalidProcessInstanceId() {
     JobQuery query = managementService.createJobQuery().processInstanceId("invalid");
     verifyQueryResults(query, 0);
     var jobQuery = managementService.createJobQuery();
@@ -248,7 +248,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByExecutionId() {
+  void testQueryByExecutionId() {
     Job job = managementService.createJobQuery().processInstanceId(processInstanceIdOne).singleResult();
     JobQuery query = managementService.createJobQuery().executionId(job.getExecutionId());
     assertThat(job.getId()).isEqualTo(query.singleResult().getId());
@@ -256,7 +256,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByInvalidExecutionId() {
+  void testQueryByInvalidExecutionId() {
     JobQuery query = managementService.createJobQuery().executionId("invalid");
     verifyQueryResults(query, 0);
     var jobQuery = managementService.createJobQuery();
@@ -270,7 +270,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByProcessDefinitionId() {
+  void testQueryByProcessDefinitionId() {
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().list().get(0);
 
     JobQuery query = managementService.createJobQuery().processDefinitionId(processDefinition.getId());
@@ -278,7 +278,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByInvalidProcessDefinitionId() {
+  void testQueryByInvalidProcessDefinitionId() {
     JobQuery query = managementService.createJobQuery().processDefinitionId("invalid");
     verifyQueryResults(query, 0);
     var jobQuery = managementService.createJobQuery();
@@ -314,13 +314,13 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByProcessDefinitionKey() {
+  void testQueryByProcessDefinitionKey() {
     JobQuery query = managementService.createJobQuery().processDefinitionKey("timerOnTask");
     verifyQueryResults(query, 3);
   }
 
   @TestTemplate
-  public void testQueryByInvalidProcessDefinitionKey() {
+  void testQueryByInvalidProcessDefinitionKey() {
     JobQuery query = managementService.createJobQuery().processDefinitionKey("invalid");
     verifyQueryResults(query, 0);
     var jobQuery = managementService.createJobQuery();
@@ -335,7 +335,7 @@ public class JobQueryTest {
 
   @TestTemplate
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/JobQueryTest.testTimeCycleQueryByProcessDefinitionId.bpmn20.xml"})
-  public void testTimeCycleQueryByProcessDefinitionKey() {
+  void testTimeCycleQueryByProcessDefinitionKey() {
     JobQuery query = managementService.createJobQuery().processDefinitionKey("process");
 
     verifyQueryResults(query, 1);
@@ -350,7 +350,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByRetriesLeft() {
+  void testQueryByRetriesLeft() {
     JobQuery query = managementService.createJobQuery().withRetriesLeft();
     verifyQueryResults(query, 4);
 
@@ -360,7 +360,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByExecutable() {
+  void testQueryByExecutable() {
     long testTime = ensureJobDueDateSet? messageDueDate.getTime() : timerThreeFireTime.getTime();
     int expectedCount = ensureJobDueDateSet? 0 : 1;
 
@@ -378,19 +378,19 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByOnlyTimers() {
+  void testQueryByOnlyTimers() {
     JobQuery query = managementService.createJobQuery().timers();
     verifyQueryResults(query, 3);
   }
 
   @TestTemplate
-  public void testQueryByOnlyMessages() {
+  void testQueryByOnlyMessages() {
     JobQuery query = managementService.createJobQuery().messages();
     verifyQueryResults(query, 1);
   }
 
   @TestTemplate
-  public void testInvalidOnlyTimersUsage() {
+  void testInvalidOnlyTimersUsage() {
     var jobQuery = managementService.createJobQuery().timers();
     try {
       jobQuery.messages();
@@ -401,7 +401,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByDuedateLowerThen() {
+  void testQueryByDuedateLowerThen() {
     JobQuery query = managementService.createJobQuery().duedateLowerThen(testStartTime);
     verifyQueryResults(query, 0);
 
@@ -421,7 +421,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByDuedateLowerThenOrEqual() {
+  void testQueryByDuedateLowerThenOrEqual() {
     JobQuery query = managementService.createJobQuery().duedateLowerThenOrEquals(testStartTime);
     verifyQueryResults(query, 0);
 
@@ -441,7 +441,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByDuedateHigherThen() {
+  void testQueryByDuedateHigherThen() {
     int startTimeExpectedCount = ensureJobDueDateSet? 4 : 3;
     int timerOneExpectedCount = ensureJobDueDateSet? 3 : 2;
     int timerTwoExpectedCount = ensureJobDueDateSet? 2 : 1;
@@ -466,7 +466,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByDuedateHigherThenOrEqual() {
+  void testQueryByDuedateHigherThenOrEqual() {
     int startTimeExpectedCount = ensureJobDueDateSet? 4 : 3;
     int timerOneExpectedCount = ensureJobDueDateSet? 3 : 2;
     int timerTwoExpectedCount = ensureJobDueDateSet? 2 : 1;
@@ -494,7 +494,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByDuedateCombinations() {
+  void testQueryByDuedateCombinations() {
     JobQuery query = managementService.createJobQuery()
         .duedateHigherThan(testStartTime)
         .duedateLowerThan(new Date(timerThreeFireTime.getTime() + ONE_SECOND));
@@ -507,7 +507,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByCreateTimeCombinations() {
+  void testQueryByCreateTimeCombinations() {
     JobQuery query = managementService.createJobQuery()
             .processInstanceId(processInstanceIdOne);
     List<Job> jobs = query.list();
@@ -536,7 +536,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void shouldReturnNoJobDueToExcludingCriteria() {
+  void shouldReturnNoJobDueToExcludingCriteria() {
     JobQuery query = managementService.createJobQuery().processInstanceId(processInstanceIdOne);
 
     List<Job> jobs = query.list();
@@ -548,7 +548,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void shouldReturnJobDueToIncludingCriteria() {
+  void shouldReturnJobDueToIncludingCriteria() {
     JobQuery query = managementService.createJobQuery().processInstanceId(processInstanceIdOne);
 
     List<Job> jobs = query.list();
@@ -598,7 +598,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByExceptionMessageNull() {
+  void testQueryByExceptionMessageNull() {
     var jobQuery = managementService.createJobQuery();
     try {
       jobQuery.exceptionMessage(null);
@@ -621,7 +621,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByInvalidFailedActivityId(){
+  void testQueryByInvalidFailedActivityId(){
     JobQuery query = managementService.createJobQuery().failedActivityId("invalid");
     verifyQueryResults(query, 0);
     var jobQuery = managementService.createJobQuery();
@@ -636,7 +636,7 @@ public class JobQueryTest {
 
 
   @TestTemplate
-  public void testJobQueryWithExceptions() {
+  void testJobQueryWithExceptions() {
 
     createJobWithoutExceptionMsg();
 
@@ -663,7 +663,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByNoRetriesLeft() {
+  void testQueryByNoRetriesLeft() {
     JobQuery query = managementService.createJobQuery().noRetriesLeft();
     verifyQueryResults(query, 0);
 
@@ -673,13 +673,13 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByActive() {
+  void testQueryByActive() {
     JobQuery query = managementService.createJobQuery().active();
     verifyQueryResults(query, 4);
   }
 
   @TestTemplate
-  public void testQueryBySuspended() {
+  void testQueryBySuspended() {
     JobQuery query = managementService.createJobQuery().suspended();
     verifyQueryResults(query, 0);
 
@@ -688,7 +688,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByJobIdsWithOneId() {
+  void testQueryByJobIdsWithOneId() {
     // given
     String id = managementService.createJobQuery().processInstanceId(processInstanceIdOne).singleResult().getId();
     // when
@@ -698,7 +698,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByJobIdsWithMultipleIds() {
+  void testQueryByJobIdsWithMultipleIds() {
     // given
     Set<String> ids = managementService.createJobQuery().list().stream()
         .map(Job::getId).collect(Collectors.toSet());
@@ -709,7 +709,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByJobIdsWithMultipleIdsIncludingFakeIds() {
+  void testQueryByJobIdsWithMultipleIdsIncludingFakeIds() {
     // given
     Set<String> ids = new HashSet<>();
     ids.addAll(managementService.createJobQuery().list().stream().map(Job::getId).collect(Collectors.toSet()));
@@ -721,7 +721,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByJobIdsWithEmptyList() {
+  void testQueryByJobIdsWithEmptyList() {
     // given
     var jobQuery = managementService.createJobQuery();
     Set<String> ids = Collections.emptySet();
@@ -733,7 +733,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByJobIdsWithNull() {
+  void testQueryByJobIdsWithNull() {
     // given
     var jobQuery = managementService.createJobQuery();
     Set<String> ids = null;
@@ -745,7 +745,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByJobIdsWithFakeIds() {
+  void testQueryByJobIdsWithFakeIds() {
     // given
     Set<String> ids = new HashSet<>();
     Collections.addAll(ids, "fakeIdOne", "fakeIdTwo");
@@ -756,7 +756,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByProcessInstanceIdsWithOneId() {
+  void testQueryByProcessInstanceIdsWithOneId() {
     // when
     JobQuery query = managementService.createJobQuery().processInstanceIds(Collections.singleton(processInstanceIdOne));
     // then
@@ -764,7 +764,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByProcessInstanceIdsWithMultipleIds() {
+  void testQueryByProcessInstanceIdsWithMultipleIds() {
     // given
     Set<String> ids = new HashSet<>();
     Collections.addAll(ids, processInstanceIdOne, processInstanceIdThree);
@@ -775,7 +775,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByProcessInstanceIdsWithMultipleIdsIncludingFakeIds() {
+  void testQueryByProcessInstanceIdsWithMultipleIdsIncludingFakeIds() {
     // given
     Set<String> ids = new HashSet<>();
     Collections.addAll(ids, processInstanceIdOne, processInstanceIdThree, "fakeIdOne", "fakeIdTwo");
@@ -786,7 +786,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByProcessInstanceIdsWithEmptyList() {
+  void testQueryByProcessInstanceIdsWithEmptyList() {
     // given
     var jobQuery = managementService.createJobQuery();
     Set<String> ids = Collections.emptySet();
@@ -798,7 +798,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByProcessInstanceIdsWithNull() {
+  void testQueryByProcessInstanceIdsWithNull() {
     // given
     var jobQuery = managementService.createJobQuery();
     Set<String> ids = null;
@@ -810,7 +810,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryByProcessInstanceIdsWithFakeIds() {
+  void testQueryByProcessInstanceIdsWithFakeIds() {
     // given
     Set<String> ids = new HashSet<>();
     Collections.addAll(ids, "fakeIdOne", "fakeIdTwo");
@@ -823,7 +823,7 @@ public class JobQueryTest {
   //sorting //////////////////////////////////////////
 
   @TestTemplate
-  public void testQuerySorting() {
+  void testQuerySorting() {
     // asc
     assertThat(managementService.createJobQuery().orderByJobId().asc().count()).isEqualTo(4);
     assertThat(managementService.createJobQuery().orderByJobDuedate().asc().count()).isEqualTo(4);
@@ -867,7 +867,7 @@ public class JobQueryTest {
   }
 
   @TestTemplate
-  public void testQueryInvalidSortingUsage() {
+  void testQueryInvalidSortingUsage() {
     var jobQuery = managementService.createJobQuery().orderByJobId();
     try {
       jobQuery.list();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/metrics/AbstractMetricsIntervalTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/metrics/AbstractMetricsIntervalTest.java
@@ -43,11 +43,11 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 public abstract class AbstractMetricsIntervalTest {
 
   @RegisterExtension
-  protected static ProcessEngineExtension ENGINE_RULE = ProcessEngineExtension.builder().build();
+  protected static ProcessEngineExtension engineExtension = ProcessEngineExtension.builder().build();
   @RegisterExtension
-  protected static ProcessEngineTestExtension TEST_RULE = new ProcessEngineTestExtension(ENGINE_RULE);
+  protected static ProcessEngineTestExtension testExtension = new ProcessEngineTestExtension(engineExtension);
 
-  protected final String REPORTER_ID = "REPORTER_ID";
+  protected static final String REPORTER_ID = "REPORTER_ID";
   protected static final int DEFAULT_INTERVAL = 15;
   protected static final int DEFAULT_INTERVAL_MILLIS = 15 * 60 * 1000;
   protected static final int MIN_OCCURENCE = 1;
@@ -111,9 +111,9 @@ public abstract class AbstractMetricsIntervalTest {
 
   @BeforeEach
   public void initMetrics() {
-    runtimeService = ENGINE_RULE.getRuntimeService();
-    processEngineConfiguration = ENGINE_RULE.getProcessEngineConfiguration();
-    managementService = ENGINE_RULE.getManagementService();
+    runtimeService = engineExtension.getRuntimeService();
+    processEngineConfiguration = engineExtension.getProcessEngineConfiguration();
+    managementService = engineExtension.getManagementService();
 
     //clean up before start
     clearMetrics();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/metrics/MetricsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/metrics/MetricsTest.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.Date;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -46,9 +45,9 @@ import org.operaton.bpm.model.bpmn.Bpmn;
 class MetricsTest {
 
   @RegisterExtension
-  protected static ProcessEngineExtension ENGINE_RULE = ProcessEngineExtension.builder().build();
+  protected static ProcessEngineExtension engineExtension = ProcessEngineExtension.builder().build();
   @RegisterExtension
-  protected static ProcessEngineTestExtension TEST_RULE = new ProcessEngineTestExtension(ENGINE_RULE);
+  protected static ProcessEngineTestExtension testExtension = new ProcessEngineTestExtension(engineExtension);
 
   protected RuntimeService runtimeService;
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
@@ -67,7 +66,7 @@ class MetricsTest {
   void initMetrics() {
     //clean up before start
     clearMetrics();
-    TEST_RULE.deploy(Bpmn.createExecutableProcess("testProcess")
+    testExtension.deploy(Bpmn.createExecutableProcess("testProcess")
         .operatonHistoryTimeToLive(180)
         .startEvent()
         .manualTask()
@@ -102,7 +101,7 @@ class MetricsTest {
   @Test
   void testEndMetricWithWaitState() {
     //given
-    TEST_RULE.deploy(Bpmn.createExecutableProcess("userProcess")
+    testExtension.deploy(Bpmn.createExecutableProcess("userProcess")
         .operatonHistoryTimeToLive(180)
         .startEvent()
         .userTask("Task")
@@ -126,8 +125,8 @@ class MetricsTest {
     assertEquals(1, end);
 
     //when completing the task
-    String id = ENGINE_RULE.getTaskService().createTaskQuery().processDefinitionKey("userProcess").singleResult().getId();
-    ENGINE_RULE.getTaskService().complete(id);
+    String id = engineExtension.getTaskService().createTaskQuery().processDefinitionKey("userProcess").singleResult().getId();
+    engineExtension.getTaskService().complete(id);
 
     //then start and end is equal
     start = managementService.createMetricsQuery()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyProcessInstantiationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/MultiTenancyProcessInstantiationTest.java
@@ -48,7 +48,7 @@ import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
 
-public class MultiTenancyProcessInstantiationTest {
+class MultiTenancyProcessInstantiationTest {
 
   protected static final String TENANT_ONE = "tenant1";
   protected static final String TENANT_TWO = "tenant2";

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancySetTaskPropertyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/tenantcheck/MultiTenancySetTaskPropertyTest.java
@@ -118,7 +118,7 @@ public class MultiTenancySetTaskPropertyTest {
   }
 
   @TestTemplate
-  public void shouldSetOperationForTaskWithAuthenticatedTenant() {
+  void shouldSetOperationForTaskWithAuthenticatedTenant() {
     // given
     identityService.setAuthentication("aUserId", null, Collections.singletonList(TENANT_ONE));
 
@@ -130,7 +130,7 @@ public class MultiTenancySetTaskPropertyTest {
   }
 
   @TestTemplate
-  public void shouldSetOperationForTaskWithNoAuthenticatedTenant() {
+  void shouldSetOperationForTaskWithNoAuthenticatedTenant() {
     // given
     identityService.setAuthentication("aUserId", null);
 
@@ -143,7 +143,7 @@ public class MultiTenancySetTaskPropertyTest {
   }
 
   @TestTemplate
-  public void shouldSetOperationForTaskWithDisabledTenantCheck() {
+  void shouldSetOperationForTaskWithDisabledTenantCheck() {
     // given
     identityService.setAuthentication("aUserId", null);
     engineRule.getProcessEngineConfiguration().setTenantCheckEnabled(false);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/diagram/ProcessDiagramRetrievalTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/diagram/ProcessDiagramRetrievalTest.java
@@ -135,7 +135,7 @@ public class ProcessDiagramRetrievalTest {
    * Tests {@link RepositoryService#getProcessModel(String)}.
    */
   @TestTemplate
-  public void testGetProcessModel() throws Exception {
+  void testGetProcessModel() throws Exception {
     if (1 == processDefinitionQuery.count()) {
       ProcessDefinition processDefinition = processDefinitionQuery.singleResult();
       InputStream expectedStream = new FileInputStream("src/test/resources/org/operaton/bpm/engine/test/api/repository/diagram/" + xmlFileName);
@@ -151,7 +151,7 @@ public class ProcessDiagramRetrievalTest {
    * Tests {@link RepositoryService#getProcessDiagram(String)}.
    */
   @TestTemplate
-  public void testGetProcessDiagram() throws Exception {
+  void testGetProcessDiagram() throws Exception {
     if (1 == processDefinitionQuery.count()) {
       ProcessDefinition processDefinition = processDefinitionQuery.singleResult();
       InputStream expectedStream = new FileInputStream("src/test/resources/org/operaton/bpm/engine/test/api/repository/diagram/" + imageFileName);
@@ -166,7 +166,7 @@ public class ProcessDiagramRetrievalTest {
   }
 
   @TestTemplate
-  public void testGetProcessDiagramAfterCacheWasCleaned() {
+  void testGetProcessDiagramAfterCacheWasCleaned() {
     if (1 == processDefinitionQuery.count()) {
       engineRule.getProcessEngineConfiguration().getDeploymentCache().discardProcessDefinitionCache();
       // given
@@ -189,7 +189,7 @@ public class ProcessDiagramRetrievalTest {
    * {@link ProcessDiagramLayoutFactory#getProcessDiagramLayout(InputStream, InputStream)}.
    */
   @TestTemplate
-  public void testGetProcessDiagramLayout() throws Exception {
+  void testGetProcessDiagramLayout() throws Exception {
     DiagramLayout processDiagramLayout;
     if (1 == processDefinitionQuery.count()) {
       ProcessDefinition processDefinition = processDefinitionQuery.singleResult();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchModificationAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchModificationAuthorizationTest.java
@@ -126,7 +126,7 @@ public class BatchModificationAuthorizationTest {
   }
 
   @TestTemplate
-  public void executeAsyncModification() {
+  void executeAsyncModification() {
     //given
     ProcessInstance processInstance1 = engineRule.getRuntimeService().startProcessInstanceByKey(ProcessModels.PROCESS_KEY);
     ProcessInstance processInstance2 = engineRule.getRuntimeService().startProcessInstanceByKey(ProcessModels.PROCESS_KEY);
@@ -162,7 +162,7 @@ public class BatchModificationAuthorizationTest {
   }
 
   @TestTemplate
-  public void executeModification() {
+  void executeModification() {
     //given
     ProcessInstance processInstance1 = engineRule.getRuntimeService().startProcessInstanceByKey(ProcessModels.PROCESS_KEY);
     ProcessInstance processInstance2 = engineRule.getRuntimeService().startProcessInstanceByKey(ProcessModels.PROCESS_KEY);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchModificationHistoryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchModificationHistoryTest.java
@@ -134,7 +134,7 @@ public class BatchModificationHistoryTest {
   }
 
   @TestTemplate
-  public void testHistoricBatchCreation() {
+  void testHistoricBatchCreation() {
     // when
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startAfterAsync("process1", 10, "user1", processDefinition.getId());
@@ -155,7 +155,7 @@ public class BatchModificationHistoryTest {
   }
 
   @TestTemplate
-  public void testHistoricBatchCompletion() {
+  void testHistoricBatchCompletion() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startAfterAsync("process1", 1, "user1", processDefinition.getId());
     helper.completeSeedJobs(batch);
@@ -173,7 +173,7 @@ public class BatchModificationHistoryTest {
   }
 
   @TestTemplate
-  public void testHistoricSeedJobLog() {
+  void testHistoricSeedJobLog() {
     // when
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.cancelAllAsync("process1", 1, "user1", processDefinition.getId());
@@ -211,7 +211,7 @@ public class BatchModificationHistoryTest {
   }
 
   @TestTemplate
-  public void testHistoricMonitorJobLog() {
+  void testHistoricMonitorJobLog() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startAfterAsync("process1", 1, "user1", processDefinition.getId());
 
@@ -272,7 +272,7 @@ public class BatchModificationHistoryTest {
   }
 
   @TestTemplate
-  public void testHistoricBatchJobLog() {
+  void testHistoricBatchJobLog() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startAfterAsync("process1", 1, "user1", processDefinition.getId());
     helper.completeSeedJobs(batch);
@@ -308,7 +308,7 @@ public class BatchModificationHistoryTest {
   }
 
   @TestTemplate
-  public void testHistoricBatchForBatchDeletion() {
+  void testHistoricBatchForBatchDeletion() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startTransitionAsync("process1", 1, "seq", processDefinition.getId());
 
@@ -323,7 +323,7 @@ public class BatchModificationHistoryTest {
   }
 
   @TestTemplate
-  public void testHistoricSeedJobLogForBatchDeletion() {
+  void testHistoricSeedJobLogForBatchDeletion() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startBeforeAsync("process1", 1, "user1", processDefinition.getId());
 
@@ -339,7 +339,7 @@ public class BatchModificationHistoryTest {
   }
 
   @TestTemplate
-  public void testHistoricMonitorJobLogForBatchDeletion() {
+  void testHistoricMonitorJobLogForBatchDeletion() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startAfterAsync("process1", 1, "user1", processDefinition.getId());
     helper.completeSeedJobs(batch);
@@ -356,7 +356,7 @@ public class BatchModificationHistoryTest {
   }
 
   @TestTemplate
-  public void testHistoricBatchJobLogForBatchDeletion() {
+  void testHistoricBatchJobLogForBatchDeletion() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startBeforeAsync("process1", 1, "user2", processDefinition.getId());
     helper.completeSeedJobs(batch);
@@ -373,7 +373,7 @@ public class BatchModificationHistoryTest {
   }
 
   @TestTemplate
-  public void testDeleteHistoricBatch() {
+  void testDeleteHistoricBatch() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startTransitionAsync("process1", 1, "seq", processDefinition.getId());
     helper.completeSeedJobs(batch);
@@ -392,7 +392,7 @@ public class BatchModificationHistoryTest {
   }
 
   @TestTemplate
-  public void testHistoricSeedJobIncidentDeletion() {
+  void testHistoricSeedJobIncidentDeletion() {
     // given
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startBeforeAsync("process1", 1, "user2", processDefinition.getId());
@@ -411,7 +411,7 @@ public class BatchModificationHistoryTest {
   }
 
   @TestTemplate
-  public void testHistoricMonitorJobIncidentDeletion() {
+  void testHistoricMonitorJobIncidentDeletion() {
     // given
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startTransitionAsync("process1", 1, "seq", processDefinition.getId());
@@ -431,7 +431,7 @@ public class BatchModificationHistoryTest {
   }
 
   @TestTemplate
-  public void testHistoricBatchJobLogIncidentDeletion() {
+  void testHistoricBatchJobLogIncidentDeletion() {
     // given
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startAfterAsync("process1", 3, "user1", processDefinition.getId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchRestartAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchRestartAuthorizationTest.java
@@ -133,7 +133,7 @@ public class BatchRestartAuthorizationTest {
   }
 
   @TestTemplate
-  public void executeBatch() {
+  void executeBatch() {
     //given
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(ProcessModels.TWO_TASKS_PROCESS);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchUpdateSuspensionStateAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/BatchUpdateSuspensionStateAuthorizationTest.java
@@ -124,7 +124,7 @@ public class BatchUpdateSuspensionStateAuthorizationTest {
   }
 
   @TestTemplate
-  public void executeBatch() {
+  void executeBatch() {
     //given
     testRule.deployAndGetDefinition(ProcessModels.TWO_TASKS_PROCESS);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CreateAndResolveIncidentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CreateAndResolveIncidentAuthorizationTest.java
@@ -80,7 +80,7 @@ public class CreateAndResolveIncidentAuthorizationTest {
   }
 
   @TestTemplate
-  public void createIncident() {
+  void createIncident() {
     //given
     testRule.deployAndGetDefinition(ProcessModels.TWO_TASKS_PROCESS);
 
@@ -102,7 +102,7 @@ public class CreateAndResolveIncidentAuthorizationTest {
   }
 
   @TestTemplate
-  public void resolveIncident() {
+  void resolveIncident() {
     testRule.deployAndGetDefinition(ProcessModels.TWO_TASKS_PROCESS);
 
     ProcessInstance processInstance = engineRule.getRuntimeService().startProcessInstanceByKey("Process");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionAsyncTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ModificationExecutionAsyncTest.java
@@ -151,7 +151,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void createBatchModification() {
+  void createBatchModification() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     List<String> processInstanceIds = helper.startInstances("process1", 2);
 
@@ -161,7 +161,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void createModificationWithNullProcessInstanceIdsListAsync() {
+  void createModificationWithNullProcessInstanceIdsListAsync() {
     var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds((List<String>) null);
 
     try {
@@ -173,7 +173,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void createModificationWithNullProcessDefinitionId() {
+  void createModificationWithNullProcessDefinitionId() {
     try {
       runtimeService.createModification(null);
       fail("Should not succeed");
@@ -184,7 +184,7 @@ public class ModificationExecutionAsyncTest {
 
 
   @TestTemplate
-  public void createModificationUsingProcessInstanceIdsListWithNullValueAsync() {
+  void createModificationUsingProcessInstanceIdsListWithNullValueAsync() {
     var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds(Arrays.asList("foo", null, "bar"));
 
     try {
@@ -196,7 +196,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void createModificationWithEmptyProcessInstanceIdsListAsync() {
+  void createModificationWithEmptyProcessInstanceIdsListAsync() {
     var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds(Collections.<String> emptyList());
     try {
       modificationBuilder.executeAsync();
@@ -207,7 +207,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void createModificationWithNullProcessInstanceIdsArrayAsync() {
+  void createModificationWithNullProcessInstanceIdsArrayAsync() {
     var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceIds((String[]) null);
 
     try {
@@ -219,7 +219,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void createModificationUsingProcessInstanceIdsArrayWithNullValueAsync() {
+  void createModificationUsingProcessInstanceIdsArrayWithNullValueAsync() {
     var modificationBuilder = runtimeService.createModification("processDefinitionId").cancelAllForActivity("user1").processInstanceIds("foo", null, "bar");
 
     try {
@@ -231,7 +231,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testNullProcessInstanceQueryAsync() {
+  void testNullProcessInstanceQueryAsync() {
     var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").processInstanceQuery(null);
 
     try {
@@ -243,7 +243,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testNullHistoricProcessInstanceQueryAsync() {
+  void testNullHistoricProcessInstanceQueryAsync() {
     var modificationBuilder = runtimeService.createModification("processDefinitionId").startAfterActivity("user1").historicProcessInstanceQuery(null);
 
     try {
@@ -255,7 +255,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void createModificationWithNonExistingProcessDefinitionId() {
+  void createModificationWithNonExistingProcessDefinitionId() {
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
     deployment.getDeployedProcessDefinitions().get(0);
 
@@ -270,7 +270,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void createSeedJob() {
+  void createSeedJob() {
     // when
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startAfterAsync("process1", 3, "user1", processDefinition.getId());
@@ -305,7 +305,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void createModificationJobs() {
+  void createModificationJobs() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     rule.getProcessEngineConfiguration().setBatchJobsPerSeed(10);
     Batch batch = helper.startAfterAsync("process1", 20, "user1", processDefinition.getId());
@@ -332,7 +332,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void createMonitorJob() {
+  void createMonitorJob() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startAfterAsync("process1", 10, "user1", processDefinition.getId());
 
@@ -355,7 +355,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void executeModificationJobsForStartAfter() {
+  void executeModificationJobsForStartAfter() {
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
     ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
 
@@ -390,7 +390,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void executeModificationJobsForStartBefore() {
+  void executeModificationJobsForStartBefore() {
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
     ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
 
@@ -425,7 +425,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void executeModificationJobsForStartTransition() {
+  void executeModificationJobsForStartTransition() {
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
     ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
 
@@ -460,7 +460,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void executeModificationJobsForCancelAll() {
+  void executeModificationJobsForCancelAll() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.cancelAllAsync("process1", 10, "user1", processDefinition.getId());
     helper.completeSeedJobs(batch);
@@ -485,7 +485,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void executeModificationJobsForStartAfterAndCancelAll() {
+  void executeModificationJobsForStartAfterAndCancelAll() {
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
     ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
     List<String> instances = helper.startInstances("process1", 10);
@@ -526,7 +526,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void executeModificationJobsForStartBeforeAndCancelAll() {
+  void executeModificationJobsForStartBeforeAndCancelAll() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     List<String> instances = helper.startInstances("process1", 10);
 
@@ -559,7 +559,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void executeModificationJobsForStartTransitionAndCancelAll() {
+  void executeModificationJobsForStartTransitionAndCancelAll() {
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
     ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
 
@@ -599,7 +599,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void executeModificationJobsForProcessInstancesWithDifferentStates() {
+  void executeModificationJobsForProcessInstancesWithDifferentStates() {
 
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
     ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
@@ -642,7 +642,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testMonitorJobPollingForCompletion() {
+  void testMonitorJobPollingForCompletion() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startAfterAsync("process1", 3, "user1", processDefinition.getId());
 
@@ -665,7 +665,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testMonitorJobRemovesBatchAfterCompletion() {
+  void testMonitorJobRemovesBatchAfterCompletion() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startBeforeAsync("process1", 10, "user2", processDefinition.getId());
     helper.completeSeedJobs(batch);
@@ -682,7 +682,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testBatchDeletionWithCascade() {
+  void testBatchDeletionWithCascade() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startTransitionAsync("process1", 10, "seq", processDefinition.getId());
     helper.completeSeedJobs(batch);
@@ -701,7 +701,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testBatchDeletionWithoutCascade() {
+  void testBatchDeletionWithoutCascade() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startBeforeAsync("process1", 10, "user2", processDefinition.getId());
     helper.completeSeedJobs(batch);
@@ -720,7 +720,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testBatchWithFailedSeedJobDeletionWithCascade() {
+  void testBatchWithFailedSeedJobDeletionWithCascade() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.cancelAllAsync("process1", 2, "user1", processDefinition.getId());
 
@@ -737,7 +737,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testBatchWithFailedModificationJobDeletionWithCascade() {
+  void testBatchWithFailedModificationJobDeletionWithCascade() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startAfterAsync("process1", 2, "user1", processDefinition.getId());
     helper.completeSeedJobs(batch);
@@ -757,7 +757,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testBatchWithFailedMonitorJobDeletionWithCascade() {
+  void testBatchWithFailedMonitorJobDeletionWithCascade() {
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(instance);
     Batch batch = helper.startBeforeAsync("process1", 2, "user2", processDefinition.getId());
     helper.completeSeedJobs(batch);
@@ -775,7 +775,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testModificationJobsExecutionByJobExecutorWithAuthorizationEnabledAndTenant() {
+  void testModificationJobsExecutionByJobExecutorWithAuthorizationEnabledAndTenant() {
     ProcessEngineConfigurationImpl processEngineConfiguration = rule.getProcessEngineConfiguration();
 
     processEngineConfiguration.setAuthorizationEnabled(true);
@@ -808,7 +808,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testBatchExecutionFailureWithMissingProcessInstance() {
+  void testBatchExecutionFailureWithMissingProcessInstance() {
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
     ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
     Batch batch = helper.startAfterAsync("process1", 2, "user1", processDefinition.getId());
@@ -852,7 +852,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testBatchExecutionFailureWithHistoricQueryThatMatchesDeletedInstance() {
+  void testBatchExecutionFailureWithHistoricQueryThatMatchesDeletedInstance() {
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
     ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
 
@@ -959,7 +959,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testBatchCreationWithProcessInstanceQuery() {
+  void testBatchCreationWithProcessInstanceQuery() {
     int processInstanceCount = 15;
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
     ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
@@ -980,7 +980,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testBatchCreationWithHistoricProcessInstanceQuery() {
+  void testBatchCreationWithHistoricProcessInstanceQuery() {
     int processInstanceCount = 15;
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
     ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
@@ -1116,7 +1116,7 @@ public class ModificationExecutionAsyncTest {
 
 
   @TestTemplate
-  public void testBatchCreationWithOverlappingProcessInstanceIdsAndQuery() {
+  void testBatchCreationWithOverlappingProcessInstanceIdsAndQuery() {
     int processInstanceCount = 15;
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
     ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
@@ -1138,7 +1138,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testBatchCreationWithOverlappingProcessInstanceIdsAndHistoricQuery() {
+  void testBatchCreationWithOverlappingProcessInstanceIdsAndHistoricQuery() {
     int processInstanceCount = 15;
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
     ProcessDefinition processDefinition = deployment.getDeployedProcessDefinitions().get(0);
@@ -1160,7 +1160,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testBatchCreationWithOverlappingHistoricQueryAndQuery() {
+  void testBatchCreationWithOverlappingHistoricQueryAndQuery() {
     // given
     int processInstanceCount = 15;
     DeploymentWithDefinitions deployment = testRule.deploy(instance);
@@ -1185,7 +1185,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testListenerInvocation() {
+  void testListenerInvocation() {
     // given
     DelegateEvent.clearEvents();
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(modify(instance)
@@ -1219,7 +1219,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testSkipListenerInvocationF() {
+  void testSkipListenerInvocationF() {
     // given
     DelegateEvent.clearEvents();
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(modify(instance)
@@ -1246,7 +1246,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testIoMappingInvocation() {
+  void testIoMappingInvocation() {
     // given
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(modify(instance)
       .activityBuilder("user1")
@@ -1278,7 +1278,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testSkipIoMappingInvocation() {
+  void testSkipIoMappingInvocation() {
     // given
 
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(modify(instance)
@@ -1306,7 +1306,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testCancelWithoutFlag() {
+  void testCancelWithoutFlag() {
     // given
     this.instance = Bpmn.createExecutableProcess("process1")
         .startEvent("start")
@@ -1334,7 +1334,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testCancelWithoutFlag2() {
+  void testCancelWithoutFlag2() {
     // given
     this.instance = Bpmn.createExecutableProcess("process1")
         .startEvent("start")
@@ -1362,7 +1362,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testCancelWithFlag() {
+  void testCancelWithFlag() {
     // given
     this.instance = Bpmn.createExecutableProcess("process1")
         .startEvent("start")
@@ -1392,7 +1392,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void testCancelWithFlagForManyInstances() {
+  void testCancelWithFlagForManyInstances() {
     // given
     this.instance = Bpmn.createExecutableProcess("process1")
         .startEvent("start")
@@ -1424,7 +1424,7 @@ public class ModificationExecutionAsyncTest {
   }
 
   @TestTemplate
-  public void shouldSetInvocationsPerBatchType() {
+  void shouldSetInvocationsPerBatchType() {
     // given
     configuration.getInvocationsPerBatchJobByBatchType()
         .put(Batch.TYPE_PROCESS_INSTANCE_MODIFICATION, 42);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationCancellationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationCancellationTest.java
@@ -56,7 +56,7 @@ import org.operaton.bpm.engine.variable.Variables;
  *
  * @author Thorben Lindhauer
  */
-public class ProcessInstanceModificationCancellationTest {
+class ProcessInstanceModificationCancellationTest {
 
   // the four patterns as described above
   protected static final String ONE_TASK_PROCESS = "org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml";

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RestartAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RestartAuthorizationTest.java
@@ -86,7 +86,7 @@ public class RestartAuthorizationTest {
   }
 
   @TestTemplate
-  public void execute() {
+  void execute() {
     //given
     ProcessDefinition processDefinition = testRule.deployAndGetDefinition(ProcessModels.TWO_TASKS_PROCESS);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CaseCallActivityTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CaseCallActivityTest.java
@@ -42,11 +42,11 @@ import static org.assertj.core.api.Assertions.fail;
  */
 public class CaseCallActivityTest extends CmmnTest {
 
-  protected final String PROCESS_DEFINITION_KEY= "process";
-  protected final String ONE_TASK_CASE = "oneTaskCase";
-  protected final String CALL_ACTIVITY_ID = "callActivity";
-  protected final String USER_TASK_ID = "userTask";
-  protected final String HUMAN_TASK_ID = "PI_HumanTask_1";
+  static final String PROCESS_DEFINITION_KEY= "process";
+  static final String ONE_TASK_CASE = "oneTaskCase";
+  static final String CALL_ACTIVITY_ID = "callActivity";
+  static final String USER_TASK_ID = "userTask";
+  static final String HUMAN_TASK_ID = "PI_HumanTask_1";
 
   @Deployment(resources = {
       "org/operaton/bpm/engine/test/bpmn/callactivity/CaseCallActivityTest.testCallCaseAsConstant.bpmn20.xml",

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/deployment/BpmnDeploymentTest.java
@@ -507,9 +507,9 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
     // then deployment contains deployed process definitions
     List<ProcessDefinition> deployedProcessDefinitions = deployment.getDeployedProcessDefinitions();
     assertThat(deployedProcessDefinitions).hasSize(1);
-    assertThat(deployment.getDeployedCaseDefinitions()).isNull();;
-    assertThat(deployment.getDeployedDecisionDefinitions()).isNull();;
-    assertThat(deployment.getDeployedDecisionRequirementsDefinitions()).isNull();;
+    assertThat(deployment.getDeployedCaseDefinitions()).isNull();
+    assertThat(deployment.getDeployedDecisionDefinitions()).isNull();
+    assertThat(deployment.getDeployedDecisionRequirementsDefinitions()).isNull();
 
     // and persisted process definition is equal to deployed process definition
     ProcessDefinition persistedProcDef = repositoryService.createProcessDefinitionQuery()
@@ -534,7 +534,7 @@ public class BpmnDeploymentTest extends PluggableProcessEngineTest {
     // and there exist no persisted process definitions
     assertThat(repositoryService.createProcessDefinitionQuery()
                                 .processDefinitionResourceName("foo.bpmn")
-                                .singleResult()).isNull();;
+                                .singleResult()).isNull();
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/casetask/CaseTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/casetask/CaseTaskTest.java
@@ -42,9 +42,9 @@ import static org.assertj.core.api.Assertions.fail;
  */
 public class CaseTaskTest extends CmmnTest {
 
-  protected final String CASE_TASK = "PI_CaseTask_1";
-  protected final String ONE_CASE_TASK_CASE = "oneCaseTaskCase";
-  protected final String ONE_TASK_CASE = "oneTaskCase";
+  static final String CASE_TASK = "PI_CaseTask_1";
+  static final String ONE_CASE_TASK_CASE = "oneCaseTaskCase";
+  static final String ONE_TASK_CASE = "oneTaskCase";
 
   @Deployment(resources = {
       "org/operaton/bpm/engine/test/api/cmmn/oneCaseTaskCase.cmmn",

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingHistoryCleanupAcquisitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingHistoryCleanupAcquisitionTest.java
@@ -59,7 +59,7 @@ public class CompetingHistoryCleanupAcquisitionTest extends ConcurrencyTestHelpe
   protected HistoryService historyService;
   protected ManagementService managementService;
 
-  protected final Date CURRENT_DATE = new GregorianCalendar(2023, Calendar.MARCH, 18, 12, 0, 0).getTime();
+  private static final Date CURRENT_DATE = new GregorianCalendar(2023, Calendar.MARCH, 18, 12, 0, 0).getTime();
 
   protected static ThreadControl cleanupThread = null;
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSuspensionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/CompetingSuspensionTest.java
@@ -43,7 +43,7 @@ import org.slf4j.Logger;
  */
 public class CompetingSuspensionTest {
 
-  protected static Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
+  protected static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
   protected ProvidedProcessEngineRule engineRule = new ProvidedProcessEngineRule();
   protected ProcessEngineTestRule testRule = new ProcessEngineTestRule(engineRule);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ControllableThread.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/ControllableThread.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
  */
 public class ControllableThread extends Thread {
 
-  private static Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
+  private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
   public ControllableThread() {
     super();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/AbstractPartitioningTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/AbstractPartitioningTest.java
@@ -42,7 +42,7 @@ public abstract class AbstractPartitioningTest extends ConcurrencyTestCase {
     processEngine.getProcessEngineConfiguration().setSkipHistoryOptimisticLockingExceptions(true);
   }
 
-  protected final BpmnModelInstance PROCESS_WITH_USERTASK = Bpmn.createExecutableProcess("process")
+  protected static final BpmnModelInstance PROCESS_WITH_USERTASK = Bpmn.createExecutableProcess("process")
     .startEvent()
       .userTask()
     .endEvent().done();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/CompetingHistoricByteArrayPartitioningTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/CompetingHistoricByteArrayPartitioningTest.java
@@ -33,9 +33,9 @@ import org.junit.Test;
 
 public class CompetingHistoricByteArrayPartitioningTest extends AbstractPartitioningTest {
 
-  protected final String VARIABLE_NAME = "aVariableName";
-  protected final String VARIABLE_VALUE = "aVariableValue";
-  protected final String ANOTHER_VARIABLE_VALUE = "anotherVariableValue";
+  static final String VARIABLE_NAME = "aVariableName";
+  static final String VARIABLE_VALUE = "aVariableValue";
+  static final String ANOTHER_VARIABLE_VALUE = "anotherVariableValue";
 
   @Test
   public void shouldSuppressOleOnConcurrentFetchAndDelete() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/CompetingHistoricVariableInstancePartitioningTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/CompetingHistoricVariableInstancePartitioningTest.java
@@ -30,9 +30,9 @@ import org.junit.Test;
 
 public class CompetingHistoricVariableInstancePartitioningTest extends AbstractPartitioningTest {
 
-  protected final String VARIABLE_NAME = "aVariableName";
-  protected final String VARIABLE_VALUE = "aVariableValue";
-  protected final String ANOTHER_VARIABLE_VALUE = "anotherVariableValue";
+  static final String VARIABLE_NAME = "aVariableName";
+  static final String VARIABLE_VALUE = "aVariableValue";
+  static final String ANOTHER_VARIABLE_VALUE = "anotherVariableValue";
 
   @Test
   public void shouldSuppressOleOnConcurrentFetchAndDelete() {

--- a/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/deployment/EnsureDbCleanTest.java
+++ b/engine/src/test/junit5/org/operaton/bpm/engine/test/junit5/deployment/EnsureDbCleanTest.java
@@ -79,7 +79,7 @@ public class EnsureDbCleanTest {
     }
 
     @RegisterExtension
-    ProcessEngineExtension extension = ProcessEngineExtension.builder()
+    static ProcessEngineExtension extension = ProcessEngineExtension.builder()
       // fail if DB is dirty after test
       .ensureCleanAfterTest(true)
       .build();

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
         <plugin>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-maven-plugin</artifactId>
-          <version>11.0.24</version>
+          <version>${version.jetty}</version>
         </plugin>
         <plugin>
           <groupId>org.eclipse.transformer</groupId>

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -450,7 +450,7 @@
                 <exclude>**/CallActivityContextSwitchTest.java</exclude>
                 <exclude>**/CdiBeanCallActivityResolutionTest.java</exclude>
 
-                <!-- TODO and weld-servlet-shaded is resolved with integration-tests-engine-jakarta -->
+                <!-- TODO and weld-servlet-shaded is resolved with integration-tests-engine -->
 
               </excludes>
               <redirectTestOutputToFile>${redirect.test.output}</redirectTestOutputToFile>

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/TestProperties.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/TestProperties.java
@@ -18,6 +18,7 @@ package org.operaton.bpm;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.stream.Stream;
 
@@ -56,18 +57,23 @@ public class TestProperties {
   public int getHttpPort() {
 
     try {
-      return Integer.parseInt(properties.getProperty("http.port"));
+      return Integer.parseInt(properties.getProperty(HTTP_PORT));
     } catch (RuntimeException e) {
       return defaultPort;
     }
   }
   
   public String getStringProperty(String propName, String defaultValue) {
-    return properties.getProperty(propName, defaultValue);    
+    String propertyValue = properties.getProperty(propName, defaultValue);
+    if (propertyValue.startsWith("${") && propertyValue.endsWith("}")) {
+      Objects.requireNonNull(defaultValue, () -> "Property " + propName + " is not set.");
+      return defaultValue;
+    }
+    return propertyValue;
   }
 
   public String getHttpHost() {
-    return properties.getProperty("http.host", "localhost");
+    return getStringProperty("http.host", "localhost");
   }
 
   public static Properties getTestProperties() throws IOException {


### PR DESCRIPTION
This PR performs various code cleanups
- Disable WADL tests
- Remove unnecessary visibility modifiers
- Remove public modifiers on JU5 test methods
- 