### PR TITLE
fix(xtac): initialize url resolver with null base url

### DIFF
--- a/clients/java/client/src/main/java/org/operaton/bpm/client/impl/ExternalTaskClientBuilderImpl.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/impl/ExternalTaskClientBuilderImpl.java
@@ -107,6 +107,7 @@ public class ExternalTaskClientBuilderImpl implements ExternalTaskClientBuilder 
     this.backoffStrategy = new ExponentialBackoffStrategy();
     this.isBackoffStrategyDisabled = false;
     this.httpClientBuilder = HttpClients.custom().useSystemProperties();
+    this.urlResolver = new PermanentUrlResolver(null);
   }
 
   @Override

--- a/clients/java/client/src/test/java/org/operaton/bpm/client/impl/ExternalTaskClientBuilderImplTest.java
+++ b/clients/java/client/src/test/java/org/operaton/bpm/client/impl/ExternalTaskClientBuilderImplTest.java
@@ -91,4 +91,14 @@ class ExternalTaskClientBuilderImplTest {
     }
   }
 
+  @Test
+  public void testBuilderWithUnsetBaseUrl() {
+    // given unbuilt builder
+    ExternalTaskClientBuilderImpl builder = new ExternalTaskClientBuilderImpl();
+
+    // when getting base url and url resolver, then they are correctly initialized
+    assertThat(builder.getBaseUrl()).isNull();
+    assertThat(builder.urlResolver).isNotNull();
+  }
+
 }


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/5112

Backported commit 94bbd59f43 from the camunda-bpm-platform repository.
Original author: Joaquín <165814090+joaquinfelici@users.noreply.github.com>