### PR TITLE
fix(engine): print correct value of processDefinitionId in toString() for events

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/event/HistoricVariableUpdateEventEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/event/HistoricVariableUpdateEventEntity.java
@@ -136,7 +136,7 @@ public class HistoricVariableUpdateEventEntity extends HistoricDetailEventEntity
            + ", eventType=" + eventType
            + ", executionId=" + executionId
            + ", id=" + id
-           + ", processDefinitionId=" + processInstanceId
+           + ", processDefinitionId=" + processDefinitionId
            + ", processInstanceId=" + processInstanceId
            + ", taskId=" + taskId
            + ", timestamp=" + timestamp

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricDetailVariableInstanceUpdateEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricDetailVariableInstanceUpdateEntity.java
@@ -154,7 +154,7 @@ public class HistoricDetailVariableInstanceUpdateEntity extends HistoricVariable
            + ", eventType=" + eventType
            + ", executionId=" + executionId
            + ", id=" + id
-           + ", processDefinitionId=" + processInstanceId
+           + ", processDefinitionId=" + processDefinitionId
            + ", processInstanceId=" + processInstanceId
            + ", taskId=" + taskId
            + ", timestamp=" + timestamp


### PR DESCRIPTION
related to camunda/camunda-bpm-platform#4927

Backported commit 8f7940067e from the camunda-bpm-platform repository.
Original author: David Benes <dbenesj@users.noreply.github.com>