### PR TITLE
fix(webapp): Handle null authentication as unauthorized

### DIFF
--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/auth/UserAuthenticationResource.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/auth/UserAuthenticationResource.java
@@ -96,6 +96,12 @@ public class UserAuthenticationResource {
     }
 
     UserAuthentication authentication = AuthenticationUtil.createAuthentication(processEngine, username);
+    if (authentication == null) {
+      if(isWebappsAuthenticationLoggingEnabled(processEngine)) {
+        LOGGER.infoWebappFailedLogin(username, "not authorized");
+      }
+      return unauthorized();
+    }
 
     ServletContext servletContext = request.getServletContext();
     Date cacheValidationTime = ServletContextUtil.getAuthCacheValidationTime(servletContext);

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/auth/UserAuthenticationResourceTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/auth/UserAuthenticationResourceTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.webapp.impl.security.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
 
 import java.util.Date;
 import jakarta.ws.rs.core.Response;
@@ -37,6 +38,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 /**
@@ -200,6 +202,26 @@ public class UserAuthenticationResourceTest {
       .get(0);
     assertThat(userAuthentication.getCacheValidationTime())
       .isEqualTo(new Date(ClockUtil.getCurrentTime().getTime() + 1000 * 60 * 5));
+  }
+
+  @Test
+  public void shouldReturnUnauthorizedOnNullAuthentication() {
+    // given
+    User jonny = identityService.newUser("jonny");
+    jonny.setPassword("jonnyspassword");
+    identityService.saveUser(jonny);
+    UserAuthenticationResource authResource = new UserAuthenticationResource();
+    authResource.request = new MockHttpServletRequest();
+
+    try (MockedStatic<AuthenticationUtil> authenticationUtilMock = mockStatic(AuthenticationUtil.class)) {
+      authenticationUtilMock.when(() -> AuthenticationUtil.createAuthentication("webapps-test-engine", "jonny")).thenReturn(null);
+
+      // when
+      Response response = authResource.doLogin("webapps-test-engine", "tasklist", "jonny", "jonnyspassword");
+
+      // then
+      Assert.assertEquals(Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
+    }
   }
 
   protected void setAuthentication(String user, String engineName) {


### PR DESCRIPTION
Related to camunda/camunda-bpm-platform#3739

Backported commit bd17e6619d from the camunda-bpm-platform repository.
Original author: Joaquín <165814090+joaquinfelici@users.noreply.github.com>