### PR TITLE
chore: bump quarkus version to 3.20.0 (latest LTS)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <version.joda-time>2.12.5</version.joda-time>
     <version.uuid-generator>4.3.0</version.uuid-generator>
     <version.feel-scala>1.19.1</version.feel-scala>
-    <version.quarkus>3.15.0</version.quarkus>
+    <version.quarkus>3.20.0</version.quarkus>
     <version.java>17</version.java>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
related to camunda/camunda-bpm-platform#4870

Backported commit c92ed54006 from the camunda-bpm-platform repository.
Original author: Helene <21290204+PHWaechtler@users.noreply.github.com>
