### PR TITLE
feat(engine): HistoricProcessInstanceQuery processInstanceIdNotIn filter

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/history-process-instance.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/history-process-instance.ftl
@@ -52,6 +52,12 @@
     "desc": "Filter by process instance ids. ${listTypeDescription}."
   },
 
+  "processInstanceIdNotIn": {
+    "type": "array",
+    "itemType": "string",
+    "desc": "Exclude instances by process instance ids. ${listTypeDescription}."
+  },
+
   "processDefinitionId": {
     "type": "string",
     "desc": "Filter by the process definition the instances run on."

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/history/HistoricProcessInstanceQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/history/HistoricProcessInstanceQueryDto.java
@@ -71,6 +71,7 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
 
   private String processInstanceId;
   private Set<String> processInstanceIds;
+  private List<String> processInstanceIdNotIn;
   private String processDefinitionId;
   private String processDefinitionKey;
   private List<String> processDefinitionKeys;
@@ -141,6 +142,11 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
   @OperatonQueryParam(value = "processInstanceIds", converter = StringSetConverter.class)
   public void setProcessInstanceIds(Set<String> processInstanceIds) {
     this.processInstanceIds = processInstanceIds;
+  }
+
+  @OperatonQueryParam(value = "processInstanceIdNotIn", converter = StringListConverter.class)
+  public void setProcessInstanceIdNotIn(List<String> processInstanceIdNotIn) {
+    this.processInstanceIdNotIn = processInstanceIdNotIn;
   }
 
   public String getProcessDefinitionId() {
@@ -410,6 +416,9 @@ public class HistoricProcessInstanceQueryDto extends AbstractQueryDto<HistoricPr
     }
     if (processInstanceIds != null) {
       query.processInstanceIds(processInstanceIds);
+    }
+    if (processInstanceIdNotIn != null && !processInstanceIdNotIn.isEmpty()) {
+      query.processInstanceIdNotIn(processInstanceIdNotIn.toArray(new String[0]));
     }
     if (processDefinitionId != null) {
       query.processDefinitionId(processDefinitionId);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/HistoricProcessInstanceRestServiceQueryTest.java
@@ -1082,6 +1082,43 @@ public class HistoricProcessInstanceRestServiceQueryTest extends AbstractRestSer
   }
 
   @Test
+  public void testQueryByProcessInstanceIdNotIn() {
+    given()
+        .queryParam("processInstanceIdNotIn", "firstProcessInstanceId,secondProcessInstanceId")
+        .then()
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .get(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
+
+    verify(mockedQuery).processInstanceIdNotIn("firstProcessInstanceId", "secondProcessInstanceId");
+    verify(mockedQuery).list();
+  }
+
+  @Test
+  public void testQueryByProcessInstanceIdNotInAsPost() {
+    Map<String, Set<String>> parameters = new HashMap<String, Set<String>>();
+
+    Set<String> processInstanceIds = new HashSet<String>();
+    processInstanceIds.add("firstProcessInstanceId");
+    processInstanceIds.add("secondProcessInstanceId");
+
+    parameters.put("processInstanceIdNotIn", processInstanceIds);
+
+    given()
+        .contentType(POST_JSON_CONTENT_TYPE)
+        .body(parameters)
+        .then()
+        .expect()
+        .statusCode(Status.OK.getStatusCode())
+        .when()
+        .post(HISTORIC_PROCESS_INSTANCE_RESOURCE_URL);
+
+    verify(mockedQuery).processInstanceIdNotIn("firstProcessInstanceId", "secondProcessInstanceId");
+    verify(mockedQuery).list();
+  }
+
+  @Test
   public void testQueryByProcessDefinitionKeyNotIn() {
     given()
       .queryParam("processDefinitionKeyNotIn", "firstProcessInstanceKey,secondProcessInstanceKey")

--- a/engine/src/main/java/org/operaton/bpm/engine/history/HistoricProcessInstanceQuery.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/history/HistoricProcessInstanceQuery.java
@@ -48,6 +48,12 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
   HistoricProcessInstanceQuery processInstanceIds(Set<String> processInstanceIds);
 
   /**
+   * Only select historic process instances whose id is not in the given set of ids.
+   * {@link ProcessInstance) ids and {@link HistoricProcessInstance} ids match.
+   */
+  HistoricProcessInstanceQuery processInstanceIdNotIn(String... processInstanceIdNotIn);
+
+  /**
    * Only select historic process instances for the given process definition
    */
   HistoricProcessInstanceQuery processDefinitionId(String processDefinitionId);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -86,6 +86,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   protected String processDefinitionKey;
   protected String[] processDefinitionKeys;
   protected Set<String> processInstanceIds;
+  protected String[] processInstanceIdNotIn;
   protected String[] tenantIds;
   protected boolean isTenantIdSet;
   protected String[] executedActivityIds;
@@ -118,6 +119,12 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   public HistoricProcessInstanceQuery processInstanceIds(Set<String> processInstanceIds) {
     ensureNotEmpty("Set of process instance ids", processInstanceIds);
     this.processInstanceIds = processInstanceIds;
+    return this;
+  }
+
+  public HistoricProcessInstanceQuery processInstanceIdNotIn(String... processInstanceIdNotIn){
+    ensureNotNull("processInstanceIdNotIn", (Object[]) processInstanceIdNotIn);
+    this.processInstanceIdNotIn = processInstanceIdNotIn;
     return this;
   }
 
@@ -341,7 +348,9 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
       || CompareUtil.areNotInAscendingOrder(startedAfter, startedBefore)
       || CompareUtil.areNotInAscendingOrder(finishedAfter, finishedBefore)
       || CompareUtil.elementIsContainedInList(processDefinitionKey, processKeyNotIn)
-      || CompareUtil.elementIsNotContainedInList(processInstanceId, processInstanceIds);
+      || CompareUtil.elementIsNotContainedInList(processInstanceId, processInstanceIds)
+      || CompareUtil.elementIsContainedInArray(processInstanceId, processInstanceIdNotIn)
+      || CompareUtil.elementsAreContainedInArray(processInstanceIds, processInstanceIdNotIn);
   }
 
   @Override
@@ -602,6 +611,10 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
 
   public Set<String> getProcessInstanceIds() {
     return processInstanceIds;
+  }
+
+  public String[] getProcessInstanceIdNotIn() {
+    return processInstanceIdNotIn;
   }
 
   public String getStartedBy() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/CompareUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/CompareUtil.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.impl.util;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
 /**
@@ -160,5 +161,12 @@ public class CompareUtil {
    */
   public static <T extends Comparable<T>> T max(T obj1, T obj2) {
     return obj1.compareTo(obj2) >= 0 ? obj1 : obj2;
+  }
+
+  public static <T> boolean elementsAreContainedInArray(Collection<T>  subset, T[]  superset) {
+    if (subset != null && !subset.isEmpty() && superset != null && superset.length > 0 && superset.length >= subset.size()) {
+      return new HashSet<>(Arrays.asList(superset)).containsAll(subset);
+    }
+    return false;
   }
 }

--- a/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/HistoricProcessInstance.xml
@@ -471,6 +471,13 @@
               <bind name="fieldName" value="'SELF.PROC_INST_ID_'" />
               <include refid="org.operaton.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection" />
             </if>
+            <if test="query.processInstanceIdNotIn != null and query.processInstanceIdNotIn.length > 0">
+            ${queryType} SELF.PROC_INST_ID_ NOT IN
+              <foreach item="processInstanceId" index="index" collection="query.processInstanceIdNotIn"
+                       open="(" separator="," close=")">
+                #{processInstanceId}
+              </foreach>
+            </if>
             <if test="query.caseInstanceId != null">
               ${queryType} SELF.CASE_INST_ID_ = #{query.caseInstanceId}
             </if>

--- a/webapps/frontend/operaton-commons-ui/lib/widgets/inline-field/cam-widget-inline-field.html
+++ b/webapps/frontend/operaton-commons-ui/lib/widgets/inline-field/cam-widget-inline-field.html
@@ -84,7 +84,7 @@
   <span ng-show="varType !== 'option'"
         class="cam-widget-inline-field btn-group">
     <button type="button"
-                ng-if="inOperator && !(varType === 'datetime' || varType === 'date' || varType === 'time')"
+                ng-if="(inOperator || notInOperator) && !(varType === 'datetime' || varType === 'date' || varType === 'time')"
                 class="btn btn-xs btn-default"
                 ng-click="expandValue()">
       <span class="glyphicon glyphicon-resize-full"></span>

--- a/webapps/frontend/operaton-commons-ui/lib/widgets/inline-field/cam-widget-inline-field.js
+++ b/webapps/frontend/operaton-commons-ui/lib/widgets/inline-field/cam-widget-inline-field.js
@@ -53,6 +53,7 @@ module.exports = [
         varValue: '=value',
         varType: '@type',
         inOperator: '=?',
+        notInOperator: '=?',
         validator: '&validate',
         change: '&',
         onStart: '&onStartEditing',

--- a/webapps/frontend/operaton-commons-ui/lib/widgets/search-pill/cam-widget-search-pill.html
+++ b/webapps/frontend/operaton-commons-ui/lib/widgets/search-pill/cam-widget-search-pill.html
@@ -130,6 +130,7 @@
         ng-keydown="onKeydown($event, 'value')"
         type="{{ valueType }}"
         in-operator="operator.value.key === 'In'"
+        not-in-operator="operator.value.key === 'NotIn'"
         change="changeSearch('value', varValue, $event)"
         on-start-editing="clearEditTrigger('value')"
         ng-if="!basic"

--- a/webapps/frontend/public/app/cockpit/locales/de.json
+++ b/webapps/frontend/public/app/cockpit/locales/de.json
@@ -1569,6 +1569,8 @@
     "PLGN_SEAR_CASE_INSTANCE_ID": "Case-Instanz-ID",
     "PLGN_SEAR_CAUSE_INCIDENT": "Verursachender Zwischenfall",
     "PLGN_SEAR_CONFIGURATION": "Konfiguration",
+    "PLGN_SEAR_COPIED": "Kopiert",
+    "PLGN_SEAR_COPY_SELECTED_IDS": "Ausgewählte Instanz-IDs kopieren",
     "PLGN_SEAR_DEFINITION_ID": "Definitions-ID",
     "PLGN_SEAR_DEFINITION_KEY": "Definitions-Schlüssel",
     "PLGN_SEAR_DEFINITION_NAME": "Definitions-Name",

--- a/webapps/frontend/public/app/cockpit/locales/en.json
+++ b/webapps/frontend/public/app/cockpit/locales/en.json
@@ -1569,6 +1569,8 @@
     "PLGN_SEAR_CASE_INSTANCE_ID": "Case Instance ID",
     "PLGN_SEAR_CAUSE_INCIDENT": "Cause Incident",
     "PLGN_SEAR_CONFIGURATION": "Configuration",
+    "PLGN_SEAR_COPIED": "Copied",
+    "PLGN_SEAR_COPY_SELECTED_IDS": "Copy selected Instance IDs",
     "PLGN_SEAR_DEFINITION_ID": "Definition ID",
     "PLGN_SEAR_DEFINITION_KEY": "Definition Key",
     "PLGN_SEAR_DEFINITION_NAME": "Definition Name",


### PR DESCRIPTION
* feat(engine): HistoricProcessInstanceQuery processInstanceIdNotIn filter
* feat(webapps): copy selected process instance ids
* fix(webapps): enable expanded edit for NotIn operator
* fix(engine-rest): fix parsing processInstanceIdNotIn

related to camunda/camunda-bpm-platform#4896

Backported commits 1427d48662 & 1db760f248 from the camunda-bpm-platform repository.
Original author: Gergely Juhasz <25517896+venetrius@users.noreply.github.com>