### PR TITLE
fix: failing IdGeneratorDataSourceTest

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/IdGeneratorDataSourceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/IdGeneratorDataSourceTest.java
@@ -58,10 +58,7 @@ public class IdGeneratorDataSourceTest {
         runtimeService.startProcessInstanceByKey("idGeneratorDataSource");
       }));
     }
-    tasks.forEach(future -> {
-      assertThatNoException().isThrownBy(future::get);
-    });
-
+    tasks.forEach(future -> assertThatNoException().isThrownBy(future::get));
     threadPool.shutdown();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/IdGeneratorDataSourceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/IdGeneratorDataSourceTest.java
@@ -16,8 +16,12 @@
  */
 package org.operaton.bpm.engine.test.api.cfg;
 
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Future;
 
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.test.Deployment;
@@ -28,7 +32,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-// TODO https://github.com/operaton/operaton/issues/500
 public class IdGeneratorDataSourceTest {
 
   @ClassRule
@@ -47,26 +50,18 @@ public class IdGeneratorDataSourceTest {
   @Deployment
   @Test
   public void testIdGeneratorDataSource() {
-    List<Thread> threads = new ArrayList<>();
-    for (int i=0; i<20; i++) {
-      Thread thread = new Thread() {
-        @Override
-        public void run() {
-          for (int j = 0; j < 5; j++) {
-            runtimeService.startProcessInstanceByKey("idGeneratorDataSource");
-          }
-        }
-      };
-      thread.start();
-      threads.add(thread);
-    }
+    var threadPool = newFixedThreadPool(20);
+    List<Future<?>> tasks = new ArrayList<>();
 
-    for (Thread thread: threads) {
-      try {
-        thread.join();
-      } catch (InterruptedException e) {
-        e.printStackTrace();
-      }
+    for (int i = 0; i < 20; i++) {
+      tasks.add(threadPool.submit(() -> {
+        runtimeService.startProcessInstanceByKey("idGeneratorDataSource");
+      }));
     }
+    tasks.forEach(future -> {
+      assertThatNoException().isThrownBy(future::get);
+    });
+
+    threadPool.shutdown();
   }
 }

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/api/cfg/IdGeneratorDataSourceTest.testIdGeneratorDataSource.bpmn20.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/api/cfg/IdGeneratorDataSourceTest.testIdGeneratorDataSource.bpmn20.xml
@@ -12,7 +12,7 @@
     
     <serviceTask id="javaService" 
                  name="Java service invocation" 
-                 operaton:class="org.operaton.bpm.engine.test.db.IdGeneratorDataSourceDoNothing" />
+                 operaton:class="org.operaton.bpm.engine.test.api.cfg.IdGeneratorDataSourceDoNothing" />
     
     <sequenceFlow id="flow2" sourceRef="javaService" targetRef="theEnd" />
     


### PR DESCRIPTION
fix(engine): failing IdGeneratorDataSourceTest

- fixes siliently failing IdGeneratorDataSourceTest
- adds assertion to prevent it from happing again

relates to #500