### PR TITLE
bugfix(wildfly): Set the correct version for the java-uuid-generator …

### DIFF
--- a/distro/wildfly/modules/src/main/modules/com/fasterxml/uuid/java-uuid-generator/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/com/fasterxml/uuid/java-uuid-generator/main/module.xml
@@ -1,6 +1,6 @@
 <module xmlns="urn:jboss:module:1.0" name="com.fasterxml.uuid.java-uuid-generator">
   <resources>
-    <resource-root path="java-uuid-generator-4.3.0.jar" />
+    <resource-root path="java-uuid-generator-5.1.0.jar" />
   </resources>
 
   <dependencies>


### PR DESCRIPTION
…in the Wildfly Module

Fixes #791 