### PR TITLE
chore: Extract constants for query parameters

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/AbstractManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/AbstractManager.java
@@ -16,8 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence;
 
-import java.util.concurrent.Callable;
-
 import org.operaton.bpm.engine.authorization.Permission;
 import org.operaton.bpm.engine.authorization.Resource;
 import org.operaton.bpm.engine.impl.AbstractQuery;
@@ -53,7 +51,6 @@ import org.operaton.bpm.engine.impl.persistence.entity.HistoricIdentityLinkLogMa
 import org.operaton.bpm.engine.impl.persistence.entity.HistoricIncidentManager;
 import org.operaton.bpm.engine.impl.persistence.entity.HistoricJobLogManager;
 import org.operaton.bpm.engine.impl.persistence.entity.HistoricProcessInstanceManager;
-import org.operaton.bpm.engine.impl.persistence.entity.ReportManager;
 import org.operaton.bpm.engine.impl.persistence.entity.HistoricTaskInstanceManager;
 import org.operaton.bpm.engine.impl.persistence.entity.HistoricVariableInstanceManager;
 import org.operaton.bpm.engine.impl.persistence.entity.IdentityInfoManager;
@@ -61,6 +58,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.IdentityLinkManager;
 import org.operaton.bpm.engine.impl.persistence.entity.JobDefinitionManager;
 import org.operaton.bpm.engine.impl.persistence.entity.JobManager;
 import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionManager;
+import org.operaton.bpm.engine.impl.persistence.entity.ReportManager;
 import org.operaton.bpm.engine.impl.persistence.entity.ResourceManager;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskManager;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskReportManager;
@@ -68,12 +66,38 @@ import org.operaton.bpm.engine.impl.persistence.entity.TenantManager;
 import org.operaton.bpm.engine.impl.persistence.entity.UserOperationLogManager;
 import org.operaton.bpm.engine.impl.persistence.entity.VariableInstanceManager;
 
+import java.util.concurrent.Callable;
+
 
 
 /**
  * @author Tom Baeyens
  */
 public abstract class AbstractManager implements Session {
+  protected static final String ACTIVITY_ID = "activityId";
+  protected static final String BATCH_ID = "batchId";
+  protected static final String BATCH_SIZE = "batchSize";
+  protected static final String CASE_INSTANCE_IDS = "caseInstanceIds";
+  protected static final String CURRENT_TIMESTAMP = "currentTimestamp";
+  protected static final String ID = "id";
+  protected static final String IS_PROCESS_DEFINITION_TENANT_ID_SET = "isProcessDefinitionTenantIdSet";
+  protected static final String IS_TENANT_ID_SET = "isTenantIdSet";
+  protected static final String JOB_DEFINITION_ID = "jobDefinitionId";
+  protected static final String MAX_RESULTS = "maxResults";
+  protected static final String MINUTE_FROM = "minuteFrom";
+  protected static final String MINUTE_TO = "minuteTo";
+  protected static final String REMOVAL_TIME = "removalTime";
+  protected static final String PROCESS_DEFINITION_ID = "processDefinitionId";
+  protected static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
+  protected static final String PROCESS_DEFINITION_TENANT_ID = "processDefinitionTenantId";
+  protected static final String PROCESS_INSTANCE_ID = "processInstanceId";
+  protected static final String PROCESS_INSTANCE_IDS = "processInstanceIds";
+  protected static final String ROOT_PROCESS_INSTANCE_ID = "rootProcessInstanceId";
+  protected static final String SUSPENSION_STATE = "suspensionState";
+  protected static final String TASK_CASE_INSTANCE_IDS = "taskCaseInstanceIds";
+  protected static final String TASK_ID = "taskId";
+  protected static final String TASK_PROCESS_INSTANCE_IDS = "taskProcessInstanceIds";
+  protected static final String TENANT_ID = "tenantId";
 
   public void insert(DbEntity dbEntity) {
     getDbEntityManager().insert(dbEntity);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/AttachmentManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/AttachmentManager.java
@@ -16,113 +16,115 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.operaton.bpm.engine.impl.db.ListQueryParameterObject;
 import org.operaton.bpm.engine.impl.db.entitymanager.operation.DbOperation;
 import org.operaton.bpm.engine.impl.persistence.AbstractHistoricManager;
 import org.operaton.bpm.engine.task.Attachment;
 
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Tom Baeyens
  */
 public class AttachmentManager extends AbstractHistoricManager {
 
-  @SuppressWarnings("unchecked")
-  public List<Attachment> findAttachmentsByProcessInstanceId(String processInstanceId) {
-    checkHistoryEnabled();
-    return getDbEntityManager().selectList("selectAttachmentsByProcessInstanceId", processInstanceId);
-  }
-
-  @SuppressWarnings("unchecked")
-  public List<Attachment> findAttachmentsByTaskId(String taskId) {
-    checkHistoryEnabled();
-    return getDbEntityManager().selectList("selectAttachmentsByTaskId", taskId);
-  }
-
-  public DbOperation addRemovalTimeToAttachmentsByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
-
-    return getDbEntityManager()
-      .updatePreserveOrder(AttachmentEntity.class, "updateAttachmentsByRootProcessInstanceId", parameters);
-  }
-
-  public DbOperation addRemovalTimeToAttachmentsByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
-
-    return getDbEntityManager()
-      .updatePreserveOrder(AttachmentEntity.class, "updateAttachmentsByProcessInstanceId", parameters);
-
-  }
-
-  @SuppressWarnings("unchecked")
-  public void deleteAttachmentsByTaskId(String taskId) {
-    checkHistoryEnabled();
-    List<AttachmentEntity> attachments = getDbEntityManager().selectList("selectAttachmentsByTaskId", taskId);
-    for (AttachmentEntity attachment: attachments) {
-      String contentId = attachment.getContentId();
-      if (contentId!=null) {
-        getByteArrayManager().deleteByteArrayById(contentId);
-      }
-      getDbEntityManager().delete(attachment);
+    @SuppressWarnings("unchecked")
+    public List<Attachment> findAttachmentsByProcessInstanceId(String processInstanceId) {
+        checkHistoryEnabled();
+        return getDbEntityManager().selectList("selectAttachmentsByProcessInstanceId", processInstanceId);
     }
-  }
 
-  public void deleteAttachmentsByProcessInstanceIds(List<String> processInstanceIds) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceIds", processInstanceIds);
-    deleteAttachments(parameters);
-  }
-
-  public void deleteAttachmentsByTaskProcessInstanceIds(List<String> processInstanceIds) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("taskProcessInstanceIds", processInstanceIds);
-    deleteAttachments(parameters);
-  }
-
-  public void deleteAttachmentsByTaskCaseInstanceIds(List<String> caseInstanceIds) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("caseInstanceIds", caseInstanceIds);
-    deleteAttachments(parameters);
-  }
-
-  protected void deleteAttachments(Map<String, Object> parameters) {
-    getDbEntityManager().deletePreserveOrder(ByteArrayEntity.class, "deleteAttachmentByteArraysByIds", parameters);
-    getDbEntityManager().deletePreserveOrder(AttachmentEntity.class, "deleteAttachmentByIds", parameters);
-  }
-
-  public Attachment findAttachmentByTaskIdAndAttachmentId(String taskId, String attachmentId) {
-    checkHistoryEnabled();
-
-    Map<String, String> parameters = new HashMap<>();
-    parameters.put("taskId", taskId);
-    parameters.put("id", attachmentId);
-
-    return (AttachmentEntity) getDbEntityManager().selectOne("selectAttachmentByTaskIdAndAttachmentId", parameters);
-  }
-
-  public DbOperation deleteAttachmentsByRemovalTime(Date removalTime, int minuteFrom, int minuteTo, int batchSize) {
-    Map<String, Object> parameters = new HashMap<>();
-    parameters.put("removalTime", removalTime);
-    if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+    @SuppressWarnings("unchecked")
+    public List<Attachment> findAttachmentsByTaskId(String taskId) {
+        checkHistoryEnabled();
+        return getDbEntityManager().selectList("selectAttachmentsByTaskId", taskId);
     }
-    parameters.put("batchSize", batchSize);
 
-    return getDbEntityManager()
-      .deletePreserveOrder(AttachmentEntity.class, "deleteAttachmentsByRemovalTime",
-        new ListQueryParameterObject(parameters, 0, batchSize));
-  }
+    public DbOperation addRemovalTimeToAttachmentsByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime,
+            Integer batchSize) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(ROOT_PROCESS_INSTANCE_ID, rootProcessInstanceId);
+        parameters.put(REMOVAL_TIME, removalTime);
+        parameters.put(MAX_RESULTS, batchSize);
+
+        return getDbEntityManager()
+                .updatePreserveOrder(AttachmentEntity.class, "updateAttachmentsByRootProcessInstanceId", parameters);
+    }
+
+    public DbOperation addRemovalTimeToAttachmentsByProcessInstanceId(String processInstanceId, Date removalTime,
+            Integer batchSize) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+        parameters.put(REMOVAL_TIME, removalTime);
+        parameters.put(MAX_RESULTS, batchSize);
+
+        return getDbEntityManager()
+                .updatePreserveOrder(AttachmentEntity.class, "updateAttachmentsByProcessInstanceId", parameters);
+
+    }
+
+    @SuppressWarnings("unchecked")
+    public void deleteAttachmentsByTaskId(String taskId) {
+        checkHistoryEnabled();
+        List<AttachmentEntity> attachments = getDbEntityManager().selectList("selectAttachmentsByTaskId", taskId);
+        for (AttachmentEntity attachment : attachments) {
+            String contentId = attachment.getContentId();
+            if (contentId != null) {
+                getByteArrayManager().deleteByteArrayById(contentId);
+            }
+            getDbEntityManager().delete(attachment);
+        }
+    }
+
+    public void deleteAttachmentsByProcessInstanceIds(List<String> processInstanceIds) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(PROCESS_INSTANCE_IDS, processInstanceIds);
+        deleteAttachments(parameters);
+    }
+
+    public void deleteAttachmentsByTaskProcessInstanceIds(List<String> processInstanceIds) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(TASK_PROCESS_INSTANCE_IDS, processInstanceIds);
+        deleteAttachments(parameters);
+    }
+
+    public void deleteAttachmentsByTaskCaseInstanceIds(List<String> caseInstanceIds) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(CASE_INSTANCE_IDS, caseInstanceIds);
+        deleteAttachments(parameters);
+    }
+
+    protected void deleteAttachments(Map<String, Object> parameters) {
+        getDbEntityManager().deletePreserveOrder(ByteArrayEntity.class, "deleteAttachmentByteArraysByIds", parameters);
+        getDbEntityManager().deletePreserveOrder(AttachmentEntity.class, "deleteAttachmentByIds", parameters);
+    }
+
+    public Attachment findAttachmentByTaskIdAndAttachmentId(String taskId, String attachmentId) {
+        checkHistoryEnabled();
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(TASK_ID, taskId);
+        parameters.put(ID, attachmentId);
+
+        return (AttachmentEntity) getDbEntityManager().selectOne("selectAttachmentByTaskIdAndAttachmentId", parameters);
+    }
+
+    public DbOperation deleteAttachmentsByRemovalTime(Date removalTime, int minuteFrom, int minuteTo, int batchSize) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(REMOVAL_TIME, removalTime);
+        if (minuteTo - minuteFrom + 1 < 60) {
+            parameters.put(MINUTE_FROM, minuteFrom);
+            parameters.put(MINUTE_TO, minuteTo);
+        }
+        parameters.put(BATCH_SIZE, batchSize);
+
+        return getDbEntityManager()
+                .deletePreserveOrder(AttachmentEntity.class, "deleteAttachmentsByRemovalTime",
+                        new ListQueryParameterObject(parameters, 0, batchSize));
+    }
 
 }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/AuthorizationManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/AuthorizationManager.java
@@ -16,37 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import static org.operaton.bpm.engine.authorization.Permissions.CREATE;
-import static org.operaton.bpm.engine.authorization.Permissions.DELETE;
-import static org.operaton.bpm.engine.authorization.Permissions.READ;
-import static org.operaton.bpm.engine.authorization.Permissions.READ_HISTORY;
-import static org.operaton.bpm.engine.authorization.Permissions.READ_INSTANCE;
-import static org.operaton.bpm.engine.authorization.Permissions.READ_TASK;
-import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
-import static org.operaton.bpm.engine.authorization.Permissions.UPDATE_INSTANCE;
-import static org.operaton.bpm.engine.authorization.ProcessDefinitionPermissions.READ_INSTANCE_VARIABLE;
-import static org.operaton.bpm.engine.authorization.Resources.AUTHORIZATION;
-import static org.operaton.bpm.engine.authorization.Resources.BATCH;
-import static org.operaton.bpm.engine.authorization.Resources.DECISION_DEFINITION;
-import static org.operaton.bpm.engine.authorization.Resources.DECISION_REQUIREMENTS_DEFINITION;
-import static org.operaton.bpm.engine.authorization.Resources.DEPLOYMENT;
-import static org.operaton.bpm.engine.authorization.Resources.HISTORIC_PROCESS_INSTANCE;
-import static org.operaton.bpm.engine.authorization.Resources.HISTORIC_TASK;
-import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
-import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
-import static org.operaton.bpm.engine.authorization.Resources.TASK;
-import static org.operaton.bpm.engine.authorization.TaskPermissions.READ_VARIABLE;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Consumer;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.authorization.Authorization;
@@ -105,6 +74,38 @@ import org.operaton.bpm.engine.impl.persistence.AbstractManager;
 import org.operaton.bpm.engine.impl.persistence.entity.util.AuthManagerUtil;
 import org.operaton.bpm.engine.impl.persistence.entity.util.AuthManagerUtil.VariablePermissions;
 import org.operaton.bpm.engine.impl.util.ResourceTypeUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static org.operaton.bpm.engine.authorization.Permissions.CREATE;
+import static org.operaton.bpm.engine.authorization.Permissions.DELETE;
+import static org.operaton.bpm.engine.authorization.Permissions.READ;
+import static org.operaton.bpm.engine.authorization.Permissions.READ_HISTORY;
+import static org.operaton.bpm.engine.authorization.Permissions.READ_INSTANCE;
+import static org.operaton.bpm.engine.authorization.Permissions.READ_TASK;
+import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
+import static org.operaton.bpm.engine.authorization.Permissions.UPDATE_INSTANCE;
+import static org.operaton.bpm.engine.authorization.ProcessDefinitionPermissions.READ_INSTANCE_VARIABLE;
+import static org.operaton.bpm.engine.authorization.Resources.AUTHORIZATION;
+import static org.operaton.bpm.engine.authorization.Resources.BATCH;
+import static org.operaton.bpm.engine.authorization.Resources.DECISION_DEFINITION;
+import static org.operaton.bpm.engine.authorization.Resources.DECISION_REQUIREMENTS_DEFINITION;
+import static org.operaton.bpm.engine.authorization.Resources.DEPLOYMENT;
+import static org.operaton.bpm.engine.authorization.Resources.HISTORIC_PROCESS_INSTANCE;
+import static org.operaton.bpm.engine.authorization.Resources.HISTORIC_TASK;
+import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
+import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
+import static org.operaton.bpm.engine.authorization.Resources.TASK;
+import static org.operaton.bpm.engine.authorization.TaskPermissions.READ_VARIABLE;
 
 /**
  * @author Daniel Meyer
@@ -1169,9 +1170,9 @@ public class AuthorizationManager extends AbstractManager {
   public DbOperation addRemovalTimeToAuthorizationsByRootProcessInstanceId(String rootProcessInstanceId,
                                                                     Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(ROOT_PROCESS_INSTANCE_ID, rootProcessInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
         .updatePreserveOrder(AuthorizationEntity.class,
@@ -1181,9 +1182,9 @@ public class AuthorizationManager extends AbstractManager {
   public DbOperation addRemovalTimeToAuthorizationsByProcessInstanceId(String processInstanceId,
                                                                 Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
         .updatePreserveOrder(AuthorizationEntity.class,
@@ -1193,12 +1194,12 @@ public class AuthorizationManager extends AbstractManager {
   public DbOperation deleteAuthorizationsByRemovalTime(Date removalTime, int minuteFrom,
                                                       int minuteTo, int batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("removalTime", removalTime);
+    parameters.put(REMOVAL_TIME, removalTime);
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
-    parameters.put("batchSize", batchSize);
+    parameters.put(BATCH_SIZE, batchSize);
 
     return getDbEntityManager()
         .deletePreserveOrder(AuthorizationEntity.class, "deleteAuthorizationsByRemovalTime",

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/BatchManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/BatchManager.java
@@ -16,16 +16,16 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.operaton.bpm.engine.batch.Batch;
 import org.operaton.bpm.engine.impl.Page;
 import org.operaton.bpm.engine.impl.batch.BatchEntity;
 import org.operaton.bpm.engine.impl.batch.BatchQueryImpl;
 import org.operaton.bpm.engine.impl.db.ListQueryParameterObject;
 import org.operaton.bpm.engine.impl.persistence.AbstractManager;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class BatchManager extends AbstractManager {
 
@@ -51,8 +51,8 @@ public class BatchManager extends AbstractManager {
 
   public void updateBatchSuspensionStateById(String batchId, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("batchId", batchId);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(BATCH_ID, batchId);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
 
     ListQueryParameterObject queryParameter = new ListQueryParameterObject();
     queryParameter.setParameter(parameters);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ByteArrayManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ByteArrayManager.java
@@ -16,15 +16,16 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
+import org.operaton.bpm.engine.impl.db.ListQueryParameterObject;
+import org.operaton.bpm.engine.impl.db.entitymanager.operation.DbOperation;
+import org.operaton.bpm.engine.impl.persistence.AbstractManager;
+import org.operaton.bpm.engine.impl.util.ClockUtil;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.operaton.bpm.engine.impl.db.ListQueryParameterObject;
-import org.operaton.bpm.engine.impl.db.entitymanager.operation.DbOperation;
-import org.operaton.bpm.engine.impl.persistence.AbstractManager;
-import org.operaton.bpm.engine.impl.util.ClockUtil;
 
 /**
  * @author Joram Barrez
@@ -48,9 +49,9 @@ public class ByteArrayManager extends AbstractManager {
 
   public DbOperation addRemovalTimeToByteArraysByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(ROOT_PROCESS_INSTANCE_ID, rootProcessInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(ByteArrayEntity.class, "updateByteArraysByRootProcessInstanceId", parameters);
@@ -58,9 +59,9 @@ public class ByteArrayManager extends AbstractManager {
 
   public List<DbOperation> addRemovalTimeToByteArraysByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     // Make individual statements for each entity type that references byte arrays.
     // This can lead to query plans that involve less aggressive locking by databases (e.g. DB2).
@@ -83,12 +84,12 @@ public class ByteArrayManager extends AbstractManager {
 
   public DbOperation deleteByteArraysByRemovalTime(Date removalTime, int minuteFrom, int minuteTo, int batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("removalTime", removalTime);
+    parameters.put(REMOVAL_TIME, removalTime);
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
-    parameters.put("batchSize", batchSize);
+    parameters.put(BATCH_SIZE, batchSize);
 
     return getDbEntityManager()
       .deletePreserveOrder(ByteArrayEntity.class, "deleteByteArraysByRemovalTime",

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/CommentManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/CommentManager.java
@@ -16,10 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.operaton.bpm.engine.impl.Direction;
 import org.operaton.bpm.engine.impl.QueryOrderingProperty;
 import org.operaton.bpm.engine.impl.QueryPropertyImpl;
@@ -30,11 +26,16 @@ import org.operaton.bpm.engine.impl.persistence.AbstractHistoricManager;
 import org.operaton.bpm.engine.task.Comment;
 import org.operaton.bpm.engine.task.Event;
 
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Tom Baeyens
  */
 public class CommentManager extends AbstractHistoricManager {
+
 
   @Override
   public void delete(DbEntity dbEntity) {
@@ -72,19 +73,19 @@ public class CommentManager extends AbstractHistoricManager {
 
   public void deleteCommentsByProcessInstanceIds(List<String> processInstanceIds) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceIds", processInstanceIds);
+    parameters.put(PROCESS_INSTANCE_IDS, processInstanceIds);
     deleteComments(parameters);
   }
 
   public void deleteCommentsByTaskProcessInstanceIds(List<String> processInstanceIds) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("taskProcessInstanceIds", processInstanceIds);
+    parameters.put(TASK_PROCESS_INSTANCE_IDS, processInstanceIds);
     deleteComments(parameters);
   }
 
   public void deleteCommentsByTaskCaseInstanceIds(List<String> caseInstanceIds) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("taskCaseInstanceIds", caseInstanceIds);
+    parameters.put(TASK_CASE_INSTANCE_IDS, caseInstanceIds);
     deleteComments(parameters);
   }
 
@@ -102,8 +103,8 @@ public class CommentManager extends AbstractHistoricManager {
     checkHistoryEnabled();
 
     Map<String, String> parameters = new HashMap<>();
-    parameters.put("taskId", taskId);
-    parameters.put("id", commentId);
+    parameters.put(TASK_ID, taskId);
+    parameters.put(ID, commentId);
 
     return (CommentEntity) getDbEntityManager().selectOne("selectCommentByTaskIdAndCommentId", parameters);
   }
@@ -112,17 +113,17 @@ public class CommentManager extends AbstractHistoricManager {
     checkHistoryEnabled();
 
     Map<String, String> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("id", commentId);
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(ID, commentId);
 
     return (CommentEntity) getDbEntityManager().selectOne("selectCommentByProcessInstanceIdAndCommentId", parameters);
   }
 
   public DbOperation addRemovalTimeToCommentsByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(ROOT_PROCESS_INSTANCE_ID, rootProcessInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(CommentEntity.class, "updateCommentsByRootProcessInstanceId", parameters);
@@ -130,9 +131,9 @@ public class CommentManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToCommentsByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(CommentEntity.class, "updateCommentsByProcessInstanceId", parameters);
@@ -140,12 +141,12 @@ public class CommentManager extends AbstractHistoricManager {
 
   public DbOperation deleteCommentsByRemovalTime(Date removalTime, int minuteFrom, int minuteTo, int batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("removalTime", removalTime);
+    parameters.put(REMOVAL_TIME, removalTime);
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
-    parameters.put("batchSize", batchSize);
+    parameters.put(BATCH_SIZE, batchSize);
 
     return getDbEntityManager()
       .deletePreserveOrder(CommentEntity.class, "deleteCommentsByRemovalTime",

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/EventSubscriptionManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/EventSubscriptionManager.java
@@ -16,13 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.operaton.bpm.engine.impl.EventSubscriptionQueryImpl;
 import org.operaton.bpm.engine.impl.Page;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
@@ -34,11 +27,18 @@ import org.operaton.bpm.engine.impl.persistence.AbstractManager;
 import org.operaton.bpm.engine.runtime.EventSubscription;
 import org.operaton.commons.utils.EnsureUtil;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Daniel Meyer
  */
 public class EventSubscriptionManager extends AbstractManager {
+  private static final String MESSAGE_NAME = "messageName";
 
   protected static final EnginePersistenceLogger LOG = ProcessEngineLogger.PERSISTENCE_LOGGER;
 
@@ -285,8 +285,8 @@ public class EventSubscriptionManager extends AbstractManager {
    */
   public EventSubscriptionEntity findMessageStartEventSubscriptionByNameAndTenantId(String messageName, String tenantId) {
     Map<String, String> parameters = new HashMap<>();
-    parameters.put("messageName", messageName);
-    parameters.put("tenantId", tenantId);
+    parameters.put(MESSAGE_NAME, messageName);
+    parameters.put(TENANT_ID, tenantId);
 
     return (EventSubscriptionEntity) getDbEntityManager().selectOne("selectMessageStartEventSubscriptionByNameAndTenantId", parameters);
   }
@@ -299,7 +299,7 @@ public class EventSubscriptionManager extends AbstractManager {
   @SuppressWarnings("unchecked")
   public List<EventSubscriptionEntity> findConditionalStartEventSubscriptionByTenantId(String tenantId) {
     Map<String, String> parameters = new HashMap<>();
-    parameters.put("tenantId", tenantId);
+    parameters.put(TENANT_ID, tenantId);
 
     configureParameterizedQuery(parameters);
     return getDbEntityManager().selectList("selectConditionalStartEventSubscriptionByTenantId", parameters);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionManager.java
@@ -16,11 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.operaton.bpm.engine.authorization.Resources;
 import org.operaton.bpm.engine.impl.AbstractQuery;
 import org.operaton.bpm.engine.impl.ExecutionQueryImpl;
@@ -35,6 +30,10 @@ import org.operaton.bpm.engine.impl.util.ImmutablePair;
 import org.operaton.bpm.engine.runtime.Execution;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Tom Baeyens
@@ -42,6 +41,7 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
 public class ExecutionManager extends AbstractManager {
 
   protected static final EnginePersistenceLogger LOG = ProcessEngineLogger.PERSISTENCE_LOGGER;
+  private static final String PARENT_EXECUTION_ID = "parentExecutionId";
 
   public void insertExecution(ExecutionEntity execution) {
     getDbEntityManager().insert(execution);
@@ -154,8 +154,8 @@ public class ExecutionManager extends AbstractManager {
   @SuppressWarnings("unchecked")
   public List<ExecutionEntity> findEventScopeExecutionsByActivityId(String activityRef, String parentExecutionId) {
     Map<String, String> parameters = new HashMap<>();
-    parameters.put("activityId", activityRef);
-    parameters.put("parentExecutionId", parentExecutionId);
+    parameters.put(ACTIVITY_ID, activityRef);
+    parameters.put(PARENT_EXECUTION_ID, parentExecutionId);
     return getDbEntityManager().selectList("selectExecutionsByParentExecutionId", parameters);
   }
 
@@ -175,32 +175,32 @@ public class ExecutionManager extends AbstractManager {
 
   public void updateExecutionSuspensionStateByProcessDefinitionId(String processDefinitionId, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processDefinitionId", processDefinitionId);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_DEFINITION_ID, processDefinitionId);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(ExecutionEntity.class, "updateExecutionSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 
   public void updateExecutionSuspensionStateByProcessInstanceId(String processInstanceId, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(ExecutionEntity.class, "updateExecutionSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 
   public void updateExecutionSuspensionStateByProcessDefinitionKey(String processDefinitionKey, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processDefinitionKey", processDefinitionKey);
-    parameters.put("isTenantIdSet", false);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_DEFINITION_KEY, processDefinitionKey);
+    parameters.put(IS_TENANT_ID_SET, false);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(ExecutionEntity.class, "updateExecutionSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 
   public void updateExecutionSuspensionStateByProcessDefinitionKeyAndTenantId(String processDefinitionKey, String tenantId, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processDefinitionKey", processDefinitionKey);
-    parameters.put("isTenantIdSet", true);
-    parameters.put("tenantId", tenantId);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_DEFINITION_KEY, processDefinitionKey);
+    parameters.put(IS_TENANT_ID_SET, true);
+    parameters.put(TENANT_ID, tenantId);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(ExecutionEntity.class, "updateExecutionSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExternalTaskManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExternalTaskManager.java
@@ -16,15 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import static org.operaton.bpm.engine.impl.ExternalTaskQueryProperty.CREATE_TIME;
-import static org.operaton.bpm.engine.impl.db.sql.DbSqlSessionFactory.POSTGRES;
-import static org.operaton.bpm.engine.impl.util.DatabaseUtil.checkDatabaseType;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.operaton.bpm.engine.externaltask.ExternalTask;
 import org.operaton.bpm.engine.impl.ExternalTaskQueryImpl;
 import org.operaton.bpm.engine.impl.ProcessEngineImpl;
@@ -37,6 +28,16 @@ import org.operaton.bpm.engine.impl.externaltask.TopicFetchInstruction;
 import org.operaton.bpm.engine.impl.persistence.AbstractManager;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.engine.impl.util.ImmutablePair;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.operaton.bpm.engine.impl.ExternalTaskQueryProperty.CREATE_TIME;
+import static org.operaton.bpm.engine.impl.db.sql.DbSqlSessionFactory.POSTGRES;
+import static org.operaton.bpm.engine.impl.util.DatabaseUtil.checkDatabaseType;
 
 /**
  * @author Thorben Lindhauer
@@ -126,11 +127,11 @@ public class ExternalTaskManager extends AbstractManager {
                                                    String processDefinitionKey,
                                                    SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("processDefinitionId", processDefinitionId);
-    parameters.put("processDefinitionKey", processDefinitionKey);
-    parameters.put("isProcessDefinitionTenantIdSet", false);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(PROCESS_DEFINITION_ID, processDefinitionId);
+    parameters.put(PROCESS_DEFINITION_KEY, processDefinitionKey);
+    parameters.put(IS_PROCESS_DEFINITION_TENANT_ID_SET, false);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(ExternalTaskEntity.class, "updateExternalTaskSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 
@@ -148,10 +149,10 @@ public class ExternalTaskManager extends AbstractManager {
 
   public void updateExternalTaskSuspensionStateByProcessDefinitionKeyAndTenantId(String processDefinitionKey, String processDefinitionTenantId, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processDefinitionKey", processDefinitionKey);
-    parameters.put("isProcessDefinitionTenantIdSet", true);
-    parameters.put("processDefinitionTenantId", processDefinitionTenantId);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_DEFINITION_KEY, processDefinitionKey);
+    parameters.put(IS_PROCESS_DEFINITION_TENANT_ID_SET, true);
+    parameters.put(PROCESS_DEFINITION_TENANT_ID, processDefinitionTenantId);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(ExternalTaskEntity.class, "updateExternalTaskSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricActivityInstanceManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricActivityInstanceManager.java
@@ -16,10 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.operaton.bpm.engine.history.HistoricActivityInstance;
 import org.operaton.bpm.engine.impl.HistoricActivityInstanceQueryImpl;
 import org.operaton.bpm.engine.impl.Page;
@@ -28,6 +24,10 @@ import org.operaton.bpm.engine.impl.db.entitymanager.operation.DbOperation;
 import org.operaton.bpm.engine.impl.history.event.HistoricActivityInstanceEventEntity;
 import org.operaton.bpm.engine.impl.persistence.AbstractHistoricManager;
 
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Tom Baeyens
@@ -44,8 +44,8 @@ public class HistoricActivityInstanceManager extends AbstractHistoricManager {
 
   public HistoricActivityInstanceEntity findHistoricActivityInstance(String activityId, String processInstanceId) {
     Map<String, String> parameters = new HashMap<>();
-    parameters.put("activityId", activityId);
-    parameters.put("processInstanceId", processInstanceId);
+    parameters.put(ACTIVITY_ID, activityId);
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
 
     return (HistoricActivityInstanceEntity) getDbEntityManager().selectOne("selectHistoricActivityInstance", parameters);
   }
@@ -77,9 +77,9 @@ public class HistoricActivityInstanceManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToActivityInstancesByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(ROOT_PROCESS_INSTANCE_ID, rootProcessInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricActivityInstanceEventEntity.class, "updateHistoricActivityInstancesByRootProcessInstanceId", parameters);
@@ -87,9 +87,9 @@ public class HistoricActivityInstanceManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToActivityInstancesByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricActivityInstanceEventEntity.class, "updateHistoricActivityInstancesByProcessInstanceId", parameters);
@@ -97,12 +97,12 @@ public class HistoricActivityInstanceManager extends AbstractHistoricManager {
 
   public DbOperation deleteHistoricActivityInstancesByRemovalTime(Date removalTime, int minuteFrom, int minuteTo, int batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("removalTime", removalTime);
+    parameters.put(REMOVAL_TIME, removalTime);
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
-    parameters.put("batchSize", batchSize);
+    parameters.put(BATCH_SIZE, batchSize);
 
     return getDbEntityManager()
       .deletePreserveOrder(HistoricActivityInstanceEntity.class, "deleteHistoricActivityInstancesByRemovalTime",

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricBatchManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricBatchManager.java
@@ -16,11 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.operaton.bpm.engine.batch.history.HistoricBatch;
 import org.operaton.bpm.engine.history.CleanableHistoricBatchReportResult;
 import org.operaton.bpm.engine.impl.CleanableHistoricBatchReportImpl;
@@ -44,7 +39,13 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.AbstractManager;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 public class HistoricBatchManager extends AbstractManager {
+  private static final String MAP = "map";
 
   public long findBatchCountByQueryCriteria(HistoricBatchQueryImpl historicBatchQuery) {
     configureQuery(historicBatchQuery);
@@ -68,11 +69,11 @@ public class HistoricBatchManager extends AbstractManager {
   @SuppressWarnings("unchecked")
   public List<String> findHistoricBatchIdsForCleanup(Integer batchSize, Map<String, Integer> batchOperationsForHistoryCleanup, int minuteFrom, int minuteTo) {
     Map<String, Object> queryParameters = new HashMap<>();
-    queryParameters.put("currentTimestamp", ClockUtil.getCurrentTime());
-    queryParameters.put("map", batchOperationsForHistoryCleanup);
+    queryParameters.put(CURRENT_TIMESTAMP, ClockUtil.getCurrentTime());
+    queryParameters.put(MAP, batchOperationsForHistoryCleanup);
     if (minuteTo - minuteFrom + 1 < 60) {
-      queryParameters.put("minuteFrom", minuteFrom);
-      queryParameters.put("minuteTo", minuteTo);
+      queryParameters.put(MINUTE_FROM, minuteFrom);
+      queryParameters.put(MINUTE_TO, minuteTo);
     }
     ListQueryParameterObject parameterObject = new ListQueryParameterObject(queryParameters, 0, batchSize);
     parameterObject.getOrderingProperties().add(new QueryOrderingProperty(new QueryPropertyImpl("END_TIME_"), Direction.ASCENDING));
@@ -168,12 +169,12 @@ public class HistoricBatchManager extends AbstractManager {
 
   public DbOperation deleteHistoricBatchesByRemovalTime(Date removalTime, int minuteFrom, int minuteTo, int batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("removalTime", removalTime);
+    parameters.put(REMOVAL_TIME, removalTime);
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
-    parameters.put("batchSize", batchSize);
+    parameters.put(BATCH_SIZE, batchSize);
 
     return getDbEntityManager()
       .deletePreserveOrder(HistoricBatchEntity.class, "deleteHistoricBatchesByRemovalTime",
@@ -190,8 +191,8 @@ public class HistoricBatchManager extends AbstractManager {
       .addRemovalTimeToJobLogByBatchId(id, removalTime);
 
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("id", id);
-    parameters.put("removalTime", removalTime);
+    parameters.put(ID, id);
+    parameters.put(REMOVAL_TIME, removalTime);
 
     getDbEntityManager()
       .updatePreserveOrder(HistoricBatchEntity.class, "updateHistoricBatchRemovalTimeById", parameters);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricCaseActivityInstanceManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricCaseActivityInstanceManager.java
@@ -16,20 +16,21 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.operaton.bpm.engine.history.HistoricCaseActivityInstance;
 import org.operaton.bpm.engine.impl.HistoricCaseActivityInstanceQueryImpl;
 import org.operaton.bpm.engine.impl.Page;
 import org.operaton.bpm.engine.impl.persistence.AbstractHistoricManager;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Sebastian Menski
  */
 public class HistoricCaseActivityInstanceManager extends AbstractHistoricManager {
+  private static final String CASE_ACTIVITY_ID = "caseActivityId";
+  private static final String CASE_INSTANCE_ID = "caseInstanceId";
 
   public void deleteHistoricCaseActivityInstancesByCaseInstanceIds(List<String> historicCaseInstanceIds) {
     if (isHistoryEnabled()) {
@@ -43,8 +44,8 @@ public class HistoricCaseActivityInstanceManager extends AbstractHistoricManager
 
   public HistoricCaseActivityInstanceEntity findHistoricCaseActivityInstance(String caseActivityId, String caseInstanceId) {
     Map<String, String> parameters = new HashMap<>();
-    parameters.put("caseActivityId", caseActivityId);
-    parameters.put("caseInstanceId", caseInstanceId);
+    parameters.put(CASE_ACTIVITY_ID, caseActivityId);
+    parameters.put(CASE_INSTANCE_ID, caseInstanceId);
 
     return (HistoricCaseActivityInstanceEntity) getDbEntityManager().selectOne("selectHistoricCaseActivityInstance", parameters);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricCaseInstanceManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricCaseInstanceManager.java
@@ -16,13 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.operaton.bpm.engine.history.HistoricCaseInstance;
 import org.operaton.bpm.engine.history.CleanableHistoricCaseInstanceReportResult;
+import org.operaton.bpm.engine.history.HistoricCaseInstance;
 import org.operaton.bpm.engine.impl.CleanableHistoricCaseInstanceReportImpl;
 import org.operaton.bpm.engine.impl.HistoricCaseInstanceQueryImpl;
 import org.operaton.bpm.engine.impl.Page;
@@ -31,6 +26,10 @@ import org.operaton.bpm.engine.impl.history.event.HistoricCaseInstanceEventEntit
 import org.operaton.bpm.engine.impl.persistence.AbstractHistoricManager;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Sebastian Menski
@@ -110,10 +109,10 @@ public class HistoricCaseInstanceManager extends AbstractHistoricManager {
   @SuppressWarnings("unchecked")
   public List<String> findHistoricCaseInstanceIdsForCleanup(int batchSize, int minuteFrom, int minuteTo) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("currentTimestamp", ClockUtil.getCurrentTime());
+    parameters.put(CURRENT_TIMESTAMP, ClockUtil.getCurrentTime());
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
     ListQueryParameterObject parameterObject = new ListQueryParameterObject(parameters, 0, batchSize);
     return getDbEntityManager().selectList("selectHistoricCaseInstanceIdsForCleanup", parameterObject);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricDetailManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricDetailManager.java
@@ -16,10 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.operaton.bpm.engine.history.HistoricDetail;
 import org.operaton.bpm.engine.impl.HistoricDetailQueryImpl;
 import org.operaton.bpm.engine.impl.Page;
@@ -28,38 +24,45 @@ import org.operaton.bpm.engine.impl.db.entitymanager.operation.DbOperation;
 import org.operaton.bpm.engine.impl.history.event.HistoricDetailEventEntity;
 import org.operaton.bpm.engine.impl.persistence.AbstractHistoricManager;
 
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * @author Tom Baeyens
  */
 public class HistoricDetailManager extends AbstractHistoricManager {
 
+  private static final String VARIABLE_INSTANCE_ID = "variableInstanceId";
+
   public void deleteHistoricDetailsByProcessInstanceIds(List<String> historicProcessInstanceIds) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceIds", historicProcessInstanceIds);
+    parameters.put(PROCESS_INSTANCE_IDS, historicProcessInstanceIds);
     deleteHistoricDetails(parameters);
   }
 
   public void deleteHistoricDetailsByTaskProcessInstanceIds(List<String> historicProcessInstanceIds) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("taskProcessInstanceIds", historicProcessInstanceIds);
+    parameters.put(TASK_PROCESS_INSTANCE_IDS, historicProcessInstanceIds);
     deleteHistoricDetails(parameters);
   }
 
   public void deleteHistoricDetailsByCaseInstanceIds(List<String> historicCaseInstanceIds) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("caseInstanceIds", historicCaseInstanceIds);
+    parameters.put(CASE_INSTANCE_IDS, historicCaseInstanceIds);
     deleteHistoricDetails(parameters);
   }
 
   public void deleteHistoricDetailsByTaskCaseInstanceIds(List<String> historicCaseInstanceIds) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("taskCaseInstanceIds", historicCaseInstanceIds);
+    parameters.put(TASK_CASE_INSTANCE_IDS, historicCaseInstanceIds);
     deleteHistoricDetails(parameters);
   }
 
   public void deleteHistoricDetailsByVariableInstanceId(String historicVariableInstanceId) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("variableInstanceId", historicVariableInstanceId);
+    parameters.put(VARIABLE_INSTANCE_ID, historicVariableInstanceId);
     deleteHistoricDetails(parameters);
   }
 
@@ -112,9 +115,9 @@ public class HistoricDetailManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToDetailsByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(ROOT_PROCESS_INSTANCE_ID, rootProcessInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricDetailEventEntity.class, "updateHistoricDetailsByRootProcessInstanceId", parameters);
@@ -122,9 +125,9 @@ public class HistoricDetailManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToDetailsByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricDetailEventEntity.class, "updateHistoricDetailsByProcessInstanceId", parameters);
@@ -132,12 +135,12 @@ public class HistoricDetailManager extends AbstractHistoricManager {
 
   public DbOperation deleteHistoricDetailsByRemovalTime(Date removalTime, int minuteFrom, int minuteTo, int batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("removalTime", removalTime);
+    parameters.put(REMOVAL_TIME, removalTime);
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
-    parameters.put("batchSize", batchSize);
+    parameters.put(BATCH_SIZE, batchSize);
 
     return getDbEntityManager()
       .deletePreserveOrder(HistoricDetailEventEntity.class, "deleteHistoricDetailsByRemovalTime",

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricExternalTaskLogManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricExternalTaskLogManager.java
@@ -16,10 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.operaton.bpm.engine.externaltask.ExternalTask;
 import org.operaton.bpm.engine.history.HistoricExternalTaskLog;
 import org.operaton.bpm.engine.impl.HistoricExternalTaskLogQueryImpl;
@@ -38,6 +34,10 @@ import org.operaton.bpm.engine.impl.history.producer.HistoryEventProducer;
 import org.operaton.bpm.engine.impl.persistence.AbstractManager;
 import org.operaton.bpm.engine.impl.util.EnsureUtil;
 
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class HistoricExternalTaskLogManager extends AbstractManager {
 
@@ -62,9 +62,9 @@ public class HistoricExternalTaskLogManager extends AbstractManager {
 
   public DbOperation addRemovalTimeToExternalTaskLogByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(ROOT_PROCESS_INSTANCE_ID, rootProcessInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricExternalTaskLogEntity.class, "updateExternalTaskLogByRootProcessInstanceId", parameters);
@@ -72,9 +72,9 @@ public class HistoricExternalTaskLogManager extends AbstractManager {
 
   public DbOperation addRemovalTimeToExternalTaskLogByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricExternalTaskLogEntity.class, "updateExternalTaskLogByProcessInstanceId", parameters);
@@ -89,12 +89,12 @@ public class HistoricExternalTaskLogManager extends AbstractManager {
 
   public DbOperation deleteExternalTaskLogByRemovalTime(Date removalTime, int minuteFrom, int minuteTo, int batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("removalTime", removalTime);
+    parameters.put(REMOVAL_TIME, removalTime);
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
-    parameters.put("batchSize", batchSize);
+    parameters.put(BATCH_SIZE, batchSize);
 
     return getDbEntityManager()
       .deletePreserveOrder(HistoricExternalTaskLogEntity.class, "deleteExternalTaskLogByRemovalTime",

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricIdentityLinkLogManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricIdentityLinkLogManager.java
@@ -16,10 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.operaton.bpm.engine.history.HistoricIdentityLinkLog;
 import org.operaton.bpm.engine.impl.HistoricIdentityLinkLogQueryImpl;
 import org.operaton.bpm.engine.impl.Page;
@@ -30,6 +26,11 @@ import org.operaton.bpm.engine.impl.history.HistoryLevel;
 import org.operaton.bpm.engine.impl.history.event.HistoricIdentityLinkLogEventEntity;
 import org.operaton.bpm.engine.impl.history.event.HistoryEventTypes;
 import org.operaton.bpm.engine.impl.persistence.AbstractHistoricManager;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Deivarayan Azhagappan
@@ -50,9 +51,9 @@ public class HistoricIdentityLinkLogManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToIdentityLinkLogByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(ROOT_PROCESS_INSTANCE_ID, rootProcessInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricIdentityLinkLogEventEntity.class, "updateIdentityLinkLogByRootProcessInstanceId", parameters);
@@ -60,9 +61,9 @@ public class HistoricIdentityLinkLogManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToIdentityLinkLogByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricIdentityLinkLogEventEntity.class, "updateIdentityLinkLogByProcessInstanceId", parameters);
@@ -90,12 +91,12 @@ public class HistoricIdentityLinkLogManager extends AbstractHistoricManager {
 
   public DbOperation deleteHistoricIdentityLinkLogByRemovalTime(Date removalTime, int minuteFrom, int minuteTo, int batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("removalTime", removalTime);
+    parameters.put(REMOVAL_TIME, removalTime);
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
-    parameters.put("batchSize", batchSize);
+    parameters.put(BATCH_SIZE, batchSize);
 
     return getDbEntityManager()
       .deletePreserveOrder(HistoricIdentityLinkLogEntity.class, "deleteHistoricIdentityLinkLogByRemovalTime",

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricIncidentManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricIncidentManager.java
@@ -16,10 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.operaton.bpm.engine.history.HistoricIncident;
 import org.operaton.bpm.engine.impl.HistoricIncidentQueryImpl;
 import org.operaton.bpm.engine.impl.Page;
@@ -30,6 +26,11 @@ import org.operaton.bpm.engine.impl.history.HistoryLevel;
 import org.operaton.bpm.engine.impl.history.event.HistoricIncidentEventEntity;
 import org.operaton.bpm.engine.impl.history.event.HistoryEventTypes;
 import org.operaton.bpm.engine.impl.persistence.AbstractHistoricManager;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Roman Smirnov
@@ -54,9 +55,9 @@ public class HistoricIncidentManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToIncidentsByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(ROOT_PROCESS_INSTANCE_ID, rootProcessInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricIncidentEventEntity.class, "updateHistoricIncidentsByRootProcessInstanceId", parameters);
@@ -64,9 +65,9 @@ public class HistoricIncidentManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToIncidentsByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricIncidentEventEntity.class, "updateHistoricIncidentsByProcessInstanceId", parameters);
@@ -109,12 +110,12 @@ public class HistoricIncidentManager extends AbstractHistoricManager {
 
   public DbOperation deleteHistoricIncidentsByRemovalTime(Date removalTime, int minuteFrom, int minuteTo, int batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("removalTime", removalTime);
+    parameters.put(REMOVAL_TIME, removalTime);
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
-    parameters.put("batchSize", batchSize);
+    parameters.put(BATCH_SIZE, batchSize);
 
     return getDbEntityManager()
       .deletePreserveOrder(HistoricIncidentEntity.class, "deleteHistoricIncidentsByRemovalTime",
@@ -123,8 +124,8 @@ public class HistoricIncidentManager extends AbstractHistoricManager {
 
   public void addRemovalTimeToHistoricIncidentsByBatchId(String batchId, Date removalTime) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("batchId", batchId);
-    parameters.put("removalTime", removalTime);
+    parameters.put(BATCH_ID, batchId);
+    parameters.put(REMOVAL_TIME, removalTime);
 
     getDbEntityManager()
       .updatePreserveOrder(HistoricIncidentEntity.class, "updateHistoricIncidentsByBatchId", parameters);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricJobLogManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricJobLogManager.java
@@ -16,10 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.operaton.bpm.engine.history.HistoricJobLog;
 import org.operaton.bpm.engine.impl.HistoricJobLogQueryImpl;
 import org.operaton.bpm.engine.impl.Page;
@@ -36,6 +32,11 @@ import org.operaton.bpm.engine.impl.history.producer.HistoryEventProducer;
 import org.operaton.bpm.engine.impl.persistence.AbstractHistoricManager;
 import org.operaton.bpm.engine.impl.util.EnsureUtil;
 import org.operaton.bpm.engine.runtime.Job;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author Roman Smirnov
@@ -69,9 +70,9 @@ public class HistoricJobLogManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToJobLogByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(ROOT_PROCESS_INSTANCE_ID, rootProcessInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricJobLogEventEntity.class, "updateJobLogByRootProcessInstanceId", parameters);
@@ -79,9 +80,9 @@ public class HistoricJobLogManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToJobLogByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricJobLogEventEntity.class, "updateJobLogByProcessInstanceId", parameters);
@@ -89,8 +90,8 @@ public class HistoricJobLogManager extends AbstractHistoricManager {
 
   public void addRemovalTimeToJobLogByBatchId(String batchId, Date removalTime) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("batchId", batchId);
-    parameters.put("removalTime", removalTime);
+    parameters.put(BATCH_ID, batchId);
+    parameters.put(REMOVAL_TIME, removalTime);
 
     getDbEntityManager()
       .updatePreserveOrder(HistoricJobLogEventEntity.class, "updateJobLogByBatchId", parameters);
@@ -157,12 +158,12 @@ public class HistoricJobLogManager extends AbstractHistoricManager {
 
   public DbOperation deleteJobLogByRemovalTime(Date removalTime, int minuteFrom, int minuteTo, int batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("removalTime", removalTime);
+    parameters.put(REMOVAL_TIME, removalTime);
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
-    parameters.put("batchSize", batchSize);
+    parameters.put(BATCH_SIZE, batchSize);
 
     return getDbEntityManager()
       .deletePreserveOrder(HistoricJobLogEventEntity.class, "deleteJobLogByRemovalTime",

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricProcessInstanceManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricProcessInstanceManager.java
@@ -16,12 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.operaton.bpm.engine.authorization.Resources;
 import org.operaton.bpm.engine.history.CleanableHistoricProcessInstanceReportResult;
 import org.operaton.bpm.engine.history.HistoricProcessInstance;
@@ -46,6 +40,13 @@ import org.operaton.bpm.engine.impl.persistence.AbstractHistoricManager;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.engine.impl.util.CollectionUtil;
 import org.operaton.bpm.engine.impl.util.ImmutablePair;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Tom Baeyens
@@ -130,10 +131,10 @@ public class HistoricProcessInstanceManager extends AbstractHistoricManager {
   @SuppressWarnings("unchecked")
   public List<String> findHistoricProcessInstanceIdsForCleanup(Integer batchSize, int minuteFrom, int minuteTo) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("currentTimestamp", ClockUtil.getCurrentTime());
+    parameters.put(CURRENT_TIMESTAMP, ClockUtil.getCurrentTime());
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
     ListQueryParameterObject parameterObject = new ListQueryParameterObject(parameters, 0, batchSize);
     return getDbEntityManager().selectList("selectHistoricProcessInstanceIdsForCleanup", parameterObject);
@@ -262,9 +263,9 @@ public class HistoricProcessInstanceManager extends AbstractHistoricManager {
     if (batchSize == null || isPerformUpdateOnly(entities, HistoricProcessInstanceEventEntity.class)) {
       // update process instance last if updated in batches to avoid orphans
       Map<String, Object> parameters = new HashMap<>();
-      parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-      parameters.put("removalTime", removalTime);
-      parameters.put("maxResults", batchSize);
+      parameters.put(ROOT_PROCESS_INSTANCE_ID, rootProcessInstanceId);
+      parameters.put(REMOVAL_TIME, removalTime);
+      parameters.put(MAX_RESULTS, batchSize);
 
       addOperation(getDbEntityManager().updatePreserveOrder(HistoricProcessInstanceEventEntity.class,
           "updateHistoricProcessInstanceEventsByRootProcessInstanceId", parameters), updateOperations);
@@ -362,9 +363,9 @@ public class HistoricProcessInstanceManager extends AbstractHistoricManager {
     if (batchSize == null || isPerformUpdateOnly(entities, HistoricProcessInstanceEventEntity.class)) {
       // update process instance last if updated in batches to avoid orphans
       Map<String, Object> parameters = new HashMap<>();
-      parameters.put("processInstanceId", processInstanceId);
-      parameters.put("removalTime", removalTime);
-      parameters.put("maxResults", batchSize);
+      parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+      parameters.put(REMOVAL_TIME, removalTime);
+      parameters.put(MAX_RESULTS, batchSize);
 
       addOperation(getDbEntityManager().updatePreserveOrder(HistoricProcessInstanceEventEntity.class,
           "updateHistoricProcessInstanceByProcessInstanceId", parameters), updateOperations);
@@ -444,12 +445,12 @@ public class HistoricProcessInstanceManager extends AbstractHistoricManager {
     deleteOperations.put(deleteAuthorizations.getEntityType(), deleteAuthorizations);
 
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("removalTime", removalTime);
+    parameters.put(REMOVAL_TIME, removalTime);
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
-    parameters.put("batchSize", batchSize);
+    parameters.put(BATCH_SIZE, batchSize);
 
     DbOperation deleteProcessInstances = getDbEntityManager()
       .deletePreserveOrder(HistoricProcessInstanceEntity.class, "deleteHistoricProcessInstancesByRemovalTime",

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricTaskInstanceManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricTaskInstanceManager.java
@@ -16,13 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
-
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.operaton.bpm.engine.authorization.Resources;
 import org.operaton.bpm.engine.history.HistoricTaskInstance;
 import org.operaton.bpm.engine.impl.HistoricTaskInstanceQueryImpl;
@@ -39,6 +32,14 @@ import org.operaton.bpm.engine.impl.history.event.HistoryEventTypes;
 import org.operaton.bpm.engine.impl.history.producer.HistoryEventProducer;
 import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.AbstractHistoricManager;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 
 /**
@@ -185,9 +186,9 @@ public class HistoricTaskInstanceManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToTaskInstancesByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(ROOT_PROCESS_INSTANCE_ID, rootProcessInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricTaskInstanceEventEntity.class, "updateHistoricTaskInstancesByRootProcessInstanceId", parameters);
@@ -195,9 +196,9 @@ public class HistoricTaskInstanceManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToTaskInstancesByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricTaskInstanceEventEntity.class, "updateHistoricTaskInstancesByProcessInstanceId", parameters);
@@ -246,12 +247,12 @@ public class HistoricTaskInstanceManager extends AbstractHistoricManager {
 
   public DbOperation deleteHistoricTaskInstancesByRemovalTime(Date removalTime, int minuteFrom, int minuteTo, int batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("removalTime", removalTime);
+    parameters.put(REMOVAL_TIME, removalTime);
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
-    parameters.put("batchSize", batchSize);
+    parameters.put(BATCH_SIZE, batchSize);
 
     return getDbEntityManager()
       .deletePreserveOrder(HistoricTaskInstanceEntity.class, "deleteHistoricTaskInstancesByRemovalTime",

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricVariableInstanceManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricVariableInstanceManager.java
@@ -16,12 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureOnlyOneNotNull;
-
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.operaton.bpm.engine.history.HistoricVariableInstance;
 import org.operaton.bpm.engine.history.HistoricVariableInstanceQuery;
 import org.operaton.bpm.engine.impl.HistoricVariableInstanceQueryImpl;
@@ -29,6 +23,13 @@ import org.operaton.bpm.engine.impl.Page;
 import org.operaton.bpm.engine.impl.db.ListQueryParameterObject;
 import org.operaton.bpm.engine.impl.db.entitymanager.operation.DbOperation;
 import org.operaton.bpm.engine.impl.persistence.AbstractHistoricManager;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureOnlyOneNotNull;
 
 
 /**
@@ -47,13 +48,13 @@ public class HistoricVariableInstanceManager extends AbstractHistoricManager {
 
   public void deleteHistoricVariableInstanceByProcessInstanceIds(List<String> historicProcessInstanceIds) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceIds", historicProcessInstanceIds);
+    parameters.put(PROCESS_INSTANCE_IDS, historicProcessInstanceIds);
     deleteHistoricVariableInstances(parameters);
   }
 
   public void deleteHistoricVariableInstancesByTaskProcessInstanceIds(List<String> historicProcessInstanceIds) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("taskProcessInstanceIds", historicProcessInstanceIds);
+    parameters.put(TASK_PROCESS_INSTANCE_IDS, historicProcessInstanceIds);
     deleteHistoricVariableInstances(parameters);
   }
 
@@ -63,7 +64,7 @@ public class HistoricVariableInstanceManager extends AbstractHistoricManager {
 
   public void deleteHistoricVariableInstancesByCaseInstanceIds(List<String> historicCaseInstanceIds) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("caseInstanceIds", historicCaseInstanceIds);
+    parameters.put(CASE_INSTANCE_IDS, historicCaseInstanceIds);
     deleteHistoricVariableInstances(parameters);
   }
 
@@ -138,9 +139,9 @@ public class HistoricVariableInstanceManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToVariableInstancesByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(ROOT_PROCESS_INSTANCE_ID, rootProcessInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricVariableInstanceEntity.class, "updateHistoricVariableInstancesByRootProcessInstanceId", parameters);
@@ -148,9 +149,9 @@ public class HistoricVariableInstanceManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToVariableInstancesByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(HistoricVariableInstanceEntity.class, "updateHistoricVariableInstancesByProcessInstanceId", parameters);
@@ -173,12 +174,12 @@ public class HistoricVariableInstanceManager extends AbstractHistoricManager {
 
   public DbOperation deleteHistoricVariableInstancesByRemovalTime(Date removalTime, int minuteFrom, int minuteTo, int batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("removalTime", removalTime);
+    parameters.put(REMOVAL_TIME, removalTime);
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
-    parameters.put("batchSize", batchSize);
+    parameters.put(BATCH_SIZE, batchSize);
 
     return getDbEntityManager()
       .deletePreserveOrder(HistoricVariableInstanceEntity.class, "deleteHistoricVariableInstancesByRemovalTime",

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/IdentityInfoManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/IdentityInfoManager.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
+import org.operaton.bpm.engine.impl.persistence.AbstractManager;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -23,13 +25,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.operaton.bpm.engine.impl.persistence.AbstractManager;
-
-
 /**
  * @author Tom Baeyens
  */
 public class IdentityInfoManager extends AbstractManager {
+  private static final String USER_ID = "userId";
+  private static final String KEY = "key";
+  private static final String TYPE = "type";
 
   public void deleteUserInfoByUserIdAndKey(String userId, String key) {
     IdentityInfoEntity identityInfoEntity = findUserInfoByUserIdAndKey(userId, key);
@@ -144,16 +146,16 @@ public class IdentityInfoManager extends AbstractManager {
 
   public IdentityInfoEntity findUserInfoByUserIdAndKey(String userId, String key) {
     Map<String, String> parameters = new HashMap<>();
-    parameters.put("userId", userId);
-    parameters.put("key", key);
+    parameters.put(USER_ID, userId);
+    parameters.put(KEY, key);
     return (IdentityInfoEntity) getDbEntityManager().selectOne("selectIdentityInfoByUserIdAndKey", parameters);
   }
 
   @SuppressWarnings("unchecked")
   public List<String> findUserInfoKeysByUserIdAndType(String userId, String type) {
     Map<String, String> parameters = new HashMap<>();
-    parameters.put("userId", userId);
-    parameters.put("type", type);
+    parameters.put(USER_ID, userId);
+    parameters.put(TYPE, type);
     return getDbEntityManager().selectList("selectIdentityInfoKeysByUserIdAndType", parameters);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/IdentityLinkManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/IdentityLinkManager.java
@@ -16,18 +16,21 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
+import org.operaton.bpm.engine.impl.persistence.AbstractManager;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.operaton.bpm.engine.impl.persistence.AbstractManager;
-
 
 /**
  * @author Tom Baeyens
  * @author Saeid Mirzaei
  */
 public class IdentityLinkManager extends AbstractManager {
+  private static final String GROUP_ID = "groupId";
+  private static final String USER_ID = "userId";
+  private static final String TYPE = "type";
+
 
   @SuppressWarnings("unchecked")
   public List<IdentityLinkEntity> findIdentityLinksByTaskId(String taskId) {
@@ -42,19 +45,19 @@ public class IdentityLinkManager extends AbstractManager {
   @SuppressWarnings("unchecked")
   public List<IdentityLinkEntity> findIdentityLinkByTaskUserGroupAndType(String taskId, String userId, String groupId, String type) {
     Map<String, String> parameters = new HashMap<>();
-    parameters.put("taskId", taskId);
-    parameters.put("userId", userId);
-    parameters.put("groupId", groupId);
-    parameters.put("type", type);
+    parameters.put(TASK_ID, taskId);
+    parameters.put(USER_ID, userId);
+    parameters.put(GROUP_ID, groupId);
+    parameters.put(TYPE, type);
     return getDbEntityManager().selectList("selectIdentityLinkByTaskUserGroupAndType", parameters);
   }
 
   @SuppressWarnings("unchecked")
   public List<IdentityLinkEntity> findIdentityLinkByProcessDefinitionUserAndGroup(String processDefinitionId, String userId, String groupId) {
     Map<String, String> parameters = new HashMap<>();
-    parameters.put("processDefinitionId", processDefinitionId);
-    parameters.put("userId", userId);
-    parameters.put("groupId", groupId);
+    parameters.put(PROCESS_DEFINITION_ID, processDefinitionId);
+    parameters.put(USER_ID, userId);
+    parameters.put(GROUP_ID, groupId);
     return getDbEntityManager().selectList("selectIdentityLinkByProcessDefinitionUserAndGroup", parameters);
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/JobDefinitionManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/JobDefinitionManager.java
@@ -16,15 +16,15 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.operaton.bpm.engine.impl.JobDefinitionQueryImpl;
 import org.operaton.bpm.engine.impl.Page;
 import org.operaton.bpm.engine.impl.db.ListQueryParameterObject;
 import org.operaton.bpm.engine.impl.persistence.AbstractManager;
 import org.operaton.bpm.engine.management.JobDefinition;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * <p>Manager implementation for {@link JobDefinitionEntity}</p>
@@ -33,6 +33,7 @@ import org.operaton.bpm.engine.management.JobDefinition;
  *
  */
 public class JobDefinitionManager extends AbstractManager {
+
 
   public JobDefinitionEntity findById(String jobDefinitionId) {
     return getDbEntityManager().selectById(JobDefinitionEntity.class, jobDefinitionId);
@@ -60,32 +61,32 @@ public class JobDefinitionManager extends AbstractManager {
 
   public void updateJobDefinitionSuspensionStateById(String jobDefinitionId, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("jobDefinitionId", jobDefinitionId);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(JOB_DEFINITION_ID, jobDefinitionId);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(JobDefinitionEntity.class, "updateJobDefinitionSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 
   public void updateJobDefinitionSuspensionStateByProcessDefinitionId(String processDefinitionId, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processDefinitionId", processDefinitionId);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_DEFINITION_ID, processDefinitionId);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(JobDefinitionEntity.class, "updateJobDefinitionSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 
   public void updateJobDefinitionSuspensionStateByProcessDefinitionKey(String processDefinitionKey, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processDefinitionKey", processDefinitionKey);
-    parameters.put("isProcessDefinitionTenantIdSet", false);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_DEFINITION_KEY, processDefinitionKey);
+    parameters.put(IS_PROCESS_DEFINITION_TENANT_ID_SET, false);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(JobDefinitionEntity.class, "updateJobDefinitionSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 
   public void updateJobDefinitionSuspensionStateByProcessDefinitionKeyAndTenantId(String processDefinitionKey, String processDefinitionTenantId, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processDefinitionKey", processDefinitionKey);
-    parameters.put("isProcessDefinitionTenantIdSet", true);
-    parameters.put("processDefinitionTenantId", processDefinitionTenantId);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_DEFINITION_KEY, processDefinitionKey);
+    parameters.put(IS_PROCESS_DEFINITION_TENANT_ID_SET, true);
+    parameters.put(PROCESS_DEFINITION_TENANT_ID, processDefinitionTenantId);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(JobDefinitionEntity.class, "updateJobDefinitionSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/MeterLogManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/MeterLogManager.java
@@ -16,15 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.operaton.bpm.engine.impl.Direction;
 import org.operaton.bpm.engine.impl.QueryOrderingProperty;
 import org.operaton.bpm.engine.impl.QueryPropertyImpl;
@@ -36,6 +27,15 @@ import org.operaton.bpm.engine.impl.metrics.MetricsQueryImpl;
 import org.operaton.bpm.engine.impl.persistence.AbstractManager;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.engine.management.MetricIntervalValue;
+
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Daniel Meyer
@@ -53,6 +53,10 @@ public class MeterLogManager extends AbstractManager {
   public static final String DELETE_TASK_METER_BY_TIMESTAMP = "deleteTaskMeterLogEntriesByTimestamp";
   public static final String DELETE_TASK_METER_BY_REMOVAL_TIME = "deleteTaskMetricsByRemovalTime";
   public static final String DELETE_TASK_METER_BY_IDS = "deleteTaskMeterLogEntriesByIds";
+  private static final String START_TIME = "startTime";
+  private static final String END_TIME = "endTime";
+  private static final String REPORTER = "reporter";
+  private static final String MILLISECONDS = "milliseconds";
 
   public void insert(MeterLogEntity meterLogEntity) {
     getDbEntityManager()
@@ -130,9 +134,9 @@ public class MeterLogManager extends AbstractManager {
   public void deleteByTimestampAndReporter(Date timestamp, String reporter) {
     Map<String, Object> parameters = new HashMap<>();
     if (timestamp != null) {
-      parameters.put("milliseconds", timestamp.getTime());
+      parameters.put(MILLISECONDS, timestamp.getTime());
     }
-    parameters.put("reporter", reporter);
+    parameters.put(REPORTER, reporter);
     getDbEntityManager().delete(MeterLogEntity.class, DELETE_ALL_METER_BY_TIMESTAMP_AND_REPORTER, parameters);
   }
 
@@ -140,8 +144,8 @@ public class MeterLogManager extends AbstractManager {
 
   public long findUniqueTaskWorkerCount(Date startTime, Date endTime) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("startTime", startTime);
-    parameters.put("endTime", endTime);
+    parameters.put(START_TIME, startTime);
+    parameters.put(END_TIME, endTime);
 
     return (Long) getDbEntityManager().selectOne(SELECT_UNIQUE_TASK_WORKER, parameters);
   }
@@ -159,12 +163,12 @@ public class MeterLogManager extends AbstractManager {
     Map<String, Object> parameters = new HashMap<>();
     // data inserted prior to now minus timeToLive-days can be removed
     Date removalTime = Date.from(currentTimestamp.toInstant().minus(timeToLive, ChronoUnit.DAYS));
-    parameters.put("removalTime", removalTime);
+    parameters.put(REMOVAL_TIME, removalTime);
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
-    parameters.put("batchSize", batchSize);
+    parameters.put(BATCH_SIZE, batchSize);
 
     return getDbEntityManager()
       .deletePreserveOrder(TaskMeterLogEntity.class, DELETE_TASK_METER_BY_REMOVAL_TIME,
@@ -174,11 +178,11 @@ public class MeterLogManager extends AbstractManager {
   @SuppressWarnings("unchecked")
   public List<String> findTaskMetricsForCleanup(int batchSize, Integer timeToLive, int minuteFrom, int minuteTo) {
     Map<String, Object> queryParameters = new HashMap<>();
-    queryParameters.put("currentTimestamp", ClockUtil.getCurrentTime());
+    queryParameters.put(CURRENT_TIMESTAMP, ClockUtil.getCurrentTime());
     queryParameters.put("timeToLive", timeToLive);
     if (minuteTo - minuteFrom + 1 < 60) {
-      queryParameters.put("minuteFrom", minuteFrom);
-      queryParameters.put("minuteTo", minuteTo);
+      queryParameters.put(MINUTE_FROM, minuteFrom);
+      queryParameters.put(MINUTE_TO, minuteTo);
     }
     ListQueryParameterObject parameterObject = new ListQueryParameterObject(queryParameters, 0, batchSize);
     parameterObject.getOrderingProperties().add(new QueryOrderingProperty(new QueryPropertyImpl("TIMESTAMP_"), Direction.ASCENDING));

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ProcessDefinitionManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ProcessDefinitionManager.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-
 /**
  * @author Tom Baeyens
  * @author Falko Menge
@@ -46,6 +45,10 @@ import java.util.Set;
  * @author Christopher Zell
  */
 public class ProcessDefinitionManager extends AbstractManager implements AbstractResourceDefinitionManager<ProcessDefinitionEntity> {
+  private static final String DEPLOYMENT_ID = "deploymentId";
+  private static final String PROCESS_DEFINITION_IDS = "processDefinitionIds";
+  private static final String PROCESS_DEFINITION_VERSION = "processDefinitionVersion";
+  private static final String PROCESS_DEFINITION_VERSION_TAG = "processDefinitionVersionTag";
 
   protected static final EnginePersistenceLogger LOG = ProcessEngineLogger.PERSISTENCE_LOGGER;
 
@@ -98,8 +101,8 @@ public class ProcessDefinitionManager extends AbstractManager implements Abstrac
    */
   public ProcessDefinitionEntity findLatestProcessDefinitionByKeyAndTenantId(String processDefinitionKey, String tenantId) {
     Map<String, String> parameters = new HashMap<>();
-    parameters.put("processDefinitionKey", processDefinitionKey);
-    parameters.put("tenantId", tenantId);
+    parameters.put(PROCESS_DEFINITION_KEY, processDefinitionKey);
+    parameters.put(TENANT_ID, tenantId);
 
     if (tenantId == null) {
       return (ProcessDefinitionEntity) getDbEntityManager().selectOne("selectLatestProcessDefinitionByKeyWithoutTenantId", parameters);
@@ -125,8 +128,8 @@ public class ProcessDefinitionManager extends AbstractManager implements Abstrac
 
   public ProcessDefinitionEntity findProcessDefinitionByDeploymentAndKey(String deploymentId, String processDefinitionKey) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("deploymentId", deploymentId);
-    parameters.put("processDefinitionKey", processDefinitionKey);
+    parameters.put(DEPLOYMENT_ID, deploymentId);
+    parameters.put(PROCESS_DEFINITION_KEY, processDefinitionKey);
     return (ProcessDefinitionEntity) getDbEntityManager().selectOne("selectProcessDefinitionByDeploymentAndKey", parameters);
   }
 
@@ -142,12 +145,12 @@ public class ProcessDefinitionManager extends AbstractManager implements Abstrac
       String tenantId) {
     Map<String, Object> parameters = new HashMap<>();
     if (processDefinitionVersion != null) {
-      parameters.put("processDefinitionVersion", processDefinitionVersion);
+      parameters.put(PROCESS_DEFINITION_VERSION, processDefinitionVersion);
     } else if (processDefinitionVersionTag != null) {
-      parameters.put("processDefinitionVersionTag", processDefinitionVersionTag);
+      parameters.put(PROCESS_DEFINITION_VERSION_TAG, processDefinitionVersionTag);
     }
-    parameters.put("processDefinitionKey", processDefinitionKey);
-    parameters.put("tenantId", tenantId);
+    parameters.put(PROCESS_DEFINITION_KEY, processDefinitionKey);
+    parameters.put(TENANT_ID, tenantId);
 
     @SuppressWarnings("unchecked")
     List<ProcessDefinitionEntity> results = getDbEntityManager().selectList("selectProcessDefinitionByKeyVersionAndTenantId", parameters);
@@ -176,7 +179,7 @@ public class ProcessDefinitionManager extends AbstractManager implements Abstrac
     Map<String, Object> params = new HashMap<>();
     params.put("key", processDefinitionKey);
     params.put("version", version);
-    params.put("tenantId", tenantId);
+    params.put(TENANT_ID, tenantId);
     return (String) getDbEntityManager().selectOne("selectPreviousProcessDefinitionId", params);
   }
 
@@ -193,9 +196,9 @@ public class ProcessDefinitionManager extends AbstractManager implements Abstrac
   @SuppressWarnings("unchecked")
   public List<ProcessDefinition> findDefinitionsByKeyAndTenantId(String processDefinitionKey, String tenantId, boolean isTenantIdSet) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processDefinitionKey", processDefinitionKey);
-    parameters.put("isTenantIdSet", isTenantIdSet);
-    parameters.put("tenantId", tenantId);
+    parameters.put(PROCESS_DEFINITION_KEY, processDefinitionKey);
+    parameters.put(IS_TENANT_ID_SET, isTenantIdSet);
+    parameters.put(TENANT_ID, tenantId);
 
     return getDbEntityManager().selectList("selectProcessDefinitions", parameters);
   }
@@ -203,8 +206,8 @@ public class ProcessDefinitionManager extends AbstractManager implements Abstrac
   @SuppressWarnings("unchecked")
   public List<ProcessDefinition> findDefinitionsByIds(Set<String> processDefinitionIds) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processDefinitionIds", processDefinitionIds);
-    parameters.put("isTenantIdSet", false);
+    parameters.put(PROCESS_DEFINITION_IDS, processDefinitionIds);
+    parameters.put(IS_TENANT_ID_SET, false);
 
     return getDbEntityManager().selectList("selectProcessDefinitions", parameters);
   }
@@ -213,25 +216,25 @@ public class ProcessDefinitionManager extends AbstractManager implements Abstrac
 
   public void updateProcessDefinitionSuspensionStateById(String processDefinitionId, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processDefinitionId", processDefinitionId);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_DEFINITION_ID, processDefinitionId);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(ProcessDefinitionEntity.class, "updateProcessDefinitionSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 
   public void updateProcessDefinitionSuspensionStateByKey(String processDefinitionKey, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processDefinitionKey", processDefinitionKey);
-    parameters.put("isTenantIdSet", false);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_DEFINITION_KEY, processDefinitionKey);
+    parameters.put(IS_TENANT_ID_SET, false);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(ProcessDefinitionEntity.class, "updateProcessDefinitionSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 
   public void updateProcessDefinitionSuspensionStateByKeyAndTenantId(String processDefinitionKey, String tenantId, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processDefinitionKey", processDefinitionKey);
-    parameters.put("isTenantIdSet", true);
-    parameters.put("tenantId", tenantId);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_DEFINITION_KEY, processDefinitionKey);
+    parameters.put(IS_TENANT_ID_SET, true);
+    parameters.put(TENANT_ID, tenantId);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(ProcessDefinitionEntity.class, "updateProcessDefinitionSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskManager.java
@@ -16,9 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.operaton.bpm.engine.authorization.Resources;
 import org.operaton.bpm.engine.impl.Page;
 import org.operaton.bpm.engine.impl.TaskQueryImpl;
@@ -29,6 +26,10 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
 import org.operaton.bpm.engine.impl.persistence.AbstractManager;
 import org.operaton.bpm.engine.task.Task;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
 
@@ -36,6 +37,8 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Tom Baeyens
  */
 public class TaskManager extends AbstractManager {
+
+  private static final String CASE_EXECUTION_ID = "caseExecutionId";
 
   public void insertTask(TaskEntity task) {
     getDbEntityManager().insert(task);
@@ -158,39 +161,39 @@ public class TaskManager extends AbstractManager {
 
   public void updateTaskSuspensionStateByProcessDefinitionId(String processDefinitionId, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processDefinitionId", processDefinitionId);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_DEFINITION_ID, processDefinitionId);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(TaskEntity.class, "updateTaskSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 
   public void updateTaskSuspensionStateByProcessInstanceId(String processInstanceId, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(TaskEntity.class, "updateTaskSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 
   public void updateTaskSuspensionStateByProcessDefinitionKey(String processDefinitionKey, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processDefinitionKey", processDefinitionKey);
-    parameters.put("isProcessDefinitionTenantIdSet", false);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_DEFINITION_KEY, processDefinitionKey);
+    parameters.put(IS_PROCESS_DEFINITION_TENANT_ID_SET, false);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(TaskEntity.class, "updateTaskSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 
   public void updateTaskSuspensionStateByProcessDefinitionKeyAndTenantId(String processDefinitionKey, String processDefinitionTenantId, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processDefinitionKey", processDefinitionKey);
-    parameters.put("isProcessDefinitionTenantIdSet", true);
-    parameters.put("processDefinitionTenantId", processDefinitionTenantId);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(PROCESS_DEFINITION_KEY, processDefinitionKey);
+    parameters.put(IS_PROCESS_DEFINITION_TENANT_ID_SET, true);
+    parameters.put(PROCESS_DEFINITION_TENANT_ID, processDefinitionTenantId);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(TaskEntity.class, "updateTaskSuspensionStateByParameters", configureParameterizedQuery(parameters));
   }
 
   public void updateTaskSuspensionStateByCaseExecutionId(String caseExecutionId, SuspensionState suspensionState) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("caseExecutionId", caseExecutionId);
-    parameters.put("suspensionState", suspensionState.getStateCode());
+    parameters.put(CASE_EXECUTION_ID, caseExecutionId);
+    parameters.put(SUSPENSION_STATE, suspensionState.getStateCode());
     getDbEntityManager().update(TaskEntity.class, "updateTaskSuspensionStateByParameters", configureParameterizedQuery(parameters));
 
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/UserOperationLogManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/UserOperationLogManager.java
@@ -16,13 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.persistence.entity;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.operaton.bpm.engine.EntityTypes;
 import org.operaton.bpm.engine.authorization.Permission;
 import org.operaton.bpm.engine.authorization.Permissions;
@@ -48,6 +41,14 @@ import org.operaton.bpm.engine.impl.repository.ResourceDefinitionEntity;
 import org.operaton.bpm.engine.impl.util.PermissionConverter;
 import org.operaton.bpm.engine.impl.util.StringUtil;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Manager for {@link UserOperationLogEntryEventEntity} that also provides a generic and some specific log methods.
  *
@@ -55,6 +56,9 @@ import org.operaton.bpm.engine.impl.util.StringUtil;
  * @author Tobias Metzke
  */
 public class UserOperationLogManager extends AbstractHistoricManager {
+
+  private static final String OPERATION_ID = "operationId";
+  private static final String ANNOTATION = "annotation";
 
   public UserOperationLogEntry findOperationLogById(String entryId) {
     return getDbEntityManager().selectById(UserOperationLogEntryEventEntity.class, entryId);
@@ -81,9 +85,9 @@ public class UserOperationLogManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToUserOperationLogByRootProcessInstanceId(String rootProcessInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("rootProcessInstanceId", rootProcessInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(ROOT_PROCESS_INSTANCE_ID, rootProcessInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(UserOperationLogEntryEventEntity.class, "updateUserOperationLogByRootProcessInstanceId", parameters);
@@ -91,9 +95,9 @@ public class UserOperationLogManager extends AbstractHistoricManager {
 
   public DbOperation addRemovalTimeToUserOperationLogByProcessInstanceId(String processInstanceId, Date removalTime, Integer batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("processInstanceId", processInstanceId);
-    parameters.put("removalTime", removalTime);
-    parameters.put("maxResults", batchSize);
+    parameters.put(PROCESS_INSTANCE_ID, processInstanceId);
+    parameters.put(REMOVAL_TIME, removalTime);
+    parameters.put(MAX_RESULTS, batchSize);
 
     return getDbEntityManager()
       .updatePreserveOrder(UserOperationLogEntryEventEntity.class, "updateUserOperationLogByProcessInstanceId", parameters);
@@ -101,8 +105,8 @@ public class UserOperationLogManager extends AbstractHistoricManager {
 
   public void updateOperationLogAnnotationByOperationId(String operationId, String annotation) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("operationId", operationId);
-    parameters.put("annotation", annotation);
+    parameters.put(OPERATION_ID, operationId);
+    parameters.put(ANNOTATION, annotation);
 
     getDbEntityManager()
         .updatePreserveOrder(UserOperationLogEntryEventEntity.class, "updateOperationLogAnnotationByOperationId", parameters);
@@ -116,12 +120,12 @@ public class UserOperationLogManager extends AbstractHistoricManager {
 
   public DbOperation deleteOperationLogByRemovalTime(Date removalTime, int minuteFrom, int minuteTo, int batchSize) {
     Map<String, Object> parameters = new HashMap<>();
-    parameters.put("removalTime", removalTime);
+    parameters.put(REMOVAL_TIME, removalTime);
     if (minuteTo - minuteFrom + 1 < 60) {
-      parameters.put("minuteFrom", minuteFrom);
-      parameters.put("minuteTo", minuteTo);
+      parameters.put(MINUTE_FROM, minuteFrom);
+      parameters.put(MINUTE_TO, minuteTo);
     }
-    parameters.put("batchSize", batchSize);
+    parameters.put(BATCH_SIZE, batchSize);
 
     return getDbEntityManager()
       .deletePreserveOrder(UserOperationLogEntryEventEntity.class, "deleteUserOperationLogByRemovalTime",
@@ -712,11 +716,11 @@ public class UserOperationLogManager extends AbstractHistoricManager {
   }
 
   public void logSetAnnotationOperation(String operationId, String tenantId) {
-    logAnnotationOperation(operationId, EntityTypes.OPERATION_LOG, "operationId", UserOperationLogEntry.OPERATION_TYPE_SET_ANNOTATION, tenantId);
+    logAnnotationOperation(operationId, EntityTypes.OPERATION_LOG, OPERATION_ID, UserOperationLogEntry.OPERATION_TYPE_SET_ANNOTATION, tenantId);
   }
 
   public void logClearAnnotationOperation(String operationId, String tenantId) {
-    logAnnotationOperation(operationId, EntityTypes.OPERATION_LOG, "operationId", UserOperationLogEntry.OPERATION_TYPE_CLEAR_ANNOTATION, tenantId);
+    logAnnotationOperation(operationId, EntityTypes.OPERATION_LOG, OPERATION_ID, UserOperationLogEntry.OPERATION_TYPE_CLEAR_ANNOTATION, tenantId);
   }
 
   public void logSetIncidentAnnotationOperation(String incidentId, String tenantId) {


### PR DESCRIPTION
This change introduces string constants for query paraeters. The class AbstractManager declares constants for parameters used by at least 2 subclasses. Parameters used by only a single implementation are added to the implementation class.

Resolves some warnings regarding string duplication.