### PR TITLE
Backport: chore(pom): add support for Spring Boot 3.4.1

### DIFF
--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/https/HttpsConfigurationEnabledTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/config/https/HttpsConfigurationEnabledTest.java
@@ -70,6 +70,6 @@ class HttpsConfigurationEnabledTest extends AbstractRestTest {
     HttpEntity<Object> requestEntity = new HttpEntity<>(null);
     Throwable exception = assertThrows(ResourceAccessException.class, () ->
         restTemplate.exchange(url, HttpMethod.GET, requestEntity, String.class));
-    assertThat(exception.getMessage()).contains("Connection refused");
+    assertThat(exception.getMessage()).contains("I/O error on GET request for \"http://localhost:8899/engine-rest/task\":");
   }
 }

--- a/distro/run/core/src/test/resources/application-test-https-enabled.yml
+++ b/distro/run/core/src/test/resources/application-test-https-enabled.yml
@@ -6,3 +6,4 @@ server:
     key-alias: localhost
     key-password: operaton
   port: 8443
+spring.http.client.factory: simple

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -189,6 +189,12 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Tomcat for resteasy and wink -->
     <dependency>
       <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Backport 7e1813e760  from C7

> chore(pom): add support for Spring Boot 3.4.1
> 
> Related to https://github.com/camunda/camunda-bpm-platform/issues/4657