### PR TITLE
chore: Revert Query#list() marked for removal

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/query/Query.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/query/Query.java
@@ -59,9 +59,8 @@ public interface Query<T extends Query< ? , ? >, U extends Object> {
    *   When a maximum results limit is specified. A maximum results limit can be specified with
    *   the process engine configuration property <code>queryMaxResultsLimit</code> (default
    *   {@link Integer#MAX_VALUE}).
-   *  @deprecated Use {@link #listPage(int, int)} instead.
+   *   Please use {@link #listPage(int, int)} instead.
    */
-  @Deprecated(forRemoval = true, since = "1.0")
   List<U> list();
 
   /**


### PR DESCRIPTION
The method Query#list() has been accidently marked for removal with #ec5b1a34 because there was mentioned to use listPage() instead. But list() is widely used and listPage() is only an alternative to consider.