### PR TITLE
chore: Removed implementations of getFeatureDescriptors

### DIFF
--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/el/CdiResolver.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/el/CdiResolver.java
@@ -22,8 +22,6 @@ import org.operaton.bpm.engine.cdi.impl.util.ProgrammaticBeanLookup;
 import jakarta.el.ELResolver;
 
 import jakarta.enterprise.inject.spi.BeanManager;
-import java.beans.FeatureDescriptor;
-import java.util.Iterator;
 
 
 /**
@@ -46,11 +44,6 @@ public class CdiResolver extends ELResolver {
   @Override
   public Class< ? > getCommonPropertyType(ELContext context, Object base) {
     return getWrappedResolver().getCommonPropertyType(context, base);
-  }
-
-  @Override
-  public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext context, Object base) {
-    return getWrappedResolver().getFeatureDescriptors(context, base);
   }
 
   @Override

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/ApplicationContextElResolver.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/ApplicationContextElResolver.java
@@ -21,9 +21,6 @@ import org.operaton.bpm.engine.ProcessEngineException;
 import jakarta.el.ELResolver;
 import org.springframework.context.ApplicationContext;
 
-import java.beans.FeatureDescriptor;
-import java.util.Iterator;
-
 /**
  * @author Tom Baeyens
  * @author Frederik Heremans
@@ -70,11 +67,6 @@ public class ApplicationContextElResolver extends ELResolver {
   @Override
   public Class< ? > getCommonPropertyType(ELContext context, Object arg) {
     return Object.class;
-  }
-
-  @Override
-  public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext context, Object arg) {
-    return null;
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/el/AbstractElResolverDelegate.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/el/AbstractElResolverDelegate.java
@@ -19,10 +19,6 @@ package org.operaton.bpm.engine.impl.el;
 import jakarta.el.ELContext;
 import jakarta.el.ELResolver;
 
-import java.beans.FeatureDescriptor;
-import java.util.Collections;
-import java.util.Iterator;
-
 /**
  * @author Thorben Lindhauer
  */
@@ -38,16 +34,6 @@ public abstract class AbstractElResolverDelegate extends ELResolver {
       return delegate.getCommonPropertyType(context, base);
     }
   }
-
-  public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext context, Object base) {
-    ELResolver delegate = getElResolverDelegate();
-    if(delegate == null) {
-      return Collections.<FeatureDescriptor>emptySet().iterator();
-    } else {
-      return delegate.getFeatureDescriptors(context, base);
-    }
-  }
-
 
   public Class<?> getType(ELContext context, Object base, Object property) {
     context.setPropertyResolved(false);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/el/ReadOnlyMapELResolver.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/el/ReadOnlyMapELResolver.java
@@ -20,8 +20,6 @@ import jakarta.el.ELContext;
 import org.operaton.bpm.engine.ProcessEngineException;
 import jakarta.el.ELResolver;
 
-import java.beans.FeatureDescriptor;
-import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -59,10 +57,6 @@ public class ReadOnlyMapELResolver extends ELResolver {
 
   public Class< ? > getCommonPropertyType(ELContext context, Object arg) {
     return Object.class;
-  }
-
-  public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext context, Object arg) {
-    return null;
   }
 
   public Class< ? > getType(ELContext context, Object arg1, Object arg2) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/el/VariableContextElResolver.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/el/VariableContextElResolver.java
@@ -21,9 +21,6 @@ import jakarta.el.ELResolver;
 import org.operaton.bpm.engine.variable.context.VariableContext;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 
-import java.beans.FeatureDescriptor;
-import java.util.Iterator;
-
 /**
  * @author Daniel Meyer
  *
@@ -64,10 +61,6 @@ public class VariableContextElResolver extends ELResolver {
 
   public Class< ? > getCommonPropertyType(ELContext arg0, Object arg1) {
     return Object.class;
-  }
-
-  public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext arg0, Object arg1) {
-    return null;
   }
 
   public Class< ? > getType(ELContext arg0, Object arg1, Object arg2) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/el/VariableScopeElResolver.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/el/VariableScopeElResolver.java
@@ -27,8 +27,6 @@ import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.ExternalTaskEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 
-import java.beans.FeatureDescriptor;
-import java.util.Iterator;
 import java.util.List;
 
 
@@ -120,10 +118,6 @@ public class VariableScopeElResolver extends ELResolver {
 
   public Class< ? > getCommonPropertyType(ELContext arg0, Object arg1) {
     return Object.class;
-  }
-
-  public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext arg0, Object arg1) {
-    return null;
   }
 
   public Class< ? > getType(ELContext arg0, Object arg1, Object arg2) {

--- a/engine/src/main/java/org/operaton/bpm/engine/test/mock/MockElResolver.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/test/mock/MockElResolver.java
@@ -19,19 +19,11 @@ package org.operaton.bpm.engine.test.mock;
 import jakarta.el.ELContext;
 import jakarta.el.ELResolver;
 
-import java.beans.FeatureDescriptor;
-import java.util.Iterator;
-
 public class MockElResolver extends ELResolver {
 
   @Override
   public Class< ? > getCommonPropertyType(ELContext context, Object base) {
     return Object.class;
-  }
-
-  @Override
-  public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext context, Object base) {
-    return null;
   }
 
   @Override

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/RootPropertyResolver.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/RootPropertyResolver.java
@@ -15,10 +15,8 @@
  */
 package org.operaton.bpm.impl.juel;
 
-import java.beans.FeatureDescriptor;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import jakarta.el.ELContext;
@@ -36,7 +34,7 @@ import jakarta.el.PropertyNotWritableException;
  * @author Christoph Beck
  */
 public class RootPropertyResolver extends ELResolver {
-	private final Map<String, Object> map = Collections.synchronizedMap(new HashMap<String, Object>());
+	private final Map<String, Object> map = Collections.synchronizedMap(new HashMap<>());
 	private final boolean readOnly;
 
 	/**
@@ -49,7 +47,7 @@ public class RootPropertyResolver extends ELResolver {
 	/**
 	 * Create a root property resolver
 	 * 
-	 * @param readOnly
+	 * @param readOnly Use {@code true} to disallow setting property values
 	 */
 	public RootPropertyResolver(boolean readOnly) {
 		this.readOnly = readOnly;
@@ -67,11 +65,6 @@ public class RootPropertyResolver extends ELResolver {
 	@Override
 	public Class<?> getCommonPropertyType(ELContext context, Object base) {
 		return isResolvable(context) ? String.class : null;
-	}
-
-	@Override
-	public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext context, Object base) {
-		return null;
 	}
 
 	@Override

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/SimpleResolver.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/SimpleResolver.java
@@ -15,9 +15,6 @@
  */
 package org.operaton.bpm.impl.juel;
 
-import java.beans.FeatureDescriptor;
-import java.util.Iterator;
-
 import jakarta.el.ArrayELResolver;
 import jakarta.el.BeanELResolver;
 import jakarta.el.CompositeELResolver;
@@ -103,11 +100,6 @@ public class SimpleResolver extends ELResolver {
 	@Override
 	public Class<?> getCommonPropertyType(ELContext context, Object base) {
 		return delegate.getCommonPropertyType(context, base);
-	}
-
-	@Override
-	public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext context, Object base) {
-		return delegate.getFeatureDescriptors(context, base);
 	}
 
 	@Override


### PR DESCRIPTION
This method has been marked for removal. It is provided as default method on the interface now. Removed implementations of the method.

relates to #674
relates to #144