### PR TITLE
chore(tests): Fix test dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,4 @@ out/jreleaser
 *.gz
 *.class
 *.zip
-
+sloc.txt

--- a/qa/integration-tests-engine/src/test/java-wildfly/org/operaton/bpm/integrationtest/util/TestContainer.java
+++ b/qa/integration-tests-engine/src/test/java-wildfly/org/operaton/bpm/integrationtest/util/TestContainer.java
@@ -47,7 +47,7 @@ public class TestContainer {
 
   public static void addContainerSpecificResourcesForNonPaWithoutWeld(WebArchive webArchive) {
     webArchive.addAsManifestResource("jboss-deployment-structure.xml");
-    webArchive.addAsLibraries(DeploymentHelper.getAssertJ());
+    webArchive.addAsLibraries(DeploymentHelper.getTestingLibs());
   }
 
   public static void addContainerSpecificResourcesForSpin(WebArchive deployment) {

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/EjbPALifecycleCallbacksTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/EjbPALifecycleCallbacksTest.java
@@ -38,7 +38,7 @@ public class EjbPALifecycleCallbacksTest extends AbstractFoxPlatformIntegrationT
   @Deployment
   public static WebArchive createDeployment() {
     var webArchive = ShrinkWrap.create(WebArchive.class, "test.war")
-        .addAsLibraries(DeploymentHelper.getAssertJ())
+        .addAsLibraries(DeploymentHelper.getTestingLibs())
         .addClass(CustomEjbProcessApplication.class)
         .addClass(AbstractFoxPlatformIntegrationTest.class);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestAdditionalResourceSuffixes.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestAdditionalResourceSuffixes.java
@@ -45,7 +45,7 @@ public class TestAdditionalResourceSuffixes extends AbstractFoxPlatformIntegrati
       return ShrinkWrap.create(WebArchive.class)
         .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
         .addAsLibraries(DeploymentHelper.getEngineCdi())
-        .addAsLibraries(DeploymentHelper.getAssertJ())
+        .addAsLibraries(DeploymentHelper.getTestingLibs())
         .addClass(AbstractFoxPlatformIntegrationTest.class)
         .addClass(DummyProcessApplication.class)
         .addAsResource("org/operaton/bpm/integrationtest/deployment/cfg/processes-additional-resource-suffixes.xml", "META-INF/processes.xml")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestCustomProcessesXmlFileLocation.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestCustomProcessesXmlFileLocation.java
@@ -43,7 +43,7 @@ public class TestCustomProcessesXmlFileLocation extends AbstractFoxPlatformInteg
     return ShrinkWrap.create(WebArchive.class, "test.war")
         .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
         .addAsLibraries(DeploymentHelper.getEngineCdi())
-        .addAsLibraries(DeploymentHelper.getAssertJ())
+        .addAsLibraries(DeploymentHelper.getTestingLibs())
         .addAsResource("org/operaton/bpm/integrationtest/deployment/cfg/processes.xml", "my/alternate/location/processes.xml")
         .addClass(AbstractFoxPlatformIntegrationTest.class)
         .addClass(CustomProcessApplication.class)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestDeploymentTenantId.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/cfg/TestDeploymentTenantId.java
@@ -35,7 +35,7 @@ public class TestDeploymentTenantId extends AbstractFoxPlatformIntegrationTest {
     return ShrinkWrap.create(WebArchive.class, "test.war")
         .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
         .addAsLibraries(DeploymentHelper.getEngineCdi())
-        .addAsLibraries(DeploymentHelper.getAssertJ())
+        .addAsLibraries(DeploymentHelper.getTestingLibs())
         .addAsResource("org/operaton/bpm/integrationtest/deployment/cfg/processes-with-tenant-id.xml", "META-INF/processes.xml")
         .addAsResource("org/operaton/bpm/integrationtest/deployment/cfg/invoice-it.bpmn20.xml")
         .addClass(AbstractFoxPlatformIntegrationTest.class)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_onePaAsLib.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_onePaAsLib.java
@@ -81,7 +81,7 @@ public class TestFoxPlatformClientAsEjbModule_onePaAsLib extends AbstractFoxPlat
       .addAsModule(foxPlatformClientJar)
       .addAsModule(testJar)
       .addAsLibrary(DeploymentHelper.getEngineCdi())
-      .addAsLibraries(DeploymentHelper.getAssertJ());
+      .addAsLibraries(DeploymentHelper.getTestingLibs());
   }
 
   @Test

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_pasAsEjbModule.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_pasAsEjbModule.java
@@ -76,7 +76,7 @@ public class TestFoxPlatformClientAsEjbModule_pasAsEjbModule extends AbstractFox
       .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
       .addClass(AbstractFoxPlatformIntegrationTest.class)
       .addClass(TestFoxPlatformClientAsEjbModule_pasAsEjbModule.class)
-      .addAsLibraries(DeploymentHelper.getAssertJ());
+      .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     return ShrinkWrap.create(EnterpriseArchive.class, "paAsEjbModule.ear")
       .addAsModule(processArchive1Jar)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_twoPasAsLib.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestFoxPlatformClientAsEjbModule_twoPasAsLib.java
@@ -83,7 +83,7 @@ public class TestFoxPlatformClientAsEjbModule_twoPasAsLib extends AbstractFoxPla
       .setManifest(new ByteArrayAsset(("Class-Path: " + foxPlatformClientJar.getName()+"\n").getBytes()))
       .addClass(AbstractFoxPlatformIntegrationTest.class)
       .addClass(TestFoxPlatformClientAsEjbModule_twoPasAsLib.class)
-      .addAsLibraries(DeploymentHelper.getAssertJ());
+      .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     return ShrinkWrap.create(EnterpriseArchive.class, "twoPasAsLib.ear")
       .addAsLibrary(processArchive1Jar)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestPaAnnotatedEjb.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestPaAnnotatedEjb.java
@@ -68,7 +68,7 @@ public class TestPaAnnotatedEjb extends AbstractFoxPlatformIntegrationTest {
     return ShrinkWrap.create(EnterpriseArchive.class, "paAsEjbModule.ear")
       .addAsModule(processArchive1Jar)
       .addAsLibrary(DeploymentHelper.getEngineCdi())
-      .addAsLibraries(DeploymentHelper.getAssertJ());
+      .addAsLibraries(DeploymentHelper.getTestingLibs());
   }
 
   @Test

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestPaAsEjbJar.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestPaAsEjbJar.java
@@ -73,7 +73,7 @@ public class TestPaAsEjbJar extends AbstractFoxPlatformIntegrationTest {
     return ShrinkWrap.create(EnterpriseArchive.class, "paAsEjbModule.ear")
       .addAsModule(processArchive1Jar)
       .addAsLibrary(DeploymentHelper.getEngineCdi())
-      .addAsLibraries(DeploymentHelper.getAssertJ());
+      .addAsLibraries(DeploymentHelper.getTestingLibs());
   }
 
   @Test

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestPaAsEjbJar.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/ear/TestPaAsEjbJar.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 import org.operaton.bpm.application.impl.ejb.DefaultEjbProcessApplication;
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.cdi.impl.util.ProgrammaticBeanLookup;
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.deployment.ear.beans.NamedCdiBean;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
@@ -63,6 +64,7 @@ public class TestPaAsEjbJar extends AbstractFoxPlatformIntegrationTest {
       .addClass(DefaultEjbProcessApplication.class)
       .addClass(NamedCdiBean.class)
       .addClass(AbstractFoxPlatformIntegrationTest.class)
+      .addClass(JobExecutorWaitUtils.class)
       .addClass(TestPaAsEjbJar.class)
       .addAsResource("org/operaton/bpm/integrationtest/deployment/ear/paAsEjbJar-process.bpmn20.xml")
       .addAsResource("META-INF/processes.xml", "META-INF/processes.xml")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestResourceName.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestResourceName.java
@@ -131,7 +131,7 @@ public class TestResourceName extends AbstractFoxPlatformIntegrationTest {
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "test.war")
         .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
         .addAsLibraries(DeploymentHelper.getEngineCdi())
-        .addAsLibraries(DeploymentHelper.getAssertJ())
+        .addAsLibraries(DeploymentHelper.getTestingLibs())
         .addAsLibraries(pa1)
         .addAsLibraries(pa2)
         .addAsLibraries(pa3)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentCustomPAName.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentCustomPAName.java
@@ -40,7 +40,7 @@ public class TestWarDeploymentCustomPAName extends AbstractFoxPlatformIntegratio
   @Deployment
   public static WebArchive processArchive() {
     return ShrinkWrap.create(WebArchive.class, "pa1.war")
-        .addAsLibraries(DeploymentHelper.getAssertJ())
+        .addAsLibraries(DeploymentHelper.getTestingLibs())
         .addAsResource("META-INF/processes.xml")
         .addClass(AbstractFoxPlatformIntegrationTest.class)
         .addClass(CustomNameServletPA.class)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentDeployChangedOnlyWithJarAsLib.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentDeployChangedOnlyWithJarAsLib.java
@@ -96,7 +96,7 @@ public class TestWarDeploymentDeployChangedOnlyWithJarAsLib extends AbstractFoxP
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "pa2.war")
         .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
         .addAsLibraries(DeploymentHelper.getEngineCdi())
-        .addAsLibraries(DeploymentHelper.getAssertJ())
+        .addAsLibraries(DeploymentHelper.getTestingLibs())
 
         .addAsLibraries(processArchiveJar)
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanCallActivityResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanCallActivityResolutionTest.java
@@ -64,7 +64,7 @@ public class CdiBeanCallActivityResolutionTest extends AbstractFoxPlatformIntegr
             .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
             .addAsLibraries(DeploymentHelper.getEngineCdi())
-            .addAsLibraries(DeploymentHelper.getAssertJ());
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResourcesForNonPa(deployment);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanResolutionOnDeploymentTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanResolutionOnDeploymentTest.java
@@ -52,7 +52,7 @@ public class CdiBeanResolutionOnDeploymentTest extends AbstractFoxPlatformIntegr
             .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
             .addAsLibraries(DeploymentHelper.getEngineCdi())
-            .addAsLibraries(DeploymentHelper.getAssertJ());
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResourcesForNonPa(deployment);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanResolutionTest.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.integrationtest.functional.cdi;
 
 import org.operaton.bpm.engine.cdi.CdiStandaloneProcessEngineConfiguration;
 import org.operaton.bpm.engine.cdi.impl.util.ProgrammaticBeanLookup;
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.functional.cdi.beans.ExampleBean;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
@@ -61,6 +62,7 @@ public class CdiBeanResolutionTest extends AbstractFoxPlatformIntegrationTest {
     WebArchive deployment = ShrinkWrap.create(WebArchive.class, "client.war")
             .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
+            .addClass(JobExecutorWaitUtils.class)
             .addAsLibraries(DeploymentHelper.getEngineCdi())
             .addAsLibraries(DeploymentHelper.getAssertJ());
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanResolutionTest.java
@@ -64,7 +64,7 @@ public class CdiBeanResolutionTest extends AbstractFoxPlatformIntegrationTest {
             .addClass(AbstractFoxPlatformIntegrationTest.class)
             .addClass(JobExecutorWaitUtils.class)
             .addAsLibraries(DeploymentHelper.getEngineCdi())
-            .addAsLibraries(DeploymentHelper.getAssertJ());
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResourcesForNonPaEmbedCdiLib(deployment);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanSignallableActivityBehaviorResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanSignallableActivityBehaviorResolutionTest.java
@@ -55,7 +55,7 @@ public class CdiBeanSignallableActivityBehaviorResolutionTest extends AbstractFo
             .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
             .addAsLibraries(DeploymentHelper.getEngineCdi())
-            .addAsLibraries(DeploymentHelper.getAssertJ());
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResourcesForNonPaEmbedCdiLib(deployment);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiCallActivityVersionTagTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiCallActivityVersionTagTest.java
@@ -48,7 +48,7 @@ public class CdiCallActivityVersionTagTest extends AbstractFoxPlatformIntegratio
             .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
             .addAsLibraries(DeploymentHelper.getEngineCdi())
-            .addAsLibraries(DeploymentHelper.getAssertJ());
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResourcesForNonPaEmbedCdiLib(deployment);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiDelegateBeanResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiDelegateBeanResolutionTest.java
@@ -64,7 +64,7 @@ public class CdiDelegateBeanResolutionTest extends AbstractFoxPlatformIntegratio
             .addClass(AbstractFoxPlatformIntegrationTest.class)
             .addClass(JobExecutorWaitUtils.class)
             .addAsLibraries(DeploymentHelper.getEngineCdi())
-            .addAsLibraries(DeploymentHelper.getAssertJ());
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
 
      TestContainer.addContainerSpecificResourcesEmbedCdiLib(webArchive);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiDelegateBeanResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiDelegateBeanResolutionTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.operaton.bpm.engine.cdi.impl.util.BeanManagerLookup;
 import org.operaton.bpm.engine.cdi.impl.util.ProgrammaticBeanLookup;
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.functional.cdi.beans.ExampleDelegateBean;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
@@ -61,6 +62,7 @@ public class CdiDelegateBeanResolutionTest extends AbstractFoxPlatformIntegratio
             .addClass(ProgrammaticBeanLookup.class)
             .addClass(BeanManagerLookup.class)
             .addClass(AbstractFoxPlatformIntegrationTest.class)
+            .addClass(JobExecutorWaitUtils.class)
             .addAsLibraries(DeploymentHelper.getEngineCdi())
             .addAsLibraries(DeploymentHelper.getAssertJ());
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/deployment/RedeployCaseClassloadingTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/deployment/RedeployCaseClassloadingTest.java
@@ -52,7 +52,7 @@ public class RedeployCaseClassloadingTest extends AbstractFoxPlatformIntegration
   public static WebArchive clientDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "client.war")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
-            .addAsLibraries(DeploymentHelper.getAssertJ());
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResources(webArchive);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/deployment/RedeployProcessClassloadingTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/deployment/RedeployProcessClassloadingTest.java
@@ -50,7 +50,7 @@ public class RedeployProcessClassloadingTest extends AbstractFoxPlatformIntegrat
   public static WebArchive clientDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "client.war")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
-            .addAsLibraries(DeploymentHelper.getAssertJ());
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResources(webArchive);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/ear/TestJavaDelegateResolution_ClientAsLibInWebModule.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/ear/TestJavaDelegateResolution_ClientAsLibInWebModule.java
@@ -16,8 +16,10 @@
  */
 package org.operaton.bpm.integrationtest.functional.classloading.ear;
 
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleDelegate;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -60,7 +62,9 @@ public class TestJavaDelegateResolution_ClientAsLibInWebModule extends AbstractF
   @Deployment(name="clientDeployment")
   public static WebArchive clientDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "client.war")
-        .addClass(AbstractFoxPlatformIntegrationTest.class);
+        .addClass(AbstractFoxPlatformIntegrationTest.class)
+        .addClass(JobExecutorWaitUtils.class)
+        .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResources(webArchive);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/jobexecution/ClassloadingDuringJobExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/jobexecution/ClassloadingDuringJobExecutionTest.java
@@ -24,6 +24,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.operaton.bpm.engine.runtime.Job;
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
@@ -63,6 +64,7 @@ public class ClassloadingDuringJobExecutionTest extends AbstractFoxPlatformInteg
   public static WebArchive clientDeployment() {
     WebArchive deployment = ShrinkWrap.create(WebArchive.class, "client.war")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
+            .addClass(JobExecutorWaitUtils.class)
             .addAsLibraries(DeploymentHelper.getAssertJ());
     TestContainer.addContainerSpecificResourcesForNonPa(deployment);
     return deployment;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/jobexecution/ClassloadingDuringJobExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/jobexecution/ClassloadingDuringJobExecutionTest.java
@@ -65,7 +65,7 @@ public class ClassloadingDuringJobExecutionTest extends AbstractFoxPlatformInteg
     WebArchive deployment = ShrinkWrap.create(WebArchive.class, "client.war")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
             .addClass(JobExecutorWaitUtils.class)
-            .addAsLibraries(DeploymentHelper.getAssertJ());
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
     TestContainer.addContainerSpecificResourcesForNonPa(deployment);
     return deployment;
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/variables/DeserializableVariableTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/variables/DeserializableVariableTest.java
@@ -59,7 +59,7 @@ public class DeserializableVariableTest extends AbstractFoxPlatformIntegrationTe
   public static WebArchive clientDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "client.war")
       .addClass(AbstractFoxPlatformIntegrationTest.class)
-      .addAsLibraries(DeploymentHelper.getAssertJ());
+      .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResources(webArchive);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseExecutionListenerResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseExecutionListenerResolutionTest.java
@@ -53,7 +53,7 @@ public class CaseExecutionListenerResolutionTest extends AbstractFoxPlatformInte
   public static WebArchive clientDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "client.war")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
-            .addAsLibraries(DeploymentHelper.getAssertJ());
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResources(webArchive);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseVariableListenerResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseVariableListenerResolutionTest.java
@@ -53,7 +53,7 @@ public class CaseVariableListenerResolutionTest extends AbstractFoxPlatformInteg
   public static WebArchive clientDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "client.war")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
-            .addAsLibraries(DeploymentHelper.getAssertJ());
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResources(webArchive);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/JavaDelegateResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/JavaDelegateResolutionTest.java
@@ -26,8 +26,11 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleDelegate;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 
 
@@ -55,7 +58,9 @@ public class JavaDelegateResolutionTest extends AbstractFoxPlatformIntegrationTe
   @Deployment(name="clientDeployment")
   public static WebArchive clientDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "client.war")
-            .addClass(AbstractFoxPlatformIntegrationTest.class);
+            .addAsLibraries(DeploymentHelper.getTestingLibs())
+            .addClass(AbstractFoxPlatformIntegrationTest.class)
+            .addClass(JobExecutorWaitUtils.class);
 
     TestContainer.addContainerSpecificResources(webArchive);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/SignallableActivityBehaviorResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/SignallableActivityBehaviorResolutionTest.java
@@ -17,8 +17,10 @@
 package org.operaton.bpm.integrationtest.functional.classloading.war;
 
 import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleSignallableActivityBehavior;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
+import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -52,7 +54,9 @@ public class SignallableActivityBehaviorResolutionTest extends AbstractFoxPlatfo
   @Deployment(name="clientDeployment")
   public static WebArchive clientDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "client.war")
-            .addClass(AbstractFoxPlatformIntegrationTest.class);
+            .addClass(AbstractFoxPlatformIntegrationTest.class)
+            .addClass(JobExecutorWaitUtils.class)
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResources(webArchive);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/TaskListenerResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/TaskListenerResolutionTest.java
@@ -50,7 +50,7 @@ public class TaskListenerResolutionTest extends AbstractFoxPlatformIntegrationTe
   public static WebArchive clientDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "client.war")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
-            .addAsLibraries(DeploymentHelper.getAssertJ());
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResources(webArchive);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/InvocationContextTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/InvocationContextTest.java
@@ -25,6 +25,7 @@ import org.operaton.bpm.engine.runtime.EventSubscription;
 import org.operaton.bpm.engine.runtime.Execution;
 import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.functional.context.beans.NoOpJavaDelegate;
 import org.operaton.bpm.integrationtest.functional.context.beans.SignalableTask;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
@@ -53,6 +54,7 @@ public class InvocationContextTest extends AbstractFoxPlatformIntegrationTest {
         .addClass(ProcessApplicationWithInvocationContext.class)
         .addClass(NoOpJavaDelegate.class)
         .addClass(SignalableTask.class)
+        .addClass(JobExecutorWaitUtils.class)
         .addAsResource("org/operaton/bpm/integrationtest/functional/context/InvocationContextTest-timer.bpmn")
         .addAsResource("org/operaton/bpm/integrationtest/functional/context/InvocationContextTest-message.bpmn")
         .addAsResource("org/operaton/bpm/integrationtest/functional/context/InvocationContextTest-signalTask.bpmn");

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/InvocationContextTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/InvocationContextTest.java
@@ -49,7 +49,7 @@ public class InvocationContextTest extends AbstractFoxPlatformIntegrationTest {
   public static WebArchive createDeployment() {
     return ShrinkWrap.create(WebArchive.class, "app.war")
         .addAsResource("META-INF/processes.xml")
-        .addAsLibraries(DeploymentHelper.getAssertJ())
+        .addAsLibraries(DeploymentHelper.getTestingLibs())
         .addClass(AbstractFoxPlatformIntegrationTest.class)
         .addClass(ProcessApplicationWithInvocationContext.class)
         .addClass(NoOpJavaDelegate.class)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/SetVariablesMigrationContextSwitchTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/SetVariablesMigrationContextSwitchTest.java
@@ -75,7 +75,7 @@ public class SetVariablesMigrationContextSwitchTest extends AbstractFoxPlatformI
   public static WebArchive clientDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "client.war")
         .addClass(AbstractFoxPlatformIntegrationTest.class)
-        .addAsLibraries(DeploymentHelper.getAssertJ());
+        .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResources(webArchive);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/local/LocalSFSBInvocationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/local/LocalSFSBInvocationTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.integrationtest.functional.ejb.local;
 
 import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.functional.ejb.local.bean.BusinessInterface;
 import org.operaton.bpm.integrationtest.functional.ejb.local.bean.LocalSFSBClientDelegateBean;
 import org.operaton.bpm.integrationtest.functional.ejb.local.bean.LocalSFSBean;
@@ -61,6 +62,7 @@ public class LocalSFSBInvocationTest extends AbstractFoxPlatformIntegrationTest 
       .addAsLibraries(DeploymentHelper.getEjbClient())
       .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
       .addClass(AbstractFoxPlatformIntegrationTest.class)
+      .addClass(JobExecutorWaitUtils.class)
       .addClass(LocalSFSBean.class) // the EJB
       .addClass(BusinessInterface.class); // the business interface
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/local/LocalSLSBInvocationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/local/LocalSLSBInvocationTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.integrationtest.functional.ejb.local;
 
 import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.functional.ejb.local.bean.BusinessInterface;
 import org.operaton.bpm.integrationtest.functional.ejb.local.bean.LocalSLSBClientDelegateBean;
 import org.operaton.bpm.integrationtest.functional.ejb.local.bean.LocalSLSBean;
@@ -61,6 +62,7 @@ public class LocalSLSBInvocationTest extends AbstractFoxPlatformIntegrationTest 
       .addAsLibraries(DeploymentHelper.getEjbClient())
       .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
       .addClass(AbstractFoxPlatformIntegrationTest.class)
+      .addClass(JobExecutorWaitUtils.class)
       .addClass(LocalSLSBean.class) // the EJB
       .addClass(BusinessInterface.class); // the business interface
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/local/LocalSingletonBeanInvocationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/local/LocalSingletonBeanInvocationTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.integrationtest.functional.ejb.local;
 
 import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.functional.ejb.local.bean.BusinessInterface;
 import org.operaton.bpm.integrationtest.functional.ejb.local.bean.LocalSingletonBean;
 import org.operaton.bpm.integrationtest.functional.ejb.local.bean.LocalSingletonBeanClientDelegateBean;
@@ -62,6 +63,7 @@ public class LocalSingletonBeanInvocationTest extends AbstractFoxPlatformIntegra
       .addAsLibraries(DeploymentHelper.getEjbClient())
       .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
       .addClass(AbstractFoxPlatformIntegrationTest.class)
+      .addClass(JobExecutorWaitUtils.class)
       .addClass(LocalSingletonBean.class) // the EJB
       .addClass(BusinessInterface.class); // the business interface
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/remote/RemoteSFSBInvocationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/remote/RemoteSFSBInvocationTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.integrationtest.functional.ejb.remote;
 
 import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.functional.ejb.remote.bean.BusinessInterface;
 import org.operaton.bpm.integrationtest.functional.ejb.remote.bean.RemoteSFSBClientDelegateBean;
 import org.operaton.bpm.integrationtest.functional.ejb.remote.bean.RemoteSFSBean;
@@ -63,6 +64,7 @@ public class RemoteSFSBInvocationTest extends AbstractFoxPlatformIntegrationTest
       .addAsLibraries(DeploymentHelper.getEjbClient())
       .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
       .addClass(AbstractFoxPlatformIntegrationTest.class)
+      .addClass(JobExecutorWaitUtils.class)
       .addClass(RemoteSFSBean.class) // the EJB
       .addClass(BusinessInterface.class); // the business interface
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/remote/RemoteSLSBInvocationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/remote/RemoteSLSBInvocationTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.integrationtest.functional.ejb.remote;
 
 import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.functional.ejb.remote.bean.BusinessInterface;
 import org.operaton.bpm.integrationtest.functional.ejb.remote.bean.RemoteSLSBClientDelegateBean;
 import org.operaton.bpm.integrationtest.functional.ejb.remote.bean.RemoteSLSBean;
@@ -62,6 +63,7 @@ public class RemoteSLSBInvocationTest extends AbstractFoxPlatformIntegrationTest
       .addAsLibraries(DeploymentHelper.getEjbClient())
       .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
       .addClass(AbstractFoxPlatformIntegrationTest.class)
+      .addClass(JobExecutorWaitUtils.class)
       .addClass(RemoteSLSBean.class) // the EJB
       .addClass(BusinessInterface.class); // the business interface
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/remote/RemoteSingletonBeanInvocationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/ejb/remote/RemoteSingletonBeanInvocationTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.integrationtest.functional.ejb.remote;
 
 import org.operaton.bpm.engine.runtime.ProcessInstance;
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.functional.ejb.remote.bean.BusinessInterface;
 import org.operaton.bpm.integrationtest.functional.ejb.remote.bean.RemoteSingletonBean;
 import org.operaton.bpm.integrationtest.functional.ejb.remote.bean.RemoteSingletonBeanClientDelegateBean;
@@ -63,6 +64,7 @@ public class RemoteSingletonBeanInvocationTest extends AbstractFoxPlatformIntegr
       .addAsLibraries(DeploymentHelper.getEjbClient())
       .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
       .addClass(AbstractFoxPlatformIntegrationTest.class)
+      .addClass(JobExecutorWaitUtils.class)
       .addClass(RemoteSingletonBean.class) // the EJB
       .addClass(BusinessInterface.class); // the business interface
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/error/CatchErrorFromProcessApplicationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/error/CatchErrorFromProcessApplicationTest.java
@@ -57,7 +57,7 @@ public class CatchErrorFromProcessApplicationTest extends AbstractFoxPlatformInt
       .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
       .addClass(AbstractFoxPlatformIntegrationTest.class)
       .addAsLibraries(DeploymentHelper.getEngineCdi())
-      .addAsLibraries(DeploymentHelper.getAssertJ());
+      .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResourcesForNonPa(deployment);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/event/CdiProcessApplicationEventSupportTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/event/CdiProcessApplicationEventSupportTest.java
@@ -45,7 +45,7 @@ public class CdiProcessApplicationEventSupportTest extends AbstractFoxPlatformIn
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "test.war")
         .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
         .addAsLibraries(DeploymentHelper.getEngineCdi())
-        .addAsLibraries(DeploymentHelper.getAssertJ())
+        .addAsLibraries(DeploymentHelper.getTestingLibs())
         .addAsResource("META-INF/processes.xml", "META-INF/processes.xml")
         .addClass(AbstractFoxPlatformIntegrationTest.class)
         .addClass(CdiEventSupportProcessApplication.class)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/event/ProcessApplicationExecutionListenerTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/event/ProcessApplicationExecutionListenerTest.java
@@ -43,7 +43,7 @@ public class ProcessApplicationExecutionListenerTest extends AbstractFoxPlatform
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "test.war")
       .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
       .addAsLibraries(DeploymentHelper.getEngineCdi())
-      .addAsLibraries(DeploymentHelper.getAssertJ())
+      .addAsLibraries(DeploymentHelper.getTestingLibs())
       .addAsResource("META-INF/processes.xml", "META-INF/processes.xml")
       .addClass(AbstractFoxPlatformIntegrationTest.class)
       .addClass(ExecutionListenerProcessApplication.class)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/event/ProcessApplicationTaskListenerTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/event/ProcessApplicationTaskListenerTest.java
@@ -47,7 +47,7 @@ public class ProcessApplicationTaskListenerTest extends AbstractFoxPlatformInteg
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "test.war")
         .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
         .addAsLibraries(DeploymentHelper.getEngineCdi())
-        .addAsLibraries(DeploymentHelper.getAssertJ())
+        .addAsLibraries(DeploymentHelper.getTestingLibs())
         .addAsResource("META-INF/processes.xml", "META-INF/processes.xml")
         .addClass(AbstractFoxPlatformIntegrationTest.class)
         .addClass(TaskListenerProcessApplication.class)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/metadata/engine/TestProcessEnginesXmlInProcessApplication.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/metadata/engine/TestProcessEnginesXmlInProcessApplication.java
@@ -43,7 +43,7 @@ public class TestProcessEnginesXmlInProcessApplication extends AbstractFoxPlatfo
         WebArchive archive = ShrinkWrap.create(WebArchive.class, "test.war")
         .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
         .addAsLibraries(DeploymentHelper.getEngineCdi())
-        .addAsLibraries(DeploymentHelper.getAssertJ())
+        .addAsLibraries(DeploymentHelper.getTestingLibs())
         .addAsResource("singleEngine.xml", "META-INF/processes.xml")
         .addClass(AbstractFoxPlatformIntegrationTest.class);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/migration/MigrationContextSwitchBeansTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/migration/MigrationContextSwitchBeansTest.java
@@ -81,7 +81,7 @@ public class MigrationContextSwitchBeansTest extends AbstractFoxPlatformIntegrat
   @Deployment(name="clientDeployment")
   public static WebArchive clientDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "client.war")
-            .addAsLibraries(DeploymentHelper.getAssertJ())
+            .addAsLibraries(DeploymentHelper.getTestingLibs())
             .addClass(AbstractFoxPlatformIntegrationTest.class);
 
     TestContainer.addContainerSpecificResources(webArchive);

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/migration/MigrationContextSwitchClassesTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/migration/MigrationContextSwitchClassesTest.java
@@ -103,7 +103,7 @@ public class MigrationContextSwitchClassesTest extends AbstractFoxPlatformIntegr
   @Deployment(name="clientDeployment")
   public static WebArchive clientDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "client.war")
-            .addAsLibraries(DeploymentHelper.getAssertJ())
+            .addAsLibraries(DeploymentHelper.getTestingLibs())
             .addClass(AbstractFoxPlatformIntegrationTest.class);
 
     TestContainer.addContainerSpecificResources(webArchive);

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/modification/ModificationContextSwitchTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/modification/ModificationContextSwitchTest.java
@@ -49,7 +49,7 @@ public class ModificationContextSwitchTest extends AbstractFoxPlatformIntegratio
   @Deployment(name="clientDeployment")
   public static WebArchive clientDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "client.war")
-            .addAsLibraries(DeploymentHelper.getAssertJ())
+            .addAsLibraries(DeploymentHelper.getTestingLibs())
             .addClass(AbstractFoxPlatformIntegrationTest.class);
 
     TestContainer.addContainerSpecificResources(webArchive);

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/GroovyAsyncScriptExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/GroovyAsyncScriptExecutionTest.java
@@ -23,6 +23,8 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
@@ -59,6 +61,7 @@ public class GroovyAsyncScriptExecutionTest extends AbstractFoxPlatformIntegrati
     WebArchive deployment = ShrinkWrap.create(WebArchive.class, "client.war")
             .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
+            .addClass(JobExecutorWaitUtils.class)
             .addAsLibraries(DeploymentHelper.getEngineCdi())
             .addAsLibraries(DeploymentHelper.getAssertJ());
     TestContainer.addContainerSpecificResourcesForNonPa(deployment);

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/GroovyAsyncScriptExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/GroovyAsyncScriptExecutionTest.java
@@ -63,7 +63,7 @@ public class GroovyAsyncScriptExecutionTest extends AbstractFoxPlatformIntegrati
             .addClass(AbstractFoxPlatformIntegrationTest.class)
             .addClass(JobExecutorWaitUtils.class)
             .addAsLibraries(DeploymentHelper.getEngineCdi())
-            .addAsLibraries(DeploymentHelper.getAssertJ());
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
     TestContainer.addContainerSpecificResourcesForNonPa(deployment);
     return deployment;
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/PaLocalScriptEngineCallActivityConditionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/scriptengine/PaLocalScriptEngineCallActivityConditionTest.java
@@ -59,7 +59,7 @@ public class PaLocalScriptEngineCallActivityConditionTest extends AbstractFoxPla
   @Deployment(name="clientDeployment")
   public static WebArchive clientDeployment() {
     WebArchive deployment = ShrinkWrap.create(WebArchive.class, "client.war")
-            .addAsLibraries(DeploymentHelper.getAssertJ())
+            .addAsLibraries(DeploymentHelper.getTestingLibs())
             .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
             .addClass(AbstractFoxPlatformIntegrationTest.class);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatAndPostDeployTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatAndPostDeployTest.java
@@ -47,7 +47,7 @@ public class PaDataFormatAndPostDeployTest extends AbstractFoxPlatformIntegratio
     return ShrinkWrap.create(WebArchive.class, "test.war")
             .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
             .addAsLibraries(DeploymentHelper.getEngineCdi())
-            .addAsLibraries(DeploymentHelper.getAssertJ())
+            .addAsLibraries(DeploymentHelper.getTestingLibs())
             .addAsResource("META-INF/processes.xml", "META-INF/processes.xml")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
             .addClass(TestConstants.class)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatConfiguratorFailingTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatConfiguratorFailingTest.java
@@ -51,7 +51,7 @@ public class PaDataFormatConfiguratorFailingTest {
   @Deployment(managed = false, name = "deployment")
   public static WebArchive createDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "PaDataFormatConfiguratorFailingTest.war")
-        .addAsLibraries(DeploymentHelper.getAssertJ())
+        .addAsLibraries(DeploymentHelper.getTestingLibs())
         .addAsResource("META-INF/processes.xml")
         .addClass(AbstractFoxPlatformIntegrationTest.class)
         .addClass(ReferenceStoringProcessApplication.class)
@@ -69,7 +69,7 @@ public class PaDataFormatConfiguratorFailingTest {
   @Deployment(name = "checkDeployment")
   public static WebArchive createCheckDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class)
-        .addAsLibraries(DeploymentHelper.getAssertJ());
+        .addAsLibraries(DeploymentHelper.getTestingLibs());
     TestContainer.addContainerSpecificResourcesForNonPa(webArchive);
     return webArchive;
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatProviderTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/PaDataFormatProviderTest.java
@@ -49,7 +49,7 @@ public class PaDataFormatProviderTest extends AbstractFoxPlatformIntegrationTest
     return ShrinkWrap.create(WebArchive.class, "PaDataFormatTest.war")
         .addAsResource("META-INF/processes.xml")
         .addClass(AbstractFoxPlatformIntegrationTest.class)
-        .addAsLibraries(DeploymentHelper.getAssertJ())
+        .addAsLibraries(DeploymentHelper.getTestingLibs())
         .addAsResource("org/operaton/bpm/integrationtest/oneTaskProcess.bpmn")
         .addClass(Foo.class)
         .addClass(FooDataFormat.class)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spring/SpringExpressionResolvingTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spring/SpringExpressionResolvingTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.integrationtest.functional.spring;
 
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.functional.spring.beans.ExampleBean;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
@@ -76,7 +77,9 @@ public class SpringExpressionResolvingTest extends AbstractFoxPlatformIntegratio
     WebArchive deployment = ShrinkWrap.create(WebArchive.class, "client.war")
             .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
-            .addAsLibraries(DeploymentHelper.getEngineCdi());
+            .addClass(JobExecutorWaitUtils.class)
+            .addAsLibraries(DeploymentHelper.getEngineCdi())
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResourcesForNonPa(deployment);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spring/SpringPAExpressionResolvingTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spring/SpringPAExpressionResolvingTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.integrationtest.functional.spring;
 
+import org.operaton.bpm.engine.test.util.JobExecutorWaitUtils;
 import org.operaton.bpm.integrationtest.functional.spring.beans.ExampleBean;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
@@ -71,7 +72,9 @@ public class SpringPAExpressionResolvingTest extends AbstractFoxPlatformIntegrat
     WebArchive deployment = ShrinkWrap.create(WebArchive.class, "client.war")
             .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
             .addClass(AbstractFoxPlatformIntegrationTest.class)
-            .addAsLibraries(DeploymentHelper.getEngineCdi());
+            .addClass(JobExecutorWaitUtils.class)
+            .addAsLibraries(DeploymentHelper.getEngineCdi())
+            .addAsLibraries(DeploymentHelper.getTestingLibs());
 
     TestContainer.addContainerSpecificResourcesForNonPa(deployment);
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/AsyncJobExecutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/transactions/AsyncJobExecutionTest.java
@@ -44,7 +44,7 @@ public class AsyncJobExecutionTest extends AbstractFoxPlatformIntegrationTest {
   @Deployment
   public static WebArchive processArchive() {
     return initWebArchiveDeployment()
-            .addAsLibraries(DeploymentHelper.getAssertJ())
+            .addAsLibraries(DeploymentHelper.getTestingLibs())
             .addClass(GetVersionInfoDelegate.class)
             .addClass(UpdateRouterConfiguration.class)
             .addClass(FailingTransactionListenerDelegate.class)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/ManagedJobExecutorTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/ManagedJobExecutorTest.java
@@ -44,6 +44,8 @@ public class ManagedJobExecutorTest {
     WebArchive archive = ShrinkWrap.create(WebArchive.class, "test.war")
         .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
         .addAsLibraries(DeploymentHelper.getEngineCdi())
+        .addClass(JobExecutorWaitUtils.class)
+        .addAsLibraries(DeploymentHelper.getTestingLibs())
         .addClass(ManagedJobExecutorTest.class)
         .addClass(ManagedJobExecutorBean.class)
         .addAsResource("org/operaton/bpm/integrationtest/jobexecutor/ManagedJobExecutorTest.testManagedExecutorUsed.bpmn20.xml");

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/SetVariablesAsyncTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/SetVariablesAsyncTest.java
@@ -66,7 +66,7 @@ public class SetVariablesAsyncTest extends AbstractFoxPlatformIntegrationTest {
   @Deployment(name="clientDeployment")
   public static WebArchive clientDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "client.war")
-        .addAsLibraries(DeploymentHelper.getAssertJ())
+        .addAsLibraries(DeploymentHelper.getTestingLibs())
         .addClass(AbstractFoxPlatformIntegrationTest.class);
 
     TestContainer.addContainerSpecificResources(webArchive);

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/util/AbstractFoxPlatformIntegrationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/util/AbstractFoxPlatformIntegrationTest.java
@@ -61,7 +61,7 @@ public abstract class AbstractFoxPlatformIntegrationTest {
     WebArchive archive = ShrinkWrap.create(WebArchive.class, name)
               .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
               .addAsLibraries(DeploymentHelper.getEngineCdi())
-              .addAsLibraries(DeploymentHelper.getAssertJ())
+              .addAsLibraries(DeploymentHelper.getTestingLibs())
               .addAsResource(processesXmlPath, "META-INF/processes.xml")
               .addClass(AbstractFoxPlatformIntegrationTest.class)
               .addClass(JobExecutorWaitUtils.class)

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/util/AbstractFoxPlatformIntegrationTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/util/AbstractFoxPlatformIntegrationTest.java
@@ -64,6 +64,7 @@ public abstract class AbstractFoxPlatformIntegrationTest {
               .addAsLibraries(DeploymentHelper.getAssertJ())
               .addAsResource(processesXmlPath, "META-INF/processes.xml")
               .addClass(AbstractFoxPlatformIntegrationTest.class)
+              .addClass(JobExecutorWaitUtils.class)
               .addClass(TestConstants.class);
 
     TestContainer.addContainerSpecificResources(archive);

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/util/DeploymentHelper.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/util/DeploymentHelper.java
@@ -16,16 +16,13 @@
  */
 package org.operaton.bpm.integrationtest.util;
 
-import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.jboss.shrinkwrap.resolver.api.maven.ScopeType;
-import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinate;
 import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenDependencies;
-import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenDependency;
 
 public class DeploymentHelper extends AbstractDeploymentHelper {
 
@@ -51,7 +48,7 @@ public class DeploymentHelper extends AbstractDeploymentHelper {
     return getEngineSpring(OPERATON_ENGINE_SPRING);
   }
 
-  public static JavaArchive[] getAssertJ() {
+  public static JavaArchive[] getTestingLibs() {
     if (cachedTestArtifacts != null) {
       return cachedTestArtifacts;
     } else {


### PR DESCRIPTION
The refactoring of tests that wait for job executions made the utility class JobExecutorWaitUtils the single instance used instead of mostly identical code duplications.

Tests that call JobExecutorWaitUtils by AbstractFoxPlatformIntegrationTest#waitForJobExecutorToProcessAllJobs need this utility class be packaged in the web archive. Furthermore, these web archives need additionally the Awaitility library being packaged. Adding this library via DeploymentHelper.

Renamed DeploymentHelper#getAssertJ -> getTestingLibs

related to https://github.com/operaton/operaton/pull/787