### PR TITLE
chore: Make interface methods to default methods which are marked for removal

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/history/HistoricVariableInstance.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/history/HistoricVariableInstance.java
@@ -66,7 +66,9 @@ public interface HistoricVariableInstance {
    *
    */
   @Deprecated(forRemoval = true, since = "1.0")
-  String getVariableName();
+  default String getVariableName() {
+    return getName();
+  }
 
   /**
    * Returns the name of the type of this variable instance.
@@ -74,7 +76,9 @@ public interface HistoricVariableInstance {
    * @deprecated Use {@link #getTypeName()} instead.
    */
   @Deprecated(forRemoval = true, since = "1.0")
-  String getVariableTypeName();
+  default String getVariableTypeName() {
+    return getTypeName();
+  }
 
   /**
    * The process definition key reference.

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/DeploymentQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/DeploymentQueryImpl.java
@@ -132,11 +132,6 @@ public class DeploymentQueryImpl extends AbstractQuery<DeploymentQuery, Deployme
   }
 
   @Override
-  public DeploymentQuery orderByDeploymenTime() {
-    return orderBy(DeploymentQueryProperty.DEPLOY_TIME);
-  }
-
-  @Override
   public DeploymentQuery orderByDeploymentTime() {
     return orderBy(DeploymentQueryProperty.DEPLOY_TIME);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/transformer/AbstractCmmnTransformListener.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/transformer/AbstractCmmnTransformListener.java
@@ -52,11 +52,6 @@ public class AbstractCmmnTransformListener implements CmmnTransformListener {
   }
 
   @Override
-  public void transformCasePlanModel(org.operaton.bpm.model.cmmn.impl.instance.CasePlanModel casePlanModel, CmmnActivity activity) {
-    transformCasePlanModel((org.operaton.bpm.model.cmmn.instance.CasePlanModel) casePlanModel, activity);
-  }
-
-  @Override
   public void transformCasePlanModel(CasePlanModel casePlanModel, CmmnActivity activity) {
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/transformer/CmmnTransformListener.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/transformer/CmmnTransformListener.java
@@ -54,7 +54,9 @@ public interface CmmnTransformListener {
    * @deprecated Use {@link #transformCasePlanModel(org.operaton.bpm.model.cmmn.instance.CasePlanModel, CmmnActivity)} instead.
    */
   @Deprecated(forRemoval = true, since = "1.0")
-  void transformCasePlanModel(org.operaton.bpm.model.cmmn.impl.instance.CasePlanModel casePlanModel, CmmnActivity caseActivity);
+  default void transformCasePlanModel(org.operaton.bpm.model.cmmn.impl.instance.CasePlanModel casePlanModel, CmmnActivity caseActivity) {
+    transformCasePlanModel((org.operaton.bpm.model.cmmn.instance.CasePlanModel) casePlanModel, caseActivity);
+  }
 
   void transformCasePlanModel(CasePlanModel casePlanModel, CmmnActivity caseActivity);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/transformer/CmmnHistoryTransformListener.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/transformer/CmmnHistoryTransformListener.java
@@ -85,11 +85,6 @@ public class CmmnHistoryTransformListener implements CmmnTransformListener {
   }
 
   @Override
-  public void transformCasePlanModel(org.operaton.bpm.model.cmmn.impl.instance.CasePlanModel casePlanModel, CmmnActivity caseActivity) {
-    transformCasePlanModel((org.operaton.bpm.model.cmmn.instance.CasePlanModel) casePlanModel, caseActivity);
-  }
-
-  @Override
   public void transformCasePlanModel(CasePlanModel casePlanModel, CmmnActivity caseActivity) {
     addCasePlanModelHandlers(caseActivity);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricVariableInstanceEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/HistoricVariableInstanceEntity.java
@@ -209,16 +209,6 @@ public class HistoricVariableInstanceEntity implements ValueFields, HistoricVari
   }
 
   @Override
-  public String getVariableTypeName() {
-    return getTypeName();
-  }
-
-  @Override
-  public String getVariableName() {
-    return name;
-  }
-
-  @Override
   public int getRevision() {
     return revision;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/repository/DeploymentBuilderImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/repository/DeploymentBuilderImpl.java
@@ -252,11 +252,6 @@ public class DeploymentBuilderImpl implements DeploymentBuilder, Serializable {
   }
 
   @Override
-  public DeploymentBuilder enableDuplicateFiltering() {
-    return enableDuplicateFiltering(false);
-  }
-
-  @Override
   public DeploymentBuilder enableDuplicateFiltering(boolean deployChangedOnly) {
     this.isDuplicateFilterEnabled = true;
     this.deployChangedOnly = deployChangedOnly;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/repository/ProcessApplicationDeploymentBuilderImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/repository/ProcessApplicationDeploymentBuilderImpl.java
@@ -114,15 +114,6 @@ public class ProcessApplicationDeploymentBuilderImpl extends DeploymentBuilderIm
     return (ProcessApplicationDeploymentBuilderImpl) super.source(source);
   }
 
-  /**
-   * @deprecated Use {@link #enableDuplicateFiltering(boolean)} instead.
-   */
-  @Override
-  @Deprecated(forRemoval = true, since = "1.0")
-  public ProcessApplicationDeploymentBuilderImpl enableDuplicateFiltering() {
-    return (ProcessApplicationDeploymentBuilderImpl) super.enableDuplicateFiltering(false);
-  }
-
   @Override
   public ProcessApplicationDeploymentBuilderImpl enableDuplicateFiltering(boolean deployChangedOnly) {
     return (ProcessApplicationDeploymentBuilderImpl) super.enableDuplicateFiltering(deployChangedOnly);

--- a/engine/src/main/java/org/operaton/bpm/engine/repository/DeploymentBuilder.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/repository/DeploymentBuilder.java
@@ -164,7 +164,9 @@ public interface DeploymentBuilder {
    * @deprecated Use {@link #enableDuplicateFiltering(boolean)} instead.
    */
   @Deprecated(forRemoval = true, since = "1.0")
-  DeploymentBuilder enableDuplicateFiltering();
+  default DeploymentBuilder enableDuplicateFiltering() {
+    return enableDuplicateFiltering(false);
+  }
 
   /**
    * Check the resources for duplicates in the set of previous deployments with

--- a/engine/src/main/java/org/operaton/bpm/engine/repository/DeploymentQuery.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/repository/DeploymentQuery.java
@@ -85,7 +85,9 @@ public interface DeploymentQuery extends Query<DeploymentQuery, Deployment>{
    * @deprecated Use {@link #orderByDeploymentTime()} instead.
    */
   @Deprecated(forRemoval = true, since = "1.0")
-  DeploymentQuery orderByDeploymenTime();
+  default DeploymentQuery orderByDeploymenTime() {
+    return orderByDeploymentTime();
+  }
 
   /** Order by deployment time (needs to be followed by {@link #asc()} or {@link #desc()}). */
   DeploymentQuery orderByDeploymentTime();

--- a/engine/src/main/java/org/operaton/bpm/engine/repository/ProcessApplicationDeploymentBuilder.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/repository/ProcessApplicationDeploymentBuilder.java
@@ -86,13 +86,6 @@ public interface ProcessApplicationDeploymentBuilder extends DeploymentBuilder {
   @Override
   ProcessApplicationDeploymentBuilder source(String source);
 
-  /**
-   * @deprecated Use {@link #enableDuplicateFiltering(boolean)} instead.
-   */
-  @Deprecated(forRemoval = true, since = "1.0")
-  @Override
-  ProcessApplicationDeploymentBuilder enableDuplicateFiltering();
-
   @Override
   ProcessApplicationDeploymentBuilder enableDuplicateFiltering(boolean deployChangedOnly);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/deploy/TestCmmnTransformListener.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/deploy/TestCmmnTransformListener.java
@@ -65,11 +65,6 @@ public class TestCmmnTransformListener implements CmmnTransformListener {
   }
 
   @Override
-  public void transformCasePlanModel(org.operaton.bpm.model.cmmn.impl.instance.CasePlanModel casePlanModel, CmmnActivity caseActivity) {
-    transformCasePlanModel((org.operaton.bpm.model.cmmn.instance.CasePlanModel) casePlanModel, caseActivity);
-  }
-
-  @Override
   public void transformCasePlanModel(CasePlanModel casePlanModel, CmmnActivity activity) {
     modelElementInstances.add(casePlanModel);
     cmmnActivities.add(activity);


### PR DESCRIPTION
The following methods have been marked for removal on interfaces, where the implementation to the recommended alternative to use can be implemented in a default method.

Removed implementations of the method in implementing classes.

- org.operaton.bpm.engine.impl.cmmn.transformer.CmmnTransformListener.transformCasePlanModel(org.operaton.bpm.model.cmmn.impl.instance.CasePlanModel, org.operaton.bpm.engine.impl.cmmn.model.CmmnActivity)
- org.operaton.bpm.engine.repository.DeploymentQuery.orderByDeploymenTime
- org.operaton.bpm.engine.history.HistoricVariableInstance.getVariableName
- org.operaton.bpm.engine.history.HistoricVariableInstance.getVariableTypeName
- org.operaton.bpm.engine.repository.DeploymentBuilder.enableDuplicateFiltering()

related to #811