### PR TITLE
refactor(tests): Refactor code that use try/fail/catch by usage assertThatThrownBy

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/GroupQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/GroupQueryTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.test.api.identity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.util.List;
@@ -295,15 +296,9 @@ class GroupQueryTest {
   @Test
   void testQueryInvalidSortingUsage() {
     var groupQuery = identityService.createGroupQuery().orderByGroupId().orderByGroupName();
-    try {
-      groupQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
-
-    try {
-      groupQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(groupQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Invalid query: call asc() or desc() after using orderByXX(): direction is null");
   }
 
   private void verifyQueryResults(GroupQuery query, int countExpected) {
@@ -312,8 +307,10 @@ class GroupQueryTest {
 
     if (countExpected == 1) {
       assertThat(query.singleResult()).isNotNull();
-    } else if (countExpected > 1){
-      verifySingleResultFails(query);
+    } else if (countExpected > 1) {
+      assertThatThrownBy(query::singleResult)
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessage("Query return %s results instead of max 1", countExpected);
     } else if (countExpected == 0) {
       assertThat(query.singleResult()).isNull();
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ActivateJobTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ActivateJobTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.mgmt;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -51,11 +51,9 @@ class ActivateJobTest {
 
   @Test
   void testActivationById_shouldThrowProcessEngineException() {
-    try {
-      managementService.activateJobById(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-    }
+    assertThatThrownBy(() -> managementService.activateJobById(null))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("jobId is null");
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/SuspensionTest.testBase.bpmn"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/JobDefinitionQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.mgmt;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -74,10 +74,9 @@ class JobDefinitionQueryTest {
     verifyQueryResults(query, 0);
     var jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
-    try {
-      jobDefinitionQuery.jobDefinitionId(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> jobDefinitionQuery.jobDefinitionId(null))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Job definition id is null");
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/JobDefinitionQueryTest.testBase.bpmn"})
@@ -103,19 +102,13 @@ class JobDefinitionQueryTest {
     verifyQueryResults(query, 0);
     var jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
-    try {
-      jobDefinitionQuery.activityIdIn(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      assertThat(e.getMessage()).isEqualTo("Activity ids is null");
-    }
+    assertThatThrownBy(() -> jobDefinitionQuery.activityIdIn((String[]) null))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Activity ids is null");
 
-    try {
-      jobDefinitionQuery.activityIdIn((String)null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      assertThat(e.getMessage()).isEqualTo("Activity ids contains null value");
-    }
+    assertThatThrownBy(() -> jobDefinitionQuery.activityIdIn((String) null))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Activity ids contains null value");
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/JobDefinitionQueryTest.testBase.bpmn"})
@@ -134,10 +127,9 @@ class JobDefinitionQueryTest {
     verifyQueryResults(query, 0);
     var jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
-    try {
-      jobDefinitionQuery.processDefinitionId(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> jobDefinitionQuery.processDefinitionId(null))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Process definition id is null");
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/JobDefinitionQueryTest.testBase.bpmn"})
@@ -156,10 +148,9 @@ class JobDefinitionQueryTest {
     verifyQueryResults(query, 0);
     var jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
-    try {
-      jobDefinitionQuery.processDefinitionKey(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> jobDefinitionQuery.processDefinitionKey(null))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Process definition key is null");
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/JobDefinitionQueryTest.testBase.bpmn"})
@@ -185,10 +176,9 @@ class JobDefinitionQueryTest {
     verifyQueryResults(query, 0);
     var jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
-    try {
-      jobDefinitionQuery.jobType(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> jobDefinitionQuery.jobType(null))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Job type is null");
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/JobDefinitionQueryTest.testBase.bpmn"})
@@ -198,10 +188,9 @@ class JobDefinitionQueryTest {
     verifyQueryResults(query, 0);
     var jobDefinitionQuery = managementService.createJobDefinitionQuery();
 
-    try {
-      jobDefinitionQuery.jobConfiguration(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> jobDefinitionQuery.jobConfiguration(null))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Job configuration is null");
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/JobDefinitionQueryTest.testBase.bpmn"})
@@ -311,20 +300,14 @@ class JobDefinitionQueryTest {
   @Test
   void testQueryInvalidSortingUsage() {
     var jobDefinitionQuery = managementService.createJobDefinitionQuery().orderByJobDefinitionId();
-    try {
-      jobDefinitionQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      testRule.assertTextPresent("call asc() or desc() after using orderByXX()", e.getMessage());
-    }
+    assertThatThrownBy(jobDefinitionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("call asc() or desc() after using orderByXX()");
 
     var jobQuery = managementService.createJobQuery();
-    try {
-      jobQuery.asc();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      testRule.assertTextPresent("You should call any of the orderBy methods first before specifying a direction", e.getMessage());
-    }
+    assertThatThrownBy(jobQuery::asc)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("You should call any of the orderBy methods first before specifying a direction");
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/JobDefinitionQueryTest.testBase.bpmn"})
@@ -344,7 +327,6 @@ class JobDefinitionQueryTest {
 
     // and
     assertThat(managementService.createJobDefinitionQuery().withOverridingJobPriority().count()).isEqualTo(1);
-
   }
 
   // Test Helpers ////////////////////////////////////////////////////////
@@ -355,18 +337,12 @@ class JobDefinitionQueryTest {
 
     if (countExpected == 1) {
       assertThat(query.singleResult()).isNotNull();
-    } else if (countExpected > 1){
-      verifySingleResultFails(query);
+    } else if (countExpected > 1) {
+      assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class)
+        .hasMessage("Query return %s results instead of max 1", countExpected);
     } else if (countExpected == 0) {
       assertThat(query.singleResult()).isNull();
     }
-  }
-
-  private void verifySingleResultFails(JobDefinitionQuery query) {
-    try {
-      query.singleResult();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {}
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/SuspendJobTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/SuspendJobTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.mgmt;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,11 +49,9 @@ class SuspendJobTest {
 
   @Test
   void testSuspensionById_shouldThrowProcessEngineException() {
-    try {
-      managementService.suspendJobById(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-    }
+    assertThatThrownBy(() -> managementService.suspendJobById(null))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("jobId is null");
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/mgmt/SuspensionTest.testBase.bpmn"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseDefinitionQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.cmmn.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -266,12 +266,9 @@ class MultiTenancyCaseDefinitionQueryTest {
   @Test
   void testFailQueryByTenantIdNull() {
     var caseDefinitionQuery = repositoryService.createCaseDefinitionQuery();
-    try {
-      caseDefinitionQuery.tenantIdIn((String) null);
-
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> caseDefinitionQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseExecutionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseExecutionQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.cmmn.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -117,12 +117,9 @@ class MultiTenancyCaseExecutionQueryTest {
   @Test
   void testFailQueryByTenantIdNull() {
     var caseExecutionQuery = caseService.createCaseExecutionQuery();
-    try {
-      caseExecutionQuery.tenantIdIn((String) null);
-
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> caseExecutionQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/MultiTenancyCaseInstanceQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.cmmn.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -117,12 +117,9 @@ class MultiTenancyCaseInstanceQueryTest {
   @Test
   void testFailQueryByTenantIdNull() {
     var caseInstanceQuery = caseService.createCaseInstanceQuery();
-    try {
-      caseInstanceQuery.tenantIdIn((String) null);
-
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> caseInstanceQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseActivityInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseActivityInstanceQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.cmmn.query.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicCaseActivityInstanceByTenantId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
@@ -132,15 +132,10 @@ class MultiTenancyHistoricCaseActivityInstanceQueryTest {
   @Test
   void shouldFailQueryByTenantIdNull() {
     var historicCaseActivityInstanceQuery = historyService.createHistoricCaseActivityInstanceQuery();
-    try {
-      // when
-      historicCaseActivityInstanceQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-
-      // then
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> historicCaseActivityInstanceQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/cmmn/query/history/MultiTenancyHistoricCaseInstanceQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.cmmn.query.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -120,12 +120,10 @@ class MultiTenancyHistoricCaseInstanceQueryTest {
   @Test
   void shouldFailQueryByTenantIdNull() {
     var historicCaseInstanceQuery = historyService.createHistoricCaseInstanceQuery();
-    try {
-      historicCaseInstanceQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> historicCaseInstanceQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDecisionDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDecisionDefinitionQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -269,12 +269,10 @@ class MultiTenancyDecisionDefinitionQueryTest {
   @Test
   void testFailQueryByTenantIdNull() {
     var decisionDefinitionQuery = repositoryService.createDecisionDefinitionQuery();
-    try {
-      decisionDefinitionQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> decisionDefinitionQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDeploymentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyDeploymentQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -136,12 +136,10 @@ class MultiTenancyDeploymentQueryTest {
   @Test
   void testFailQueryByTenantIdNull() {
     var deploymentQuery = repositoryService.createDeploymentQuery();
-    try {
-      deploymentQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> deploymentQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyEventSubscriptionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyEventSubscriptionQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -144,12 +144,10 @@ class MultiTenancyEventSubscriptionQueryTest {
   @Test
   void testFailQueryByTenantIdNull() {
     var eventSubscriptionQuery = runtimeService.createEventSubscriptionQuery();
-    try {
-      eventSubscriptionQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> eventSubscriptionQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyExecutionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyExecutionQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -120,12 +120,10 @@ class MultiTenancyExecutionQueryTest {
   @Test
   void testFailQueryByTenantIdNull() {
     var executionQuery = runtimeService.createExecutionQuery();
-    try {
-      executionQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> executionQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyExternalTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyExternalTaskQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -115,12 +115,10 @@ class MultiTenancyExternalTaskQueryTest {
   @Test
   void testFailQueryByTenantIdNull() {
     var externalTaskQuery = externalTaskService.createExternalTaskQuery();
-    try {
-      externalTaskQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> externalTaskQuery.tenantIdIn((String) null))
+      .isInstanceOf(NullValueException.class)
+      .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyIncidentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyIncidentQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -111,12 +111,10 @@ class MultiTenancyIncidentQueryTest {
   @Test
   void testFailQueryByTenantIdNull() {
     var incidentQuery = runtimeService.createIncidentQuery();
-    try {
-      incidentQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> incidentQuery.tenantIdIn((String[]) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds is null");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyJobDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyJobDefinitionQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -144,12 +144,10 @@ class MultiTenancyJobDefinitionQueryTest {
   @Test
   void testFailQueryByTenantIdNull() {
     var jobDefinitionQuery = managementService.createJobDefinitionQuery();
-    try {
-      jobDefinitionQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> jobDefinitionQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyJobQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyJobQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -147,12 +147,10 @@ class MultiTenancyJobQueryTest {
   @Test
   void testFailQueryByTenantIdNull() {
     var jobQuery = managementService.createJobQuery();
-    try {
-      jobQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> jobQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyProcessDefinitionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyProcessDefinitionQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -269,12 +269,10 @@ class MultiTenancyProcessDefinitionQueryTest {
   @Test
   void testFailQueryByTenantIdNull() {
     var processDefinitionQuery = repositoryService.createProcessDefinitionQuery();
-    try {
-      processDefinitionQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> processDefinitionQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyProcessInstanceQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -121,12 +121,10 @@ class MultiTenancyProcessInstanceQueryTest {
   @Test
   void testFailQueryByTenantIdNull() {
     var processInstanceQuery = runtimeService.createProcessInstanceQuery();
-    try {
-      processInstanceQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> processInstanceQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyVariableInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyVariableInstanceQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -113,12 +113,10 @@ class MultiTenancyVariableInstanceQueryTest {
   @Test
   void testFailQueryByTenantIdNull() {
     var variableInstanceQuery = runtimeService.createVariableInstanceQuery();
-    try {
-      variableInstanceQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> variableInstanceQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricActivityInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricActivityInstanceQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicActivityInstanceByTenantId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
@@ -136,15 +136,10 @@ class MultiTenancyHistoricActivityInstanceQueryTest {
   @Test
   void shouldFailQueryByTenantIdNull() {
     var historicActivityInstanceQuery = historyService.createHistoricActivityInstanceQuery();
-    try {
-      // when
-      historicActivityInstanceQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-
-      // then
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> historicActivityInstanceQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDecisionInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDecisionInstanceQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicDecisionInstanceByTenantId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
@@ -120,12 +120,10 @@ class MultiTenancyHistoricDecisionInstanceQueryTest {
   @Test
   void shouldFailQueryByTenantIdNull() {
     var historicDecisionInstanceQuery = historyService.createHistoricDecisionInstanceQuery();
-    try {
-      historicDecisionInstanceQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> historicDecisionInstanceQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailFormPropertyQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailFormPropertyQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicDetailByTenantId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
@@ -160,15 +160,10 @@ class MultiTenancyHistoricDetailFormPropertyQueryTest {
   void shouldFailQueryByTenantIdNull() {
     var historicDetailQuery = historyService.createHistoricDetailQuery()
         .formFields();
-    try {
-      // when
-      historicDetailQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-
-      // then
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> historicDetailQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricIncidentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricIncidentQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicIncidentByTenantId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
@@ -139,15 +139,10 @@ class MultiTenancyHistoricIncidentQueryTest {
   @Test
   void shouldFailQueryByTenantIdNull() {
     var historicIncidentQuery = historyService.createHistoricIncidentQuery();
-    try {
-      // when
-      historicIncidentQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-
-      // then
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> historicIncidentQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricJobLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricJobLogQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicJobLogByTenantId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
@@ -140,15 +140,10 @@ class MultiTenancyHistoricJobLogQueryTest {
   @Test
   void shouldFailQueryByTenantIdNull() {
     var historicJobLogQuery = historyService.createHistoricJobLogQuery();
-    try {
-      // when
-      historicJobLogQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-
-      // then
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> historicJobLogQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricProcessInstanceQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -124,12 +124,10 @@ class MultiTenancyHistoricProcessInstanceQueryTest {
   @Test
   void shouldFailQueryByTenantIdNull() {
     var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
-    try {
-      historicProcessInstanceQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> historicProcessInstanceQuery.tenantIdIn((String) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds contains null value");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricTaskInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricTaskInstanceQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.multitenancy.query.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicTaskInstanceByTenantId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
@@ -145,15 +145,10 @@ class MultiTenancyHistoricTaskInstanceQueryTest {
   @Test
   void shouldFailQueryByTenantIdNull() {
     var historicTaskInstanceQuery = historyService.createHistoricTaskInstanceQuery();
-    try {
-      // when
-      historicTaskInstanceQuery.tenantIdIn((String) null);
 
-      fail("expected exception");
-
-      // then
-    } catch (NullValueException e) {
-    }
+    assertThatThrownBy(() -> historicTaskInstanceQuery.tenantIdIn((String[]) null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessage("tenantIds is null");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DeploymentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/DeploymentQueryTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Date;
 import java.util.List;
@@ -63,13 +63,10 @@ class DeploymentQueryTest {
       .addClasspathResource("org/operaton/bpm/engine/test/repository/two.bpmn20.xml")
       .deploy()
       .getId();
-
-
   }
 
   @AfterEach
   void tearDown() {
-
     repositoryService.deleteDeployment(deploymentOneId, true);
     repositoryService.deleteDeployment(deploymentTwoId, true);
   }
@@ -80,12 +77,9 @@ class DeploymentQueryTest {
     assertThat(query.list()).hasSize(2);
     assertThat(query.count()).isEqualTo(2);
 
-    try {
-      query.singleResult();
-      fail("");
-    } catch (ProcessEngineException e) {
-      assertThat(e.getMessage()).isEqualTo("Query return 2 results instead of max 1");
-    }
+    assertThatThrownBy(query::singleResult)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Query return 2 results instead of max 1");
   }
 
   @Test
@@ -104,12 +98,9 @@ class DeploymentQueryTest {
     assertThat(query.count()).isZero();
     var deploymentQuery = repositoryService.createDeploymentQuery();
 
-    try {
-      deploymentQuery.deploymentId(null);
-      fail("");
-    } catch (ProcessEngineException e) {
-      assertThat(e.getMessage()).isEqualTo("Deployment id is null");
-    }
+    assertThatThrownBy(() -> deploymentQuery.deploymentId(null))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Deployment id is null");
   }
 
   @Test
@@ -128,12 +119,9 @@ class DeploymentQueryTest {
     assertThat(query.count()).isZero();
     var deploymentQuery = repositoryService.createDeploymentQuery();
 
-    try {
-      deploymentQuery.deploymentName(null);
-      fail("");
-    } catch (ProcessEngineException e) {
-      assertThat(e.getMessage()).isEqualTo("deploymentName is null");
-    }
+    assertThatThrownBy(() -> deploymentQuery.deploymentName(null))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("deploymentName is null");
   }
 
   @Test
@@ -156,12 +144,9 @@ class DeploymentQueryTest {
     assertThat(query.count()).isZero();
     var deploymentQuery = repositoryService.createDeploymentQuery();
 
-    try {
-      deploymentQuery.deploymentNameLike(null);
-      fail("");
-    } catch (ProcessEngineException e) {
-      assertThat(e.getMessage()).isEqualTo("deploymentNameLike is null");
-    }
+    assertThatThrownBy(() -> deploymentQuery.deploymentNameLike(null))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("deploymentNameLike is null");
   }
 
   @Test
@@ -176,12 +161,9 @@ class DeploymentQueryTest {
     assertThat(count).isZero();
     var deploymentQuery = repositoryService.createDeploymentQuery();
 
-    try {
-      deploymentQuery.deploymentBefore(null);
-      fail("Exception expected");
-    } catch (NullValueException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentQuery.deploymentBefore(null))
+      .isInstanceOf(NullValueException.class)
+      .hasMessage("deploymentBefore is null");
   }
 
   @Test
@@ -196,12 +178,8 @@ class DeploymentQueryTest {
     assertThat(count).isEqualTo(2);
     var deploymentQuery = repositoryService.createDeploymentQuery();
 
-    try {
-      deploymentQuery.deploymentAfter(null);
-      fail("Exception expected");
-    } catch (NullValueException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentQuery.deploymentAfter(null))
+      .isInstanceOf(NullValueException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CaseExecutionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CaseExecutionQueryTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.test.api.runtime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.caseExecutionByDefinitionId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.caseExecutionByDefinitionKey;
@@ -111,10 +112,9 @@ class CaseExecutionQueryTest {
   }
 
   private void verifySingleResultFails(CaseExecutionQuery query) {
-    try {
-      query.singleResult();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(query::singleResult)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageMatching("Query return \\d+ results instead of max 1");
   }
 
   @Test
@@ -145,11 +145,9 @@ class CaseExecutionQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseDefinitionKey(null);
-      fail("Exception expected");
-    } catch (NotValidException e) {}
-
+    assertThatThrownBy(() -> query.caseDefinitionKey(null))
+      .isInstanceOf(NotValidException.class)
+      .hasMessage("caseDefinitionKey is null");
   }
 
   @Test
@@ -185,11 +183,9 @@ class CaseExecutionQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseDefinitionId(null);
-      fail("Exception expected");
-    } catch (NotValidException e) {}
-
+    assertThatThrownBy(() -> query.caseDefinitionId(null))
+      .isInstanceOf(NotValidException.class)
+      .hasMessage("caseDefinitionId is null");
   }
 
   @Test
@@ -225,11 +221,9 @@ class CaseExecutionQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseInstanceId(null);
-      fail("Exception expected");
-    } catch (NotValidException e) {}
-
+    assertThatThrownBy(() -> query.caseInstanceId(null))
+      .isInstanceOf(NotValidException.class)
+      .hasMessage("caseInstanceId is null");
   }
 
   @Test
@@ -249,11 +243,9 @@ class CaseExecutionQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseInstanceBusinessKey(null);
-      fail("Exception expected");
-    } catch (NotValidException e) {}
-
+    assertThatThrownBy(() -> query.caseInstanceBusinessKey(null))
+      .isInstanceOf(NotValidException.class)
+      .hasMessage("caseInstanceBusinessKey is null");
   }
 
   @Test
@@ -317,11 +309,9 @@ class CaseExecutionQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseExecutionId(null);
-      fail("Exception expected");
-    } catch (NotValidException e) {}
-
+    assertThatThrownBy(() -> query.caseExecutionId(null))
+      .isInstanceOf(NotValidException.class)
+      .hasMessage("caseExecutionId is null");
   }
 
   @Test
@@ -346,11 +336,9 @@ class CaseExecutionQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.activityId(null);
-      fail("Exception expected");
-    } catch (NotValidException e) {}
-
+    assertThatThrownBy(() -> query.activityId(null))
+      .isInstanceOf(NotValidException.class)
+      .hasMessage("activityId is null");
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneMilestoneCase.cmmn"})
@@ -535,10 +523,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.variableValueEquals("aByteArrayValue", bytes);
 
-    try {
-      caseExecutionQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Variables of type ByteArray cannot be used to query");
   }
 
   @Test
@@ -556,10 +543,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.variableValueEquals("aSerializableValue", serializable);
 
-    try {
-      caseExecutionQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Object values cannot be used to query");
   }
 
   @Test
@@ -676,10 +662,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.variableValueNotEquals("aByteArrayValue", bytes);
 
-    try {
-      caseExecutionQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Variables of type ByteArray cannot be used to query");
   }
 
   @Test
@@ -697,10 +682,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.variableValueNotEquals("aSerializableValue", serializable);
 
-    try {
-      caseExecutionQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Object values cannot be used to query");
   }
 
   @Test
@@ -841,10 +825,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.variableValueGreaterThan("aByteArrayValue", bytes);
 
-    try {
-      caseExecutionQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Variables of type ByteArray cannot be used to query");
   }
 
   @Test
@@ -862,10 +845,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.variableValueGreaterThan("aSerializableValue", serializable);
 
-    try {
-      caseExecutionQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Object values cannot be used to query");
   }
 
   @Test
@@ -1044,10 +1026,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.variableValueGreaterThanOrEqual("aByteArrayValue", bytes);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Variables of type ByteArray cannot be used to query");
   }
 
   @Test
@@ -1065,10 +1046,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.variableValueGreaterThanOrEqual("aSerializableValue", serializable);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Object values cannot be used to query");
   }
 
   @Test
@@ -1210,10 +1190,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.variableValueLessThan("aByteArrayValue", bytes);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Variables of type ByteArray cannot be used to query");
   }
 
   @Test
@@ -1231,10 +1210,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.variableValueLessThan("aSerializableValue", serializable);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Object values cannot be used to query");
   }
 
   @Test
@@ -1413,10 +1391,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.variableValueLessThanOrEqual("aByteArrayValue", bytes);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Variables of type ByteArray cannot be used to query");
   }
 
   @Test
@@ -1434,10 +1411,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.variableValueLessThanOrEqual("aSerializableValue", serializable);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Object values cannot be used to query");
   }
 
   @Test
@@ -1609,10 +1585,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.caseInstanceVariableValueEquals("aByteArrayValue", bytes);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Variables of type ByteArray cannot be used to query");
   }
 
   @Test
@@ -1630,10 +1605,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.caseInstanceVariableValueEquals("aSerializableValue", serializable);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Object values cannot be used to query");
   }
 
   @Test
@@ -1750,10 +1724,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.caseInstanceVariableValueNotEquals("aByteArrayValue", bytes);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Variables of type ByteArray cannot be used to query");
   }
 
   @Test
@@ -1771,10 +1744,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.caseInstanceVariableValueNotEquals("aSerializableValue", serializable);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Object values cannot be used to query");
   }
 
   @Test
@@ -1917,10 +1889,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.caseInstanceVariableValueGreaterThan("aByteArrayValue", bytes);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Variables of type ByteArray cannot be used to query");
   }
 
   @Test
@@ -1938,10 +1909,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.caseInstanceVariableValueGreaterThan("aSerializableValue", serializable);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Object values cannot be used to query");
   }
 
   @Test
@@ -2121,10 +2091,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.caseInstanceVariableValueGreaterThanOrEqual("aByteArrayValue", bytes);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Variables of type ByteArray cannot be used to query");
   }
 
   @Test
@@ -2142,10 +2111,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.caseInstanceVariableValueGreaterThanOrEqual("aSerializableValue", serializable);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Object values cannot be used to query");
   }
 
   @Test
@@ -2288,10 +2256,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.caseInstanceVariableValueLessThan("aByteArrayValue", bytes);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Variables of type ByteArray cannot be used to query");
   }
 
   @Test
@@ -2309,10 +2276,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.caseInstanceVariableValueLessThan("aSerializableValue", serializable);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Object values cannot be used to query");
   }
 
   @Test
@@ -2491,10 +2457,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.caseInstanceVariableValueLessThanOrEqual("aByteArrayValue", bytes);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Variables of type ByteArray cannot be used to query");
   }
 
   @Test
@@ -2512,10 +2477,9 @@ class CaseExecutionQueryTest {
     CaseExecutionQuery query = caseService.createCaseExecutionQuery();
     var caseExecutionQuery = query.caseInstanceVariableValueLessThanOrEqual("aSerializableValue", serializable);
 
-    try {
-      caseExecutionQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(caseExecutionQuery::list)
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessage("Object values cannot be used to query");
   }
 
   @Test

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/filter/SecurityFilterRulesTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/filter/SecurityFilterRulesTest.java
@@ -118,73 +118,53 @@ public class SecurityFilterRulesTest {
 
   @Test
   public void shouldRejectEngineApi_GET() {
+    authenticatedForEngine("otherEngine", () -> {
+      Authorization authorization =
+        getAuthorization("POST", applicationPath + "/api/engine/engine/default/bar");
 
-    authenticatedForEngine("otherEngine", new Runnable() {
-      @Override
-      public void run() {
-
-        Authorization authorization =
-          getAuthorization("POST", applicationPath + "/api/engine/engine/default/bar");
-
-        assertThat(authorization.isGranted()).isFalse();
-        assertThat(authorization.isAuthenticated()).isFalse();
-      }
+      assertThat(authorization.isGranted()).isFalse();
+      assertThat(authorization.isAuthenticated()).isFalse();
     });
   }
 
   @Test
   public void shouldGrantEngineApi_GET() {
+    authenticatedForEngine("default", () -> {
+      Authorization authorization =
+        getAuthorization("POST", applicationPath + "/api/engine/engine/default/bar");
 
-    authenticatedForEngine("default", new Runnable() {
-      @Override
-      public void run() {
-
-        Authorization authorization =
-          getAuthorization("POST", applicationPath + "/api/engine/engine/default/bar");
-
-        assertThat(authorization.isGranted()).isTrue();
-        assertThat(authorization.isAuthenticated()).isTrue();
-      }
+      assertThat(authorization.isGranted()).isTrue();
+      assertThat(authorization.isAuthenticated()).isTrue();
     });
   }
 
   @Test
   public void shouldRejectCockpitPluginApi_GET() {
+    authenticatedForEngine("otherEngine", () -> {
+      Authorization authorization = getAuthorization("POST",
+        applicationPath + "/api/cockpit/plugin/" +
+          "reporting-process-count/default/process-instance-count");
 
-    authenticatedForEngine("otherEngine", new Runnable() {
-      @Override
-      public void run() {
-
-        Authorization authorization = getAuthorization("POST",
-          applicationPath + "/api/cockpit/plugin/" +
-            "reporting-process-count/default/process-instance-count");
-
-        assertThat(authorization.isGranted()).isFalse();
-        assertThat(authorization.isAuthenticated()).isFalse();
-      }
+      assertThat(authorization.isGranted()).isFalse();
+      assertThat(authorization.isAuthenticated()).isFalse();
     });
   }
 
   @Test
   public void shouldPassCockpitPluginApi_GET_LOGGED_IN() {
-    authenticatedForEngine("default", new Runnable() {
-      @Override
-      public void run() {
+    authenticatedForEngine("default", () -> {
+      Authorization authorization =
+        getAuthorization("POST",
+          applicationPath + "/api/cockpit/plugin/" +
+            "reporting-process-count/default/process-instance-count");
 
-        Authorization authorization =
-          getAuthorization("POST",
-            applicationPath + "/api/cockpit/plugin/" +
-              "reporting-process-count/default/process-instance-count");
-
-        assertThat(authorization.isGranted()).isTrue();
-        assertThat(authorization.isAuthenticated()).isTrue();
-      }
+      assertThat(authorization.isGranted()).isTrue();
+      assertThat(authorization.isAuthenticated()).isTrue();
     });
   }
 
   @Test
   public void shouldPassCockpit_GET_LOGGED_OUT() {
-
     Authorization authorization =
       getAuthorization("GET", applicationPath + "/app/cockpit/non-existing-engine/foo");
 
@@ -194,33 +174,23 @@ public class SecurityFilterRulesTest {
 
   @Test
   public void shouldPassCockpit_GET_LOGGED_IN() {
+  authenticatedForApp("default", "cockpit", () -> {
+      Authorization authorization =
+        getAuthorization("GET", applicationPath + "/app/cockpit/default/");
 
-    authenticatedForApp("default", "cockpit", new Runnable() {
-
-      @Override
-      public void run() {
-        Authorization authorization =
-          getAuthorization("GET", applicationPath + "/app/cockpit/default/");
-
-        assertThat(authorization.isGranted()).isTrue();
-        assertThat(authorization.isAuthenticated()).isTrue();
-      }
+      assertThat(authorization.isGranted()).isTrue();
+      assertThat(authorization.isAuthenticated()).isTrue();
     });
   }
 
   @Test
   public void shouldPassCockpitNonExistingEngine_GET_LOGGED_IN() {
+    authenticatedForApp("default", "cockpit", () -> {
+      Authorization authorization =
+        getAuthorization("GET", applicationPath + "/app/cockpit/non-existing-engine/");
 
-    authenticatedForApp("default", "cockpit", new Runnable() {
-
-      @Override
-      public void run() {
-        Authorization authorization =
-          getAuthorization("GET", applicationPath + "/app/cockpit/non-existing-engine/");
-
-        assertThat(authorization.isGranted()).isTrue();
-        assertThat(authorization.isAuthenticated()).isFalse();
-      }
+      assertThat(authorization.isGranted()).isTrue();
+      assertThat(authorization.isAuthenticated()).isFalse();
     });
   }
 
@@ -228,39 +198,30 @@ public class SecurityFilterRulesTest {
   @Test
   public void shouldRejectTasklistApi_GET() {
 
-    authenticatedForEngine("otherEngine", new Runnable() {
-      @Override
-      public void run() {
+    authenticatedForEngine("otherEngine", () -> {
+      Authorization authorization =
+        getAuthorization("POST",
+          applicationPath + "/api/tasklist/plugin/example-plugin/default/example-resource");
 
-        Authorization authorization =
-          getAuthorization("POST",
-            applicationPath + "/api/tasklist/plugin/example-plugin/default/example-resource");
-
-        assertThat(authorization.isGranted()).isFalse();
-        assertThat(authorization.isAuthenticated()).isFalse();
-      }
+      assertThat(authorization.isGranted()).isFalse();
+      assertThat(authorization.isAuthenticated()).isFalse();
     });
   }
 
   @Test
   public void shouldPassTasklistApi_GET_LOGGED_IN() {
-    authenticatedForEngine("default", new Runnable() {
-      @Override
-      public void run() {
+    authenticatedForEngine("default", () -> {
+      Authorization authorization =
+        getAuthorization("POST",
+          applicationPath + "/api/tasklist/plugin/example-plugin/default/example-resource");
 
-        Authorization authorization =
-          getAuthorization("POST",
-            applicationPath + "/api/tasklist/plugin/example-plugin/default/example-resource");
-
-        assertThat(authorization.isGranted()).isTrue();
-        assertThat(authorization.isAuthenticated()).isTrue();
-      }
+      assertThat(authorization.isGranted()).isTrue();
+      assertThat(authorization.isAuthenticated()).isTrue();
     });
   }
 
   @Test
-  public void shouldRejectTasklistApi_GET_LOGGED_OUT()
-  {
+  public void shouldRejectTasklistApi_GET_LOGGED_OUT() {
     Authorization authorization =
       getAuthorization("POST",
         applicationPath + "/api/tasklist/plugin/example-plugin/default/example-resource");
@@ -271,24 +232,18 @@ public class SecurityFilterRulesTest {
 
   @Test
   public void shouldPassTasklistPluginResource_GET_LOGGED_IN() {
+    authenticatedForEngine("default", () -> {
+      Authorization authorization =
+        getAuthorization("GET",
+          applicationPath + "/api/tasklist/plugin/example-plugin/static/example-resource");
 
-    authenticatedForEngine("default", new Runnable() {
-      @Override
-      public void run() {
-
-        Authorization authorization =
-          getAuthorization("GET",
-            applicationPath + "/api/tasklist/plugin/example-plugin/static/example-resource");
-
-        assertThat(authorization.isGranted()).isTrue();
-        assertThat(authorization.isAuthenticated()).isFalse();
-      }
+      assertThat(authorization.isGranted()).isTrue();
+      assertThat(authorization.isAuthenticated()).isFalse();
     });
   }
 
   @Test
   public void shouldPassTasklistPluginResource_GET_LOGGED_OUT() {
-
     Authorization authorization =
       getAuthorization("GET",
         applicationPath + "/api/tasklist/plugin/example-plugin/static/example-resource");
@@ -300,7 +255,6 @@ public class SecurityFilterRulesTest {
 
   @Test
   public void shouldPassTasklist_GET_LOGGED_OUT() {
-
     Authorization authorization =
       getAuthorization("GET", applicationPath + "/app/tasklist/non-existing-engine");
 
@@ -310,23 +264,17 @@ public class SecurityFilterRulesTest {
 
   @Test
   public void shouldPassTasklist_GET_LOGGED_IN() {
+    authenticatedForApp("default", "tasklist", () -> {
+      Authorization authorization =
+        getAuthorization("GET", applicationPath + "/app/tasklist/default/");
 
-    authenticatedForApp("default", "tasklist", new Runnable() {
-
-      @Override
-      public void run() {
-        Authorization authorization =
-          getAuthorization("GET", applicationPath + "/app/tasklist/default/");
-
-        assertThat(authorization.isGranted()).isTrue();
-        assertThat(authorization.isAuthenticated()).isTrue();
-      }
+      assertThat(authorization.isGranted()).isTrue();
+      assertThat(authorization.isAuthenticated()).isTrue();
     });
   }
 
   @Test
   public void shouldRejectAdminApi_GET_LOGGED_OUT() {
-
     Authorization authorization =
       getAuthorization("GET", applicationPath + "/api/admin/auth/user/some-engine/");
 
@@ -342,23 +290,17 @@ public class SecurityFilterRulesTest {
 
   @Test
   public void shouldPassAdminApi_GET_LOGGED_IN() {
+    authenticatedForApp("default", "admin", () -> {
+      Authorization authorization =
+        getAuthorization("GET", applicationPath + "/api/admin/foo/");
 
-    authenticatedForApp("default", "admin", new Runnable() {
-
-      @Override
-      public void run() {
-        Authorization authorization =
-          getAuthorization("GET", applicationPath + "/api/admin/foo/");
-
-        assertThat(authorization.isGranted()).isTrue();
-        assertThat(authorization.isAuthenticated()).isFalse();
-      }
+      assertThat(authorization.isGranted()).isTrue();
+      assertThat(authorization.isAuthenticated()).isFalse();
     });
   }
 
   @Test
   public void shouldPassAdminApi_AnonymousEndpoints_LOGGED_OUT() {
-
     Authorization authorization =
       getAuthorization("GET", applicationPath + "/api/admin/auth/user/bar");
 
@@ -387,7 +329,6 @@ public class SecurityFilterRulesTest {
 
   @Test
   public void shouldRejectAdminApiPlugin_GET_LOGGED_OUT() {
-
     Authorization authorization =
       getAuthorization("GET",
         applicationPath + "/api/admin/plugin/adminPlugins/some-engine/endpoint");
@@ -398,24 +339,18 @@ public class SecurityFilterRulesTest {
 
   @Test
   public void shouldPassAdminApiPlugin_GET_LOGGED_IN() {
+    authenticatedForApp("default", "admin", () -> {
+      Authorization authorization =
+        getAuthorization("GET",
+          applicationPath + "/api/admin/plugin/adminPlugins/some-engine");
 
-    authenticatedForApp("default", "admin", new Runnable() {
-
-      @Override
-      public void run() {
-        Authorization authorization =
-          getAuthorization("GET",
-            applicationPath + "/api/admin/plugin/adminPlugins/some-engine");
-
-        assertThat(authorization.isGranted()).isTrue();
-        assertThat(authorization.isAuthenticated()).isFalse();
-      }
+      assertThat(authorization.isGranted()).isTrue();
+      assertThat(authorization.isAuthenticated()).isFalse();
     });
   }
 
   @Test
   public void shouldPassAdmin_GET_LOGGED_OUT() {
-
     Authorization authorization =
       getAuthorization("GET", applicationPath + "/app/admin/default");
 
@@ -425,24 +360,18 @@ public class SecurityFilterRulesTest {
 
   @Test
   public void shouldPassAdmin_GET_LOGGED_IN() {
+    authenticatedForApp("default", "admin", () -> {
+      Authorization authorization =
+        getAuthorization("GET", applicationPath + "/app/admin/default/");
 
-    authenticatedForApp("default", "admin", new Runnable() {
-
-      @Override
-      public void run() {
-        Authorization authorization =
-          getAuthorization("GET", applicationPath + "/app/admin/default/");
-
-        assertThat(authorization.isGranted()).isTrue();
-        assertThat(authorization.isAuthenticated()).isTrue();
-      }
+      assertThat(authorization.isGranted()).isTrue();
+      assertThat(authorization.isAuthenticated()).isTrue();
     });
   }
 
 
   @Test
   public void shouldPassAdminResources_GET_LOGGED_OUT() {
-
     Authorization authorization =
       getAuthorization("GET", applicationPath + "/app/admin/scripts");
 
@@ -452,23 +381,17 @@ public class SecurityFilterRulesTest {
 
   @Test
   public void shouldPassAdminResources_GET_LOGGED_IN() {
+  authenticatedForApp("default", "admin", () -> {
+      Authorization authorization =
+        getAuthorization("GET", applicationPath + "/app/admin/scripts");
 
-    authenticatedForApp("default", "admin", new Runnable() {
-
-      @Override
-      public void run() {
-        Authorization authorization =
-          getAuthorization("GET", applicationPath + "/app/admin/scripts");
-
-        assertThat(authorization.isGranted()).isTrue();
-        assertThat(authorization.isAuthenticated()).isFalse();
-      }
+      assertThat(authorization.isGranted()).isTrue();
+      assertThat(authorization.isAuthenticated()).isFalse();
     });
   }
 
   @Test
   public void shouldPassAdminLicenseCheck_GET_LOGGED_OUT() {
-
     Authorization authorization =
       getAuthorization("GET", applicationPath + "/api/admin/plugin/license/default/check-key");
 
@@ -485,7 +408,6 @@ public class SecurityFilterRulesTest {
   }
 
   private static List<SecurityFilterRule> loadFilterRules(String appPath) throws IOException {
-
     try (InputStream is = new FileInputStream(FILTER_RULES_FILE)) {
       return FilterRules.load(is, appPath);
     }


### PR DESCRIPTION
Refactors tests that test for expected exceptions with pattern
```
  try {
     // do something
     fail("expected");
  } catch (ExpectedException) {}
```

  to use AssertJ's assertThatThrownBy

This resolves Sonar warnings of type [java:S108](https://sonarcloud.io/organizations/operaton/rules?open=java%3AS108&rule_key=java%3AS108) because of removal of empty catch blocks.

related to #564