### PR TITLE
chore: Adjust modifiers or names to match naming conventions

### DIFF
--- a/clients/java/client/src/test/java/org/operaton/bpm/client/variable/DateValueMapperTest.java
+++ b/clients/java/client/src/test/java/org/operaton/bpm/client/variable/DateValueMapperTest.java
@@ -34,9 +34,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class DateValueMapperTest {
 
-  protected static final String DATE_FORMAT = "dd.MM.yyyy - HH:mm:ss.SSSZ";
-  protected final Date VARIABLE_VALUE_DATE = new GregorianCalendar(2018, Calendar.JANUARY, 1, 8, 0, 0).getTime();
-  protected final String VARIABLE_VALUE_DATE_SERIALIZED = new SimpleDateFormat(DATE_FORMAT).format(VARIABLE_VALUE_DATE);
+  private static final String DATE_FORMAT = "dd.MM.yyyy - HH:mm:ss.SSSZ";
+  private static final Date VARIABLE_VALUE_DATE = new GregorianCalendar(2018, Calendar.JANUARY, 1, 8, 0, 0).getTime();
+  private static final String VARIABLE_VALUE_DATE_SERIALIZED = new SimpleDateFormat(DATE_FORMAT).format(VARIABLE_VALUE_DATE);
 
   protected DateValueMapper dateValueMapper;
 

--- a/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/AbstractHttpRequest.java
+++ b/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/AbstractHttpRequest.java
@@ -34,7 +34,7 @@ import org.operaton.connect.spi.Connector;
 
 public class AbstractHttpRequest<Q extends HttpBaseRequest<?, ?>, R extends HttpResponse> extends AbstractConnectorRequest<R> {
 
-  private final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
+  private static final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
 
   public AbstractHttpRequest(Connector connector) {
     super(connector);

--- a/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/HttpResponseImpl.java
+++ b/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/HttpResponseImpl.java
@@ -29,7 +29,7 @@ import org.operaton.commons.utils.IoUtil;
 
 public class HttpResponseImpl extends AbstractCloseableConnectorResponse implements HttpResponse {
 
-  private final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
+  private static final HttpConnectorLogger LOG = HttpLogger.HTTP_LOGGER;
 
   protected CloseableHttpResponse httpResponse;
 

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebIT.java
@@ -39,7 +39,7 @@ public abstract class AbstractWebIT {
 
   protected static final String TASKLIST_PATH = "app/tasklist/default/";
   protected static final String HOST_NAME = "localhost";
-  public String APP_BASE_PATH;
+  protected String appBasePath;
 
   protected String appUrl;
   protected TestUtil testUtil;
@@ -67,8 +67,8 @@ public abstract class AbstractWebIT {
     testProperties = new TestProperties();
 
     // Get the application base path
-    APP_BASE_PATH = testProperties.getApplicationPath("/" + ctxPath);
-    LOGGER.info("Connecting to application " + APP_BASE_PATH);
+    appBasePath = testProperties.getApplicationPath("/" + ctxPath);
+    LOGGER.info("Connecting to application " + appBasePath);
 
     // Create ClientConfig and register JacksonFeature for POJO mapping
     ClientConfig clientConfig = new ClientConfig();

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/PluginsRootResourceIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/PluginsRootResourceIT.java
@@ -105,7 +105,7 @@ class PluginsRootResourceIT extends AbstractWebIT {
     JerseyClient client = (JerseyClient) JerseyClientBuilder.newClient();
 
     // Build the target URI using the base path and path parameter
-    String fullPath = APP_BASE_PATH + path;
+    String fullPath = appBasePath + path;
 
     // Perform the GET request to fetch the asset
     return client.target(fullPath)  // Use target() to define the endpoint

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/ProblemDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/ProblemDto.java
@@ -32,7 +32,7 @@ public class ProblemDto {
   protected int line;
   protected int column;
   protected String mainElementId;
-  protected List<String> еlementIds;
+  protected List<String> elementIds;
 
   // transformer /////////////////////////////
 
@@ -43,7 +43,7 @@ public class ProblemDto {
     dto.setLine(problem.getLine());
     dto.setColumn(problem.getColumn());
     dto.setMainElementId(problem.getMainElementId());
-    dto.setЕlementIds(problem.getElementIds());
+    dto.setElementIds(problem.getElementIds());
 
     return dto;
   }
@@ -82,12 +82,12 @@ public class ProblemDto {
     this.mainElementId = mainElementId;
   }
 
-  public List<String> getЕlementIds() {
-    return еlementIds;
+  public List<String> getElementIds() {
+    return elementIds;
   }
 
-  public void setЕlementIds(List<String> elementIds) {
-    this.еlementIds = elementIds;
+  public void setElementIds(List<String> elementIds) {
+    this.elementIds = elementIds;
   }
 
 }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/EmptyHalCollection.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/EmptyHalCollection.java
@@ -30,8 +30,8 @@ public class EmptyHalCollection extends HalCollectionResource<EmptyHalCollection
   }
 
   public EmptyHalCollection(long count) {
-    _links = Collections.emptyMap();
-    _embedded = Collections.emptyMap();
+    links = Collections.emptyMap();
+    embedded = Collections.emptyMap();
     this.count = count;
   }
 

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/EmptyHalResource.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/EmptyHalResource.java
@@ -26,8 +26,8 @@ public class EmptyHalResource extends HalResource<EmptyHalResource> {
   public static final HalResource INSTANCE = new EmptyHalResource();
 
   public EmptyHalResource() {
-    _links = Collections.emptyMap();
-    _embedded = Collections.emptyMap();
+    links = Collections.emptyMap();
+    embedded = Collections.emptyMap();
   }
 
   @SuppressWarnings("unchecked")

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/HalResource.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/HalResource.java
@@ -33,10 +33,10 @@ import java.util.TreeMap;
 public abstract class HalResource<T extends HalResource<?>> {
 
   /** This resource links */
-  protected Map<String, HalLink> _links;
+  protected Map<String, HalLink> links;
 
   /** Embedded resources */
-  protected Map<String, Object> _embedded;
+  protected Map<String, Object> embedded;
 
   // the linker used by this resource
   protected transient HalLinker linker;
@@ -46,18 +46,18 @@ public abstract class HalResource<T extends HalResource<?>> {
   }
 
   public Map<String, HalLink> get_links() {
-    return _links;
+    return links;
   }
 
   public Map<String, Object> get_embedded() {
-    return _embedded;
+    return embedded;
   }
 
   public void addLink(String rel, String href) {
-    if(_links == null) {
-      _links = new TreeMap<>();
+    if(this.links == null) {
+      this.links = new TreeMap<>();
     }
-    _links.put(rel, new HalLink(href));
+    this.links.put(rel, new HalLink(href));
   }
 
   public void addLink(String rel, URI hrefUri) {
@@ -70,10 +70,10 @@ public abstract class HalResource<T extends HalResource<?>> {
   }
 
   private void addEmbeddedObject(String name, Object embedded) {
-    if(_embedded == null) {
-      _embedded = new TreeMap<>();
+    if(this.embedded == null) {
+      this.embedded = new TreeMap<>();
     }
-    _embedded.put(name, embedded);
+    this.embedded.put(name, embedded);
   }
 
   public void addEmbedded(String name, List<HalResource<?>> embeddedCollection) {
@@ -84,7 +84,7 @@ public abstract class HalResource<T extends HalResource<?>> {
   }
 
   public Object getEmbedded(String name) {
-    return _embedded.get(name);
+    return embedded.get(name);
   }
 
   /**

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/AbstractDefinitionDeployer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/AbstractDefinitionDeployer.java
@@ -46,7 +46,7 @@ public abstract class AbstractDefinitionDeployer<DefinitionEntity extends Resour
 
   public static final String[] DIAGRAM_SUFFIXES = new String[] { "png", "jpg", "gif", "svg" };
 
-  private final CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
+  private static final CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
 
   protected IdGenerator idGenerator;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/RestartProcessInstancesBatchCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/RestartProcessInstancesBatchCmd.java
@@ -45,7 +45,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
  */
 public class RestartProcessInstancesBatchCmd extends AbstractRestartProcessInstanceCmd<Batch> {
 
-  private final CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
+  private static final CommandLogger LOG = ProcessEngineLogger.CMD_LOGGER;
 
   public RestartProcessInstancesBatchCmd(CommandExecutor commandExecutor, RestartProcessInstanceBuilderImpl builder) {
     super(commandExecutor, builder);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/parser/HistoryParseListener.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/parser/HistoryParseListener.java
@@ -59,14 +59,14 @@ public class HistoryParseListener implements BpmnParseListener {
   // listeners can be reused for a given process engine instance but cannot be cached in static fields since
   // different process engine instances on the same Classloader may have different HistoryEventProducer
   // configurations wired
-  protected ExecutionListener PROCESS_INSTANCE_START_LISTENER;
-  protected ExecutionListener PROCESS_INSTANCE_END_LISTENER;
+  protected ExecutionListener processInstanceStartListener;
+  protected ExecutionListener processInstanceEndListener;
 
-  protected ExecutionListener ACTIVITY_INSTANCE_START_LISTENER;
-  protected ExecutionListener ACTIVITY_INSTANCE_END_LISTENER;
+  protected ExecutionListener activityInstanceStartListener;
+  protected ExecutionListener activityInstanceEndListener;
 
-  protected TaskListener USER_TASK_ASSIGNMENT_HANDLER;
-  protected TaskListener USER_TASK_ID_HANDLER;
+  protected TaskListener userTaskAssignmentHandler;
+  protected TaskListener userTaskIdHandler;
 
   // The history level set in the process engine configuration
   protected HistoryLevel historyLevel;
@@ -76,21 +76,21 @@ public class HistoryParseListener implements BpmnParseListener {
   }
 
   protected void initExecutionListeners(HistoryEventProducer historyEventProducer) {
-    PROCESS_INSTANCE_START_LISTENER = new ProcessInstanceStartListener(historyEventProducer);
-    PROCESS_INSTANCE_END_LISTENER = new ProcessInstanceEndListener(historyEventProducer);
+    processInstanceStartListener = new ProcessInstanceStartListener(historyEventProducer);
+    processInstanceEndListener = new ProcessInstanceEndListener(historyEventProducer);
 
-    ACTIVITY_INSTANCE_START_LISTENER = new ActivityInstanceStartListener(historyEventProducer);
-    ACTIVITY_INSTANCE_END_LISTENER = new ActivityInstanceEndListener(historyEventProducer);
+    activityInstanceStartListener = new ActivityInstanceStartListener(historyEventProducer);
+    activityInstanceEndListener = new ActivityInstanceEndListener(historyEventProducer);
 
-    USER_TASK_ASSIGNMENT_HANDLER = new ActivityInstanceUpdateListener(historyEventProducer);
-    USER_TASK_ID_HANDLER = USER_TASK_ASSIGNMENT_HANDLER;
+    userTaskAssignmentHandler = new ActivityInstanceUpdateListener(historyEventProducer);
+    userTaskIdHandler = userTaskAssignmentHandler;
   }
 
   @Override
   public void parseProcess(Element processElement, ProcessDefinitionEntity processDefinition) {
     ensureHistoryLevelInitialized();
     if (historyLevel.isHistoryEventProduced(HistoryEventTypes.PROCESS_INSTANCE_END, null)) {
-      processDefinition.addBuiltInListener(PvmEvent.EVENTNAME_END, PROCESS_INSTANCE_END_LISTENER);
+      processDefinition.addBuiltInListener(PvmEvent.EVENTNAME_END, processInstanceEndListener);
     }
   }
 
@@ -136,8 +136,8 @@ public class HistoryParseListener implements BpmnParseListener {
 
     if (historyLevel.isHistoryEventProduced(HistoryEventTypes.TASK_INSTANCE_CREATE, null)) {
       TaskDefinition taskDefinition = ((UserTaskActivityBehavior) activity.getActivityBehavior()).getTaskDefinition();
-      taskDefinition.addBuiltInTaskListener(TaskListener.EVENTNAME_ASSIGNMENT, USER_TASK_ASSIGNMENT_HANDLER);
-      taskDefinition.addBuiltInTaskListener(TaskListener.EVENTNAME_CREATE, USER_TASK_ID_HANDLER);
+      taskDefinition.addBuiltInTaskListener(TaskListener.EVENTNAME_ASSIGNMENT, userTaskAssignmentHandler);
+      taskDefinition.addBuiltInTaskListener(TaskListener.EVENTNAME_CREATE, userTaskIdHandler);
     }
   }
 
@@ -279,10 +279,10 @@ public class HistoryParseListener implements BpmnParseListener {
   protected void addActivityHandlers(ActivityImpl activity) {
     ensureHistoryLevelInitialized();
     if (historyLevel.isHistoryEventProduced(HistoryEventTypes.ACTIVITY_INSTANCE_START, null)) {
-      activity.addBuiltInListener(PvmEvent.EVENTNAME_START, ACTIVITY_INSTANCE_START_LISTENER, 0);
+      activity.addBuiltInListener(PvmEvent.EVENTNAME_START, activityInstanceStartListener, 0);
     }
     if (historyLevel.isHistoryEventProduced(HistoryEventTypes.ACTIVITY_INSTANCE_END, null)) {
-      activity.addBuiltInListener(PvmEvent.EVENTNAME_END, ACTIVITY_INSTANCE_END_LISTENER);
+      activity.addBuiltInListener(PvmEvent.EVENTNAME_END, activityInstanceEndListener);
     }
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/transformer/CmmnHistoryTransformListener.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/transformer/CmmnHistoryTransformListener.java
@@ -51,13 +51,13 @@ public class CmmnHistoryTransformListener implements CmmnTransformListener {
   // listeners can be reused for a given process engine instance but cannot be cached in static fields since
   // different process engine instances on the same Classloader may have different HistoryEventProducer
   // configurations wired
-  protected CaseExecutionListener CASE_INSTANCE_CREATE_LISTENER;
-  protected CaseExecutionListener CASE_INSTANCE_UPDATE_LISTENER;
-  protected CaseExecutionListener CASE_INSTANCE_CLOSE_LISTENER;
+  protected CaseExecutionListener caseInstanceCreateListener;
+  protected CaseExecutionListener caseInstanceUpdateListener;
+  protected CaseExecutionListener caseInstanceCloseListener;
 
-  protected CaseExecutionListener CASE_ACTIVITY_INSTANCE_CREATE_LISTENER;
-  protected CaseExecutionListener CASE_ACTIVITY_INSTANCE_UPDATE_LISTENER;
-  protected CaseExecutionListener CASE_ACTIVITY_INSTANCE_END_LISTENER;
+  protected CaseExecutionListener caseActivityInstanceCreateListener;
+  protected CaseExecutionListener caseActivityInstanceUpdateListener;
+  protected CaseExecutionListener caseActivityInstanceEndListener;
 
   // The history level set in the process engine configuration
   protected HistoryLevel historyLevel;
@@ -67,13 +67,13 @@ public class CmmnHistoryTransformListener implements CmmnTransformListener {
   }
 
   protected void initCaseExecutionListeners(CmmnHistoryEventProducer historyEventProducer) {
-    CASE_INSTANCE_CREATE_LISTENER = new CaseInstanceCreateListener(historyEventProducer);
-    CASE_INSTANCE_UPDATE_LISTENER = new CaseInstanceUpdateListener(historyEventProducer);
-    CASE_INSTANCE_CLOSE_LISTENER = new CaseInstanceCloseListener(historyEventProducer);
+    caseInstanceCreateListener = new CaseInstanceCreateListener(historyEventProducer);
+    caseInstanceUpdateListener = new CaseInstanceUpdateListener(historyEventProducer);
+    caseInstanceCloseListener = new CaseInstanceCloseListener(historyEventProducer);
 
-    CASE_ACTIVITY_INSTANCE_CREATE_LISTENER = new CaseActivityInstanceCreateListener(historyEventProducer);
-    CASE_ACTIVITY_INSTANCE_UPDATE_LISTENER = new CaseActivityInstanceUpdateListener(historyEventProducer);
-    CASE_ACTIVITY_INSTANCE_END_LISTENER = new CaseActivityInstanceEndListener(historyEventProducer);
+    caseActivityInstanceCreateListener = new CaseActivityInstanceCreateListener(historyEventProducer);
+    caseActivityInstanceUpdateListener = new CaseActivityInstanceUpdateListener(historyEventProducer);
+    caseActivityInstanceEndListener = new CaseActivityInstanceEndListener(historyEventProducer);
   }
 
   @Override
@@ -138,17 +138,17 @@ public class CmmnHistoryTransformListener implements CmmnTransformListener {
     if (caseActivity != null) {
       if (historyLevel.isHistoryEventProduced(HistoryEventTypes.CASE_INSTANCE_CREATE, null)) {
         for (String event : ItemHandler.CASE_PLAN_MODEL_CREATE_EVENTS) {
-          caseActivity.addBuiltInListener(event, CASE_INSTANCE_CREATE_LISTENER);
+          caseActivity.addBuiltInListener(event, caseInstanceCreateListener);
         }
       }
       if (historyLevel.isHistoryEventProduced(HistoryEventTypes.CASE_INSTANCE_UPDATE, null)) {
         for (String event : ItemHandler.CASE_PLAN_MODEL_UPDATE_EVENTS) {
-          caseActivity.addBuiltInListener(event, CASE_INSTANCE_UPDATE_LISTENER);
+          caseActivity.addBuiltInListener(event, caseInstanceUpdateListener);
         }
       }
       if (historyLevel.isHistoryEventProduced(HistoryEventTypes.CASE_INSTANCE_CLOSE, null)) {
         for (String event : ItemHandler.CASE_PLAN_MODEL_CLOSE_EVENTS) {
-          caseActivity.addBuiltInListener(event, CASE_INSTANCE_CLOSE_LISTENER);
+          caseActivity.addBuiltInListener(event, caseInstanceCloseListener);
         }
       }
     }
@@ -159,17 +159,17 @@ public class CmmnHistoryTransformListener implements CmmnTransformListener {
     if (caseActivity != null) {
       if (historyLevel.isHistoryEventProduced(HistoryEventTypes.CASE_ACTIVITY_INSTANCE_CREATE, null)) {
         for (String event : ItemHandler.TASK_OR_STAGE_CREATE_EVENTS) {
-          caseActivity.addBuiltInListener(event, CASE_ACTIVITY_INSTANCE_CREATE_LISTENER);
+          caseActivity.addBuiltInListener(event, caseActivityInstanceCreateListener);
         }
       }
       if (historyLevel.isHistoryEventProduced(HistoryEventTypes.CASE_ACTIVITY_INSTANCE_UPDATE, null)) {
         for (String event : ItemHandler.TASK_OR_STAGE_UPDATE_EVENTS) {
-          caseActivity.addBuiltInListener(event, CASE_ACTIVITY_INSTANCE_UPDATE_LISTENER);
+          caseActivity.addBuiltInListener(event, caseActivityInstanceUpdateListener);
         }
       }
       if (historyLevel.isHistoryEventProduced(HistoryEventTypes.CASE_ACTIVITY_INSTANCE_END, null)) {
         for (String event : ItemHandler.TASK_OR_STAGE_END_EVENTS) {
-          caseActivity.addBuiltInListener(event, CASE_ACTIVITY_INSTANCE_END_LISTENER);
+          caseActivity.addBuiltInListener(event, caseActivityInstanceEndListener);
         }
       }
     }
@@ -180,17 +180,17 @@ public class CmmnHistoryTransformListener implements CmmnTransformListener {
     if (caseActivity != null) {
       if (historyLevel.isHistoryEventProduced(HistoryEventTypes.CASE_ACTIVITY_INSTANCE_CREATE, null)) {
         for (String event : ItemHandler.EVENT_LISTENER_OR_MILESTONE_CREATE_EVENTS) {
-          caseActivity.addBuiltInListener(event, CASE_ACTIVITY_INSTANCE_CREATE_LISTENER);
+          caseActivity.addBuiltInListener(event, caseActivityInstanceCreateListener);
         }
       }
       if (historyLevel.isHistoryEventProduced(HistoryEventTypes.CASE_ACTIVITY_INSTANCE_UPDATE, null)) {
         for (String event : ItemHandler.EVENT_LISTENER_OR_MILESTONE_UPDATE_EVENTS) {
-          caseActivity.addBuiltInListener(event, CASE_ACTIVITY_INSTANCE_UPDATE_LISTENER);
+          caseActivity.addBuiltInListener(event, caseActivityInstanceUpdateListener);
         }
       }
       if (historyLevel.isHistoryEventProduced(HistoryEventTypes.CASE_ACTIVITY_INSTANCE_END, null)) {
         for (String event : ItemHandler.EVENT_LISTENER_OR_MILESTONE_END_EVENTS) {
-          caseActivity.addBuiltInListener(event, CASE_ACTIVITY_INSTANCE_END_LISTENER);
+          caseActivity.addBuiltInListener(event, caseActivityInstanceEndListener);
         }
       }
     }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/AcquireJobsRunnable.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/AcquireJobsRunnable.java
@@ -31,7 +31,7 @@ public abstract class AcquireJobsRunnable implements Runnable {
 
   protected volatile boolean isInterrupted = false;
   protected volatile boolean isJobAdded = false;
-  protected final Object MONITOR = new Object();
+  protected final Object monitor = new Object();
   protected final AtomicBoolean isWaiting = new AtomicBoolean(false);
 
   protected AcquireJobsRunnable(JobExecutor jobExecutor) {
@@ -45,10 +45,10 @@ public abstract class AcquireJobsRunnable implements Runnable {
 
     try {
       LOG.debugJobAcquisitionThreadSleeping(millis);
-      synchronized (MONITOR) {
+      synchronized (monitor) {
         if(!isInterrupted) {
           isWaiting.set(true);
-          MONITOR.wait(millis);
+          monitor.wait(millis);
         }
       }
       LOG.jobExecutorThreadWokeUp();
@@ -62,10 +62,10 @@ public abstract class AcquireJobsRunnable implements Runnable {
   }
 
   public void stop() {
-    synchronized (MONITOR) {
+    synchronized (monitor) {
       isInterrupted = true;
       if(isWaiting.compareAndSet(true, false)) {
-        MONITOR.notifyAll();
+        monitor.notifyAll();
       }
     }
   }
@@ -75,8 +75,8 @@ public abstract class AcquireJobsRunnable implements Runnable {
     if(isWaiting.compareAndSet(true, false)) {
       // ensures we only notify once
       // I am OK with the race condition
-      synchronized (MONITOR) {
-        MONITOR.notifyAll();
+      synchronized (monitor) {
+        monitor.notifyAll();
       }
     }
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/MessageAddedNotification.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/MessageAddedNotification.java
@@ -26,7 +26,7 @@ import org.operaton.bpm.engine.impl.interceptor.CommandContext;
  */
 public class MessageAddedNotification implements TransactionListener {
 
-  private final JobExecutorLogger LOG = ProcessEngineLogger.JOB_EXECUTOR_LOGGER;
+  private static final JobExecutorLogger LOG = ProcessEngineLogger.JOB_EXECUTOR_LOGGER;
 
   protected JobExecutor jobExecutor;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/SequentialJobAcquisitionRunnable.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/SequentialJobAcquisitionRunnable.java
@@ -45,7 +45,7 @@ import org.operaton.bpm.engine.impl.util.ClassLoaderUtil;
  */
 public class SequentialJobAcquisitionRunnable extends AcquireJobsRunnable {
 
-  protected final JobExecutorLogger LOG = ProcessEngineLogger.JOB_EXECUTOR_LOGGER;
+  protected static final JobExecutorLogger LOG = ProcessEngineLogger.JOB_EXECUTOR_LOGGER;
 
   protected JobAcquisitionContext acquisitionContext;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/process/ScopeImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/process/ScopeImpl.java
@@ -124,7 +124,7 @@ public abstract class ScopeImpl extends CoreActivity implements PvmScope {
    * The value is the error callback, which is called if the activity is not
    * read till the end of parsing.
    */
-  protected final Map<String, BacklogErrorCallback> BACKLOG = new HashMap<>();
+  protected final Map<String, BacklogErrorCallback> backlog = new HashMap<>();
 
   /**
    * Returns the backlog error callback's.
@@ -132,7 +132,7 @@ public abstract class ScopeImpl extends CoreActivity implements PvmScope {
    * @return the callback's
    */
   public Collection<BacklogErrorCallback> getBacklogErrorCallbacks() {
-    return BACKLOG.values();
+    return backlog.values();
   }
 
   /**
@@ -141,7 +141,7 @@ public abstract class ScopeImpl extends CoreActivity implements PvmScope {
    * @return true if empty, false otherwise
    */
   public boolean isBacklogEmpty() {
-    return BACKLOG.isEmpty();
+    return backlog.isEmpty();
   }
 
   /**
@@ -151,7 +151,7 @@ public abstract class ScopeImpl extends CoreActivity implements PvmScope {
    * @param callback the error callback which should called if activity will not be read
    */
   public void addToBacklog(String activityRef, BacklogErrorCallback callback) {
-    BACKLOG.put(activityRef, callback);
+    backlog.put(activityRef, callback);
   }
 
   @Override
@@ -161,8 +161,8 @@ public abstract class ScopeImpl extends CoreActivity implements PvmScope {
       if (processDefinition.findActivity(activityId) != null) {
         throw new PvmException("duplicate activity id '" + activityId + "'");
       }
-      if (BACKLOG.containsKey(activityId)) {
-        BACKLOG.remove(activityId);
+      if (backlog.containsKey(activityId)) {
+        backlog.remove(activityId);
       }
       namedFlowActivities.put(activityId, activity);
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/HistoryCleanupSchedulerCmdTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/HistoryCleanupSchedulerCmdTest.java
@@ -43,27 +43,28 @@ import org.operaton.bpm.engine.impl.persistence.entity.JobManager;
 
 class HistoryCleanupSchedulerCmdTest {
 
-    @Mock
-    private CommandContext commandContext;
-    @Mock
-    private JobEntity jobEntity;
-    @Mock
-    private DbMetricsReporter dbMetricsReporter;
-    @Mock
-    private JobManager jobManager;
-    @Spy
-    private ProcessEngineConfigurationImpl engineConfigurationSpy;
-    @Mock
-    private MockedStatic<HistoryCleanupHelper> mockedHistoryCleanupHelper;
+  @Mock
+  private CommandContext commandContext;
+  @Mock
+  private JobEntity jobEntity;
+  @Mock
+  private DbMetricsReporter dbMetricsReporter;
+  @Mock
+  private JobManager jobManager;
+  @Spy
+  private ProcessEngineConfigurationImpl engineConfigurationSpy;
+  @Mock
+  private MockedStatic<HistoryCleanupHelper> mockedHistoryCleanupHelper;
 
-    private HistoryCleanupSchedulerCmd historyCleanupSchedulerCmd;
-    private Map<String, Long> reports;
-    private HistoryCleanupJobHandlerConfiguration configuration;
-    private final String jobId = "testJobId";
+  private HistoryCleanupSchedulerCmd historyCleanupSchedulerCmd;
+  private Map<String, Long> reports;
+  private HistoryCleanupJobHandlerConfiguration configuration;
 
-    String METRICS_KEY = "Key";
-    Long METRICS_VALUE = 123L;
-    private AutoCloseable closeable;
+  static final String JOB_ID = "testJobId";
+  static final String METRICS_KEY = "Key";
+  static final Long METRICS_VALUE = 123L;
+
+  private AutoCloseable closeable;
 
   @BeforeEach
   void setUp() {
@@ -71,7 +72,7 @@ class HistoryCleanupSchedulerCmdTest {
 
         when(commandContext.getProcessEngineConfiguration()).thenReturn(engineConfigurationSpy);
         when(commandContext.getJobManager()).thenReturn(jobManager);
-        when(jobManager.findJobById(jobId)).thenReturn(jobEntity);
+        when(jobManager.findJobById(JOB_ID)).thenReturn(jobEntity);
 
         when(engineConfigurationSpy.getDbMetricsReporter()).thenReturn(dbMetricsReporter);
 
@@ -93,7 +94,7 @@ class HistoryCleanupSchedulerCmdTest {
         // given
         engineConfigurationSpy.setMetricsEnabled(true);
         engineConfigurationSpy.setHistoryCleanupMetricsEnabled(true);
-        historyCleanupSchedulerCmd = new HistoryCleanupSchedulerCmd(false, reports, configuration, jobId);
+        historyCleanupSchedulerCmd = new HistoryCleanupSchedulerCmd(false, reports, configuration, JOB_ID);
 
         // when
         historyCleanupSchedulerCmd.execute(commandContext);
@@ -107,7 +108,7 @@ class HistoryCleanupSchedulerCmdTest {
         // given
         engineConfigurationSpy.setMetricsEnabled(false);
         engineConfigurationSpy.setHistoryCleanupMetricsEnabled(true);
-        historyCleanupSchedulerCmd = new HistoryCleanupSchedulerCmd(false, reports, configuration, jobId);
+        historyCleanupSchedulerCmd = new HistoryCleanupSchedulerCmd(false, reports, configuration, JOB_ID);
 
         // when
         historyCleanupSchedulerCmd.execute(commandContext);
@@ -122,7 +123,7 @@ class HistoryCleanupSchedulerCmdTest {
         // given
         engineConfigurationSpy.setMetricsEnabled(true);
         engineConfigurationSpy.setHistoryCleanupMetricsEnabled(false);
-        historyCleanupSchedulerCmd = new HistoryCleanupSchedulerCmd(false, reports, configuration, jobId);
+        historyCleanupSchedulerCmd = new HistoryCleanupSchedulerCmd(false, reports, configuration, JOB_ID);
 
         // when
         historyCleanupSchedulerCmd.execute(commandContext);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/HistoricRootProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/HistoricRootProcessInstanceTest.java
@@ -66,9 +66,9 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
  */
 class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
 
-  protected final String CALLED_PROCESS_KEY = "calledProcess";
+  static final String CALLED_PROCESS_KEY = "calledProcess";
 
-  protected final BpmnModelInstance CALLED_PROCESS = Bpmn.createExecutableProcess(CALLED_PROCESS_KEY)
+  static final BpmnModelInstance CALLED_PROCESS = Bpmn.createExecutableProcess(CALLED_PROCESS_KEY)
       .operatonHistoryTimeToLive(180)
       .startEvent()
       .userTask("userTask")
@@ -80,8 +80,8 @@ class HistoricRootProcessInstanceTest extends AbstractRemovalTimeTest {
       .endEvent()
       .done();
 
-  protected final String CALLING_PROCESS_KEY = "callingProcess";
-  protected final BpmnModelInstance CALLING_PROCESS = Bpmn.createExecutableProcess(CALLING_PROCESS_KEY)
+  static final String CALLING_PROCESS_KEY = "callingProcess";
+  static final BpmnModelInstance CALLING_PROCESS = Bpmn.createExecutableProcess(CALLING_PROCESS_KEY)
     .startEvent()
       .callActivity()
         .calledElement(CALLED_PROCESS_KEY)

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/RemovalTimeStrategyEndTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/RemovalTimeStrategyEndTest.java
@@ -95,9 +95,9 @@ class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
     clearAuthorization();
   }
 
-  protected final String CALLED_PROCESS_KEY = "calledProcess";
+  static final String CALLED_PROCESS_KEY = "calledProcess";
 
-  protected final BpmnModelInstance CALLED_PROCESS = Bpmn.createExecutableProcess(CALLED_PROCESS_KEY)
+  static final BpmnModelInstance CALLED_PROCESS = Bpmn.createExecutableProcess(CALLED_PROCESS_KEY)
       .operatonHistoryTimeToLive(180)
       .startEvent()
       .userTask("userTask")
@@ -106,16 +106,16 @@ class RemovalTimeStrategyEndTest extends AbstractRemovalTimeTest {
       .endEvent()
       .done();
 
-  protected final String CALLING_PROCESS_KEY = "callingProcess";
-  protected final BpmnModelInstance CALLING_PROCESS = Bpmn.createExecutableProcess(CALLING_PROCESS_KEY)
+  static final String CALLING_PROCESS_KEY = "callingProcess";
+  static final BpmnModelInstance CALLING_PROCESS = Bpmn.createExecutableProcess(CALLING_PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .callActivity()
         .calledElement(CALLED_PROCESS_KEY)
     .endEvent().done();
 
-  protected final Date START_DATE = new Date(1363607000000L);
-  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+  static final Date START_DATE = new Date(1363607000000L);
+  static final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   @Deployment(resources = {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupRemovalTimeTest.java
@@ -199,15 +199,15 @@ class HistoryCleanupRemovalTimeTest {
     engineRule.getProcessEngine().close();
   }
 
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .userTask("userTask").name("userTask")
     .endEvent().done();
 
 
-  protected final BpmnModelInstance CALLED_PROCESS_INCIDENT = Bpmn.createExecutableProcess(PROCESS_KEY)
+  static final BpmnModelInstance CALLED_PROCESS_INCIDENT = Bpmn.createExecutableProcess(PROCESS_KEY)
     .operatonHistoryTimeToLive(null)
     .startEvent()
       .scriptTask()
@@ -217,25 +217,25 @@ class HistoryCleanupRemovalTimeTest {
       .userTask("userTask")
     .endEvent().done();
 
-  protected final String CALLING_PROCESS_KEY = "callingProcess";
+  static final String CALLING_PROCESS_KEY = "callingProcess";
 
-  protected final BpmnModelInstance CALLING_PROCESS = Bpmn.createExecutableProcess(CALLING_PROCESS_KEY)
+  static final BpmnModelInstance CALLING_PROCESS = Bpmn.createExecutableProcess(CALLING_PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .callActivity()
         .calledElement(PROCESS_KEY)
     .endEvent().done();
 
-  protected final BpmnModelInstance CALLING_PROCESS_WO_TTL = Bpmn.createExecutableProcess(CALLING_PROCESS_KEY)
+  static final BpmnModelInstance CALLING_PROCESS_WO_TTL = Bpmn.createExecutableProcess(CALLING_PROCESS_KEY)
       .operatonHistoryTimeToLive(null)
       .startEvent()
         .callActivity()
           .calledElement(PROCESS_KEY)
       .endEvent().done();
 
-  protected final String CALLING_PROCESS_CALLS_DMN_KEY = "callingProcessCallsDmn";
+  static final String CALLING_PROCESS_CALLS_DMN_KEY = "callingProcessCallsDmn";
 
-  protected final BpmnModelInstance CALLING_PROCESS_CALLS_DMN = Bpmn.createExecutableProcess(CALLING_PROCESS_CALLS_DMN_KEY)
+  static final BpmnModelInstance CALLING_PROCESS_CALLS_DMN = Bpmn.createExecutableProcess(CALLING_PROCESS_CALLS_DMN_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .businessRuleTask()
@@ -243,7 +243,7 @@ class HistoryCleanupRemovalTimeTest {
         .operatonDecisionRef("dish-decision")
     .endEvent().done();
 
-  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+  static final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   @Deployment(resources = {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerActivityInstancesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerActivityInstancesTest.java
@@ -49,20 +49,20 @@ class HistoryCleanupSchedulerActivityInstancesTest extends AbstractHistoryCleanu
   @RegisterExtension
   static ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
   
-  protected RuntimeService runtimeService;
-  protected TaskService taskService;
+  RuntimeService runtimeService;
+  TaskService taskService;
+
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+    .operatonHistoryTimeToLive(5)
+    .startEvent()
+      .userTask("userTask").name("userTask")
+    .endEvent().done();
 
   @BeforeEach
   void init() {
     initEngineConfiguration(engineRule, engineConfiguration);
   }
-
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
-    .operatonHistoryTimeToLive(5)
-    .startEvent()
-      .userTask("userTask").name("userTask")
-    .endEvent().done();
 
   @Test
   void shouldScheduleToNow() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerAttachmentsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerAttachmentsTest.java
@@ -50,22 +50,22 @@ class HistoryCleanupSchedulerAttachmentsTest extends AbstractHistoryCleanupSched
   @RegisterExtension
   static ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
-  protected RuntimeService runtimeService;
-  protected TaskService taskService;
+  RuntimeService runtimeService;
+  TaskService taskService;
 
-  @BeforeEach
-  void init() {
-    initEngineConfiguration(engineRule, engineConfiguration);
-  }
-
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .userTask("userTask").name("userTask")
     .endEvent().done();
 
-  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+  static final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+
+  @BeforeEach
+  void init() {
+    initEngineConfiguration(engineRule, engineConfiguration);
+  }
 
   @Test
   void shouldScheduleToNow() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerAuthorizationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerAuthorizationsTest.java
@@ -50,20 +50,12 @@ class HistoryCleanupSchedulerAuthorizationsTest extends AbstractHistoryCleanupSc
   @RegisterExtension
   static ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
-  protected RuntimeService runtimeService;
-  protected TaskService taskService;
-  protected AuthorizationService authorizationService;
+  RuntimeService runtimeService;
+  TaskService taskService;
+  AuthorizationService authorizationService;
 
-  @BeforeEach
-  void init() {
-    initEngineConfiguration(engineRule, engineConfiguration);
-
-    engineConfiguration.setEnableHistoricInstancePermissions(true);
-    engineConfiguration.setAuthorizationEnabled(false);
-  }
-
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .userTask("userTask").name("userTask")
@@ -72,7 +64,15 @@ class HistoryCleanupSchedulerAuthorizationsTest extends AbstractHistoryCleanupSc
         .multiInstanceDone()
     .endEvent().done();
 
-  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+  static final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+
+  @BeforeEach
+  void init() {
+    initEngineConfiguration(engineRule, engineConfiguration);
+
+    engineConfiguration.setEnableHistoricInstancePermissions(true);
+    engineConfiguration.setAuthorizationEnabled(false);
+  }
 
   @Test
   void shouldScheduleToNow() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerBatchesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerBatchesTest.java
@@ -61,15 +61,15 @@ class HistoryCleanupSchedulerBatchesTest extends AbstractHistoryCleanupScheduler
   protected RuntimeService runtimeService;
   protected TaskService taskService;
 
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .userTask()
     .endEvent().done();
 
-  protected final String CALLING_PROCESS_KEY = "callingProcess";
-  protected final BpmnModelInstance CALLING_PROCESS = Bpmn.createExecutableProcess(CALLING_PROCESS_KEY)
+  static final String CALLING_PROCESS_KEY = "callingProcess";
+  static final BpmnModelInstance CALLING_PROCESS = Bpmn.createExecutableProcess(CALLING_PROCESS_KEY)
     .startEvent()
       .callActivity()
         .calledElement(PROCESS_KEY)
@@ -78,7 +78,7 @@ class HistoryCleanupSchedulerBatchesTest extends AbstractHistoryCleanupScheduler
           .multiInstanceDone()
     .endEvent().done();
 
-  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+  static final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   void shouldScheduleToNow() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerCommentsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerCommentsTest.java
@@ -46,16 +46,16 @@ class HistoryCleanupSchedulerCommentsTest extends AbstractHistoryCleanupSchedule
   @RegisterExtension
   static ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
-  protected RuntimeService runtimeService;
-  protected TaskService taskService;
+  RuntimeService runtimeService;
+  TaskService taskService;
 
   @BeforeEach
   void init() {
     initEngineConfiguration(engineRule, engineConfiguration);
   }
 
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .userTask("userTask").name("userTask")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerDecisionsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerDecisionsTest.java
@@ -59,8 +59,8 @@ class HistoryCleanupSchedulerDecisionsTest extends AbstractHistoryCleanupSchedul
     initEngineConfiguration(engineRule, engineConfiguration);
   }
 
-  protected final String CALLING_PROCESS_CALLS_DMN_KEY = "callingProcessCallsDmn";
-  protected final BpmnModelInstance CALLING_PROCESS_CALLS_DMN = Bpmn.createExecutableProcess(CALLING_PROCESS_CALLS_DMN_KEY)
+  static final String CALLING_PROCESS_CALLS_DMN_KEY = "callingProcessCallsDmn";
+  static final BpmnModelInstance CALLING_PROCESS_CALLS_DMN = Bpmn.createExecutableProcess(CALLING_PROCESS_CALLS_DMN_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .businessRuleTask()
@@ -71,7 +71,7 @@ class HistoryCleanupSchedulerDecisionsTest extends AbstractHistoryCleanupSchedul
         .multiInstanceDone()
     .endEvent().done();
 
-  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+  static final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   @Deployment(resources = {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerDetailsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerDetailsTest.java
@@ -51,16 +51,16 @@ class HistoryCleanupSchedulerDetailsTest extends AbstractHistoryCleanupScheduler
   @RegisterExtension
   static ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
-  protected RuntimeService runtimeService;
-  protected TaskService taskService;
+  RuntimeService runtimeService;
+  TaskService taskService;
 
   @BeforeEach
   void init() {
     initEngineConfiguration(engineRule, engineConfiguration);
   }
 
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .userTask("userTask").name("userTask")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerExternalTaskLogsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerExternalTaskLogsTest.java
@@ -50,11 +50,11 @@ class HistoryCleanupSchedulerExternalTaskLogsTest extends AbstractHistoryCleanup
   @RegisterExtension
   static ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
-  protected RuntimeService runtimeService;
-  protected ExternalTaskService externalTaskService;
+  RuntimeService runtimeService;
+  ExternalTaskService externalTaskService;
 
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .userTask("userTask").name("userTask")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerIdentityLinkLogsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerIdentityLinkLogsTest.java
@@ -57,8 +57,8 @@ class HistoryCleanupSchedulerIdentityLinkLogsTest extends AbstractHistoryCleanup
     initEngineConfiguration(engineRule, engineConfiguration);
   }
 
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .userTask("userTask").name("userTask")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerIncidentsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerIncidentsTest.java
@@ -56,9 +56,9 @@ class HistoryCleanupSchedulerIncidentsTest  extends AbstractHistoryCleanupSchedu
   void init() {
     initEngineConfiguration(engineRule, engineConfiguration);
   }
-  
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .scriptTask()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerJobLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerJobLogTest.java
@@ -57,8 +57,8 @@ class HistoryCleanupSchedulerJobLogTest extends AbstractHistoryCleanupSchedulerT
     initEngineConfiguration(engineRule, engineConfiguration);
   }
 
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .scriptTask()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerProcessInstancesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerProcessInstancesTest.java
@@ -59,14 +59,14 @@ class HistoryCleanupSchedulerProcessInstancesTest extends AbstractHistoryCleanup
     initEngineConfiguration(engineRule, engineConfiguration);
   }
 
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .userTask("userTask").name("userTask")
     .endEvent().done();
 
-  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+  static final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   void shouldScheduleToNow() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerTaskInstancesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerTaskInstancesTest.java
@@ -61,8 +61,8 @@ class HistoryCleanupSchedulerTaskInstancesTest extends AbstractHistoryCleanupSch
     initEngineConfiguration(engineRule, engineConfiguration);
   }
 
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .userTask("userTask").name("userTask")
@@ -71,7 +71,7 @@ class HistoryCleanupSchedulerTaskInstancesTest extends AbstractHistoryCleanupSch
         .multiInstanceDone()
     .endEvent().done();
 
-  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+  static final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   void shouldScheduleToNow() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerTaskMetricsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerTaskMetricsTest.java
@@ -55,13 +55,13 @@ class HistoryCleanupSchedulerTaskMetricsTest extends AbstractHistoryCleanupSched
   protected RuntimeService runtimeService;
   protected TaskService taskService;
 
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
     .startEvent()
       .userTask()
     .endEvent().done();
 
-  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+  static final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   void shouldScheduleToNow() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerUserOperationLogsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerUserOperationLogsTest.java
@@ -50,12 +50,12 @@ class HistoryCleanupSchedulerUserOperationLogsTest extends AbstractHistoryCleanu
   @RegisterExtension
   static ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
-  protected RuntimeService runtimeService;
-  protected TaskService taskService;
-  protected IdentityService identityService;
+  RuntimeService runtimeService;
+  TaskService taskService;
+  IdentityService identityService;
 
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
       .startEvent().operatonAsyncBefore()
     .endEvent().done();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerVariableInstancesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/cleanup/HistoryCleanupSchedulerVariableInstancesTest.java
@@ -59,14 +59,14 @@ class HistoryCleanupSchedulerVariableInstancesTest extends AbstractHistoryCleanu
   protected RuntimeService runtimeService;
   protected TaskService taskService;
 
-  protected final String PROCESS_KEY = "process";
-  protected final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
+  static final String PROCESS_KEY = "process";
+  static final BpmnModelInstance PROCESS = Bpmn.createExecutableProcess(PROCESS_KEY)
     .operatonHistoryTimeToLive(5)
     .startEvent()
       .userTask()
     .endEvent().done();
 
-  protected final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+  static final Date END_DATE = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
   @Test
   void shouldScheduleToNow() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceAsyncOperationsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceAsyncOperationsTest.java
@@ -55,7 +55,7 @@ class ManagementServiceAsyncOperationsTest extends AbstractAsyncOperationsTest {
   @RegisterExtension
   static ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 
-  protected final Date TEST_DUE_DATE = new Date(1675752840000L);
+  static final Date TEST_DUE_DATE = new Date(1675752840000L);
 
   protected List<String> processInstanceIds;
   protected List<String> ids;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.java
@@ -87,7 +87,7 @@ class ManagementServiceTest {
 
   protected boolean tearDownEnsureJobDueDateNotNull;
 
-  protected final Date TEST_DUE_DATE = new Date(1675752840000L);
+  static final Date TEST_DUE_DATE = new Date(1675752840000L);
 
   @AfterEach
   void tearDown() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
@@ -60,13 +60,13 @@ class MultiTenancyHistoricExternalTaskLogTest {
   protected IdentityService identityService;
   protected ExternalTaskService externalTaskService;
 
-  protected final String TENANT_NULL = null;
-  protected final String TENANT_ONE = "tenant1";
-  protected final String TENANT_TWO = "tenant2";
+  static final String TENANT_NULL = null;
+  static final String TENANT_ONE = "tenant1";
+  static final String TENANT_TWO = "tenant2";
 
-  protected final String WORKER_ID = "aWorkerId";
-  protected final String ERROR_DETAILS = "These are the error details!";
-  protected final long LOCK_DURATION = 5 * 60L * 1000L;
+  static final String WORKER_ID = "aWorkerId";
+  static final String ERROR_DETAILS = "These are the error details!";
+  static final long LOCK_DURATION = 5 * 60L * 1000L;
 
 
   @BeforeEach

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RootProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RootProcessInstanceTest.java
@@ -38,27 +38,6 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
  */
 class RootProcessInstanceTest {
 
-  protected final String CALLED_PROCESS_KEY = "calledProcess";
-  protected final BpmnModelInstance CALLED_PROCESS = Bpmn.createExecutableProcess(CALLED_PROCESS_KEY)
-    .startEvent()
-      .userTask("userTask")
-    .endEvent().done();
-
-  protected final String CALLED_AND_CALLING_PROCESS_KEY = "calledAndCallingProcess";
-  protected final BpmnModelInstance CALLED_AND_CALLING_PROCESS =
-    Bpmn.createExecutableProcess(CALLED_AND_CALLING_PROCESS_KEY)
-    .startEvent()
-      .callActivity()
-        .calledElement(CALLED_PROCESS_KEY)
-    .endEvent().done();
-
-  protected final String CALLING_PROCESS_KEY = "callingProcess";
-  protected final BpmnModelInstance CALLING_PROCESS = Bpmn.createExecutableProcess(CALLING_PROCESS_KEY)
-    .startEvent()
-      .callActivity()
-        .calledElement(CALLED_AND_CALLING_PROCESS_KEY)
-    .endEvent().done();
-
   @RegisterExtension
   static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
   @RegisterExtension
@@ -66,6 +45,27 @@ class RootProcessInstanceTest {
 
   RuntimeService runtimeService;
   FormService formService;
+
+  static final String CALLED_PROCESS_KEY = "calledProcess";
+  static final BpmnModelInstance CALLED_PROCESS = Bpmn.createExecutableProcess(CALLED_PROCESS_KEY)
+    .startEvent()
+      .userTask("userTask")
+    .endEvent().done();
+
+  static final String CALLED_AND_CALLING_PROCESS_KEY = "calledAndCallingProcess";
+  static final BpmnModelInstance CALLED_AND_CALLING_PROCESS =
+    Bpmn.createExecutableProcess(CALLED_AND_CALLING_PROCESS_KEY)
+    .startEvent()
+      .callActivity()
+        .calledElement(CALLED_PROCESS_KEY)
+    .endEvent().done();
+
+  static final String CALLING_PROCESS_KEY = "callingProcess";
+  static final BpmnModelInstance CALLING_PROCESS = Bpmn.createExecutableProcess(CALLING_PROCESS_KEY)
+    .startEvent()
+      .callActivity()
+        .calledElement(CALLED_AND_CALLING_PROCESS_KEY)
+    .endEvent().done();
 
   @Test
   void shouldPointToItself() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/builtin/PostParseListener.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/builtin/PostParseListener.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 
 public class PostParseListener extends AbstractBpmnParseListener {
 
-  Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
+  private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
   @Override
   public void parseUserTask(final Element userTaskElement, final ScopeImpl scope, final ActivityImpl activity) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/builtin/PreParseListener.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/builtin/PreParseListener.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 
 public class PreParseListener extends AbstractBpmnParseListener {
 
-  Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
+  private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
   @Override
   public void parseUserTask(final Element userTaskElement, final ScopeImpl scope, final ActivityImpl activity) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/builtin/TestTaskListener.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/tasklistener/builtin/TestTaskListener.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 
 public class TestTaskListener implements TaskListener {
 
-  Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
+  private static final Logger LOG = ProcessEngineLogger.TEST_LOGGER.getLogger();
 
   @Override
   public void notify(DelegateTask delegateTask) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.java
@@ -34,21 +34,21 @@ import static org.assertj.core.api.Assertions.fail;
  */
 public class DmnDecisionTaskTest extends CmmnTest {
 
-  public static final String CMMN_CALL_DECISION_CONSTANT = "org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.testCallDecisionAsConstant.cmmn";
-  public static final String CMMN_CALL_DECISION_CONSTANT_WITH_MANUAL_ACTIVATION = "org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.testCallDecisionAsConstantWithManualActiovation.cmmn";
-  public static final String CMMN_CALL_DECISION_EXPRESSION = "org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.testCallDecisionAsExpressionStartsWithDollar.cmmn";
-  public static final String CMMN_CALL_DECISION_EXPRESSION_WITH_MANUAL_ACTIVATION = "org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.testCallDecisionAsExpressionStartsWithDollarWithManualActiovation.cmmn";
+  static final String CMMN_CALL_DECISION_CONSTANT = "org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.testCallDecisionAsConstant.cmmn";
+  static final String CMMN_CALL_DECISION_CONSTANT_WITH_MANUAL_ACTIVATION = "org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.testCallDecisionAsConstantWithManualActiovation.cmmn";
+  static final String CMMN_CALL_DECISION_EXPRESSION = "org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.testCallDecisionAsExpressionStartsWithDollar.cmmn";
+  static final String CMMN_CALL_DECISION_EXPRESSION_WITH_MANUAL_ACTIVATION = "org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.testCallDecisionAsExpressionStartsWithDollarWithManualActiovation.cmmn";
 
-  public static final String DECISION_OKAY_DMN = "org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.testDecisionOkay.dmn11.xml";
-  public static final String DECISION_NOT_OKAY_DMN = "org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.testDecisionNotOkay.dmn11.xml";
-  public static final String DECISION_POJO_DMN = "org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.testPojo.dmn11.xml";
+  static final String DECISION_OKAY_DMN = "org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.testDecisionOkay.dmn11.xml";
+  static final String DECISION_NOT_OKAY_DMN = "org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.testDecisionNotOkay.dmn11.xml";
+  static final String DECISION_POJO_DMN = "org/operaton/bpm/engine/test/cmmn/decisiontask/DmnDecisionTaskTest.testPojo.dmn11.xml";
 
-  public static final String DECISION_LITERAL_EXPRESSION_DMN = "org/operaton/bpm/engine/test/dmn/deployment/DecisionWithLiteralExpression.dmn";
-  public static final String DRD_DISH_RESOURCE = "org/operaton/bpm/engine/test/dmn/deployment/drdDish.dmn11.xml";
+  static final String DECISION_LITERAL_EXPRESSION_DMN = "org/operaton/bpm/engine/test/dmn/deployment/DecisionWithLiteralExpression.dmn";
+  static final String DRD_DISH_RESOURCE = "org/operaton/bpm/engine/test/dmn/deployment/drdDish.dmn11.xml";
 
-  protected final String CASE_KEY = "case";
-  protected final String DECISION_TASK = "PI_DecisionTask_1";
-  protected final String DECISION_KEY = "testDecision";
+  static final String CASE_KEY = "case";
+  static final String DECISION_TASK = "PI_DecisionTask_1";
+  static final String DECISION_KEY = "testDecision";
 
   @Deployment(resources = {CMMN_CALL_DECISION_CONSTANT, DECISION_OKAY_DMN})
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/SkipHistoryOptimisticLockingExceptionsDisabledTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/concurrency/partitioning/SkipHistoryOptimisticLockingExceptionsDisabledTest.java
@@ -30,9 +30,9 @@ import org.junit.Test;
 
 public class SkipHistoryOptimisticLockingExceptionsDisabledTest extends AbstractPartitioningTest {
 
-  protected final String VARIABLE_NAME = "aVariableName";
-  protected final String VARIABLE_VALUE = "aVariableValue";
-  protected final String ANOTHER_VARIABLE_VALUE = "anotherVariableValue";
+  static final String VARIABLE_NAME = "aVariableName";
+  static final String VARIABLE_VALUE = "aVariableValue";
+  static final String ANOTHER_VARIABLE_VALUE = "anotherVariableValue";
 
   @Test
   public void testHistoryOptimisticLockingExceptionsNotSkipped() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
@@ -1031,12 +1031,11 @@ class HistoricCaseActivityInstanceTest extends CmmnTest {
   }
 
   protected class CaseExecutionStateCountMap extends HashMap<CaseExecutionState, Long> {
-    public static final Collection<CaseExecutionState> ALL_STATES = CaseExecutionState.CASE_EXECUTION_STATES.values();
-    public static final Collection<CaseExecutionState> ENDED_STATES = Arrays.asList(COMPLETED, TERMINATED);
-    public final Collection<CaseExecutionState> NOT_ENDED_STATES;
+    private static final Collection<CaseExecutionState> ALL_STATES = CaseExecutionState.CASE_EXECUTION_STATES.values();
+    private static final Collection<CaseExecutionState> ENDED_STATES = Arrays.asList(COMPLETED, TERMINATED);
+    private static final Collection<CaseExecutionState> NOT_ENDED_STATES = new ArrayList<>(ALL_STATES);
 
-    public CaseExecutionStateCountMap() {
-      NOT_ENDED_STATES = new ArrayList<>(ALL_STATES);
+    {
       NOT_ENDED_STATES.removeAll(ENDED_STATES);
     }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricExternalTaskLogQuerySortingTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricExternalTaskLogQuerySortingTest.java
@@ -63,8 +63,8 @@ import org.junit.rules.RuleChain;
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 public class HistoricExternalTaskLogQuerySortingTest {
 
-  protected final String WORKER_ID = "aWorkerId";
-  protected final long LOCK_DURATION = 5 * 60L * 1000L;
+  private static final String WORKER_ID = "aWorkerId";
+  private static final Long LOCK_DURATION = 5 * 60L * 1000L;
 
   protected ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
   protected AuthorizationTestRule authRule = new AuthorizationTestRule(engineRule);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/PartitioningTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/PartitioningTest.java
@@ -77,7 +77,7 @@ public class PartitioningTest {
     managementService = engineRule.getManagementService();
   }
 
-  protected final BpmnModelInstance PROCESS_WITH_USERTASK = Bpmn.createExecutableProcess("process")
+  private static final BpmnModelInstance PROCESS_WITH_USERTASK = Bpmn.createExecutableProcess("process")
     .startEvent()
       .userTask()
     .endEvent().done();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/UserOperationLogAnnotationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/UserOperationLogAnnotationTest.java
@@ -44,15 +44,15 @@ import org.junit.rules.RuleChain;
 @RequiredHistoryLevel(HISTORY_FULL)
 public class UserOperationLogAnnotationTest {
 
-  protected static final String USER_ID = "demo";
-  protected static final String TASK_ID = "aTaskId";
-  protected static final String ANNOTATION = "anAnnotation";
-  protected static final String TASK_NAME = "aTaskName";
-  protected static final String OPERATION_ID = "operationId";
-  protected final Date CREATE_TIME = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
+  static final String USER_ID = "demo";
+  static final String TASK_ID = "aTaskId";
+  static final String ANNOTATION = "anAnnotation";
+  static final String TASK_NAME = "aTaskName";
+  static final String OPERATION_ID = "operationId";
+  static final Date CREATE_TIME = new GregorianCalendar(2013, Calendar.MARCH, 18, 13, 0, 0).getTime();
 
-  protected ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
-  protected ProcessEngineTestRule engineTestRule = new ProcessEngineTestRule(engineRule);
+  ProcessEngineRule engineRule = new ProvidedProcessEngineRule();
+  ProcessEngineTestRule engineTestRule = new ProcessEngineTestRule(engineRule);
 
   @Rule
   public RuleChain ruleChain = RuleChain.outerRule(engineRule).around(engineTestRule);

--- a/examples/invoice/src/main/java/org/operaton/bpm/example/invoice/service/ArchiveInvoiceService.java
+++ b/examples/invoice/src/main/java/org/operaton/bpm/example/invoice/service/ArchiveInvoiceService.java
@@ -29,7 +29,7 @@ import org.operaton.bpm.engine.variable.value.FileValue;
  */
 public class ArchiveInvoiceService implements JavaDelegate {
 
-  private final Logger LOGGER = Logger.getLogger(ArchiveInvoiceService.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(ArchiveInvoiceService.class.getName());
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {
@@ -44,7 +44,5 @@ public class ArchiveInvoiceService implements JavaDelegate {
       LOGGER.info("\n\n  ... Now archiving invoice "+execution.getVariable("invoiceNumber")
           +", filename: "+invoiceDocumentVar.getFilename()+" \n\n");
     }
-
   }
-
 }

--- a/examples/invoice/src/main/java/org/operaton/bpm/example/invoice/service/NotifyCreditorService.java
+++ b/examples/invoice/src/main/java/org/operaton/bpm/example/invoice/service/NotifyCreditorService.java
@@ -27,7 +27,7 @@ import org.operaton.bpm.engine.delegate.JavaDelegate;
  */
 public class NotifyCreditorService implements JavaDelegate {
 
-  private final Logger LOGGER = Logger.getLogger(NotifyCreditorService.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(NotifyCreditorService.class.getName());
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/util/ParseCmmnModelRule.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/util/ParseCmmnModelRule.java
@@ -31,7 +31,7 @@ import java.io.InputStream;
  */
 public class ParseCmmnModelRule implements BeforeEachCallback {
 
-  protected CmmnModelInstance CmmnModelInstance;
+  protected CmmnModelInstance cmmnModelInstance;
 
   @Override
   public void beforeEach(ExtensionContext context){
@@ -46,7 +46,7 @@ public class ParseCmmnModelRule implements BeforeEachCallback {
 
       InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream(cmmnResourceName);
       try {
-        CmmnModelInstance = Cmmn.readModelFromStream(resourceAsStream);
+        cmmnModelInstance = Cmmn.readModelFromStream(resourceAsStream);
       } finally {
         IoUtil.closeSilently(resourceAsStream);
       }
@@ -54,7 +54,7 @@ public class ParseCmmnModelRule implements BeforeEachCallback {
   }
 
   public CmmnModelInstance getCmmnModel() {
-    return CmmnModelInstance;
+    return cmmnModelInstance;
   }
 
 }

--- a/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/DeleteDeploymentCascadeTest.java
+++ b/qa/large-data-tests/src/test/java/org/operaton/bpm/qa/largedata/DeleteDeploymentCascadeTest.java
@@ -41,7 +41,7 @@ class DeleteDeploymentCascadeTest {
 
   protected static final String DATA_PREFIX = DeleteDeploymentCascadeTest.class.getSimpleName();
 
-  protected int GENERATE_PROCESS_INSTANCES_COUNT = 2500;
+  static final int GENERATE_PROCESS_INSTANCES_COUNT = 2500;
   protected ProcessEngine processEngine;
   protected RepositoryService repositoryService;
   protected HistoryService historyService;

--- a/webapps/assembly/src/main/java/org/operaton/bpm/cockpit/plugin/test/AbstractCockpitPluginTest.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/cockpit/plugin/test/AbstractCockpitPluginTest.java
@@ -71,12 +71,12 @@ public abstract class AbstractCockpitPluginTest {
 
   @Before
   public void before() {
-    RUNTIME_DELEGATE.ENGINE = getProcessEngine();
+    RUNTIME_DELEGATE.engine = getProcessEngine();
   }
 
   @After
   public void after() {
-    RUNTIME_DELEGATE.ENGINE = null;
+    RUNTIME_DELEGATE.engine = null;
     getProcessEngine().getIdentityService().clearAuthentication();
   }
 
@@ -141,13 +141,13 @@ public abstract class AbstractCockpitPluginTest {
 
   private static class TestCockpitRuntimeDelegate extends DefaultCockpitRuntimeDelegate {
 
-    public ProcessEngine ENGINE;
+    public ProcessEngine engine;
 
     @Override
     public ProcessEngine getProcessEngine(String processEngineName) {
 
       // always return default engine for plugin tests
-      return ENGINE;
+      return engine;
     }
   }
 }

--- a/webapps/assembly/src/test/java/org/operaton/bpm/admin/plugin/base/AbstractAdminPluginTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/admin/plugin/base/AbstractAdminPluginTest.java
@@ -52,12 +52,12 @@ public abstract class AbstractAdminPluginTest {
 
   @Before
   public void before() {
-    RUNTIME_DELEGATE.ENGINE = getProcessEngine();
+    RUNTIME_DELEGATE.engine = getProcessEngine();
   }
 
   @After
   public void after() {
-    RUNTIME_DELEGATE.ENGINE = null;
+    RUNTIME_DELEGATE.engine = null;
     getProcessEngine().getIdentityService().clearAuthentication();
   }
 
@@ -67,13 +67,13 @@ public abstract class AbstractAdminPluginTest {
 
   private static class TestAdminRuntimeDelegate extends DefaultAdminRuntimeDelegate {
 
-    public ProcessEngine ENGINE;
+    public ProcessEngine engine;
 
     @Override
     public ProcessEngine getProcessEngine(String processEngineName) {
 
       // always return default engine for plugin tests
-      return ENGINE;
+      return engine;
     }
   }
 }


### PR DESCRIPTION
Fields that are named UPPERCASE are expected to be constant. Added static final modifier where these fields are effective constants.

Renamed fields when they should be instance fields (only few cases).

Removed unnecesssary visibility modifiers esp. in tests.

Resolved Sonar issues of type: "Field names should comply with a naming convention java:S116"

related to #511 