### PR TITLE
Resolve Sonar warnings on empty methods

### DIFF
--- a/engine-plugins/identity-ldap/src/main/java/org/operaton/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
+++ b/engine-plugins/identity-ldap/src/main/java/org/operaton/bpm/identity/impl/ldap/LdapIdentityProviderSession.java
@@ -77,10 +77,6 @@ public class LdapIdentityProviderSession implements ReadOnlyIdentityProvider {
 
   // Session Lifecycle //////////////////////////////////
 
-  public void flush() {
-    // nothing to do
-  }
-
   public void close() {
     ldapClient.closeLdapCtx();
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/BatchMonitorJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/BatchMonitorJobHandler.java
@@ -77,9 +77,4 @@ public class BatchMonitorJobHandler implements JobHandler<BatchMonitorJobConfigu
     }
   }
 
-  @Override
-  public void onDelete(BatchMonitorJobConfiguration configuration, JobEntity jobEntity) {
-    // do nothing
-  }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/BatchSeedJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/BatchSeedJobHandler.java
@@ -88,9 +88,4 @@ public class BatchSeedJobHandler implements JobHandler<BatchSeedJobConfiguration
     }
   }
 
-  @Override
-  public void onDelete(BatchSeedJobConfiguration configuration, JobEntity jobEntity) {
-    // do nothing
-  }
-
-}
+ }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetExternalTaskPriorityCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetExternalTaskPriorityCmd.java
@@ -47,6 +47,7 @@ public class SetExternalTaskPriorityCmd extends ExternalTaskCmd {
 
   @Override
   protected void validateInput() {
+    // no input validation needed
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskVariablesCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SetTaskVariablesCmd.java
@@ -101,13 +101,4 @@ public class SetTaskVariablesCmd extends AbstractSetVariableCmd implements Varia
     onLocalVariableChanged();
   }
 
-  @Override
-  public void onDelete(VariableInstanceEntity variableInstance, AbstractVariableScope sourceScope) {
-    onLocalVariableChanged();
-  }
-
-  @Override
-  public void onUpdate(VariableInstanceEntity variableInstance, AbstractVariableScope sourceScope) {
-    onLocalVariableChanged();
-  }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/UnlockExternalTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/UnlockExternalTaskCmd.java
@@ -31,6 +31,7 @@ public class UnlockExternalTaskCmd extends ExternalTaskCmd {
 
   @Override
   protected void validateInput() {
+    // no input validation needed
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/execution/CaseExecutionImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/execution/CaseExecutionImpl.java
@@ -71,9 +71,6 @@ public class CaseExecutionImpl extends CmmnExecution implements Serializable {
 
   protected VariableStore<SimpleVariableInstance> variableStore = new VariableStore<>();
 
-  public CaseExecutionImpl() {
-  }
-
   // case definition id ///////////////////////////////////////////////////////
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/handler/CmmnHandlerContext.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/handler/CmmnHandlerContext.java
@@ -38,9 +38,6 @@ public class CmmnHandlerContext implements HandlerContext {
   protected CmmnActivity parent;
   protected Deployment deployment;
 
-  public CmmnHandlerContext() {
-  }
-
   public CmmnModelInstance getModel() {
     return model;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/scope/VariableInstanceLifecycleListener.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/scope/VariableInstanceLifecycleListener.java
@@ -25,9 +25,9 @@ import org.operaton.bpm.engine.impl.core.variable.CoreVariableInstance;
  */
 public interface VariableInstanceLifecycleListener<T extends CoreVariableInstance> {
 
-  void onCreate(T variableInstance, AbstractVariableScope sourceScope);
+  default void onCreate(T variableInstance, AbstractVariableScope sourceScope) {}
 
-  void onDelete(T variableInstance, AbstractVariableScope sourceScope);
+  default void onDelete(T variableInstance, AbstractVariableScope sourceScope) {}
 
-  void onUpdate(T variableInstance, AbstractVariableScope sourceScope);
+  default void onUpdate(T variableInstance, AbstractVariableScope sourceScope) {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/PermissionCheck.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/PermissionCheck.java
@@ -42,9 +42,6 @@ public class PermissionCheck {
 
   protected Long authorizationNotFoundReturnValue = null;
 
-  public PermissionCheck() {
-  }
-
   public Permission getPermission() {
     return permission;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/DbEntityManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/DbEntityManager.java
@@ -625,11 +625,6 @@ public class DbEntityManager implements Session, EntityLoadListener {
     dbOperationManager.addOperation(dbOperation);
   }
 
-  @Override
-  public void close() {
-
-  }
-
   public boolean isDeleted(DbEntity object) {
     return dbEntityCache.isDeleted(object);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/entity/repository/DecisionDefinitionEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/entity/repository/DecisionDefinitionEntity.java
@@ -57,10 +57,6 @@ public class DecisionDefinitionEntity extends DmnDecisionImpl implements Decisio
   protected Integer historyTimeToLive;
   protected String versionTag;
 
-  public DecisionDefinitionEntity() {
-
-  }
-
   @Override
   public String getId() {
     return id;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/event/HistoricFormPropertyEventEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/event/HistoricFormPropertyEventEntity.java
@@ -29,9 +29,6 @@ public class HistoricFormPropertyEventEntity extends HistoricDetailEventEntity {
   protected String propertyId;
   protected String propertyValue;
 
-  public HistoricFormPropertyEventEntity() {
-  }
-
   public String getPropertyId() {
     return propertyId;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/Session.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/Session.java
@@ -22,7 +22,7 @@ package org.operaton.bpm.engine.impl.interceptor;
  */
 public interface Session {
 
-  void flush();
+  default void flush() {}
 
-  void close();
+  default void close() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/TxContextCommandContextFactory.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/TxContextCommandContextFactory.java
@@ -28,9 +28,6 @@ public class TxContextCommandContextFactory extends CommandContextFactory {
 
   protected TransactionContextFactory transactionContextFactory;
 
-  public TxContextCommandContextFactory() {
-  }
-
   @Override
   public CommandContext createCommandContext() {
     return new CommandContext(processEngineConfiguration, transactionContextFactory);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/AsyncContinuationJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/AsyncContinuationJobHandler.java
@@ -166,8 +166,4 @@ public class AsyncContinuationJobHandler implements JobHandler<AsyncContinuation
 
   }
 
-  @Override
-  public void onDelete(AsyncContinuationConfiguration configuration, JobEntity jobEntity) {
-    // do nothing
-  }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/JobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/JobHandler.java
@@ -38,6 +38,6 @@ public interface JobHandler<T extends JobHandlerConfiguration> {
    * @param configuration the job handler configuration
    * @param jobEntity the job entity to be deleted
    */
-  void onDelete(T configuration, JobEntity jobEntity);
+  default void onDelete(T configuration, JobEntity jobEntity) {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/ProcessEventJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/ProcessEventJobHandler.java
@@ -73,9 +73,4 @@ public class ProcessEventJobHandler implements JobHandler<EventSubscriptionJobCo
 
   }
 
-  @Override
-  public void onDelete(EventSubscriptionJobConfiguration configuration, JobEntity jobEntity) {
-    // do nothing
-  }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerChangeJobDefinitionSuspensionStateJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerChangeJobDefinitionSuspensionStateJobHandler.java
@@ -186,9 +186,4 @@ public abstract class TimerChangeJobDefinitionSuspensionStateJobHandler implemen
 
   }
 
-  @Override
-  public void onDelete(JobDefinitionSuspensionStateConfiguration configuration, JobEntity jobEntity) {
-    // do nothing
-  }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerChangeProcessDefinitionSuspensionStateJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerChangeProcessDefinitionSuspensionStateJobHandler.java
@@ -168,9 +168,4 @@ public abstract class TimerChangeProcessDefinitionSuspensionStateJobHandler impl
 
   }
 
-  @Override
-  public void onDelete(ProcessDefinitionSuspensionStateConfiguration configuration, JobEntity jobEntity) {
-    // do nothing
-  }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerEventJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerEventJobHandler.java
@@ -106,9 +106,4 @@ public abstract class TimerEventJobHandler implements JobHandler<TimerJobConfigu
 
   }
 
-  @Override
-  public void onDelete(TimerJobConfiguration configuration, JobEntity jobEntity) {
-    // do nothing
-  }
-
-}
+ }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/HistoryCleanupJobDeclaration.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/HistoryCleanupJobDeclaration.java
@@ -48,11 +48,7 @@ public class HistoryCleanupJobDeclaration extends JobDeclaration<HistoryCleanupC
     return new EverLivingJobEntity();
   }
 
-  @Override
-  protected void postInitialize(HistoryCleanupContext context, EverLivingJobEntity job) {
-  }
-
-  @Override
+   @Override
   public EverLivingJobEntity reconfigure(HistoryCleanupContext context, EverLivingJobEntity job) {
     HistoryCleanupJobHandlerConfiguration configuration = resolveJobHandlerConfiguration(context);
     job.setJobHandlerConfiguration(configuration);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/HistoryCleanupJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/HistoryCleanupJobHandler.java
@@ -96,8 +96,4 @@ public class HistoryCleanupJobHandler implements JobHandler<HistoryCleanupJobHan
     return TYPE;
   }
 
-  @Override
-  public void onDelete(HistoryCleanupJobHandlerConfiguration configuration, JobEntity jobEntity) {
-  }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/HistoryCleanupJobHandlerConfiguration.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/HistoryCleanupJobHandlerConfiguration.java
@@ -52,9 +52,6 @@ public class HistoryCleanupJobHandlerConfiguration implements JobHandlerConfigur
 
   private int minuteTo = 59;
 
-  public HistoryCleanupJobHandlerConfiguration() {
-  }
-
   @Override
   public String toCanonicalString() {
     JsonObject json = JsonUtil.createObject();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/instance/MigratingCompensationEventSubscriptionInstance.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/instance/MigratingCompensationEventSubscriptionInstance.java
@@ -71,10 +71,12 @@ public class MigratingCompensationEventSubscriptionInstance extends MigratingPro
 
   @Override
   public void migrateDependentEntities() {
+    // No dependent entities to migrate for event subscriptions
   }
 
   @Override
   public void addMigratingDependentInstance(MigratingInstance migratingInstance) {
+    // No dependent instances to add for event subscriptions
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/instance/MigratingEventScopeInstance.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/instance/MigratingEventScopeInstance.java
@@ -215,6 +215,7 @@ public class MigratingEventScopeInstance extends MigratingScopeInstance {
 
   @Override
   public void removeUnmappedDependentInstances() {
+    // nothing to do here, as this instance does not have any
   }
 
   public MigratingCompensationEventSubscriptionInstance getEventSubscription() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/instance/MigratingUserTaskInstance.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/instance/MigratingUserTaskInstance.java
@@ -46,6 +46,7 @@ public class MigratingUserTaskInstance implements MigratingInstance {
 
   @Override
   public void migrateDependentEntities() {
+    // nothing to do
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/mock/MockElResolver.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/mock/MockElResolver.java
@@ -47,6 +47,7 @@ public class MockElResolver extends ELResolver {
 
   @Override
   public void setValue(ELContext context, Object base, Object property, Object value) {
+    throw new UnsupportedOperationException();
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/AbstractManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/AbstractManager.java
@@ -267,14 +267,6 @@ public abstract class AbstractManager implements Session {
     return getSession(TenantManager.class);
   }
 
-  @Override
-  public void close() {
-  }
-
-  @Override
-  public void flush() {
-  }
-
   // authorizations ///////////////////////////////////////
 
   protected CommandContext getCommandContext() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/DeploymentManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/DeploymentManager.java
@@ -267,14 +267,6 @@ public class DeploymentManager extends AbstractManager {
     return getDbEntityManager().selectList("selectDeploymentIdsByProcessInstances", processInstanceIds);
   }
 
-  @Override
-  public void close() {
-  }
-
-  @Override
-  public void flush() {
-  }
-
   // helper /////////////////////////////////////////////////
 
   protected void createDefaultAuthorizations(DeploymentEntity deployment) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionEntity.java
@@ -241,9 +241,6 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
   protected transient List<VariableInstanceLifecycleListener<VariableInstanceEntity>> registeredVariableListeners
     = new ArrayList<>();
 
-  public ExecutionEntity() {
-  }
-
   /**
    * creates a new execution. properties processDefinition, processInstance and
    * activity will be initialized.

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/IncidentStatisticsEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/IncidentStatisticsEntity.java
@@ -26,8 +26,6 @@ public class IncidentStatisticsEntity implements IncidentStatistics {
   protected String incidentType;
   protected int incidentCount;
 
-  public IncidentStatisticsEntity() {}
-
   @Override
   public String getIncidentType() {
     return incidentType;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/VariableInstanceConcurrentLocalInitializer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/VariableInstanceConcurrentLocalInitializer.java
@@ -36,15 +36,4 @@ public class VariableInstanceConcurrentLocalInitializer
   public void onCreate(VariableInstanceEntity variableInstance, AbstractVariableScope sourceScope) {
     variableInstance.setConcurrentLocal(!execution.isScope() || execution.getParent() != null && execution.isExecutingScopeLeafActivity());
   }
-
-  @Override
-  public void onDelete(VariableInstanceEntity variableInstance, AbstractVariableScope sourceScope) {
-
-  }
-
-  @Override
-  public void onUpdate(VariableInstanceEntity variableInstance, AbstractVariableScope sourceScope) {
-
-  }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/VariableInstanceEntityPersistenceListener.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/VariableInstanceEntityPersistenceListener.java
@@ -32,13 +32,4 @@ public class VariableInstanceEntityPersistenceListener implements VariableInstan
     VariableInstanceEntity.insert(variable);
   }
 
-  @Override
-  public void onDelete(VariableInstanceEntity variable, AbstractVariableScope sourceScope) {
-    variable.delete();
-  }
-
-  @Override
-  public void onUpdate(VariableInstanceEntity variable, AbstractVariableScope sourceScope) {
-  }
-
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/VariableInstanceSequenceCounterListener.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/VariableInstanceSequenceCounterListener.java
@@ -28,10 +28,6 @@ public class VariableInstanceSequenceCounterListener implements VariableInstance
   public static final VariableInstanceSequenceCounterListener INSTANCE = new VariableInstanceSequenceCounterListener();
 
   @Override
-  public void onCreate(VariableInstanceEntity variableInstance, AbstractVariableScope sourceScope) {
-  }
-
-  @Override
   public void onDelete(VariableInstanceEntity variableInstance, AbstractVariableScope sourceScope) {
     variableInstance.incrementSequenceCounter();
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/util/TypedValueField.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/util/TypedValueField.java
@@ -298,6 +298,7 @@ public class TypedValueField implements DbEntityLifecycleAware, CommandContextLi
 
   @Override
   public void postLoad() {
+    // no-op
   }
 
   public void clear() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/ExecutionImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/ExecutionImpl.java
@@ -85,9 +85,6 @@ public class ExecutionImpl extends PvmExecutionImpl implements
 
   // lifecycle methods ////////////////////////////////////////////////////////
 
-  public ExecutionImpl() {
-  }
-
   /** creates a new execution. properties processDefinition, processInstance and activity will be initialized. */
   @Override
   public ExecutionImpl createExecution() {

--- a/engine/src/main/java/org/operaton/bpm/engine/management/TablePage.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/management/TablePage.java
@@ -52,10 +52,6 @@ public class TablePage {
    */
   protected List<Map<String, Object>> rowData;
 
-  public TablePage() {
-
-  }
-
   public String getTableName() {
     return tableName;
   }

--- a/engine/src/test/java/org/operaton/bpm/container/impl/jmx/kernel/util/TestService.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/jmx/kernel/util/TestService.java
@@ -23,12 +23,12 @@ public class TestService implements PlatformService<TestService>, TestServiceMBe
 
   @Override
   public void start(PlatformServiceContainer mBeanServiceContainer) {
-
+    // nothing to do
   }
 
   @Override
   public void stop(PlatformServiceContainer mBeanServiceContainer) {
-
+    // nothing to do
   }
 
   @Override

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/test/TestHelperTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/test/TestHelperTest.java
@@ -68,12 +68,15 @@ class TestHelperTest {
   static class SomeTestClass {
 
     public void testSomethingWithPublicAccessor() {
+      // no-op
     }
 
     void testSomethingWithPackagePrivateAccessor() {
+      // no-op
     }
 
     protected void testSomethingWithProtected() {
+      // no-op
     }
 
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/IdGeneratorDataSourceDoNothing.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/IdGeneratorDataSourceDoNothing.java
@@ -24,6 +24,7 @@ public class IdGeneratorDataSourceDoNothing implements ActivityBehavior {
 
   @Override
   public void execute(ActivityExecution execution) throws Exception {
+    // no-op
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/SelfCancellationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/SelfCancellationTest.java
@@ -308,6 +308,7 @@ public class SelfCancellationTest {
 
     @Override
     public void execute(ActivityExecution execution) throws Exception {
+      // no-op
     }
 
     @Override

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationIncidentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationIncidentTest.java
@@ -50,6 +50,7 @@ public class MigrationIncidentTest {
 
     @Override
     public void execute(DelegateExecution execution) throws Exception {
+      // no-op
     }
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationSignallableServiceTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationSignallableServiceTaskTest.java
@@ -118,7 +118,7 @@ class MigrationSignallableServiceTaskTest {
 
     @Override
     public void execute(ActivityExecution execution) throws Exception {
-
+      // no-op
     }
 
     @Override

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/DelegateVarMappingThrowBpmnErrorOutput.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/DelegateVarMappingThrowBpmnErrorOutput.java
@@ -30,6 +30,7 @@ public class DelegateVarMappingThrowBpmnErrorOutput implements DelegateVariableM
 
   @Override
   public void mapInputVariables(DelegateExecution superExecution, VariableMap subVariables) {
+    // no-op
   }
 
   @Override

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/DelegateVarMappingThrowExceptionOutput.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/DelegateVarMappingThrowExceptionOutput.java
@@ -30,6 +30,7 @@ public class DelegateVarMappingThrowExceptionOutput implements DelegateVariableM
 
   @Override
   public void mapInputVariables(DelegateExecution superExecution, VariableMap subVariables) {
+    // no.op
   }
 
   @Override

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/parse/BpmnParseTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/parse/BpmnParseTest.java
@@ -551,6 +551,7 @@ class BpmnParseTest {
   @Deployment
   @Test
   void testParseDiagramInterchangeElementsForUnknownModelElements() {
+    // test behavior defined by @Deployment annotation
   }
 
   /**
@@ -559,13 +560,13 @@ class BpmnParseTest {
   @Test
   @Deployment
   void testParseDefinitionWithDeprecatedActivitiNamespace(){
-
+    // test behavior defined by @Deployment annotation
   }
 
   @Test
   @Deployment
   void testParseDefinitionWithOperatonNamespace(){
-
+    // test behavior defined by @Deployment annotation
   }
 
   @Deployment

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/operation/TaskWaitState.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/operation/TaskWaitState.java
@@ -27,6 +27,7 @@ public class TaskWaitState extends TaskActivityBehavior {
 
   @Override
   protected void performStart(CmmnActivityExecution execution) {
+    // nothing to do
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/TweetExceptionHandler.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/TweetExceptionHandler.java
@@ -56,11 +56,6 @@ public class TweetExceptionHandler implements JobHandler<JobHandlerConfiguration
     return () -> null;
   }
 
-  @Override
-  public void onDelete(JobHandlerConfiguration configuration, JobEntity jobEntity) {
-    // do nothing
-  }
-
   public int getExceptionsRemaining() {
     return exceptionsRemaining.get();
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/TweetHandler.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/TweetHandler.java
@@ -68,9 +68,4 @@ public class TweetHandler implements JobHandler<TweetJobConfiguration> {
     }
   }
 
-  @Override
-  public void onDelete(TweetJobConfiguration configuration, JobEntity jobEntity) {
-    // do nothing
-  }
-
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/TweetNestedCommandExceptionHandler.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/TweetNestedCommandExceptionHandler.java
@@ -56,9 +56,4 @@ public class TweetNestedCommandExceptionHandler implements JobHandler<JobHandler
     return () -> null;
   }
 
-  @Override
-  public void onDelete(JobHandlerConfiguration configuration, JobEntity jobEntity) {
-    // do nothing
-  }
-
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/pvm/activities/ReusableSubProcess.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/pvm/activities/ReusableSubProcess.java
@@ -46,6 +46,7 @@ public class ReusableSubProcess implements SubProcessActivityBehavior {
 
   @Override
   public void passOutputVariables(ActivityExecution targetExecution, VariableScope calledElementInstance) {
+    // no-op
   }
 
   @Override

--- a/jakarta-ee/jobexecutor-ra/src/main/java/org/operaton/bpm/container/impl/threading/ra/outbound/JcaExecutorServiceManagedConnectionFactory.java
+++ b/jakarta-ee/jobexecutor-ra/src/main/java/org/operaton/bpm/container/impl/threading/ra/outbound/JcaExecutorServiceManagedConnectionFactory.java
@@ -44,9 +44,6 @@ public class JcaExecutorServiceManagedConnectionFactory implements ManagedConnec
   protected transient ResourceAdapter ra;
   protected transient PrintWriter logwriter;
 
-  public JcaExecutorServiceManagedConnectionFactory() {
-  }
-
   public Object createConnectionFactory(ConnectionManager cxManager) throws ResourceException {
     return new JcaExecutorServiceConnectionFactoryImpl(this, cxManager);
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/beans/GroovyProcessEnginePlugin.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/beans/GroovyProcessEnginePlugin.java
@@ -29,7 +29,7 @@ public class GroovyProcessEnginePlugin implements ProcessEnginePlugin {
 
   @Override
   public void preInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
-
+    // no pre-initialization logic needed
   }
 
   @Override
@@ -44,6 +44,6 @@ public class GroovyProcessEnginePlugin implements ProcessEnginePlugin {
 
   @Override
   public void postProcessEngineBuild(ProcessEngine processEngine) {
-
+    // no post-processing logic needed
   }
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/beans/ExampleSignallableActivityBehaviorBean.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/beans/ExampleSignallableActivityBehaviorBean.java
@@ -31,6 +31,7 @@ public class ExampleSignallableActivityBehaviorBean extends AbstractBpmnActivity
 
   @Override
   public void execute(ActivityExecution execution) throws Exception {
+    // no-op
   }
 
   @Override

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/beans/RetryConfig.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/beans/RetryConfig.java
@@ -20,9 +20,6 @@ import jakarta.inject.Named;
 
 @Named
 public class RetryConfig {
-  public RetryConfig() {
-  }
-
   public String defaultConfig() {
     return "PT1M,PT2M,PT3M,PT4M,PT5M,PT6M";
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/classes/MyPojo.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/classes/MyPojo.java
@@ -18,9 +18,6 @@ package org.operaton.bpm.integrationtest.functional.context.classes;
 
 public class MyPojo {
 
-    public MyPojo() {
-    }
-
     public String name;
     public int prio;
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/dataformat/CustomDataFormatConfigurator.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/dataformat/CustomDataFormatConfigurator.java
@@ -27,9 +27,6 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
  */
 public class CustomDataFormatConfigurator implements DataFormatConfigurator<JacksonJsonDataFormat> {
 
-  public CustomDataFormatConfigurator() {
-  }
-
   @Override
   public Class<JacksonJsonDataFormat> getDataFormatClass() {
     return JacksonJsonDataFormat.class;

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/dataformat/FooSpin.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/dataformat/FooSpin.java
@@ -43,7 +43,7 @@ public class FooSpin extends Spin<FooSpin> {
 
   @Override
   public void writeToWriter(Writer writer) {
-
+    // no-op
   }
 
   @Override

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spring/beans/RetryConfig.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spring/beans/RetryConfig.java
@@ -20,9 +20,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class RetryConfig {
-  public RetryConfig() {
-  }
-
   public String defaultConfig() {
     return "PT1M,PT2M,PT3M,PT4M,PT5M,PT6M";
   }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/classes/MyPojo.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/jobexecutor/classes/MyPojo.java
@@ -18,9 +18,6 @@ package org.operaton.bpm.integrationtest.jobexecutor.classes;
 
 public class MyPojo {
 
-    public MyPojo() {
-    }
-
     public String name;
     public int prio;
 

--- a/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/client/ClientFactory.java
+++ b/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/client/ClientFactory.java
@@ -179,6 +179,7 @@ public class ClientFactory
 
   @Override
   public void afterPropertiesSet() {
+    // no-op
   }
 
   public ClientConfiguration getClientConfiguration() {

--- a/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/client/ClientPostProcessor.java
+++ b/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/client/ClientPostProcessor.java
@@ -124,8 +124,4 @@ public class ClientPostProcessor implements BeanDefinitionRegistryPostProcessor 
     }
   }
 
-  @Override
-  public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
-  }
-
 }

--- a/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/subscription/SpringTopicSubscriptionImpl.java
+++ b/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/subscription/SpringTopicSubscriptionImpl.java
@@ -273,6 +273,7 @@ public class SpringTopicSubscriptionImpl
 
   @Override
   public void afterPropertiesSet() {
+    // no-op
   }
 
 }

--- a/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/subscription/SubscriptionPostProcessor.java
+++ b/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/subscription/SubscriptionPostProcessor.java
@@ -95,8 +95,4 @@ public class SubscriptionPostProcessor implements BeanDefinitionRegistryPostProc
     return annotation;
   }
 
-  @Override
-  public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
-  }
-
 }

--- a/spring-boot-starter/starter-client/spring/src/test/java/org/operaton/bpm/client/spring/subscription/configuration/HandlerClassAnnotationConfiguration.java
+++ b/spring-boot-starter/starter-client/spring/src/test/java/org/operaton/bpm/client/spring/subscription/configuration/HandlerClassAnnotationConfiguration.java
@@ -26,7 +26,7 @@ public class HandlerClassAnnotationConfiguration implements ExternalTaskHandler 
 
   @Override
   public void execute(ExternalTask externalTask, ExternalTaskService externalTaskService) {
-
+    // no-op
   }
 
 }

--- a/spring-boot-starter/starter-rest/src/main/java/org/operaton/bpm/spring/boot/starter/rest/OperatonJerseyResourceConfig.java
+++ b/spring-boot-starter/starter-rest/src/main/java/org/operaton/bpm/spring/boot/starter/rest/OperatonJerseyResourceConfig.java
@@ -44,8 +44,12 @@ public class OperatonJerseyResourceConfig extends ResourceConfig implements Init
     log.info("Finished configuring operaton rest api.");
   }
 
+  /**
+   * Override this method to register additional resources or features.
+   * This can be useful for adding custom exception mappers, filters, or other JAX-RS components.
+   */
   protected void registerAdditionalResources() {
-
+    // no-op
   }
 
 }

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/plugin/ApplicationContextClassloaderSwitchPlugin.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/plugin/ApplicationContextClassloaderSwitchPlugin.java
@@ -39,10 +39,12 @@ public class ApplicationContextClassloaderSwitchPlugin implements ProcessEngineP
 
   @Override
   public void postInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
+    // nothing to do
   }
 
   @Override
   public void postProcessEngineBuild(ProcessEngine processEngine) {
+    // nothing to do
   }
 
   @Override

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/property/EventingProperty.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/property/EventingProperty.java
@@ -44,10 +44,6 @@ public class EventingProperty {
    */
   private Boolean skippable = Boolean.TRUE;
 
-  public EventingProperty() {
-
-  }
-
   public boolean isExecution() {
     return BooleanUtils.isTrue(execution);
   }

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/util/SpringBootProcessEnginePlugin.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/util/SpringBootProcessEnginePlugin.java
@@ -51,11 +51,11 @@ public class SpringBootProcessEnginePlugin extends SpringProcessEnginePlugin {
   }
 
   public void preInit(SpringProcessEngineConfiguration processEngineConfiguration) {
-
+    // nothing to do
   }
 
   public void postInit(SpringProcessEngineConfiguration processEngineConfiguration) {
-
+    // nothing to do
   }
 
   public void postProcessEngineBuild(ProcessEngineImpl processEngine) {


### PR DESCRIPTION
This resolves Sonar warnings of type java:S1186: "Methods should not be empty [java:S1186](https://sonarcloud.io/organizations/operaton/rules?open=java%3AS1186&rule_key=java%3AS1186)"

- remove empty default constructors
- make some interface methods to empty default methods and remove empty implementations
- add comments to empty method bodies

