### PR TITLE
chore(bom): upgrade commons-fileupload to 1.6.0 (#916)

### DIFF
--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -163,7 +163,7 @@
       <dependency>
         <groupId>commons-fileupload</groupId>
         <artifactId>commons-fileupload</artifactId>
-        <version>1.5</version>
+        <version>1.6.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
This pull request updates commons-fileupload from version 1.5 to 1.6.0 as requested in issue #916, which was flagged by a security scanner.

