### PR TITLE
fix(deps): Override commons-compress to 1.27.1

### DIFF
--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -71,6 +71,11 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.27.1</version>
+      </dependency>
+      <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
         <version>${version.testcontainers}</version>


### PR DESCRIPTION
Closes #931
This PR updates the 'commons-compress' dependency to version 1.27.1 to address the reported vulnerability.
The dependency version is now explicitly managed in the `bom/internal-dependencies/pom.xml` file to override the transitive dependency from testcontainers.