### PR TITLE
chore: Updated Groovy to 4.0.27

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -17,7 +17,7 @@
     <version.jersey3>3.1.10</version.jersey3>
     <!-- use minimum version of resteasy and jersey -->
     <version.jaxrs.api>2.0.1.Final</version.jaxrs.api>
-    <version.groovy>4.0.26</version.groovy>
+    <version.groovy>4.0.27</version.groovy>
     <version.jython>2.7.4</version.jython>
     <version.graal.js>21.3.14</version.graal.js>
     <version.nashorn>15.6</version.nashorn>


### PR DESCRIPTION
Fixes an issue with transient dependencies on some machines