### PR TITLE
feat(engine-plugins): Support FEEL Scala Engine (#5018)

### DIFF
--- a/engine-dmn/feel-scala/src/main/resources/META-INF/services/org.camunda.feel.valuemapper.CustomValueMapper
+++ b/engine-dmn/feel-scala/src/main/resources/META-INF/services/org.camunda.feel.valuemapper.CustomValueMapper
@@ -1,0 +1,1 @@
+org.camunda.feel.impl.JavaValueMapper

--- a/engine-plugins/spin-plugin/src/main/resources/META-INF/services/org.camunda.feel.valuemapper.CustomValueMapper
+++ b/engine-plugins/spin-plugin/src/main/resources/META-INF/services/org.camunda.feel.valuemapper.CustomValueMapper
@@ -1,0 +1,1 @@
+org.operaton.spin.plugin.impl.feel.integration.SpinValueMapper

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -629,6 +629,8 @@
                 <!-- CAM-1778 -->
                 <exludes>**/TestWarDeploymentWithProcessEnginePlugin.java</exludes>
                 <exclude>**/SpringServletPATimerStartEventExpressionTest.java</exclude>
+                <!-- https://github.com/camunda/camunda-bpm-platform/issues/5037-->
+                <exclude>**/FeelEngineTest.java</exclude>
               </excludes>
               <redirectTestOutputToFile>${redirect.test.output}</redirectTestOutputToFile>
             </configuration>

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -629,8 +629,6 @@
                 <!-- CAM-1778 -->
                 <exludes>**/TestWarDeploymentWithProcessEnginePlugin.java</exludes>
                 <exclude>**/SpringServletPATimerStartEventExpressionTest.java</exclude>
-                <!-- https://github.com/camunda/camunda-bpm-platform/issues/5037-->
-                <exclude>**/FeelEngineTest.java</exclude>
               </excludes>
               <redirectTestOutputToFile>${redirect.test.output}</redirectTestOutputToFile>
             </configuration>

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/FeelContextDelegate.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/FeelContextDelegate.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.integrationtest.functional.spin;
+
+import java.util.Map;
+import org.operaton.bpm.engine.delegate.DelegateExecution;
+import org.operaton.bpm.engine.delegate.JavaDelegate;
+
+public class FeelContextDelegate implements JavaDelegate {
+
+  @Override
+  public void execute(DelegateExecution execution) throws Exception {
+    Map<String, Object> context = (Map<String, Object>) execution.getVariable("context");
+    Map<String, Object> nestedMap = (Map<String, Object>) context.get("innerContext");
+
+    String content = (String) nestedMap.get("content");
+    execution.setVariable("result", content);
+  }
+}

--- a/qa/integration-tests-engine/src/test/resources/org/operaton/bpm/integrationtest/functional/spin/feel/feel-spin-input-output.bpmn
+++ b/qa/integration-tests-engine/src/test/resources/org/operaton/bpm/integrationtest/functional/spin/feel/feel-spin-input-output.bpmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:operaton="http://operaton.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://operaton.org/schema/modeler/1.0" id="Definitions_0vzco26" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Operaton Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Operaton Platform" modeler:executionPlatformVersion="7.22.0">
+  <bpmn:process id="feelComplexContextProcess" isExecutable="true" operaton:historyTimeToLive="12">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1kk88fy</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1kk88fy" sourceRef="StartEvent_1" targetRef="Activity_1q08bp7" />
+    <bpmn:endEvent id="Event_1y282u4">
+      <bpmn:incoming>Flow_0sl4a4f</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0ali2qn" sourceRef="Activity_1q08bp7" targetRef="Activity_1v9lsig" />
+    <bpmn:serviceTask id="Activity_1q08bp7" operaton:class="org.operaton.bpm.integrationtest.functional.spin.FeelContextDelegate">
+      <bpmn:extensionElements>
+        <operaton:inputOutput>
+          <operaton:inputParameter name="context">
+            <operaton:script scriptFormat="feel">
+        {
+          text: "Hello from FEEL",
+          numbers: [1, 2, 3],
+          addOne: function(x) x + 1,
+          innerContext: {
+            content: "contentFromInnerContext",
+            sky: "blue"
+          }
+        }
+      </operaton:script>
+          </operaton:inputParameter>
+        </operaton:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1kk88fy</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ali2qn</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0sl4a4f" sourceRef="Activity_1v9lsig" targetRef="Event_1y282u4" />
+    <bpmn:userTask id="Activity_1v9lsig">
+      <bpmn:incoming>Flow_0ali2qn</bpmn:incoming>
+      <bpmn:outgoing>Flow_0sl4a4f</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+</bpmn:definitions>

--- a/qa/integration-tests-engine/src/test/resources/org/operaton/bpm/integrationtest/functional/spin/feel/feel-spin-json-decision.dmn
+++ b/qa/integration-tests-engine/src/test/resources/org/operaton/bpm/integrationtest/functional/spin/feel/feel-spin-json-decision.dmn
@@ -2,6 +2,7 @@
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              id="definitions"
              name="operaton"
+             xmlns:operaton="http://operaton.org/schema/1.0/dmn"
              namespace="http://operaton.org/schema/1.0/dmn">
   <decision id="feel-spin-json-decision" name="decision" operaton:historyTimeToLive="P180D">
     <decisionTable id="decisionTable_1">

--- a/qa/integration-tests-engine/src/test/resources/org/operaton/bpm/integrationtest/functional/spin/feel/feel-spin-process.bpmn
+++ b/qa/integration-tests-engine/src/test/resources/org/operaton/bpm/integrationtest/functional/spin/feel/feel-spin-process.bpmn
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  id="definitions"
+  targetNamespace="Examples"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:operaton="http://operaton.org/schema/1.0/bpmn">
+
+  <process id="feelScriptExecution" isExecutable="true" operaton:historyTimeToLive="180">
+
+    <startEvent id="theStart" name="Start" />
+
+    <sequenceFlow id="flow0" sourceRef="theStart" targetRef="checkAmount" />
+
+    <exclusiveGateway id="checkAmount" name="Check Amount" gatewayDirection="Diverging">
+      <incoming>flow0</incoming>
+      <outgoing>flowApprove</outgoing>
+      <outgoing>flowRequestInvoice</outgoing>
+    </exclusiveGateway>
+
+    <sequenceFlow id="flowApprove" name="amount.valueSmall"
+                  sourceRef="checkAmount" targetRef="taskApprove">
+      <conditionExpression xsi:type="tFormalExpression" language="feel">
+        amount.value &lt; 25
+      </conditionExpression>
+    </sequenceFlow>
+
+    <sequenceFlow id="flowRequestInvoice" name="amount.valueLarge"
+                  sourceRef="checkAmount" targetRef="taskRequestInvoice">
+      <conditionExpression xsi:type="tFormalExpression" language="feel">
+        amount.value &gt;= 25
+      </conditionExpression>
+    </sequenceFlow>
+
+    <userTask id="taskApprove" name="Approve Spending">
+      <incoming>flowApprove</incoming>
+      <outgoing>flowFromApprove</outgoing>
+    </userTask>
+
+    <userTask id="taskRequestInvoice" name="Request Invoice">
+      <incoming>flowRequestInvoice</incoming>
+      <outgoing>flowFromRequestInvoice</outgoing>
+    </userTask>
+
+    <sequenceFlow id="flowFromApprove" sourceRef="taskApprove" targetRef="mergePaths" />
+    <sequenceFlow id="flowFromRequestInvoice" sourceRef="taskRequestInvoice" targetRef="mergePaths" />
+
+    <exclusiveGateway id="mergePaths" name="Merge Paths" gatewayDirection="Converging">
+      <incoming>flowFromApprove</incoming>
+      <incoming>flowFromRequestInvoice</incoming>
+      <outgoing>flowToEnd</outgoing>
+    </exclusiveGateway>
+
+    <sequenceFlow id="flowToEnd" sourceRef="mergePaths" targetRef="theEnd" />
+
+    <endEvent id="theEnd" name="End" />
+
+  </process>
+
+</definitions>

--- a/qa/integration-tests-engine/src/test/resources/org/operaton/bpm/integrationtest/functional/spin/feel/feel-spin-xml-decision.dmn
+++ b/qa/integration-tests-engine/src/test/resources/org/operaton/bpm/integrationtest/functional/spin/feel/feel-spin-xml-decision.dmn
@@ -2,6 +2,7 @@
 <definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
              id="definitions"
              name="operaton"
+             xmlns:operaton="http://operaton.org/schema/1.0/dmn"
              namespace="http://operaton.org/schema/1.0/dmn">
   <decision id="feel-spin-xml-decision" name="decision" operaton:historyTimeToLive="P180D">
     <decisionTable id="decisionTable_1">


### PR DESCRIPTION
related to: camunda/camunda-bpm-platform/issues/2384
related to #945 

* feat(engine-plugins): Support FEEL Scala Engine
* feat(feel-scala): register the FEEL JavaValueMapper SPI
* feat(feel): configure wildfly distro
* camunda-engine-plugin-spin should be optional

related to: camunda/camunda-bpm-platform/issues/2384 ---------

Co-authored-by: Tassilo Weidner <3015690+tasso94@users.noreply.github.com>
Co-authored-by: yanavasileva <yanavasileva@users.noreply.github.com>

Backported commit 4ad576e8d5 from the camunda-bpm-platform repository.
Original author: Joaquín <165814090+joaquinfelici@users.noreply.github.com>