### PR TITLE
Remove trailing comma in VALID_DATABASES

### DIFF
--- a/.devenv/scripts/build/build-and-run-database-update-tests.sh
+++ b/.devenv/scripts/build/build-and-run-database-update-tests.sh
@@ -3,7 +3,7 @@
 EXECUTE_BUILD=true
 EXECUTE_TEST=true
 DATABASE="h2"
-VALID_DATABASES=("h2" "postgresql" "postgresql-xa" "mysql" "mariadb", "oracle" "db2" "sqlserver")
+VALID_DATABASES=("h2" "postgresql" "postgresql-xa" "mysql" "mariadb" "oracle" "db2" "sqlserver")
 
 ##########################################################################
 check_valid_values() {


### PR DESCRIPTION
Causes a build error, because "mariadb" is not recognized as a valid value