### PR TITLE
#564 Replace try/catch with expected failure in test code

### DIFF
--- a/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
+++ b/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
@@ -150,7 +150,7 @@ class FileValueTypeImplTest {
     properties.put("mimeType", null);
     properties.put("encoding", "someEncoding");
 
-    assertThatThrownBy(() -> type.createValue(file, properties), "expected exception")
+    assertThatThrownBy(() -> type.createValue(file, properties))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("The provided mime type is null. Set a non-null value info property with key 'filename'");
 
@@ -160,7 +160,7 @@ class FileValueTypeImplTest {
     properties.put("mimeType", "someMimetype");
     properties.put("encoding", null);
 
-    assertThatThrownBy(() -> type.createValue(file2, properties), "expected exception")
+    assertThatThrownBy(() -> type.createValue(file2, properties))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("The provided encoding is null. Set a non-null value info property with key 'encoding'");
   }

--- a/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
+++ b/commons/typed-values/src/test/java/org/operaton/bpm/engine/test/variables/FileValueTypeImplTest.java
@@ -144,35 +144,25 @@ class FileValueTypeImplTest {
   @Test
   void createValueWithNullProperties() {
     // given
-    InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
+    final InputStream file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
     Map<String, Object> properties = new HashMap<>();
     properties.put("filename", "someFileName");
     properties.put("mimeType", null);
     properties.put("encoding", "someEncoding");
 
-    // when
-    try {
-      type.createValue(file, properties);
-      fail("expected exception");
-    } catch (IllegalArgumentException e) {
-      // then
-      assertThat(e.getMessage()).contains("The provided mime type is null. Set a non-null value info property with key 'filename'");
-    }
+    assertThatThrownBy(() -> type.createValue(file, properties), "expected exception")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("The provided mime type is null. Set a non-null value info property with key 'filename'");
 
     // given
-    file = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
+    final InputStream file2 = this.getClass().getClassLoader().getResourceAsStream("org/operaton/bpm/engine/test/variables/simpleFile.txt");
 
     properties.put("mimeType", "someMimetype");
     properties.put("encoding", null);
 
-    // when
-    try {
-      type.createValue(file, properties);
-      fail("expected exception");
-    } catch (IllegalArgumentException e) {
-      // then
-      assertThat(e.getMessage()).contains("The provided encoding is null. Set a non-null value info property with key 'encoding'");
-    }
+    assertThatThrownBy(() -> type.createValue(file2, properties), "expected exception")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("The provided encoding is null. Set a non-null value info property with key 'encoding'");
   }
 
   @Test

--- a/commons/utils/src/test/java/org/operaton/commons/utils/EnsureUtilTest.java
+++ b/commons/utils/src/test/java/org/operaton/commons/utils/EnsureUtilTest.java
@@ -41,7 +41,7 @@ class EnsureUtilTest {
   @Test
   void shouldFailEnsureNotNull() {
     String string = null;
-    assertThatThrownBy(() -> EnsureUtil.ensureNotNull("string", string), "Expected: IllegalArgumentException")
+    assertThatThrownBy(() -> EnsureUtil.ensureNotNull("string", string))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -60,7 +60,7 @@ class EnsureUtilTest {
   @Test
   void shouldFailEnsureParameterInstanceOfClass() {
     Object string = "string";
-    assertThatThrownBy(() -> EnsureUtil.ensureParamInstanceOf("string", string, Integer.class), "Expected: IllegalArgumentException")
+    assertThatThrownBy(() -> EnsureUtil.ensureParamInstanceOf("string", string, Integer.class))
         .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/commons/utils/src/test/java/org/operaton/commons/utils/EnsureUtilTest.java
+++ b/commons/utils/src/test/java/org/operaton/commons/utils/EnsureUtilTest.java
@@ -19,6 +19,7 @@ package org.operaton.commons.utils;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Fail.fail;
 
 /**
@@ -32,7 +33,6 @@ class EnsureUtilTest {
 
     try {
       EnsureUtil.ensureNotNull("string", string);
-
     } catch(IllegalArgumentException e) {
       fail("Not expected the following exception: ", e);
     }
@@ -41,14 +41,8 @@ class EnsureUtilTest {
   @Test
   void shouldFailEnsureNotNull() {
     String string = null;
-
-    try {
-      EnsureUtil.ensureNotNull("string", string);
-      fail("Expected: IllegalArgumentException");
-
-    } catch(IllegalArgumentException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> EnsureUtil.ensureNotNull("string", string), "Expected: IllegalArgumentException")
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -58,7 +52,6 @@ class EnsureUtilTest {
     try{
       assertThat(EnsureUtil.ensureParamInstanceOf("string", string, String.class))
         .isInstanceOf(String.class);
-
     } catch(IllegalArgumentException e) {
       fail("Not expected the following exception: ", e);
     }
@@ -67,12 +60,7 @@ class EnsureUtilTest {
   @Test
   void shouldFailEnsureParameterInstanceOfClass() {
     Object string = "string";
-
-    try{
-      EnsureUtil.ensureParamInstanceOf("string", string, Integer.class);
-      fail("Expected: IllegalArgumentException");
-    } catch(IllegalArgumentException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> EnsureUtil.ensureParamInstanceOf("string", string, Integer.class), "Expected: IllegalArgumentException")
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/commons/utils/src/test/java/org/operaton/commons/utils/IoUtilTest.java
+++ b/commons/utils/src/test/java/org/operaton/commons/utils/IoUtilTest.java
@@ -70,7 +70,7 @@ public class IoUtilTest {
 
   @Test
   void shouldFailGetFileContentAsStringWithGarbageAsFilename() {
-    assertThatThrownBy(() -> IoUtil.fileAsString("asd123"), "Expected: IoUtilException")
+    assertThatThrownBy(() -> IoUtil.fileAsString("asd123"))
         .isInstanceOf(IoUtilException.class);
   }
 
@@ -92,7 +92,7 @@ public class IoUtilTest {
 
   @Test
   void shouldFailGetFileContentAsStreamWithGarbageAsFilename() {
-    assertThatThrownBy(() -> IoUtil.fileAsStream("asd123"), "Expected: IoUtilException")
+    assertThatThrownBy(() -> IoUtil.fileAsStream("asd123"))
         .isInstanceOf(IoUtilException.class);
   }
 
@@ -107,13 +107,13 @@ public class IoUtilTest {
 
   @Test
   void shouldFailGetFileFromClassPathWithGarbage() {
-    assertThatThrownBy(() -> IoUtil.getClasspathFile("asd123"), "Expected: IoUtilException")
+    assertThatThrownBy(() -> IoUtil.getClasspathFile("asd123"))
         .isInstanceOf(IoUtilException.class);
   }
 
   @Test
   void shouldFailGetFileFromClassPathWithNull() {
-    assertThatThrownBy(() -> IoUtil.getClasspathFile(null), "Expected: IoUtilException")
+    assertThatThrownBy(() -> IoUtil.getClasspathFile(null))
         .isInstanceOf(IoUtilException.class);
   }
 

--- a/commons/utils/src/test/java/org/operaton/commons/utils/IoUtilTest.java
+++ b/commons/utils/src/test/java/org/operaton/commons/utils/IoUtilTest.java
@@ -25,6 +25,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 /**
@@ -69,12 +70,8 @@ public class IoUtilTest {
 
   @Test
   void shouldFailGetFileContentAsStringWithGarbageAsFilename() {
-    try {
-      IoUtil.fileAsString("asd123");
-      fail("Expected: IoUtilException");
-    } catch (IoUtilException e) {
-      // happy way
-    }
+    assertThatThrownBy(() -> IoUtil.fileAsString("asd123"), "Expected: IoUtilException")
+        .isInstanceOf(IoUtilException.class);
   }
 
   @Test
@@ -95,12 +92,8 @@ public class IoUtilTest {
 
   @Test
   void shouldFailGetFileContentAsStreamWithGarbageAsFilename() {
-    try {
-      IoUtil.fileAsStream("asd123");
-      fail("Expected: IoUtilException");
-    } catch(IoUtilException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> IoUtil.fileAsStream("asd123"), "Expected: IoUtilException")
+        .isInstanceOf(IoUtilException.class);
   }
 
   @Test
@@ -114,22 +107,14 @@ public class IoUtilTest {
 
   @Test
   void shouldFailGetFileFromClassPathWithGarbage() {
-    try {
-      IoUtil.getClasspathFile("asd123");
-      fail("Expected: IoUtilException");
-    } catch(IoUtilException e) {
-      // happy way
-    }
+    assertThatThrownBy(() -> IoUtil.getClasspathFile("asd123"), "Expected: IoUtilException")
+        .isInstanceOf(IoUtilException.class);
   }
 
   @Test
   void shouldFailGetFileFromClassPathWithNull() {
-    try {
-      IoUtil.getClasspathFile(null);
-      fail("Expected: IoUtilException");
-    } catch(IoUtilException e) {
-      // happy way
-    }
+    assertThatThrownBy(() -> IoUtil.getClasspathFile(null), "Expected: IoUtilException")
+        .isInstanceOf(IoUtilException.class);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExternalTaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExternalTaskRestServiceQueryTest.java
@@ -267,7 +267,7 @@ public class ExternalTaskRestServiceQueryTest extends AbstractRestServiceTest {
   }
 
   @Test
-  void testGETQuerySorting() {
+  void testSortingParameters() {
     // desc
     InOrder inOrder = Mockito.inOrder(mockQuery);
     executeAndVerifyGETSorting("id", "desc", Status.OK);

--- a/engine/src/test/java/org/operaton/bpm/application/impl/context/ProcessApplicationContextTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/context/ProcessApplicationContextTest.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.application.impl.context;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -151,7 +150,7 @@ class ProcessApplicationContextTest {
     try {
       ProcessApplicationContext.setCurrentProcessApplication(nonExistingName);
 
-      assertThatThrownBy(() -> getCurrentContextApplication(), "should not succeed")
+      assertThatThrownBy(this::getCurrentContextApplication)
           .isInstanceOf(ProcessEngineException.class)
           .hasMessageContaining("A process application with name '" + nonExistingName + "' is not registered");
 

--- a/engine/src/test/java/org/operaton/bpm/application/impl/context/ProcessApplicationContextTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/context/ProcessApplicationContextTest.java
@@ -151,13 +151,9 @@ class ProcessApplicationContextTest {
     try {
       ProcessApplicationContext.setCurrentProcessApplication(nonExistingName);
 
-      try {
-        getCurrentContextApplication();
-        fail("should not succeed");
-
-      } catch (ProcessEngineException e) {
-        assertThat(e.getMessage()).contains("A process application with name '" + nonExistingName + "' is not registered");
-      }
+      assertThatThrownBy(() -> getCurrentContextApplication(), "should not succeed")
+          .isInstanceOf(ProcessEngineException.class)
+          .hasMessageContaining("A process application with name '" + nonExistingName + "' is not registered");
 
     } finally {
       ProcessApplicationContext.clear();

--- a/engine/src/test/java/org/operaton/bpm/container/impl/jmx/kernel/MBeanServiceContainerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/jmx/kernel/MBeanServiceContainerTest.java
@@ -32,6 +32,7 @@ import org.operaton.bpm.container.impl.jmx.kernel.util.StopServiceDeploymentOper
 import org.operaton.bpm.container.impl.jmx.kernel.util.TestService;
 import org.operaton.bpm.container.impl.jmx.kernel.util.TestServiceType;
 import org.operaton.bpm.container.impl.spi.PlatformService;
+import org.operaton.bpm.engine.ProcessEngineException;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -95,7 +96,7 @@ class MBeanServiceContainerTest {
     assertThat(serviceContainer.<TestService>getService(service1ObjectName)).isNotNull();
     assertThat(serviceContainer.<TestService>getService(service1ObjectName)).isEqualTo(service1);
     // as long it is started, I cannot start a second service with the same name:
-    assertThatThrownBy(() -> serviceContainer.startService(service1Name, service1), "exception expected")
+    assertThatThrownBy(() -> serviceContainer.startService(service1Name, service1))
         .isInstanceOf(Exception.class)
         .hasMessageContaining("service with same name already registered");
 
@@ -119,7 +120,7 @@ class MBeanServiceContainerTest {
     // now it's gone
     assertThat(serviceContainer.<TestService>getService(service1ObjectName)).isNull();
 
-    assertThatThrownBy(() -> serviceContainer.stopService(service1Name), "exception expected")
+    assertThatThrownBy(() -> serviceContainer.stopService(service1Name))
         .isInstanceOf(Exception.class)
         .hasMessageContaining("no such service registered");
 
@@ -219,7 +220,7 @@ class MBeanServiceContainerTest {
         .addStep(new StartServiceDeploymentOperationStep(service2Name, service2))
         .addStep(new FailingDeploymentOperationStep());
 
-    assertThatThrownBy(deploymentOperationBuilder::execute, "Exception expected")
+    assertThatThrownBy(deploymentOperationBuilder::execute)
         .isInstanceOf(Exception.class)
         .hasMessageContaining("Exception while performing 'test failing op' => 'failing step'");
 
@@ -234,8 +235,8 @@ class MBeanServiceContainerTest {
       .addStep(new StartServiceDeploymentOperationStep(service2Name, service2))
       .addStep(new FailingDeploymentOperationStep());
 
-    assertThatThrownBy(deploymentOperationBuilder1::execute, "Exception expected")
-        .isInstanceOf(Exception.class)
+    assertThatThrownBy(deploymentOperationBuilder1::execute)
+        .isInstanceOf(ProcessEngineException.class)
         .hasMessageContaining("Exception while performing 'test failing op' => 'failing step'");
 
     // none of the services were registered

--- a/engine/src/test/java/org/operaton/bpm/container/impl/jmx/kernel/MBeanServiceContainerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/jmx/kernel/MBeanServiceContainerTest.java
@@ -16,9 +16,6 @@
  */
 package org.operaton.bpm.container.impl.jmx.kernel;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-
 import java.util.List;
 import java.util.Set;
 
@@ -35,6 +32,8 @@ import org.operaton.bpm.container.impl.jmx.kernel.util.StopServiceDeploymentOper
 import org.operaton.bpm.container.impl.jmx.kernel.util.TestService;
 import org.operaton.bpm.container.impl.jmx.kernel.util.TestServiceType;
 import org.operaton.bpm.container.impl.spi.PlatformService;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Testcases for the {@link MBeanServiceContainer} Kernel.
@@ -96,12 +95,9 @@ class MBeanServiceContainerTest {
     assertThat(serviceContainer.<TestService>getService(service1ObjectName)).isNotNull();
     assertThat(serviceContainer.<TestService>getService(service1ObjectName)).isEqualTo(service1);
     // as long it is started, I cannot start a second service with the same name:
-    try {
-      serviceContainer.startService(service1Name, service1);
-      fail("exception expected");
-    } catch(Exception e) {
-      assertThat(e.getMessage()).contains("service with same name already registered");
-    }
+    assertThatThrownBy(() -> serviceContainer.startService(service1Name, service1), "exception expected")
+        .isInstanceOf(Exception.class)
+        .hasMessageContaining("service with same name already registered");
 
     // but, I can start a service with a different name:
     serviceContainer.startService(service2Name, service2);
@@ -123,12 +119,9 @@ class MBeanServiceContainerTest {
     // now it's gone
     assertThat(serviceContainer.<TestService>getService(service1ObjectName)).isNull();
 
-    try {
-      serviceContainer.stopService(service1Name);
-      fail("exception expected");
-    }catch(Exception e) {
-      assertThat(e.getMessage()).contains("no such service registered");
-    }
+    assertThatThrownBy(() -> serviceContainer.stopService(service1Name), "exception expected")
+        .isInstanceOf(Exception.class)
+        .hasMessageContaining("no such service registered");
 
   }
 
@@ -226,15 +219,9 @@ class MBeanServiceContainerTest {
         .addStep(new StartServiceDeploymentOperationStep(service2Name, service2))
         .addStep(new FailingDeploymentOperationStep());
 
-    try {
-      deploymentOperationBuilder.execute();
-
-      fail("Exception expected");
-
-    } catch(Exception e) {
-      assertThat(e.getMessage()).contains("Exception while performing 'test failing op' => 'failing step'");
-
-    }
+    assertThatThrownBy(deploymentOperationBuilder::execute, "Exception expected")
+        .isInstanceOf(Exception.class)
+        .hasMessageContaining("Exception while performing 'test failing op' => 'failing step'");
 
     // none of the services were registered
     assertThat(serviceContainer.<TestService>getService(service1ObjectName)).isNull();
@@ -246,15 +233,10 @@ class MBeanServiceContainerTest {
       .addStep(new StartServiceDeploymentOperationStep(service1Name, service1))
       .addStep(new StartServiceDeploymentOperationStep(service2Name, service2))
       .addStep(new FailingDeploymentOperationStep());
-    try {
-      deploymentOperationBuilder1.execute();
 
-      fail("Exception expected");
-
-    } catch(Exception e) {
-      assertThat(e.getMessage()).contains("Exception while performing 'test failing op' => 'failing step'");
-
-    }
+    assertThatThrownBy(deploymentOperationBuilder1::execute, "Exception expected")
+        .isInstanceOf(Exception.class)
+        .hasMessageContaining("Exception while performing 'test failing op' => 'failing step'");
 
     // none of the services were registered
     assertThat(serviceContainer.<TestService>getService(service1ObjectName)).isNull();

--- a/engine/src/test/java/org/operaton/bpm/container/impl/metadata/PropertyHelperTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/metadata/PropertyHelperTest.java
@@ -16,10 +16,6 @@
  */
 package org.operaton.bpm.container.impl.metadata;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.Assertions.within;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -30,6 +26,8 @@ import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.cfg.StandaloneProcessEngineConfiguration;
 import org.operaton.bpm.engine.impl.jobexecutor.DefaultJobExecutor;
 import org.operaton.bpm.engine.impl.jobexecutor.JobExecutor;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Thorben Lindhauer
@@ -133,12 +131,8 @@ class PropertyHelperTest {
     Map<String, String> propertiesToSet = new HashMap<>();
     propertiesToSet.put("aNonExistingProperty", "someValue");
 
-    try {
-      PropertyHelper.applyProperties(engineConfiguration, propertiesToSet);
-      fail("Exception expected");
-    } catch (Exception e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> PropertyHelper.applyProperties(engineConfiguration, propertiesToSet), fail("Exception expected"))
+        .isInstanceOf(Exception.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/container/impl/metadata/PropertyHelperTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/metadata/PropertyHelperTest.java
@@ -131,7 +131,7 @@ class PropertyHelperTest {
     Map<String, String> propertiesToSet = new HashMap<>();
     propertiesToSet.put("aNonExistingProperty", "someValue");
 
-    assertThatThrownBy(() -> PropertyHelper.applyProperties(engineConfiguration, propertiesToSet), fail("Exception expected"))
+    assertThatThrownBy(() -> PropertyHelper.applyProperties(engineConfiguration, propertiesToSet), "Exception expected")
         .isInstanceOf(Exception.class);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/container/impl/metadata/PropertyHelperTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/metadata/PropertyHelperTest.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
+import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.cfg.StandaloneProcessEngineConfiguration;
 import org.operaton.bpm.engine.impl.jobexecutor.DefaultJobExecutor;
@@ -131,8 +132,8 @@ class PropertyHelperTest {
     Map<String, String> propertiesToSet = new HashMap<>();
     propertiesToSet.put("aNonExistingProperty", "someValue");
 
-    assertThatThrownBy(() -> PropertyHelper.applyProperties(engineConfiguration, propertiesToSet), "Exception expected")
-        .isInstanceOf(Exception.class);
+    assertThatThrownBy(() -> PropertyHelper.applyProperties(engineConfiguration, propertiesToSet))
+        .isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/util/ImmutablePairTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/util/ImmutablePairTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.impl.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.util.HashMap;
@@ -73,12 +74,9 @@ class ImmutablePairTest {
   void shouldFailWithNonComparableTypes() {
     final ImmutablePair<Object, Object> pair1 = new ImmutablePair<>(new Object(), new Object());
     final ImmutablePair<Object, Object> pair2 = new ImmutablePair<>(new Object(), new Object());
-    try {
-      pair1.compareTo(pair2);
-      fail("Pairs should not be comparable");
-    } catch (IllegalArgumentException e) {
-      assertThat(e).hasMessageContaining("Please provide comparable elements");
-    }
+    assertThatThrownBy(() -> pair1.compareTo(pair2), "Pairs should not be comparable")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Please provide comparable elements");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/util/ImmutablePairTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/util/ImmutablePairTest.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.impl.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map.Entry;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DefaultUserPermissionNameForTaskCfgTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DefaultUserPermissionNameForTaskCfgTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.test.api.authorization;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
@@ -72,14 +73,9 @@ class DefaultUserPermissionNameForTaskCfgTest {
     testProcessEngineCfg.setDefaultUserPermissionNameForTask("UNSUPPORTED");
 
     // if
-    try {
-      testProcessEngineCfg.initDefaultUserPermissionForTask();
-      fail("Exception expected");
-
-    } catch(ProcessEngineException e) {
-      String expectedExceptionMessage = String.format("Invalid value '%s' for configuration property 'defaultUserPermissionNameForTask'.", "UNSUPPORTED");
-      assertThat(e.getMessage()).contains(expectedExceptionMessage);
-    }
+    assertThatThrownBy(testProcessEngineCfg::initDefaultUserPermissionForTask, "Exception expected")
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining(String.format("Invalid value '%s' for configuration property 'defaultUserPermissionNameForTask'.", "UNSUPPORTED"));
   }
 
   @Test
@@ -90,14 +86,9 @@ class DefaultUserPermissionNameForTaskCfgTest {
     testProcessEngineCfg.setDefaultUserPermissionNameForTask(null);
 
     // if
-    try {
-      testProcessEngineCfg.initDefaultUserPermissionForTask();
-      fail("Exception expected");
-
-    } catch(ProcessEngineException e) {
-      String expectedExceptionMessage = "Invalid value 'null' for configuration property 'defaultUserPermissionNameForTask'.";
-      assertThat(e.getMessage()).contains(expectedExceptionMessage);
-    }
+    assertThatThrownBy(testProcessEngineCfg::initDefaultUserPermissionForTask, "Exception expected")
+        .isInstanceOf(ProcessEngineException.class)
+        .hasMessageContaining(String.format("Invalid value 'null' for configuration property 'defaultUserPermissionNameForTask'."));
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DefaultUserPermissionNameForTaskCfgTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DefaultUserPermissionNameForTaskCfgTest.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.test.api.authorization;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngine;
@@ -73,7 +72,7 @@ class DefaultUserPermissionNameForTaskCfgTest {
     testProcessEngineCfg.setDefaultUserPermissionNameForTask("UNSUPPORTED");
 
     // if
-    assertThatThrownBy(testProcessEngineCfg::initDefaultUserPermissionForTask, "Exception expected")
+    assertThatThrownBy(testProcessEngineCfg::initDefaultUserPermissionForTask)
         .isInstanceOf(ProcessEngineException.class)
         .hasMessageContaining(String.format("Invalid value '%s' for configuration property 'defaultUserPermissionNameForTask'.", "UNSUPPORTED"));
   }
@@ -86,7 +85,7 @@ class DefaultUserPermissionNameForTaskCfgTest {
     testProcessEngineCfg.setDefaultUserPermissionNameForTask(null);
 
     // if
-    assertThatThrownBy(testProcessEngineCfg::initDefaultUserPermissionForTask, "Exception expected")
+    assertThatThrownBy(testProcessEngineCfg::initDefaultUserPermissionForTask)
         .isInstanceOf(ProcessEngineException.class)
         .hasMessageContaining(String.format("Invalid value 'null' for configuration property 'defaultUserPermissionNameForTask'."));
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DelegationAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DelegationAuthorizationTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.CREATE;
 import static org.operaton.bpm.engine.authorization.Permissions.CREATE_INSTANCE;
@@ -27,9 +28,6 @@ import static org.operaton.bpm.engine.authorization.Resources.TASK;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.form.StartFormData;
@@ -1049,12 +1047,8 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
     String taskId = selectSingleTask().getId();
     createGrantAuthorization(TASK, taskId, userId, UPDATE);
 
-    try {
-      // when
-      taskService.complete(taskId);
-      fail("Exception expected: It should not be possible to execute the command inside JavaDelegate");
-    } catch (AuthorizationException e) {
-    }
+    assertThatThrownBy(() -> taskService.complete(taskId), "Exception expected: It should not be possible to execute the command inside JavaDelegate")
+        .isInstanceOf(AuthorizationException.class);
 
     // then
     assertThat(MyDelegationService.currentAuthentication).isNotNull();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DelegationAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DelegationAuthorizationTest.java
@@ -1047,7 +1047,7 @@ public class DelegationAuthorizationTest extends AuthorizationTest {
     String taskId = selectSingleTask().getId();
     createGrantAuthorization(TASK, taskId, userId, UPDATE);
 
-    assertThatThrownBy(() -> taskService.complete(taskId), "Exception expected: It should not be possible to execute the command inside JavaDelegate")
+    assertThatThrownBy(() -> taskService.complete(taskId), "It should not be possible to execute the command inside JavaDelegate")
         .isInstanceOf(AuthorizationException.class);
 
     // then

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/FormAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/FormAuthorizationTest.java
@@ -29,11 +29,12 @@ import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 import static org.operaton.bpm.engine.authorization.Resources.TASK;
 import static org.operaton.bpm.engine.authorization.TaskPermissions.READ_VARIABLE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import java.io.InputStream;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,19 +85,14 @@ class FormAuthorizationTest extends AuthorizationTest {
   void testGetStartFormDataWithoutAuthorizations() {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
-
-    try {
-      // when
-      formService.getStartFormData(processDefinitionId);
-      fail("Exception expected: It should not be possible to get start form data");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.getStartFormData(processDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get start form data")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -120,18 +116,14 @@ class FormAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(RENDERED_FORM_PROCESS_KEY).getId();
 
-    try {
-      // when
-      formService.getRenderedStartForm(processDefinitionId);
-      fail("Exception expected: It should not be possible to get start form data");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.getRenderedStartForm(processDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get start form data")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -154,18 +146,14 @@ class FormAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(RENDERED_FORM_PROCESS_KEY).getId();
 
-    try {
-      // when
-      formService.getStartFormVariables(processDefinitionId);
-      fail("Exception expected: It should not be possible to get start form data");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.getStartFormVariables(processDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get start form data")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -190,17 +178,13 @@ class FormAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
 
-    try {
-      // when
-      formService.submitStartForm(processDefinitionId, null);
-      fail("Exception expected: It should not possible to submit a start form");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(CREATE.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.submitStartForm(processDefinitionId, null));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to submit a start form")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(CREATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
   }
 
   @Test
@@ -209,18 +193,14 @@ class FormAuthorizationTest extends AuthorizationTest {
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
 
-    try {
-      // when
-      formService.submitStartForm(processDefinitionId, null);
-      fail("Exception expected: It should not possible to submit a start form");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(CREATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.submitStartForm(processDefinitionId, null));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to submit a start form")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(CREATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -229,17 +209,13 @@ class FormAuthorizationTest extends AuthorizationTest {
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, FORM_PROCESS_KEY, userId, CREATE_INSTANCE);
 
-    try {
-      // when
-      formService.submitStartForm(processDefinitionId, null);
-      fail("Exception expected: It should not possible to submit a start form");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(CREATE.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.submitStartForm(processDefinitionId, null));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to submit a start form")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(CREATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
   }
 
   @Test
@@ -264,34 +240,26 @@ class FormAuthorizationTest extends AuthorizationTest {
     String taskId = "myTask";
     createTask(taskId);
 
-    try {
-      // when
-      formService.getTaskFormData(taskId);
-      fail("Exception expected: It should not possible to get task form data");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(taskId, message);
-      testRule.assertTextPresent(TASK.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.getTaskFormData(taskId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form data")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(taskId, message);
+    testRule.assertTextPresent(TASK.resourceName(), message);
 
     // given (2)
     setReadVariableAsDefaultReadVariablePermission();
 
-    try {
-      // when (2)
-      formService.getTaskFormData(taskId);
-      fail("Exception expected: It should not possible to get task form data");
-    } catch (AuthorizationException e) {
-      // then (2)
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ_VARIABLE.getName(), message);
-      testRule.assertTextPresent(taskId, message);
-      testRule.assertTextPresent(TASK.resourceName(), message);
-    }
+    thrown = catchThrowable(() -> formService.getTaskFormData(taskId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form data")
+        .isInstanceOf(AuthorizationException.class);
+    message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ_VARIABLE.getName(), message);
+    testRule.assertTextPresent(taskId, message);
+    testRule.assertTextPresent(TASK.resourceName(), message);
 
     deleteTask(taskId, true);
   }
@@ -339,40 +307,32 @@ class FormAuthorizationTest extends AuthorizationTest {
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
 
-    try {
-      // when
-      formService.getTaskFormData(taskId);
-      fail("Exception expected: It should not possible to get task form data");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(taskId, message);
-      testRule.assertTextPresent(TASK.resourceName(), message);
-      testRule.assertTextPresent(READ_TASK.getName(), message);
-      testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.getTaskFormData(taskId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form data")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(taskId, message);
+    testRule.assertTextPresent(TASK.resourceName(), message);
+    testRule.assertTextPresent(READ_TASK.getName(), message);
+    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
 
     // given (2)
     setReadVariableAsDefaultReadVariablePermission();
 
-    try {
-      // when (2)
-      formService.getTaskFormData(taskId);
-      fail("Exception expected: It should not possible to get task form data");
-    } catch (AuthorizationException e) {
-      // then (2)
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ_VARIABLE.getName(), message);
-      testRule.assertTextPresent(taskId, message);
-      testRule.assertTextPresent(TASK.resourceName(), message);
-      testRule.assertTextPresent(READ_TASK_VARIABLE.getName(), message);
-      testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    thrown = catchThrowable(() -> formService.getTaskFormData(taskId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form data")
+        .isInstanceOf(AuthorizationException.class);
+    message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ_VARIABLE.getName(), message);
+    testRule.assertTextPresent(taskId, message);
+    testRule.assertTextPresent(TASK.resourceName(), message);
+    testRule.assertTextPresent(READ_TASK_VARIABLE.getName(), message);
+    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -471,35 +431,26 @@ class FormAuthorizationTest extends AuthorizationTest {
     String taskId = "myTask";
     createTask(taskId);
 
-    try {
-      // when
-      formService.getRenderedTaskForm(taskId);
-      fail("Exception expected: It should not possible to get rendered task form");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(taskId, message);
-      testRule.assertTextPresent(TASK.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.getRenderedTaskForm(taskId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get rendered task form")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(taskId, message);
+    testRule.assertTextPresent(TASK.resourceName(), message);
 
     // given (2)
     setReadVariableAsDefaultReadVariablePermission();
 
-    try {
-      // when (2)
-      formService.getRenderedTaskForm(taskId);
-      fail("Exception expected: It should not possible to get rendered task form");
-    } catch (AuthorizationException e) {
-      // then (2)
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ_VARIABLE.getName(), message);
-      testRule.assertTextPresent(taskId, message);
-      testRule.assertTextPresent(TASK.resourceName(), message);
-    }
-
+    thrown = catchThrowable(() -> formService.getRenderedTaskForm(taskId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get rendered task form")
+        .isInstanceOf(AuthorizationException.class);
+    message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ_VARIABLE.getName(), message);
+    testRule.assertTextPresent(taskId, message);
+    testRule.assertTextPresent(TASK.resourceName(), message);
 
     deleteTask(taskId, true);
   }
@@ -541,40 +492,32 @@ class FormAuthorizationTest extends AuthorizationTest {
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
 
-    try {
-      // when
-      formService.getRenderedTaskForm(taskId);
-      fail("Exception expected: It should not possible to get rendered task form");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(taskId, message);
-      testRule.assertTextPresent(TASK.resourceName(), message);
-      testRule.assertTextPresent(READ_TASK.getName(), message);
-      testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.getRenderedTaskForm(taskId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get rendered task form")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(taskId, message);
+    testRule.assertTextPresent(TASK.resourceName(), message);
+    testRule.assertTextPresent(READ_TASK.getName(), message);
+    testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
 
     // given (2)
     setReadVariableAsDefaultReadVariablePermission();
 
-    try {
-      // when (2)
-      formService.getRenderedTaskForm(taskId);
-      fail("Exception expected: It should not possible to get rendered task form");
-    } catch (AuthorizationException e) {
-      // then (2)
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ_VARIABLE.getName(), message);
-      testRule.assertTextPresent(taskId, message);
-      testRule.assertTextPresent(TASK.resourceName(), message);
-      testRule.assertTextPresent(READ_TASK_VARIABLE.getName(), message);
-      testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    thrown = catchThrowable(() -> formService.getRenderedTaskForm(taskId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get rendered task form")
+        .isInstanceOf(AuthorizationException.class);
+    message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ_VARIABLE.getName(), message);
+    testRule.assertTextPresent(taskId, message);
+    testRule.assertTextPresent(TASK.resourceName(), message);
+    testRule.assertTextPresent(READ_TASK_VARIABLE.getName(), message);
+    testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -673,34 +616,26 @@ class FormAuthorizationTest extends AuthorizationTest {
     String taskId = "myTask";
     createTask(taskId);
 
-    try {
-      // when
-      formService.getTaskFormVariables(taskId);
-      fail("Exception expected: It should not possible to get task form variables");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(taskId, message);
-      testRule.assertTextPresent(TASK.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.getTaskFormVariables(taskId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form variables")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(taskId, message);
+    testRule.assertTextPresent(TASK.resourceName(), message);
 
     // given (2)
     setReadVariableAsDefaultReadVariablePermission();
 
-    try {
-      // when (2)
-      formService.getTaskFormVariables(taskId);
-      fail("Exception expected: It should not possible to get task form variables");
-    } catch (AuthorizationException e) {
-      // then (2)
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ_VARIABLE.getName(), message);
-      testRule.assertTextPresent(taskId, message);
-      testRule.assertTextPresent(TASK.resourceName(), message);
-    }
+    thrown = catchThrowable(() -> formService.getTaskFormVariables(taskId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form variables")
+        .isInstanceOf(AuthorizationException.class);
+    message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ_VARIABLE.getName(), message);
+    testRule.assertTextPresent(taskId, message);
+    testRule.assertTextPresent(TASK.resourceName(), message);
 
     deleteTask(taskId, true);
   }
@@ -746,40 +681,33 @@ class FormAuthorizationTest extends AuthorizationTest {
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
 
-    try {
-      // when
-      formService.getTaskFormVariables(taskId);
-      fail("Exception expected: It should not possible to get task form variables");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(taskId, message);
-      testRule.assertTextPresent(TASK.resourceName(), message);
-      testRule.assertTextPresent(READ_TASK.getName(), message);
-      testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.getTaskFormVariables(taskId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form variables")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(taskId, message);
+    testRule.assertTextPresent(TASK.resourceName(), message);
+    testRule.assertTextPresent(READ_TASK.getName(), message);
+    testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
 
     // given (2)
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
 
-    try {
-      // when (2)
-      formService.getTaskFormVariables(taskId);
-      fail("Exception expected: It should not possible to get task form variables");
-    } catch (AuthorizationException e) {
-      // then (2)
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ_VARIABLE.getName(), message);
-      testRule.assertTextPresent(taskId, message);
-      testRule.assertTextPresent(TASK.resourceName(), message);
-      testRule.assertTextPresent(READ_TASK_VARIABLE.getName(), message);
-      testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    thrown = catchThrowable(() -> formService.getTaskFormVariables(taskId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form variables")
+        .isInstanceOf(AuthorizationException.class);
+    message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ_VARIABLE.getName(), message);
+    testRule.assertTextPresent(taskId, message);
+    testRule.assertTextPresent(TASK.resourceName(), message);
+    testRule.assertTextPresent(READ_TASK_VARIABLE.getName(), message);
+    testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -888,18 +816,14 @@ class FormAuthorizationTest extends AuthorizationTest {
     String taskId = "myTask";
     createTask(taskId);
 
-    try {
-      // when
-      formService.submitTaskForm(taskId, null);
-      fail("Exception expected: It should not possible to submit a task form");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(taskId, message);
-      testRule.assertTextPresent(TASK.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.submitTaskForm(taskId, null));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to submit a task form")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(taskId, message);
+    testRule.assertTextPresent(TASK.resourceName(), message);
 
     deleteTask(taskId, true);
   }
@@ -929,21 +853,17 @@ class FormAuthorizationTest extends AuthorizationTest {
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
 
-    try {
-      // when
-      formService.submitTaskForm(taskId, null);
-      fail("Exception expected: It should not possible to submit a task form");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(taskId, message);
-      testRule.assertTextPresent(TASK.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_TASK.getName(), message);
-      testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.submitTaskForm(taskId, null));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to submit a task form")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(taskId, message);
+    testRule.assertTextPresent(TASK.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_TASK.getName(), message);
+    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -1015,18 +935,14 @@ class FormAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
 
-    try {
-      // when
-      formService.getStartFormKey(processDefinitionId);
-      fail("Exception expected: It should not possible to get a start form key");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.getStartFormKey(processDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get a start form key")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -1049,18 +965,14 @@ class FormAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
 
-    try {
-      // when
-      formService.getTaskFormKey(processDefinitionId, "task");
-      fail("Exception expected: It should not possible to get a task form key");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.getTaskFormKey(processDefinitionId, "task"));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get a task form key")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -1094,18 +1006,15 @@ class FormAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
 
-    try {
-      // when
-      formService.getDeployedStartForm(processDefinitionId);
-      fail("Exception expected: It should not possible to get a deployed start form");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.getDeployedStartForm(processDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get a deployed start form")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   // get deployed task form////////////////////////////////////////
@@ -1128,18 +1037,15 @@ class FormAuthorizationTest extends AuthorizationTest {
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
 
-    try {
-      // when
-      formService.getDeployedTaskForm(taskId);
-      fail("Exception expected: It should not possible to get a deployed task form");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-      testRule.assertTextPresent(TASK.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> formService.getDeployedTaskForm(taskId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get a deployed task form")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
+    testRule.assertTextPresent(TASK.resourceName(), message);
+
   }
 
   // helper ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/FormAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/FormAuthorizationTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.CREATE;
 import static org.operaton.bpm.engine.authorization.Permissions.CREATE_INSTANCE;
@@ -29,12 +30,10 @@ import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 import static org.operaton.bpm.engine.authorization.Resources.TASK;
 import static org.operaton.bpm.engine.authorization.TaskPermissions.READ_VARIABLE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import java.io.InputStream;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -83,16 +82,14 @@ class FormAuthorizationTest extends AuthorizationTest {
 
   @Test
   void testGetStartFormDataWithoutAuthorizations() {
-    // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
-    Throwable thrown = catchThrowable(() -> formService.getStartFormData(processDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get start form data")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
+    assertThatThrownBy(() -> formService.getStartFormData(processDefinitionId))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(FORM_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -113,17 +110,14 @@ class FormAuthorizationTest extends AuthorizationTest {
 
   @Test
   void testGetRenderedStartFormWithoutAuthorization() {
-    // given
     String processDefinitionId = selectProcessDefinitionByKey(RENDERED_FORM_PROCESS_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> formService.getRenderedStartForm(processDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get start form data")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    assertThatThrownBy(() -> formService.getRenderedStartForm(processDefinitionId))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(RENDERED_FORM_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -143,17 +137,14 @@ class FormAuthorizationTest extends AuthorizationTest {
 
   @Test
   void testGetStartFormVariablesWithoutAuthorization() {
-    // given
     String processDefinitionId = selectProcessDefinitionByKey(RENDERED_FORM_PROCESS_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> formService.getStartFormVariables(processDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get start form data")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    assertThatThrownBy(() -> formService.getStartFormVariables(processDefinitionId))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(RENDERED_FORM_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -175,16 +166,14 @@ class FormAuthorizationTest extends AuthorizationTest {
 
   @Test
   void testSubmitStartFormWithoutAuthorization() {
-    // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> formService.submitStartForm(processDefinitionId, null));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to submit a start form")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(CREATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    assertThatThrownBy(() -> formService.submitStartForm(processDefinitionId, null),
+            "It should not possible to submit a start form")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(CREATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName());
   }
 
   @Test
@@ -193,14 +182,14 @@ class FormAuthorizationTest extends AuthorizationTest {
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, CREATE);
 
-    Throwable thrown = catchThrowable(() -> formService.submitStartForm(processDefinitionId, null));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to submit a start form")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(CREATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> formService.submitStartForm(processDefinitionId, null),
+            "It should not possible to submit a start form")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(CREATE_INSTANCE.getName())
+        .hasMessageContaining(FORM_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -209,13 +198,13 @@ class FormAuthorizationTest extends AuthorizationTest {
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, FORM_PROCESS_KEY, userId, CREATE_INSTANCE);
 
-    Throwable thrown = catchThrowable(() -> formService.submitStartForm(processDefinitionId, null));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to submit a start form")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(CREATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> formService.submitStartForm(processDefinitionId, null),
+            "It should not possible to submit a start form")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(CREATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName());
   }
 
   @Test
@@ -240,26 +229,27 @@ class FormAuthorizationTest extends AuthorizationTest {
     String taskId = "myTask";
     createTask(taskId);
 
-    Throwable thrown = catchThrowable(() -> formService.getTaskFormData(taskId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form data")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(taskId, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> formService.getTaskFormData(taskId),
+            "It should not possible to get task form data")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(TASK.resourceName());
+
 
     // given (2)
     setReadVariableAsDefaultReadVariablePermission();
 
-    thrown = catchThrowable(() -> formService.getTaskFormData(taskId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form data")
-        .isInstanceOf(AuthorizationException.class);
-    message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ_VARIABLE.getName(), message);
-    testRule.assertTextPresent(taskId, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
+    // when + then (2)
+    assertThatThrownBy(() -> formService.getTaskFormData(taskId),
+            "It should not possible to get task form data")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ_VARIABLE.getName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(TASK.resourceName());
 
     deleteTask(taskId, true);
   }
@@ -307,32 +297,32 @@ class FormAuthorizationTest extends AuthorizationTest {
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
 
-    Throwable thrown = catchThrowable(() -> formService.getTaskFormData(taskId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form data")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(taskId, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
-    testRule.assertTextPresent(READ_TASK.getName(), message);
-    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> formService.getTaskFormData(taskId),
+            "It should not possible to get task form data")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(TASK.resourceName())
+        .hasMessageContaining(READ_TASK.getName())
+        .hasMessageContaining(FORM_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
 
     // given (2)
     setReadVariableAsDefaultReadVariablePermission();
 
-    thrown = catchThrowable(() -> formService.getTaskFormData(taskId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form data")
-        .isInstanceOf(AuthorizationException.class);
-    message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ_VARIABLE.getName(), message);
-    testRule.assertTextPresent(taskId, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
-    testRule.assertTextPresent(READ_TASK_VARIABLE.getName(), message);
-    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then (2)
+    assertThatThrownBy(() -> formService.getTaskFormData(taskId),
+            "It should not possible to get task form data")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ_VARIABLE.getName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(TASK.resourceName())
+        .hasMessageContaining(READ_TASK_VARIABLE.getName())
+        .hasMessageContaining(FORM_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -431,26 +421,26 @@ class FormAuthorizationTest extends AuthorizationTest {
     String taskId = "myTask";
     createTask(taskId);
 
-    Throwable thrown = catchThrowable(() -> formService.getRenderedTaskForm(taskId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get rendered task form")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(taskId, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> formService.getRenderedTaskForm(taskId),
+            "It should not possible to get rendered task form")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(TASK.resourceName());
 
     // given (2)
     setReadVariableAsDefaultReadVariablePermission();
 
-    thrown = catchThrowable(() -> formService.getRenderedTaskForm(taskId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get rendered task form")
-        .isInstanceOf(AuthorizationException.class);
-    message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ_VARIABLE.getName(), message);
-    testRule.assertTextPresent(taskId, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
+    // when + then (2)
+    assertThatThrownBy(() -> formService.getRenderedTaskForm(taskId),
+            "It should not possible to get rendered task form")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ_VARIABLE.getName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(TASK.resourceName());
 
     deleteTask(taskId, true);
   }
@@ -492,32 +482,32 @@ class FormAuthorizationTest extends AuthorizationTest {
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
 
-    Throwable thrown = catchThrowable(() -> formService.getRenderedTaskForm(taskId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get rendered task form")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(taskId, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
-    testRule.assertTextPresent(READ_TASK.getName(), message);
-    testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> formService.getRenderedTaskForm(taskId),
+            "It should not possible to get rendered task form")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(TASK.resourceName())
+        .hasMessageContaining(READ_TASK.getName())
+        .hasMessageContaining(RENDERED_FORM_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
 
     // given (2)
     setReadVariableAsDefaultReadVariablePermission();
 
-    thrown = catchThrowable(() -> formService.getRenderedTaskForm(taskId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get rendered task form")
-        .isInstanceOf(AuthorizationException.class);
-    message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ_VARIABLE.getName(), message);
-    testRule.assertTextPresent(taskId, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
-    testRule.assertTextPresent(READ_TASK_VARIABLE.getName(), message);
-    testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then (2)
+    assertThatThrownBy(() -> formService.getRenderedTaskForm(taskId),
+            "It should not possible to get rendered task form")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ_VARIABLE.getName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(TASK.resourceName())
+        .hasMessageContaining(READ_TASK_VARIABLE.getName())
+        .hasMessageContaining(RENDERED_FORM_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -616,26 +606,26 @@ class FormAuthorizationTest extends AuthorizationTest {
     String taskId = "myTask";
     createTask(taskId);
 
-    Throwable thrown = catchThrowable(() -> formService.getTaskFormVariables(taskId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form variables")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(taskId, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> formService.getTaskFormVariables(taskId),
+            "It should not possible to get task form variables")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(TASK.resourceName());
 
     // given (2)
     setReadVariableAsDefaultReadVariablePermission();
 
-    thrown = catchThrowable(() -> formService.getTaskFormVariables(taskId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form variables")
-        .isInstanceOf(AuthorizationException.class);
-    message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ_VARIABLE.getName(), message);
-    testRule.assertTextPresent(taskId, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
+    // when + then (2)
+    assertThatThrownBy(() -> formService.getTaskFormVariables(taskId),
+            "It should not possible to get task form variables")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ_VARIABLE.getName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(TASK.resourceName());
 
     deleteTask(taskId, true);
   }
@@ -681,33 +671,32 @@ class FormAuthorizationTest extends AuthorizationTest {
     startProcessInstanceByKey(RENDERED_FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
 
-    Throwable thrown = catchThrowable(() -> formService.getTaskFormVariables(taskId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form variables")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(taskId, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
-    testRule.assertTextPresent(READ_TASK.getName(), message);
-    testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> formService.getTaskFormVariables(taskId),
+            "It should not possible to get task form variables")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(TASK.resourceName())
+        .hasMessageContaining(READ_TASK.getName())
+        .hasMessageContaining(RENDERED_FORM_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
 
     // given (2)
     processEngineConfiguration.setEnforceSpecificVariablePermission(true);
 
-    thrown = catchThrowable(() -> formService.getTaskFormVariables(taskId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get task form variables")
-        .isInstanceOf(AuthorizationException.class);
-    message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ_VARIABLE.getName(), message);
-    testRule.assertTextPresent(taskId, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
-    testRule.assertTextPresent(READ_TASK_VARIABLE.getName(), message);
-    testRule.assertTextPresent(RENDERED_FORM_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then (2)
+    assertThatThrownBy(() -> formService.getTaskFormVariables(taskId),
+            "It should not possible to get task form variables")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ_VARIABLE.getName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(TASK.resourceName())
+        .hasMessageContaining(READ_TASK_VARIABLE.getName())
+        .hasMessageContaining(RENDERED_FORM_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -816,14 +805,14 @@ class FormAuthorizationTest extends AuthorizationTest {
     String taskId = "myTask";
     createTask(taskId);
 
-    Throwable thrown = catchThrowable(() -> formService.submitTaskForm(taskId, null));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to submit a task form")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(taskId, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> formService.submitTaskForm(taskId, null),
+            "It should not possible to submit a task form")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(TASK.resourceName());
 
     deleteTask(taskId, true);
   }
@@ -853,17 +842,17 @@ class FormAuthorizationTest extends AuthorizationTest {
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
 
-    Throwable thrown = catchThrowable(() -> formService.submitTaskForm(taskId, null));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to submit a task form")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(taskId, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_TASK.getName(), message);
-    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> formService.submitTaskForm(taskId, null),
+            "It should not possible to submit a task form")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(TASK.resourceName())
+        .hasMessageContaining(UPDATE_TASK.getName())
+        .hasMessageContaining(FORM_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -935,14 +924,14 @@ class FormAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> formService.getStartFormKey(processDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get a start form key")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> formService.getStartFormKey(processDefinitionId),
+            "It should not possible to get a start form key")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(FORM_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -965,14 +954,14 @@ class FormAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> formService.getTaskFormKey(processDefinitionId, "task"));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get a task form key")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> formService.getTaskFormKey(processDefinitionId, "task"),
+            "It should not possible to get a task form key")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(FORM_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -1006,15 +995,14 @@ class FormAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(FORM_PROCESS_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> formService.getDeployedStartForm(processDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get a deployed start form")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> formService.getDeployedStartForm(processDefinitionId),
+            "It should not possible to get a deployed start form")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(FORM_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   // get deployed task form////////////////////////////////////////
@@ -1037,15 +1025,14 @@ class FormAuthorizationTest extends AuthorizationTest {
     startProcessInstanceByKey(FORM_PROCESS_KEY);
     String taskId = selectSingleTask().getId();
 
-    Throwable thrown = catchThrowable(() -> formService.getDeployedTaskForm(taskId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not possible to get a deployed task form")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(FORM_PROCESS_KEY, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> formService.getDeployedTaskForm(taskId),
+            "It should not possible to get a deployed task form")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(FORM_PROCESS_KEY)
+        .hasMessageContaining(TASK.resourceName());
   }
 
   // helper ////////////////////////////////////////////////////////////////////////////////

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobAuthorizationTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.ALL;
 import static org.operaton.bpm.engine.authorization.Permissions.READ;
@@ -23,12 +24,11 @@ import static org.operaton.bpm.engine.authorization.Permissions.READ_INSTANCE;
 import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.test.util.QueryTestHelper.verifyQueryResults;
 
 import java.util.Date;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -333,17 +333,13 @@ class JobAuthorizationTest extends AuthorizationTest {
     disableAuthorization();
     String jobId = selectJobByProcessInstanceId(processInstanceId).getId();
 
-    try {
-      // when
-      managementService.getJobExceptionStacktrace(jobId);
-      fail("Exception expected: It should not be possible to get the exception stacktrace");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName() + "' permission on resource '" + processInstanceId + "' of type '" + PROCESS_INSTANCE.resourceName() + "' or '", message);
-      testRule.assertTextPresent(READ_INSTANCE.getName() + "' permission on resource '" + ONE_INCIDENT_PROCESS_KEY + "' of type '" + PROCESS_DEFINITION.resourceName() + "'", message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.getJobExceptionStacktrace(jobId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get the exception stacktrace")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName() + "' permission on resource '" + processInstanceId + "' of type '" + PROCESS_INSTANCE.resourceName() + "' or '", message);
+    testRule.assertTextPresent(READ_INSTANCE.getName() + "' permission on resource '" + ONE_INCIDENT_PROCESS_KEY + "' of type '" + PROCESS_DEFINITION.resourceName() + "'", message);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobAuthorizationTest.java
@@ -28,7 +28,6 @@ import static org.operaton.bpm.engine.test.util.QueryTestHelper.verifyQueryResul
 
 import java.util.Date;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -333,13 +332,13 @@ class JobAuthorizationTest extends AuthorizationTest {
     disableAuthorization();
     String jobId = selectJobByProcessInstanceId(processInstanceId).getId();
 
-    Throwable thrown = catchThrowable(() -> managementService.getJobExceptionStacktrace(jobId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get the exception stacktrace")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName() + "' permission on resource '" + processInstanceId + "' of type '" + PROCESS_INSTANCE.resourceName() + "' or '", message);
-    testRule.assertTextPresent(READ_INSTANCE.getName() + "' permission on resource '" + ONE_INCIDENT_PROCESS_KEY + "' of type '" + PROCESS_DEFINITION.resourceName() + "'", message);
+    // when + then
+    assertThatThrownBy(() -> managementService.getJobExceptionStacktrace(jobId),
+            "It should not be possible to get the exception stacktrace")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName() + "' permission on resource '" + processInstanceId + "' of type '" + PROCESS_INSTANCE.resourceName() + "' or '")
+        .hasMessageContaining(READ_INSTANCE.getName() + "' permission on resource '" + ONE_INCIDENT_PROCESS_KEY + "' of type '" + PROCESS_DEFINITION.resourceName() + "'");
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobDefinitionAuthorizationTest.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.READ;
@@ -26,7 +26,6 @@ import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 import static org.operaton.bpm.engine.test.util.QueryTestHelper.verifyQueryResults;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -123,14 +122,14 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionById(jobDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionById(jobDefinitionId),
+            "It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -171,15 +170,14 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     suspendJobDefinitionById(jobDefinitionId);
 
-    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionById(jobDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to activate a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> managementService.activateJobDefinitionById(jobDefinitionId),
+            "It should not be possible to activate a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -223,16 +221,16 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
 
-    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionById(jobDefinitionId, true));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionById(jobDefinitionId, true),
+            "It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -244,17 +242,16 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
 
-    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionById(jobDefinitionId, true));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionById(jobDefinitionId, true),
+            "It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -333,17 +330,16 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
 
-    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionById(jobDefinitionId, true));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> managementService.activateJobDefinitionById(jobDefinitionId, true),
+            "It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -356,16 +352,16 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
 
-    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionById(jobDefinitionId, true));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> managementService.activateJobDefinitionById(jobDefinitionId, true),
+            "It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -443,15 +439,14 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionByProcessDefinitionId(processDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionId(processDefinitionId),
+            "It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -492,15 +487,14 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     suspendJobDefinitionByProcessDefinitionId(processDefinitionId);
 
-    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionByProcessDefinitionId(processDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to activate a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionId(processDefinitionId),
+            "It should not be possible to activate a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -545,17 +539,16 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
 
-    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionByProcessDefinitionId(processDefinitionId, true));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionId(processDefinitionId, true),
+            "It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -567,16 +560,16 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
 
-    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionByProcessDefinitionId(processDefinitionId, true));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionId(processDefinitionId, true),
+            "It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -655,17 +648,16 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
 
-    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionByProcessDefinitionId(processDefinitionId, true));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionId(processDefinitionId, true),
+            "It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -678,17 +670,16 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
 
-    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionByProcessDefinitionId(processDefinitionId, true));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionId(processDefinitionId, true),
+            "It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -763,15 +754,13 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
 
   @Test
   void testSuspendByProcessDefinitionKeyWithoutAuthorization() {
-    // given
-    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY),
+            "It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -809,14 +798,14 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY);
 
-    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY),
+            "It should not be possible to activate a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -858,17 +847,16 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
 
-    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true),
+            "It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -879,17 +867,16 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
 
-    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true),
+            "It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -964,17 +951,16 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
 
-    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true),
+            "It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -986,17 +972,16 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
 
-    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true),
+            "It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(TIMER_BOUNDARY_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/JobDefinitionAuthorizationTest.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.test.api.authorization;
 
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.READ;
 import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
@@ -24,11 +26,9 @@ import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 import static org.operaton.bpm.engine.test.util.QueryTestHelper.verifyQueryResults;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.management.JobDefinition;
@@ -123,18 +123,14 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
 
-    try {
-      // when
-      managementService.suspendJobDefinitionById(jobDefinitionId);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionById(jobDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -175,18 +171,15 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     String jobDefinitionId = selectJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     suspendJobDefinitionById(jobDefinitionId);
 
-    try {
-      // when
-      managementService.activateJobDefinitionById(jobDefinitionId);
-      fail("Exception expected: It should not be possible to activate a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionById(jobDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to activate a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -230,20 +223,16 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     startProcessInstanceByKey(TIMER_BOUNDARY_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
 
-    try {
-      // when
-      managementService.suspendJobDefinitionById(jobDefinitionId, true);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionById(jobDefinitionId, true));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -255,20 +244,17 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
 
-    try {
-      // when
-      managementService.suspendJobDefinitionById(jobDefinitionId, true);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionById(jobDefinitionId, true));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -347,20 +333,17 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
 
-    try {
-      // when
-      managementService.activateJobDefinitionById(jobDefinitionId, true);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionById(jobDefinitionId, true));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -373,20 +356,16 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
 
-    try {
-      // when
-      managementService.activateJobDefinitionById(jobDefinitionId, true);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionById(jobDefinitionId, true));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -464,18 +443,15 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
 
-    try {
-      // when
-      managementService.suspendJobDefinitionByProcessDefinitionId(processDefinitionId);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionByProcessDefinitionId(processDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -516,18 +492,15 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     String processDefinitionId = selectProcessDefinitionByKey(TIMER_BOUNDARY_PROCESS_KEY).getId();
     suspendJobDefinitionByProcessDefinitionId(processDefinitionId);
 
-    try {
-      // when
-      managementService.activateJobDefinitionByProcessDefinitionId(processDefinitionId);
-      fail("Exception expected: It should not be possible to activate a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionByProcessDefinitionId(processDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to activate a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -572,20 +545,17 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
 
-    try {
-      // when
-      managementService.suspendJobDefinitionByProcessDefinitionId(processDefinitionId, true);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionByProcessDefinitionId(processDefinitionId, true));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -597,20 +567,16 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
 
-    try {
-      // when
-      managementService.suspendJobDefinitionByProcessDefinitionId(processDefinitionId, true);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionByProcessDefinitionId(processDefinitionId, true));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -689,20 +655,17 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
 
-    try {
-      // when
-      managementService.activateJobDefinitionByProcessDefinitionId(processDefinitionId, true);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionByProcessDefinitionId(processDefinitionId, true));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -715,20 +678,17 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
 
-    try {
-      // when
-      managementService.activateJobDefinitionByProcessDefinitionId(processDefinitionId, true);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionByProcessDefinitionId(processDefinitionId, true));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -804,19 +764,14 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
   @Test
   void testSuspendByProcessDefinitionKeyWithoutAuthorization() {
     // given
-
-    try {
-      // when
-      managementService.suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -854,18 +809,14 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY);
 
-    try {
-      // when
-      managementService.activateJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -907,20 +858,17 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
 
-    try {
-      // when
-      managementService.suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -931,20 +879,17 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
 
-    try {
-      // when
-      managementService.suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -1019,20 +964,17 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
 
-    try {
-      // when
-      managementService.activateJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -1044,20 +986,17 @@ class JobDefinitionAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_DEFINITION, TIMER_BOUNDARY_PROCESS_KEY, userId, UPDATE);
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE);
 
-    try {
-      // when
-      managementService.activateJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true);
-      fail("Exception expected: It should not be possible to suspend a job definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> managementService.activateJobDefinitionByProcessDefinitionKey(TIMER_BOUNDARY_PROCESS_KEY, true));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend a job definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(TIMER_BOUNDARY_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessDefinitionAuthorizationTest.java
@@ -33,7 +33,6 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
@@ -209,14 +208,14 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> ((RepositoryServiceImpl)repositoryService).getDeployedProcessDefinition(processDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get the process definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> ((RepositoryServiceImpl)repositoryService).getDeployedProcessDefinition(processDefinitionId),
+            "It should not be possible to get the process definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -239,14 +238,14 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> repositoryService.getProcessDiagram(processDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get the process diagram")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+    // when + then
+    assertThatThrownBy(() -> repositoryService.getProcessDiagram(processDefinitionId),
+            "It should not be possible to get the process diagram")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -270,15 +269,14 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> repositoryService.getProcessModel(processDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get the process model")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> repositoryService.getProcessModel(processDefinitionId),
+            "It should not be possible to get the process model")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -301,15 +299,14 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> repositoryService.getBpmnModelInstance(processDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get the bpmn model instance")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> repositoryService.getBpmnModelInstance(processDefinitionId),
+            "It should not be possible to get the bpmn model instance")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -332,15 +329,14 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> repositoryService.getProcessDiagramLayout(processDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get the process diagram layout")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> repositoryService.getProcessDiagramLayout(processDefinitionId),
+            "It should not be possible to get the process diagram layout")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -364,16 +360,15 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> repositoryService.suspendProcessDefinitionById(processDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend the process definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(ProcessDefinitionPermissions.SUSPEND.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> repositoryService.suspendProcessDefinitionById(processDefinitionId),
+            "It should not be possible to suspend the process definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(ProcessDefinitionPermissions.SUSPEND.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -412,16 +407,15 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     suspendProcessDefinitionById(processDefinitionId);
 
-    Throwable thrown = catchThrowable(() -> repositoryService.activateProcessDefinitionById(processDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to activate the process definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(ProcessDefinitionPermissions.SUSPEND.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> repositoryService.activateProcessDefinitionById(processDefinitionId),
+            "It should not be possible to activate the process definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(ProcessDefinitionPermissions.SUSPEND.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -463,19 +457,18 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE);
 
-    Throwable thrown = catchThrowable(() -> repositoryService.suspendProcessDefinitionById(processDefinitionId, true, null));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend the process definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> repositoryService.suspendProcessDefinitionById(processDefinitionId, true, null),
+            "It should not be possible to suspend the process definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(ProcessInstancePermissions.SUSPEND.getName())
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(SUSPEND_INSTANCE.getName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -487,19 +480,18 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE, ProcessInstancePermissions.SUSPEND);
 
-    Throwable thrown = catchThrowable(() -> repositoryService.suspendProcessDefinitionById(processDefinitionId, true, null));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend the process definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> repositoryService.suspendProcessDefinitionById(processDefinitionId, true, null))
+        .withFailMessage("It should not be possible to suspend the process definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(ProcessInstancePermissions.SUSPEND.getName())
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(SUSPEND_INSTANCE.getName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -613,19 +605,18 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     suspendProcessDefinitionById(processDefinitionId);
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE, ProcessDefinitionPermissions.SUSPEND);
 
-    Throwable thrown = catchThrowable(() -> repositoryService.activateProcessDefinitionById(processDefinitionId, true, null));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend the process definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> repositoryService.activateProcessDefinitionById(processDefinitionId, true, null))
+        .withFailMessage("It should not be possible to activate the process definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(ProcessInstancePermissions.SUSPEND.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(SUSPEND_INSTANCE.getName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -638,19 +629,18 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     suspendProcessDefinitionById(processDefinitionId);
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE);
 
-    Throwable thrown = catchThrowable(() -> repositoryService.activateProcessDefinitionById(processDefinitionId, true, null));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to activate the process definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> repositoryService.activateProcessDefinitionById(processDefinitionId, true, null))
+        .withFailMessage("It should not be possible to activate the process definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(ProcessInstancePermissions.SUSPEND.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(SUSPEND_INSTANCE.getName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -763,17 +753,14 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
 
   @Test
   void testSuspendProcessDefinitionByKeyWithoutAuthorization() {
-    // given
-    Throwable thrown = catchThrowable(() -> repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend the process definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(ProcessDefinitionPermissions.SUSPEND.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    assertThatThrownBy(() -> repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY),
+            "It should not be possible to suspend the process definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(ProcessDefinitionPermissions.SUSPEND.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -809,16 +796,15 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
 
-    Throwable thrown = catchThrowable(() ->  repositoryService.activateProcessDefinitionByKey(ONE_TASK_PROCESS_KEY));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to activate the process definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(ProcessDefinitionPermissions.SUSPEND.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> repositoryService.activateProcessDefinitionByKey(ONE_TASK_PROCESS_KEY),
+            "It should not be possible to activate the process definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(ProcessDefinitionPermissions.SUSPEND.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -856,19 +842,18 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE, ProcessDefinitionPermissions.SUSPEND);
 
-    Throwable thrown = catchThrowable(() -> repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend the process definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(ProcessDefinitionPermissions.SUSPEND.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null),
+            "It should not be possible to suspend the process definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(ProcessInstancePermissions.SUSPEND.getName())
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(SUSPEND_INSTANCE.getName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -879,19 +864,18 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE, ProcessInstancePermissions.SUSPEND);
 
-    Throwable thrown = catchThrowable(() -> repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend the process definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null),
+            "It should not be possible to suspend the process definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(ProcessInstancePermissions.SUSPEND.getName())
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(SUSPEND_INSTANCE.getName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -1000,19 +984,18 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE);
 
-    Throwable thrown = catchThrowable(() -> repositoryService.activateProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to activate the process definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> repositoryService.activateProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null),
+            "It should not be possible to activate the process definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(ProcessInstancePermissions.SUSPEND.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(SUSPEND_INSTANCE.getName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -1024,19 +1007,18 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE, ProcessDefinitionPermissions.SUSPEND);
 
-    Throwable thrown = catchThrowable(() -> repositoryService.activateProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to activate the process definition")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
-    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> repositoryService.activateProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null),
+            "It should not be possible to activate the process definition")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(ProcessInstancePermissions.SUSPEND.getName())
+        .hasMessageContaining(PROCESS_INSTANCE.resourceName())
+        .hasMessageContaining(SUSPEND_INSTANCE.getName())
+        .hasMessageContaining(UPDATE_INSTANCE.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessDefinitionAuthorizationTest.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
@@ -208,18 +209,14 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
-    try {
-      // when
-      ((RepositoryServiceImpl)repositoryService).getDeployedProcessDefinition(processDefinitionId);
-      fail("Exception expected: It should not be possible to get the process definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> ((RepositoryServiceImpl)repositoryService).getDeployedProcessDefinition(processDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get the process definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -242,18 +239,14 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
-    try {
-      // when
-      repositoryService.getProcessDiagram(processDefinitionId);
-      fail("Exception expected: It should not be possible to get the process diagram");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.getProcessDiagram(processDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get the process diagram")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -277,18 +270,15 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
-    try {
-      // when
-      repositoryService.getProcessModel(processDefinitionId);
-      fail("Exception expected: It should not be possible to get the process model");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.getProcessModel(processDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get the process model")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -311,18 +301,15 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
-    try {
-      // when
-      repositoryService.getBpmnModelInstance(processDefinitionId);
-      fail("Exception expected: It should not be possible to get the bpmn model instance");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.getBpmnModelInstance(processDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get the bpmn model instance")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -345,18 +332,15 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
-    try {
-      // when
-      repositoryService.getProcessDiagramLayout(processDefinitionId);
-      fail("Exception expected: It should not be possible to get the process diagram layout");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.getProcessDiagramLayout(processDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to get the process diagram layout")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -380,19 +364,16 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
 
-    try {
-      // when
-      repositoryService.suspendProcessDefinitionById(processDefinitionId);
-      fail("Exception expected: It should not be possible to suspend the process definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(ProcessDefinitionPermissions.SUSPEND.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.suspendProcessDefinitionById(processDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend the process definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(ProcessDefinitionPermissions.SUSPEND.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -431,19 +412,16 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     suspendProcessDefinitionById(processDefinitionId);
 
-    try {
-      // when
-      repositoryService.activateProcessDefinitionById(processDefinitionId);
-      fail("Exception expected: It should not be possible to activate the process definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(ProcessDefinitionPermissions.SUSPEND.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.activateProcessDefinitionById(processDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to activate the process definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(ProcessDefinitionPermissions.SUSPEND.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -485,22 +463,19 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     String processDefinitionId = selectProcessDefinitionByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE);
 
-    try {
-      // when
-      repositoryService.suspendProcessDefinitionById(processDefinitionId, true, null);
-      fail("Exception expected: It should not be possible to suspend the process definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.suspendProcessDefinitionById(processDefinitionId, true, null));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend the process definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -512,22 +487,19 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE, ProcessInstancePermissions.SUSPEND);
 
-    try {
-      // when
-      repositoryService.suspendProcessDefinitionById(processDefinitionId, true, null);
-      fail("Exception expected: It should not be possible to suspend the process definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.suspendProcessDefinitionById(processDefinitionId, true, null));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend the process definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -641,22 +613,19 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     suspendProcessDefinitionById(processDefinitionId);
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE, ProcessDefinitionPermissions.SUSPEND);
 
-    try {
-      // when
-      repositoryService.activateProcessDefinitionById(processDefinitionId, true, null);
-      fail("Exception expected: It should not be possible to activate the process definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.activateProcessDefinitionById(processDefinitionId, true, null));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend the process definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -669,22 +638,19 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     suspendProcessDefinitionById(processDefinitionId);
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE);
 
-    try {
-      // when
-      repositoryService.activateProcessDefinitionById(processDefinitionId, true, null);
-      fail("Exception expected: It should not be possible to activate the process definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.activateProcessDefinitionById(processDefinitionId, true, null));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to activate the process definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -798,20 +764,16 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
   @Test
   void testSuspendProcessDefinitionByKeyWithoutAuthorization() {
     // given
+    Throwable thrown = catchThrowable(() -> repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend the process definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(ProcessDefinitionPermissions.SUSPEND.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
 
-    try {
-      // when
-      repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
-      fail("Exception expected: It should not be possible to suspend the process definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(ProcessDefinitionPermissions.SUSPEND.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
   }
 
   @Test
@@ -847,19 +809,16 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
 
-    try {
-      // when
-      repositoryService.activateProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
-      fail("Exception expected: It should not be possible to activate the process definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(ProcessDefinitionPermissions.SUSPEND.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() ->  repositoryService.activateProcessDefinitionByKey(ONE_TASK_PROCESS_KEY));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to activate the process definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(ProcessDefinitionPermissions.SUSPEND.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -897,22 +856,19 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE, ProcessDefinitionPermissions.SUSPEND);
 
-    try {
-      // when
-      repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null);
-      fail("Exception expected: It should not be possible to suspend the process definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(ProcessDefinitionPermissions.SUSPEND.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend the process definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(ProcessDefinitionPermissions.SUSPEND.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -923,22 +879,19 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createGrantAuthorization(PROCESS_INSTANCE, processInstanceId, userId, UPDATE, ProcessInstancePermissions.SUSPEND);
 
-    try {
-      // when
-      repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null);
-      fail("Exception expected: It should not be possible to suspend the process definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to suspend the process definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -1047,22 +1000,19 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE);
 
-    try {
-      // when
-      repositoryService.activateProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null);
-      fail("Exception expected: It should not be possible to activate the process definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.activateProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to activate the process definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test
@@ -1074,22 +1024,19 @@ class ProcessDefinitionAuthorizationTest extends AuthorizationTest {
     suspendProcessDefinitionByKey(ONE_TASK_PROCESS_KEY);
     createGrantAuthorization(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, UPDATE, ProcessDefinitionPermissions.SUSPEND);
 
-    try {
-      // when
-      repositoryService.activateProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null);
-      fail("Exception expected: It should not be possible to activate the process definition");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
-      testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
-      testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
-      testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.activateProcessDefinitionByKey(ONE_TASK_PROCESS_KEY, true, null));
+    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to activate the process definition")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(ProcessInstancePermissions.SUSPEND.getName(), message);
+    testRule.assertTextPresent(PROCESS_INSTANCE.resourceName(), message);
+    testRule.assertTextPresent(UPDATE_INSTANCE.getName(), message);
+    testRule.assertTextPresent(SUSPEND_INSTANCE.getName(), message);
+    testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
+    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
+
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceCommentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceCommentAuthorizationTest.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 package org.operaton.bpm.engine.test.api.authorization;
-import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_INSTANCE;
 
@@ -81,7 +80,8 @@ class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createComment(TASK_ID, processInstanceId, "aComment");
 
-    assertThatThrownBy(() -> taskService.deleteProcessInstanceComments(processInstanceId),"Exception expected: It should not be possible to delete a comment.")
+    // when + then
+    assertThatThrownBy(() -> taskService.deleteProcessInstanceComments(processInstanceId),"It should not be possible to delete a comment.")
         .isInstanceOf(AuthorizationException.class)
         .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'UPDATE'");
 
@@ -192,7 +192,7 @@ class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createComment(null, processInstanceId, "aComment");
 
-    assertThatThrownBy(() -> taskService.deleteProcessInstanceComments(processInstanceId), "Exception expected: It should not be possible to delete a comment.")
+    assertThatThrownBy(() -> taskService.deleteProcessInstanceComments(processInstanceId), "It should not be possible to delete a comment.")
         .isInstanceOf(AuthorizationException.class)
         .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'UPDATE'");
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceCommentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ProcessInstanceCommentAuthorizationTest.java
@@ -81,15 +81,9 @@ class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createComment(TASK_ID, processInstanceId, "aComment");
 
-    try {
-      // when
-      taskService.deleteProcessInstanceComments(processInstanceId);
-      fail("Exception expected: It should not be possible to delete a comment.");
-    } catch (AuthorizationException e) {
-      // then
-      testRule.assertTextPresent("The user with id 'test' does not have one of the following permissions: 'UPDATE'",
-          e.getMessage());
-    }
+    assertThatThrownBy(() -> taskService.deleteProcessInstanceComments(processInstanceId),"Exception expected: It should not be possible to delete a comment.")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'UPDATE'");
 
     // triggers a db clean up
     deleteTask(TASK_ID, true);
@@ -198,15 +192,9 @@ class ProcessInstanceCommentAuthorizationTest extends AuthorizationTest {
     String processInstanceId = startProcessInstanceByKey(ONE_TASK_PROCESS_KEY).getId();
     createComment(null, processInstanceId, "aComment");
 
-    try {
-      // when
-      taskService.deleteProcessInstanceComments(processInstanceId);
-      fail("Exception expected: It should not be possible to delete a comment.");
-    } catch (AuthorizationException e) {
-      // then
-      testRule.assertTextPresent("The user with id 'test' does not have one of the following permissions: 'UPDATE'",
-          e.getMessage());
-    }
+    assertThatThrownBy(() -> taskService.deleteProcessInstanceComments(processInstanceId), "Exception expected: It should not be possible to delete a comment.")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'UPDATE'");
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SetTaskPropertyAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/SetTaskPropertyAuthorizationTest.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.engine.test.api.authorization;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.TASK_ASSIGN;
@@ -32,7 +31,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.operaton.bpm.engine.AuthorizationException;
@@ -97,7 +95,7 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
   void shouldSetOperationStandaloneWithoutAuthorization() {
     // given
     createTask(taskId);
-    assertThatThrownBy(() -> operation.accept(taskService, taskId, value), "Exception expected: It should not be possible to " + operationName)
+    assertThatThrownBy(() -> operation.accept(taskService, taskId, value), "It should not be possible to " + operationName)
         .isInstanceOf(AuthorizationException.class)
         .hasMessageContaining("The user with id '" + userId + "' does not have one of the following permissions: 'TASK_ASSIGN'");
     deleteTask(taskId, true);
@@ -163,17 +161,16 @@ public class SetTaskPropertyAuthorizationTest extends AuthorizationTest {
     startProcessInstanceByKey(PROCESS_KEY);
     String taskId = selectSingleTask().getId();
 
-    Throwable thrown = catchThrowable(() -> operation.accept(taskService, taskId, value));
-    Assertions.assertThat(thrown).as("Exception expected: It should not be possible to " + operationName)
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(taskId, message);
-    testRule.assertTextPresent(TASK.resourceName(), message);
-    testRule.assertTextPresent(UPDATE_TASK.getName(), message);
-    testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-
+    // when + then
+    assertThatThrownBy(() -> operation.accept(taskService, taskId, value),
+            "It should not be possible to " + operationName)
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(TASK.resourceName())
+        .hasMessageContaining(UPDATE_TASK.getName())
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @TestTemplate

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskCommentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskCommentAuthorizationTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.authorization;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
 import static org.operaton.bpm.engine.authorization.Resources.TASK;
 
@@ -42,16 +42,9 @@ class TaskCommentAuthorizationTest extends AuthorizationTest {
     Comment createdComment = createComment(TASK_ID, null, "aComment");
     var createdCommentId = createdComment.getId();
 
-    try {
-      // when
-      taskService.deleteTaskComment(TASK_ID, createdCommentId);
-      fail("Exception expected: It should not be possible to delete a comment.");
-    } catch (AuthorizationException e) {
-      // then
-      testRule.assertTextPresent(
-          "The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource 'myTask' of type 'Task' or 'UPDATE' permission on resource 'myTask' of type 'Task'",
-          e.getMessage());
-    }
+    assertThatThrownBy(() -> taskService.deleteTaskComment(TASK_ID, createdCommentId), "Exception expected: It should not be possible to delete a comment.")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource 'myTask' of type 'Task' or 'UPDATE' permission on resource 'myTask' of type 'Task'");
 
     // triggers a db clean up
     deleteTask(TASK_ID, true);
@@ -81,16 +74,9 @@ class TaskCommentAuthorizationTest extends AuthorizationTest {
     createTask(TASK_ID);
     createComment(TASK_ID, null, "aComment");
 
-    try {
-      // when
-      taskService.deleteTaskComments(TASK_ID);
-      fail("Exception expected: It should not be possible to delete a comment.");
-    } catch (AuthorizationException e) {
-      // then
-      testRule.assertTextPresent(
-          "The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource 'myTask' of type 'Task' or 'UPDATE' permission on resource 'myTask' of type 'Task'",
-          e.getMessage());
-    }
+    assertThatThrownBy(() -> taskService.deleteTaskComments(TASK_ID), "Exception expected: It should not be possible to delete a comment.")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource 'myTask' of type 'Task' or 'UPDATE' permission on resource 'myTask' of type 'Task'");
 
     // triggers a db clean up
     deleteTask(TASK_ID, true);
@@ -123,16 +109,9 @@ class TaskCommentAuthorizationTest extends AuthorizationTest {
     Comment createdComment = createComment(TASK_ID, null, "originalComment");
     var createdCommentId = createdComment.getId();
 
-    try {
-      // when
-      taskService.updateTaskComment(TASK_ID, createdCommentId, "updateMessage");
-      fail("Exception expected: It should not be possible to delete a comment.");
-    } catch (AuthorizationException e) {
-      // then
-      testRule.assertTextPresent(
-          "The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource 'myTask' of type 'Task' or 'UPDATE' permission on resource 'myTask' of type 'Task'",
-          e.getMessage());
-    }
+    assertThatThrownBy(() -> taskService.updateTaskComment(TASK_ID, createdCommentId, "updateMessage"), "Exception expected: It should not be possible to delete a comment.")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource 'myTask' of type 'Task' or 'UPDATE' permission on resource 'myTask' of type 'Task'");
 
     // triggers a db clean up
     deleteTask(TASK_ID, true);
@@ -167,16 +146,9 @@ class TaskCommentAuthorizationTest extends AuthorizationTest {
     var taskId = selectSingleTask().getId();
     var createdCommentId = createComment(taskId, processInstance.getId(), "aComment").getId();
 
-    try {
-      // when
-      taskService.deleteTaskComment(taskId, createdCommentId);
-      fail("Exception expected: It should not be possible to delete a comment.");
-    } catch (AuthorizationException e) {
-      // then
-      testRule.assertTextPresent(
-          "The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource",
-          e.getMessage());
-    }
+    assertThatThrownBy(() -> taskService.deleteTaskComment(taskId, createdCommentId), "Exception expected: It should not be possible to delete a comment.")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource");
   }
 
   @Test
@@ -206,16 +178,10 @@ class TaskCommentAuthorizationTest extends AuthorizationTest {
     var taskId = task.getId();
     createComment(taskId, processInstance.getId(), "aComment");
 
-    try {
-      // when
-      taskService.deleteTaskComments(taskId);
-      fail("Exception expected: It should not be possible to delete a comment.");
-    } catch (AuthorizationException e) {
-      // then
-      testRule.assertTextPresent(
-          "The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource",
-          e.getMessage());
-    }
+    assertThatThrownBy(() -> taskService.deleteTaskComments(taskId), "Exception expected: It should not be possible to delete a comment.")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource");
+
   }
 
   @Test
@@ -245,16 +211,10 @@ class TaskCommentAuthorizationTest extends AuthorizationTest {
     var taskId = selectSingleTask().getId();
     var createdCommentId = createComment(taskId, processInstance.getId(), "originalComment").getId();
 
-    try {
-      // when
-      taskService.updateTaskComment(taskId, createdCommentId, "updateMessage");
-      fail("Exception expected: It should not be possible to delete a comment.");
-    } catch (AuthorizationException e) {
-      // then
-      testRule.assertTextPresent(
-          "The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource",
-          e.getMessage());
-    }
+    assertThatThrownBy(() -> taskService.updateTaskComment(taskId, createdCommentId, "updateMessage"), "Exception expected: It should not be possible to delete a comment.")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource");
+
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskCommentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/TaskCommentAuthorizationTest.java
@@ -18,7 +18,10 @@ package org.operaton.bpm.engine.test.api.authorization;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.operaton.bpm.engine.authorization.Permissions.TASK_WORK;
 import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
+import static org.operaton.bpm.engine.authorization.Permissions.UPDATE_TASK;
+import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;
 import static org.operaton.bpm.engine.authorization.Resources.TASK;
 
 import java.util.Collections;
@@ -42,9 +45,16 @@ class TaskCommentAuthorizationTest extends AuthorizationTest {
     Comment createdComment = createComment(TASK_ID, null, "aComment");
     var createdCommentId = createdComment.getId();
 
-    assertThatThrownBy(() -> taskService.deleteTaskComment(TASK_ID, createdCommentId), "Exception expected: It should not be possible to delete a comment.")
+    // when + then
+    assertThatThrownBy(() -> taskService.deleteTaskComment(TASK_ID, createdCommentId),
+            "It should not be possible to delete a comment.")
         .isInstanceOf(AuthorizationException.class)
-        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource 'myTask' of type 'Task' or 'UPDATE' permission on resource 'myTask' of type 'Task'");
+        .hasMessageContaining(userId)
+        .hasMessageContaining(TASK_WORK.getName())
+        .hasMessageContaining(TASK_ID)
+        .hasMessageContaining(TASK.resourceName())
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(TASK.resourceName());
 
     // triggers a db clean up
     deleteTask(TASK_ID, true);
@@ -74,9 +84,16 @@ class TaskCommentAuthorizationTest extends AuthorizationTest {
     createTask(TASK_ID);
     createComment(TASK_ID, null, "aComment");
 
-    assertThatThrownBy(() -> taskService.deleteTaskComments(TASK_ID), "Exception expected: It should not be possible to delete a comment.")
+    // when + then
+    assertThatThrownBy(() -> taskService.deleteTaskComments(TASK_ID),
+            "It should not be possible to delete a comment.")
         .isInstanceOf(AuthorizationException.class)
-        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource 'myTask' of type 'Task' or 'UPDATE' permission on resource 'myTask' of type 'Task'");
+        .hasMessageContaining(userId)
+        .hasMessageContaining(TASK_WORK.getName())
+        .hasMessageContaining(TASK_ID)
+        .hasMessageContaining(TASK.resourceName())
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(TASK.resourceName());
 
     // triggers a db clean up
     deleteTask(TASK_ID, true);
@@ -109,9 +126,16 @@ class TaskCommentAuthorizationTest extends AuthorizationTest {
     Comment createdComment = createComment(TASK_ID, null, "originalComment");
     var createdCommentId = createdComment.getId();
 
-    assertThatThrownBy(() -> taskService.updateTaskComment(TASK_ID, createdCommentId, "updateMessage"), "Exception expected: It should not be possible to delete a comment.")
+    // when + then
+    assertThatThrownBy(() -> taskService.updateTaskComment(TASK_ID, createdCommentId, "updateMessage"),
+            "It should not be possible to delete a comment.")
         .isInstanceOf(AuthorizationException.class)
-        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource 'myTask' of type 'Task' or 'UPDATE' permission on resource 'myTask' of type 'Task'");
+        .hasMessageContaining(userId)
+        .hasMessageContaining(TASK_WORK.getName())
+        .hasMessageContaining(TASK_ID)
+        .hasMessageContaining(TASK.resourceName())
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(TASK.resourceName());
 
     // triggers a db clean up
     deleteTask(TASK_ID, true);
@@ -146,9 +170,14 @@ class TaskCommentAuthorizationTest extends AuthorizationTest {
     var taskId = selectSingleTask().getId();
     var createdCommentId = createComment(taskId, processInstance.getId(), "aComment").getId();
 
-    assertThatThrownBy(() -> taskService.deleteTaskComment(taskId, createdCommentId), "Exception expected: It should not be possible to delete a comment.")
+    // when + then
+    assertThatThrownBy(() -> taskService.deleteTaskComment(taskId, createdCommentId),
+            "It should not be possible to delete a comment.")
         .isInstanceOf(AuthorizationException.class)
-        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource");
+        .hasMessageContaining(userId)
+        .hasMessageContaining(TASK_WORK.getName())
+        .hasMessageContaining(UPDATE_TASK.getName())
+        .hasMessageContaining(TASK.resourceName());
   }
 
   @Test
@@ -178,10 +207,18 @@ class TaskCommentAuthorizationTest extends AuthorizationTest {
     var taskId = task.getId();
     createComment(taskId, processInstance.getId(), "aComment");
 
-    assertThatThrownBy(() -> taskService.deleteTaskComments(taskId), "Exception expected: It should not be possible to delete a comment.")
+    // when + then
+    assertThatThrownBy(() -> taskService.deleteTaskComments(taskId),
+            "It should not be possible to delete a comment.")
         .isInstanceOf(AuthorizationException.class)
-        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource");
-
+        .hasMessageContaining(userId)
+        .hasMessageContaining(TASK_WORK.getName())
+        .hasMessageContaining(UPDATE_TASK.getName())
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(TASK.resourceName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName())
+        .hasMessageContaining(processInstance.getProcessDefinitionKey());
   }
 
   @Test
@@ -211,10 +248,17 @@ class TaskCommentAuthorizationTest extends AuthorizationTest {
     var taskId = selectSingleTask().getId();
     var createdCommentId = createComment(taskId, processInstance.getId(), "originalComment").getId();
 
-    assertThatThrownBy(() -> taskService.updateTaskComment(taskId, createdCommentId, "updateMessage"), "Exception expected: It should not be possible to delete a comment.")
+    // when + then
+    assertThatThrownBy(() -> taskService.updateTaskComment(taskId, createdCommentId, "updateMessage"),
+            "It should not be possible to delete a comment.")
         .isInstanceOf(AuthorizationException.class)
-        .hasMessageContaining("The user with id 'test' does not have one of the following permissions: 'TASK_WORK' permission on resource");
-
+        .hasMessageContaining(userId)
+        .hasMessageContaining(TASK_WORK.getName())
+        .hasMessageContaining(UPDATE_TASK.getName())
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(TASK.resourceName())
+        .hasMessageContaining(taskId)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/dmn/DecisionDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/dmn/DecisionDefinitionAuthorizationTest.java
@@ -21,11 +21,12 @@ import static org.operaton.bpm.engine.authorization.Permissions.READ;
 import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
 import static org.operaton.bpm.engine.authorization.Resources.DECISION_DEFINITION;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.operaton.bpm.engine.test.util.QueryTestHelper.verifyQueryResults;
 
 import java.io.InputStream;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
@@ -119,19 +120,15 @@ class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
 
-    try {
-      // when
-      repositoryService.getDecisionDefinition(decisionDefinitionId);
-      fail("Exception expected");
+    Throwable thrown = catchThrowable(() -> repositoryService.getDecisionDefinition(decisionDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(DECISION_DEFINITION_KEY, message);
+    testRule.assertTextPresent(DECISION_DEFINITION.resourceName(), message);
 
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(DECISION_DEFINITION_KEY, message);
-      testRule.assertTextPresent(DECISION_DEFINITION.resourceName(), message);
-    }
   }
 
   @Test
@@ -152,19 +149,14 @@ class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
 
-    try {
-      // when
-      repositoryService.getDecisionDiagram(decisionDefinitionId);
-      fail("Exception expected");
-
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(DECISION_DEFINITION_KEY, message);
-      testRule.assertTextPresent(DECISION_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.getDecisionDiagram(decisionDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(DECISION_DEFINITION_KEY, message);
+    testRule.assertTextPresent(DECISION_DEFINITION.resourceName(), message);
   }
 
   @Test
@@ -186,19 +178,15 @@ class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
 
-    try {
-      // when
-      repositoryService.getDecisionModel(decisionDefinitionId);
-      fail("Exception expected");
+    Throwable thrown = catchThrowable(() -> repositoryService.getDecisionModel(decisionDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(DECISION_DEFINITION_KEY, message);
+    testRule.assertTextPresent(DECISION_DEFINITION.resourceName(), message);
 
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(DECISION_DEFINITION_KEY, message);
-      testRule.assertTextPresent(DECISION_DEFINITION.resourceName(), message);
-    }
   }
 
   @Test
@@ -219,19 +207,15 @@ class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
     // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
 
-    try {
-      // when
-      repositoryService.getDmnModelInstance(decisionDefinitionId);
-      fail("Exception expected");
+    Throwable thrown = catchThrowable(() -> repositoryService.getDmnModelInstance(decisionDefinitionId));
+    Assertions.assertThat(thrown).as("Exception expected")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(READ.getName(), message);
+    testRule.assertTextPresent(DECISION_DEFINITION_KEY, message);
+    testRule.assertTextPresent(DECISION_DEFINITION.resourceName(), message);
 
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ.getName(), message);
-      testRule.assertTextPresent(DECISION_DEFINITION_KEY, message);
-      testRule.assertTextPresent(DECISION_DEFINITION.resourceName(), message);
-    }
   }
 
   @Test
@@ -265,19 +249,15 @@ class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
   void testDecisionDefinitionUpdateTimeToLiveWithoutAuthorizations() {
     //given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
-    try {
-      //when
-      repositoryService.updateDecisionDefinitionHistoryTimeToLive(decisionDefinitionId, 6);
-      fail("Exception expected");
 
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(DECISION_DEFINITION_KEY, message);
-      testRule.assertTextPresent(DECISION_DEFINITION.resourceName(), message);
-    }
+    Throwable thrown = catchThrowable(() -> repositoryService.updateDecisionDefinitionHistoryTimeToLive(decisionDefinitionId, 4));
+    Assertions.assertThat(thrown).as("Exception expected")
+        .isInstanceOf(AuthorizationException.class);
+    String message = thrown.getMessage();
+    testRule.assertTextPresent(userId, message);
+    testRule.assertTextPresent(UPDATE.getName(), message);
+    testRule.assertTextPresent(DECISION_DEFINITION_KEY, message);
+    testRule.assertTextPresent(DECISION_DEFINITION.resourceName(), message);
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/dmn/DecisionDefinitionAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/dmn/DecisionDefinitionAuthorizationTest.java
@@ -16,17 +16,16 @@
  */
 package org.operaton.bpm.engine.test.api.authorization.dmn;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.READ;
 import static org.operaton.bpm.engine.authorization.Permissions.UPDATE;
 import static org.operaton.bpm.engine.authorization.Resources.DECISION_DEFINITION;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.operaton.bpm.engine.test.util.QueryTestHelper.verifyQueryResults;
 
 import java.io.InputStream;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.AuthorizationException;
@@ -117,18 +116,14 @@ class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
 
   @Test
   void testGetDecisionDefinitionWithoutAuthorizations() {
-    // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> repositoryService.getDecisionDefinition(decisionDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(DECISION_DEFINITION_KEY, message);
-    testRule.assertTextPresent(DECISION_DEFINITION.resourceName(), message);
-
+    assertThatThrownBy(() -> repositoryService.getDecisionDefinition(decisionDefinitionId))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(DECISION_DEFINITION_KEY)
+        .hasMessageContaining(DECISION_DEFINITION.resourceName());
   }
 
   @Test
@@ -146,17 +141,14 @@ class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
 
   @Test
   void testGetDecisionDiagramWithoutAuthorizations() {
-    // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> repositoryService.getDecisionDiagram(decisionDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(DECISION_DEFINITION_KEY, message);
-    testRule.assertTextPresent(DECISION_DEFINITION.resourceName(), message);
+    assertThatThrownBy(() -> repositoryService.getDecisionDiagram(decisionDefinitionId))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(DECISION_DEFINITION_KEY)
+        .hasMessageContaining(DECISION_DEFINITION.resourceName());
   }
 
   @Test
@@ -175,18 +167,14 @@ class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
 
   @Test
   void testGetDecisionModelWithoutAuthorizations() {
-    // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> repositoryService.getDecisionModel(decisionDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(DECISION_DEFINITION_KEY, message);
-    testRule.assertTextPresent(DECISION_DEFINITION.resourceName(), message);
-
+    assertThatThrownBy(() -> repositoryService.getDecisionModel(decisionDefinitionId))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(DECISION_DEFINITION_KEY)
+        .hasMessageContaining(DECISION_DEFINITION.resourceName());
   }
 
   @Test
@@ -204,18 +192,14 @@ class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
 
   @Test
   void testGetDmnModelInstanceWithoutAuthorizations() {
-    // given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> repositoryService.getDmnModelInstance(decisionDefinitionId));
-    Assertions.assertThat(thrown).as("Exception expected")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(READ.getName(), message);
-    testRule.assertTextPresent(DECISION_DEFINITION_KEY, message);
-    testRule.assertTextPresent(DECISION_DEFINITION.resourceName(), message);
-
+    assertThatThrownBy(() -> repositoryService.getDmnModelInstance(decisionDefinitionId))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ.getName())
+        .hasMessageContaining(DECISION_DEFINITION_KEY)
+        .hasMessageContaining(DECISION_DEFINITION.resourceName());
   }
 
   @Test
@@ -247,18 +231,14 @@ class DecisionDefinitionAuthorizationTest extends AuthorizationTest {
 
   @Test
   void testDecisionDefinitionUpdateTimeToLiveWithoutAuthorizations() {
-    //given
     String decisionDefinitionId = selectDecisionDefinitionByKey(DECISION_DEFINITION_KEY).getId();
 
-    Throwable thrown = catchThrowable(() -> repositoryService.updateDecisionDefinitionHistoryTimeToLive(decisionDefinitionId, 4));
-    Assertions.assertThat(thrown).as("Exception expected")
-        .isInstanceOf(AuthorizationException.class);
-    String message = thrown.getMessage();
-    testRule.assertTextPresent(userId, message);
-    testRule.assertTextPresent(UPDATE.getName(), message);
-    testRule.assertTextPresent(DECISION_DEFINITION_KEY, message);
-    testRule.assertTextPresent(DECISION_DEFINITION.resourceName(), message);
-
+    assertThatThrownBy(() -> repositoryService.updateDecisionDefinitionHistoryTimeToLive(decisionDefinitionId, 4))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(DECISION_DEFINITION_KEY)
+        .hasMessageContaining(DECISION_DEFINITION.resourceName());
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricExternalTaskLogAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricExternalTaskLogAuthorizationTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.test.api.authorization.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.READ_HISTORY;
@@ -187,18 +188,14 @@ class HistoricExternalTaskLogAuthorizationTest extends AuthorizationTest {
       .getId();
     enableAuthorization();
 
-    try {
-      // when
-      historyService.getHistoricExternalTaskLogErrorDetails(failedHistoricExternalTaskLogId);
-      fail("Exception expected: It should not be possible to retrieve the error details");
-    } catch (AuthorizationException e) {
-      // then
-      String exceptionMessage = e.getMessage();
-      testRule.assertTextPresent(userId, exceptionMessage);
-      testRule.assertTextPresent(READ_HISTORY.getName(), exceptionMessage);
-      testRule.assertTextPresent(DEFAULT_PROCESS_KEY, exceptionMessage);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), exceptionMessage);
-    }
+    assertThatThrownBy(
+        () -> historyService.getHistoricExternalTaskLogErrorDetails(failedHistoricExternalTaskLogId),
+        "Exception expected: It should not be possible to retrieve the error details")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ_HISTORY.getName())
+        .hasMessageContaining(DEFAULT_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricExternalTaskLogAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricExternalTaskLogAuthorizationTest.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.test.api.authorization.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.READ_HISTORY;
 import static org.operaton.bpm.engine.authorization.Resources.PROCESS_DEFINITION;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricJobLogAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricJobLogAuthorizationTest.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.test.api.authorization.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Permissions.READ_HISTORY;
@@ -366,7 +365,6 @@ class HistoricJobLogAuthorizationTest extends AuthorizationTest {
         .hasMessageContaining(READ_HISTORY.getName())
         .hasMessageContaining(ONE_INCIDENT_PROCESS_KEY)
         .hasMessageContaining(PROCESS_DEFINITION.resourceName());
-
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricJobLogAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricJobLogAuthorizationTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.test.api.authorization.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
@@ -357,18 +358,15 @@ class HistoricJobLogAuthorizationTest extends AuthorizationTest {
     String jobLogId = historyService.createHistoricJobLogQuery().failureLog().listPage(0, 1).get(0).getId();
     enableAuthorization();
 
-    try {
-      // when
-      historyService.getHistoricJobLogExceptionStacktrace(jobLogId);
-      fail("Exception expected: It should not be possible to get the historic job log exception stacktrace");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(READ_HISTORY.getName(), message);
-      testRule.assertTextPresent(ONE_INCIDENT_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    assertThatThrownBy(
+        () -> historyService.getHistoricJobLogExceptionStacktrace(jobLogId),
+        "Exception expected: It should not be possible to get the historic job log exception stacktrace")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(READ_HISTORY.getName())
+        .hasMessageContaining(ONE_INCIDENT_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
+
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricProcessInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricProcessInstanceAuthorizationTest.java
@@ -260,7 +260,7 @@ class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest {
 
     assertThatThrownBy(
         () -> historyService.deleteHistoricProcessInstance(processInstanceId),
-        "Exception expected: It should not be possible to delete the historic process instance")
+        "It should not be possible to delete the historic process instance")
         .isInstanceOf(AuthorizationException.class)
         .hasMessageContaining(userId)
         .hasMessageContaining(DELETE_HISTORY.getName())
@@ -512,11 +512,9 @@ class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest {
         .createHistoricProcessInstanceReport()
         .processDefinitionIdIn(processInstance1.getProcessDefinitionId(), processInstance2.getProcessDefinitionId());
 
-    assertThatThrownBy(
-        () -> historicProcessInstanceReport.duration(PeriodUnit.MONTH),
-        "Exception expected: It should not be possible to create a historic process instance report"
+    assertThatThrownBy(() -> historicProcessInstanceReport.duration(PeriodUnit.MONTH),
+        "It should not be possible to create a historic process instance report"
     ).isInstanceOf(AuthorizationException.class);
-
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricProcessInstanceAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/HistoricProcessInstanceAuthorizationTest.java
@@ -258,18 +258,14 @@ class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest {
     taskService.complete(taskId);
     enableAuthorization();
 
-    try {
-      // when
-      historyService.deleteHistoricProcessInstance(processInstanceId);
-      fail("Exception expected: It should not be possible to delete the historic process instance");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(DELETE_HISTORY.getName(), message);
-      testRule.assertTextPresent(PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-    }
+    assertThatThrownBy(
+        () -> historyService.deleteHistoricProcessInstance(processInstanceId),
+        "Exception expected: It should not be possible to delete the historic process instance")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(DELETE_HISTORY.getName())
+        .hasMessageContaining(PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName());
   }
 
   @Test
@@ -516,15 +512,11 @@ class HistoricProcessInstanceAuthorizationTest extends AuthorizationTest {
         .createHistoricProcessInstanceReport()
         .processDefinitionIdIn(processInstance1.getProcessDefinitionId(), processInstance2.getProcessDefinitionId());
 
-    // when
-    try {
-      historicProcessInstanceReport.duration(PeriodUnit.MONTH);
+    assertThatThrownBy(
+        () -> historicProcessInstanceReport.duration(PeriodUnit.MONTH),
+        "Exception expected: It should not be possible to create a historic process instance report"
+    ).isInstanceOf(AuthorizationException.class);
 
-      // then
-      fail("Exception expected: It should not be possible to create a historic process instance report");
-    } catch (AuthorizationException e) {
-      // expected
-    }
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/UserOperationLogAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/UserOperationLogAuthorizationTest.java
@@ -53,7 +53,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Roman Smirnov
@@ -1508,17 +1508,14 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     // when
-    try {
-      historyService.deleteUserOperationLogEntry(entryId);
-      fail("Exception expected: It should not be possible to delete the user operation log");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(DELETE.getName(), message);
-      testRule.assertTextPresent(OPERATION_LOG_CATEGORY.resourceName(), message);
-      testRule.assertTextPresent(CATEGORY_TASK_WORKER, message);
-    }
+    assertThatThrownBy(
+        () -> historyService.deleteUserOperationLogEntry(entryId),
+        "Exception expected: It should not be possible to delete the user operation log")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(DELETE.getName())
+        .hasMessageContaining(OPERATION_LOG_CATEGORY.resourceName())
+        .hasMessageContaining(CATEGORY_TASK_WORKER);
 
     deleteTask(taskId, true);
   }
@@ -1535,18 +1532,14 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ONE_TASK_PROCESS_KEY, userId, DELETE_HISTORY);
 
-    // when
-    try {
-      historyService.deleteUserOperationLogEntry(entryId);
-      fail("Exception expected: It should not be possible to delete the user operation log");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(DELETE.getName(), message);
-      testRule.assertTextPresent(OPERATION_LOG_CATEGORY.resourceName(), message);
-      testRule.assertTextPresent(CATEGORY_TASK_WORKER, message);
-    }
+    assertThatThrownBy(
+        () -> historyService.deleteUserOperationLogEntry(entryId),
+        "Exception expected: It should not be possible to delete the user operation log")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(DELETE.getName())
+        .hasMessageContaining(OPERATION_LOG_CATEGORY.resourceName())
+        .hasMessageContaining(CATEGORY_TASK_WORKER);
 
     deleteTask(taskId, true);
   }
@@ -1563,18 +1556,14 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ANY, userId, DELETE_HISTORY);
 
-    // when
-    try {
-      historyService.deleteUserOperationLogEntry(entryId);
-      fail("Exception expected: It should not be possible to delete the user operation log");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(DELETE.getName(), message);
-      testRule.assertTextPresent(OPERATION_LOG_CATEGORY.resourceName(), message);
-      testRule.assertTextPresent(CATEGORY_TASK_WORKER, message);
-    }
+    assertThatThrownBy(
+        () -> historyService.deleteUserOperationLogEntry(entryId),
+        "Exception expected: It should not be possible to delete the user operation log")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(DELETE.getName())
+        .hasMessageContaining(OPERATION_LOG_CATEGORY.resourceName())
+        .hasMessageContaining(CATEGORY_TASK_WORKER);
 
     deleteTask(taskId, true);
   }
@@ -1634,21 +1623,17 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
     String entryId = historyService.createUserOperationLogQuery().entityType("Task").singleResult().getId();
     enableAuthorization();
 
-    try {
-      // when
-      historyService.deleteUserOperationLogEntry(entryId);
-      fail("Exception expected: It should not be possible to delete the user operation log");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(DELETE_HISTORY.getName(), message);
-      testRule.assertTextPresent(ONE_TASK_PROCESS_KEY, message);
-      testRule.assertTextPresent(PROCESS_DEFINITION.resourceName(), message);
-      testRule.assertTextPresent(DELETE.getName(), message);
-      testRule.assertTextPresent(OPERATION_LOG_CATEGORY.resourceName(), message);
-      testRule.assertTextPresent(CATEGORY_TASK_WORKER, message);
-    }
+    assertThatThrownBy(() -> historyService.deleteUserOperationLogEntry(entryId),
+        "Exception expected: It should not be possible to delete the user operation log")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(DELETE_HISTORY.getName())
+        .hasMessageContaining(ONE_TASK_PROCESS_KEY)
+        .hasMessageContaining(PROCESS_DEFINITION.resourceName())
+        .hasMessageContaining(DELETE.getName())
+        .hasMessageContaining(OPERATION_LOG_CATEGORY.resourceName())
+        .hasMessageContaining(CATEGORY_TASK_WORKER);
+
   }
 
   @Test
@@ -1776,18 +1761,14 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
     String entryId = historyService.createUserOperationLogQuery().singleResult().getId();
     enableAuthorization();
 
-    // when
-    try {
-      historyService.deleteUserOperationLogEntry(entryId);
-      fail("Exception expected: It should not be possible to delete the user operation log");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(DELETE.getName(), message);
-      testRule.assertTextPresent(OPERATION_LOG_CATEGORY.resourceName(), message);
-      testRule.assertTextPresent(CATEGORY_TASK_WORKER, message);
-    }
+    assertThatThrownBy(() -> historyService.deleteUserOperationLogEntry(entryId),
+        "Exception expected: It should not be possible to delete the user operation log")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(DELETE.getName())
+        .hasMessageContaining(OPERATION_LOG_CATEGORY.resourceName())
+        .hasMessageContaining(CATEGORY_TASK_WORKER);
+
   }
 
   @Test
@@ -1803,18 +1784,14 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ONE_TASK_CASE_KEY, userId, DELETE_HISTORY);
 
-    // when
-    try {
-      historyService.deleteUserOperationLogEntry(entryId);
-      fail("Exception expected: It should not be possible to delete the user operation log");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(DELETE.getName(), message);
-      testRule.assertTextPresent(OPERATION_LOG_CATEGORY.resourceName(), message);
-      testRule.assertTextPresent(CATEGORY_TASK_WORKER, message);
-    }
+    assertThatThrownBy(() -> historyService.deleteUserOperationLogEntry(entryId),
+        "Exception expected: It should not be possible to delete the user operation log")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(DELETE.getName())
+        .hasMessageContaining(OPERATION_LOG_CATEGORY.resourceName())
+        .hasMessageContaining(CATEGORY_TASK_WORKER);
+
   }
 
   @Test
@@ -1830,18 +1807,14 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ANY, userId, DELETE_HISTORY);
 
-    // when
-    try {
-      historyService.deleteUserOperationLogEntry(entryId);
-      fail("Exception expected: It should not be possible to delete the user operation log");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(DELETE.getName(), message);
-      testRule.assertTextPresent(OPERATION_LOG_CATEGORY.resourceName(), message);
-      testRule.assertTextPresent(CATEGORY_TASK_WORKER, message);
-    }
+    assertThatThrownBy(() -> historyService.deleteUserOperationLogEntry(entryId),
+        "Exception expected: It should not be possible to delete the user operation log")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(DELETE.getName())
+        .hasMessageContaining(OPERATION_LOG_CATEGORY.resourceName())
+        .hasMessageContaining(CATEGORY_TASK_WORKER);
+
   }
 
   @Test
@@ -1971,19 +1944,13 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     enableAuthorization();
 
-    try {
-      // when
-      historyService.setAnnotationForOperationLogById(operationId, "anAnnotation");
-
-      fail("Exception expected: It should not be possible to update the user operation log");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(OPERATION_LOG_CATEGORY.resourceName(), message);
-      testRule.assertTextPresent(CATEGORY_TASK_WORKER, message);
-    }
+    assertThatThrownBy(() -> historyService.setAnnotationForOperationLogById(operationId, "anAnnotation"),
+        "Exception expected: It should not be possible to update the user operation log")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(OPERATION_LOG_CATEGORY.resourceName())
+        .hasMessageContaining(CATEGORY_TASK_WORKER);
 
     // cleanup
     deleteTask("aTaskId", true);
@@ -2071,19 +2038,13 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     enableAuthorization();
 
-    try {
-      // when
-      historyService.setAnnotationForOperationLogById(operationId, "anAnnotation");
-
-      fail("Exception expected: It should not be possible to update the user operation log");
-    } catch (AuthorizationException e) {
-      // then
-      String message = e.getMessage();
-      testRule.assertTextPresent(userId, message);
-      testRule.assertTextPresent(UPDATE.getName(), message);
-      testRule.assertTextPresent(OPERATION_LOG_CATEGORY.resourceName(), message);
-      testRule.assertTextPresent(CATEGORY_TASK_WORKER, message);
-    }
+    assertThatThrownBy(() -> historyService.setAnnotationForOperationLogById(operationId, "anAnnotation"),
+        "Exception expected: It should not be possible to update the user operation log")
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessageContaining(userId)
+        .hasMessageContaining(UPDATE.getName())
+        .hasMessageContaining(OPERATION_LOG_CATEGORY.resourceName())
+        .hasMessageContaining(CATEGORY_TASK_WORKER);
 
     // cleanup
     deleteTask("aTaskId", true);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/UserOperationLogAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/history/UserOperationLogAuthorizationTest.java
@@ -1508,9 +1508,8 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     // when
-    assertThatThrownBy(
-        () -> historyService.deleteUserOperationLogEntry(entryId),
-        "Exception expected: It should not be possible to delete the user operation log")
+    assertThatThrownBy(() -> historyService.deleteUserOperationLogEntry(entryId),
+        "It should not be possible to delete the user operation log")
         .isInstanceOf(AuthorizationException.class)
         .hasMessageContaining(userId)
         .hasMessageContaining(DELETE.getName())
@@ -1534,7 +1533,7 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     assertThatThrownBy(
         () -> historyService.deleteUserOperationLogEntry(entryId),
-        "Exception expected: It should not be possible to delete the user operation log")
+        "It should not be possible to delete the user operation log")
         .isInstanceOf(AuthorizationException.class)
         .hasMessageContaining(userId)
         .hasMessageContaining(DELETE.getName())
@@ -1558,7 +1557,7 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
 
     assertThatThrownBy(
         () -> historyService.deleteUserOperationLogEntry(entryId),
-        "Exception expected: It should not be possible to delete the user operation log")
+        "It should not be possible to delete the user operation log")
         .isInstanceOf(AuthorizationException.class)
         .hasMessageContaining(userId)
         .hasMessageContaining(DELETE.getName())
@@ -1624,7 +1623,7 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     assertThatThrownBy(() -> historyService.deleteUserOperationLogEntry(entryId),
-        "Exception expected: It should not be possible to delete the user operation log")
+        "It should not be possible to delete the user operation log")
         .isInstanceOf(AuthorizationException.class)
         .hasMessageContaining(userId)
         .hasMessageContaining(DELETE_HISTORY.getName())
@@ -1633,7 +1632,6 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
         .hasMessageContaining(DELETE.getName())
         .hasMessageContaining(OPERATION_LOG_CATEGORY.resourceName())
         .hasMessageContaining(CATEGORY_TASK_WORKER);
-
   }
 
   @Test
@@ -1762,13 +1760,12 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     assertThatThrownBy(() -> historyService.deleteUserOperationLogEntry(entryId),
-        "Exception expected: It should not be possible to delete the user operation log")
+        "It should not be possible to delete the user operation log")
         .isInstanceOf(AuthorizationException.class)
         .hasMessageContaining(userId)
         .hasMessageContaining(DELETE.getName())
         .hasMessageContaining(OPERATION_LOG_CATEGORY.resourceName())
         .hasMessageContaining(CATEGORY_TASK_WORKER);
-
   }
 
   @Test
@@ -1785,13 +1782,12 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ONE_TASK_CASE_KEY, userId, DELETE_HISTORY);
 
     assertThatThrownBy(() -> historyService.deleteUserOperationLogEntry(entryId),
-        "Exception expected: It should not be possible to delete the user operation log")
+        "It should not be possible to delete the user operation log")
         .isInstanceOf(AuthorizationException.class)
         .hasMessageContaining(userId)
         .hasMessageContaining(DELETE.getName())
         .hasMessageContaining(OPERATION_LOG_CATEGORY.resourceName())
         .hasMessageContaining(CATEGORY_TASK_WORKER);
-
   }
 
   @Test
@@ -1808,13 +1804,12 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
     createGrantAuthorizationWithoutAuthentication(PROCESS_DEFINITION, ANY, userId, DELETE_HISTORY);
 
     assertThatThrownBy(() -> historyService.deleteUserOperationLogEntry(entryId),
-        "Exception expected: It should not be possible to delete the user operation log")
+        "It should not be possible to delete the user operation log")
         .isInstanceOf(AuthorizationException.class)
         .hasMessageContaining(userId)
         .hasMessageContaining(DELETE.getName())
         .hasMessageContaining(OPERATION_LOG_CATEGORY.resourceName())
         .hasMessageContaining(CATEGORY_TASK_WORKER);
-
   }
 
   @Test
@@ -1945,7 +1940,7 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     assertThatThrownBy(() -> historyService.setAnnotationForOperationLogById(operationId, "anAnnotation"),
-        "Exception expected: It should not be possible to update the user operation log")
+        "It should not be possible to update the user operation log")
         .isInstanceOf(AuthorizationException.class)
         .hasMessageContaining(userId)
         .hasMessageContaining(UPDATE.getName())
@@ -2039,7 +2034,7 @@ class UserOperationLogAuthorizationTest extends AuthorizationTest {
     enableAuthorization();
 
     assertThatThrownBy(() -> historyService.setAnnotationForOperationLogById(operationId, "anAnnotation"),
-        "Exception expected: It should not be possible to update the user operation log")
+        "It should not be possible to update the user operation log")
         .isInstanceOf(AuthorizationException.class)
         .hasMessageContaining(userId)
         .hasMessageContaining(UPDATE.getName())

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceCaseInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceCaseInstanceTest.java
@@ -817,14 +817,10 @@ class CaseServiceCaseInstanceTest {
 
     caseService.completeCaseExecution(caseInstanceId);
 
-    try {
-      // when
-      caseService.terminateCaseExecution(caseInstanceId);
-      fail("It should not be possible to terminate a task.");
-    } catch (NotAllowedException e) {
-      boolean result = e.getMessage().contains("The case execution must be in state 'active' to terminate");
-      assertThat(result).isTrue();
-    }
+    assertThatThrownBy(() -> caseService.terminateCaseExecution(caseInstanceId), "It should not be possible to terminate a task.")
+        .isInstanceOf(NotAllowedException.class)
+        .hasMessageContaining("The case execution must be in state 'active' to terminate");
+
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceCaseInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceCaseInstanceTest.java
@@ -820,7 +820,6 @@ class CaseServiceCaseInstanceTest {
     assertThatThrownBy(() -> caseService.terminateCaseExecution(caseInstanceId), "It should not be possible to terminate a task.")
         .isInstanceOf(NotAllowedException.class)
         .hasMessageContaining("The case execution must be in state 'active' to terminate");
-
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceTest.java
@@ -1503,19 +1503,12 @@ class CaseServiceTest {
   @Test
   void testGetVariablesInvalidCaseExecutionId() {
 
-    try {
-      caseService.getVariables("invalid");
-      fail("The case execution should not be found.");
-    } catch (NotFoundException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> caseService.getVariables("invalid"), "The case execution should not be found.")
+        .isInstanceOf(NotFoundException.class);
 
-    try {
-      caseService.getVariables(null);
-      fail("The case execution should not be found.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> caseService.getVariables(null), "The case execution should not be found.")
+        .isInstanceOf(NotValidException.class);
+
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -1597,20 +1590,11 @@ class CaseServiceTest {
 
   @Test
   void testGetVariablesWithVariablesNamesInvalidCaseExecutionId() {
+    assertThatThrownBy(() -> caseService.getVariables("invalid", null), "The case execution should not be found.")
+        .isInstanceOf(NotFoundException.class);
 
-    try {
-      caseService.getVariables("invalid", null);
-      fail("The case execution should not be found.");
-    } catch (NotFoundException e) {
-      // expected
-    }
-
-    try {
-      caseService.getVariables(null, null);
-      fail("The case execution should not be found.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> caseService.getVariables(null, null), "The case execution should not be found.")
+        .isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -1689,20 +1673,12 @@ class CaseServiceTest {
 
   @Test
   void testGetVariablesLocalInvalidCaseExecutionId() {
+    assertThatThrownBy(() -> caseService.getVariablesLocal("invalid"), "The case execution should not be found.")
+        .isInstanceOf(NotFoundException.class);
 
-    try {
-      caseService.getVariablesLocal("invalid");
-      fail("The case execution should not be found.");
-    } catch (NotFoundException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> caseService.getVariablesLocal(null), "The case execution should not be found.")
+        .isInstanceOf(NotValidException.class);
 
-    try {
-      caseService.getVariablesLocal(null);
-      fail("The case execution should not be found.");
-    } catch (NotValidException e) {
-      // expected
-    }
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -1790,19 +1766,12 @@ class CaseServiceTest {
   @Test
   void testGetVariablesLocalWithVariablesNamesInvalidCaseExecutionId() {
 
-    try {
-      caseService.getVariablesLocal("invalid", null);
-      fail("The case execution should not be found.");
-    } catch (NotFoundException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> caseService.getVariablesLocal("invalid", null), "The case execution should not be found.")
+        .isInstanceOf(NotFoundException.class);
 
-    try {
-      caseService.getVariablesLocal(null, null);
-      fail("The case execution should not be found.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> caseService.getVariablesLocal(null, null), "The case execution should not be found.")
+        .isInstanceOf(NotValidException.class);
+
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -1895,19 +1864,10 @@ class CaseServiceTest {
 
   @Test
   void testGetVariableLocalInvalidCaseExecutionId() {
-    try {
-      caseService.getVariableLocal("invalid", "aVariableName");
-      fail("The case execution should not be found.");
-    } catch (NotFoundException e) {
-      // expected
-    }
-
-    try {
-      caseService.getVariableLocal(null, "aVariableName");
-      fail("The case execution should not be found.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> caseService.getVariableLocal("invalid", "aVariableName"), "The case execution should not be found.")
+        .isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(() -> caseService.getVariableLocal(null, "aVariableName"), "The case execution should not be found.")
+        .isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -1951,19 +1911,10 @@ class CaseServiceTest {
 
   @Test
   void testGetVariableTypedInvalidCaseExecutionId() {
-    try {
-      caseService.getVariableTyped("invalid", "aVariableName");
-      fail("The case execution should not be found.");
-    } catch (NotFoundException e) {
-      // expected
-    }
-
-    try {
-      caseService.getVariableTyped(null, "aVariableName");
-      fail("The case execution should not be found.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> caseService.getVariableTyped("invalid", "aVariableName"), "The case execution should not be found.")
+        .isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(() -> caseService.getVariableTyped(null, "aVariableName"), "The case execution should not be found.")
+        .isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -2228,19 +2179,10 @@ class CaseServiceTest {
 
   @Test
   void testGetVariableLocalTypedInvalidCaseExecutionId() {
-    try {
-      caseService.getVariableLocalTyped("invalid", "aVariableName");
-      fail("The case execution should not be found.");
-    } catch (NotFoundException e) {
-      // expected
-    }
-
-    try {
-      caseService.getVariableLocalTyped(null, "aVariableName");
-      fail("The case execution should not be found.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> caseService.getVariableLocalTyped("invalid", "aVariableName"), "The case execution should not be found.")
+        .isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(() -> caseService.getVariableLocalTyped(null, "aVariableName"), "The case execution should not be found.")
+        .isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/SetExternalTasksRetriesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/SetExternalTasksRetriesTest.java
@@ -120,7 +120,7 @@ class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
 
     externalTaskIds.add("nonExistingExternalTaskId");
 
-    assertThatThrownBy(() -> externalTaskService.setRetries(externalTaskIds, 10), "exception expected")
+    assertThatThrownBy(() -> externalTaskService.setRetries(externalTaskIds, 10))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("Cannot find external task with id nonExistingExternalTaskId");
 
@@ -137,7 +137,7 @@ class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
 
     externalTaskIds.add(null);
 
-    assertThatThrownBy(() -> externalTaskService.setRetries(externalTaskIds, 10), "exception expected")
+    assertThatThrownBy(() -> externalTaskService.setRetries(externalTaskIds, 10))
         .isInstanceOf(BadUserRequestException.class)
         .hasMessageContaining("External task id cannot be null");
 
@@ -163,7 +163,7 @@ class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
     externalTaskIds.add("nonExistingExternalTaskId");
     Batch batch = externalTaskService.setRetriesAsync(externalTaskIds, null, 10);
 
-    assertThatThrownBy(() -> executeSeedAndBatchJobs(batch), "exception expected")
+    assertThatThrownBy(() -> executeSeedAndBatchJobs(batch))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("Cannot find external task with id nonExistingExternalTaskId");
 
@@ -198,7 +198,7 @@ class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
 
     List<String> externalTaskIds = Arrays.asList("externalTaskId");
 
-    assertThatThrownBy(() -> externalTaskService.setRetries(externalTaskIds, -10), "exception expected")
+    assertThatThrownBy(() -> externalTaskService.setRetries(externalTaskIds, -10))
         .isInstanceOf(BadUserRequestException.class)
         .hasMessageContaining("The number of retries cannot be negative");
 
@@ -211,7 +211,7 @@ class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
 
     Batch batch = externalTaskService.setRetriesAsync(externalTaskIds, null, -10);
 
-    assertThatThrownBy(() -> executeSeedAndBatchJobs(batch), "exception expected")
+    assertThatThrownBy(() -> executeSeedAndBatchJobs(batch))
         .isInstanceOf(BadUserRequestException.class)
         .hasMessageContaining("The number of retries cannot be negative");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/SetExternalTasksRetriesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/SetExternalTasksRetriesTest.java
@@ -17,7 +17,7 @@
 package org.operaton.bpm.engine.test.api.externaltask;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -120,12 +120,10 @@ class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
 
     externalTaskIds.add("nonExistingExternalTaskId");
 
-    try {
-      externalTaskService.setRetries(externalTaskIds, 10);
-      fail("exception expected");
-    } catch (NotFoundException e) {
-      assertThat(e.getMessage()).contains("Cannot find external task with id nonExistingExternalTaskId");
-    }
+    assertThatThrownBy(() -> externalTaskService.setRetries(externalTaskIds, 10), "exception expected")
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Cannot find external task with id nonExistingExternalTaskId");
+
   }
 
   @Test
@@ -139,22 +137,18 @@ class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
 
     externalTaskIds.add(null);
 
-    try {
-      externalTaskService.setRetries(externalTaskIds, 10);
-      fail("exception expected");
-    } catch (BadUserRequestException e) {
-      assertThat(e.getMessage()).contains("External task id cannot be null");
-    }
+    assertThatThrownBy(() -> externalTaskService.setRetries(externalTaskIds, 10), "exception expected")
+        .isInstanceOf(BadUserRequestException.class)
+        .hasMessageContaining("External task id cannot be null");
+
   }
 
   @Test
   void shouldFailForNullExternalTaskIdsSync() {
-    try {
-      externalTaskService.setRetries((List<String>) null, 10);
-      fail("exception expected");
-    } catch (BadUserRequestException e) {
-      assertThat(e.getMessage()).contains("externalTaskIds is empty");
-    }
+    assertThatThrownBy(() -> externalTaskService.setRetries((List<String>) null, 10))
+        .isInstanceOf(BadUserRequestException.class)
+        .hasMessageContaining("externalTaskIds is empty");
+
   }
 
   @Test
@@ -169,12 +163,10 @@ class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
     externalTaskIds.add("nonExistingExternalTaskId");
     Batch batch = externalTaskService.setRetriesAsync(externalTaskIds, null, 10);
 
-    try {
-      executeSeedAndBatchJobs(batch);
-      fail("exception expected");
-    } catch (NotFoundException e) {
-      assertThat(e.getMessage()).contains("Cannot find external task with id nonExistingExternalTaskId");
-    }
+    assertThatThrownBy(() -> executeSeedAndBatchJobs(batch), "exception expected")
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Cannot find external task with id nonExistingExternalTaskId");
+
   }
 
   @Test
@@ -188,22 +180,17 @@ class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
 
     externalTaskIds.add(null);
 
-    try {
-      externalTaskService.setRetriesAsync(externalTaskIds, null, 10);
-      fail("exception expected");
-    } catch (BadUserRequestException e) {
-      assertThat(e.getMessage()).contains("External task id cannot be null");
-    }
+    assertThatThrownBy(() -> externalTaskService.setRetriesAsync(externalTaskIds, null, 10))
+        .isInstanceOf(BadUserRequestException.class)
+        .hasMessageContaining("External task id cannot be null");
+
   }
 
   @Test
   void shouldFailForNullExternalTaskIdsAsync() {
-    try {
-      externalTaskService.setRetriesAsync((List<String>) null, null, 10);
-      fail("exception expected");
-    } catch (BadUserRequestException e) {
-      assertThat(e.getMessage()).contains("externalTaskIds is empty");
-    }
+    assertThatThrownBy(() -> externalTaskService.setRetriesAsync((List<String>) null, null, 10))
+        .isInstanceOf(BadUserRequestException.class)
+        .hasMessageContaining("externalTaskIds is empty");
   }
 
   @Test
@@ -211,12 +198,10 @@ class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
 
     List<String> externalTaskIds = Arrays.asList("externalTaskId");
 
-    try {
-      externalTaskService.setRetries(externalTaskIds, -10);
-      fail("exception expected");
-    } catch (BadUserRequestException e) {
-      assertThat(e.getMessage()).contains("The number of retries cannot be negative");
-    }
+    assertThatThrownBy(() -> externalTaskService.setRetries(externalTaskIds, -10), "exception expected")
+        .isInstanceOf(BadUserRequestException.class)
+        .hasMessageContaining("The number of retries cannot be negative");
+
   }
 
   @Test
@@ -226,12 +211,10 @@ class SetExternalTasksRetriesTest extends AbstractAsyncOperationsTest {
 
     Batch batch = externalTaskService.setRetriesAsync(externalTaskIds, null, -10);
 
-    try {
-      executeSeedAndBatchJobs(batch);
-      fail("exception expected");
-    } catch (BadUserRequestException e) {
-      assertThat(e.getMessage()).contains("The number of retries cannot be negative");
-    }
+    assertThatThrownBy(() -> executeSeedAndBatchJobs(batch), "exception expected")
+        .isInstanceOf(BadUserRequestException.class)
+        .hasMessageContaining("The number of retries cannot be negative");
+
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterQueryTest.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.test.api.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -81,7 +80,7 @@ class FilterQueryTest {
     FilterQuery query = filterService.createFilterQuery();
     assertThat(query.count()).isEqualTo(4);
     assertThat(query.list()).hasSize(4);
-    assertThatThrownBy(() -> query.singleResult(), "Exception expected").isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -107,7 +106,7 @@ class FilterQueryTest {
   @Test
   void testQueryByResourceType() {
     FilterQuery query = filterService.createFilterQuery().filterResourceType(EntityTypes.TASK);
-    assertThatThrownBy(() -> query.singleResult(), "Exception expected").isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
     assertThat(query.list()).hasSize(4);
     assertThat(query.count()).isEqualTo(4);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/filter/FilterQueryTest.java
@@ -81,13 +81,7 @@ class FilterQueryTest {
     FilterQuery query = filterService.createFilterQuery();
     assertThat(query.count()).isEqualTo(4);
     assertThat(query.list()).hasSize(4);
-    try {
-      query.singleResult();
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.singleResult(), "Exception expected").isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -113,13 +107,7 @@ class FilterQueryTest {
   @Test
   void testQueryByResourceType() {
     FilterQuery query = filterService.createFilterQuery().filterResourceType(EntityTypes.TASK);
-    try {
-      query.singleResult();
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.singleResult(), "Exception expected").isInstanceOf(ProcessEngineException.class);
     assertThat(query.list()).hasSize(4);
     assertThat(query.count()).isEqualTo(4);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
@@ -177,12 +177,7 @@ class FormServiceTest {
 
   @Test
   void testGetTaskFormNullTaskId() {
-    try {
-      formService.getRenderedTaskForm(null);
-      fail("ProcessEngineException expected");
-    } catch (ProcessEngineException ae) {
-      // Expected Exception
-    }
+    assertThatThrownBy(() -> formService.getRenderedTaskForm(null), "ProcessEngineException expected").isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.engine.test.api.form;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
-import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.test.util.OperatonFormUtils.findAllOperatonFormDefinitionEntities;
 import static org.operaton.bpm.engine.variable.Variables.booleanValue;
 import static org.operaton.bpm.engine.variable.Variables.createVariables;
@@ -177,7 +176,7 @@ class FormServiceTest {
 
   @Test
   void testGetTaskFormNullTaskId() {
-    assertThatThrownBy(() -> formService.getRenderedTaskForm(null), "ProcessEngineException expected").isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(() -> formService.getRenderedTaskForm(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BulkHistoryDeleteTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BulkHistoryDeleteTest.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.engine.test.api.history;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.history.UserOperationLogEntry.CATEGORY_OPERATOR;
 import static org.operaton.bpm.engine.history.UserOperationLogEntry.OPERATION_TYPE_DELETE_HISTORY;
 
@@ -534,16 +533,16 @@ public class BulkHistoryDeleteTest {
     final List<String> ids = prepareHistoricProcesses();
     runtimeService.deleteProcessInstances(ids, null, true, true);
 
-    assertThatThrownBy(
-        () -> historyService.deleteHistoricProcessInstancesBulk(null),
-        "Empty process instance ids exception was expected"
-    ).isInstanceOf(BadUserRequestException.class).hasMessageContaining("processInstanceIds is null");
+    assertThatThrownBy(() -> historyService.deleteHistoricProcessInstancesBulk(null),
+        "Empty process instance ids exception was expected")
+            .isInstanceOf(BadUserRequestException.class)
+            .hasMessageContaining("processInstanceIds is null");
 
-    List<String> emptyPocessInstanceIds = emptyList();
-    assertThatThrownBy(
-        () -> historyService.deleteHistoricProcessInstancesBulk(emptyPocessInstanceIds),
-        "Empty process instance ids exception was expected"
-    ).isInstanceOf(BadUserRequestException.class).hasMessageContaining("processInstanceIds is empty");
+    List<String> emptyProcessInstanceIds = emptyList();
+    assertThatThrownBy(() -> historyService.deleteHistoricProcessInstancesBulk(emptyProcessInstanceIds),
+        "Empty process instance ids exception was expected")
+            .isInstanceOf(BadUserRequestException.class)
+            .hasMessageContaining("processInstanceIds is empty");
 
   }
 
@@ -555,8 +554,8 @@ public class BulkHistoryDeleteTest {
     runtimeService.deleteProcessInstances(ids.subList(1, ids.size()), null, true, true);
 
     assertThatThrownBy(() -> historyService.deleteHistoricProcessInstancesBulk(ids), "Not all processes are finished exception was expected")
-        .isInstanceOf(BadUserRequestException.class).hasMessageContaining("Process instance is still running, cannot delete historic process instance");
-
+          .isInstanceOf(BadUserRequestException.class)
+          .hasMessageContaining("Process instance is still running, cannot delete historic process instance");
   }
 
   private void collectHistoricDecisionInputIds(List<HistoricDecisionInstance> historicDecisionInstances, List<String> historicDecisionInputIds, List<String> inputByteArrayIds) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BulkHistoryDeleteTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/BulkHistoryDeleteTest.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.test.api.history;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.history.UserOperationLogEntry.CATEGORY_OPERATOR;
 import static org.operaton.bpm.engine.history.UserOperationLogEntry.OPERATION_TYPE_DELETE_HISTORY;
@@ -533,20 +534,16 @@ public class BulkHistoryDeleteTest {
     final List<String> ids = prepareHistoricProcesses();
     runtimeService.deleteProcessInstances(ids, null, true, true);
 
-    try {
-      historyService.deleteHistoricProcessInstancesBulk(null);
-      fail("Empty process instance ids exception was expected");
-    } catch (BadUserRequestException ex) {
-      assertThat(ex.getMessage()).contains("processInstanceIds is null");
-    }
+    assertThatThrownBy(
+        () -> historyService.deleteHistoricProcessInstancesBulk(null),
+        "Empty process instance ids exception was expected"
+    ).isInstanceOf(BadUserRequestException.class).hasMessageContaining("processInstanceIds is null");
 
     List<String> emptyPocessInstanceIds = emptyList();
-    try {
-      historyService.deleteHistoricProcessInstancesBulk(emptyPocessInstanceIds);
-      fail("Empty process instance ids exception was expected");
-    } catch (BadUserRequestException ex) {
-      assertThat(ex.getMessage()).contains("processInstanceIds is empty");
-    }
+    assertThatThrownBy(
+        () -> historyService.deleteHistoricProcessInstancesBulk(emptyPocessInstanceIds),
+        "Empty process instance ids exception was expected"
+    ).isInstanceOf(BadUserRequestException.class).hasMessageContaining("processInstanceIds is empty");
 
   }
 
@@ -557,12 +554,8 @@ public class BulkHistoryDeleteTest {
     final List<String> ids = prepareHistoricProcesses();
     runtimeService.deleteProcessInstances(ids.subList(1, ids.size()), null, true, true);
 
-    try {
-      historyService.deleteHistoricProcessInstancesBulk(ids);
-      fail("Not all processes are finished exception was expected");
-    } catch (BadUserRequestException ex) {
-      assertThat(ex.getMessage()).contains("Process instance is still running, cannot delete historic process instance");
-    }
+    assertThatThrownBy(() -> historyService.deleteHistoricProcessInstancesBulk(ids), "Not all processes are finished exception was expected")
+        .isInstanceOf(BadUserRequestException.class).hasMessageContaining("Process instance is still running, cannot delete historic process instance");
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricBatchQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricBatchQueryTest.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.test.api.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicBatchByEndTime;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicBatchById;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicBatchByStartTime;
@@ -142,8 +141,9 @@ class HistoricBatchQueryTest {
   @Test
   void testBatchQueryByIdNull() {
     var historicBatchQuery = historyService.createHistoricBatchQuery();
-    assertThatThrownBy(() -> historicBatchQuery.batchId(null), "exception expected")
-        .isInstanceOf(NullValueException.class).hasMessageContaining("Batch id is null");
+    assertThatThrownBy(() -> historicBatchQuery.batchId(null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessageContaining("Batch id is null");
   }
 
   @Test
@@ -199,8 +199,9 @@ class HistoricBatchQueryTest {
   @Test
   void testBatchQueryByTypeNull() {
     var historicBatchQuery = historyService.createHistoricBatchQuery();
-    assertThatThrownBy(() -> historicBatchQuery.type(null), "exception expected")
-        .isInstanceOf(NullValueException.class).hasMessageContaining("Type is null");
+    assertThatThrownBy(() -> historicBatchQuery.type(null))
+        .isInstanceOf(NullValueException.class)
+        .hasMessageContaining("Type is null");
   }
 
   @Test
@@ -311,7 +312,7 @@ class HistoricBatchQueryTest {
   @Test
   void testBatchQueryOrderingPropertyWithoutOrder() {
     var historicBatchQuery = historyService.createHistoricBatchQuery().orderById();
-    assertThatThrownBy(() -> historicBatchQuery.singleResult(), "exception expected")
+    assertThatThrownBy(historicBatchQuery::singleResult)
         .isInstanceOf(NotValidException.class)
         .hasMessageContaining("Invalid query: call asc() or desc() after using orderByXX()");
   }
@@ -319,7 +320,8 @@ class HistoricBatchQueryTest {
   @Test
   void testBatchQueryOrderWithoutOrderingProperty() {
     var historicBatchQuery = historyService.createHistoricBatchQuery();
-    assertThatThrownBy(() -> historicBatchQuery.asc(), "exception expected")
-        .isInstanceOf(NotValidException.class).hasMessageContaining("You should call any of the orderBy methods first before specifying a direction");
+    assertThatThrownBy(historicBatchQuery::asc)
+        .isInstanceOf(NotValidException.class)
+        .hasMessageContaining("You should call any of the orderBy methods first before specifying a direction");
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricBatchQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricBatchQueryTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.test.api.history;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicBatchByEndTime;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicBatchById;
@@ -141,13 +142,8 @@ class HistoricBatchQueryTest {
   @Test
   void testBatchQueryByIdNull() {
     var historicBatchQuery = historyService.createHistoricBatchQuery();
-    try {
-      historicBatchQuery.batchId(null);
-      fail("exception expected");
-    }
-    catch (NullValueException e) {
-      assertThat(e.getMessage()).contains("Batch id is null");
-    }
+    assertThatThrownBy(() -> historicBatchQuery.batchId(null), "exception expected")
+        .isInstanceOf(NullValueException.class).hasMessageContaining("Batch id is null");
   }
 
   @Test
@@ -203,13 +199,8 @@ class HistoricBatchQueryTest {
   @Test
   void testBatchQueryByTypeNull() {
     var historicBatchQuery = historyService.createHistoricBatchQuery();
-    try {
-      historicBatchQuery.type(null);
-      fail("exception expected");
-    }
-    catch (NullValueException e) {
-      assertThat(e.getMessage()).contains("Type is null");
-    }
+    assertThatThrownBy(() -> historicBatchQuery.type(null), "exception expected")
+        .isInstanceOf(NullValueException.class).hasMessageContaining("Type is null");
   }
 
   @Test
@@ -320,24 +311,15 @@ class HistoricBatchQueryTest {
   @Test
   void testBatchQueryOrderingPropertyWithoutOrder() {
     var historicBatchQuery = historyService.createHistoricBatchQuery().orderById();
-    try {
-      historicBatchQuery.singleResult();
-      fail("exception expected");
-    }
-    catch (NotValidException e) {
-      assertThat(e.getMessage()).contains("Invalid query: call asc() or desc() after using orderByXX()");
-    }
+    assertThatThrownBy(() -> historicBatchQuery.singleResult(), "exception expected")
+        .isInstanceOf(NotValidException.class)
+        .hasMessageContaining("Invalid query: call asc() or desc() after using orderByXX()");
   }
 
   @Test
   void testBatchQueryOrderWithoutOrderingProperty() {
     var historicBatchQuery = historyService.createHistoricBatchQuery();
-    try {
-      historicBatchQuery.asc();
-      fail("exception expected");
-    }
-    catch (NotValidException e) {
-      assertThat(e.getMessage()).contains("You should call any of the orderBy methods first before specifying a direction");
-    }
+    assertThatThrownBy(() -> historicBatchQuery.asc(), "exception expected")
+        .isInstanceOf(NotValidException.class).hasMessageContaining("You should call any of the orderBy methods first before specifying a direction");
   }
 }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/QueryTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/QueryTest.java
@@ -24,6 +24,7 @@ import org.operaton.bpm.model.bpmn.instance.Task;
 import org.operaton.bpm.model.xml.type.ModelElementType;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 /**
@@ -99,19 +100,11 @@ class QueryTest {
   @Test
   void testSingleResult() {
     assertThat(startSucceeding.singleResult().getId()).isEqualTo("user");
-    try {
-      gateway1Succeeding.singleResult();
-      fail("gateway1 has more than one succeeding flow node");
-    }
-    catch (Exception e) {
-      assertThat(e).isInstanceOf(BpmnModelException.class).hasMessageEndingWith("<2>");
-    }
-    try {
-      gateway2Succeeding.singleResult();
-      fail("gateway2 has more than one succeeding flow node");
-    }
-    catch (Exception e) {
-      assertThat(e).isInstanceOf(BpmnModelException.class).hasMessageEndingWith("<3>");
-    }
+    assertThatThrownBy(() -> gateway1Succeeding.singleResult(), "gateway1 has more than one succeeding flow node")
+        .isInstanceOf(BpmnModelException.class)
+        .hasMessageEndingWith("<2>");
+    assertThatThrownBy(() -> gateway2Succeeding.singleResult(), "gateway2 has more than one succeeding flow node")
+        .isInstanceOf(BpmnModelException.class)
+        .hasMessageEndingWith("<3>");
   }
 }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/QueryTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/QueryTest.java
@@ -25,7 +25,6 @@ import org.operaton.bpm.model.xml.type.ModelElementType;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Sebastian Menski

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
@@ -1090,10 +1090,8 @@ public class ProcessBuilderTest {
     var eventBasedGatewayBuilder = Bpmn.createProcess()
       .startEvent()
       .eventBasedGateway();
-    assertThatThrownBy(eventBasedGatewayBuilder::operatonAsyncAfter, "Expected UnsupportedOperationException")
-        .isInstanceOf(UnsupportedOperationException.class);
-    assertThatThrownBy(() -> eventBasedGatewayBuilder.operatonAsyncAfter(true), "Expected UnsupportedOperationException")
-        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(eventBasedGatewayBuilder::operatonAsyncAfter).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> eventBasedGatewayBuilder.operatonAsyncAfter(true)).isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test
@@ -3131,7 +3129,7 @@ public class ProcessBuilderTest {
       .boundaryEvent()
       .compensateEventDefinition();
 
-    assertThatThrownBy(() -> compensateEventDefinitionBuilder.activityRef("nonExistingTask"), "should fail")
+    assertThatThrownBy(() -> compensateEventDefinitionBuilder.activityRef("nonExistingTask"))
         .isInstanceOf(BpmnModelException.class)
         .hasMessageContaining("Activity with id 'nonExistingTask' does not exist");
   }
@@ -3156,7 +3154,7 @@ public class ProcessBuilderTest {
       .boundaryEvent("boundary")
       .compensateEventDefinition();
 
-    assertThatThrownBy(() -> compensateEventDefinitionBuilder.activityRef("subProcessTask"), "should fail")
+    assertThatThrownBy(() -> compensateEventDefinitionBuilder.activityRef("subProcessTask"))
         .isInstanceOf(BpmnModelException.class)
         .hasMessageContaining("Activity with id 'subProcessTask' must be in the same scope as 'boundary'");
   }
@@ -3505,7 +3503,7 @@ public class ProcessBuilderTest {
       .userTask()
       .endEvent();
 
-    assertThatThrownBy(() -> eventSubProcess.subProcessDone(), "eventSubProcess has returned a builder after completion")
+    assertThatThrownBy(eventSubProcess::subProcessDone, "eventSubProcess has returned a builder after completion")
         .isInstanceOf(BpmnModelException.class)
         .hasMessageContaining("Unable to find a parent subProcess.");
   }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/builder/ProcessBuilderTest.java
@@ -1090,19 +1090,10 @@ public class ProcessBuilderTest {
     var eventBasedGatewayBuilder = Bpmn.createProcess()
       .startEvent()
       .eventBasedGateway();
-    try {
-      eventBasedGatewayBuilder.operatonAsyncAfter();
-      fail("Expected UnsupportedOperationException");
-    } catch(UnsupportedOperationException ex) {
-      // happy path
-    }
-
-    try {
-      eventBasedGatewayBuilder.operatonAsyncAfter(true) ;
-      fail("Expected UnsupportedOperationException");
-    } catch(UnsupportedOperationException ex) {
-      // happy ending :D
-    }
+    assertThatThrownBy(eventBasedGatewayBuilder::operatonAsyncAfter, "Expected UnsupportedOperationException")
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> eventBasedGatewayBuilder.operatonAsyncAfter(true), "Expected UnsupportedOperationException")
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test
@@ -3140,12 +3131,9 @@ public class ProcessBuilderTest {
       .boundaryEvent()
       .compensateEventDefinition();
 
-    try {
-      compensateEventDefinitionBuilder.activityRef("nonExistingTask");
-      fail("should fail");
-    } catch (BpmnModelException e) {
-      assertThat(e).hasMessageContaining("Activity with id 'nonExistingTask' does not exist");
-    }
+    assertThatThrownBy(() -> compensateEventDefinitionBuilder.activityRef("nonExistingTask"), "should fail")
+        .isInstanceOf(BpmnModelException.class)
+        .hasMessageContaining("Activity with id 'nonExistingTask' does not exist");
   }
 
   @Test
@@ -3168,12 +3156,9 @@ public class ProcessBuilderTest {
       .boundaryEvent("boundary")
       .compensateEventDefinition();
 
-    try {
-      compensateEventDefinitionBuilder.activityRef("subProcessTask");
-      fail("should fail");
-    } catch (BpmnModelException e) {
-      assertThat(e).hasMessageContaining("Activity with id 'subProcessTask' must be in the same scope as 'boundary'");
-    }
+    assertThatThrownBy(() -> compensateEventDefinitionBuilder.activityRef("subProcessTask"), "should fail")
+        .isInstanceOf(BpmnModelException.class)
+        .hasMessageContaining("Activity with id 'subProcessTask' must be in the same scope as 'boundary'");
   }
 
   @Test
@@ -3520,13 +3505,9 @@ public class ProcessBuilderTest {
       .userTask()
       .endEvent();
 
-    try {
-      eventSubProcess.subProcessDone();
-      fail("eventSubProcess has returned a builder after completion");
-    } catch (BpmnModelException e) {
-      assertThat(e).hasMessageContaining("Unable to find a parent subProcess.");
-
-    }
+    assertThatThrownBy(() -> eventSubProcess.subProcessDone(), "eventSubProcess has returned a builder after completion")
+        .isInstanceOf(BpmnModelException.class)
+        .hasMessageContaining("Unable to find a parent subProcess.");
   }
 
   @Test

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/EventBasedGatewayTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/EventBasedGatewayTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 class EventBasedGatewayTest extends AbstractGatewayTest<EventBasedGateway> {
@@ -48,19 +49,11 @@ class EventBasedGatewayTest extends AbstractGatewayTest<EventBasedGateway> {
   @Test
   void shouldFailSetAsyncAfterToEventBasedGateway() {
     // fetching should fail
-    try {
-      gateway.isOperatonAsyncAfter();
-      fail("Expected: UnsupportedOperationException");
-    } catch(UnsupportedOperationException ex) {
-      // True
-    }
+    assertThatThrownBy(() -> gateway.isOperatonAsyncAfter(), "Expected: UnsupportedOperationException")
+        .isInstanceOf(UnsupportedOperationException.class);
 
     // set the attribute should fail to!
-    try {
-      gateway.setOperatonAsyncAfter(false);
-      fail("Expected: UnsupportedOperationException");
-    } catch(UnsupportedOperationException ex) {
-      // True
-    }
+    assertThatThrownBy(() -> gateway.setOperatonAsyncAfter(false), "Expected: UnsupportedOperationException")
+        .isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/EventBasedGatewayTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/instance/EventBasedGatewayTest.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 class EventBasedGatewayTest extends AbstractGatewayTest<EventBasedGateway> {
 
@@ -49,11 +48,9 @@ class EventBasedGatewayTest extends AbstractGatewayTest<EventBasedGateway> {
   @Test
   void shouldFailSetAsyncAfterToEventBasedGateway() {
     // fetching should fail
-    assertThatThrownBy(() -> gateway.isOperatonAsyncAfter(), "Expected: UnsupportedOperationException")
-        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> gateway.isOperatonAsyncAfter()).isInstanceOf(UnsupportedOperationException.class);
 
     // set the attribute should fail to!
-    assertThatThrownBy(() -> gateway.setOperatonAsyncAfter(false), "Expected: UnsupportedOperationException")
-        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> gateway.setOperatonAsyncAfter(false)).isInstanceOf(UnsupportedOperationException.class);
   }
 }

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn10/Cmmn10Test.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn10/Cmmn10Test.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.model.cmmn10;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Collection;
@@ -184,13 +185,8 @@ class Cmmn10Test {
     HumanTask humanTask = modelInstance.newInstance(HumanTask.class);
     casePlanModel.getPlanItemDefinitions().add(humanTask);
 
-    try {
-      Cmmn.writeModelToStream(System.out, modelInstance);
-      fail("cannot save cmmn 1.0 model");
-    }
-    catch (Exception e) {
-      // expected exception
-    }
+    assertThatThrownBy(() -> Cmmn.writeModelToStream(System.out, modelInstance), "cannot save cmmn 1.0 model")
+        .isInstanceOf(Exception.class);
   }
 
   @Test
@@ -209,13 +205,8 @@ class Cmmn10Test {
     Event event = modelInstance.newInstance(Event.class);
     casePlanModel.getPlanItemDefinitions().add(event);
 
-    try {
-      Cmmn.writeModelToStream(System.out, modelInstance);
-      fail("cannot save cmmn 1.1 model");
-    }
-    catch (Exception e) {
-      // expected exception
-    }
+    assertThatThrownBy(() -> Cmmn.writeModelToStream(System.out, modelInstance), "cannot save cmmn 1.0 model")
+        .isInstanceOf(Exception.class);
   }
 
   protected CmmnModelInstance getCmmnModelInstance() {

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn10/Cmmn10Test.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn10/Cmmn10Test.java
@@ -44,6 +44,7 @@ import org.operaton.bpm.model.cmmn.instance.PlanItem;
 import org.operaton.bpm.model.cmmn.instance.Sentry;
 import org.operaton.bpm.model.cmmn.instance.TimerEvent;
 import org.operaton.bpm.model.cmmn.instance.UserEvent;
+import org.operaton.bpm.model.xml.ModelValidationException;
 
 /**
  * @author Roman Smirnov
@@ -184,8 +185,8 @@ class Cmmn10Test {
     HumanTask humanTask = modelInstance.newInstance(HumanTask.class);
     casePlanModel.getPlanItemDefinitions().add(humanTask);
 
-    assertThatThrownBy(() -> Cmmn.writeModelToStream(System.out, modelInstance), "cannot save cmmn 1.0 model")
-        .isInstanceOf(Exception.class);
+    assertThatThrownBy(() -> Cmmn.writeModelToStream(System.out, modelInstance), "save cmmn 1.0 model should fail")
+        .isInstanceOf(ModelValidationException.class);
   }
 
   @Test
@@ -204,8 +205,8 @@ class Cmmn10Test {
     Event event = modelInstance.newInstance(Event.class);
     casePlanModel.getPlanItemDefinitions().add(event);
 
-    assertThatThrownBy(() -> Cmmn.writeModelToStream(System.out, modelInstance), "cannot save cmmn 1.0 model")
-        .isInstanceOf(Exception.class);
+    assertThatThrownBy(() -> Cmmn.writeModelToStream(System.out, modelInstance), "save cmmn 1.1 model should fail")
+        .isInstanceOf(ModelValidationException.class);
   }
 
   protected CmmnModelInstance getCmmnModelInstance() {

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn10/Cmmn10Test.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn10/Cmmn10Test.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.model.cmmn10;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Collection;
 

--- a/spin/core/src/test/java/org/operaton/spin/impl/util/RewindableReaderTest.java
+++ b/spin/core/src/test/java/org/operaton/spin/impl/util/RewindableReaderTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RewindableReaderTest {
 
@@ -153,12 +153,7 @@ class RewindableReaderTest {
     assertThat(SpinIoUtil.getStringFromReader(reader))
       .isEqualTo(EXAMPLE_INPUT_STRING.substring(DEFAULT_BUFFER_SIZE + 5));
 
-    try {
-      reader.rewind();
-      fail("IOException expected");
-    } catch (IOException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> reader.rewind(), "IOException expected").isInstanceOf(IOException.class);
 
     // exceeding with read()
     reader = newReaderInstance(EXAMPLE_INPUT_STRING, DEFAULT_BUFFER_SIZE);
@@ -167,12 +162,7 @@ class RewindableReaderTest {
     reader.read(buffer);
     reader.read();
 
-    try {
-      reader.rewind();
-      fail("IOException expected");
-    } catch (IOException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> reader.rewind(), "IOException expected").isInstanceOf(IOException.class);
 
     // repeated read(char[])
     reader = newReaderInstance(EXAMPLE_INPUT_STRING, DEFAULT_BUFFER_SIZE);
@@ -181,12 +171,7 @@ class RewindableReaderTest {
     reader.read(buffer);
     reader.read(buffer);
 
-    try {
-      reader.rewind();
-      fail("IOException expected");
-    } catch (IOException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> reader.rewind(), "IOException expected").isInstanceOf(IOException.class);
   }
 
   @Test

--- a/spin/core/src/test/java/org/operaton/spin/impl/util/RewindableReaderTest.java
+++ b/spin/core/src/test/java/org/operaton/spin/impl/util/RewindableReaderTest.java
@@ -153,7 +153,7 @@ class RewindableReaderTest {
     assertThat(SpinIoUtil.getStringFromReader(reader))
       .isEqualTo(EXAMPLE_INPUT_STRING.substring(DEFAULT_BUFFER_SIZE + 5));
 
-    assertThatThrownBy(() -> reader.rewind(), "IOException expected").isInstanceOf(IOException.class);
+    assertThatThrownBy(reader::rewind).isInstanceOf(IOException.class);
 
     // exceeding with read()
     reader = newReaderInstance(EXAMPLE_INPUT_STRING, DEFAULT_BUFFER_SIZE);
@@ -162,7 +162,7 @@ class RewindableReaderTest {
     reader.read(buffer);
     reader.read();
 
-    assertThatThrownBy(() -> reader.rewind(), "IOException expected").isInstanceOf(IOException.class);
+    assertThatThrownBy(reader::rewind).isInstanceOf(IOException.class);
 
     // repeated read(char[])
     reader = newReaderInstance(EXAMPLE_INPUT_STRING, DEFAULT_BUFFER_SIZE);
@@ -171,7 +171,7 @@ class RewindableReaderTest {
     reader.read(buffer);
     reader.read(buffer);
 
-    assertThatThrownBy(() -> reader.rewind(), "IOException expected").isInstanceOf(IOException.class);
+    assertThatThrownBy(reader::rewind).isInstanceOf(IOException.class);
   }
 
   @Test

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeCreateTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeCreateTest.java
@@ -17,7 +17,7 @@
 package org.operaton.spin.json.tree;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.spin.DataFormats.json;
 import static org.operaton.spin.Spin.JSON;
 import static org.operaton.spin.Spin.S;
@@ -26,6 +26,7 @@ import static org.operaton.spin.json.JsonTestConstants.EXAMPLE_EMPTY_STRING;
 import static org.operaton.spin.json.JsonTestConstants.EXAMPLE_INVALID_JSON;
 import static org.operaton.spin.json.JsonTestConstants.EXAMPLE_JSON;
 
+import java.io.IOException;
 import java.io.Reader;
 
 import org.junit.jupiter.api.Test;
@@ -89,171 +90,75 @@ class JsonTreeCreateTest {
   void shouldFailForNull() {
     SpinJsonNode jsonNode = null;
     var json = json();
-
-    try {
-      JSON(jsonNode);
-      fail("Expected IllegalArgumentException");
-    } catch(IllegalArgumentException e) {
-      // expected
-    }
-
-    try {
-      S(jsonNode, json);
-      fail("Expected IllegalArgumentException");
-    } catch(IllegalArgumentException e) {
-      // expected
-    }
-
-    try {
-      S(jsonNode);
-      fail("Expected IllegalArgumentException");
-    } catch(IllegalArgumentException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> JSON(jsonNode), "Expected IllegalArgumentException")
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> S(jsonNode, json), "Expected IllegalArgumentException")
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> S(jsonNode), "Expected IllegalArgumentException")
+        .isInstanceOf(IllegalArgumentException.class);
 
     Reader reader = null;
-
-    try {
-      JSON(reader);
-      fail("Expected IllegalArgumentException");
-    } catch(IllegalArgumentException e) {
-      // expected
-    }
-
-    try {
-      S(reader, json);
-      fail("Expected IllegalArgumentException");
-    } catch(IllegalArgumentException e) {
-      // expected
-    }
-
-    try {
-      S(reader);
-      fail("Expected IllegalArgumentException");
-    } catch(IllegalArgumentException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> JSON(jsonNode), "Expected IllegalArgumentException")
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> S(reader, json), "Expected IllegalArgumentException")
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> S(reader), "Expected IllegalArgumentException")
+        .isInstanceOf(IllegalArgumentException.class);
 
     String inputString = null;
-
-    try {
-      JSON(inputString);
-      fail("Expected IllegalArgumentException");
-    } catch(IllegalArgumentException e) {
-      // expected
-    }
-
-    try {
-      S(inputString, json);
-      fail("Expected IllegalArgumentException");
-    } catch(IllegalArgumentException e) {
-      // expected
-    }
-
-    try {
-      S(inputString, DataFormats.JSON_DATAFORMAT_NAME);
-      fail("Expected IllegalArgumentException");
-    } catch(IllegalArgumentException e) {
-      // expected
-    }
-
-    try {
-      S(inputString);
-      fail("Expected IllegalArgumentException");
-    } catch(IllegalArgumentException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> JSON(inputString), "Expected IllegalArgumentException")
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> S(inputString, json), "Expected IllegalArgumentException")
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> S(inputString, DataFormats.JSON_DATAFORMAT_NAME), "Expected IllegalArgumentException")
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> S(inputString), "Expected IllegalArgumentException")
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void shouldFailForInvalidJson() {
     var json = json();
-    try {
-      JSON(EXAMPLE_INVALID_JSON);
-      fail("Expected IllegalArgumentException");
-    } catch(SpinDataFormatException e) {
-      // expected
-    }
-
-    try {
-      S(EXAMPLE_INVALID_JSON, json);
-      fail("Expected IllegalArgumentException");
-    } catch(SpinDataFormatException e) {
-      // expected
-    }
-
-    try {
-      S(EXAMPLE_INVALID_JSON, DataFormats.JSON_DATAFORMAT_NAME);
-      fail("Expected IllegalArgumentException");
-    } catch(SpinDataFormatException e) {
-      // expected
-    }
-
-    try {
-      S(EXAMPLE_INVALID_JSON);
-      fail("Expected IllegalArgumentException");
-    } catch(SpinDataFormatException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> JSON(EXAMPLE_INVALID_JSON), "Expected SpinDataFormatException")
+        .isInstanceOf(SpinDataFormatException.class);
+    assertThatThrownBy(() -> S(EXAMPLE_INVALID_JSON, json), "Expected SpinDataFormatException")
+        .isInstanceOf(SpinDataFormatException.class);
+    assertThatThrownBy(() -> S(EXAMPLE_INVALID_JSON, DataFormats.JSON_DATAFORMAT_NAME), "Expected SpinDataFormatException")
+        .isInstanceOf(SpinDataFormatException.class);
+    assertThatThrownBy(() -> S(EXAMPLE_INVALID_JSON), "Expected SpinDataFormatException")
+        .isInstanceOf(SpinDataFormatException.class);
   }
 
   @Test
   void shouldFailForEmptyString() {
     var json = json();
-    try {
-      JSON(EXAMPLE_EMPTY_STRING);
-      fail("Expected IllegalArgumentException");
-    } catch(SpinDataFormatException e) {
-      // expected
-    }
-
-    try {
-      S(EXAMPLE_EMPTY_STRING, json);
-      fail("Expected IllegalArgumentException");
-    } catch(SpinDataFormatException e) {
-      // expected
-    }
-
-    try {
-      S(EXAMPLE_EMPTY_STRING, DataFormats.JSON_DATAFORMAT_NAME);
-      fail("Expected IllegalArgumentException");
-    } catch(SpinDataFormatException e) {
-      // expected
-    }
-
-    try {
-      S(EXAMPLE_EMPTY_STRING);
-      fail("Expected IllegalArgumentException");
-    } catch(SpinDataFormatException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> JSON(EXAMPLE_EMPTY_STRING), "Expected SpinDataFormatException")
+        .isInstanceOf(SpinDataFormatException.class);
+    assertThatThrownBy(() -> S(EXAMPLE_EMPTY_STRING, json), "Expected SpinDataFormatException")
+        .isInstanceOf(SpinDataFormatException.class);
+    assertThatThrownBy(() -> S(EXAMPLE_EMPTY_STRING, DataFormats.JSON_DATAFORMAT_NAME), "Expected SpinDataFormatException")
+        .isInstanceOf(SpinDataFormatException.class);
+    assertThatThrownBy(() -> S(EXAMPLE_EMPTY_STRING), "Expected SpinDataFormatException")
+        .isInstanceOf(SpinDataFormatException.class);
   }
 
   @Test
-  void shouldFailForEmptyReader() {
-    Reader input1 = stringAsReader(EXAMPLE_EMPTY_STRING);
+  void shouldFailForEmptyReader() throws IOException {
     var json = json();
-    try {
-      JSON(input1);
-      fail("Expected IllegalArgumentException");
-    } catch(SpinDataFormatException e) {
-      // expected
+
+    try (Reader input1 = stringAsReader(EXAMPLE_EMPTY_STRING)) {
+      assertThatThrownBy(() -> JSON(input1), "Expected SpinDataFormatException")
+          .isInstanceOf(SpinDataFormatException.class);
     }
 
-    Reader input2 = stringAsReader(EXAMPLE_EMPTY_STRING);
-    try {
-      S(input2, json);
-      fail("Expected IllegalArgumentException");
-    } catch(SpinDataFormatException e) {
-      // expected
+    try (Reader input2 = stringAsReader(EXAMPLE_EMPTY_STRING)) {
+      assertThatThrownBy(() -> S(input2, json), "Expected SpinDataFormatException")
+          .isInstanceOf(SpinDataFormatException.class);
     }
 
-    Reader input3 = stringAsReader(EXAMPLE_EMPTY_STRING);
-    try {
-      S(input3);
-      fail("Expected IllegalArgumentException");
-    } catch(SpinDataFormatException e) {
-      // expected
+    try (Reader input3 = stringAsReader(EXAMPLE_EMPTY_STRING)) {
+      assertThatThrownBy(() -> S(input3), "Expected SpinDataFormatException")
+          .isInstanceOf(SpinDataFormatException.class);
     }
   }
 
@@ -283,11 +188,7 @@ class JsonTreeCreateTest {
 
   @Test
   void shouldFailForUnescapedString() {
-    try {
-      JSON("a String");
-      fail("expected exception");
-    } catch (SpinDataFormatException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> JSON("a String"), "expected exception")
+        .isInstanceOf(SpinDataFormatException.class);
   }
 }

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeCreateTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeCreateTest.java
@@ -56,8 +56,7 @@ class JsonTreeCreateTest {
 
   @Test
   void shouldCreateObjectDeclaredInput() {
-    Object input = EXAMPLE_JSON;
-    SpinJsonNode jsonNode = JSON(input);
+    SpinJsonNode jsonNode = JSON(EXAMPLE_JSON);
     assertThat(jsonNode.prop("order")).isNotNull();
   }
 
@@ -90,56 +89,38 @@ class JsonTreeCreateTest {
   void shouldFailForNull() {
     SpinJsonNode jsonNode = null;
     var json = json();
-    assertThatThrownBy(() -> JSON(jsonNode), "Expected IllegalArgumentException")
-        .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(() -> S(jsonNode, json), "Expected IllegalArgumentException")
-        .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(() -> S(jsonNode), "Expected IllegalArgumentException")
-        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> JSON(jsonNode)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> S(jsonNode, json)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> S(jsonNode)).isInstanceOf(IllegalArgumentException.class);
 
     Reader reader = null;
-    assertThatThrownBy(() -> JSON(jsonNode), "Expected IllegalArgumentException")
-        .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(() -> S(reader, json), "Expected IllegalArgumentException")
-        .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(() -> S(reader), "Expected IllegalArgumentException")
-        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> JSON(jsonNode)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> S(reader, json)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> S(reader)).isInstanceOf(IllegalArgumentException.class);
 
     String inputString = null;
-    assertThatThrownBy(() -> JSON(inputString), "Expected IllegalArgumentException")
-        .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(() -> S(inputString, json), "Expected IllegalArgumentException")
-        .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(() -> S(inputString, DataFormats.JSON_DATAFORMAT_NAME), "Expected IllegalArgumentException")
-        .isInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(() -> S(inputString), "Expected IllegalArgumentException")
-        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> JSON(inputString)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> S(inputString, json)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> S(inputString, DataFormats.JSON_DATAFORMAT_NAME)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> S(inputString)).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void shouldFailForInvalidJson() {
     var json = json();
-    assertThatThrownBy(() -> JSON(EXAMPLE_INVALID_JSON), "Expected SpinDataFormatException")
-        .isInstanceOf(SpinDataFormatException.class);
-    assertThatThrownBy(() -> S(EXAMPLE_INVALID_JSON, json), "Expected SpinDataFormatException")
-        .isInstanceOf(SpinDataFormatException.class);
-    assertThatThrownBy(() -> S(EXAMPLE_INVALID_JSON, DataFormats.JSON_DATAFORMAT_NAME), "Expected SpinDataFormatException")
-        .isInstanceOf(SpinDataFormatException.class);
-    assertThatThrownBy(() -> S(EXAMPLE_INVALID_JSON), "Expected SpinDataFormatException")
-        .isInstanceOf(SpinDataFormatException.class);
+    assertThatThrownBy(() -> JSON(EXAMPLE_INVALID_JSON)).isInstanceOf(SpinDataFormatException.class);
+    assertThatThrownBy(() -> S(EXAMPLE_INVALID_JSON, json)).isInstanceOf(SpinDataFormatException.class);
+    assertThatThrownBy(() -> S(EXAMPLE_INVALID_JSON, DataFormats.JSON_DATAFORMAT_NAME)).isInstanceOf(SpinDataFormatException.class);
+    assertThatThrownBy(() -> S(EXAMPLE_INVALID_JSON)).isInstanceOf(SpinDataFormatException.class);
   }
 
   @Test
   void shouldFailForEmptyString() {
     var json = json();
-    assertThatThrownBy(() -> JSON(EXAMPLE_EMPTY_STRING), "Expected SpinDataFormatException")
-        .isInstanceOf(SpinDataFormatException.class);
-    assertThatThrownBy(() -> S(EXAMPLE_EMPTY_STRING, json), "Expected SpinDataFormatException")
-        .isInstanceOf(SpinDataFormatException.class);
-    assertThatThrownBy(() -> S(EXAMPLE_EMPTY_STRING, DataFormats.JSON_DATAFORMAT_NAME), "Expected SpinDataFormatException")
-        .isInstanceOf(SpinDataFormatException.class);
-    assertThatThrownBy(() -> S(EXAMPLE_EMPTY_STRING), "Expected SpinDataFormatException")
-        .isInstanceOf(SpinDataFormatException.class);
+    assertThatThrownBy(() -> JSON(EXAMPLE_EMPTY_STRING)).isInstanceOf(SpinDataFormatException.class);
+    assertThatThrownBy(() -> S(EXAMPLE_EMPTY_STRING, json)).isInstanceOf(SpinDataFormatException.class);
+    assertThatThrownBy(() -> S(EXAMPLE_EMPTY_STRING, DataFormats.JSON_DATAFORMAT_NAME)).isInstanceOf(SpinDataFormatException.class);
+    assertThatThrownBy(() -> S(EXAMPLE_EMPTY_STRING)).isInstanceOf(SpinDataFormatException.class);
   }
 
   @Test
@@ -147,18 +128,15 @@ class JsonTreeCreateTest {
     var json = json();
 
     try (Reader input1 = stringAsReader(EXAMPLE_EMPTY_STRING)) {
-      assertThatThrownBy(() -> JSON(input1), "Expected SpinDataFormatException")
-          .isInstanceOf(SpinDataFormatException.class);
+      assertThatThrownBy(() -> JSON(input1)).isInstanceOf(SpinDataFormatException.class);
     }
 
     try (Reader input2 = stringAsReader(EXAMPLE_EMPTY_STRING)) {
-      assertThatThrownBy(() -> S(input2, json), "Expected SpinDataFormatException")
-          .isInstanceOf(SpinDataFormatException.class);
+      assertThatThrownBy(() -> S(input2, json)).isInstanceOf(SpinDataFormatException.class);
     }
 
     try (Reader input3 = stringAsReader(EXAMPLE_EMPTY_STRING)) {
-      assertThatThrownBy(() -> S(input3), "Expected SpinDataFormatException")
-          .isInstanceOf(SpinDataFormatException.class);
+      assertThatThrownBy(() -> S(input3)).isInstanceOf(SpinDataFormatException.class);
     }
   }
 
@@ -188,7 +166,6 @@ class JsonTreeCreateTest {
 
   @Test
   void shouldFailForUnescapedString() {
-    assertThatThrownBy(() -> JSON("a String"), "expected exception")
-        .isInstanceOf(SpinDataFormatException.class);
+    assertThatThrownBy(() -> JSON("a String")).isInstanceOf(SpinDataFormatException.class);
   }
 }

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeCreateTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/JsonTreeCreateTest.java
@@ -94,7 +94,7 @@ class JsonTreeCreateTest {
     assertThatThrownBy(() -> S(jsonNode)).isInstanceOf(IllegalArgumentException.class);
 
     Reader reader = null;
-    assertThatThrownBy(() -> JSON(jsonNode)).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> JSON(reader)).isInstanceOf(IllegalArgumentException.class);
     assertThatThrownBy(() -> S(reader, json)).isInstanceOf(IllegalArgumentException.class);
     assertThatThrownBy(() -> S(reader)).isInstanceOf(IllegalArgumentException.class);
 

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/type/JsonJacksonTreeTypeDetectionTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/type/JsonJacksonTreeTypeDetectionTest.java
@@ -23,15 +23,15 @@ import org.operaton.spin.impl.json.jackson.format.SetJacksonJsonTypeDetector;
 import org.operaton.spin.json.mapping.Customer;
 import org.operaton.spin.json.mapping.RegularCustomer;
 import org.operaton.spin.spi.DataFormatMapper;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.spin.DataFormats.json;
 
 import java.util.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 class JsonJacksonTreeTypeDetectionTest {
 
@@ -136,15 +136,9 @@ class JsonJacksonTreeTypeDetectionTest {
 
   @Test
   void shouldHandleNullParameter() {
-    // given
     DataFormatMapper mapper = json().getMapper();
-    // when, then
-    try {
-      mapper.getCanonicalTypeName(null);
-      fail("Expected IllegalArgumentException");
-    } catch (IllegalArgumentException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> mapper.getCanonicalTypeName(null), "Expected IllegalArgumentException")
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/type/JsonJacksonTreeTypeDetectionTest.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/tree/type/JsonJacksonTreeTypeDetectionTest.java
@@ -137,8 +137,7 @@ class JsonJacksonTreeTypeDetectionTest {
   @Test
   void shouldHandleNullParameter() {
     DataFormatMapper mapper = json().getMapper();
-    assertThatThrownBy(() -> mapper.getCanonicalTypeName(null), "Expected IllegalArgumentException")
-        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> mapper.getCanonicalTypeName(null)).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/csrf/it/CsrfPreventionIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/csrf/it/CsrfPreventionIT.java
@@ -32,7 +32,6 @@ import org.springframework.test.annotation.DirtiesContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 @SpringBootTest(classes = { FilterTestApp.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {"server.error.include-message=always"})
@@ -84,12 +83,11 @@ class CsrfPreventionIT {
             "/operaton/api/admin/auth/user/default/login/welcome", "Content-Type",
         "application/x-www-form-urlencoded");
 
-    assertThatThrownBy(urlConnection::getContent, "Exception expected!")
+    assertThatThrownBy(urlConnection::getContent)
         .isInstanceOf(IOException.class)
         .hasMessageContaining("Server returned HTTP response code: 403 for URL");
     assertThat(httpClientExtension.getHeaderXsrfToken()).isEqualTo("Required");
     assertThat(httpClientExtension.getErrorResponseContent()).contains("CSRFPreventionFilter: Token provided via HTTP Header is absent/empty.");
-
   }
 
 }

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/csrf/it/CsrfPreventionIT.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/csrf/it/CsrfPreventionIT.java
@@ -31,6 +31,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.annotation.DirtiesContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 @SpringBootTest(classes = { FilterTestApp.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -79,22 +80,15 @@ class CsrfPreventionIT {
 
   @Test
   void shouldRejectModifyingRequest() {
-    // given
-
-    // when
     URLConnection urlConnection = httpClientExtension.performPostRequest("http://localhost:" + port +
             "/operaton/api/admin/auth/user/default/login/welcome", "Content-Type",
         "application/x-www-form-urlencoded");
 
-    try {
-      urlConnection.getContent();
-      fail("Exception expected!");
-    } catch (IOException e) {
-      // then
-      assertThat(e).hasMessageContaining("Server returned HTTP response code: 403 for URL");
-      assertThat(httpClientExtension.getHeaderXsrfToken()).isEqualTo("Required");
-      assertThat(httpClientExtension.getErrorResponseContent()).contains("CSRFPreventionFilter: Token provided via HTTP Header is absent/empty.");
-    }
+    assertThatThrownBy(urlConnection::getContent, "Exception expected!")
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Server returned HTTP response code: 403 for URL");
+    assertThat(httpClientExtension.getHeaderXsrfToken()).isEqualTo("Required");
+    assertThat(httpClientExtension.getErrorResponseContent()).contains("CSRFPreventionFilter: Token provided via HTTP Header is absent/empty.");
 
   }
 

--- a/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/OperatonNoJpaAutoConfigurationIT.java
+++ b/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/OperatonNoJpaAutoConfigurationIT.java
@@ -56,7 +56,7 @@ class OperatonNoJpaAutoConfigurationIT extends AbstractOperatonAutoConfiguration
     TestEntity testEntity = testEntityRepository.save(new TestEntity());
     Map<String, Object> variables = new HashMap<>();
     variables.put("test", testEntity);
-    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("TestProcess", variables), "")
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("TestProcess", variables), "ProcessEngineException is expected when JPA is disabled.")
         .isInstanceOf(ProcessEngineException.class);
   }
 

--- a/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/OperatonNoJpaAutoConfigurationIT.java
+++ b/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/OperatonNoJpaAutoConfigurationIT.java
@@ -57,7 +57,6 @@ class OperatonNoJpaAutoConfigurationIT extends AbstractOperatonAutoConfiguration
     Map<String, Object> variables = new HashMap<>();
     variables.put("test", testEntity);
     assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("TestProcess", variables), "")
-        .isNotNull()
         .isInstanceOf(ProcessEngineException.class);
   }
 

--- a/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/OperatonNoJpaAutoConfigurationIT.java
+++ b/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/OperatonNoJpaAutoConfigurationIT.java
@@ -32,8 +32,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ActiveProfiles;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 @SpringBootTest(classes = {TestApplication.class},
   webEnvironment = WebEnvironment.NONE,
@@ -56,12 +56,9 @@ class OperatonNoJpaAutoConfigurationIT extends AbstractOperatonAutoConfiguration
     TestEntity testEntity = testEntityRepository.save(new TestEntity());
     Map<String, Object> variables = new HashMap<>();
     variables.put("test", testEntity);
-    try {
-      runtimeService.startProcessInstanceByKey("TestProcess", variables);
-      fail("");
-    } catch (ProcessEngineException e) {
-      assertThat(e).isNotNull();
-    }
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("TestProcess", variables), "")
+        .isNotNull()
+        .isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCalledProcessInstanceTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsCalledProcessInstanceTest.java
@@ -19,6 +19,8 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.assertions.helpers.ProcessAssertTestCase;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.test.assertions.bpmn.BpmnAwareTests.*;
 
 import org.junit.jupiter.api.Test;
@@ -97,12 +99,8 @@ class ProcessEngineTestsCalledProcessInstanceTest extends ProcessAssertTestCase 
   }
 
   private void assertFailureOnCalledProcessInstance(Runnable runnable) {
-    try {
-      runnable.run();
-      fail("call to calledProcessInstance() should have thrown an error");
-    } catch (IllegalStateException iae) {
-      // expected
-    }
+    assertThatThrownBy(runnable::run, "call to calledProcessInstance() should have thrown an error")
+        .isInstanceOf(IllegalStateException.class);
   }
 
   @Test

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsTest.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.test.assertions.bpmn;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.test.assertions.bpmn.AbstractAssertions.init;
 import static org.operaton.bpm.engine.test.assertions.bpmn.AbstractAssertions.processEngine;
@@ -111,14 +112,9 @@ class ProcessEngineTestsTest {
     // Given
     processEnginesMockedStatic.when(ProcessEngines::getProcessEngines).thenReturn(new HashMap<String,ProcessEngine>());
     reset();
-    try {
-      // When
-      processEngine();
-      fail("Process engine should not be initialized");
-    } catch (IllegalStateException e) {
-      // Then
-      assertThat(e).hasMessage("No ProcessEngine found to be registered with ProcessEngines!");
-    }
+    assertThatThrownBy(AbstractAssertions::processEngine, "Process engine should not be initialized")
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("No ProcessEngine found to be registered with ProcessEngines!");
   }
 
   @Test
@@ -129,14 +125,9 @@ class ProcessEngineTestsTest {
     multipleEnginesMap.put("test2", mock(ProcessEngine.class));
     processEnginesMockedStatic.when(ProcessEngines::getProcessEngines).thenReturn(multipleEnginesMap);
     reset();
-    try {
-      // When
-      processEngine();
-      fail("Process engine should not be initialized");
-    } catch (IllegalStateException e) {
-      // Then
-      assertThat(e).hasMessage("2 ProcessEngines initialized. Call BpmnAwareTests.init(ProcessEngine processEngine) first!");
-    }
+    assertThatThrownBy(AbstractAssertions::processEngine, "Process engine should not be initialized")
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("2 ProcessEngines initialized. Call BpmnAwareTests.init(ProcessEngine processEngine) first!");
   }
 
   @Test

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsTest.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.test.assertions.bpmn;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 import static org.operaton.bpm.engine.test.assertions.bpmn.AbstractAssertions.init;
 import static org.operaton.bpm.engine.test.assertions.bpmn.AbstractAssertions.processEngine;
 import static org.operaton.bpm.engine.test.assertions.bpmn.AbstractAssertions.reset;

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsWithVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsWithVariablesTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 public class ProcessEngineTestsWithVariablesTest {
 
@@ -88,7 +87,7 @@ public class ProcessEngineTestsWithVariablesTest {
     // Given we replace the last key with its integer value
     keys.set(keys.size() - 1, values.get(values.size() - 1));
     // When we construct the variables map, we expect an exception to be thrown
-    assertThatThrownBy(() -> returnedMap(keys, values), "IllegalArgumentException or AssertionError expected!")
+    assertThatThrownBy(() -> returnedMap(keys, values), "ClassCastException, IllegalArgumentException or AssertionError expected!")
         .isInstanceOfAny(ClassCastException.class, IllegalArgumentException.class, AssertionError.class);
   }
 
@@ -99,7 +98,7 @@ public class ProcessEngineTestsWithVariablesTest {
     // Given we replace the last key with a null pointer
     keys.set(keys.size() - 1, null);
     // When we construct the variables map, we expect an exception to be thrown
-    assertThatThrownBy(() -> returnedMap(keys, values), "IllegalArgumentException expected!")
+    assertThatThrownBy(() -> returnedMap(keys, values), "IllegalArgumentException or AssertionError expected!")
         .isInstanceOfAny(IllegalArgumentException.class, AssertionError.class);
   }
 

--- a/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsWithVariablesTest.java
+++ b/test-utils/assert/core/src/test/java/org/operaton/bpm/engine/test/assertions/bpmn/ProcessEngineTestsWithVariablesTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 public class ProcessEngineTestsWithVariablesTest {
@@ -86,15 +87,9 @@ public class ProcessEngineTestsWithVariablesTest {
     initProcessEngineTestsWithVariablesTest(key1, value1, key2, value2, key3, value3);
     // Given we replace the last key with its integer value
     keys.set(keys.size() - 1, values.get(values.size() - 1));
-    // When we construct the variables map
-    try {
-      returnedMap(keys, values);
-      // Then we expect an exception to be thrown
-    } catch (Throwable t) {
-      assertThat(t).isInstanceOfAny(ClassCastException.class, IllegalArgumentException.class, AssertionError.class);
-      return;
-    }
-    fail("IllegalArgumentException or AssertionError expected!");
+    // When we construct the variables map, we expect an exception to be thrown
+    assertThatThrownBy(() -> returnedMap(keys, values), "IllegalArgumentException or AssertionError expected!")
+        .isInstanceOfAny(ClassCastException.class, IllegalArgumentException.class, AssertionError.class);
   }
 
   @MethodSource("data")
@@ -103,15 +98,9 @@ public class ProcessEngineTestsWithVariablesTest {
     initProcessEngineTestsWithVariablesTest(key1, value1, key2, value2, key3, value3);
     // Given we replace the last key with a null pointer
     keys.set(keys.size() - 1, null);
-    // When we construct the variables map
-    try {
-      returnedMap(keys, values);
-      // Then we expect an exception to be thrown
-    } catch (Throwable t) {
-      assertThat(t).isInstanceOfAny(IllegalArgumentException.class, AssertionError.class);
-      return;
-    }
-    fail("IllegalArgumentException expected!");
+    // When we construct the variables map, we expect an exception to be thrown
+    assertThatThrownBy(() -> returnedMap(keys, values), "IllegalArgumentException expected!")
+        .isInstanceOfAny(IllegalArgumentException.class, AssertionError.class);
   }
 
   @MethodSource("data")


### PR DESCRIPTION
Replace try/catch with expected failure in test code

- this is one of the multiple future PR's coming for this feature 

related to #564