### PR TITLE
chore: upgrade scala-feel from 1.19.1 to 1.19.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <version.mybatis>3.5.19</version.mybatis>
     <version.joda-time>2.12.5</version.joda-time>
     <version.uuid-generator>5.1.0</version.uuid-generator>
-    <version.feel-scala>1.19.1</version.feel-scala>
+    <version.feel-scala>1.19.3</version.feel-scala>
     <version.quarkus>3.23.0</version.quarkus>
     <version.java>17</version.java>
     <version.spring-boot>3.5.3</version.spring-boot>


### PR DESCRIPTION
### 📄 Summary

Updated the `scala-feel` engine dependency from version `1.19.1` to `1.19.3`.

### 🔗 Related Issues

Closes #967

### 📌 Motivation and Context

Keeping dependencies up to date ensures compatibility with the latest features, bug fixes, and improved FEEL expression evaluation.

### 🛠️ Implementation Details

- Updated `pom.xml` to use `scala-feel` version `1.19.3`
- Verified successful build and runtime behavior after the upgrade
- Confirmed no regressions in FEEL evaluation logic

### 🖼️ Screenshots or Logs (if applicable)

_Not applicable_

### 💥 Breaking Changes?

- [ ] Yes
- [x] No

---

### ✅ Pull Request Checklist

#### 📋 Administrative
- [x] I have read and followed the [contribution guidelines](https://github.com/operaton/operaton/blob/main/CONTRIBUTING.md)
- [x] I confirm that my contribution complies with the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) and the [Code of Conduct](https://github.com/operaton/operaton/blob/main/CODE_OF_CONDUCT.md)
- [x] I confirm that I own the copyright of the code submitted and I license it under the Apache License 2.0
- [x] This PR references an issue (e.g., `Fixes #123`)

#### 🔧 Code Quality
- [x] Java code is formatted correctly
- [x] No unrelated code changes, reformatting, or refactoring are included

#### 🧪 Testing
- [x] I have read and followed the [Testing Guidelines](https://github.com/operaton/operaton/blob/main/TESTING.md)
- [x] `mvn clean test` passes all unit tests

#### 🧹 Project Hygiene
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Branch is up to date with `main`

---

### 🧭 Change Type

Please select the type of change this PR introduces:

- [ ] 🐛 Bugfix
- [ ] ✨ Feature
- [ ] 💄 Code style update (formatting, renaming)
- [ ] 🔨 Refactoring (no functional or API changes)
- [x] 🏗 Build-related changes
- [ ] 📝 Documentation content changes
- [ ] 🔧 Other (please describe):

<!-- e.g., internal tooling, test configuration -->
