### PR TITLE
fix(build): Do not fail the Publish job when cache delete fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,9 @@ jobs:
           TOMCAT_VERSION=$(xq --xpath project/properties/version.tomcat parent/pom.xml)
           echo "PROJECT_VERSION=$PROJECT_VERSION" >> $GITHUB_ENV
           echo "TOMCAT_VERSION=$TOMCAT_VERSION" >> $GITHUB_ENV
-          gh cache delete ${{ github.run_id }}-build-artifacts
+      - name: Delete build cache
+        continue-on-error: true
+        run: gh cache delete ${{ github.run_id }}-build-artifacts
       - name: Upload distro Tomcat
         id: upload-distro-tomcat
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
On user forks the "gh cache delete" action may fail due to lack of permission.

related to #915