### PR TITLE
fix(tests): Fix execution of JUnit 4 based tests

### DIFF
--- a/engine-plugins/identity-ldap/pom.xml
+++ b/engine-plugins/identity-ldap/pom.xml
@@ -59,6 +59,13 @@
           <trimStackTrace>false</trimStackTrace>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit47</artifactId>
+            <version>3.5.2</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
The JUnit 4 based tests of the module have not been executed because surefire is executed with junit-platform provider by default. Adding the dependency to surefire-junit47 resolves this.

closes #996