### PR TITLE
refactor: use isEmpty() to check whether a StringBuilder is empty or not

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/application/ProcessApplicationManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/application/ProcessApplicationManager.java
@@ -270,7 +270,7 @@ public class ProcessApplicationManager {
   public String getRegistrationSummary() {
     StringBuilder builder = new StringBuilder();
     for (Entry<String, DefaultProcessApplicationRegistration> entry : registrationsByDeploymentId.entrySet()) {
-      if(builder.length()>0) {
+      if(!builder.isEmpty()) {
         builder.append(", ");
       }
       builder.append(entry.getKey());

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/BpmnParse.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/BpmnParse.java
@@ -2055,7 +2055,7 @@ public class BpmnParse extends Parse {
 
     StringBuilder builder = new StringBuilder();
     for (String e : docStrings) {
-      if (builder.length() != 0) {
+      if (!builder.isEmpty()) {
         builder.append("\n\n");
       }
 
@@ -3037,7 +3037,7 @@ public class BpmnParse extends Parse {
         character = iterator.next();
       }
 
-      if (stringBuilder.length() > 0) {
+      if (!stringBuilder.isEmpty()) {
         result.add(stringBuilder.toString().trim());
       }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/handler/ItemHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/handler/ItemHandler.java
@@ -700,7 +700,7 @@ public abstract class ItemHandler extends CmmnElementHandler<CmmnElement, CmmnAc
         continue;
       }
 
-      if (builder.length() != 0) {
+      if (!builder.isEmpty()) {
         builder.append("\n\n");
       }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/database/PurgeDatabaseTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/database/PurgeDatabaseTest.java
@@ -98,7 +98,7 @@ public class PurgeDatabaseTest extends AbstractFoxPlatformIntegrationTest {
       }
     }
 
-    if (outputMessage.length() > 0) {
+    if (!outputMessage.isEmpty()) {
       outputMessage.insert(0, "DB NOT CLEAN: \n");
       /** skip drop and recreate if a table prefix is used */
       if (databaseTablePrefix.isEmpty()) {

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/Authorization.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/filter/Authorization.java
@@ -100,7 +100,7 @@ public class Authorization {
 
     for (Object o: collection) {
 
-      if (builder.length() > 0) {
+      if (!builder.isEmpty()) {
         builder.append(delimiter);
       }
 


### PR DESCRIPTION
Refactors the logic behind checking whether a StringBuilder is empty, by using `isEmpty()`

Closes #1003 

