### PR TITLE
build(wildfly): Remove /lib folder from distro

### DIFF
--- a/distro/wildfly/assembly/assembly.xml
+++ b/distro/wildfly/assembly/assembly.xml
@@ -36,31 +36,6 @@
         </excludes>
       </unpackOptions>
     </dependencySet>
-    <dependencySet>
-      <outputDirectory>lib</outputDirectory>
-      <includes>
-        <include>org.operaton.bpm.jakartaee:operaton-ejb-client:jar:${project.version}</include>
-        <include>org.operaton.bpm:*</include>
-        <include>org.operaton.bpm.identity:*</include>
-        <include>org.operaton.bpm.model:*</include>
-        <include>org.operaton.bpm.juel:*</include>
-        <include>org.mybatis:mybatis:jar:*</include>
-        <include>com.fasterxml.uuid:java-uuid-generator:jar:*</include>
-        <include>joda-time:joda-time:jar:*</include>
-        <include>org.apache.groovy:groovy:jar:*</include>
-        <include>org.apache.groovy:groovy-jsr223:jar:*</include>
-        <include>org.apache.groovy:groovy-json:jar:*</include>
-        <include>org.apache.groovy:groovy-xml:jar:*</include>
-        <include>org.apache.groovy:groovy-templates:jar:*</include>
-        <include>org.apache.groovy:groovy-dateutil:jar:*</include>
-        <include>org.apache.groovy:groovy-datetime:jar:*</include>
-        <include>org.graalvm.js:*</include>
-        <include>org.graalvm.regex:regex:jar:*</include>
-        <include>org.graalvm.truffle:truffle-api:jar:*</include>
-        <include>org.graalvm.sdk:graal-sdk:jar:*</include>
-        <include>com.ibm.icu:icu4j:jar:*</include>
-      </includes>
-    </dependencySet>
   </dependencySets>
   <fileSets>
     <fileSet>


### PR DESCRIPTION
The /lib folder in the distribution contains redundant libraries, which are already included in the distro in modules.

Reduces the size of the tar.gz file from 451 MB to 415 MB (-46 MB).