### PR TITLE
chore(deps): Pin Groovy version for Wildfly modules

### DIFF
--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -18,6 +18,17 @@
     <!-- json-smart and accessors-smart are runtime dependencies of json-path -->
     <third-party-bom-scopes>compile|runtime</third-party-bom-scopes>
   </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.groovy</groupId>
+        <artifactId>groovy-bom</artifactId>
+        <version>${version.groovy}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.operaton.bpm.wildfly</groupId>


### PR DESCRIPTION
Import the Groovy BOM for dependency management. This overloads implicit behaviour that could lead for pulling a newer Groovy version than defined by parent/pom.xml.

closes #1049