### PR TITLE
Fix typo: rename 'tenand' to 'tenant' across codebase

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/decision-definition/key/{key}/tenant-id/{tenant-id}/evaluate/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/decision-definition/key/{key}/tenant-id/{tenant-id}/evaluate/post.ftl
@@ -30,7 +30,7 @@
         mediaType = "application/json"
         dto = "EvaluateDecisionDto"
         examples = [ '"example-1": {
-                       "summary": "POST /decision-definition/key/aKey/tenand-id/aTenantId/evaluate",
+                       "summary": "POST /decision-definition/key/aKey/tenant-id/aTenantId/evaluate",
                        "value": {
                          "variables" : {
                            "amount" : { "value" : 600, "type" : "Double" },
@@ -49,7 +49,7 @@
         desc = "Request successful."
         examples = ['"example-1": {
                        "summary": "Status 200 response",
-                       "description": "Response for POST `/decision-definition/akey/aKey/tenand-id/aTenantId/evaluate`",
+                       "description": "Response for POST `/decision-definition/akey/aKey/tenant-id/aTenantId/evaluate`",
                        "value": [
                          {
                            "result": { "value" : "management", "type" : "String", "valueInfo" : null }

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/process-definition/key/{key}/tenant-id/{tenant-id}/rendered-form/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/process-definition/key/{key}/tenant-id/{tenant-id}/rendered-form/get.ftl
@@ -36,7 +36,7 @@
         desc = "Request successful."
         examples = ['"example-1": {
                        "summary": "Status 200 Response",
-                       "description": "A `/process-definition/key/anKey/tenand-id/aTenantId/rendered-form` HTML
+                       "description": "A `/process-definition/key/anKey/tenant-id/aTenantId/rendered-form` HTML
                                        GET response body providing the rendered (generated) form content.",
                        "value": "<form class=\\"form-horizontal\\">
                                   <div class=\\"control-group\\">

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/cmd/EvaluateDecisionCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/cmd/EvaluateDecisionCmd.java
@@ -48,7 +48,7 @@ public class EvaluateDecisionCmd implements Command<DmnDecisionResult> {
   protected Integer version;
   protected VariableMap variables;
   protected String decisionDefinitionTenantId;
-  protected boolean isTenandIdSet;
+  protected boolean isTenantIdSet;
 
   public EvaluateDecisionCmd(DecisionEvaluationBuilderImpl builder) {
     this.decisionDefinitionKey = builder.getDecisionDefinitionKey();
@@ -56,7 +56,7 @@ public class EvaluateDecisionCmd implements Command<DmnDecisionResult> {
     this.version = builder.getVersion();
     this.variables = Variables.fromMap(builder.getVariables());
     this.decisionDefinitionTenantId = builder.getDecisionDefinitionTenantId();
-    this.isTenandIdSet = builder.isTenantIdSet();
+    this.isTenantIdSet = builder.isTenantIdSet();
   }
 
   @Override
@@ -108,16 +108,16 @@ public class EvaluateDecisionCmd implements Command<DmnDecisionResult> {
   protected DecisionDefinition findByKey(DeploymentCache deploymentCache) {
     DecisionDefinition decisionDefinition = null;
 
-    if (version == null && !isTenandIdSet) {
+    if (version == null && !isTenantIdSet) {
       decisionDefinition = deploymentCache.findDeployedLatestDecisionDefinitionByKey(decisionDefinitionKey);
     }
-    else if (version == null && isTenandIdSet) {
+    else if (version == null && isTenantIdSet) {
       decisionDefinition = deploymentCache.findDeployedLatestDecisionDefinitionByKeyAndTenantId(decisionDefinitionKey, decisionDefinitionTenantId);
     }
-    else if (version != null && !isTenandIdSet) {
+    else if (version != null && !isTenantIdSet) {
       decisionDefinition = deploymentCache.findDeployedDecisionDefinitionByKeyAndVersion(decisionDefinitionKey, version);
     }
-    else if (version != null && isTenandIdSet) {
+    else if (version != null && isTenantIdSet) {
       decisionDefinition = deploymentCache.findDeployedDecisionDefinitionByKeyVersionAndTenantId(decisionDefinitionKey, version, decisionDefinitionTenantId);
     }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/cmd/EvaluateDecisionTableCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/cmd/EvaluateDecisionTableCmd.java
@@ -50,7 +50,7 @@ public class EvaluateDecisionTableCmd implements Command<DmnDecisionTableResult>
   protected Integer version;
   protected VariableMap variables;
   protected String decisionDefinitionTenantId;
-  protected boolean isTenandIdSet;
+  protected boolean isTenantIdSet;
 
   public EvaluateDecisionTableCmd(DecisionTableEvaluationBuilderImpl builder) {
     this.decisionDefinitionKey = builder.getDecisionDefinitionKey();
@@ -58,7 +58,7 @@ public class EvaluateDecisionTableCmd implements Command<DmnDecisionTableResult>
     this.version = builder.getVersion();
     this.variables = Variables.fromMap(builder.getVariables());
     this.decisionDefinitionTenantId = builder.getDecisionDefinitionTenantId();
-    this.isTenandIdSet = builder.isTenantIdSet();
+    this.isTenantIdSet = builder.isTenantIdSet();
   }
 
   @Override
@@ -110,16 +110,16 @@ public class EvaluateDecisionTableCmd implements Command<DmnDecisionTableResult>
   protected DecisionDefinition findByKey(DeploymentCache deploymentCache) {
     DecisionDefinition decisionDefinition = null;
 
-    if (version == null && !isTenandIdSet) {
+    if (version == null && !isTenantIdSet) {
       decisionDefinition = deploymentCache.findDeployedLatestDecisionDefinitionByKey(decisionDefinitionKey);
     }
-    else if (version == null && isTenandIdSet) {
+    else if (version == null && isTenantIdSet) {
       decisionDefinition = deploymentCache.findDeployedLatestDecisionDefinitionByKeyAndTenantId(decisionDefinitionKey, decisionDefinitionTenantId);
     }
-    else if (version != null && !isTenandIdSet) {
+    else if (version != null && !isTenantIdSet) {
       decisionDefinition = deploymentCache.findDeployedDecisionDefinitionByKeyAndVersion(decisionDefinitionKey, version);
     }
-    else if (version != null && isTenandIdSet) {
+    else if (version != null && isTenantIdSet) {
       decisionDefinition = deploymentCache.findDeployedDecisionDefinitionByKeyVersionAndTenantId(decisionDefinitionKey, version, decisionDefinitionTenantId);
     }
 

--- a/webapps/frontend/ui/tasklist/tests/specs/process-start-spec.js
+++ b/webapps/frontend/ui/tasklist/tests/specs/process-start-spec.js
@@ -376,7 +376,7 @@ describe.skip('Tasklist Start Spec', function() {
       });
     });
 
-    it('should display the tenand id of process definitions', function() {
+    it('should display the tenant id of process definitions', function() {
       // when
       dashboardPage.startProcess.openStartDialog();
 


### PR DESCRIPTION
Hi! This is my first contribution to the project. 

I found and fixed the typo "tenand" → "tenant" in 16 places across 5 files as requested in issue #1054.

The changes include:
- Variable names in Java files
- Test descriptions 
- API documentation URLs

I confirm that my contribution and following ones comply with the Apache License 2.0 and the Code of Conduct.

Fixes #1054