### PR TITLE
build(deps): Upgrade to Tomcat 11.0.10

### DIFF
--- a/.github/jreleaser/changelog.tpl
+++ b/.github/jreleaser/changelog.tpl
@@ -46,16 +46,17 @@ The Wildfly distribution has been upgraded to Wildfly 36.0.1.
 
 Operaton uses the following versions of its dependencies:
 
-| Dependency | Version |
-|------------|---------|
-| Java       | 17      |
-| Spring Boot | 3.5.3  |
-| Wildfly    | 36.0.1  |
-| Tomcat    | 11.0.9  |
-| Jakarta EE | 10.0.0 |
-| BPMN       | 2.0     |
-| DMN        | 1.3     |
-| CMMN       | 1.1    |
+| Dependency  | Version |
+|-------------|---------|
+| Java        | 17      |
+| Spring Boot | 3.5.4   |
+| Spring      | 6.2.9   |
+| Wildfly     | 36.0.1  |
+| Tomcat      | 11.0.10 |
+| Jakarta EE  | 10.0.0  |
+| BPMN        | 2.0     |
+| DMN         | 1.3     |
+| CMMN        | 1.1     |
 
 {{changelogContributors}}
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -43,7 +43,7 @@
     <!-- application servers -->
     <version.wildfly>36.0.1.Final</version.wildfly>
     <version.wildfly.core>28.0.1.Final</version.wildfly.core>
-    <version.tomcat>11.0.9</version.tomcat>
+    <version.tomcat>11.0.10</version.tomcat>
     <version.arquillian>1.10.0.Final</version.arquillian>
     <version.shrinkwrap.resolvers>3.3.3</version.shrinkwrap.resolvers>
     <version.selenium>4.31.0</version.selenium>


### PR DESCRIPTION
Resolves CVE-2025-48989

closes #1064 