### PR TITLE
Backport 694726279a (prepare codebase for db 7.24.0 / 1.0.0-rc-1 development)

### DIFF
--- a/connect/pom.xml
+++ b/connect/pom.xml
@@ -13,7 +13,7 @@
   <name>Operaton - Connect - Root</name>
   <description>${project.name}</description>
   <properties>
-    <connect.version.old>7.22.0</connect.version.old>
+    <connect.version.old>1.0.0-beta-5</connect.version.old>
     <maven-bundle-plugin.version>5.1.1</maven-bundle-plugin.version>
     <license.includeTransitiveDependencies>false</license.includeTransitiveDependencies>
     <additionalparam>-Xdoclint:none</additionalparam>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -27,7 +27,6 @@
     <version.db2-11.5>11.5.9.0</version.db2-11.5>
     <version.db2>12.1.2.0</version.db2>
     <version.postgresql>42.7.7</version.postgresql>
-    <version.liquibase>4.32.0</version.liquibase>
     <operaton.dbscheme.current.version>7.24.0</operaton.dbscheme.current.version>
 
     <!-- needed for sql script and backward compatibility checks -->

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -27,11 +27,12 @@
     <version.db2-11.5>11.5.9.0</version.db2-11.5>
     <version.db2>12.1.2.0</version.db2>
     <version.postgresql>42.7.7</version.postgresql>
-    <operaton.dbscheme.current.version>7.23.1</operaton.dbscheme.current.version>
+    <version.liquibase>4.32.0</version.liquibase>
+    <operaton.dbscheme.current.version>7.24.0</operaton.dbscheme.current.version>
 
     <!-- needed for sql script and backward compatibility checks -->
-    <operaton.dbscheme.previous.artifactVersion>1.0.0-beta-2</operaton.dbscheme.previous.artifactVersion>
-    <operaton.dbscheme.previous.version>7.22.0</operaton.dbscheme.previous.version>
+    <operaton.dbscheme.previous.artifactVersion>1.0.0-beta-5</operaton.dbscheme.previous.artifactVersion>
+    <operaton.dbscheme.previous.version>7.23.1</operaton.dbscheme.previous.version>
 
     <!-- Testcontainers JDBC URL parameters. By default, an empty string -->
     <database.tc.params>TC_DAEMON=true</database.tc.params>

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.db2.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.db2.create.engine.sql
@@ -66,7 +66,7 @@ create table ACT_GE_SCHEMA_LOG (
 );
 
 insert into ACT_GE_SCHEMA_LOG
-values ('0', CURRENT_TIMESTAMP, '7.23.0');
+values ('0', CURRENT_TIMESTAMP, '7.24.0');
 
 create table ACT_RE_DEPLOYMENT (
     ID_ varchar(64) not null,

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.h2.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.h2.create.engine.sql
@@ -66,7 +66,7 @@ create table ACT_GE_SCHEMA_LOG (
 );
 
 insert into ACT_GE_SCHEMA_LOG
-values ('0', CURRENT_TIMESTAMP, '7.23.0');
+values ('0', CURRENT_TIMESTAMP, '7.24.0');
 
 create table ACT_RE_DEPLOYMENT (
     ID_ varchar(64),

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.mariadb.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.mariadb.create.engine.sql
@@ -66,7 +66,7 @@ create table ACT_GE_SCHEMA_LOG (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_bin;
 
 insert into ACT_GE_SCHEMA_LOG
-values ('0', CURRENT_TIMESTAMP, '7.23.0');
+values ('0', CURRENT_TIMESTAMP, '7.24.0');
 
 create table ACT_RE_DEPLOYMENT (
     ID_ varchar(64),

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.mssql.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.mssql.create.engine.sql
@@ -66,7 +66,7 @@ create table ACT_GE_SCHEMA_LOG (
 );
 
 insert into ACT_GE_SCHEMA_LOG
-values ('0', CURRENT_TIMESTAMP, '7.23.0');
+values ('0', CURRENT_TIMESTAMP, '7.24.0');
 
 create table ACT_RE_DEPLOYMENT (
     ID_ nvarchar(64),

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.mysql.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.mysql.create.engine.sql
@@ -66,7 +66,7 @@ create table ACT_GE_SCHEMA_LOG (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_bin;
 
 insert into ACT_GE_SCHEMA_LOG
-values ('0', CURRENT_TIMESTAMP, '7.23.0');
+values ('0', CURRENT_TIMESTAMP, '7.24.0');
 
 create table ACT_RE_DEPLOYMENT (
     ID_ varchar(64),

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.oracle.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.oracle.create.engine.sql
@@ -66,7 +66,7 @@ create table ACT_GE_SCHEMA_LOG (
 );
 
 insert into ACT_GE_SCHEMA_LOG
-values ('0', CURRENT_TIMESTAMP, '7.23.0');
+values ('0', CURRENT_TIMESTAMP, '7.24.0');
 
 create table ACT_RE_DEPLOYMENT (
     ID_ NVARCHAR2(64),

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.postgres.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/create/activiti.postgres.create.engine.sql
@@ -66,7 +66,7 @@ create table ACT_GE_SCHEMA_LOG (
 );
 
 insert into ACT_GE_SCHEMA_LOG
-values ('0', CURRENT_TIMESTAMP, '7.23.0');
+values ('0', CURRENT_TIMESTAMP, '7.24.0');
 
 create table ACT_RE_DEPLOYMENT (
     ID_ varchar(64),

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/operaton-changelog.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/operaton-changelog.xml
@@ -152,4 +152,16 @@
     <tagDatabase tag="7.23.0"/>
   </changeSet>
 
+  <changeSet author="Operaton" id="7.23-to-7.24">
+    <sqlFile path="upgrade/${db.name}_engine_7.23_to_7.24.sql"
+             encoding="UTF-8"
+             relativeToChangelogFile="true"
+             splitStatements="true"
+             stripComments="true"/>
+  </changeSet>
+
+  <changeSet author="Operaton" id="7.24.0-tag">
+    <tagDatabase tag="7.24.0"/>
+  </changeSet>
+
 </databaseChangeLog>

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/db2_engine_7.23_to_7.24.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/db2_engine_7.23_to_7.24.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. Camunda licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1300', CURRENT_TIMESTAMP, '7.24.0');

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/h2_engine_7.23_to_7.24.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/h2_engine_7.23_to_7.24.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. Camunda licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1300', CURRENT_TIMESTAMP, '7.24.0');

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/mariadb_engine_7.23_to_7.24.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/mariadb_engine_7.23_to_7.24.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. Camunda licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1300', CURRENT_TIMESTAMP, '7.24.0');

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/mariadb_engine_7.23_to_7.24.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/mariadb_engine_7.23_to_7.24.sql
@@ -1,12 +1,11 @@
 --
--- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
--- under one or more contributor license agreements. See the NOTICE file
--- distributed with this work for additional information regarding copyright
--- ownership. Camunda licenses this file to you under the Apache License,
--- Version 2.0; you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
+-- Copyright 2025 the Operaton contributors.
 --
---     http://www.apache.org/licenses/LICENSE-2.0
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at:
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
 --
 -- Unless required by applicable law or agreed to in writing, software
 -- distributed under the License is distributed on an "AS IS" BASIS,

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/mssql_engine_7.23_to_7.24.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/mssql_engine_7.23_to_7.24.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. Camunda licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1300', CURRENT_TIMESTAMP, '7.24.0');

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/mysql_engine_7.23_to_7.24.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/mysql_engine_7.23_to_7.24.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. Camunda licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1300', CURRENT_TIMESTAMP, '7.24.0');

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/oracle_engine_7.23_to_7.24.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/oracle_engine_7.23_to_7.24.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. Camunda licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1300', CURRENT_TIMESTAMP, '7.24.0');

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/postgres_engine_7.23_to_7.24.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/upgrade/postgres_engine_7.23_to_7.24.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+-- under one or more contributor license agreements. See the NOTICE file
+-- distributed with this work for additional information regarding copyright
+-- ownership. Camunda licenses this file to you under the Apache License,
+-- Version 2.0; you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+insert into ACT_GE_SCHEMA_LOG
+values ('1300', CURRENT_TIMESTAMP, '7.24.0');

--- a/qa/test-db-instance-migration/pom.xml
+++ b/qa/test-db-instance-migration/pom.xml
@@ -40,6 +40,7 @@
     <module>test-fixture-721</module>
     <module>test-fixture-722</module>
     <module>test-fixture-723</module>
+    <module>test-fixture-724</module>
     <module>test-migration</module>
   </modules>
   <profiles>

--- a/qa/test-db-instance-migration/test-fixture-724/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-724/pom.xml
@@ -1,0 +1,149 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.operaton.bpm.qa.upgrade</groupId>
+    <artifactId>operaton-qa-db-instance-migration</artifactId>
+    <version>1.0.0-beta-5-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>operaton-qa-upgrade-test-fixture-724</artifactId>
+  <packaging>jar</packaging>
+  <name>operaton BPM - QA - upgrade - instance migration - test fixture - 7.24.0</name>
+
+  <properties>
+    <!-- delete when 7.24 is released -->
+    <operaton.version.current>${project.version}</operaton.version.current>
+    <operaton.version.previous>7.23.0</operaton.version.previous>
+  </properties>
+
+  <!-- uncomment when 7.24 is released -->
+  <!--   <dependencyManagement> -->
+  <!--     <dependencies> -->
+  <!--       <dependency> -->
+  <!--         <groupId>org.operaton.bpm</groupId> -->
+  <!--         <artifactId>operaton-bom</artifactId> -->
+  <!--         <version>7.24.0</version> -->
+  <!--         <scope>import</scope> -->
+  <!--         <type>pom</type> -->
+  <!--       </dependency> -->
+  <!--     </dependencies> -->
+  <!--   </dependencyManagement> -->
+
+  <dependencies>
+    <dependency>
+      <groupId>org.operaton.bpm</groupId>
+      <artifactId>operaton-engine</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.operaton.spin</groupId>
+      <artifactId>operaton-spin-dataformat-json-jackson</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.operaton.bpm</groupId>
+      <artifactId>operaton-engine-plugin-spin</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.operaton.bpm.qa.upgrade</groupId>
+      <artifactId>operaton-qa-upgrade-scenario-util</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>instance-migration</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>update-db</id>
+                <phase>generate-test-resources</phase>
+                <goals>
+                  <goal>update</goal>
+                </goals>
+                <configuration>
+                  <changeLogFile>operaton-changelog.xml</changeLogFile>
+                  <changeLogDirectory>${project.build.directory}/scripts-current/sql/liquibase/</changeLogDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- provide sql scripts -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack-current-sql-scripts</id>
+                <phase>generate-test-sources</phase>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.operaton.bpm.distro</groupId>
+                      <artifactId>operaton-sql-scripts</artifactId>
+                      <!-- Replace after 7.24.0 release -->
+                      <version>${operaton.version.current}</version>
+                      <!--<version>7.24.0</version>-->
+                      <type>test-jar</type>
+                      <outputDirectory>${project.build.directory}/scripts-current</outputDirectory>
+                      <overWrite>true</overWrite>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- uncomment when 7.24 is released -->
+          <!--<plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <configuration>
+              <cleanupDaemonThreads>false</cleanupDaemonThreads>
+              <includeProjectDependencies>true</includeProjectDependencies>
+              <includePluginDependencies>false</includePluginDependencies>
+              <classpathScope>test</classpathScope>
+            </configuration>
+            <executions>
+              <execution>
+                <id>create-test-fixture</id>
+                <goals>
+                  <goal>java</goal>
+                </goals>
+                <phase>process-test-classes</phase>
+                <configuration>
+                  <mainClass>org.operaton.bpm.qa.upgrade.TestFixture</mainClass>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>-->
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+</project>

--- a/qa/test-db-instance-migration/test-fixture-724/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-724/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <!-- delete when 7.24 is released -->
     <operaton.version.current>${project.version}</operaton.version.current>
-    <operaton.version.previous>7.23.0</operaton.version.previous>
+    <operaton.version.previous>7.23.1</operaton.version.previous>
   </properties>
 
   <!-- uncomment when 7.24 is released -->

--- a/qa/test-db-instance-migration/test-fixture-724/pom.xml
+++ b/qa/test-db-instance-migration/test-fixture-724/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.operaton.bpm.qa.upgrade</groupId>
     <artifactId>operaton-qa-db-instance-migration</artifactId>
-    <version>1.0.0-beta-5-SNAPSHOT</version>
+    <version>1.0.0-rc-1-SNAPSHOT</version>
   </parent>
 
   <artifactId>operaton-qa-upgrade-test-fixture-724</artifactId>

--- a/qa/test-db-instance-migration/test-fixture-724/src/main/java/org/operaton/bpm/qa/upgrade/TestFixture.java
+++ b/qa/test-db-instance-migration/test-fixture-724/src/main/java/org/operaton/bpm/qa/upgrade/TestFixture.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.qa.upgrade;
+
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.ProcessEngineConfiguration;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+
+public class TestFixture {
+
+  public static final String ENGINE_VERSION = "7.24.0";
+
+  public TestFixture(ProcessEngine processEngine) {
+  }
+
+  public static void main(String... args) {
+    ProcessEngineConfigurationImpl processEngineConfiguration = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration
+      .createProcessEngineConfigurationFromResource("operaton.cfg.xml");
+    ProcessEngine processEngine = processEngineConfiguration.buildProcessEngine();
+
+    // register test scenarios
+    ScenarioRunner runner = new ScenarioRunner(processEngine, ENGINE_VERSION);
+
+    // example scenario setup
+    // runner.setupScenarios(ExampleScenario.class);
+
+    processEngine.close();
+  }
+}

--- a/qa/test-db-instance-migration/test-fixture-724/src/main/resources/operaton.cfg.xml
+++ b/qa/test-db-instance-migration/test-fixture-724/src/main/resources/operaton.cfg.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="processEngineConfiguration" class="org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+
+    <property name="jdbcUrl" value="${database.url}" />
+    <property name="jdbcDriver" value="${database.driver}" />
+    <property name="jdbcUsername" value="${database.username}" />
+    <property name="jdbcPassword" value="${database.password}" />
+
+    <!-- Database configurations -->
+    <property name="databaseSchemaUpdate" value="false" />
+
+    <!-- job executor configurations -->
+    <property name="jobExecutorActivate" value="false" />
+
+    <!-- mail server configurations -->
+    <property name="mailServerPort" value="${mail.server.port}" />
+    <property name="history" value="full" />
+
+    <!-- turn off metrics reporter -->
+    <property name="dbMetricsReporterActivate" value="false" />
+    <property name="taskMetricsEnabled" value="false" />
+
+    <property name="defaultSerializationFormat" value="application/json"/>
+
+    <property name="jdbcBatchProcessing" value="${jdbcBatchProcessing}"/>
+
+  </bean>
+
+</beans>

--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -10,7 +10,7 @@
   <name>Operaton - QA - test new schema with old engine</name>
   <description>${project.name}</description>
   <properties>
-    <operaton.old.engine.version>7.23.0</operaton.old.engine.version>
+    <operaton.old.engine.version>7.23.1</operaton.old.engine.version>
     <surefire.memArgs>-Xmx2g -XX:MetaspaceSize=128m</surefire.memArgs>
   </properties>
   <build>
@@ -92,7 +92,7 @@
             <groupId>org.operaton.bpm</groupId>
             <artifactId>operaton-bom</artifactId>
             <!-- Cannot use variables due to bug in Maven Release Plugin -->
-            <version>7.23.0</version>
+            <version>1.0.0-beta-5</version>
             <scope>import</scope>
             <type>pom</type>
           </dependency>

--- a/qa/test-old-engine/pom.xml
+++ b/qa/test-old-engine/pom.xml
@@ -10,7 +10,7 @@
   <name>Operaton - QA - test new schema with old engine</name>
   <description>${project.name}</description>
   <properties>
-    <operaton.old.engine.version>7.22.0</operaton.old.engine.version>
+    <operaton.old.engine.version>7.23.0</operaton.old.engine.version>
     <surefire.memArgs>-Xmx2g -XX:MetaspaceSize=128m</surefire.memArgs>
   </properties>
   <build>
@@ -92,7 +92,7 @@
             <groupId>org.operaton.bpm</groupId>
             <artifactId>operaton-bom</artifactId>
             <!-- Cannot use variables due to bug in Maven Release Plugin -->
-            <version>7.22.0</version>
+            <version>7.23.0</version>
             <scope>import</scope>
             <type>pom</type>
           </dependency>

--- a/spin/pom.xml
+++ b/spin/pom.xml
@@ -14,7 +14,7 @@
   <description>${project.name}</description>
   <properties>
     <json-unit.version>4.1.1</json-unit.version>
-    <spin.version.old>7.22.0</spin.version.old>
+    <spin.version.old>1.0.0-beta-5</spin.version.old>
     <license.includeTransitiveDependencies>false</license.includeTransitiveDependencies>
     <additionalparam>-Xdoclint:none</additionalparam>
   </properties>


### PR DESCRIPTION
This PR will backport 694726279a  from camunda-bpm-platform

>     chore(release): prepare codebase for 7.24 development (#5071)
>     
>         * chore(release): prepare codebase for 7.24 development
>     
>         Related to https://github.com/camunda/camunda-bpm-platform/issues/4713
>     
>         * Fix test fixture 723 version

HEADS-UP: Do not merge before 1.0.0-beta-5 is released. This pr needs to be updated after operaton 1.0.0-beta-5

|Operaton Version | Db Schema Version|
|------------------|--------------------|
|1.0.0-beta-5 | 7.23.0|
|1.0.0-rc-1 | 7.24.0|
