### PR TITLE
refactor(engine): convert constant interfaces to utility classes (15/40)

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/authorization/Groups.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/authorization/Groups.java
@@ -21,10 +21,11 @@ package org.operaton.bpm.engine.authorization;
  *
  * @author Nico Rehwaldt
  */
-public interface Groups {
+public final class Groups {
 
-  String OPERATON_ADMIN = "operaton-admin";
-  String GROUP_TYPE_SYSTEM = "SYSTEM";
-  String GROUP_TYPE_WORKFLOW = "WORKFLOW";
+  public static final String OPERATON_ADMIN = "operaton-admin";
+  public static final String GROUP_TYPE_SYSTEM = "SYSTEM";
+  public static final String GROUP_TYPE_WORKFLOW = "WORKFLOW";
 
+  private Groups() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/AuthorizationQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/AuthorizationQueryProperty.java
@@ -24,8 +24,10 @@ import org.operaton.bpm.engine.query.QueryProperty;
  *
  * @author Daniel Meyer
  */
-public interface AuthorizationQueryProperty {
+final class AuthorizationQueryProperty {
 
-  QueryProperty RESOURCE_TYPE = new QueryPropertyImpl("RESOURCE_TYPE_");
-  QueryProperty RESOURCE_ID = new QueryPropertyImpl("RESOURCE_ID_");
+  public static final QueryProperty RESOURCE_TYPE = new QueryPropertyImpl("RESOURCE_TYPE_");
+  public static final QueryProperty RESOURCE_ID = new QueryPropertyImpl("RESOURCE_ID_");
+
+  private AuthorizationQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/BatchQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/BatchQueryProperty.java
@@ -23,12 +23,11 @@ import org.operaton.bpm.engine.query.QueryProperty;
  * Contains the possible properties that can be used in a {@link BatchQuery}.
  *
  */
-public interface BatchQueryProperty {
+public final class BatchQueryProperty {
 
-  QueryProperty ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty START_TIME = new QueryPropertyImpl("START_TIME_");
 
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
-
-  QueryProperty START_TIME = new QueryPropertyImpl("START_TIME_");
-
+  private BatchQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/CleanableHistoricInstanceReportProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/CleanableHistoricInstanceReportProperty.java
@@ -18,7 +18,9 @@ package org.operaton.bpm.engine.impl;
 
 import org.operaton.bpm.engine.query.QueryProperty;
 
-public interface CleanableHistoricInstanceReportProperty {
+public final class CleanableHistoricInstanceReportProperty {
 
-  QueryProperty FINISHED_AMOUNT = new QueryPropertyImpl("FINISHED_");
+  public static final QueryProperty FINISHED_AMOUNT = new QueryPropertyImpl("FINISHED_");
+
+  private CleanableHistoricInstanceReportProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/DeploymentQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/DeploymentQueryProperty.java
@@ -26,11 +26,12 @@ import org.operaton.bpm.engine.repository.DeploymentQuery;
  *
  * @author Joram Barrez
  */
-public interface DeploymentQueryProperty {
+final class DeploymentQueryProperty {
 
-  QueryProperty DEPLOYMENT_ID = new QueryPropertyImpl("ID_");
-  QueryProperty DEPLOYMENT_NAME = new QueryPropertyImpl("NAME_");
-  QueryProperty DEPLOY_TIME = new QueryPropertyImpl("DEPLOY_TIME_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty DEPLOYMENT_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty DEPLOYMENT_NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty DEPLOY_TIME = new QueryPropertyImpl("DEPLOY_TIME_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
 
+  private DeploymentQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/EventSubscriptionQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/EventSubscriptionQueryProperty.java
@@ -23,12 +23,12 @@ import org.operaton.bpm.engine.query.QueryProperty;
 /**
  * @author Daniel Meyer
  */
-public interface EventSubscriptionQueryProperty {
+final class EventSubscriptionQueryProperty {
 
   // properties used in event subscription queries:
 
-  QueryProperty CREATED = new QueryPropertyImpl("CREATED_");
+  public static final QueryProperty CREATED = new QueryPropertyImpl("CREATED_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
 
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
-
+  private  EventSubscriptionQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ExecutionQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ExecutionQueryProperty.java
@@ -24,12 +24,14 @@ import org.operaton.bpm.engine.runtime.ExecutionQuery;
  *
  * @author Joram Barrez
  */
-public interface ExecutionQueryProperty {
+final class ExecutionQueryProperty {
 
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
-  QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("ID_");
-  QueryProperty SEQUENCE_COUNTER = new QueryPropertyImpl("SEQUENCE_COUNTER_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty SEQUENCE_COUNTER = new QueryPropertyImpl("SEQUENCE_COUNTER_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private ExecutionQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ExternalTaskQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ExternalTaskQueryProperty.java
@@ -22,15 +22,17 @@ import org.operaton.bpm.engine.query.QueryProperty;
  * @author Thorben Lindhauer
  *
  */
-public interface ExternalTaskQueryProperty {
+public final class ExternalTaskQueryProperty {
 
-  QueryProperty ID = new QueryPropertyImpl("ID_");
-  QueryProperty LOCK_EXPIRATION_TIME = new QueryPropertyImpl("LOCK_EXP_TIME_");
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
-  QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROC_DEF_KEY_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
-  QueryProperty PRIORITY = new QueryPropertyImpl("PRIORITY_");
-  QueryProperty CREATE_TIME = new QueryPropertyImpl("CREATE_TIME_");
+  public static final QueryProperty ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty LOCK_EXPIRATION_TIME = new QueryPropertyImpl("LOCK_EXP_TIME_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROC_DEF_KEY_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty PRIORITY = new QueryPropertyImpl("PRIORITY_");
+  public static final QueryProperty CREATE_TIME = new QueryPropertyImpl("CREATE_TIME_");
+
+  private ExternalTaskQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/GroupQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/GroupQueryProperty.java
@@ -26,9 +26,11 @@ import org.operaton.bpm.engine.query.QueryProperty;
  *
  * @author Joram Barrez
  */
-public interface GroupQueryProperty {
+public final class GroupQueryProperty {
 
-  QueryProperty GROUP_ID = new QueryPropertyImpl("ID_");
-  QueryProperty NAME = new QueryPropertyImpl("NAME_");
-  QueryProperty TYPE = new QueryPropertyImpl("TYPE_");
+  public static final QueryProperty GROUP_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty TYPE = new QueryPropertyImpl("TYPE_");
+
+  private GroupQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricActivityInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricActivityInstanceQueryProperty.java
@@ -25,18 +25,20 @@ import org.operaton.bpm.engine.query.QueryProperty;
  *
  * @author Tom Baeyens
  */
-public interface HistoricActivityInstanceQueryProperty {
+final class HistoricActivityInstanceQueryProperty {
 
-  QueryProperty HISTORIC_ACTIVITY_INSTANCE_ID = new QueryPropertyImpl("ID_");
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
-  QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
-  QueryProperty ACTIVITY_ID = new QueryPropertyImpl("ACT_ID_");
-  QueryProperty ACTIVITY_NAME = new QueryPropertyImpl("ACT_NAME_");
-  QueryProperty ACTIVITY_TYPE = new QueryPropertyImpl("ACT_TYPE_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
-  QueryProperty START = new QueryPropertyImpl("START_TIME_");
-  QueryProperty END = new QueryPropertyImpl("END_TIME_");
-  QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
-  QueryProperty SEQUENCE_COUNTER = new QueryPropertyImpl("SEQUENCE_COUNTER_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty HISTORIC_ACTIVITY_INSTANCE_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
+  public static final QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
+  public static final QueryProperty ACTIVITY_ID = new QueryPropertyImpl("ACT_ID_");
+  public static final QueryProperty ACTIVITY_NAME = new QueryPropertyImpl("ACT_NAME_");
+  public static final QueryProperty ACTIVITY_TYPE = new QueryPropertyImpl("ACT_TYPE_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
+  public static final QueryProperty START = new QueryPropertyImpl("START_TIME_");
+  public static final QueryProperty END = new QueryPropertyImpl("END_TIME_");
+  public static final QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
+  public static final QueryProperty SEQUENCE_COUNTER = new QueryPropertyImpl("SEQUENCE_COUNTER_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private HistoricActivityInstanceQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricActivityStatisticsQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricActivityStatisticsQueryProperty.java
@@ -23,8 +23,9 @@ import org.operaton.bpm.engine.query.QueryProperty;
  * @author Roman Smirnov
  *
  */
-public interface HistoricActivityStatisticsQueryProperty {
+final class HistoricActivityStatisticsQueryProperty {
 
-  QueryProperty ACTIVITY_ID_ = new QueryPropertyImpl("ID_");
+  public static final QueryProperty ACTIVITY_ID_ = new QueryPropertyImpl("ID_");
 
+  private HistoricActivityStatisticsQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricBatchQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricBatchQueryProperty.java
@@ -23,11 +23,13 @@ import org.operaton.bpm.engine.query.QueryProperty;
  * Contains the possible properties that can be used in a {@link HistoricBatchQuery}.
  *
  */
-public interface HistoricBatchQueryProperty {
+public final class HistoricBatchQueryProperty {
 
-  QueryProperty ID = new QueryPropertyImpl("ID_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
-  QueryProperty START_TIME = new QueryPropertyImpl("START_TIME_");
-  QueryProperty END_TIME = new QueryPropertyImpl("END_TIME_");
+  public static final QueryProperty ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty START_TIME = new QueryPropertyImpl("START_TIME_");
+  public static final QueryProperty END_TIME = new QueryPropertyImpl("END_TIME_");
+
+  private  HistoricBatchQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricCaseActivityInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricCaseActivityInstanceQueryProperty.java
@@ -25,17 +25,19 @@ import org.operaton.bpm.engine.query.QueryProperty;
  *
  * @author Sebastian Menski
  */
-public interface HistoricCaseActivityInstanceQueryProperty {
+final class HistoricCaseActivityInstanceQueryProperty {
 
-  QueryProperty HISTORIC_CASE_ACTIVITY_INSTANCE_ID = new QueryPropertyImpl("ID_");
-  QueryProperty CASE_INSTANCE_ID = new QueryPropertyImpl("CASE_INST_ID_");
-  QueryProperty CASE_ACTIVITY_ID = new QueryPropertyImpl("CASE_ACT_ID_");
-  QueryProperty CASE_ACTIVITY_NAME = new QueryPropertyImpl("CASE_ACT_NAME_");
-  QueryProperty CASE_ACTIVITY_TYPE = new QueryPropertyImpl("CASE_ACT_TYPE_");
-  QueryProperty CASE_DEFINITION_ID = new QueryPropertyImpl("CASE_DEF_ID_");
-  QueryProperty CREATE = new QueryPropertyImpl("CREATE_TIME_");
-  QueryProperty END = new QueryPropertyImpl("END_TIME_");
-  QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty HISTORIC_CASE_ACTIVITY_INSTANCE_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty CASE_INSTANCE_ID = new QueryPropertyImpl("CASE_INST_ID_");
+  public static final QueryProperty CASE_ACTIVITY_ID = new QueryPropertyImpl("CASE_ACT_ID_");
+  public static final QueryProperty CASE_ACTIVITY_NAME = new QueryPropertyImpl("CASE_ACT_NAME_");
+  public static final QueryProperty CASE_ACTIVITY_TYPE = new QueryPropertyImpl("CASE_ACT_TYPE_");
+  public static final QueryProperty CASE_DEFINITION_ID = new QueryPropertyImpl("CASE_DEF_ID_");
+  public static final QueryProperty CREATE = new QueryPropertyImpl("CREATE_TIME_");
+  public static final QueryProperty END = new QueryPropertyImpl("END_TIME_");
+  public static final QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private  HistoricCaseActivityInstanceQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricCaseInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricCaseInstanceQueryProperty.java
@@ -18,20 +18,21 @@ package org.operaton.bpm.engine.impl;
 
 import org.operaton.bpm.engine.query.QueryProperty;
 
-
 /**
  * Contains the possible properties which can be used in a {@link HistoricCaseInstanceQueryProperty}.
  *
  * @author Sebastian Menski
  */
-public interface HistoricCaseInstanceQueryProperty {
+final class HistoricCaseInstanceQueryProperty {
 
-  QueryProperty PROCESS_INSTANCE_ID_ = new QueryPropertyImpl("CASE_INST_ID_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("CASE_DEF_ID_");
-  QueryProperty BUSINESS_KEY = new QueryPropertyImpl("BUSINESS_KEY_");
-  QueryProperty CREATE_TIME = new QueryPropertyImpl("CREATE_TIME_");
-  QueryProperty CLOSE_TIME = new QueryPropertyImpl("CLOSE_TIME_");
-  QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty PROCESS_INSTANCE_ID_ = new QueryPropertyImpl("CASE_INST_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("CASE_DEF_ID_");
+  public static final QueryProperty BUSINESS_KEY = new QueryPropertyImpl("BUSINESS_KEY_");
+  public static final QueryProperty CREATE_TIME = new QueryPropertyImpl("CREATE_TIME_");
+  public static final QueryProperty CLOSE_TIME = new QueryPropertyImpl("CLOSE_TIME_");
+  public static final QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private HistoricCaseInstanceQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricDecisionInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricDecisionInstanceQueryProperty.java
@@ -24,9 +24,11 @@ import org.operaton.bpm.engine.query.QueryProperty;
  *
  * @author Philipp Ossler
  */
-public interface HistoricDecisionInstanceQueryProperty {
+final class HistoricDecisionInstanceQueryProperty {
 
-  QueryProperty EVALUATION_TIME = new QueryPropertyImpl("EVAL_TIME_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty EVALUATION_TIME = new QueryPropertyImpl("EVAL_TIME_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private  HistoricDecisionInstanceQueryProperty() {}
 
 }


### PR DESCRIPTION
Refactors constant definitions by replacing `interface` constants with
`final` utility classes and static final fields. Adds private constructors
to prevent instantiation.

Updated 15 of 40 classes:
- Groups
- AuthorizationQueryProperty
- BatchQueryProperty
- CleanableHistoricInstanceReportProperty
- DeploymentQueryProperty
- EventSubscriptionQueryProperty
- ExecutionQueryProperty
- ExternalTaskQueryProperty
- GroupQueryProperty
- HistoricActivityInstanceQueryProperty
- HistoricActivityStatisticsQueryProperty
- HistoricBatchQueryProperty
- HistoricCaseActivityInstanceQueryProperty
- HistoricCaseInstanceQueryProperty
- HistoricDecisionInstanceQueryProperty

related to #1059
