### PR TITLE
feat(build): Add rewrite.yml

### DIFF
--- a/rewrite.yml
+++ b/rewrite.yml
@@ -1,0 +1,23 @@
+---
+type: specs.openrewrite.org/v1beta/style
+name: org.operaton.style.OperatonJavaStyle
+styleConfigs:
+  - org.openrewrite.java.style.ImportLayoutStyle:
+      classCountToUseStarImport: 15
+      nameCountToUseStarImport: 8
+      layout:
+        - import java.*
+        - import jakarta.*
+        - <blank line>
+        - import all other imports
+        - <blank line>
+        - import org.operaton.*
+        - <blank line>
+        - import static org.operaton.*
+        - import static all other imports
+  - org.openrewrite.java.style.TabsAndIndentsStyle:
+      useTabCharacter: false
+      tabSize: 2
+      indentSize: 2
+      continuationIndent: 2
+      indentsRelativeToExpressionStart: false


### PR DESCRIPTION
Adds a style definition for Operaton projects that can be used to harmonize the Java imports.

related to #1104 

For testing execute
```
 mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.openrewrite.java.OrderImports -Drewrite.exportDatatables=true -Drewrite.activeStyles=org.operaton.style.OperatonJavaStyle -f commons
```