### PR TITLE
refactor(engine): convert constant interfaces to utility classes (16-30/40)

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/authorization/Groups.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/authorization/Groups.java
@@ -21,10 +21,11 @@ package org.operaton.bpm.engine.authorization;
  *
  * @author Nico Rehwaldt
  */
-public interface Groups {
+public final class Groups {
 
-  String OPERATON_ADMIN = "operaton-admin";
-  String GROUP_TYPE_SYSTEM = "SYSTEM";
-  String GROUP_TYPE_WORKFLOW = "WORKFLOW";
+  public static final String OPERATON_ADMIN = "operaton-admin";
+  public static final String GROUP_TYPE_SYSTEM = "SYSTEM";
+  public static final String GROUP_TYPE_WORKFLOW = "WORKFLOW";
 
+  private Groups() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/AuthorizationQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/AuthorizationQueryProperty.java
@@ -24,8 +24,10 @@ import org.operaton.bpm.engine.query.QueryProperty;
  *
  * @author Daniel Meyer
  */
-public interface AuthorizationQueryProperty {
+final class AuthorizationQueryProperty {
 
-  QueryProperty RESOURCE_TYPE = new QueryPropertyImpl("RESOURCE_TYPE_");
-  QueryProperty RESOURCE_ID = new QueryPropertyImpl("RESOURCE_ID_");
+  public static final QueryProperty RESOURCE_TYPE = new QueryPropertyImpl("RESOURCE_TYPE_");
+  public static final QueryProperty RESOURCE_ID = new QueryPropertyImpl("RESOURCE_ID_");
+
+  private AuthorizationQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/BatchQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/BatchQueryProperty.java
@@ -23,12 +23,11 @@ import org.operaton.bpm.engine.query.QueryProperty;
  * Contains the possible properties that can be used in a {@link BatchQuery}.
  *
  */
-public interface BatchQueryProperty {
+public final class BatchQueryProperty {
 
-  QueryProperty ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty START_TIME = new QueryPropertyImpl("START_TIME_");
 
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
-
-  QueryProperty START_TIME = new QueryPropertyImpl("START_TIME_");
-
+  private BatchQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/CleanableHistoricInstanceReportProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/CleanableHistoricInstanceReportProperty.java
@@ -18,7 +18,9 @@ package org.operaton.bpm.engine.impl;
 
 import org.operaton.bpm.engine.query.QueryProperty;
 
-public interface CleanableHistoricInstanceReportProperty {
+public final class CleanableHistoricInstanceReportProperty {
 
-  QueryProperty FINISHED_AMOUNT = new QueryPropertyImpl("FINISHED_");
+  public static final QueryProperty FINISHED_AMOUNT = new QueryPropertyImpl("FINISHED_");
+
+  private CleanableHistoricInstanceReportProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/DeploymentQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/DeploymentQueryProperty.java
@@ -26,11 +26,12 @@ import org.operaton.bpm.engine.repository.DeploymentQuery;
  *
  * @author Joram Barrez
  */
-public interface DeploymentQueryProperty {
+final class DeploymentQueryProperty {
 
-  QueryProperty DEPLOYMENT_ID = new QueryPropertyImpl("ID_");
-  QueryProperty DEPLOYMENT_NAME = new QueryPropertyImpl("NAME_");
-  QueryProperty DEPLOY_TIME = new QueryPropertyImpl("DEPLOY_TIME_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty DEPLOYMENT_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty DEPLOYMENT_NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty DEPLOY_TIME = new QueryPropertyImpl("DEPLOY_TIME_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
 
+  private DeploymentQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/EventSubscriptionQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/EventSubscriptionQueryProperty.java
@@ -23,12 +23,12 @@ import org.operaton.bpm.engine.query.QueryProperty;
 /**
  * @author Daniel Meyer
  */
-public interface EventSubscriptionQueryProperty {
+final class EventSubscriptionQueryProperty {
 
   // properties used in event subscription queries:
 
-  QueryProperty CREATED = new QueryPropertyImpl("CREATED_");
+  public static final QueryProperty CREATED = new QueryPropertyImpl("CREATED_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
 
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
-
+  private  EventSubscriptionQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ExecutionQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ExecutionQueryProperty.java
@@ -24,12 +24,14 @@ import org.operaton.bpm.engine.runtime.ExecutionQuery;
  *
  * @author Joram Barrez
  */
-public interface ExecutionQueryProperty {
+final class ExecutionQueryProperty {
 
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
-  QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("ID_");
-  QueryProperty SEQUENCE_COUNTER = new QueryPropertyImpl("SEQUENCE_COUNTER_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty SEQUENCE_COUNTER = new QueryPropertyImpl("SEQUENCE_COUNTER_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private ExecutionQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ExternalTaskQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ExternalTaskQueryProperty.java
@@ -22,15 +22,17 @@ import org.operaton.bpm.engine.query.QueryProperty;
  * @author Thorben Lindhauer
  *
  */
-public interface ExternalTaskQueryProperty {
+public final class ExternalTaskQueryProperty {
 
-  QueryProperty ID = new QueryPropertyImpl("ID_");
-  QueryProperty LOCK_EXPIRATION_TIME = new QueryPropertyImpl("LOCK_EXP_TIME_");
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
-  QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROC_DEF_KEY_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
-  QueryProperty PRIORITY = new QueryPropertyImpl("PRIORITY_");
-  QueryProperty CREATE_TIME = new QueryPropertyImpl("CREATE_TIME_");
+  public static final QueryProperty ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty LOCK_EXPIRATION_TIME = new QueryPropertyImpl("LOCK_EXP_TIME_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROC_DEF_KEY_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty PRIORITY = new QueryPropertyImpl("PRIORITY_");
+  public static final QueryProperty CREATE_TIME = new QueryPropertyImpl("CREATE_TIME_");
+
+  private ExternalTaskQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/GroupQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/GroupQueryProperty.java
@@ -26,9 +26,11 @@ import org.operaton.bpm.engine.query.QueryProperty;
  *
  * @author Joram Barrez
  */
-public interface GroupQueryProperty {
+public final class GroupQueryProperty {
 
-  QueryProperty GROUP_ID = new QueryPropertyImpl("ID_");
-  QueryProperty NAME = new QueryPropertyImpl("NAME_");
-  QueryProperty TYPE = new QueryPropertyImpl("TYPE_");
+  public static final QueryProperty GROUP_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty TYPE = new QueryPropertyImpl("TYPE_");
+
+  private GroupQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricActivityInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricActivityInstanceQueryProperty.java
@@ -25,18 +25,20 @@ import org.operaton.bpm.engine.query.QueryProperty;
  *
  * @author Tom Baeyens
  */
-public interface HistoricActivityInstanceQueryProperty {
+final class HistoricActivityInstanceQueryProperty {
 
-  QueryProperty HISTORIC_ACTIVITY_INSTANCE_ID = new QueryPropertyImpl("ID_");
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
-  QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
-  QueryProperty ACTIVITY_ID = new QueryPropertyImpl("ACT_ID_");
-  QueryProperty ACTIVITY_NAME = new QueryPropertyImpl("ACT_NAME_");
-  QueryProperty ACTIVITY_TYPE = new QueryPropertyImpl("ACT_TYPE_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
-  QueryProperty START = new QueryPropertyImpl("START_TIME_");
-  QueryProperty END = new QueryPropertyImpl("END_TIME_");
-  QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
-  QueryProperty SEQUENCE_COUNTER = new QueryPropertyImpl("SEQUENCE_COUNTER_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty HISTORIC_ACTIVITY_INSTANCE_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
+  public static final QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
+  public static final QueryProperty ACTIVITY_ID = new QueryPropertyImpl("ACT_ID_");
+  public static final QueryProperty ACTIVITY_NAME = new QueryPropertyImpl("ACT_NAME_");
+  public static final QueryProperty ACTIVITY_TYPE = new QueryPropertyImpl("ACT_TYPE_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
+  public static final QueryProperty START = new QueryPropertyImpl("START_TIME_");
+  public static final QueryProperty END = new QueryPropertyImpl("END_TIME_");
+  public static final QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
+  public static final QueryProperty SEQUENCE_COUNTER = new QueryPropertyImpl("SEQUENCE_COUNTER_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private HistoricActivityInstanceQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricActivityStatisticsQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricActivityStatisticsQueryProperty.java
@@ -23,8 +23,9 @@ import org.operaton.bpm.engine.query.QueryProperty;
  * @author Roman Smirnov
  *
  */
-public interface HistoricActivityStatisticsQueryProperty {
+final class HistoricActivityStatisticsQueryProperty {
 
-  QueryProperty ACTIVITY_ID_ = new QueryPropertyImpl("ID_");
+  public static final QueryProperty ACTIVITY_ID_ = new QueryPropertyImpl("ID_");
 
+  private HistoricActivityStatisticsQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricBatchQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricBatchQueryProperty.java
@@ -23,11 +23,13 @@ import org.operaton.bpm.engine.query.QueryProperty;
  * Contains the possible properties that can be used in a {@link HistoricBatchQuery}.
  *
  */
-public interface HistoricBatchQueryProperty {
+public final class HistoricBatchQueryProperty {
 
-  QueryProperty ID = new QueryPropertyImpl("ID_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
-  QueryProperty START_TIME = new QueryPropertyImpl("START_TIME_");
-  QueryProperty END_TIME = new QueryPropertyImpl("END_TIME_");
+  public static final QueryProperty ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty START_TIME = new QueryPropertyImpl("START_TIME_");
+  public static final QueryProperty END_TIME = new QueryPropertyImpl("END_TIME_");
+
+  private  HistoricBatchQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricCaseActivityInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricCaseActivityInstanceQueryProperty.java
@@ -25,17 +25,19 @@ import org.operaton.bpm.engine.query.QueryProperty;
  *
  * @author Sebastian Menski
  */
-public interface HistoricCaseActivityInstanceQueryProperty {
+final class HistoricCaseActivityInstanceQueryProperty {
 
-  QueryProperty HISTORIC_CASE_ACTIVITY_INSTANCE_ID = new QueryPropertyImpl("ID_");
-  QueryProperty CASE_INSTANCE_ID = new QueryPropertyImpl("CASE_INST_ID_");
-  QueryProperty CASE_ACTIVITY_ID = new QueryPropertyImpl("CASE_ACT_ID_");
-  QueryProperty CASE_ACTIVITY_NAME = new QueryPropertyImpl("CASE_ACT_NAME_");
-  QueryProperty CASE_ACTIVITY_TYPE = new QueryPropertyImpl("CASE_ACT_TYPE_");
-  QueryProperty CASE_DEFINITION_ID = new QueryPropertyImpl("CASE_DEF_ID_");
-  QueryProperty CREATE = new QueryPropertyImpl("CREATE_TIME_");
-  QueryProperty END = new QueryPropertyImpl("END_TIME_");
-  QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty HISTORIC_CASE_ACTIVITY_INSTANCE_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty CASE_INSTANCE_ID = new QueryPropertyImpl("CASE_INST_ID_");
+  public static final QueryProperty CASE_ACTIVITY_ID = new QueryPropertyImpl("CASE_ACT_ID_");
+  public static final QueryProperty CASE_ACTIVITY_NAME = new QueryPropertyImpl("CASE_ACT_NAME_");
+  public static final QueryProperty CASE_ACTIVITY_TYPE = new QueryPropertyImpl("CASE_ACT_TYPE_");
+  public static final QueryProperty CASE_DEFINITION_ID = new QueryPropertyImpl("CASE_DEF_ID_");
+  public static final QueryProperty CREATE = new QueryPropertyImpl("CREATE_TIME_");
+  public static final QueryProperty END = new QueryPropertyImpl("END_TIME_");
+  public static final QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private  HistoricCaseActivityInstanceQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricCaseInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricCaseInstanceQueryProperty.java
@@ -18,20 +18,21 @@ package org.operaton.bpm.engine.impl;
 
 import org.operaton.bpm.engine.query.QueryProperty;
 
-
 /**
  * Contains the possible properties which can be used in a {@link HistoricCaseInstanceQueryProperty}.
  *
  * @author Sebastian Menski
  */
-public interface HistoricCaseInstanceQueryProperty {
+final class HistoricCaseInstanceQueryProperty {
 
-  QueryProperty PROCESS_INSTANCE_ID_ = new QueryPropertyImpl("CASE_INST_ID_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("CASE_DEF_ID_");
-  QueryProperty BUSINESS_KEY = new QueryPropertyImpl("BUSINESS_KEY_");
-  QueryProperty CREATE_TIME = new QueryPropertyImpl("CREATE_TIME_");
-  QueryProperty CLOSE_TIME = new QueryPropertyImpl("CLOSE_TIME_");
-  QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty PROCESS_INSTANCE_ID_ = new QueryPropertyImpl("CASE_INST_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("CASE_DEF_ID_");
+  public static final QueryProperty BUSINESS_KEY = new QueryPropertyImpl("BUSINESS_KEY_");
+  public static final QueryProperty CREATE_TIME = new QueryPropertyImpl("CREATE_TIME_");
+  public static final QueryProperty CLOSE_TIME = new QueryPropertyImpl("CLOSE_TIME_");
+  public static final QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private HistoricCaseInstanceQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricDecisionInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricDecisionInstanceQueryProperty.java
@@ -24,9 +24,11 @@ import org.operaton.bpm.engine.query.QueryProperty;
  *
  * @author Philipp Ossler
  */
-public interface HistoricDecisionInstanceQueryProperty {
+final class HistoricDecisionInstanceQueryProperty {
 
-  QueryProperty EVALUATION_TIME = new QueryPropertyImpl("EVAL_TIME_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty EVALUATION_TIME = new QueryPropertyImpl("EVAL_TIME_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private  HistoricDecisionInstanceQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricDetailQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricDetailQueryProperty.java
@@ -25,13 +25,15 @@ import org.operaton.bpm.engine.query.QueryProperty;
  *
  * @author Tom Baeyens
  */
-public interface HistoricDetailQueryProperty {
+final class HistoricDetailQueryProperty {
 
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
-  QueryProperty VARIABLE_NAME = new QueryPropertyImpl("NAME_");
-  QueryProperty VARIABLE_TYPE = new QueryPropertyImpl("TYPE_");
-  QueryProperty VARIABLE_REVISION = new QueryPropertyImpl("REV_");
-  QueryProperty TIME = new QueryPropertyImpl("TIME_");
-  QueryProperty SEQUENCE_COUNTER = new QueryPropertyImpl("SEQUENCE_COUNTER_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
+  public static final QueryProperty VARIABLE_NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty VARIABLE_TYPE = new QueryPropertyImpl("TYPE_");
+  public static final QueryProperty VARIABLE_REVISION = new QueryPropertyImpl("REV_");
+  public static final QueryProperty TIME = new QueryPropertyImpl("TIME_");
+  public static final QueryProperty SEQUENCE_COUNTER = new QueryPropertyImpl("SEQUENCE_COUNTER_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private HistoricDetailQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricExternalTaskLogQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricExternalTaskLogQueryProperty.java
@@ -18,20 +18,22 @@ package org.operaton.bpm.engine.impl;
 
 import org.operaton.bpm.engine.query.QueryProperty;
 
-public interface HistoricExternalTaskLogQueryProperty {
+final class HistoricExternalTaskLogQueryProperty {
 
-  QueryProperty EXTERNAL_TASK_ID = new QueryPropertyImpl("EXT_TASK_ID_");
-  QueryProperty TIMESTAMP = new QueryPropertyImpl("TIMESTAMP_");
-  QueryProperty TOPIC_NAME = new QueryPropertyImpl("TOPIC_NAME_");
-  QueryProperty WORKER_ID = new QueryPropertyImpl("WORKER_ID_");
-  QueryProperty ACTIVITY_ID = new QueryPropertyImpl("ACT_ID_");
-  QueryProperty ACTIVITY_INSTANCE_ID = new QueryPropertyImpl("ACT_INST_ID_");
-  QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
-  QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROC_DEF_KEY_");
-  QueryProperty RETRIES = new QueryPropertyImpl("RETRIES_");
-  QueryProperty PRIORITY = new QueryPropertyImpl("PRIORITY_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty EXTERNAL_TASK_ID = new QueryPropertyImpl("EXT_TASK_ID_");
+  public static final QueryProperty TIMESTAMP = new QueryPropertyImpl("TIMESTAMP_");
+  public static final QueryProperty TOPIC_NAME = new QueryPropertyImpl("TOPIC_NAME_");
+  public static final QueryProperty WORKER_ID = new QueryPropertyImpl("WORKER_ID_");
+  public static final QueryProperty ACTIVITY_ID = new QueryPropertyImpl("ACT_ID_");
+  public static final QueryProperty ACTIVITY_INSTANCE_ID = new QueryPropertyImpl("ACT_INST_ID_");
+  public static final QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROC_DEF_KEY_");
+  public static final QueryProperty RETRIES = new QueryPropertyImpl("RETRIES_");
+  public static final QueryProperty PRIORITY = new QueryPropertyImpl("PRIORITY_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private HistoricExternalTaskLogQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricIdentityLinkLogQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricIdentityLinkLogQueryProperty.java
@@ -18,17 +18,19 @@ package org.operaton.bpm.engine.impl;
 
 import org.operaton.bpm.engine.query.QueryProperty;
 
-public interface HistoricIdentityLinkLogQueryProperty {
+final class HistoricIdentityLinkLogQueryProperty {
 
-  QueryProperty ID = new QueryPropertyImpl("ID_");
-  QueryProperty TIME = new QueryPropertyImpl("TIMESTAMP_");
-  QueryProperty TYPE = new QueryPropertyImpl("TYPE_");
-  QueryProperty USER_ID = new QueryPropertyImpl("USER_ID_");
-  QueryProperty GROUP_ID = new QueryPropertyImpl("GROUP_ID_");
-  QueryProperty TASK_ID = new QueryPropertyImpl("TASK_ID_");
-  QueryProperty PROC_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
-  QueryProperty PROC_DEFINITION_KEY = new QueryPropertyImpl("PROC_DEF_KEY_");
-  QueryProperty OPERATION_TYPE = new QueryPropertyImpl("OPERATION_TYPE_");
-  QueryProperty ASSIGNER_ID = new QueryPropertyImpl("ASSIGNER_ID_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty TIME = new QueryPropertyImpl("TIMESTAMP_");
+  public static final QueryProperty TYPE = new QueryPropertyImpl("TYPE_");
+  public static final QueryProperty USER_ID = new QueryPropertyImpl("USER_ID_");
+  public static final QueryProperty GROUP_ID = new QueryPropertyImpl("GROUP_ID_");
+  public static final QueryProperty TASK_ID = new QueryPropertyImpl("TASK_ID_");
+  public static final QueryProperty PROC_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
+  public static final QueryProperty PROC_DEFINITION_KEY = new QueryPropertyImpl("PROC_DEF_KEY_");
+  public static final QueryProperty OPERATION_TYPE = new QueryPropertyImpl("OPERATION_TYPE_");
+  public static final QueryProperty ASSIGNER_ID = new QueryPropertyImpl("ASSIGNER_ID_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private HistoricIdentityLinkLogQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricIncidentQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricIncidentQueryProperty.java
@@ -22,23 +22,25 @@ import org.operaton.bpm.engine.query.QueryProperty;
  * @author Roman Smirnov
  *
  */
-public interface HistoricIncidentQueryProperty {
+final class HistoricIncidentQueryProperty {
 
-  QueryProperty INCIDENT_ID = new QueryPropertyImpl("ID_");
-  QueryProperty INCIDENT_MESSAGE = new QueryPropertyImpl("INCIDENT_MSG_");
-  QueryProperty INCIDENT_CREATE_TIME = new QueryPropertyImpl("CREATE_TIME_");
-  QueryProperty INCIDENT_END_TIME = new QueryPropertyImpl("END_TIME_");
-  QueryProperty INCIDENT_TYPE = new QueryPropertyImpl("INCIDENT_TYPE_");
-  QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
-  QueryProperty ACTIVITY_ID = new QueryPropertyImpl("ACTIVITY_ID_");
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
-  QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROC_DEF_KEY_");
-  QueryProperty CAUSE_INCIDENT_ID = new QueryPropertyImpl("CAUSE_INCIDENT_ID_");
-  QueryProperty ROOT_CAUSE_INCIDENT_ID = new QueryPropertyImpl("ROOT_CAUSE_INCIDENT_ID_");
-  QueryProperty HISTORY_CONFIGURATION = new QueryPropertyImpl("HISTORY_CONFIGURATION_");
-  QueryProperty CONFIGURATION = new QueryPropertyImpl("CONFIGURATION_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
-  QueryProperty INCIDENT_STATE = new QueryPropertyImpl("INCIDENT_STATE_");
+  public static final QueryProperty INCIDENT_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty INCIDENT_MESSAGE = new QueryPropertyImpl("INCIDENT_MSG_");
+  public static final QueryProperty INCIDENT_CREATE_TIME = new QueryPropertyImpl("CREATE_TIME_");
+  public static final QueryProperty INCIDENT_END_TIME = new QueryPropertyImpl("END_TIME_");
+  public static final QueryProperty INCIDENT_TYPE = new QueryPropertyImpl("INCIDENT_TYPE_");
+  public static final QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
+  public static final QueryProperty ACTIVITY_ID = new QueryPropertyImpl("ACTIVITY_ID_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROC_DEF_KEY_");
+  public static final QueryProperty CAUSE_INCIDENT_ID = new QueryPropertyImpl("CAUSE_INCIDENT_ID_");
+  public static final QueryProperty ROOT_CAUSE_INCIDENT_ID = new QueryPropertyImpl("ROOT_CAUSE_INCIDENT_ID_");
+  public static final QueryProperty HISTORY_CONFIGURATION = new QueryPropertyImpl("HISTORY_CONFIGURATION_");
+  public static final QueryProperty CONFIGURATION = new QueryPropertyImpl("CONFIGURATION_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty INCIDENT_STATE = new QueryPropertyImpl("INCIDENT_STATE_");
+
+  private HistoricIncidentQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricJobLogQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricJobLogQueryProperty.java
@@ -22,22 +22,24 @@ import org.operaton.bpm.engine.query.QueryProperty;
  * @author Roman Smirnov
  *
  */
-public interface HistoricJobLogQueryProperty {
+final class HistoricJobLogQueryProperty {
 
-  QueryProperty JOB_ID = new QueryPropertyImpl("JOB_ID_");
-  QueryProperty JOB_DEFINITION_ID = new QueryPropertyImpl("JOB_DEF_ID_");
-  QueryProperty TIMESTAMP = new QueryPropertyImpl("TIMESTAMP_");
-  QueryProperty ACTIVITY_ID = new QueryPropertyImpl("ACT_ID_");
-  QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROCESS_INSTANCE_ID_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROCESS_DEF_ID_");
-  QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROCESS_DEF_KEY_");
-  QueryProperty DEPLOYMENT_ID = new QueryPropertyImpl("DEPLOYMENT_ID_");
-  QueryProperty DUEDATE = new QueryPropertyImpl("JOB_DUEDATE_");
-  QueryProperty RETRIES = new QueryPropertyImpl("JOB_RETRIES_");
-  QueryProperty PRIORITY = new QueryPropertyImpl("JOB_PRIORITY_");
-  QueryProperty SEQUENCE_COUNTER = new QueryPropertyImpl("SEQUENCE_COUNTER_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
-  QueryProperty HOSTNAME = new QueryPropertyImpl("HOSTNAME_");
+  public static final QueryProperty JOB_ID = new QueryPropertyImpl("JOB_ID_");
+  public static final QueryProperty JOB_DEFINITION_ID = new QueryPropertyImpl("JOB_DEF_ID_");
+  public static final QueryProperty TIMESTAMP = new QueryPropertyImpl("TIMESTAMP_");
+  public static final QueryProperty ACTIVITY_ID = new QueryPropertyImpl("ACT_ID_");
+  public static final QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROCESS_INSTANCE_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROCESS_DEF_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROCESS_DEF_KEY_");
+  public static final QueryProperty DEPLOYMENT_ID = new QueryPropertyImpl("DEPLOYMENT_ID_");
+  public static final QueryProperty DUEDATE = new QueryPropertyImpl("JOB_DUEDATE_");
+  public static final QueryProperty RETRIES = new QueryPropertyImpl("JOB_RETRIES_");
+  public static final QueryProperty PRIORITY = new QueryPropertyImpl("JOB_PRIORITY_");
+  public static final QueryProperty SEQUENCE_COUNTER = new QueryPropertyImpl("SEQUENCE_COUNTER_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty HOSTNAME = new QueryPropertyImpl("HOSTNAME_");
+
+  private HistoricJobLogQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceQueryProperty.java
@@ -24,17 +24,19 @@ import org.operaton.bpm.engine.query.QueryProperty;
  *
  * @author Joram Barrez
  */
-public interface HistoricProcessInstanceQueryProperty {
+final class HistoricProcessInstanceQueryProperty {
 
-  QueryProperty PROCESS_INSTANCE_ID_ = new QueryPropertyImpl("PROC_INST_ID_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
-  QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROC_DEF_KEY_");
-  QueryProperty PROCESS_DEFINITION_NAME = new QueryPropertyImpl("NAME_");
-  QueryProperty PROCESS_DEFINITION_VERSION = new QueryPropertyImpl("VERSION_");
-  QueryProperty BUSINESS_KEY = new QueryPropertyImpl("BUSINESS_KEY_");
-  QueryProperty START_TIME = new QueryPropertyImpl("START_TIME_");
-  QueryProperty END_TIME = new QueryPropertyImpl("END_TIME_");
-  QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty PROCESS_INSTANCE_ID_ = new QueryPropertyImpl("PROC_INST_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROC_DEF_KEY_");
+  public static final QueryProperty PROCESS_DEFINITION_NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty PROCESS_DEFINITION_VERSION = new QueryPropertyImpl("VERSION_");
+  public static final QueryProperty BUSINESS_KEY = new QueryPropertyImpl("BUSINESS_KEY_");
+  public static final QueryProperty START_TIME = new QueryPropertyImpl("START_TIME_");
+  public static final QueryProperty END_TIME = new QueryPropertyImpl("END_TIME_");
+  public static final QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private HistoricProcessInstanceQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricTaskInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricTaskInstanceQueryProperty.java
@@ -22,28 +22,30 @@ import org.operaton.bpm.engine.query.QueryProperty;
 /**
  * @author Tom Baeyens
  */
-public interface HistoricTaskInstanceQueryProperty {
+final class HistoricTaskInstanceQueryProperty {
 
-  QueryProperty HISTORIC_TASK_INSTANCE_ID = new QueryPropertyImpl("ID_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
-  QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
-  QueryProperty ACTIVITY_INSTANCE_ID = new QueryPropertyImpl("ACT_INST_ID_");
-  QueryProperty TASK_NAME = new QueryPropertyImpl("NAME_");
-  QueryProperty TASK_DESCRIPTION = new QueryPropertyImpl("DESCRIPTION_");
-  QueryProperty TASK_ASSIGNEE = new QueryPropertyImpl("ASSIGNEE_");
-  QueryProperty TASK_OWNER = new QueryPropertyImpl("OWNER_");
-  QueryProperty TASK_DEFINITION_KEY = new QueryPropertyImpl("TASK_DEF_KEY_");
-  QueryProperty DELETE_REASON = new QueryPropertyImpl("DELETE_REASON_");
-  QueryProperty START = new QueryPropertyImpl("START_TIME_");
-  QueryProperty END = new QueryPropertyImpl("END_TIME_");
-  QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
-  QueryProperty TASK_PRIORITY = new QueryPropertyImpl("PRIORITY_");
-  QueryProperty TASK_DUE_DATE = new QueryPropertyImpl("DUE_DATE_");
-  QueryProperty TASK_FOLLOW_UP_DATE = new QueryPropertyImpl("FOLLOW_UP_DATE_");
-  QueryProperty CASE_DEFINITION_ID = new QueryPropertyImpl("CASE_DEFINITION_ID_");
-  QueryProperty CASE_INSTANCE_ID = new QueryPropertyImpl("CASE_INSTANCE_ID_");
-  QueryProperty CASE_EXECUTION_ID = new QueryPropertyImpl("CASE_EXECUTION_ID_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty HISTORIC_TASK_INSTANCE_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
+  public static final QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
+  public static final QueryProperty ACTIVITY_INSTANCE_ID = new QueryPropertyImpl("ACT_INST_ID_");
+  public static final QueryProperty TASK_NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty TASK_DESCRIPTION = new QueryPropertyImpl("DESCRIPTION_");
+  public static final QueryProperty TASK_ASSIGNEE = new QueryPropertyImpl("ASSIGNEE_");
+  public static final QueryProperty TASK_OWNER = new QueryPropertyImpl("OWNER_");
+  public static final QueryProperty TASK_DEFINITION_KEY = new QueryPropertyImpl("TASK_DEF_KEY_");
+  public static final QueryProperty DELETE_REASON = new QueryPropertyImpl("DELETE_REASON_");
+  public static final QueryProperty START = new QueryPropertyImpl("START_TIME_");
+  public static final QueryProperty END = new QueryPropertyImpl("END_TIME_");
+  public static final QueryProperty DURATION = new QueryPropertyImpl("DURATION_");
+  public static final QueryProperty TASK_PRIORITY = new QueryPropertyImpl("PRIORITY_");
+  public static final QueryProperty TASK_DUE_DATE = new QueryPropertyImpl("DUE_DATE_");
+  public static final QueryProperty TASK_FOLLOW_UP_DATE = new QueryPropertyImpl("FOLLOW_UP_DATE_");
+  public static final QueryProperty CASE_DEFINITION_ID = new QueryPropertyImpl("CASE_DEFINITION_ID_");
+  public static final QueryProperty CASE_INSTANCE_ID = new QueryPropertyImpl("CASE_INSTANCE_ID_");
+  public static final QueryProperty CASE_EXECUTION_ID = new QueryPropertyImpl("CASE_EXECUTION_ID_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private HistoricTaskInstanceQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricVariableInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricVariableInstanceQueryProperty.java
@@ -25,9 +25,11 @@ import org.operaton.bpm.engine.query.QueryProperty;
  *
  * @author Christian Lipphardt (Camunda)
  */
-public interface HistoricVariableInstanceQueryProperty {
+final class HistoricVariableInstanceQueryProperty {
 
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
-  QueryProperty VARIABLE_NAME = new QueryPropertyImpl("NAME_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
+  public static final QueryProperty VARIABLE_NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private HistoricVariableInstanceQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/IncidentQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/IncidentQueryProperty.java
@@ -21,19 +21,21 @@ import org.operaton.bpm.engine.query.QueryProperty;
 /**
  * @author roman.smirnov
  */
-public interface IncidentQueryProperty {
+final class IncidentQueryProperty {
 
-  QueryProperty INCIDENT_ID = new QueryPropertyImpl("ID_");
-  QueryProperty INCIDENT_MESSAGE = new QueryPropertyImpl("INCIDENT_MSG_");
-  QueryProperty INCIDENT_TIMESTAMP = new QueryPropertyImpl("INCIDENT_TIMESTAMP_");
-  QueryProperty INCIDENT_TYPE = new QueryPropertyImpl("INCIDENT_TYPE_");
-  QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
-  QueryProperty ACTIVITY_ID = new QueryPropertyImpl("ACTIVITY_ID_");
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
-  QueryProperty CAUSE_INCIDENT_ID = new QueryPropertyImpl("CAUSE_INCIDENT_ID_");
-  QueryProperty ROOT_CAUSE_INCIDENT_ID = new QueryPropertyImpl("ROOT_CAUSE_INCIDENT_ID_");
-  QueryProperty CONFIGURATION = new QueryPropertyImpl("CONFIGURATION_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty INCIDENT_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty INCIDENT_MESSAGE = new QueryPropertyImpl("INCIDENT_MSG_");
+  public static final QueryProperty INCIDENT_TIMESTAMP = new QueryPropertyImpl("INCIDENT_TIMESTAMP_");
+  public static final QueryProperty INCIDENT_TYPE = new QueryPropertyImpl("INCIDENT_TYPE_");
+  public static final QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
+  public static final QueryProperty ACTIVITY_ID = new QueryPropertyImpl("ACTIVITY_ID_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
+  public static final QueryProperty CAUSE_INCIDENT_ID = new QueryPropertyImpl("CAUSE_INCIDENT_ID_");
+  public static final QueryProperty ROOT_CAUSE_INCIDENT_ID = new QueryPropertyImpl("ROOT_CAUSE_INCIDENT_ID_");
+  public static final QueryProperty CONFIGURATION = new QueryPropertyImpl("CONFIGURATION_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private IncidentQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/JobDefinitionQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/JobDefinitionQueryProperty.java
@@ -24,14 +24,16 @@ import org.operaton.bpm.engine.query.QueryProperty;
  *
  * @author roman.smirnov
  */
-public interface JobDefinitionQueryProperty {
+final class JobDefinitionQueryProperty {
 
-  QueryProperty JOB_DEFINITION_ID = new QueryPropertyImpl("ID_");
-  QueryProperty ACTIVITY_ID = new QueryPropertyImpl("ACT_ID_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
-  QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROC_DEF_KEY_");
-  QueryProperty JOB_TYPE = new QueryPropertyImpl("JOB_TYPE_");
-  QueryProperty JOB_CONFIGURATION = new QueryPropertyImpl("JOB_CONFIGURATION_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty JOB_DEFINITION_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty ACTIVITY_ID = new QueryPropertyImpl("ACT_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROC_DEF_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROC_DEF_KEY_");
+  public static final QueryProperty JOB_TYPE = new QueryPropertyImpl("JOB_TYPE_");
+  public static final QueryProperty JOB_CONFIGURATION = new QueryPropertyImpl("JOB_CONFIGURATION_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private JobDefinitionQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/JobQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/JobQueryProperty.java
@@ -24,17 +24,19 @@ import org.operaton.bpm.engine.runtime.JobQuery;
  *
  * @author Joram Barrez
  */
-public interface JobQueryProperty {
+public final class JobQueryProperty {
 
-  QueryProperty JOB_ID = new QueryPropertyImpl("ID_");
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROCESS_INSTANCE_ID_");
-  QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROCESS_DEF_ID_");
-  QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROCESS_DEF_KEY_");
-  QueryProperty DUEDATE = new QueryPropertyImpl("DUEDATE_");
-  QueryProperty RETRIES = new QueryPropertyImpl("RETRIES_");
-  QueryProperty TYPE = new QueryPropertyImpl("TYPE_");
-  QueryProperty PRIORITY = new QueryPropertyImpl("PRIORITY_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty JOB_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROCESS_INSTANCE_ID_");
+  public static final QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("PROCESS_DEF_ID_");
+  public static final QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("PROCESS_DEF_KEY_");
+  public static final QueryProperty DUEDATE = new QueryPropertyImpl("DUEDATE_");
+  public static final QueryProperty RETRIES = new QueryPropertyImpl("RETRIES_");
+  public static final QueryProperty TYPE = new QueryPropertyImpl("TYPE_");
+  public static final QueryProperty PRIORITY = new QueryPropertyImpl("PRIORITY_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private JobQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ProcessDefinitionQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ProcessDefinitionQueryProperty.java
@@ -25,16 +25,18 @@ import org.operaton.bpm.engine.repository.ProcessDefinitionQuery;
  *
  * @author Joram Barrez
  */
-public interface ProcessDefinitionQueryProperty {
+final class ProcessDefinitionQueryProperty {
 
-  QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
-  QueryProperty PROCESS_DEFINITION_CATEGORY = new QueryPropertyImpl("CATEGORY_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("ID_");
-  QueryProperty PROCESS_DEFINITION_VERSION = new QueryPropertyImpl("VERSION_");
-  QueryProperty PROCESS_DEFINITION_NAME = new QueryPropertyImpl("NAME_");
-  QueryProperty DEPLOYMENT_ID = new QueryPropertyImpl("DEPLOYMENT_ID_");
-  QueryProperty DEPLOY_TIME = new QueryPropertyImpl("DEPLOY_TIME_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
-  QueryProperty VERSION_TAG = new QueryPropertyImpl("VERSION_TAG_");
+  public static final QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
+  public static final QueryProperty PROCESS_DEFINITION_CATEGORY = new QueryPropertyImpl("CATEGORY_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty PROCESS_DEFINITION_VERSION = new QueryPropertyImpl("VERSION_");
+  public static final QueryProperty PROCESS_DEFINITION_NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty DEPLOYMENT_ID = new QueryPropertyImpl("DEPLOYMENT_ID_");
+  public static final QueryProperty DEPLOY_TIME = new QueryPropertyImpl("DEPLOY_TIME_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty VERSION_TAG = new QueryPropertyImpl("VERSION_TAG_");
+
+  private ProcessDefinitionQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ProcessInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ProcessInstanceQueryProperty.java
@@ -25,12 +25,14 @@ import org.operaton.bpm.engine.runtime.ProcessInstanceQuery;
  *
  * @author Joram Barrez
  */
-public interface ProcessInstanceQueryProperty {
+final class ProcessInstanceQueryProperty {
 
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("ID_");
-  QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
-  QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("ID_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
-  QueryProperty BUSINESS_KEY = new QueryPropertyImpl("BUSINESS_KEY_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty PROCESS_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
+  public static final QueryProperty PROCESS_DEFINITION_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty BUSINESS_KEY = new QueryPropertyImpl("BUSINESS_KEY_");
+
+  private ProcessInstanceQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/TaskQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/TaskQueryProperty.java
@@ -26,22 +26,24 @@ import org.operaton.bpm.engine.task.TaskQuery;
  *
  * @author Joram Barrez
  */
-public interface TaskQueryProperty {
+public final class TaskQueryProperty {
 
-  QueryProperty TASK_ID = new QueryPropertyImpl("ID_");
-  QueryProperty NAME = new QueryPropertyImpl("NAME_");
-  QueryProperty NAME_CASE_INSENSITIVE = new QueryPropertyImpl("NAME_", "LOWER");
-  QueryProperty DESCRIPTION = new QueryPropertyImpl("DESCRIPTION_");
-  QueryProperty PRIORITY = new QueryPropertyImpl("PRIORITY_");
-  QueryProperty ASSIGNEE = new QueryPropertyImpl("ASSIGNEE_");
-  QueryProperty CREATE_TIME = new QueryPropertyImpl("CREATE_TIME_");
-  QueryProperty LAST_UPDATED = new QueryPropertyImpl("LAST_UPDATED_");
-  QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
-  QueryProperty CASE_INSTANCE_ID = new QueryPropertyImpl("CASE_INST_ID_");
-  QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
-  QueryProperty CASE_EXECUTION_ID = new QueryPropertyImpl("CASE_EXECUTION_ID_");
-  QueryProperty DUE_DATE = new QueryPropertyImpl("DUE_DATE_");
-  QueryProperty FOLLOW_UP_DATE = new QueryPropertyImpl("FOLLOW_UP_DATE_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty TASK_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty NAME_CASE_INSENSITIVE = new QueryPropertyImpl("NAME_", "LOWER");
+  public static final QueryProperty DESCRIPTION = new QueryPropertyImpl("DESCRIPTION_");
+  public static final QueryProperty PRIORITY = new QueryPropertyImpl("PRIORITY_");
+  public static final QueryProperty ASSIGNEE = new QueryPropertyImpl("ASSIGNEE_");
+  public static final QueryProperty CREATE_TIME = new QueryPropertyImpl("CREATE_TIME_");
+  public static final QueryProperty LAST_UPDATED = new QueryPropertyImpl("LAST_UPDATED_");
+  public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
+  public static final QueryProperty CASE_INSTANCE_ID = new QueryPropertyImpl("CASE_INST_ID_");
+  public static final QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
+  public static final QueryProperty CASE_EXECUTION_ID = new QueryPropertyImpl("CASE_EXECUTION_ID_");
+  public static final QueryProperty DUE_DATE = new QueryPropertyImpl("DUE_DATE_");
+  public static final QueryProperty FOLLOW_UP_DATE = new QueryPropertyImpl("FOLLOW_UP_DATE_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private TaskQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseInstanceQueryProperty.java
@@ -23,11 +23,13 @@ import org.operaton.bpm.engine.query.QueryProperty;
  * @author Roman Smirnov
  *
  */
-public interface CaseInstanceQueryProperty {
+final class CaseInstanceQueryProperty {
 
-  QueryProperty CASE_INSTANCE_ID = new QueryPropertyImpl("ID_");
-  QueryProperty CASE_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
-  QueryProperty CASE_DEFINITION_ID = new QueryPropertyImpl("CASE_DEF_ID_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty CASE_INSTANCE_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty CASE_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
+  public static final QueryProperty CASE_DEFINITION_ID = new QueryPropertyImpl("CASE_DEF_ID_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private CaseInstanceQueryProperty() {}
 
 }


### PR DESCRIPTION
Refactors constant definitions by replacing `interface` constants with
`final` utility classes and static final fields. Adds private constructors
to prevent instantiation.

Updated 15 of 40 classes:
- HistoricDetailQueryProperty
- HistoricIdentityLinkLogQueryProperty
- HistoricIncidentQueryProperty
- HistoricJobLogQueryProperty
- HistoricJobQueryProperty
- HistoricProcessInstanceQueryProperty
- HistoricTaskInstanceQueryProperty
- IdentityLinkQueryProperty
- IncidentQueryProperty
- JobDefinitionQueryProperty
- JobQueryProperty
- ProcessDefinitionQueryProperty
- ProcessInstanceQueryProperty
- TaskQueryProperty
- VariableInstanceQueryProperty
- VariableInstanceStatisticsQueryProperty

related to #1059
