### PR TITLE
chore(deps): Upgrade to SpringBoot 3.5.5

### DIFF
--- a/.github/jreleaser/changelog.tpl
+++ b/.github/jreleaser/changelog.tpl
@@ -28,7 +28,7 @@ This release is feature complete and compatible with [**Camunda 7.23.0
 
 Operaton is based on:
 
-- **Spring Boot 3.5.4** (upgrade from 3.4.4)
+- **Spring Boot 3.5.5** (upgrade from 3.4.4)
 - **Spring Framework 6.2.10** (upgrade from 6.2.5)
 
 ### Quarkus Extension

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <version.feel-scala>1.19.3</version.feel-scala>
     <version.quarkus>3.24.2</version.quarkus>
     <version.java>17</version.java>
-    <version.spring-boot>3.5.4</version.spring-boot>
+    <version.spring-boot>3.5.5</version.spring-boot>
     <version.liquibase>4.33.0</version.liquibase>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
Upgrade to [Spring Boot 3.5.5](https://github.com/spring-projects/spring-boot/releases/tag/v3.5.5).

This resolves a vulnerability in Tomcat and updates several dependencies.