### PR TITLE
refactor(engine): convert constant interfaces to utility classes (31~40/40)

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/TenantQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/TenantQueryProperty.java
@@ -22,9 +22,11 @@ import org.operaton.bpm.engine.query.QueryProperty;
 /**
  * Contains the possible properties that can be used by the {@link TenantQuery}.
  */
-public interface TenantQueryProperty {
+final class TenantQueryProperty {
 
-  QueryProperty GROUP_ID = new QueryPropertyImpl("ID_");
-  QueryProperty NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty GROUP_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty NAME = new QueryPropertyImpl("NAME_");
+
+  private TenantQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/UserQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/UserQueryProperty.java
@@ -26,11 +26,13 @@ import org.operaton.bpm.engine.query.QueryProperty;
  *
  * @author Joram Barrez
  */
-public interface UserQueryProperty {
+public final class UserQueryProperty {
 
-  QueryProperty USER_ID = new QueryPropertyImpl("ID_");
-  QueryProperty FIRST_NAME = new QueryPropertyImpl("FIRST_");
-  QueryProperty LAST_NAME = new QueryPropertyImpl("LAST_");
-  QueryProperty EMAIL = new QueryPropertyImpl("EMAIL_");
+  public static final QueryProperty USER_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty FIRST_NAME = new QueryPropertyImpl("FIRST_");
+  public static final QueryProperty LAST_NAME = new QueryPropertyImpl("LAST_");
+  public static final QueryProperty EMAIL = new QueryPropertyImpl("EMAIL_");
+
+  private UserQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/VariableInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/VariableInstanceQueryProperty.java
@@ -21,20 +21,22 @@ import org.operaton.bpm.engine.query.QueryProperty;
 /**
  * @author roman.smirnov
  */
-public interface VariableInstanceQueryProperty {
+public final class VariableInstanceQueryProperty {
 
-  QueryProperty VARIABLE_NAME = new QueryPropertyImpl("NAME_");
-  QueryProperty VARIABLE_TYPE = new QueryPropertyImpl("TYPE_");
-  QueryProperty ACTIVITY_INSTANCE_ID = new QueryPropertyImpl("ACT_INST_ID_");
-  QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
-  QueryProperty TASK_ID = new QueryPropertyImpl("TASK_ID_");
-  QueryProperty CASE_EXECUTION_ID = new QueryPropertyImpl("CASE_EXECUTION_ID_");
-  QueryProperty CASE_INSTANCE_ID = new QueryPropertyImpl("CASE_INST_ID_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty VARIABLE_NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty VARIABLE_TYPE = new QueryPropertyImpl("TYPE_");
+  public static final QueryProperty ACTIVITY_INSTANCE_ID = new QueryPropertyImpl("ACT_INST_ID_");
+  public static final QueryProperty EXECUTION_ID = new QueryPropertyImpl("EXECUTION_ID_");
+  public static final QueryProperty TASK_ID = new QueryPropertyImpl("TASK_ID_");
+  public static final QueryProperty CASE_EXECUTION_ID = new QueryPropertyImpl("CASE_EXECUTION_ID_");
+  public static final QueryProperty CASE_INSTANCE_ID = new QueryPropertyImpl("CASE_INST_ID_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
 
-  QueryProperty TEXT = new QueryPropertyImpl("TEXT_");
-  QueryProperty TEXT_AS_LOWER = new QueryPropertyImpl("TEXT_", "LOWER");
-  QueryProperty DOUBLE = new QueryPropertyImpl("DOUBLE_");
-  QueryProperty LONG = new QueryPropertyImpl("LONG_");
+  public static final QueryProperty TEXT = new QueryPropertyImpl("TEXT_");
+  public static final QueryProperty TEXT_AS_LOWER = new QueryPropertyImpl("TEXT_", "LOWER");
+  public static final QueryProperty DOUBLE = new QueryPropertyImpl("DOUBLE_");
+  public static final QueryProperty LONG = new QueryPropertyImpl("LONG_");
+
+  private VariableInstanceQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/repository/CaseDefinitionQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/repository/CaseDefinitionQueryProperty.java
@@ -23,14 +23,16 @@ import org.operaton.bpm.engine.query.QueryProperty;
  * @author Roman Smirnov
  *
  */
-public interface CaseDefinitionQueryProperty {
+final class CaseDefinitionQueryProperty {
 
-  QueryProperty CASE_DEFINITION_ID = new QueryPropertyImpl("ID_");
-  QueryProperty CASE_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
-  QueryProperty CASE_DEFINITION_NAME = new QueryPropertyImpl("NAME_");
-  QueryProperty CASE_DEFINITION_VERSION = new QueryPropertyImpl("VERSION_");
-  QueryProperty CASE_DEFINITION_CATEGORY = new QueryPropertyImpl("CATEGORY_");
-  QueryProperty DEPLOYMENT_ID = new QueryPropertyImpl("DEPLOYMENT_ID_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty CASE_DEFINITION_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty CASE_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
+  public static final QueryProperty CASE_DEFINITION_NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty CASE_DEFINITION_VERSION = new QueryPropertyImpl("VERSION_");
+  public static final QueryProperty CASE_DEFINITION_CATEGORY = new QueryPropertyImpl("CATEGORY_");
+  public static final QueryProperty DEPLOYMENT_ID = new QueryPropertyImpl("DEPLOYMENT_ID_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private CaseDefinitionQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseExecutionQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseExecutionQueryProperty.java
@@ -23,11 +23,13 @@ import org.operaton.bpm.engine.query.QueryProperty;
  * @author Roman Smirnov
  *
  */
-public interface CaseExecutionQueryProperty {
+public final class CaseExecutionQueryProperty {
 
-  QueryProperty CASE_EXECUTION_ID = new QueryPropertyImpl("ID_");
-  QueryProperty CASE_DEFINITION_ID = new QueryPropertyImpl("CASE_DEF_ID_");
-  QueryProperty CASE_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty CASE_EXECUTION_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty CASE_DEFINITION_ID = new QueryPropertyImpl("CASE_DEF_ID_");
+  public static final QueryProperty CASE_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+
+  private CaseExecutionQueryProperty() {}
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseSentryPartQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/CaseSentryPartQueryProperty.java
@@ -23,11 +23,13 @@ import org.operaton.bpm.engine.query.QueryProperty;
  * @author Roman Smirnov
  *
  */
-public interface CaseSentryPartQueryProperty {
+final class CaseSentryPartQueryProperty {
 
-  QueryProperty CASE_SENTRY_PART_ID = new QueryPropertyImpl("ID_");
-  QueryProperty CASE_INSTANCE_ID = new QueryPropertyImpl("CASE_INST_ID_");
-  QueryProperty CASE_EXECUTION_ID = new QueryPropertyImpl("CASE_EXEC_ID");
-  QueryProperty SENTRY_ID = new QueryPropertyImpl("SENTRY_ID_");
-  QueryProperty SOURCE = new QueryPropertyImpl("SOURCE");
+  public static final QueryProperty CASE_SENTRY_PART_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty CASE_INSTANCE_ID = new QueryPropertyImpl("CASE_INST_ID_");
+  public static final QueryProperty CASE_EXECUTION_ID = new QueryPropertyImpl("CASE_EXEC_ID");
+  public static final QueryProperty SENTRY_ID = new QueryPropertyImpl("SENTRY_ID_");
+  public static final QueryProperty SOURCE = new QueryPropertyImpl("SOURCE");
+
+  private CaseSentryPartQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/entity/repository/DecisionDefinitionQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/entity/repository/DecisionDefinitionQueryProperty.java
@@ -22,16 +22,18 @@ import org.operaton.bpm.engine.query.QueryProperty;
 /**
  * Properties to sort decision definition queries by
  */
-public interface DecisionDefinitionQueryProperty {
+final class DecisionDefinitionQueryProperty {
 
-  QueryProperty DECISION_DEFINITION_ID = new QueryPropertyImpl("ID_");
-  QueryProperty DECISION_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
-  QueryProperty DECISION_DEFINITION_NAME = new QueryPropertyImpl("NAME_");
-  QueryProperty DECISION_DEFINITION_VERSION = new QueryPropertyImpl("VERSION_");
-  QueryProperty DECISION_DEFINITION_CATEGORY = new QueryPropertyImpl("CATEGORY_");
-  QueryProperty DEPLOYMENT_ID = new QueryPropertyImpl("DEPLOYMENT_ID_");
-  QueryProperty DEPLOY_TIME = new QueryPropertyImpl("DEPLOY_TIME_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
-  QueryProperty VERSION_TAG = new QueryPropertyImpl("VERSION_TAG_");
-  QueryProperty DECISION_REQUIREMENTS_DEFINITION_KEY = new QueryPropertyImpl("DEC_REQ_KEY_");
+  public static final QueryProperty DECISION_DEFINITION_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty DECISION_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
+  public static final QueryProperty DECISION_DEFINITION_NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty DECISION_DEFINITION_VERSION = new QueryPropertyImpl("VERSION_");
+  public static final QueryProperty DECISION_DEFINITION_CATEGORY = new QueryPropertyImpl("CATEGORY_");
+  public static final QueryProperty DEPLOYMENT_ID = new QueryPropertyImpl("DEPLOYMENT_ID_");
+  public static final QueryProperty DEPLOY_TIME = new QueryPropertyImpl("DEPLOY_TIME_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty VERSION_TAG = new QueryPropertyImpl("VERSION_TAG_");
+  public static final QueryProperty DECISION_REQUIREMENTS_DEFINITION_KEY = new QueryPropertyImpl("DEC_REQ_KEY_");
+
+  private DecisionDefinitionQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/entity/repository/DecisionRequirementsDefinitionQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/entity/repository/DecisionRequirementsDefinitionQueryProperty.java
@@ -22,14 +22,15 @@ import org.operaton.bpm.engine.query.QueryProperty;
 /**
  * Properties to sort decision requirements definition queries by.
  */
-public interface DecisionRequirementsDefinitionQueryProperty {
+final class DecisionRequirementsDefinitionQueryProperty {
 
-  QueryProperty DECISION_REQUIREMENTS_DEFINITION_ID = new QueryPropertyImpl("ID_");
-  QueryProperty DECISION_REQUIREMENTS_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
-  QueryProperty DECISION_REQUIREMENTS_DEFINITION_NAME = new QueryPropertyImpl("NAME_");
-  QueryProperty DECISION_REQUIREMENTS_DEFINITION_VERSION = new QueryPropertyImpl("VERSION_");
-  QueryProperty DECISION_REQUIREMENTS_DEFINITION_CATEGORY = new QueryPropertyImpl("CATEGORY_");
-  QueryProperty DEPLOYMENT_ID = new QueryPropertyImpl("DEPLOYMENT_ID_");
-  QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty DECISION_REQUIREMENTS_DEFINITION_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty DECISION_REQUIREMENTS_DEFINITION_KEY = new QueryPropertyImpl("KEY_");
+  public static final QueryProperty DECISION_REQUIREMENTS_DEFINITION_NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty DECISION_REQUIREMENTS_DEFINITION_VERSION = new QueryPropertyImpl("VERSION_");
+  public static final QueryProperty DECISION_REQUIREMENTS_DEFINITION_CATEGORY = new QueryPropertyImpl("CATEGORY_");
+  public static final QueryProperty DEPLOYMENT_ID = new QueryPropertyImpl("DEPLOYMENT_ID_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
 
+  private  DecisionRequirementsDefinitionQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/filter/FilterQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/filter/FilterQueryProperty.java
@@ -22,13 +22,14 @@ import org.operaton.bpm.engine.query.QueryProperty;
 /**
  * @author Sebastian Menski
  */
-public interface FilterQueryProperty {
+final class FilterQueryProperty {
 
-  QueryProperty FILTER_ID = new QueryPropertyImpl("ID_");
-  QueryProperty RESOURCE_TYPE = new QueryPropertyImpl("RESOURCE_TYPE_");
-  QueryProperty NAME = new QueryPropertyImpl("NAME_");
-  QueryProperty OWNER = new QueryPropertyImpl("OWNER_");
-  QueryProperty QUERY = new QueryPropertyImpl("QUERY_");
-  QueryProperty PROPERTIES = new QueryPropertyImpl("PROPERTIES_");
+  public static final QueryProperty FILTER_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty RESOURCE_TYPE = new QueryPropertyImpl("RESOURCE_TYPE_");
+  public static final QueryProperty NAME = new QueryPropertyImpl("NAME_");
+  public static final QueryProperty OWNER = new QueryPropertyImpl("OWNER_");
+  public static final QueryProperty QUERY = new QueryPropertyImpl("QUERY_");
+  public static final QueryProperty PROPERTIES = new QueryPropertyImpl("PROPERTIES_");
 
+  private  FilterQueryProperty() {}
 }

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/Ordering.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/Ordering.java
@@ -16,7 +16,9 @@
  */
 package org.operaton.bpm.spring.boot.starter.configuration;
 
-public interface Ordering {
+public class Ordering {
 
-  int DEFAULT_ORDER = 0;
+  public static final int DEFAULT_ORDER = 0;
+
+  private Ordering() {}
 }


### PR DESCRIPTION
Refactors constant definitions by replacing interface constants with
final utility classes and static final fields. Adds private constructors
to prevent instantiation.

Updated 10 of 40 classes:

- TenantQueryProperty
- UserQueryProperty
- VariableInstanceQueryProperty
- CaseDefinitionQueryProperty
- CaseExecutionQueryProperty
- CaseSentryPartQueryProperty
- DecisionDefinitionQueryProperty
- DecisionRequirementsDefinitionQueryProperty   
- FilterQueryProperty
- Ordering

related to #1059