### PR TITLE
refactor: replace deprecated StringUtils.isEmpty() with StringUtils.hasText()

### DIFF
--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/SpringBootProcessApplication.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/SpringBootProcessApplication.java
@@ -131,7 +131,7 @@ public class SpringBootProcessApplication extends SpringProcessApplication {
 
     @Override
     public void setServletContext(ServletContext servletContext) {
-      if (!StringUtils.isEmpty(servletContext.getContextPath())) {
+      if (StringUtils.hasText(servletContext.getContextPath())) {
         contextPath = servletContext.getContextPath();
       }
     }

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/impl/DefaultDatasourceConfiguration.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/impl/DefaultDatasourceConfiguration.java
@@ -61,11 +61,11 @@ public class DefaultDatasourceConfiguration extends AbstractOperatonConfiguratio
     configuration.setDatabaseType(database.getType());
     configuration.setDatabaseSchemaUpdate(database.getSchemaUpdate());
 
-    if (!StringUtils.isEmpty(database.getTablePrefix())) {
+    if (StringUtils.hasText(database.getTablePrefix())) {
       configuration.setDatabaseTablePrefix(database.getTablePrefix());
     }
 
-    if(!StringUtils.isEmpty(database.getSchemaName())) {
+    if(StringUtils.hasText(database.getSchemaName())) {
       configuration.setDatabaseSchema(database.getSchemaName());
     }
 

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/impl/DefaultHistoryLevelAutoHandlingConfiguration.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/impl/DefaultHistoryLevelAutoHandlingConfiguration.java
@@ -33,7 +33,7 @@ public class DefaultHistoryLevelAutoHandlingConfiguration extends AbstractOperat
   @Override
   public void preInit(SpringProcessEngineConfiguration configuration) {
     final String determineHistoryLevel = historyLevelDeterminator.determineHistoryLevel();
-    if (!StringUtils.isEmpty(determineHistoryLevel)) {
+    if (StringUtils.hasText(determineHistoryLevel)) {
       configuration.setHistory(determineHistoryLevel);
     }
   }

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/impl/DefaultProcessEngineConfiguration.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/impl/DefaultProcessEngineConfiguration.java
@@ -55,7 +55,7 @@ public class DefaultProcessEngineConfiguration extends AbstractOperatonConfigura
 
   private void setProcessEngineName(SpringProcessEngineConfiguration configuration) {
     String processEngineName = StringUtils.trimAllWhitespace(operatonBpmProperties.getProcessEngineName());
-    if (!StringUtils.isEmpty(processEngineName) && !processEngineName.contains("-")) {
+    if (StringUtils.hasText(processEngineName) && !processEngineName.contains("-")) {
 
       if (operatonBpmProperties.getGenerateUniqueProcessEngineName()) {
         if (!ProcessEngines.NAME_DEFAULT.equals(processEngineName)) {


### PR DESCRIPTION
- Replace 5 instances of deprecated Spring StringUtils.isEmpty() method
- Update logic to use the recommended StringUtils.hasText() method
- Affects 4 files in spring-boot-starter module
- No functional changes, only method signature updates