### PR TITLE
refactor: upgrade httpclient5 to 5.5 and resolve deprecated API usage

### DIFF
--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -182,7 +182,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>
-        <version>5.4.3</version>
+        <version>${version.httpclient5}</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/AbstractEmptyBodyFilterTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/AbstractEmptyBodyFilterTest.java
@@ -69,7 +69,7 @@ public abstract class AbstractEmptyBodyFilterTest extends AbstractRestServiceTes
 
   @BeforeEach
   public void setUpHttpClientAndRuntimeData() {
-    client = HttpClients.createDefault();
+    client = HttpClients.createSystem();
     reqConfig = RequestConfig.custom().setConnectTimeout(3 * 60 * 1000).setSocketTimeout(10 * 60 * 1000).build();
 
     ProcessDefinition mockDefinition = MockProvider.createMockDefinition();

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -35,7 +35,7 @@
     <version.hikaricp>4.0.3</version.hikaricp>
     <version.jackson>2.15.2</version.jackson>
     <version.httpclient>4.5.14</version.httpclient>
-    <version.httpclient5>5.4.1</version.httpclient5>
+    <version.httpclient5>5.5</version.httpclient5>
     <version.assertj>3.27.3</version.assertj>
     <version.mockito>5.19.0</version.mockito>
     <version.jna>5.17.0</version.jna>


### PR DESCRIPTION
- Update version property from 5.4.1 to 5.5
- Use property reference instead of hardcoded version
- Replace deprecated HttpClients.createDefault() with createSystem()

Issue #1121