### PR TITLE
feat: upgrade JDBC drivers to latest versions

### DIFF
--- a/.github/jreleaser/changelog.tpl
+++ b/.github/jreleaser/changelog.tpl
@@ -110,10 +110,10 @@ Operaton is now tested against the following databases:
 |----------------------|--------------------------------|------------------|----------------|
 | H2                   | n/a                            | n/a              | 2.3.232        |
 | PostgreSQL           | postgres                       | 9.6.12           | 42.7.7         |
-| MySQL                | mysql                          | 5.7.34           | 9.3.0          |
-| MariaDB              | mariadb                        | 10.3.6           | 1.7.6          |
-| Oracle               | gvenzl/oracle-xe               | 18.4.0-slim      | 23.5.0.24.07   |                
-| Microsoft SQL Server | mcr.microsoft.com/mssql/server | 2017-CU12        | 12.10.0.jre8   |
+| MySQL                | mysql                          | 5.7.34           | 9.4.0          |
+| MariaDB              | mariadb                        | 10.3.6           | 1.8.0          |
+| Oracle               | gvenzl/oracle-xe               | 18.4.0-slim      | 23.9.0.25.07   |                
+| Microsoft SQL Server | mcr.microsoft.com/mssql/server | 2017-CU12        | 12.10.1.jre11   |
 | DB2                  | icr.io/db2_community/db2       | 11.5.0.0a        | 12.1.2.0       |
 
 ### Database Schema Upgrade Tests

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -19,11 +19,11 @@
     <!-- database driver versions -->
     <version.h2>2.3.232</version.h2>
     <version.h2-v1>1.4.200</version.h2-v1><!-- used for instance migration qa -->
-    <version.oracle>23.5.0.24.07</version.oracle>
-    <version.mariadb>1.7.6</version.mariadb>
+    <version.oracle>23.9.0.25.07</version.oracle>
+    <version.mariadb>1.8.0</version.mariadb>
     <version.mariadb-v1>1.1.8</version.mariadb-v1>
-    <version.mysql>9.3.0</version.mysql>
-    <version.sqlserver>12.10.0.jre8</version.sqlserver>
+    <version.mysql>9.4.0</version.mysql>
+    <version.sqlserver>12.10.1.jre11</version.sqlserver>
     <version.db2-11.5>11.5.9.0</version.db2-11.5>
     <version.db2>12.1.2.0</version.db2>
     <version.postgresql>42.7.7</version.postgresql>

--- a/qa/tomcat-runtime/pom.xml
+++ b/qa/tomcat-runtime/pom.xml
@@ -53,7 +53,6 @@
     <dependency>
       <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>
-      <version>${version.mysql}</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/qa/wildfly-runtime/src/main/common/modules/com/microsoft/sqlserver/mssql-jdbc/main/module.xml
+++ b/qa/wildfly-runtime/src/main/common/modules/com/microsoft/sqlserver/mssql-jdbc/main/module.xml
@@ -1,6 +1,6 @@
 <module xmlns="urn:jboss:module:1.1" name="com.microsoft.sqlserver.mssql-jdbc">
   <resources>
-    <resource-root path="mssql-jdbc-12.10.0.jre8.jar"/>
+    <resource-root path="mssql-jdbc-12.10.1.jre11.jar"/>
   </resources>
   
   <dependencies>

--- a/qa/wildfly-runtime/src/main/common/modules/com/mysql/mysql-connector-j/main/module.xml
+++ b/qa/wildfly-runtime/src/main/common/modules/com/mysql/mysql-connector-j/main/module.xml
@@ -2,7 +2,7 @@
 <module xmlns="urn:jboss:module:1.1" name="com.mysql.mysql-connector-j">
 
     <resources>
-        <resource-root path="mysql-connector-j-9.3.0.jar"/>
+        <resource-root path="mysql-connector-j-9.4.0.jar"/>
     </resources>
 
     <dependencies>

--- a/qa/wildfly-runtime/src/main/common/modules/com/oracle/database/jdbc/ojdbc11/main/module.xml
+++ b/qa/wildfly-runtime/src/main/common/modules/com/oracle/database/jdbc/ojdbc11/main/module.xml
@@ -1,6 +1,6 @@
 <module xmlns="urn:jboss:module:1.1" name="com.oracle.database.jdbc.ojdbc11">
   <resources>
-    <resource-root path="ojdbc11-23.5.0.24.07.jar"/>
+    <resource-root path="ojdbc11-23.9.0.25.07.jar"/>
   </resources>
 
   <dependencies>

--- a/qa/wildfly-runtime/src/main/common/modules/org/mariadb/jdbc/mariadb-java-client/main/module.xml
+++ b/qa/wildfly-runtime/src/main/common/modules/org/mariadb/jdbc/mariadb-java-client/main/module.xml
@@ -1,6 +1,6 @@
 <module xmlns="urn:jboss:module:1.1" name="org.mariadb.jdbc.mariadb-java-client">
     <resources>
-        <resource-root path="mariadb-java-client-1.7.6.jar"/>
+        <resource-root path="mariadb-java-client-1.8.0.jar"/>
     </resources>
     <dependencies>
         <module name="jakarta.enterprise.api"/>


### PR DESCRIPTION
- SQL Server: 12.10.0.jre8 → 12.10.1.jre11
- MySQL: 9.3.0 → 9.4.0
- Oracle: 23.5.0.24.07 → 23.9.0.25.07
- MariaDB: 1.7.6 → 1.8.0
- Update WildFly module JAR references
- Clean up dependency management in tomcat-runtime

Files updated:
- database/pom.xml: Update version properties
- qa/tomcat-runtime/pom.xml: Clean up dependency management
- qa/wildfly-runtime module.xml files: Update JAR filenames

Issue #1122