### PR TITLE
chore(deps): Remove dependency on org.apache.httpcomponents:httpclient/httpcore

### DIFF
--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -444,12 +444,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.glassfish.jersey.connectors</groupId>
-        <artifactId>jersey-apache-connector</artifactId>
-        <version>${version.jersey3}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs</artifactId>
         <version>${version.resteasy}</version>

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -98,11 +98,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -155,11 +155,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <scope>test</scope>

--- a/engine-rest/pom.xml
+++ b/engine-rest/pom.xml
@@ -52,11 +52,6 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
-      <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpcore</artifactId>
-        <version>${version.apache.httpcore}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/qa/integration-tests-webapps/integration-tests/pom.xml
+++ b/qa/integration-tests-webapps/integration-tests/pom.xml
@@ -9,7 +9,6 @@
   <artifactId>operaton-qa-integration-tests-webapps</artifactId>
   <name>Operaton - QA Integration Tests - Webapps ITs</name>
   <description>${project.name}</description>
-
   <!--
     Maven modules running these tests with the failsafe plugin should declare the following system property:
 
@@ -17,8 +16,6 @@
         (e.g. set to "${project.build.directory}/selenium-screenshots");
         no screenshots created if not set
    -->
-
-
   <dependencies>
     <!-- set shrinkwrap artifacts -->
     <dependency>
@@ -101,5 +98,4 @@
       <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
   </dependencies>
-
 </project>


### PR DESCRIPTION
- Replaced outdated jersey-apache-client4 with jersey-apache-connector 3.1.10
- Updated dependency management in BOM and 4 test modules
- Eliminated javax namespace usage for Jakarta EE migration

Issue #962