### PR TITLE
fix: Update tomcat-jdbc and tomcat-juli dependencies versions

### DIFF
--- a/qa/performance-tests-engine/pom.xml
+++ b/qa/performance-tests-engine/pom.xml
@@ -42,12 +42,12 @@
     <dependency>
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-jdbc</artifactId>
-      <version>7.0.33</version>
+      <version>${version.tomcat}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-juli</artifactId>
-      <version>7.0.33</version>
+      <version>${version.tomcat}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.uuid</groupId>


### PR DESCRIPTION
Update tomcat-jdbc and tomcat-juli dependencies to use the globally defined Tomcat version in the project.


closes #1136