### PR TITLE
OpenRewrite code cleanups

### DIFF
--- a/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
@@ -183,9 +183,8 @@ public class EngineRule implements BeforeEachCallback, AfterEachCallback {
     String endpoint = String.format(URI_DEPLOYMENT_DELETE, getEngineUrl(), deploymentId);
 
     List<String> queryParameters = new ArrayList<>();
-    parameters.forEach((key, value) -> {
-      queryParameters.add(key + "=" + value);
-    });
+    parameters.forEach((key, value) ->
+      queryParameters.add(key + "=" + value));
 
     if (!queryParameters.isEmpty()) {
       endpoint = endpoint + "?" + String.join("&", queryParameters);

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/task/ExternalTaskHandlerIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/task/ExternalTaskHandlerIT.java
@@ -112,9 +112,8 @@ public class ExternalTaskHandlerIT {
   @Test
   public void shouldCompleteTask() {
     // given
-    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
-      client.complete(task);
-    });
+    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) ->
+      client.complete(task));
 
     // when
     client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
@@ -329,9 +328,8 @@ public class ExternalTaskHandlerIT {
   @Test
   public void shouldCompleteById() {
     // given
-    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
-      client.complete(task.getId(), null, null);
-    });
+    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) ->
+      client.complete(task.getId(), null, null));
 
     // when
     client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
@@ -350,10 +348,9 @@ public class ExternalTaskHandlerIT {
   @Test
   public void shouldLock() {
     // given
-    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
+    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) ->
       // an external task may be locked again by the same worker
-      client.lock(task, LOCK_DURATION * 10);
-    });
+      client.lock(task, LOCK_DURATION * 10));
 
     // when
     client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
@@ -370,10 +367,9 @@ public class ExternalTaskHandlerIT {
   @Test
   public void shouldLockById() {
     // given
-    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
+    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) ->
       // an external task may be locked again by the same worker
-      client.lock(task.getId(), LOCK_DURATION * 10);
-    });
+      client.lock(task.getId(), LOCK_DURATION * 10));
 
     // when
     client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
@@ -390,9 +386,8 @@ public class ExternalTaskHandlerIT {
   @Test
   public void shouldExtendLock() {
     // given
-    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
-      client.extendLock(task, LOCK_DURATION * 10);
-    });
+    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) ->
+      client.extendLock(task, LOCK_DURATION * 10));
 
     // when
     client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
@@ -411,9 +406,8 @@ public class ExternalTaskHandlerIT {
   @Test
   public void shouldExtendLockById() {
     // given
-    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
-      client.extendLock(task.getId(), LOCK_DURATION * 10);
-    });
+    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) ->
+      client.extendLock(task.getId(), LOCK_DURATION * 10));
 
     // when
     client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
@@ -455,9 +449,8 @@ public class ExternalTaskHandlerIT {
   @Test
   public void shouldInvokeHandleBpmnError() {
     // given
-    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
-      client.handleBpmnError(task, "500");
-    });
+    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) ->
+      client.handleBpmnError(task, "500"));
 
     // when
     client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
@@ -508,9 +501,8 @@ public class ExternalTaskHandlerIT {
   public void shouldInvokeHandleBpmnErrorWithErrorMessage() {
     // given
     String anErrorMessage = "meaningful error message";
-    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
-      client.handleBpmnError(task, "500", anErrorMessage);
-    });
+    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) ->
+      client.handleBpmnError(task, "500", anErrorMessage));
 
     // when
     client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
@@ -533,9 +525,8 @@ public class ExternalTaskHandlerIT {
   @Test
   public void shouldInvokeHandleBpmnErrorById() {
     // given
-    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
-      client.handleBpmnError(task.getId(), "500", null, null);
-    });
+    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) ->
+      client.handleBpmnError(task.getId(), "500", null, null));
 
     // when
     client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
@@ -554,9 +545,8 @@ public class ExternalTaskHandlerIT {
   @Test
   public void shouldInvokeHandleFailure() {
     // given
-    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
-      client.handleFailure(task, "my-message", "my-details", 0, 0);
-    });
+    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) ->
+      client.handleFailure(task, "my-message", "my-details", 0, 0));
 
     // when
     client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
@@ -575,9 +565,8 @@ public class ExternalTaskHandlerIT {
   @Test
   public void shouldInvokeHandleFailureWithRetries() {
     // given
-    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
-      client.handleFailure(task, "my-message", "my-details", 1, 0);
-    });
+    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) ->
+      client.handleFailure(task, "my-message", "my-details", 1, 0));
 
     // when
     client.subscribe(EXTERNAL_TASK_TOPIC_FOO)
@@ -602,9 +591,8 @@ public class ExternalTaskHandlerIT {
   @Test
   public void shouldInvokeHandleFailureById() {
     // given
-    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) -> {
-      client.handleFailure(task.getId(), "my-message", "my-details", 0, 0);
-    });
+    RecordingExternalTaskHandler handler = new RecordingExternalTaskHandler((task, client) ->
+      client.handleFailure(task.getId(), "my-message", "my-details", 0, 0));
 
     // when
     client.subscribe(EXTERNAL_TASK_TOPIC_FOO)

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/variable/PrimitiveVariableIT.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/variable/PrimitiveVariableIT.java
@@ -61,7 +61,7 @@ public class PrimitiveVariableIT {
   protected static final String VARIABLE_NAME_NULL = "nullValue";
 
   protected static final int VARIABLE_VALUE_INT = 123;
-  protected static final long VARIABLE_VALUE_LONG = 123l;
+  protected static final long VARIABLE_VALUE_LONG = 123L;
   protected static final short VARIABLE_VALUE_SHORT = (short) 123;
   protected static final double VARIABLE_VALUE_DOUBLE = 12.34;
   protected static final String VARIABLE_VALUE_STRING = "bar";

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/task/OrderingConfig.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/task/OrderingConfig.java
@@ -110,7 +110,7 @@ public class OrderingConfig {
    * Returns the last configured field in this {@link OrderingConfig}.
    */
   protected OrderingProperty getLastConfiguredProperty() {
-    return !orderingProperties.isEmpty() ? orderingProperties.get(orderingProperties.size() - 1) : null;
+    return orderingProperties.isEmpty() ? null : orderingProperties.get(orderingProperties.size() - 1);
   }
 
   /**

--- a/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/value/PrimitiveTypeValueImpl.java
+++ b/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/value/PrimitiveTypeValueImpl.java
@@ -78,7 +78,7 @@ public class PrimitiveTypeValueImpl<T> extends AbstractTypedValue<T> implements 
         return false;
     } else if (!value.equals(other.value))
       return false;
-    return !(isTransient != other.isTransient());
+    return isTransient == other.isTransient();
   }
 
 

--- a/commons/utils/src/main/java/org/operaton/commons/utils/cache/ConcurrentLruCache.java
+++ b/commons/utils/src/main/java/org/operaton/commons/utils/cache/ConcurrentLruCache.java
@@ -122,6 +122,7 @@ public class ConcurrentLruCache<K, V> implements Cache<K, V> {
    */
   protected void removeAll(K key) {
     while (keys.remove(key)) {
+      continue;
     }
   }
 

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
@@ -49,7 +49,7 @@ public abstract class AbstractWebappUiIT extends AbstractWebIT {
   @BeforeAll
   static void createDriver() {
     String chromeDriverExecutable = "chromedriver";
-    if (System.getProperty( "os.name" ).toLowerCase(Locale.US).indexOf("windows") > -1) {
+    if (System.getProperty("os.name").toLowerCase(Locale.US).contains("windows")) {
       chromeDriverExecutable += ".exe";
     }
 

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/extension/BpmPlatformParser1_1.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/extension/BpmPlatformParser1_1.java
@@ -395,14 +395,12 @@ public class BpmPlatformParser1_1 extends AbstractParser {
 
 
       while(reader.hasNext() && !reader.isEndElement()) {
-        switch (reader.getLocalName()) {
-          case SUBSYSTEM: {
-            try {
-              final BpmPlatformParser1_1 parser = new BpmPlatformParser1_1();
-              parser.parse(reader, operations, subsystemAddress);
-            } catch (Exception e) {
-              throw new XMLStreamException(e);
-            }
+        if (reader.getLocalName() == SUBSYSTEM) {
+          try {
+            final BpmPlatformParser1_1 parser = new BpmPlatformParser1_1();
+            parser.parse(reader, operations, subsystemAddress);
+          } catch (Exception e) {
+            throw new XMLStreamException(e);
           }
         }
       }

--- a/engine-cdi/src/test/java/org/operaton/bpm/engine/cdi/test/api/BusinessProcessBeanTest.java
+++ b/engine-cdi/src/test/java/org/operaton/bpm/engine/cdi/test/api/BusinessProcessBeanTest.java
@@ -152,7 +152,7 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     BusinessProcess businessProcess = getBeanInstance(BusinessProcess.class);
 
     // initially, the variable cache is empty
-    assertThat(businessProcess.getVariableCache()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getVariableCache()).isEqualTo(Collections.emptyMap());
 
     // set a variable
     businessProcess.setVariable("aVariableName", "aVariableValue");
@@ -166,7 +166,7 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     businessProcess.startProcessByKey("businessProcessBeanTest");
 
     // now the variable cache is empty again:
-    assertThat(businessProcess.getVariableCache()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getVariableCache()).isEqualTo(Collections.emptyMap());
 
     // set a variable
     businessProcess.setVariable("anotherVariableName", "aVariableValue");
@@ -181,7 +181,7 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     BusinessProcess businessProcess = getBeanInstance(BusinessProcess.class);
 
     // initially, the variable cache is empty
-    assertThat(businessProcess.getCachedVariableMap()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getCachedVariableMap()).isEqualTo(Collections.emptyMap());
 
     // set a variable
     businessProcess.setVariable("aVariableName", "aVariableValue");
@@ -195,7 +195,7 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     businessProcess.startProcessByKey("businessProcessBeanTest");
 
     // now the variable cache is empty again:
-    assertThat(businessProcess.getCachedVariableMap()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getCachedVariableMap()).isEqualTo(Collections.emptyMap());
 
     // set a variable
     businessProcess.setVariable("anotherVariableName", "aVariableValue");
@@ -211,7 +211,7 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     BusinessProcess businessProcess = getBeanInstance(BusinessProcess.class);
 
     // initially, the variable cache is empty
-    assertThat(businessProcess.getAndClearVariableCache()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getAndClearVariableCache()).isEqualTo(Collections.emptyMap());
 
     // set a variable
     businessProcess.setVariable("aVariableName", "aVariableValue");
@@ -220,12 +220,12 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     assertThat(businessProcess.getAndClearVariableCache()).isEqualTo(Collections.singletonMap("aVariableName", "aVariableValue"));
 
     // now the variable cache is empty
-    assertThat(businessProcess.getAndClearVariableCache()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getAndClearVariableCache()).isEqualTo(Collections.emptyMap());
 
     businessProcess.startProcessByKey("businessProcessBeanTest");
 
     // now the variable cache is empty again:
-    assertThat(businessProcess.getVariableCache()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getVariableCache()).isEqualTo(Collections.emptyMap());
 
     // set a variable
     businessProcess.setVariable("anotherVariableName", "aVariableValue");
@@ -240,7 +240,7 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     BusinessProcess businessProcess = getBeanInstance(BusinessProcess.class);
 
     // initially, the variable cache is empty
-    assertThat(businessProcess.getAndClearCachedVariableMap()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getAndClearCachedVariableMap()).isEqualTo(Collections.emptyMap());
 
     // set a variable
     businessProcess.setVariable("aVariableName", "aVariableValue");
@@ -249,12 +249,12 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     assertThat(businessProcess.getAndClearCachedVariableMap()).isEqualTo(Collections.singletonMap("aVariableName", "aVariableValue"));
 
     // now the variable cache is empty
-    assertThat(businessProcess.getAndClearCachedVariableMap()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getAndClearCachedVariableMap()).isEqualTo(Collections.emptyMap());
 
     businessProcess.startProcessByKey("businessProcessBeanTest");
 
     // now the variable cache is empty again:
-    assertThat(businessProcess.getAndClearCachedVariableMap()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getAndClearCachedVariableMap()).isEqualTo(Collections.emptyMap());
 
     // set a variable
     businessProcess.setVariable("anotherVariableName", "aVariableValue");
@@ -270,7 +270,7 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     BusinessProcess businessProcess = getBeanInstance(BusinessProcess.class);
 
     // initially, the variable cache is empty
-    assertThat(businessProcess.getVariableLocalCache()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getVariableLocalCache()).isEqualTo(Collections.emptyMap());
 
     // set a variable - this should fail before the process is started
     try {
@@ -284,7 +284,7 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     businessProcess.startProcessByKey("businessProcessBeanTest");
 
     // now the variable cache is empty again:
-    assertThat(businessProcess.getVariableLocalCache()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getVariableLocalCache()).isEqualTo(Collections.emptyMap());
 
     // set a variable
     businessProcess.setVariableLocal("anotherVariableName", "aVariableValue");
@@ -302,7 +302,7 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     BusinessProcess businessProcess = getBeanInstance(BusinessProcess.class);
 
     // initially, the variable cache is empty
-    assertThat(businessProcess.getCachedLocalVariableMap()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getCachedLocalVariableMap()).isEqualTo(Collections.emptyMap());
 
     // set a variable - this should fail before the process is started
     try {
@@ -316,7 +316,7 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     businessProcess.startProcessByKey("businessProcessBeanTest");
 
     // now the variable cache is empty again:
-    assertThat(businessProcess.getCachedLocalVariableMap()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getCachedLocalVariableMap()).isEqualTo(Collections.emptyMap());
 
     // set a variable
     businessProcess.setVariableLocal("anotherVariableName", "aVariableValue");
@@ -357,7 +357,7 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     BusinessProcess businessProcess = getBeanInstance(BusinessProcess.class);
 
     // initially, the variable cache is empty
-    assertThat(businessProcess.getAndClearVariableLocalCache()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getAndClearVariableLocalCache()).isEqualTo(Collections.emptyMap());
 
     // set a variable - this should fail before the process is started
     try {
@@ -369,12 +369,12 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     }
 
     // the variable cache is still empty
-    assertThat(businessProcess.getAndClearVariableLocalCache()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getAndClearVariableLocalCache()).isEqualTo(Collections.emptyMap());
 
     businessProcess.startProcessByKey("businessProcessBeanTest");
 
     // now the variable cache is empty again:
-    assertThat(businessProcess.getVariableLocalCache()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getVariableLocalCache()).isEqualTo(Collections.emptyMap());
 
     // set a variable
     businessProcess.setVariableLocal("anotherVariableName", "aVariableValue");
@@ -389,7 +389,7 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     BusinessProcess businessProcess = getBeanInstance(BusinessProcess.class);
 
     // initially, the variable cache is empty
-    assertThat(businessProcess.getAndClearCachedLocalVariableMap()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getAndClearCachedLocalVariableMap()).isEqualTo(Collections.emptyMap());
 
     // set a variable - this should fail before the process is started
     try {
@@ -401,12 +401,12 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     }
 
     // the variable cache is still empty
-    assertThat(businessProcess.getAndClearCachedLocalVariableMap()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getAndClearCachedLocalVariableMap()).isEqualTo(Collections.emptyMap());
 
     businessProcess.startProcessByKey("businessProcessBeanTest");
 
     // now the variable cache is empty again:
-    assertThat(businessProcess.getAndClearCachedLocalVariableMap()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getAndClearCachedLocalVariableMap()).isEqualTo(Collections.emptyMap());
 
     // set a variable
     businessProcess.setVariableLocal("anotherVariableName", "aVariableValue");
@@ -454,10 +454,10 @@ public class BusinessProcessBeanTest extends CdiProcessEngineTestCase {
     assertThat(runtimeService.getVariable(businessProcess.getExecutionId(), "aVariableLocalName")).isNotNull();
 
     // the cache is empty
-    assertThat(businessProcess.getCachedVariableMap()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getCachedVariableMap()).isEqualTo(Collections.emptyMap());
 
     // the cache is empty
-    assertThat(businessProcess.getCachedLocalVariableMap()).isEqualTo(Collections.EMPTY_MAP);
+    assertThat(businessProcess.getCachedLocalVariableMap()).isEqualTo(Collections.emptyMap());
 
   }
 

--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/ldap/util/LdapTestExtension.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/ldap/util/LdapTestExtension.java
@@ -39,10 +39,10 @@ public class LdapTestExtension implements BeforeAllCallback, AfterAllCallback {
     private static final String ADMIN_DN = "cn=admin,dc=operaton,dc=org";
     private LdapTestContext ldapTestContextContext;
 
-    private int additionalNumberOfUsers = 0;
-    private int additionalNumberOfGroups = 0;
-    private int additionalNumberOfRoles = 0;
-    private boolean posixContext = false;
+    private int additionalNumberOfUsers;
+    private int additionalNumberOfGroups;
+    private int additionalNumberOfRoles;
+    private boolean posixContext;
 
     private final GenericContainer<?> ldapContainer = new GenericContainer<>("osixia/openldap:latest")
             .withExposedPorts(389)

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/UserDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/UserDto.java
@@ -63,7 +63,7 @@ public class UserDto {
 
     if (firstName != null ? !firstName.equals(userDto.firstName) : userDto.firstName != null) return false;
     if (id != null ? !id.equals(userDto.id) : userDto.id != null) return false;
-    return !(lastName != null ? !lastName.equals(userDto.lastName) : userDto.lastName != null);
+    return lastName == null ? userDto.lastName != null : !lastName.equals(userDto.lastName);
   }
 
   @Override

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/ProcessDefinitionResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/ProcessDefinitionResourceImpl.java
@@ -255,8 +255,6 @@ public class ProcessDefinitionResourceImpl implements ProcessDefinitionResource 
       processModelIn = engine.getRepositoryService().getProcessModel(processDefinitionId);
       byte[] processModel = IoUtil.readInputStream(processModelIn, "processModelBpmn20Xml");
       return ProcessDefinitionDiagramDto.create(processDefinitionId, new String(processModel, UTF_8));
-    } catch (AuthorizationException e) {
-      throw e;
     } catch (NotFoundException e) {
       throw new InvalidRequestException(Status.NOT_FOUND, e, "No matching definition with id " + processDefinitionId);
     } finally {

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/impl/ProcessInstanceCommentResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/impl/ProcessInstanceCommentResourceImpl.java
@@ -73,8 +73,6 @@ public class ProcessInstanceCommentResourceImpl implements ProcessInstanceCommen
     TaskService taskService = engine.getTaskService();
     try {
       taskService.deleteProcessInstanceComment(processInstanceId, commentId);
-    } catch (AuthorizationException e) {
-      throw e;
     } catch (NullValueException e) {
       throw new InvalidRequestException(Status.BAD_REQUEST, e.getMessage());
     }
@@ -91,8 +89,6 @@ public class ProcessInstanceCommentResourceImpl implements ProcessInstanceCommen
     TaskService taskService = engine.getTaskService();
     try {
       taskService.updateProcessInstanceComment(processInstanceId, comment.getId(), comment.getMessage());
-    } catch (AuthorizationException e) {
-      throw e;
     } catch (NullValueException e) {
       throw new InvalidRequestException(Status.BAD_REQUEST, e.getMessage());
     }
@@ -109,8 +105,6 @@ public class ProcessInstanceCommentResourceImpl implements ProcessInstanceCommen
 
     try {
       taskService.deleteProcessInstanceComments(processInstanceId);
-    } catch (AuthorizationException e) {
-      throw e;
     } catch (NullValueException e) {
       throw new InvalidRequestException(Status.BAD_REQUEST, e.getMessage());
     }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/task/impl/TaskCommentResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/task/impl/TaskCommentResourceImpl.java
@@ -88,8 +88,6 @@ public class TaskCommentResourceImpl implements TaskCommentResource {
     TaskService taskService = engine.getTaskService();
     try {
       taskService.deleteTaskComment(taskId, commentId);
-    } catch (AuthorizationException e) {
-      throw e;
     } catch (NullValueException e) {
       throw new InvalidRequestException(Status.BAD_REQUEST, e.getMessage());
     }
@@ -101,8 +99,6 @@ public class TaskCommentResourceImpl implements TaskCommentResource {
 
     try {
       engine.getTaskService().updateTaskComment(taskId, comment.getId(), comment.getMessage());
-    } catch (AuthorizationException e) {
-      throw e;
     } catch (NullValueException e) {
       throw new InvalidRequestException(Status.BAD_REQUEST, e.getMessage());
     }
@@ -115,8 +111,6 @@ public class TaskCommentResourceImpl implements TaskCommentResource {
 
     try {
       taskService.deleteTaskComments(taskId);
-    } catch (AuthorizationException e) {
-      throw e;
     } catch (NullValueException e) {
       throw new InvalidRequestException(Status.BAD_REQUEST, e.getMessage());
     }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/task/impl/TaskResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/task/impl/TaskResourceImpl.java
@@ -465,8 +465,6 @@ public class TaskResourceImpl implements TaskResource {
     try {
       identityService.clearAuthentication();
       return action.get();
-    } catch (Exception e) {
-      throw e;
     } finally {
       identityService.setAuthentication(currentAuthentication);
     }

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/ResourceUtil.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/ResourceUtil.java
@@ -61,6 +61,6 @@ public class ResourceUtil implements Resource {
         return false;
     } else if (!resourceName.equals(other.resourceName))
       return false;
-    return !(resourceType != other.resourceType);
+    return resourceType == other.resourceType;
   }
 }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/MockProvider.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/MockProvider.java
@@ -537,7 +537,7 @@ public abstract class MockProvider {
 
   // Historic Process Instance
   public static final String EXAMPLE_HISTORIC_PROCESS_INSTANCE_DELETE_REASON = "aDeleteReason";
-  public static final long EXAMPLE_HISTORIC_PROCESS_INSTANCE_DURATION_MILLIS = 2000l;
+  public static final long EXAMPLE_HISTORIC_PROCESS_INSTANCE_DURATION_MILLIS = 2000L;
   public static final String EXAMPLE_HISTORIC_PROCESS_INSTANCE_START_TIME = withTimezone("2013-04-23T13:42:43");
   public static final String EXAMPLE_HISTORIC_PROCESS_INSTANCE_END_TIME = withTimezone("2013-04-23T13:42:43");
   public static final String EXAMPLE_HISTORIC_PROCESS_INSTANCE_REMOVAL_TIME = withTimezone("2013-04-26T13:42:43");
@@ -563,7 +563,7 @@ public abstract class MockProvider {
   public static final int EXAMPLE_HISTORIC_PROC_INST_DURATION_REPORT_PERIOD = 1;
 
   // Historic Case Instance
-  public static final long EXAMPLE_HISTORIC_CASE_INSTANCE_DURATION_MILLIS = 2000l;
+  public static final long EXAMPLE_HISTORIC_CASE_INSTANCE_DURATION_MILLIS = 2000L;
   public static final String EXAMPLE_HISTORIC_CASE_INSTANCE_CREATE_TIME = withTimezone("2013-04-23T13:42:43");
   public static final String EXAMPLE_HISTORIC_CASE_INSTANCE_CLOSE_TIME = withTimezone("2013-04-23T13:42:43");
   public static final String EXAMPLE_HISTORIC_CASE_INSTANCE_CREATE_USER_ID = "aCreateUserId";
@@ -590,7 +590,7 @@ public abstract class MockProvider {
   public static final String EXAMPLE_HISTORIC_ACTIVITY_INSTANCE_START_TIME = withTimezone("2013-04-23T13:42:43");
   public static final String EXAMPLE_HISTORIC_ACTIVITY_INSTANCE_END_TIME = withTimezone("2013-04-23T18:42:43");
   public static final String EXAMPLE_HISTORIC_ACTIVITY_INSTANCE_REMOVAL_TIME = withTimezone("2013-04-23T13:42:43");
-  public static final long EXAMPLE_HISTORIC_ACTIVITY_INSTANCE_DURATION = 2000l;
+  public static final long EXAMPLE_HISTORIC_ACTIVITY_INSTANCE_DURATION = 2000L;
   public static final String EXAMPLE_HISTORIC_ACTIVITY_INSTANCE_STARTED_AFTER = withTimezone("2013-04-23T13:42:43");
   public static final String EXAMPLE_HISTORIC_ACTIVITY_INSTANCE_STARTED_BEFORE = withTimezone("2013-01-23T13:42:43");
   public static final String EXAMPLE_HISTORIC_ACTIVITY_INSTANCE_FINISHED_AFTER = withTimezone("2013-01-23T13:42:43");
@@ -612,7 +612,7 @@ public abstract class MockProvider {
   public static final String EXAMPLE_HISTORIC_CASE_ACTIVITY_INSTANCE_CALLED_CASE_INSTANCE_ID = "aCalledCaseInstanceId";
   public static final String EXAMPLE_HISTORIC_CASE_ACTIVITY_INSTANCE_CREATE_TIME = withTimezone("2014-04-23T18:42:42");
   public static final String EXAMPLE_HISTORIC_CASE_ACTIVITY_INSTANCE_END_TIME = withTimezone("2014-04-23T18:42:43");
-  public static final long EXAMPLE_HISTORIC_CASE_ACTIVITY_INSTANCE_DURATION = 2000l;
+  public static final long EXAMPLE_HISTORIC_CASE_ACTIVITY_INSTANCE_DURATION = 2000L;
   public static final boolean EXAMPLE_HISTORIC_CASE_ACTIVITY_INSTANCE_IS_REQUIRED = true;
   public static final boolean EXAMPLE_HISTORIC_CASE_ACTIVITY_INSTANCE_IS_AVAILABLE = true;
   public static final boolean EXAMPLE_HISTORIC_CASE_ACTIVITY_INSTANCE_IS_ENABLED = true;

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/NoIntermediaryInvocation.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/NoIntermediaryInvocation.java
@@ -62,7 +62,7 @@ public class NoIntermediaryInvocation implements VerificationInOrderMode, Verifi
     throw new RuntimeException("Applies only to inorder verification");
   }
 
-  public static final NoIntermediaryInvocation immediatelyAfter() {
+  public static NoIntermediaryInvocation immediatelyAfter() {
     return new NoIntermediaryInvocation();
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/variable/EqualsNullValue.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/helper/variable/EqualsNullValue.java
@@ -40,7 +40,7 @@ public class EqualsNullValue extends BaseMatcher<TypedValue> {
       return false;
     }
 
-    return !(typedValue.getValue() != null);
+    return typedValue.getValue() == null;
   }
 
   public static EqualsNullValue matcher() {

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricBatchReportServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricBatchReportServiceTest.java
@@ -51,8 +51,8 @@ public class CleanableHistoricBatchReportServiceTest extends AbstractRestService
 
   private static final String EXAMPLE_TYPE = "batchId1";
   private static final int EXAMPLE_TTL = 5;
-  private static final long EXAMPLE_FINISHED_COUNT = 10l;
-  private static final long EXAMPLE_CLEANABLE_COUNT = 5l;
+  private static final long EXAMPLE_FINISHED_COUNT = 10L;
+  private static final long EXAMPLE_CLEANABLE_COUNT = 5L;
 
   @RegisterExtension
   public static TestContainerExtension rule = new TestContainerExtension();

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricCaseInstanceReportServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricCaseInstanceReportServiceTest.java
@@ -57,8 +57,8 @@ public class CleanableHistoricCaseInstanceReportServiceTest extends AbstractRest
   private static final String EXAMPLE_CD_NAME = "aName";
   private static final int EXAMPLE_CD_VERSION = 42;
   private static final int EXAMPLE_TTL = 5;
-  private static final long EXAMPLE_FINISHED_CI_COUNT = 10l;
-  private static final long EXAMPLE_CLEANABLE_CI_COUNT = 5l;
+   private static final long EXAMPLE_FINISHED_CI_COUNT = 10L;
+  private static final long EXAMPLE_CLEANABLE_CI_COUNT = 5L;
   private static final String EXAMPLE_TENANT_ID = "aTenantId";
 
   protected static final String ANOTHER_EXAMPLE_CD_ID = "anotherCaseDefId";

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricDecisionInstanceReportServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricDecisionInstanceReportServiceTest.java
@@ -57,8 +57,8 @@ public class CleanableHistoricDecisionInstanceReportServiceTest extends Abstract
   private static final String EXAMPLE_DD_NAME = "aName";
   private static final int EXAMPLE_DD_VERSION = 42;
   private static final int EXAMPLE_TTL = 5;
-  private static final long EXAMPLE_FINISHED_DI_COUNT = 1000l;
-  private static final long EXAMPLE_CLEANABLE_DI_COUNT = 567l;
+  private static final long EXAMPLE_FINISHED_DI_COUNT = 1000L;
+  private static final long EXAMPLE_CLEANABLE_DI_COUNT = 567L;
   private static final String EXAMPLE_TENANT_ID = "aTenantId";
 
   protected static final String ANOTHER_EXAMPLE_DD_ID = "anotherDefId";

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricProcessInstanceReportServiceTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/history/CleanableHistoricProcessInstanceReportServiceTest.java
@@ -56,8 +56,8 @@ public class CleanableHistoricProcessInstanceReportServiceTest extends AbstractR
   private static final String EXAMPLE_PD_KEY = "aKey";
   private static final int EXAMPLE_PD_VERSION = 42;
   private static final int EXAMPLE_TTL = 5;
-  private static final long EXAMPLE_FINISHED_PI_COUNT = 10l;
-  private static final long EXAMPLE_CLEANABLE_PI_COUNT = 5l;
+  private static final long EXAMPLE_FINISHED_PI_COUNT = 10L;
+  private static final long EXAMPLE_CLEANABLE_PI_COUNT = 5L;
   private static final String EXAMPLE_TENANT_ID = "aTenantId";
 
   protected static final String ANOTHER_EXAMPLE_PROCESS_DEFINITION_ID = "anotherDefId";

--- a/engine-spring/src/test/java/org/operaton/bpm/engine/spring/test/scripttask/AbstractScriptTaskTest.java
+++ b/engine-spring/src/test/java/org/operaton/bpm/engine/spring/test/scripttask/AbstractScriptTaskTest.java
@@ -112,10 +112,10 @@ public abstract class AbstractScriptTaskTest {
 
     // THEN
     // an exception is thrown
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
         // WHEN
         // we start an instance of this process
-        runtimeService.startProcessInstanceByKey("testProcess");})
+        runtimeService.startProcessInstanceByKey("testProcess"))
       .isInstanceOf(ScriptEvaluationException.class)
       .hasMessageContaining("testbean");
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/AbstractQuery.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/AbstractQuery.java
@@ -213,7 +213,7 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
   public long evaluateExpressionsAndExecuteCount(CommandContext commandContext) {
     validate();
     evaluateExpressions();
-    return !hasExcludingConditions() ? executeCount(commandContext) : 0l;
+    return hasExcludingConditions() ? 0l : executeCount(commandContext);
   }
 
   public abstract long executeCount(CommandContext commandContext);
@@ -222,7 +222,7 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
     checkMaxResultsLimit();
     validate();
     evaluateExpressions();
-    return !hasExcludingConditions() ? executeList(commandContext, page) : new ArrayList<>();
+    return hasExcludingConditions() ? new ArrayList<>() : executeList(commandContext, page);
   }
 
   /**
@@ -392,7 +392,7 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
   public List<String> evaluateExpressionsAndExecuteIdsList(CommandContext commandContext) {
     validate();
     evaluateExpressions();
-    return !hasExcludingConditions() ? executeIdsList(commandContext) : new ArrayList<>();
+    return hasExcludingConditions() ? new ArrayList<>() : executeIdsList(commandContext);
   }
 
   public List<String> executeIdsList(CommandContext commandContext) {
@@ -402,7 +402,7 @@ public abstract class AbstractQuery<T extends Query<?,?>, U> extends ListQueryPa
   public List<ImmutablePair<String, String>> evaluateExpressionsAndExecuteDeploymentIdMappingsList(CommandContext commandContext) {
     validate();
     evaluateExpressions();
-    return !hasExcludingConditions() ? executeDeploymentIdMappingsList(commandContext) : new ArrayList<>();
+    return hasExcludingConditions() ? new ArrayList<>() : executeDeploymentIdMappingsList(commandContext);
   }
 
   public List<ImmutablePair<String, String>> executeDeploymentIdMappingsList(CommandContext commandContext) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/CronExpression.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/CronExpression.java
@@ -343,11 +343,11 @@ public class CronExpression implements Serializable, Cloneable {
                 String expr = exprsTok.nextToken().trim();
 
                 // throw an exception if L is used with other days of the month
-                if(exprOn == DAY_OF_MONTH && expr.indexOf('L') != -1 && expr.length() > 1 && expr.indexOf(",") >= 0) {
+                if(exprOn == DAY_OF_MONTH && expr.indexOf('L') != -1 && expr.length() > 1 && expr.contains(",")) {
                     throw new ParseException("Support for specifying 'L' and 'LW' with other days of the month is not implemented", -1);
                 }
                 // throw an exception if L is used with other days of the week
-                if(exprOn == DAY_OF_WEEK && expr.indexOf('L') != -1 && expr.length() > 1  && expr.indexOf(",") >= 0) {
+                if(exprOn == DAY_OF_WEEK && expr.indexOf('L') != -1 && expr.length() > 1  && expr.contains(",")) {
                     throw new ParseException("Support for specifying 'L' with other days of the week is not implemented", -1);
                 }
                 if(exprOn == DAY_OF_WEEK && expr.indexOf('#') != -1 && expr.indexOf('#', expr.indexOf('#') +1) != -1) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/HistoryCleanupCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/HistoryCleanupCmd.java
@@ -95,7 +95,7 @@ public class HistoryCleanupCmd implements Command<Job> {
 
     writeUserOperationLog(context);
 
-    return !historyCleanupJobs.isEmpty() ? historyCleanupJobs.get(0) : null;
+    return historyCleanupJobs.isEmpty() ? null : historyCleanupJobs.get(0);
   }
 
   protected List<Job> getHistoryCleanupJobs() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/BatchDbSqlSession.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/BatchDbSqlSession.java
@@ -56,16 +56,8 @@ public class BatchDbSqlSession extends DbSqlSession {
   @Override
   public FlushResult executeDbOperations(List<DbOperation> operations) {
     for (DbOperation operation : operations) {
-
-      try {
-        // stage operation
-        executeDbOperation(operation);
-
-      } catch (Exception ex) {
-        // exception is wrapped later
-        throw ex;
-
-      }
+      // stage operation
+      executeDbOperation(operation);
     }
 
     List<BatchResult> batchResults;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/DbSqlSession.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/DbSqlSession.java
@@ -303,12 +303,7 @@ public abstract class DbSqlSession extends AbstractPersistenceSession {
 
   protected void executeInsertEntity(String insertStatement, Object parameter) {
     LOG.executeDatabaseOperation("INSERT", parameter);
-    try {
-      sqlSession.insert(insertStatement, parameter);
-    } catch (Exception e) {
-      // exception is wrapped later
-      throw e;
-    }
+    sqlSession.insert(insertStatement, parameter);
   }
 
   @SuppressWarnings("unused")
@@ -334,24 +329,14 @@ public abstract class DbSqlSession extends AbstractPersistenceSession {
   protected int executeDelete(String deleteStatement, Object parameter) {
     // map the statement
     String mappedDeleteStatement = dbSqlSessionFactory.mapStatement(deleteStatement);
-    try {
-      return sqlSession.delete(mappedDeleteStatement, parameter);
-    } catch (Exception e) {
-      // Exception is wrapped later
-      throw e;
-    }
+    return sqlSession.delete(mappedDeleteStatement, parameter);
   }
 
   // update ////////////////////////////////////////
 
   public int executeUpdate(String updateStatement, Object parameter) {
     String mappedUpdateStatement = dbSqlSessionFactory.mapStatement(updateStatement);
-    try {
-      return sqlSession.update(mappedUpdateStatement, parameter);
-    } catch (Exception e) {
-      // Exception is wrapped later
-      throw e;
-    }
+    return sqlSession.update(mappedUpdateStatement, parameter);
   }
 
   public int update(String updateStatement, Object parameter) {
@@ -390,14 +375,7 @@ public abstract class DbSqlSession extends AbstractPersistenceSession {
   }
 
   public List<BatchResult> flushBatchOperations() {
-    try {
-      return sqlSession.flushStatements();
-
-    } catch (PersistenceException ex) {
-      // exception is wrapped later
-      throw ex;
-
-    }
+    return sqlSession.flushStatements();
   }
 
   @Override
@@ -648,8 +626,6 @@ public abstract class DbSqlSession extends AbstractPersistenceSession {
           }
           LOG.fetchDatabaseTables("jdbc metadata", tableNames);
         }
-      } catch (SQLException se) {
-        throw se;
       } finally {
         if (tablesRs != null) {
           tablesRs.close();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/externaltask/FetchAndLockBuilderImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/externaltask/FetchAndLockBuilderImpl.java
@@ -95,7 +95,7 @@ public class FetchAndLockBuilderImpl implements FetchAndLockBuilder {
   }
 
   protected void configureLastOrderingPropertyDirection(Direction direction) {
-    QueryOrderingProperty lastProperty = !orderingProperties.isEmpty() ? getLastElement(orderingProperties) : null;
+    QueryOrderingProperty lastProperty = orderingProperties.isEmpty() ? null : getLastElement(orderingProperties);
 
     ensureNotNull(NotValidException.class, "You should call any of the orderBy methods first before specifying a direction", "currentOrderingProperty", lastProperty);
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/event/SimpleIpBasedProvider.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/event/SimpleIpBasedProvider.java
@@ -43,7 +43,7 @@ public class SimpleIpBasedProvider implements HostnameProvider {
     return createId(localIp, processEngineConfiguration.getProcessEngineName());
   }
 
-  public static final String createId(String ip, String engineName) {
+  public static String createId(String ip, String engineName) {
     return ip + "$" + engineName;
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerStartEventJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerStartEventJobHandler.java
@@ -44,13 +44,7 @@ public class TimerStartEventJobHandler extends TimerEventJobHandler {
 
     String definitionKey = configuration.getTimerElementKey();
     ProcessDefinition processDefinition = deploymentCache.findDeployedLatestProcessDefinitionByKeyAndTenantId(definitionKey, tenantId);
-
-    try {
-      startProcessInstance(commandContext, tenantId, processDefinition);
-    }
-    catch (RuntimeException e) {
-      throw e;
-    }
+    startProcessInstance(commandContext, tenantId, processDefinition);
   }
 
   protected void startProcessInstance(CommandContext commandContext, String tenantId, ProcessDefinition processDefinition) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ExecutionEntity.java
@@ -872,7 +872,7 @@ public class ExecutionEntity extends PvmExecutionImpl implements Execution, Proc
 
       String compositeId = activityId + ":" + nextId;
       if (compositeId.length() > 64) {
-        return String.valueOf(nextId);
+        return nextId;
       } else {
         return compositeId;
       }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TableDataManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TableDataManager.java
@@ -280,8 +280,6 @@ public class TableDataManager extends AbstractManager {
           result.addColumnMetaData(name, type);
         }
 
-      } catch (SQLException se) {
-        throw se;
       } finally {
         if (resultSet != null) {
           resultSet.close();

--- a/engine/src/main/junit-shared/org/operaton/bpm/engine/impl/test/TestHelper.java
+++ b/engine/src/main/junit-shared/org/operaton/bpm/engine/impl/test/TestHelper.java
@@ -194,9 +194,9 @@ public abstract class TestHelper {
   private static String createResourceName(Class< ? > type, String name, String suffix) {
     StringBuilder r = new StringBuilder(type.getName().replace('.', '/'));
     if (name != null) {
-      r.append("." + name);
+      r.append(".").append(name);
     }
-    return r.append("." + suffix).toString();
+    return r.append(".").append(suffix).toString();
   }
 
   public static boolean annotationRequiredHistoryLevelCheck(ProcessEngine processEngine, RequiredHistoryLevel annotation, Class<?> testClass, String methodName) {

--- a/engine/src/test/java/org/operaton/bpm/container/impl/jmx/kernel/MBeanServiceContainerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/jmx/kernel/MBeanServiceContainerTest.java
@@ -194,7 +194,7 @@ class MBeanServiceContainerTest {
     serviceNames = serviceContainer.getServiceNames(TestServiceType.TYPE1);
     assertThat(serviceNames).containsExactlyInAnyOrder(service1Name, service2Name);
 
-    serviceNames = serviceContainer.<TestService>getServiceNames(TestServiceType.TYPE2);
+    serviceNames = serviceContainer.getServiceNames(TestServiceType.TYPE2);
     assertThat(serviceNames).containsExactlyInAnyOrder(service3Name, service4Name);
 
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DeploymentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/DeploymentAuthorizationTest.java
@@ -554,10 +554,9 @@ class DeploymentAuthorizationTest extends AuthorizationTest {
   void shouldNotRegisterProcessApplicationWithoutAuthorization() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.registerProcessApplication(null, null);
-    })
+      managementService.registerProcessApplication(null, null))
         // then
         .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.SET));
   }
@@ -619,10 +618,9 @@ class DeploymentAuthorizationTest extends AuthorizationTest {
   void shouldNotUnregisterProcessApplicationWithoutAuthorization() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.unregisterProcessApplication("anyDeploymentId", true);
-    })
+      managementService.unregisterProcessApplication("anyDeploymentId", true))
         // then
         .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.SET));
   }
@@ -685,10 +683,9 @@ class DeploymentAuthorizationTest extends AuthorizationTest {
   void shouldNotGetProcessApplicationForDeploymentWithoutAuthorization() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.getProcessApplicationForDeployment("anyDeploymentId");
-    })
+      managementService.getProcessApplicationForDeployment("anyDeploymentId"))
         // then
         .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.READ));
   }
@@ -742,10 +739,9 @@ class DeploymentAuthorizationTest extends AuthorizationTest {
   void shouldNotGetRegisteredDeploymentsWithoutAuthorization() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.getRegisteredDeployments();
-    })
+      managementService.getRegisteredDeployments())
         // then
         .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.READ));
   }
@@ -802,10 +798,9 @@ class DeploymentAuthorizationTest extends AuthorizationTest {
     String deploymentId = createDeployment(null, FIRST_RESOURCE).getId();
     enableAuthorization();
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.registerDeploymentForJobExecutor(deploymentId);
-    })
+      managementService.registerDeploymentForJobExecutor(deploymentId))
         // then
         .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.SET));
   }
@@ -859,10 +854,9 @@ class DeploymentAuthorizationTest extends AuthorizationTest {
   void shouldNotUnregisterDeploymentWithoutAuthorization() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.unregisterDeploymentForJobExecutor("anyDeploymentId");
-    })
+      managementService.unregisterDeploymentForJobExecutor("anyDeploymentId"))
         // then
         .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.SET));
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ManagementAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/ManagementAuthorizationTest.java
@@ -99,10 +99,9 @@ class ManagementAuthorizationTest extends AuthorizationTest {
   void shouldNotGetTableCountWithoutAuthorization() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.getTableCount();
-    })
+      managementService.getTableCount())
         // then
         .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.READ));
   }
@@ -153,10 +152,9 @@ class ManagementAuthorizationTest extends AuthorizationTest {
   void shouldNotGetTableNameWithoutAuthorization() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.getTableName(ProcessDefinitionEntity.class);
-    })
+      managementService.getTableName(ProcessDefinitionEntity.class))
         // then
         .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.READ));
   }
@@ -205,10 +203,9 @@ class ManagementAuthorizationTest extends AuthorizationTest {
   void shouldNotGetTableMetaDataWithoutAuthorization() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.getTableMetaData("ACT_RE_PROCDEF");
-    })
+      managementService.getTableMetaData("ACT_RE_PROCDEF"))
         // then
         .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.READ));
   }
@@ -219,10 +216,9 @@ class ManagementAuthorizationTest extends AuthorizationTest {
   void shouldNotPerformTablePageQueryWithoutAuthorization() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.createTablePageQuery().tableName("ACT_RE_PROCDEF").listPage(0, Integer.MAX_VALUE);
-    })
+      managementService.createTablePageQuery().tableName("ACT_RE_PROCDEF").listPage(0, Integer.MAX_VALUE))
         // then
         .hasMessage(REQUIRED_ADMIN_AUTH_EXCEPTION);
   }
@@ -282,10 +278,9 @@ class ManagementAuthorizationTest extends AuthorizationTest {
   @Test
   void shouldNotGetHistoryLevelWithoutAuthorization() {
     // given
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.getHistoryLevel();
-    })
+      managementService.getHistoryLevel())
         // then
         .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.READ));
   }
@@ -296,10 +291,9 @@ class ManagementAuthorizationTest extends AuthorizationTest {
   void shouldNotPerformDataSchemaUpgradeWithoutAuthorization() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.databaseSchemaUpgrade(null, null, null);
-    })
+      managementService.databaseSchemaUpgrade(null, null, null))
         // then
         .hasMessage(REQUIRED_ADMIN_AUTH_EXCEPTION);
   }
@@ -349,10 +343,9 @@ class ManagementAuthorizationTest extends AuthorizationTest {
     // given
     createGrantAuthorization(Resources.TASK, "*", userId, TaskPermissions.DELETE);
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.getProperties();
-    })
+      managementService.getProperties())
     // then
     .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.READ));
   }
@@ -361,10 +354,9 @@ class ManagementAuthorizationTest extends AuthorizationTest {
   void shouldNotGetPropertiesWithoutAuthorization() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.getProperties();
-    })
+      managementService.getProperties())
         // then
         .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.READ));
   }
@@ -415,10 +407,9 @@ class ManagementAuthorizationTest extends AuthorizationTest {
   void shouldNotSetPropertyWithoutAuthorization() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.setProperty(DUMMY_PROPERTY, DUMMY_VALUE);
-    })
+      managementService.setProperty(DUMMY_PROPERTY, DUMMY_VALUE))
         // then
         .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.SET));
   }
@@ -474,10 +465,9 @@ class ManagementAuthorizationTest extends AuthorizationTest {
   void shouldNotDeletePropertyWithoutAuthorization() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.deleteProperty(DUMMY_PROPERTY);
-    })
+      managementService.deleteProperty(DUMMY_PROPERTY))
         // then
         .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.DELETE));
   }
@@ -539,10 +529,9 @@ class ManagementAuthorizationTest extends AuthorizationTest {
   void shouldNotGetTelemetryDataWithoutAdminAndPermission() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.getTelemetryData();
-    })
+      managementService.getTelemetryData())
     // then
       .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.READ));
   }
@@ -596,10 +585,9 @@ class ManagementAuthorizationTest extends AuthorizationTest {
   void shouldNotDeleteMetricsWithoutAuthorization() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.deleteMetrics(null);
-    })
+      managementService.deleteMetrics(null))
         // then
         .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.DELETE));
   }
@@ -650,10 +638,9 @@ class ManagementAuthorizationTest extends AuthorizationTest {
   void shouldNotDeleteTaskMetricsWithoutAuthorization() {
     // given
 
-    assertThatThrownBy(() -> {
+    assertThatThrownBy(() ->
       // when
-      managementService.deleteTaskMetrics(null);
-    })
+      managementService.deleteTaskMetrics(null))
         // then
         .hasMessageContaining(permissionException(Resources.SYSTEM, SystemPermissions.DELETE));
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/context/DelegateExecutionContextTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/context/DelegateExecutionContextTest.java
@@ -70,7 +70,7 @@ class DelegateExecutionContextTest {
       .endEvent()
       .done();
 
-  protected static final BpmnModelInstance getSingleUserTaskProcessWithSignalStartEventSubprocess() {
+  protected static BpmnModelInstance getSingleUserTaskProcessWithSignalStartEventSubprocess() {
     ProcessBuilder processBuilder = Bpmn.createExecutableProcess();
     BpmnModelInstance model = processBuilder
         .operatonHistoryTimeToLive(180)

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupDmnDisabledTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupDmnDisabledTest.java
@@ -52,9 +52,8 @@ class HistoryCleanupDmnDisabledTest {
 
   @RegisterExtension
   static ProcessEngineExtension engineRule = ProcessEngineExtension.builder()
-    .configurator(configuration -> {
-      configuration.setDmnEnabled(false);
-    }).build();
+    .configurator(configuration ->
+      configuration.setDmnEnabled(false)).build();
   @RegisterExtension
   ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupHistoricBatchTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryCleanupHistoricBatchTest.java
@@ -69,9 +69,8 @@ class HistoryCleanupHistoricBatchTest {
 
   @RegisterExtension
   static ProcessEngineExtension engineRule = ProcessEngineExtension.builder()
-    .configurator(configuration -> {
-      configuration.setHistoryCleanupDegreeOfParallelism(3);
-    }).build();
+    .configurator(configuration ->
+      configuration.setHistoryCleanupDegreeOfParallelism(3)).build();
   @RegisterExtension
   ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);
   @RegisterExtension

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/helper/BatchSetRemovalTimeExtension.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/helper/BatchSetRemovalTimeExtension.java
@@ -164,10 +164,9 @@ public class BatchSetRemovalTimeExtension extends BatchExtension {
     engineRule.getAuthorizationService()
         .createAuthorizationQuery()
         .list()
-        .forEach(authorization -> {
+        .forEach(authorization ->
           engineRule.getAuthorizationService()
-              .deleteAuthorization(authorization.getId());
-        });
+              .deleteAuthorization(authorization.getId()));
   }
 
   public class TestProcessBuilder {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/helper/BatchSetRemovalTimeRule.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/removaltime/batch/helper/BatchSetRemovalTimeRule.java
@@ -164,10 +164,9 @@ public class BatchSetRemovalTimeRule extends BatchRule {
     engineRule.getAuthorizationService()
         .createAuthorizationQuery()
         .list()
-        .forEach(authorization -> {
+        .forEach(authorization ->
           engineRule.getAuthorizationService()
-              .deleteAuthorization(authorization.getId());
-        });
+              .deleteAuthorization(authorization.getId()));
   }
 
   public class TestProcessBuilder {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/FailingDelegate.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/FailingDelegate.java
@@ -27,7 +27,7 @@ public class FailingDelegate implements JavaDelegate {
 
     Boolean fail = (Boolean) execution.getVariable("fail");
 
-    if (fail != null && fail == true) {
+    if (fail != null && fail) {
       throw new ProcessEngineException("Expected exception");
     }
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/metrics/FailingDelegate.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/metrics/FailingDelegate.java
@@ -27,7 +27,7 @@ public class FailingDelegate implements JavaDelegate {
 
     Boolean fail = (Boolean) execution.getVariable("fail");
 
-    if (fail != null && fail == true) {
+    if (fail != null && fail) {
       throw new ProcessEngineException("Expected exception");
     }
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/metrics/RootProcessInstanceMetricsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/metrics/RootProcessInstanceMetricsTest.java
@@ -89,7 +89,7 @@ public class RootProcessInstanceMetricsTest extends AbstractMetricsTest {
   @Test
   void shouldCountRootProcessInstanceWithCallActivities() {
     // given
-    BpmnModelInstance callingInstance = getCallingInstance(BASE_INSTANCE_KEY, Collections.EMPTY_MAP);
+    BpmnModelInstance callingInstance = getCallingInstance(BASE_INSTANCE_KEY, Collections.emptyMap());
     testRule.deploy(BASE_INSTANCE, callingInstance);
 
     // when

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricActivityInstancesForOptimizeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/optimize/GetCompletedHistoricActivityInstancesForOptimizeTest.java
@@ -291,7 +291,8 @@ class GetCompletedHistoricActivityInstancesForOptimizeTest {
   }
 
   private void assertThatActivitiesHaveAllImportantInformation(List<HistoricActivityInstance> completedHistoricActivityInstances) {
-    HistoricActivityInstance startEvent = null, endEvent = null;
+    HistoricActivityInstance startEvent = null;
+    HistoricActivityInstance endEvent = null;
     for (HistoricActivityInstance completedHistoricActivityInstance : completedHistoricActivityInstances) {
       if ("startEvent".equals(completedHistoricActivityInstance.getActivityId())) {
         startEvent = completedHistoricActivityInstance;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RepositoryServiceTest.java
@@ -1230,7 +1230,7 @@ class RepositoryServiceTest {
     assertThat(start.getId()).isEqualTo("start");
     assertThat(start.getProperty("name")).isEqualTo("S t a r t");
     assertThat(start.getProperty("documentation")).isEqualTo("the start event");
-    assertThat(start.getActivities()).isEqualTo(Collections.EMPTY_LIST);
+    assertThat(start.getActivities()).isEqualTo(Collections.emptyList());
     List<PvmTransition> outgoingTransitions = start.getOutgoingTransitions();
     assertThat(outgoingTransitions).hasSize(1);
     assertThat(outgoingTransitions.get(0).getProperty(BpmnParse.PROPERTYNAME_CONDITION_TEXT)).isEqualTo("${a == b}");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/diagram/ProcessDiagramRetrievalTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/diagram/ProcessDiagramRetrievalTest.java
@@ -240,13 +240,13 @@ public class ProcessDiagramRetrievalTest {
     html.append("        border-radius: 5px; -moz-border-radius: 5px;\n");
     html.append("      }\n");
     if (highlightedActivityId != null && !highlightedActivityId.isEmpty()) {
-      html.append("      #" + highlightedActivityId + " {border: 2px solid red;}\n");
+      html.append("      #").append(highlightedActivityId).append(" {border: 2px solid red;}\n");
     }
     html.append("    --></style>");
     html.append("  </head>\n");
     html.append("  <body>\n");
     html.append("    <div style=\"position: relative\">\n");
-    html.append("      <img src=\"" + imageUrl + "\" />\n");
+    html.append("      <img src=\"").append(imageUrl).append("\" />\n");
 
     List<DiagramNode> nodes = new ArrayList<>(processDiagramLayout.getNodes());
     // sort the nodes according to their ID property.
@@ -254,12 +254,12 @@ public class ProcessDiagramRetrievalTest {
     for (DiagramNode node : nodes) {
       html.append("      <div");
       html.append(" class=\"BPMNElement\"");
-      html.append(" id=\"" + node.getId() + "\"");
+      html.append(" id=\"").append(node.getId()).append("\"");
       html.append(" style=\"");
       html.append(" left: " + (int) (node.getX() - 2) + "px;");
       html.append(" top: " + (int) (node.getY() - 2) + "px;");
-      html.append(" width: " + node.getWidth().intValue() + "px;");
-      html.append(" height: " + node.getHeight().intValue() + "px;\"></div>\n");
+      html.append(" width: ").append(node.getWidth().intValue()).append("px;");
+      html.append(" height: ").append(node.getHeight().intValue()).append("px;\"></div>\n");
     }
     html.append("    </div>\n");
     html.append("  </body>\n");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/FailingDelegate.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/FailingDelegate.java
@@ -31,7 +31,7 @@ public class FailingDelegate implements JavaDelegate {
     String message = execution.hasVariable("message") ?
         (String) execution.getVariable("message") : EXCEPTION_MESSAGE;
 
-    if (fail == null || fail == true) {
+    if (fail == null || fail) {
       throw new ProcessEngineException(message);
     }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.java
@@ -997,7 +997,7 @@ public class RuntimeServiceTest {
   @Test
   void testSetVariablesUnexistingExecutionId() {
     try {
-      runtimeService.setVariables("unexistingexecution", Collections.EMPTY_MAP);
+      runtimeService.setVariables("unexistingexecution", Collections.emptyMap());
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
       testRule.assertTextPresent("execution unexistingexecution doesn't exist", ae.getMessage());
@@ -1008,7 +1008,7 @@ public class RuntimeServiceTest {
   @Test
   void testSetVariablesNullExecutionId() {
     try {
-      runtimeService.setVariables(null, Collections.EMPTY_MAP);
+      runtimeService.setVariables(null, Collections.emptyMap());
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
       testRule.assertTextPresent("executionId is null", ae.getMessage());
@@ -1221,7 +1221,7 @@ public class RuntimeServiceTest {
   @Test
   void testRemoveVariablesNullExecutionId() {
     try {
-      runtimeService.removeVariables(null, Collections.EMPTY_LIST);
+      runtimeService.removeVariables(null, Collections.emptyList());
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
       testRule.assertTextPresent("executionId is null", ae.getMessage());
@@ -1279,7 +1279,7 @@ public class RuntimeServiceTest {
   @Test
   void testRemoveVariablesLocalNullExecutionId() {
     try {
-      runtimeService.removeVariablesLocal(null, Collections.EMPTY_LIST);
+      runtimeService.removeVariablesLocal(null, Collections.emptyList());
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
       testRule.assertTextPresent("executionId is null", ae.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryOrTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryOrTest.java
@@ -1359,9 +1359,9 @@ class TaskQueryOrTest {
   }
 
   protected HashMap<String, Date> createFollowUpAndDueDateTasks() throws ParseException {
-    final Date date = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("27/07/2017 01:12:13"),
-      oneHourAgo = new Date(date.getTime() - 60 * 60 * 1000),
-      oneHourLater = new Date(date.getTime() + 60 * 60 * 1000);
+    final Date date = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("27/07/2017 01:12:13");
+    final Date oneHourAgo = new Date(date.getTime() - 60 * 60 * 1000);
+    final Date oneHourLater = new Date(date.getTime() + 60 * 60 * 1000);
 
     Task taskDueBefore = taskService.newTask();
     taskDueBefore.setFollowUpDate(new Date(oneHourAgo.getTime() - 1000));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskServiceTest.java
@@ -1239,7 +1239,7 @@ class TaskServiceTest {
     taskService.saveTask(task);
 
     String taskId = task.getId();
-    taskService.complete(taskId, Collections.EMPTY_MAP);
+    taskService.complete(taskId, Collections.emptyMap());
 
     if (processEngineConfiguration.getHistoryLevel().getId() >= ProcessEngineConfigurationImpl.HISTORYLEVEL_ACTIVITY) {
       historyService.deleteHistoricTaskInstance(taskId);
@@ -1580,7 +1580,7 @@ class TaskServiceTest {
     taskService.saveTask(task);
 
     String taskId = task.getId();
-    taskService.resolveTask(taskId, Collections.EMPTY_MAP);
+    taskService.resolveTask(taskId, Collections.emptyMap());
 
     if (processEngineConfiguration.getHistoryLevel().getId()>= ProcessEngineConfigurationImpl.HISTORYLEVEL_AUDIT) {
       historyService.deleteHistoricTaskInstance(taskId);
@@ -2303,7 +2303,7 @@ class TaskServiceTest {
   @Test
   void testRemoveVariablesNullTaskId() {
     try {
-      taskService.removeVariables(null, Collections.EMPTY_LIST);
+      taskService.removeVariables(null, Collections.emptyList());
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
       testRule.assertTextPresent("taskId is null", ae.getMessage());
@@ -2379,7 +2379,7 @@ class TaskServiceTest {
   @Test
   void testRemoveVariablesLocalNullTaskId() {
     try {
-      taskService.removeVariablesLocal(null, Collections.EMPTY_LIST);
+      taskService.removeVariablesLocal(null, Collections.emptyList());
       fail("ProcessEngineException expected");
     } catch (ProcessEngineException ae) {
       testRule.assertTextPresent("taskId is null", ae.getMessage());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/OperatonFormDefinitionStrictParseTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/OperatonFormDefinitionStrictParseTest.java
@@ -82,9 +82,8 @@ class OperatonFormDefinitionStrictParseTest {
     processEngineConfiguration.setDisableStrictOperatonFormParsing(false);
 
     // then deployment fails with an exception
-    assertThatThrownBy(() -> {
-      testRule.deploy(FORM);
-    }).isInstanceOf(ProcessEngineException.class)
+    assertThatThrownBy(() ->
+      testRule.deploy(FORM)).isInstanceOf(ProcessEngineException.class)
     .hasMessageContaining("ENGINE-09033 Could not parse Operaton Form resource org/operaton/bpm/engine/test/bpmn/OperatonFormDefinitionStrictParseTest.anyForm.form.");
     assertThat(repositoryService.createDeploymentQuery().list()).isEmpty();
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/deployment/VersionedDeploymentHandler.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/deployment/VersionedDeploymentHandler.java
@@ -69,7 +69,7 @@ public class VersionedDeploymentHandler implements DeploymentHandler {
 
     String deploymentId = repositoryService.createProcessDefinitionQuery()
         .processDefinitionKey(candidateProcessDefinitionKey)
-        .versionTag(String.valueOf(candidateVersionTag))
+        .versionTag(candidateVersionTag)
         .orderByProcessDefinitionVersion()
         .desc()
         .singleResult()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/el/ExpressionManagerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/el/ExpressionManagerTest.java
@@ -197,8 +197,8 @@ class ExpressionManagerTest {
     // when
     runtimeService.startProcessInstanceByKey("testProcess",
         Variables.createVariables()
-            .putValue("total", new BigDecimal(123))
-            .putValue("myValue", new BigDecimal(0)));
+            .putValue("total", BigDecimal.valueOf(123))
+            .putValue("myValue", BigDecimal.valueOf(0)));
 
     // then
     HistoricActivityInstance userTask = historyService.createHistoricActivityInstanceQuery()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/sentry/SentryEntryCriteriaTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/sentry/SentryEntryCriteriaTest.java
@@ -543,19 +543,16 @@ class SentryEntryCriteriaTest extends CmmnTest {
     assertThat(thirdHumanTask.isAvailable()).isTrue();
 
 
-    assertThatThrownBy(() -> {
-      manualStart(firstHumanTaskId);
-    }).withFailMessage("First human task should be available.")
+    assertThatThrownBy(() ->
+      manualStart(firstHumanTaskId)).withFailMessage("First human task should be available.")
       .isInstanceOf(NotAllowedException.class);
 
-    assertThatThrownBy(() -> {
-      manualStart(secondHumanTaskId);
-    }).withFailMessage("It should not be possible to start the second human task manually.")
+    assertThatThrownBy(() ->
+      manualStart(secondHumanTaskId)).withFailMessage("It should not be possible to start the second human task manually.")
       .isInstanceOf(NotAllowedException.class);
 
-    assertThatThrownBy(() -> {
-      manualStart(thirdHumanTaskId);
-    }).withFailMessage("It should not be possible to third the second human task manually.")
+    assertThatThrownBy(() ->
+      manualStart(thirdHumanTaskId)).withFailMessage("It should not be possible to third the second human task manually.")
       .isInstanceOf(NotAllowedException.class);
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/errorcode/conf/CustomErrorCodeProviderTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/errorcode/conf/CustomErrorCodeProviderTest.java
@@ -50,7 +50,7 @@ class CustomErrorCodeProviderTest {
   @RegisterExtension
   static ProcessEngineExtension engineRule = ProcessEngineExtension.builder()
     .randomEngineName().closeEngineAfterAllTests()
-    .configurator(c -> {
+    .configurator(c ->
       c.setCustomExceptionCodeProvider(new ExceptionCodeProvider() {
         
         @Override
@@ -63,8 +63,7 @@ class CustomErrorCodeProviderTest {
           return PROVIDED_CUSTOM_CODE;
         }
         
-      });
-    })
+      }))
     .build();
   @RegisterExtension
   ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/FirstFailingDelegate.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/FirstFailingDelegate.java
@@ -32,7 +32,7 @@ public class FirstFailingDelegate implements JavaDelegate {
   public void execute(DelegateExecution execution) throws Exception {
     Boolean fail = (Boolean) execution.getVariable("firstFail");
 
-    if (fail == null || fail == true) {
+    if (fail == null || fail) {
       throw new ProcessEngineException(FIRST_EXCEPTION_MESSAGE);
     }
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricDetailQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricDetailQueryTest.java
@@ -523,9 +523,8 @@ class HistoricDetailQueryTest {
     HistoricDetailQuery query = historyService.createHistoricDetailQuery();
 
     // then
-    assertThatThrownBy(() -> {
-      query.variableNameLike(null);
-    })
+    assertThatThrownBy(() ->
+      query.variableNameLike(null))
         .isInstanceOf(NullValueException.class)
         .hasMessageContaining("Variable name like is null");
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/SecondFailingDelegate.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/SecondFailingDelegate.java
@@ -32,7 +32,7 @@ public class SecondFailingDelegate implements JavaDelegate {
   public void execute(DelegateExecution execution) throws Exception {
     Boolean fail = (Boolean) execution.getVariable("secondFail");
 
-    if (fail == null || fail == true) {
+    if (fail == null || fail) {
       throw new ProcessEngineException(SECOND_EXCEPTION_MESSAGE);
     }
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/BackoffJobAcquisitionStrategyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/BackoffJobAcquisitionStrategyTest.java
@@ -36,11 +36,11 @@ class BackoffJobAcquisitionStrategyTest {
 
   // strategy configuration
   protected static final long BASE_IDLE_WAIT_TIME = 50;
-  protected static final float IDLE_INCREASE_FACTOR = 1.5f;
+  protected static final float IDLE_INCREASE_FACTOR = 1.5F;
   protected static final long MAX_IDLE_TIME = 500;
 
   protected static final long BASE_BACKOFF_WAIT_TIME = 80;
-  protected static final float BACKOFF_INCREASE_FACTOR = 2.0f;
+  protected static final float BACKOFF_INCREASE_FACTOR = 2.0F;
   protected static final long MAX_BACKOFF_TIME = 1000;
 
   protected static final int DECREASE_THRESHOLD = 3;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobAcquisitionBackoffTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobAcquisitionBackoffTest.java
@@ -49,9 +49,8 @@ class JobAcquisitionBackoffTest {
   @RegisterExtension
   static ProcessEngineExtension engineRule = ProcessEngineExtension.builder()
     .randomEngineName().closeEngineAfterEachTest()
-    .configurator(configuration -> {
-      configuration.setJobExecutor(new ControllableJobExecutor());
-    })
+    .configurator(configuration ->
+      configuration.setJobExecutor(new ControllableJobExecutor()))
     .build();
   @RegisterExtension
   ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobAcquisitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobAcquisitionTest.java
@@ -50,9 +50,8 @@ class JobAcquisitionTest {
   @RegisterExtension
   static ProcessEngineExtension engineRule = ProcessEngineExtension.builder()
     .randomEngineName().closeEngineAfterAllTests()
-    .configurator(configuration -> {
-      configuration.setJobExecutor(new ControllableJobExecutor());
-    })
+    .configurator(configuration ->
+      configuration.setJobExecutor(new ControllableJobExecutor()))
     .build();
   @RegisterExtension
   ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorShutdownTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/jobexecutor/JobExecutorShutdownTest.java
@@ -68,9 +68,8 @@ class JobExecutorShutdownTest {
   @RegisterExtension
   static ProcessEngineExtension engineRule = ProcessEngineExtension.builder()
     .randomEngineName().closeEngineAfterEachTest()
-    .configurator(configuration -> {
-      configuration.setJobExecutor(buildControllableJobExecutor());
-    })
+    .configurator(configuration ->
+      configuration.setJobExecutor(buildControllableJobExecutor()))
     .build();
   @RegisterExtension
   ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineRule);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/logging/TestMdcFacade.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/logging/TestMdcFacade.java
@@ -132,8 +132,7 @@ public final class TestMdcFacade {
    * Asserts all test inserted properties in the MDC are still there.
    */
   public void assertAllInsertedPropertiesAreInMdc() {
-    this.keyValuePairs.forEach((k, v) -> {
-      assertThat(MdcAccess.get(k)).isNotNull();
-    });
+    this.keyValuePairs.forEach((k, v) ->
+      assertThat(MdcAccess.get(k)).isNotNull());
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/persistence/SuppressSqlExceptionsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/persistence/SuppressSqlExceptionsTest.java
@@ -111,10 +111,9 @@ class SuppressSqlExceptionsTest {
     // given
     failForSqlStatement("selectJob");
 
-    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() -> {
+    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() ->
       // when
-      managementService.executeJob("anId");
-    });
+      managementService.executeJob("anId"));
 
     // then
     assertThat(exceptionsByHierarchy.next())
@@ -129,12 +128,11 @@ class SuppressSqlExceptionsTest {
   void shouldThrowExceptionOnSelectionWithListInReturn() {
     // given
 
-    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() -> {
+    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() ->
       // when
       runtimeService.createNativeProcessInstanceQuery()
           .sql("foo")
-          .list();
-    });
+          .list());
 
     // then
     assertThat(exceptionsByHierarchy.next())
@@ -150,10 +148,9 @@ class SuppressSqlExceptionsTest {
     // given
     failForSqlStatement("selectDeploymentCountByQueryCriteria");
 
-    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() -> {
+    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() ->
       // when
-      repositoryService.createDeploymentQuery().count();
-    });
+      repositoryService.createDeploymentQuery().count());
 
     // then
     assertThat(exceptionsByHierarchy.next())
@@ -178,10 +175,9 @@ class SuppressSqlExceptionsTest {
 
     String businessKey = generateString(1_000);
 
-    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() -> {
+    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() ->
       // when
-      runtimeService.startProcessInstanceByKey("process", businessKey);
-    });
+      runtimeService.startProcessInstanceByKey("process", businessKey));
 
     // then
     assertThat(exceptionsByHierarchy.next())
@@ -216,10 +212,9 @@ class SuppressSqlExceptionsTest {
     authorizationTwo.setResourceId("foo");
     authorizationTwo.setResource(Resources.TASK);
 
-    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() -> {
+    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() ->
       // when
-      authorizationService.saveAuthorization(authorizationTwo);
-    });
+      authorizationService.saveAuthorization(authorizationTwo));
 
     // then
     assertThat(exceptionsByHierarchy.next())
@@ -248,10 +243,9 @@ class SuppressSqlExceptionsTest {
     Filter foo = filterService.newTaskFilter("foo");
     filterService.saveFilter(foo);
 
-    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() -> {
+    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() ->
       // when
-      filterService.deleteFilter(foo.getId());
-    });
+      filterService.deleteFilter(foo.getId()));
 
     // then
     assertThat(exceptionsByHierarchy.next())
@@ -282,10 +276,9 @@ class SuppressSqlExceptionsTest {
     User user = identityService.newUser("foo");
     identityService.saveUser(user);
 
-    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() -> {
+    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() ->
       // when
-      identityService.deleteUser("foo");
-    });
+      identityService.deleteUser("foo"));
 
     // then
     assertThat(exceptionsByHierarchy.next())
@@ -328,7 +321,7 @@ class SuppressSqlExceptionsTest {
 
     CommandExecutor commandExecutor = engineConfig.getCommandExecutorTxRequired();
 
-    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() -> {
+    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() ->
       // when
       commandExecutor.execute(c -> {
         runtimeService.setVariable(processInstanceId, "foo", variableValue);
@@ -338,9 +331,7 @@ class SuppressSqlExceptionsTest {
         trimHistoricDetailValue(c);
 
         return null;
-      });
-
-    });
+      }));
 
     // then
     assertThat(exceptionsByHierarchy.next())
@@ -381,12 +372,11 @@ class SuppressSqlExceptionsTest {
 
     engineTestRule.deploy(modelInstance);
 
-    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() -> {
+    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() ->
       // when
       repositoryService.updateProcessDefinitionSuspensionState()
           .byProcessDefinitionKey("process")
-          .suspend();
-    });
+          .suspend());
 
     // then
     assertThat(exceptionsByHierarchy.next())
@@ -423,12 +413,11 @@ class SuppressSqlExceptionsTest {
         .endEvent()
         .done();
 
-    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() -> {
+    Iterator<Throwable> exceptionsByHierarchy = catchExceptionHierarchy(() ->
       // when
       repositoryService.createDeployment()
           .addModelInstance("process.bpmn", modelInstance)
-          .deploy();
-    });
+          .deploy());
 
     // then
     assertThat(exceptionsByHierarchy.next())

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryOrTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/HistoricTaskInstanceQueryOrTest.java
@@ -839,9 +839,9 @@ class HistoricTaskInstanceQueryOrTest {
   }
 
   public HashMap<String, Date> createFollowUpAndDueDateTasks() throws ParseException {
-    final Date date = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("27/07/2017 01:12:13"),
-      oneHourAgo = new Date(date.getTime() - 60 * 60 * 1000),
-      oneHourLater = new Date(date.getTime() + 60 * 60 * 1000);
+    final Date date = new SimpleDateFormat("dd/MM/yyyy hh:mm:ss").parse("27/07/2017 01:12:13");
+    final Date oneHourAgo = new Date(date.getTime() - 60 * 60 * 1000);
+    final Date oneHourLater = new Date(date.getTime() + 60 * 60 * 1000);
 
     Task taskDueBefore = taskService.newTask();
     taskDueBefore.setFollowUpDate(new Date(oneHourAgo.getTime() - 1000));

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/pvm/activities/EmbeddedSubProcess.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/pvm/activities/EmbeddedSubProcess.java
@@ -57,7 +57,7 @@ public class EmbeddedSubProcess implements CompositeActivityBehavior {
     if(outgoingTransitions.isEmpty()) {
       execution.end(true);
     }else {
-      execution.leaveActivityViaTransitions(outgoingTransitions, Collections.EMPTY_LIST);
+      execution.leaveActivityViaTransitions(outgoingTransitions, Collections.emptyList());
     }
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/pvm/activities/EventScopeCreatingSubprocess.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/pvm/activities/EventScopeCreatingSubprocess.java
@@ -72,7 +72,7 @@ public class EventScopeCreatingSubprocess implements CompositeActivityBehavior {
     if(outgoingTransitions.isEmpty()) {
       outgoingExecution.end(true);
     }else {
-      outgoingExecution.leaveActivityViaTransitions(outgoingTransitions, Collections.EMPTY_LIST);
+      outgoingExecution.leaveActivityViaTransitions(outgoingTransitions, Collections.emptyList());
     }
   }
 

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/BooleanOperations.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/BooleanOperations.java
@@ -95,7 +95,7 @@ public final class BooleanOperations {
 		throw new ELException(LocalMessages.get("error.compare.types", o1.getClass(), o2.getClass()));
 	}
 
-	public static final boolean lt(TypeConverter converter, Object o1, Object o2) {
+	public static boolean lt(TypeConverter converter, Object o1, Object o2) {
 		if (o1 == o2) {
 			return false;
 		}
@@ -105,7 +105,7 @@ public final class BooleanOperations {
 		return lt0(converter, o1, o2);
 	}
 
-	public static final boolean gt(TypeConverter converter, Object o1, Object o2) {
+	public static boolean gt(TypeConverter converter, Object o1, Object o2) {
 		if (o1 == o2) {
 			return false;
 		}
@@ -115,7 +115,7 @@ public final class BooleanOperations {
 		return gt0(converter, o1, o2);
 	}
 
-	public static final boolean ge(TypeConverter converter, Object o1, Object o2) {
+	public static boolean ge(TypeConverter converter, Object o1, Object o2) {
 		if (o1 == o2) {
 			return true;
 		}
@@ -125,7 +125,7 @@ public final class BooleanOperations {
 		return !lt0(converter, o1, o2);
 	}
 
-	public static final boolean le(TypeConverter converter, Object o1, Object o2) {
+	public static boolean le(TypeConverter converter, Object o1, Object o2) {
 		if (o1 == o2) {
 			return true;
 		}
@@ -135,7 +135,7 @@ public final class BooleanOperations {
 		return !gt0(converter, o1, o2);
 	}
 
-	public static final boolean eq(TypeConverter converter, Object o1, Object o2) {
+	public static boolean eq(TypeConverter converter, Object o1, Object o2) {
 		if (o1 == o2) {
 			return true;
 		}
@@ -171,11 +171,11 @@ public final class BooleanOperations {
 		return o1.equals(o2);
 	}
 
-	public static final boolean ne(TypeConverter converter, Object o1, Object o2) {
+	public static boolean ne(TypeConverter converter, Object o1, Object o2) {
 		return !eq(converter, o1, o2);
 	}
 
-	public static final boolean empty(TypeConverter converter, Object o) {
+	public static boolean empty(TypeConverter converter, Object o) {
 		if (o == null || "".equals(o)) {
 			return true;
 		}

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/NumberOperations.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/NumberOperations.java
@@ -61,7 +61,7 @@ public final class NumberOperations {
 		return value instanceof BigDecimal || isFloatOrDoubleOrDotEe(value);
 	}
 
-	public static final Number add(TypeConverter converter, Object o1, Object o2) {
+	public static Number add(TypeConverter converter, Object o1, Object o2) {
 		if (o1 == null && o2 == null) {
 			return LONG_ZERO;
 		}
@@ -80,7 +80,7 @@ public final class NumberOperations {
 		return converter.convert(o1, Long.class) + converter.convert(o2, Long.class);
 	}
 
-	public static final Number sub(TypeConverter converter, Object o1, Object o2) {
+	public static Number sub(TypeConverter converter, Object o1, Object o2) {
 		if (o1 == null && o2 == null) {
 			return LONG_ZERO;
 		}
@@ -99,7 +99,7 @@ public final class NumberOperations {
 		return converter.convert(o1, Long.class) - converter.convert(o2, Long.class);
 	}
 
-	public static final Number mul(TypeConverter converter, Object o1, Object o2) {
+	public static Number mul(TypeConverter converter, Object o1, Object o2) {
 		if (o1 == null && o2 == null) {
 			return LONG_ZERO;
 		}
@@ -118,7 +118,7 @@ public final class NumberOperations {
 		return converter.convert(o1, Long.class) * converter.convert(o2, Long.class);
 	}
 
-	public static final Number div(TypeConverter converter, Object o1, Object o2) {
+	public static Number div(TypeConverter converter, Object o1, Object o2) {
 		if (o1 == null && o2 == null) {
 			return LONG_ZERO;
 		}
@@ -128,7 +128,7 @@ public final class NumberOperations {
 		return converter.convert(o1, Double.class) / converter.convert(o2, Double.class);
 	}
 
-	public static final Number mod(TypeConverter converter, Object o1, Object o2) {
+	public static Number mod(TypeConverter converter, Object o1, Object o2) {
 		if (o1 == null && o2 == null) {
 			return LONG_ZERO;
 		}
@@ -141,7 +141,7 @@ public final class NumberOperations {
 		return converter.convert(o1, Long.class) % converter.convert(o2, Long.class);
 	}
 
-	public static final Number neg(TypeConverter converter, Object value) {
+	public static Number neg(TypeConverter converter, Object value) {
 		if (value == null) {
 			return LONG_ZERO;
 		}

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/Parser.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/Parser.java
@@ -637,27 +637,24 @@ public class Parser {
 	 */
 	protected AstNode nonliteral() throws Scanner.ScanException, ParseException {
 		AstNode v = null;
-		switch (token.getSymbol()) {
-			case IDENTIFIER:
-				String name = consumeToken().getImage();
-				if (token.getSymbol() == Scanner.Symbol.COLON && lookahead(0).getSymbol() == Scanner.Symbol.IDENTIFIER && lookahead(1).getSymbol() == Scanner.Symbol.LPAREN) { // ns:f(...)
-					consumeToken();
-					name += ":" + token.getImage();
-					consumeToken();
-				}
-				if (token.getSymbol() == Scanner.Symbol.LPAREN) { // function
-					v = function(name, params());
-				} else { // identifier
-					v = identifier(name);
-				}
-				break;
-			case LPAREN:
-				consumeToken();
-				v = expr(true);
-				consumeToken(Scanner.Symbol.RPAREN);
-				v = new AstNested(v);
-				break;
-		}
+    if (token.getSymbol() == Scanner.Symbol.IDENTIFIER) {
+      String name = consumeToken().getImage();
+      if (token.getSymbol() == Scanner.Symbol.COLON && lookahead(0).getSymbol() == Scanner.Symbol.IDENTIFIER && lookahead(1).getSymbol() == Scanner.Symbol.LPAREN) { // ns:f(...)
+        consumeToken();
+        name += ":" + token.getImage();
+        consumeToken();
+      }
+      if (token.getSymbol() == Scanner.Symbol.LPAREN) { // function
+        v = function(name, params());
+      } else { // identifier
+        v = identifier(name);
+      }
+    } else if (token.getSymbol() == Scanner.Symbol.LPAREN) {
+      consumeToken();
+      v = expr(true);
+      consumeToken(Scanner.Symbol.RPAREN);
+      v = new AstNested(v);
+    }
 		return v;
 	}
 

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/Scanner.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/Scanner.java
@@ -419,19 +419,19 @@ public class Scanner {
 	}
 
 	protected Token nextToken() throws ScanException {
+		char inputCharAtPosition = input.charAt(position);
 		if (isEval()) {
-			if (input.charAt(position) == '}') {
+			if (inputCharAtPosition == '}') {
 				return fixed(Symbol.END_EVAL);
 			}
 			return nextEval();
 		} else {
 			if (position+1 < input.length() && input.charAt(position+1) == '{') {
-				switch (input.charAt(position)) {
-					case '#':
-						return fixed(Symbol.START_EVAL_DEFERRED);
-					case '$':
-						return fixed(Symbol.START_EVAL_DYNAMIC);
-				}
+        if (inputCharAtPosition == '#') {
+          return fixed(Symbol.START_EVAL_DEFERRED);
+        } else if (inputCharAtPosition == '$') {
+          return fixed(Symbol.START_EVAL_DYNAMIC);
+        }
 			}
 			return nextText();
 		}

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/TypeConverterImpl.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/TypeConverterImpl.java
@@ -80,7 +80,7 @@ public class TypeConverterImpl implements TypeConverter {
       }
     }
     if (value instanceof Character character) {
-      return new BigDecimal((short) character.charValue());
+      return BigDecimal.valueOf((short) character.charValue());
     }
     throw new ELException(LocalMessages.get(ERROR_COERCE_TYPE, value.getClass(), BigDecimal.class));
   }

--- a/pom.xml
+++ b/pom.xml
@@ -83,10 +83,27 @@
         <version>6.12.0</version>
         <configuration>
           <activeRecipes>
-            <recipe>org.openrewrite.java.testing.junit5.JUnit5BestPractices</recipe>
+            <recipe>org.operaton.recipe.CodeCleanup</recipe>
           </activeRecipes>
+          <failOnDryRunResults>true</failOnDryRunResults>
+          <exclusions>
+            <exclusion>**/node/**</exclusion>
+            <!-- undesired changes, e.g. recipes that break compilation -->
+            <!-- org.openrewrite.staticanalysis.FinalizePrivateFields -->
+            <exclusion>**/FeelIntegrationTest.java</exclusion>
+            <exclusion>**/RegisterNewProcessEngineTest.java</exclusion>
+            <!-- org.openrewrite.staticanalysis.UseDiamondOperator -->
+            <exclusion>**/OperatonListImpl.java</exclusion>
+            <!-- org.openrewrite.staticanalysis.SimplifyBooleanExpression -->
+            <exclusion>**/DmnEvaluated*putImpl.java</exclusion>
+          </exclusions>
         </configuration>
         <dependencies>
+          <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-static-analysis</artifactId>
+            <version>1.20.0</version>
+          </dependency>
           <dependency>
             <groupId>org.openrewrite.recipe</groupId>
             <artifactId>rewrite-testing-frameworks</artifactId>
@@ -591,41 +608,6 @@
           <plugin>
             <groupId>com.mycila</groupId>
             <artifactId>license-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>openrewrite</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.openrewrite.maven</groupId>
-            <artifactId>rewrite-maven-plugin</artifactId>
-            <version>6.12.0</version>
-            <configuration>
-              <activeRecipes>
-                org.openrewrite.java.RemoveUnusedImports,
-                org.openrewrite.java.testing.cleanup.TestsShouldNotBePublic,
-                org.openrewrite.staticanalysis.ModifierOrder
-              </activeRecipes>
-              <failOnDryRunResults>true</failOnDryRunResults>
-              <exclusions>
-                **/node/**
-              </exclusions>
-            </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.openrewrite.recipe</groupId>
-                <artifactId>rewrite-static-analysis</artifactId>
-                <version>1.20.0</version>
-              </dependency>
-              <dependency>
-                <groupId>org.openrewrite.recipe</groupId>
-                <artifactId>rewrite-testing-frameworks</artifactId>
-                <version>3.12.0</version>
-              </dependency>
-            </dependencies>
           </plugin>
         </plugins>
       </build>

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/migration/MigrationContextSwitchClassesTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/migration/MigrationContextSwitchClassesTest.java
@@ -49,7 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(ArquillianExtension.class)
 public class MigrationContextSwitchClassesTest extends AbstractFoxPlatformIntegrationTest {
 
-  public static final BpmnModelInstance oneTaskProcess(String key) {
+  public static BpmnModelInstance oneTaskProcess(String key) {
     return  Bpmn.createExecutableProcess(key)
         .operatonHistoryTimeToLive(180)
       .startEvent()
@@ -58,7 +58,7 @@ public class MigrationContextSwitchClassesTest extends AbstractFoxPlatformIntegr
       .done();
   }
 
-  public static final BpmnModelInstance subProcessProcess(String key) {
+  public static BpmnModelInstance subProcessProcess(String key) {
     return  Bpmn.createExecutableProcess(key)
         .operatonHistoryTimeToLive(180)
       .startEvent()

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/SpinClassloadingTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/SpinClassloadingTest.java
@@ -39,7 +39,7 @@ import static org.operaton.bpm.engine.variable.Variables.serializedObjectValue;
 public class SpinClassloadingTest extends AbstractFoxPlatformIntegrationTest {
 
   @Deployment(name="pa")
-  public static final WebArchive createPaDeployment() {
+  public static WebArchive createPaDeployment() {
 
     var webArchive = initWebArchiveDeployment().addAsResource("org/operaton/bpm/integrationtest/functional/spin/SpinClassloadingTest.bpmn")
             .addClass(XmlSerializable.class)
@@ -50,7 +50,7 @@ public class SpinClassloadingTest extends AbstractFoxPlatformIntegrationTest {
   }
 
   @Deployment(name="client-app")
-  public static final WebArchive createClientAppDeployment() {
+  public static WebArchive createClientAppDeployment() {
     WebArchive webArchive = ShrinkWrap.create(WebArchive.class)
         .addClass(AbstractFoxPlatformIntegrationTest.class);
 

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebappUiIntegrationTest.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebappUiIntegrationTest.java
@@ -44,7 +44,7 @@ public class AbstractWebappUiIntegrationTest extends AbstractWebIntegrationTest 
   @BeforeAll
   public static void createDriver() {
     String chromeDriverExecutable = "chromedriver";
-    if (System.getProperty( "os.name" ).toLowerCase(Locale.US).indexOf("windows") > -1) {
+    if (System.getProperty("os.name").toLowerCase(Locale.US).contains("windows")) {
       chromeDriverExecutable += ".exe";
     }
 

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/HttpHeaderSecurityIT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/HttpHeaderSecurityIT.java
@@ -103,7 +103,7 @@ public class HttpHeaderSecurityIT extends AbstractWebIntegrationTest {
       }
     }
 
-    Assertions.fail("Header '%s' didn't match.\nExpected:\t%s \nActual:\t%s".formatted(expectedName, expectedValue, values));
+    Assertions.fail("Header '%s' didn't match.%nExpected:\t%s %nActual:\t%s".formatted(expectedName, expectedValue, values));
   }
 
 }

--- a/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/loadgenerator/LoadGenerator.java
+++ b/qa/performance-tests-engine/src/main/java/org/operaton/bpm/qa/performance/engine/loadgenerator/LoadGenerator.java
@@ -138,7 +138,7 @@ public class LoadGenerator {
       StringBuilder statusMessage = new StringBuilder();
 
       if (color) {
-        statusMessage.append(CLEAR_LINE + ANSI_YELLOW);
+        statusMessage.append(CLEAR_LINE).append(ANSI_YELLOW);
       }
 
       statusMessage.append("%6.2f".formatted(progress));

--- a/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/timestamp/IncidentTimestampScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-710/src/main/java/org/operaton/bpm/qa/upgrade/timestamp/IncidentTimestampScenario.java
@@ -95,7 +95,7 @@ public class IncidentTimestampScenario extends AbstractTimestampMigrationScenari
 
       Boolean fail = (Boolean) execution.getVariable("fail");
 
-      if (fail == null || fail == true) {
+      if (fail == null || fail) {
         throw new ProcessEngineException(EXCEPTION_MESSAGE);
       }
 

--- a/qa/test-db-instance-migration/test-fixture-716/src/main/java/org/operaton/bpm/qa/upgrade/pvm/AsyncJoinScenario.java
+++ b/qa/test-db-instance-migration/test-fixture-716/src/main/java/org/operaton/bpm/qa/upgrade/pvm/AsyncJoinScenario.java
@@ -36,21 +36,17 @@ public final class AsyncJoinScenario {
 
   @DescribesScenario("asyncJoinParallel")
   public static ScenarioSetup createJobsForParallelJoin() {
-    return (engine, scenarioName) -> {
-      engine.getRuntimeService().startProcessInstanceByKey("async-join-parallel-716", scenarioName);
-
+    return (engine, scenarioName) ->
       // result: two jobs have been created, one for each concurrent execution
       // reaching the parallel join gateway
-    };
+      engine.getRuntimeService().startProcessInstanceByKey("async-join-parallel-716", scenarioName);
   }
 
   @DescribesScenario("asyncJoinInclusive")
   public static ScenarioSetup createJobsForInclusiveJoin() {
-    return (engine, scenarioName) -> {
-      engine.getRuntimeService().startProcessInstanceByKey("async-join-inclusive-716", scenarioName);
-
+    return (engine, scenarioName) ->
       // result: two jobs have been created, one for each concurrent execution
       // reaching the inclusive join gateway
-    };
+      engine.getRuntimeService().startProcessInstanceByKey("async-join-inclusive-716", scenarioName);
   }
 }

--- a/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/timestamp/IncidentTimestampUpdateScenario.java
+++ b/qa/test-db-rolling-update/rolling-update-util/src/main/java/org/operaton/bpm/qa/rolling/update/scenarios/timestamp/IncidentTimestampUpdateScenario.java
@@ -96,7 +96,7 @@ public class IncidentTimestampUpdateScenario extends AbstractTimestampUpdateScen
 
       Boolean fail = (Boolean) execution.getVariable("fail");
 
-      if (fail == null || fail == true) {
+      if (fail == null || fail) {
         throw new ProcessEngineException(EXCEPTION_MESSAGE);
       }
 

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -21,3 +21,86 @@ styleConfigs:
       indentSize: 2
       continuationIndent: 2
       indentsRelativeToExpressionStart: false
+---
+# see https://docs.openrewrite.org/recipes/staticanalysis/codecleanup
+type: specs.openrewrite.org/v1beta/recipe
+name: org.operaton.recipe.CodeCleanup
+displayName: Code cleanup
+description: Automatically cleanup code and common SAST issues, e.g. remove unnecessary parentheses, simplify expressions.
+recipeList:
+  # Applicable recipes from org.openrewrite.staticanalysis.CommonStaticAnalysis
+  - org.openrewrite.staticanalysis.AbstractClassPublicConstructor
+  - org.openrewrite.staticanalysis.AtomicPrimitiveEqualsUsesGet
+  - org.openrewrite.staticanalysis.BigDecimalDoubleConstructorRecipe
+  - org.openrewrite.staticanalysis.BigDecimalRoundingConstantsToEnums
+  - org.openrewrite.staticanalysis.BooleanChecksNotInverted
+  - org.openrewrite.staticanalysis.CaseInsensitiveComparisonsDoNotChangeCase
+  - org.openrewrite.staticanalysis.CatchClauseOnlyRethrows
+  # Disabled due to https://github.com/operaton/operaton/issues/1157:
+  #- org.openrewrite.staticanalysis.ChainStringBuilderAppendCalls
+  - org.openrewrite.staticanalysis.CollectionToArrayShouldHaveProperType
+  - org.openrewrite.staticanalysis.CovariantEquals
+  - org.openrewrite.staticanalysis.DefaultComesLast
+  - org.openrewrite.staticanalysis.EmptyBlock
+  - org.openrewrite.staticanalysis.EqualsAvoidsNull
+  - org.openrewrite.staticanalysis.ExplicitInitialization
+  - org.openrewrite.staticanalysis.ExternalizableHasNoArgsConstructor
+  - org.openrewrite.staticanalysis.FinalizePrivateFields
+  # Not safe:
+  # - org.openrewrite.staticanalysis.FallThrough
+  - org.openrewrite.staticanalysis.FinalClass
+  - org.openrewrite.staticanalysis.FixStringFormatExpressions
+  - org.openrewrite.staticanalysis.ForLoopIncrementInUpdate
+  - org.openrewrite.staticanalysis.IndexOfChecksShouldUseAStartPosition
+  - org.openrewrite.staticanalysis.IndexOfReplaceableByContains
+  - org.openrewrite.staticanalysis.IndexOfShouldNotCompareGreaterThanZero
+  - org.openrewrite.staticanalysis.InlineVariable
+  - org.openrewrite.staticanalysis.IsEmptyCallOnCollections
+  - org.openrewrite.staticanalysis.LambdaBlockToExpression
+  - org.openrewrite.staticanalysis.MethodNameCasing
+  - org.openrewrite.staticanalysis.MinimumSwitchCases
+  - org.openrewrite.staticanalysis.ModifierOrder
+  - org.openrewrite.staticanalysis.MultipleVariableDeclarations
+  # Too much noise in equals/hashCode implementations:
+  # - org.openrewrite.staticanalysis.NeedBraces
+  - org.openrewrite.staticanalysis.NestedEnumsAreNotStatic
+  - org.openrewrite.staticanalysis.NewStringBuilderBufferWithCharArgument
+  - org.openrewrite.staticanalysis.NoDoubleBraceInitialization
+  - org.openrewrite.staticanalysis.NoEmptyCollectionWithRawType
+  - org.openrewrite.staticanalysis.NoEqualityInForCondition
+  - org.openrewrite.staticanalysis.NoFinalizer
+  - org.openrewrite.staticanalysis.NoPrimitiveWrappersForToStringOrCompareTo
+  - org.openrewrite.staticanalysis.NoRedundantJumpStatements
+  - org.openrewrite.staticanalysis.NoToStringOnStringType
+  - org.openrewrite.staticanalysis.NoValueOfOnStringType
+  - org.openrewrite.staticanalysis.ObjectFinalizeCallsSuper
+  - org.openrewrite.staticanalysis.PreferSystemGetPropertyOverGetenv
+  - org.openrewrite.staticanalysis.PrimitiveWrapperClassConstructorToValueOf
+  - org.openrewrite.staticanalysis.RedundantFileCreation
+  - org.openrewrite.staticanalysis.RemoveExtraSemicolons
+  - org.openrewrite.staticanalysis.RemoveRedundantNullCheckBeforeInstanceof
+  - org.openrewrite.staticanalysis.RemoveRedundantNullCheckBeforeLiteralEquals
+  - org.openrewrite.staticanalysis.RenameMethodsNamedHashcodeEqualOrToString
+  - org.openrewrite.staticanalysis.ReplaceClassIsInstanceWithInstanceof
+  - org.openrewrite.staticanalysis.ReplaceLambdaWithMethodReference
+  - org.openrewrite.staticanalysis.ReplaceStringBuilderWithString
+  - org.openrewrite.staticanalysis.SimplifyArraysAsList
+  - org.openrewrite.staticanalysis.SimplifyBooleanExpression
+  - org.openrewrite.staticanalysis.SimplifyBooleanReturn
+  - org.openrewrite.staticanalysis.StaticMethodNotFinal
+  - org.openrewrite.staticanalysis.StringLiteralEquality
+  - org.openrewrite.staticanalysis.UnnecessaryCloseInTryWithResources
+  - org.openrewrite.staticanalysis.UnnecessaryExplicitTypeArguments
+  - org.openrewrite.staticanalysis.UnnecessaryParentheses
+  - org.openrewrite.staticanalysis.UnnecessaryPrimitiveAnnotations
+  - org.openrewrite.staticanalysis.UnnecessaryReturnAsLastStatement
+  - org.openrewrite.staticanalysis.UpperCaseLiteralSuffixes
+  - org.openrewrite.staticanalysis.UseDiamondOperator
+  - org.openrewrite.staticanalysis.UseJavaStyleArrayDeclarations
+  - org.openrewrite.staticanalysis.WhileInsteadOfFor
+  - org.openrewrite.staticanalysis.WriteOctalValuesAsDecimal
+  - org.openrewrite.kotlin.cleanup.EqualsMethodUsage
+  - org.openrewrite.kotlin.cleanup.ImplicitParameterInLambda
+  - org.openrewrite.kotlin.cleanup.ReplaceCharToIntWithCode
+  - org.openrewrite.staticanalysis.CustomImportOrder
+

--- a/spin/core/src/test/java/org/operaton/spin/spi/DataFormatLoadingTest.java
+++ b/spin/core/src/test/java/org/operaton/spin/spi/DataFormatLoadingTest.java
@@ -135,7 +135,7 @@ class DataFormatLoadingTest {
 
     // when a map of configuration properties is passed to the "load" method
     DataFormats.getInstance().registerDataFormats(DataFormats.class.getClassLoader(),
-                                                  Collections.EMPTY_LIST,
+      Collections.emptyList(),
                                                   Collections.singletonMap("conditional-prop", true));
 
     // then the configuration property is applied

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/Ordering.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/Ordering.java
@@ -16,7 +16,7 @@
  */
 package org.operaton.bpm.spring.boot.starter.configuration;
 
-public class Ordering {
+public final class Ordering {
 
   public static final int DEFAULT_ORDER = 0;
 

--- a/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/configuration/impl/GenericPropertiesConfigurationTest.java
+++ b/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/configuration/impl/GenericPropertiesConfigurationTest.java
@@ -51,7 +51,7 @@ class GenericPropertiesConfigurationTest {
   @Test
   void genericBindingTestAsString() {
     final int batchPollTimeValue = Integer.MAX_VALUE;
-    operatonBpmProperties.getGenericProperties().getProperties().put("batch-poll-time", Integer.valueOf(batchPollTimeValue).toString());
+    operatonBpmProperties.getGenericProperties().getProperties().put("batch-poll-time", Integer.toString(batchPollTimeValue));
     genericPropertiesConfiguration.preInit(processEngineConfiguration);
     assertThat(processEngineConfiguration.getBatchPollTime()).isEqualTo(batchPollTimeValue);
   }

--- a/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/cmmn/AbstractCaseAssert.java
+++ b/test-utils/assert/core/src/main/java/org/operaton/bpm/engine/test/assertions/cmmn/AbstractCaseAssert.java
@@ -595,18 +595,18 @@ public abstract class AbstractCaseAssert<S extends AbstractCaseAssert<S, A>, A e
   @Override
   protected String toString(A caseExecution) {
     if (caseExecution != null) {
-      return !actual.getCaseInstanceId().equals(actual.getId()) ? "%s {id='%s', activityId='%s', caseInstanceId='%s'}".formatted(
-        caseExecution.getActivityType(),
-        caseExecution.getId(),
-        caseExecution.getActivityId(),
-        caseExecution.getCaseInstanceId())
-          : (
+      return actual.getCaseInstanceId().equals(actual.getId()) ? (
         "%s {id='%s', activityId='%s'" + (((CaseInstance) caseExecution).getBusinessKey() != null ? ", businessKey='%s'}"
           : "}")).formatted(
         CaseInstance.class.getSimpleName(),
         caseExecution.getId(),
         caseExecution.getActivityId(),
-        ((CaseInstance) caseExecution).getBusinessKey());
+        ((CaseInstance) caseExecution).getBusinessKey())
+          : "%s {id='%s', activityId='%s', caseInstanceId='%s'}".formatted(
+        caseExecution.getActivityType(),
+        caseExecution.getId(),
+        caseExecution.getActivityId(),
+        caseExecution.getCaseInstanceId());
     }
     return null;
   }


### PR DESCRIPTION
Applied cleanups of these recipes:

1. org.openrewrite.staticanalysis.IndexOfReplaceableByContains
2. org.openrewrite.staticanalysis.ChainStringBuilderAppendCalls
3. org.openrewrite.staticanalysis.BigDecimalDoubleConstructorRecipe
4. org.openrewrite.staticanalysis.BooleanChecksNotInverted
5. org.openrewrite.staticanalysis.EmptyBlock
6. org.openrewrite.staticanalysis.CatchClauseOnlyRethrows
7. org.openrewrite.staticanalysis.FinalClass
8. org.openrewrite.staticanalysis.ExplicitInitialization
9. org.openrewrite.staticanalysis.FixStringFormatExpressions
10. org.openrewrite.staticanalysis.LambdaBlockToExpression
11. org.openrewrite.staticanalysis.NoValueOfOnStringType
12. org.openrewrite.staticanalysis.MinimumSwitchCases
13. org.openrewrite.staticanalysis.NoEmptyCollectionWithRawType
14. org.openrewrite.staticanalysis.MultipleVariableDeclarations
15. org.openrewrite.staticanalysis.NoPrimitiveWrappersForToStringOrCompareTo
16. org.openrewrite.staticanalysis.StaticMethodNotFinal
17. org.openrewrite.staticanalysis.SimplifyBooleanExpression
18. org.openrewrite.staticanalysis.UpperCaseLiteralSuffixes
19. org.openrewrite.staticanalysis.UnnecessaryExplicitTypeArguments

- Added a composite recipe to `rewrite.yml` with all already applied recipes.
- Configure OpenRewrite Maven plugin
