### PR TITLE
refactor: remove string concatenation from StringBuilder.append() calls

### DIFF
--- a/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
@@ -284,13 +284,13 @@ public class EngineRule implements BeforeEachCallback, AfterEachCallback {
       if (!map.isEmpty()) {
         String variablesAsString = objectMapper.writeValueAsString(map);
         payload.append("\"variables\": ")
-                .append(variablesAsString)
-                .append(",");
+          .append(variablesAsString)
+          .append(",");
       }
       if (businessKey != null) {
         payload.append("\"businessKey\": \"")
-                .append(businessKey)
-                .append("\"");
+          .append(businessKey)
+          .append("\"");
       } else {
         payload.append("\"businessKey\": null");
       }

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
@@ -283,11 +283,14 @@ public class EngineRule implements BeforeEachCallback, AfterEachCallback {
       payload.append("{");
       if (!map.isEmpty()) {
         String variablesAsString = objectMapper.writeValueAsString(map);
-        payload.append("\"variables\": " + variablesAsString);
-        payload.append(",");
+        payload.append("\"variables\": ")
+                .append(variablesAsString)
+                .append(",");
       }
       if (businessKey != null) {
-        payload.append("\"businessKey\": \"" + businessKey + "\"");
+          payload.append("\"businessKey\": \"")
+                  .append(businessKey)
+                  .append("\"");
       } else {
         payload.append("\"businessKey\": null");
       }

--- a/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
+++ b/clients/java/client/src/it/java/org/operaton/bpm/client/rule/EngineRule.java
@@ -288,9 +288,9 @@ public class EngineRule implements BeforeEachCallback, AfterEachCallback {
                 .append(",");
       }
       if (businessKey != null) {
-          payload.append("\"businessKey\": \"")
-                  .append(businessKey)
-                  .append("\"");
+        payload.append("\"businessKey\": \"")
+                .append(businessKey)
+                .append("\"");
       } else {
         payload.append("\"businessKey\": null");
       }

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/config/ManagedProcessEngineMetadata.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/config/ManagedProcessEngineMetadata.java
@@ -205,9 +205,9 @@ public class ManagedProcessEngineMetadata {
       ProcessEnginePluginXml pluginConfiguration = pluginConfigurations.get(i);
       if (pluginConfiguration.getPluginClass() == null || pluginConfiguration.getPluginClass().isEmpty()) {
         isValid = false;
-          validationErrorBuilder.append(" property 'class' in plugin[")
-                  .append(i)
-                  .append("] cannot be null \n");
+        validationErrorBuilder.append(" property 'class' in plugin[")
+          .append(i)
+          .append("] cannot be null \n");
       }
     }
 

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/config/ManagedProcessEngineMetadata.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/config/ManagedProcessEngineMetadata.java
@@ -205,7 +205,9 @@ public class ManagedProcessEngineMetadata {
       ProcessEnginePluginXml pluginConfiguration = pluginConfigurations.get(i);
       if (pluginConfiguration.getPluginClass() == null || pluginConfiguration.getPluginClass().isEmpty()) {
         isValid = false;
-        validationErrorBuilder.append(" property 'class' in plugin[" + i + "] cannot be null \n");
+          validationErrorBuilder.append(" property 'class' in plugin[")
+                  .append(i)
+                  .append("] cannot be null \n");
       }
     }
 

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/ProcessApplicationDeploymentService.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/ProcessApplicationDeploymentService.java
@@ -231,17 +231,17 @@ public class ProcessApplicationDeploymentService implements Service<ProcessAppli
     } else if (isValidValueForResumePreviousBy(resumePreviousBy)) {
       deploymentBuilder.resumePreviousVersionsBy(resumePreviousBy);
     } else {
-        b.append("Illegal value passed for property ")
-                .append(ProcessArchiveXml.PROP_RESUME_PREVIOUS_BY)
-                .append(". Value was ")
-                .append(resumePreviousBy)
-                .append(", expected ")
-                .append(ResumePreviousBy.RESUME_BY_DEPLOYMENT_NAME)
-                .append(" or ")
-                .append(ResumePreviousBy.RESUME_BY_PROCESS_DEFINITION_KEY)
-                .append(".");
+      b.append("Illegal value passed for property ")
+        .append(ProcessArchiveXml.PROP_RESUME_PREVIOUS_BY)
+        .append(". Value was ")
+        .append(resumePreviousBy)
+        .append(", expected ")
+        .append(ResumePreviousBy.RESUME_BY_DEPLOYMENT_NAME)
+        .append(" or ")
+        .append(ResumePreviousBy.RESUME_BY_PROCESS_DEFINITION_KEY)
+        .append(".");
 
-        throw new IllegalArgumentException(b.toString());
+      throw new IllegalArgumentException(b.toString());
     }
   }
 

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/ProcessApplicationDeploymentService.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/ProcessApplicationDeploymentService.java
@@ -254,7 +254,7 @@ public class ProcessApplicationDeploymentService implements Service<ProcessAppli
    * @param deploymentName
    */
   protected void logDeploymentSummary(Collection<String> resourceNames, String deploymentName, String processApplicationName) {
-    // log a summary of the deploymen
+    // log a summary of the deployment
     StringBuilder builder = new StringBuilder();
     builder.append("Deployment summary for process archive '")
           .append(deploymentName)

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/ProcessApplicationDeploymentService.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/ProcessApplicationDeploymentService.java
@@ -231,12 +231,17 @@ public class ProcessApplicationDeploymentService implements Service<ProcessAppli
     } else if (isValidValueForResumePreviousBy(resumePreviousBy)) {
       deploymentBuilder.resumePreviousVersionsBy(resumePreviousBy);
     } else {
-      StringBuilder b = new StringBuilder();
-      b.append("Illegal value passed for property ").append(ProcessArchiveXml.PROP_RESUME_PREVIOUS_BY);
-      b.append(". Value was ").append(resumePreviousBy);
-      b.append(" expected ").append(ResumePreviousBy.RESUME_BY_DEPLOYMENT_NAME);
-      b.append(" or ").append(ResumePreviousBy.RESUME_BY_PROCESS_DEFINITION_KEY).append(".");
-      throw new IllegalArgumentException(b.toString());
+        b.append("Illegal value passed for property ")
+                .append(ProcessArchiveXml.PROP_RESUME_PREVIOUS_BY)
+                .append(". Value was ")
+                .append(resumePreviousBy)
+                .append(", expected ")
+                .append(ResumePreviousBy.RESUME_BY_DEPLOYMENT_NAME)
+                .append(" or ")
+                .append(ResumePreviousBy.RESUME_BY_PROCESS_DEFINITION_KEY)
+                .append(".");
+
+        throw new IllegalArgumentException(b.toString());
     }
   }
 
@@ -249,13 +254,18 @@ public class ProcessApplicationDeploymentService implements Service<ProcessAppli
    * @param deploymentName
    */
   protected void logDeploymentSummary(Collection<String> resourceNames, String deploymentName, String processApplicationName) {
-    // log a summary of the deployment
+    // log a summary of the deploymen
     StringBuilder builder = new StringBuilder();
-    builder.append("Deployment summary for process archive '"+deploymentName+"' of process application '"+processApplicationName+"': \n");
-    builder.append("\n");
+    builder.append("Deployment summary for process archive '")
+          .append(deploymentName)
+          .append("' of process application '")
+          .append(processApplicationName)
+          .append("':\n\n");
+
     for (String resourceName : resourceNames) {
-      builder.append("        "+resourceName);
-      builder.append("\n");
+      builder.append("        ")
+              .append(resourceName)
+              .append("\n");
     }
     LOGGER.log(Level.INFO, builder.toString());
   }

--- a/engine/src/main/java/org/operaton/bpm/container/impl/ContainerIntegrationLogger.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/ContainerIntegrationLogger.java
@@ -173,20 +173,20 @@ public class ContainerIntegrationLogger extends ProcessEngineLogger {
   }
 
   public void deploymentSummary(Collection<String> deploymentResourceNames, String deploymentName) {
+      StringBuilder builder = new StringBuilder();
+      builder.append("Deployment summary for process archive '")
+              .append(deploymentName)
+              .append("':\n\n");
 
-    StringBuilder builder = new StringBuilder();
-    builder.append("Deployment summary for process archive '" + deploymentName + "': \n");
-    builder.append("\n");
-    for (String resourceName : deploymentResourceNames) {
-      builder.append("        ");
-      builder.append(resourceName);
-      builder.append("\n");
-    }
+      for (String resourceName : deploymentResourceNames) {
+          builder.append("        ")
+                  .append(resourceName)
+                  .append("\n");
+      }
 
-    logInfo(
-        "023",
-        builder.toString());
-
+      logInfo(
+              "023",
+              builder.toString());
   }
 
   public void foundProcessesXmlFile(String string) {

--- a/engine/src/main/java/org/operaton/bpm/container/impl/ContainerIntegrationLogger.java
+++ b/engine/src/main/java/org/operaton/bpm/container/impl/ContainerIntegrationLogger.java
@@ -173,20 +173,18 @@ public class ContainerIntegrationLogger extends ProcessEngineLogger {
   }
 
   public void deploymentSummary(Collection<String> deploymentResourceNames, String deploymentName) {
-      StringBuilder builder = new StringBuilder();
-      builder.append("Deployment summary for process archive '")
-              .append(deploymentName)
-              .append("':\n\n");
+    StringBuilder builder = new StringBuilder();
+    builder.append("Deployment summary for process archive '")
+      .append(deploymentName)
+      .append("':\n\n");
 
-      for (String resourceName : deploymentResourceNames) {
-          builder.append("        ")
-                  .append(resourceName)
-                  .append("\n");
-      }
+    for (String resourceName : deploymentResourceNames) {
+      builder.append("        ")
+        .append(resourceName)
+        .append("\n");
+    }
 
-      logInfo(
-              "023",
-              builder.toString());
+    logInfo("023", builder.toString());
   }
 
   public void foundProcessesXmlFile(String string) {

--- a/engine/src/main/junit-shared/org/operaton/bpm/engine/impl/test/TestHelper.java
+++ b/engine/src/main/junit-shared/org/operaton/bpm/engine/impl/test/TestHelper.java
@@ -194,7 +194,7 @@ public abstract class TestHelper {
   private static String createResourceName(Class< ? > type, String name, String suffix) {
     StringBuilder r = new StringBuilder(type.getName().replace('.', '/'));
     if (name != null) {
-      r.append(".").append(name);
+        r.append(".").append(name);
     }
     return r.append(".").append(suffix).toString();
   }

--- a/engine/src/main/junit-shared/org/operaton/bpm/engine/impl/test/TestHelper.java
+++ b/engine/src/main/junit-shared/org/operaton/bpm/engine/impl/test/TestHelper.java
@@ -194,7 +194,7 @@ public abstract class TestHelper {
   private static String createResourceName(Class< ? > type, String name, String suffix) {
     StringBuilder r = new StringBuilder(type.getName().replace('.', '/'));
     if (name != null) {
-        r.append(".").append(name);
+      r.append(".").append(name);
     }
     return r.append(".").append(suffix).toString();
   }

--- a/engine/src/main/junit-shared/org/operaton/bpm/engine/test/util/ExecutionTreeProcessDefinitionIdAssertion.java
+++ b/engine/src/main/junit-shared/org/operaton/bpm/engine/test/util/ExecutionTreeProcessDefinitionIdAssertion.java
@@ -38,14 +38,16 @@ public class ExecutionTreeProcessDefinitionIdAssertion implements ExecutionTreeA
 
     if (!nonMatchingExecutions.isEmpty()) {
       StringBuilder sb = new StringBuilder();
-      sb.append("Expected all executions to have process definition id " + expectedProcessDefinitionId + "\n");
-      sb.append("Actual Tree: \n");
-      sb.append(tree);
-      sb.append("\nExecutions with unexpected process definition id:\n");
-      sb.append("[\n");
+      sb.append("Expected all executions to have process definition id ")
+              .append(expectedProcessDefinitionId)
+              .append("\n");
+      sb.append("Actual Tree: \n")
+              .append(tree)
+              .append("\nExecutions with unexpected process definition id:\n")
+              .append("[\n");
       for (Execution execution : nonMatchingExecutions) {
-        sb.append(execution);
-        sb.append("\n");
+          sb.append(execution)
+                  .append("\n");
       }
       sb.append("]\n");
       fail(sb.toString());

--- a/engine/src/main/junit-shared/org/operaton/bpm/engine/test/util/ExecutionTreeProcessDefinitionIdAssertion.java
+++ b/engine/src/main/junit-shared/org/operaton/bpm/engine/test/util/ExecutionTreeProcessDefinitionIdAssertion.java
@@ -39,14 +39,14 @@ public class ExecutionTreeProcessDefinitionIdAssertion implements ExecutionTreeA
     if (!nonMatchingExecutions.isEmpty()) {
       StringBuilder sb = new StringBuilder();
       sb.append("Expected all executions to have process definition id ")
-              .append(expectedProcessDefinitionId)
-              .append("\n");
+        .append(expectedProcessDefinitionId)
+        .append("\n");
       sb.append("Actual Tree: \n")
-              .append(tree)
-              .append("\nExecutions with unexpected process definition id:\n")
-              .append("[\n");
+        .append(tree)
+        .append("\nExecutions with unexpected process definition id:\n")
+        .append("[\n");
       for (Execution execution : nonMatchingExecutions) {
-          sb.append(execution).append("\n");
+        sb.append(execution).append("\n");
       }
       sb.append("]\n");
       fail(sb.toString());

--- a/engine/src/main/junit-shared/org/operaton/bpm/engine/test/util/ExecutionTreeProcessDefinitionIdAssertion.java
+++ b/engine/src/main/junit-shared/org/operaton/bpm/engine/test/util/ExecutionTreeProcessDefinitionIdAssertion.java
@@ -46,8 +46,7 @@ public class ExecutionTreeProcessDefinitionIdAssertion implements ExecutionTreeA
               .append("\nExecutions with unexpected process definition id:\n")
               .append("[\n");
       for (Execution execution : nonMatchingExecutions) {
-          sb.append(execution)
-                  .append("\n");
+          sb.append(execution).append("\n");
       }
       sb.append("]\n");
       fail(sb.toString());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/persistence/DatabaseNamingConsistencyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/persistence/DatabaseNamingConsistencyTest.java
@@ -63,14 +63,14 @@ public class DatabaseNamingConsistencyTest {
               lineNumber.getAndIncrement();
               Matcher matcher = pattern.matcher(line);
               while (matcher.find()) {
-                  errorMessageBuilder
-                          .append("Found illegal lowercase column name ")
-                          .append(matcher.group(1))
-                          .append(" in SQL ")
-                          .append(file)
-                          .append(" at line ")
-                          .append(lineNumber.get())
-                          .append(". All SQL column names should be uppercase.\n");
+                errorMessageBuilder
+                  .append("Found illegal lowercase column name ")
+                  .append(matcher.group(1))
+                  .append(" in SQL ")
+                  .append(file)
+                  .append(" at line ")
+                  .append(lineNumber.get())
+                  .append(". All SQL column names should be uppercase.\n");
               }
             });
           }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/persistence/DatabaseNamingConsistencyTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/persistence/DatabaseNamingConsistencyTest.java
@@ -63,9 +63,14 @@ public class DatabaseNamingConsistencyTest {
               lineNumber.getAndIncrement();
               Matcher matcher = pattern.matcher(line);
               while (matcher.find()) {
-                errorMessageBuilder.append(
-                    "Found illegal lowercase column name " + matcher.group(1) + " in SQL " + file + " at line "
-                        + lineNumber + ". All SQL column names should be uppercase.\n");
+                  errorMessageBuilder
+                          .append("Found illegal lowercase column name ")
+                          .append(matcher.group(1))
+                          .append(" in SQL ")
+                          .append(file)
+                          .append(" at line ")
+                          .append(lineNumber.get())
+                          .append(". All SQL column names should be uppercase.\n");
               }
             });
           }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/XmlListSerializable.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/XmlListSerializable.java
@@ -36,9 +36,9 @@ public class XmlListSerializable<T> {
 
     jsonBuilder.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?><xmlSerializable>");
     for (int i = 0; i < listProperty.size(); i++) {
-        jsonBuilder.append("<listProperty>")
-                .append(listProperty.get(i))
-                .append("</listProperty>");
+      jsonBuilder.append("<listProperty>")
+        .append(listProperty.get(i))
+        .append("</listProperty>");
     }
     jsonBuilder.append("</xmlSerializable>");
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/XmlListSerializable.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/spin/XmlListSerializable.java
@@ -36,7 +36,9 @@ public class XmlListSerializable<T> {
 
     jsonBuilder.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?><xmlSerializable>");
     for (int i = 0; i < listProperty.size(); i++) {
-      jsonBuilder.append("<listProperty>" + listProperty.get(i) + "</listProperty>");
+        jsonBuilder.append("<listProperty>")
+                .append(listProperty.get(i))
+                .append("</listProperty>");
     }
     jsonBuilder.append("</xmlSerializable>");
 

--- a/webapps/assembly/src/main/runtime/test/java/org/operaton/bpm/pa/rest/TestServlet.java
+++ b/webapps/assembly/src/main/runtime/test/java/org/operaton/bpm/pa/rest/TestServlet.java
@@ -108,11 +108,11 @@ public class TestServlet extends HttpServlet {
       if (!TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK.contains(tableNameWithoutPrefix)) {
         Long count = tableCounts.get(tableName);
         if (count != 0L) {
-            outputMessage.append("  ")
-                    .append(tableName)
-                    .append(": ")
-                    .append(count)
-                    .append(" record(s)\n");
+          outputMessage.append("  ")
+            .append(tableName)
+            .append(": ")
+            .append(count)
+            .append(" record(s)\n");
         }
       }
     }

--- a/webapps/assembly/src/main/runtime/test/java/org/operaton/bpm/pa/rest/TestServlet.java
+++ b/webapps/assembly/src/main/runtime/test/java/org/operaton/bpm/pa/rest/TestServlet.java
@@ -108,7 +108,11 @@ public class TestServlet extends HttpServlet {
       if (!TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK.contains(tableNameWithoutPrefix)) {
         Long count = tableCounts.get(tableName);
         if (count != 0L) {
-          outputMessage.append("  " + tableName + ": " + count + " record(s)\n");
+            outputMessage.append("  ")
+                    .append(tableName)
+                    .append(": ")
+                    .append(count)
+                    .append(" record(s)\n");
         }
       }
     }

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/engine/WebappsDatabaseNamingConsistencyTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/engine/WebappsDatabaseNamingConsistencyTest.java
@@ -57,14 +57,13 @@ public class WebappsDatabaseNamingConsistencyTest {
               lineNumber.getAndIncrement();
               Matcher matcher = pattern.matcher(line);
               while (matcher.find()) {
-                  errorMessageBuilder.append("Found illegal lowercase column name ")
-                          .append(matcher.group(1))
-                          .append(" in SQL ")
-                          .append(file)
-                          .append(" at line ")
-                          .append(lineNumber)
-                          .append(". All SQL column names should be uppercase.\n");
-
+                errorMessageBuilder.append("Found illegal lowercase column name ")
+                  .append(matcher.group(1))
+                  .append(" in SQL ")
+                  .append(file)
+                  .append(" at line ")
+                  .append(lineNumber)
+                  .append(". All SQL column names should be uppercase.\n");
               }
             });
           }

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/engine/WebappsDatabaseNamingConsistencyTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/engine/WebappsDatabaseNamingConsistencyTest.java
@@ -57,9 +57,14 @@ public class WebappsDatabaseNamingConsistencyTest {
               lineNumber.getAndIncrement();
               Matcher matcher = pattern.matcher(line);
               while (matcher.find()) {
-                errorMessageBuilder.append(
-                    "Found illegal lowercase column name " + matcher.group(1) + " in SQL " + file + " at line "
-                        + lineNumber + ". All SQL column names should be uppercase.\n");
+                  errorMessageBuilder.append("Found illegal lowercase column name ")
+                          .append(matcher.group(1))
+                          .append(" in SQL ")
+                          .append(file)
+                          .append(" at line ")
+                          .append(lineNumber)
+                          .append(". All SQL column names should be uppercase.\n");
+
               }
             });
           }


### PR DESCRIPTION
All instances of StringBuilder.append() with string concatenation have been refactored to use multiple append calls for improved readability.

closes #1157 
