### PR TITLE
Cleanup rewrite.yml & organize imports

### DIFF
--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/MscExecutorService.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/MscExecutorService.java
@@ -16,21 +16,22 @@
  */
 package org.operaton.bpm.container.impl.jboss.service;
 
-import org.jboss.msc.service.Service;
-import org.jboss.msc.service.StartContext;
-import org.jboss.msc.service.StartException;
-import org.jboss.msc.service.StopContext;
-import org.jboss.threads.EnhancedQueueExecutor;
-import org.operaton.bpm.container.ExecutorService;
-import org.operaton.bpm.engine.impl.ProcessEngineImpl;
-import org.operaton.bpm.engine.impl.jobexecutor.ExecuteJobsRunnable;
-
 import java.util.List;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.threads.EnhancedQueueExecutor;
+
+import org.operaton.bpm.container.ExecutorService;
+import org.operaton.bpm.engine.impl.ProcessEngineImpl;
+import org.operaton.bpm.engine.impl.jobexecutor.ExecuteJobsRunnable;
 
 public class MscExecutorService implements Service<MscExecutorService>, ExecutorService {
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CreateAndResolveIncidentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CreateAndResolveIncidentTest.java
@@ -42,9 +42,9 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
+ import static org.operaton.bpm.engine.impl.test.TestHelper.executeJobIgnoringException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.operaton.bpm.engine.impl.test.TestHelper.executeJobIgnoringException;
 
 public class CreateAndResolveIncidentTest {
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationHistoryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationHistoryTest.java
@@ -41,8 +41,8 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 import org.operaton.bpm.engine.variable.Variables;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.impl.test.TestHelper.executeJobIgnoringException;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Thorben Lindhauer

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/async/AsyncAfterTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/async/AsyncAfterTest.java
@@ -44,9 +44,9 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
+ import static org.operaton.bpm.engine.impl.test.TestHelper.executeJobIgnoringException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.operaton.bpm.engine.impl.test.TestHelper.executeJobIgnoringException;
 
 /**
  * @author Daniel Meyer

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/async/FoxJobRetryCmdTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/async/FoxJobRetryCmdTest.java
@@ -49,9 +49,9 @@ import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.bpm.model.bpmn.instance.MessageEventDefinition;
 
+import static org.operaton.bpm.engine.impl.test.TestHelper.executeJobIgnoringException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.operaton.bpm.engine.impl.test.TestHelper.executeJobIgnoringException;
 
 class FoxJobRetryCmdTest {
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/parse/RetryIntervalsConfigurationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/parse/RetryIntervalsConfigurationTest.java
@@ -37,8 +37,8 @@ import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.impl.test.TestHelper.executeJobIgnoringException;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class RetryIntervalsConfigurationTest extends AbstractAsyncOperationsTest {
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/CustomHistoryLevelIncidentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/CustomHistoryLevelIncidentTest.java
@@ -60,8 +60,8 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP;
 import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_CLEANUP_STRATEGY_END_TIME_BASED;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.operaton.bpm.engine.impl.test.TestHelper.executeJobIgnoringException;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Parameterized
 public class CustomHistoryLevelIncidentTest {

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebIntegrationTest.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebIntegrationTest.java
@@ -16,17 +16,17 @@
  */
 package org.operaton.bpm;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
+import java.util.logging.Logger;
 import jakarta.ws.rs.core.MediaType;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
 import kong.unirest.HttpResponse;
 import kong.unirest.ObjectMapper;
 import kong.unirest.Unirest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.openqa.selenium.chrome.ChromeDriverService;
-
-import java.util.List;
-import java.util.logging.Logger;
 
 import static jakarta.ws.rs.core.HttpHeaders.SET_COOKIE;
 

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/rest/RestIT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/rest/RestIT.java
@@ -16,6 +16,13 @@
  */
 package org.operaton.bpm.rest;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.Unirest;
@@ -23,16 +30,10 @@ import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import org.operaton.bpm.AbstractWebIntegrationTest;
 import org.operaton.bpm.engine.rest.hal.Hal;
 import org.operaton.bpm.engine.rest.mapper.JacksonConfigurator;
-
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.logging.Logger;
 
 import static jakarta.ws.rs.core.HttpHeaders.ACCEPT;
 import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/rest/RestJaxRs2IT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/rest/RestJaxRs2IT.java
@@ -16,14 +16,6 @@
  */
 package org.operaton.bpm.rest;
 
-import kong.unirest.HttpResponse;
-import kong.unirest.JsonNode;
-import kong.unirest.Unirest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
-import org.operaton.bpm.AbstractWebIntegrationTest;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +25,15 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import kong.unirest.HttpResponse;
+import kong.unirest.JsonNode;
+import kong.unirest.Unirest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import org.operaton.bpm.AbstractWebIntegrationTest;
 
 import static jakarta.ws.rs.core.HttpHeaders.ACCEPT;
 import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -48,103 +48,31 @@ name: org.operaton.recipe.CodeCleanup
 displayName: Code cleanup
 description: Automatically cleanup code and common SAST issues, e.g. remove unnecessary parentheses, simplify expressions.
 recipeList:
-  # Applicable recipes from org.openrewrite.staticanalysis.CommonStaticAnalysis
-  - org.openrewrite.staticanalysis.AbstractClassPublicConstructor
-  - org.openrewrite.staticanalysis.AtomicPrimitiveEqualsUsesGet
-  - org.openrewrite.staticanalysis.BigDecimalDoubleConstructorRecipe
-  - org.openrewrite.staticanalysis.BigDecimalRoundingConstantsToEnums
-  - org.openrewrite.staticanalysis.BooleanChecksNotInverted
-  - org.openrewrite.staticanalysis.CaseInsensitiveComparisonsDoNotChangeCase
-  - org.openrewrite.staticanalysis.CatchClauseOnlyRethrows
-  - org.openrewrite.staticanalysis.ChainStringBuilderAppendCalls
-  - org.openrewrite.staticanalysis.CollectionToArrayShouldHaveProperType
-  - org.openrewrite.staticanalysis.CovariantEquals
-  - org.openrewrite.staticanalysis.DefaultComesLast
-  - org.openrewrite.staticanalysis.EmptyBlock
-  - org.openrewrite.staticanalysis.EqualsAvoidsNull
-  - org.openrewrite.staticanalysis.ExplicitInitialization
-  - org.openrewrite.staticanalysis.ExternalizableHasNoArgsConstructor
-  - org.openrewrite.staticanalysis.FinalizePrivateFields
-  - org.openrewrite.staticanalysis.FallThrough
-  - org.openrewrite.staticanalysis.FinalClass
-  - org.openrewrite.staticanalysis.FixStringFormatExpressions
-  - org.openrewrite.staticanalysis.ForLoopIncrementInUpdate
-  - org.openrewrite.staticanalysis.IndexOfChecksShouldUseAStartPosition
-  - org.openrewrite.staticanalysis.IndexOfReplaceableByContains
-  - org.openrewrite.staticanalysis.IndexOfShouldNotCompareGreaterThanZero
-  - org.openrewrite.staticanalysis.InlineVariable
-  - org.openrewrite.staticanalysis.IsEmptyCallOnCollections
-  - org.openrewrite.staticanalysis.LambdaBlockToExpression
-  - org.openrewrite.staticanalysis.MethodNameCasing
-  - org.openrewrite.staticanalysis.MinimumSwitchCases
-  - org.openrewrite.staticanalysis.ModifierOrder
-  - org.openrewrite.staticanalysis.MultipleVariableDeclarations
-  - org.openrewrite.staticanalysis.NeedBraces
-  - org.openrewrite.staticanalysis.NestedEnumsAreNotStatic
-  - org.openrewrite.staticanalysis.NewStringBuilderBufferWithCharArgument
-  - org.openrewrite.staticanalysis.NoDoubleBraceInitialization
-  - org.openrewrite.staticanalysis.NoEmptyCollectionWithRawType
-  - org.openrewrite.staticanalysis.NoEqualityInForCondition
-  - org.openrewrite.staticanalysis.NoFinalizer
-  - org.openrewrite.staticanalysis.NoPrimitiveWrappersForToStringOrCompareTo
-  - org.openrewrite.staticanalysis.NoRedundantJumpStatements
-  - org.openrewrite.staticanalysis.NoToStringOnStringType
-  - org.openrewrite.staticanalysis.NoValueOfOnStringType
-  - org.openrewrite.staticanalysis.ObjectFinalizeCallsSuper
-  - org.openrewrite.staticanalysis.PreferSystemGetPropertyOverGetenv
-  - org.openrewrite.staticanalysis.PrimitiveWrapperClassConstructorToValueOf
-  - org.openrewrite.staticanalysis.RedundantFileCreation
-  - org.openrewrite.staticanalysis.RemoveExtraSemicolons
-  - org.openrewrite.staticanalysis.RemoveRedundantNullCheckBeforeInstanceof
-  - org.openrewrite.staticanalysis.RemoveRedundantNullCheckBeforeLiteralEquals
-  - org.openrewrite.staticanalysis.RenameMethodsNamedHashcodeEqualOrToString
-  - org.openrewrite.staticanalysis.ReplaceClassIsInstanceWithInstanceof
-  - org.openrewrite.staticanalysis.ReplaceLambdaWithMethodReference
-  - org.openrewrite.staticanalysis.ReplaceStringBuilderWithString
-  - org.openrewrite.staticanalysis.SimplifyArraysAsList
-  - org.openrewrite.staticanalysis.SimplifyBooleanExpression
-  - org.openrewrite.staticanalysis.SimplifyBooleanReturn
-  - org.openrewrite.staticanalysis.StaticMethodNotFinal
-  - org.openrewrite.staticanalysis.StringLiteralEquality
-  - org.openrewrite.staticanalysis.UnnecessaryCloseInTryWithResources
-  - org.openrewrite.staticanalysis.UnnecessaryExplicitTypeArguments
-  - org.openrewrite.staticanalysis.UnnecessaryParentheses
-  - org.openrewrite.staticanalysis.UnnecessaryPrimitiveAnnotations
-  - org.openrewrite.staticanalysis.UnnecessaryReturnAsLastStatement
-  - org.openrewrite.staticanalysis.UpperCaseLiteralSuffixes
-  - org.openrewrite.staticanalysis.UseDiamondOperator
-  - org.openrewrite.staticanalysis.UseJavaStyleArrayDeclarations
-  - org.openrewrite.staticanalysis.WhileInsteadOfFor
-  - org.openrewrite.staticanalysis.WriteOctalValuesAsDecimal
-  - org.openrewrite.kotlin.cleanup.EqualsMethodUsage
-  - org.openrewrite.kotlin.cleanup.ImplicitParameterInLambda
-  - org.openrewrite.kotlin.cleanup.ReplaceCharToIntWithCode
-  - org.openrewrite.staticanalysis.CustomImportOrder
+  - org.openrewrite.staticanalysis.CommonStaticAnalysis
   # Java cleanups
-  # - org.openrewrite.java.OrderImports
-  - org.openrewrite.staticanalysis.UnnecessaryThrows
-  - org.openrewrite.java.RemoveUnusedImports
-  - org.openrewrite.staticanalysis.UseStandardCharset
-  - org.openrewrite.staticanalysis.MissingOverrideAnnotation
-  - org.openrewrite.staticanalysis.HideUtilityClassConstructor
-  - org.openrewrite.staticanalysis.UseLambdaForFunctionalInterface
-  - org.openrewrite.staticanalysis.CombineSemanticallyEqualCatchBlocks
+  - org.openrewrite.staticanalysis.AddSerialAnnotationToSerialVersionUID
   - org.openrewrite.staticanalysis.AvoidBoxedBooleanExpressions
+  - org.openrewrite.staticanalysis.CombineSemanticallyEqualCatchBlocks
+  - org.openrewrite.staticanalysis.HideUtilityClassConstructor
+  - org.openrewrite.staticanalysis.InstanceOfPatternMatch
+  - org.openrewrite.staticanalysis.MissingOverrideAnnotation
+  - org.openrewrite.staticanalysis.UnnecessaryThrows
+  - org.openrewrite.staticanalysis.UseLambdaForFunctionalInterface
+  - org.openrewrite.staticanalysis.UseStandardCharset
+  - org.openrewrite.java.RemoveUnusedImports
   - org.openrewrite.java.SimplifySingleElementAnnotation
   - org.openrewrite.java.migrate.lang.StringFormatted
-  - org.openrewrite.staticanalysis.AddSerialAnnotationToSerialVersionUID
   - org.openrewrite.java.migrate.UpgradeToJava17
   - org.openrewrite.java.migrate.DeprecatedLogRecordThreadID
-  - org.openrewrite.staticanalysis.InstanceOfPatternMatch
   # Testing
+  - org.openrewrite.java.testing.assertj.AssertJShortRulesRecipes$AbstractShortAssertIsZeroRecipe
+  - org.openrewrite.java.testing.assertj.CollapseConsecutiveAssertThatStatements
   - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertions
   - org.openrewrite.java.testing.assertj.SimplifyAssertJAssertion
-  - org.openrewrite.java.testing.cleanup.SimplifyTestThrows
-  - org.openrewrite.java.testing.mockito.SimplifyMockitoVerifyWhenGiven
-  - org.openrewrite.java.testing.cleanup.TestsShouldNotBePublic
   - org.openrewrite.java.testing.cleanup.AssertionsArgumentOrder
-  - org.openrewrite.java.testing.assertj.CollapseConsecutiveAssertThatStatements
-  - org.openrewrite.java.testing.assertj.AssertJShortRulesRecipes$AbstractShortAssertIsZeroRecipe
+  - org.openrewrite.java.testing.cleanup.SimplifyTestThrows
+  - org.openrewrite.java.testing.cleanup.TestsShouldNotBePublic
+  - org.openrewrite.java.testing.mockito.SimplifyMockitoVerifyWhenGiven
   - org.openrewrite.java.testing.assertj.StaticImports
   # Logging
   - org.openrewrite.java.logging.slf4j.ParameterizedLogging


### PR DESCRIPTION
This PR activates the composite recipe `org.openrewrite.staticanalysis.CommonStaticAnalysis` and removes all included recipes. The remaining are sorted alphabetically.