### PR TITLE
fix(openApi): add missing quotation marks (backport d8ea83c750)

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/create/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/authorization/create/post.ftl
@@ -46,9 +46,9 @@
                          "removalTime": "2018-02-10T14:33:19.000+0200",
                          "rootProcessInstanceId": "f8259e5d-ab9d-11e8-8449-e4a7a094a9d6",
                          "links":[
-                           {"method": "GET", href":"http://localhost:8080/engine-rest/authorization/anAuthorizationId", "rel":"self"},
-                           {"method": "PUT", href":"http://localhost:8080/engine-rest/authorization/anAuthorizationId", "rel":"update"},
-                           {"method": "DELETE", href":"http://localhost:8080/engine-rest/authorization/anAuthorizationId", "rel":"delete"}
+                           {"method": "GET", "href":"http://localhost:8080/engine-rest/authorization/anAuthorizationId", "rel":"self"},
+                           {"method": "PUT", "href":"http://localhost:8080/engine-rest/authorization/anAuthorizationId", "rel":"update"},
+                           {"method": "DELETE", "href":"http://localhost:8080/engine-rest/authorization/anAuthorizationId", "rel":"delete"}
                          ]
                        }
                      }']


### PR DESCRIPTION
Backport of camunda/camunda-bpm-platform@d8ea83c750  
Original author: @HeleneW-dot  
Related to: https://github.com/camunda/camunda-bpm-platform/issues/5383  

### What I changed
- Added missing quotation marks for `"href"` in `engine-rest-openapi/src/main/templates/paths/authorization/create/post.ftl`

### Verification
- Ran `./mvnw clean install`
- Some tests in module `operaton-xml-model` failed locally, but this change only affects `engine-rest-openapi`
- CI should confirm the result

---

I confirm that my contribution and following ones comply with the **Apache License 2.0** and the **Code of Conduct**.
