### PR TITLE
Make Integration Tests for Web Apps runnable

### DIFF
--- a/.github/scripts/install-chrome-and-driver.sh
+++ b/.github/scripts/install-chrome-and-driver.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="https://googlechromelabs.github.io/chrome-for-testing"
+
+echo "➡️  Detecting current Stable-Version..."
+VERSION=$(curl -s "$BASE_URL/last-known-good-versions.json" | jq -r '.channels.Stable.version')
+MILESTONE=$(echo "$VERSION" | cut -d. -f1)
+
+echo "📦 Stable Chrome Version: $VERSION (Milestone $MILESTONE)"
+
+JSON_URL="$BASE_URL/latest-versions-per-milestone-with-downloads.json"
+
+CHROME_URL=$(curl -s "$JSON_URL" \
+  | jq -r --arg m "$MILESTONE" '.milestones[$m].downloads.chrome[] | select(.platform=="linux64").url')
+
+DRIVER_URL=$(curl -s "$JSON_URL" \
+  | jq -r --arg m "$MILESTONE" '.milestones[$m].downloads.chromedriver[] | select(.platform=="linux64").url')
+
+echo "⬇️  Downloading Chrome: $CHROME_URL"
+echo "⬇️  Downloading Chromedriver: $DRIVER_URL"
+
+curl -sSL "$CHROME_URL" -o /tmp/chrome.zip
+unzip -q /tmp/chrome.zip -d /tmp/
+sudo rm -rf /opt/chrome
+sudo mv /tmp/chrome-linux64 /opt/chrome
+sudo ln -sf /opt/chrome/chrome /usr/local/bin/google-chrome
+
+curl -sSL "$DRIVER_URL" -o /tmp/driver.zip
+unzip -q /tmp/driver.zip -d /tmp/
+sudo mv /tmp/chromedriver-linux64/chromedriver /usr/local/bin/
+sudo chmod +x /usr/local/bin/chromedriver
+
+echo "✅ Installation complete!"
+google-chrome --version
+chromedriver --version

--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -30,7 +30,7 @@ on:
         description: 'Integration Tests: Test suite to run'
         type: choice
         required: true
-        default: '["engine"]'
+        default: '["engine", "webapps"]'
         options:
           - '["engine"]'
           - '["webapps"]'

--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -326,6 +326,12 @@ jobs:
         run: |
           .devenv/scripts/build/build-and-run-integration-tests.sh --testsuite=${{ matrix.testsuite }} --distro=${{ matrix.distro }} --db=${{ matrix.database }} --no-test
           .devenv/scripts/build/build-and-run-database-update-tests.sh --db=${{ matrix.database }} --no-test
+      - name: Install Chromedriver
+        id: install-chromedriver
+        if: ${{ matrix.testsuite == 'webapps' }}
+        shell: bash
+        run: |
+          .github/scripts/install-chrome-and-driver.sh
       - name: Execute Integration Tests
         id: maven-integration-tests
         shell: bash

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
@@ -48,20 +48,9 @@ public abstract class AbstractWebappUiIT extends AbstractWebIT {
 
   @BeforeAll
   static void createDriver() {
-    String chromeDriverExecutable = "chromedriver";
-    if (System.getProperty("os.name").toLowerCase(Locale.US).contains("windows")) {
-      chromeDriverExecutable += ".exe";
-    }
-
-    File chromeDriver = new File("target/chromedriver/" + chromeDriverExecutable);
-    if (!chromeDriver.exists()) {
-      throw new RuntimeException("chromedriver could not be located!");
-    }
-
     ChromeDriverService chromeDriverService = new ChromeDriverService.Builder()
         .withVerbose(true)
         .usingAnyFreePort()
-        .usingDriverExecutable(chromeDriver)
         .build();
 
     ChromeOptions chromeOptions = new ChromeOptions()

--- a/distro/run/qa/pom.xml
+++ b/distro/run/qa/pom.xml
@@ -11,10 +11,7 @@
   <name>Operaton - Run - QA</name>
   <description>${project.name}</description>
   <properties>
-    <!-- default os -->
-    <os.type>linux64</os.type>
     <version.httpcomponents>4.5.10</version.httpcomponents>
-    <version.chromedriver>112.0.5615.49</version.chromedriver>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/distro/run/qa/runtime/pom.xml
+++ b/distro/run/qa/runtime/pom.xml
@@ -165,48 +165,9 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
-            <groupId>com.googlecode.maven-download-plugin</groupId>
-            <artifactId>download-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>wget</goal>
-                </goals>
-                <configuration>
-                  <url>https://chromedriver.storage.googleapis.com/${version.chromedriver}/chromedriver_${os.type}.zip</url>
-                  <outputFileName>chromedriver.zip</outputFileName>
-                  <unpack>true</unpack>
-                  <outputDirectory>${project.build.directory}/chromedriver</outputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
-    <profile>
-      <id>windows</id>
-      <activation>
-        <os>
-          <family>windows</family>
-        </os>
-      </activation>
-      <properties>
-        <os.type>win32</os.type>
-      </properties>
-    </profile>
-    <profile>
-      <id>mac</id>
-      <activation>
-        <os>
-          <family>mac</family>
-        </os>
-      </activation>
-      <properties>
-        <os.type>mac64</os.type>
-      </properties>
-    </profile>
+
   </profiles>
 </project>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -41,6 +41,11 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.operaton.commons</groupId>
+      <artifactId>operaton-commons-utils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
       <artifactId>jackson-jakarta-rs-json-provider</artifactId>
       <version>2.20.0</version>

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebappUiIntegrationTest.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebappUiIntegrationTest.java
@@ -16,10 +16,8 @@
  */
 package org.operaton.bpm;
 
-import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Locale;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebappUiIntegrationTest.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebappUiIntegrationTest.java
@@ -42,20 +42,10 @@ public class AbstractWebappUiIntegrationTest extends AbstractWebIntegrationTest 
 
   @BeforeAll
   static void createDriver() {
-    String chromeDriverExecutable = "chromedriver";
-    if (System.getProperty("os.name").toLowerCase(Locale.US).contains("windows")) {
-      chromeDriverExecutable += ".exe";
-    }
-
-    File chromeDriver = new File("target/chromedriver/" + chromeDriverExecutable);
-    if (!chromeDriver.exists()) {
-      throw new RuntimeException("chromedriver could not be located!");
-    }
 
     ChromeDriverService chromeDriverService = new ChromeDriverService.Builder()
             .withVerbose(true)
             .usingAnyFreePort()
-            .usingDriverExecutable(chromeDriver)
             .build();
 
     ChromeOptions chromeOptions = new ChromeOptions()

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/TestProperties.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/TestProperties.java
@@ -73,7 +73,7 @@ public class TestProperties {
   }
 
   public String getWebappCtxPath() {
-    return getStringProperty("webapp.ctx.path", "camunda/");
+    return getStringProperty("webapp.ctx.path", "operaton/");
   }
 
   public String getRestCtxPath() {

--- a/qa/integration-tests-webapps/pom.xml
+++ b/qa/integration-tests-webapps/pom.xml
@@ -14,7 +14,7 @@
     <cargo.timeout>120000</cargo.timeout>
     <cargo.deploy.timeout>60000</cargo.deploy.timeout>
     <!-- Needs to be adjusted with every WildFly update -->
-    <cargo.wildfly.container.id>wildfly36x</cargo.wildfly.container.id>
+    <cargo.wildfly.container.id>wildfly37x</cargo.wildfly.container.id>
     <redirect.test.output>true</redirect.test.output>
     <http.ctx-path.webapp>operaton/</http.ctx-path.webapp>
     <http.ctx-path.rest>engine-rest/</http.ctx-path.rest>

--- a/qa/integration-tests-webapps/pom.xml
+++ b/qa/integration-tests-webapps/pom.xml
@@ -18,9 +18,6 @@
     <redirect.test.output>true</redirect.test.output>
     <http.ctx-path.webapp>operaton/</http.ctx-path.webapp>
     <http.ctx-path.rest>engine-rest/</http.ctx-path.rest>
-    <version.chromedriver>112.0.5615.49</version.chromedriver>
-    <!-- default os -->
-    <os.type>linux64</os.type>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -142,49 +139,5 @@
         <module>shared-engine</module>
       </modules>
     </profile>
-    <profile>
-      <id>chromedriver-windows</id>
-      <activation>
-        <os>
-          <family>windows</family>
-        </os>
-      </activation>
-      <properties>
-        <os.type>win32</os.type>
-      </properties>
-    </profile>
-    <profile>
-      <id>chromedriver-osx</id>
-      <activation>
-        <os>
-          <family>mac</family>
-        </os>
-      </activation>
-      <properties>
-        <os.type>mac64</os.type>
-      </properties>
-    </profile>
   </profiles>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>com.googlecode.maven-download-plugin</groupId>
-        <artifactId>download-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>wget</goal>
-            </goals>
-            <configuration>
-              <url>https://chromedriver.storage.googleapis.com/${version.chromedriver}/chromedriver_${os.type}.zip</url>
-              <outputFileName>chromedriver.zip</outputFileName>
-              <unpack>true</unpack>
-              <outputDirectory>${project.build.directory}/chromedriver</outputDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/qa/integration-tests-webapps/shared-engine/pom.xml
+++ b/qa/integration-tests-webapps/shared-engine/pom.xml
@@ -89,6 +89,8 @@
                 <home>${jboss.runtime}</home>
                 <timeout>${cargo.timeout}</timeout>
                 <output>${project.build.directory}/cargo.log</output>
+                <log>${project.build.directory}/server.log</log>
+                <logLevel>DEBUG</logLevel>
               </container>
               <configuration>
                 <type>standalone</type>

--- a/qa/wildfly-runtime/src/main/wildfly/standalone/configuration/standalone.xml
+++ b/qa/wildfly-runtime/src/main/wildfly/standalone/configuration/standalone.xml
@@ -73,7 +73,7 @@
     <profile>
         <subsystem xmlns="urn:jboss:domain:logging:8.0">
             <console-handler name="CONSOLE">
-                <level name="INFO"/>
+                <level name="DEBUG"/>
                 <formatter>
                     <named-formatter name="COLOR-PATTERN"/>
                 </formatter>
@@ -86,6 +86,9 @@
                 <suffix value=".yyyy-MM-dd"/>
                 <append value="true"/>
             </periodic-rotating-file-handler>
+            <logger category="org.operaton">
+                <level name="DEBUG" />
+            </logger>
             <logger category="org.jboss.weld">
                 <level name="INFO"/>
             </logger>

--- a/qa/wildfly-runtime/src/main/wildfly/standalone/configuration/standalone.xml
+++ b/qa/wildfly-runtime/src/main/wildfly/standalone/configuration/standalone.xml
@@ -73,7 +73,7 @@
     <profile>
         <subsystem xmlns="urn:jboss:domain:logging:8.0">
             <console-handler name="CONSOLE">
-                <level name="DEBUG"/>
+                <level name="INFO"/>
                 <formatter>
                     <named-formatter name="COLOR-PATTERN"/>
                 </formatter>
@@ -86,9 +86,6 @@
                 <suffix value=".yyyy-MM-dd"/>
                 <append value="true"/>
             </periodic-rotating-file-handler>
-            <logger category="org.operaton">
-                <level name="DEBUG" />
-            </logger>
             <logger category="org.jboss.weld">
                 <level name="INFO"/>
             </logger>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/pom.xml
@@ -10,36 +10,8 @@
   <packaging>pom</packaging>
   <name>Operaton - Spring Boot Starter - QA - Webapps</name>
   <description>${project.name}</description>
-  <properties>
-    <!-- default os -->
-    <os.type>linux64</os.type>
-  </properties>
   <modules>
     <module>invoice-example</module>
     <module>runtime</module>
   </modules>
-  <profiles>
-    <profile>
-      <id>windows</id>
-      <activation>
-        <os>
-          <family>windows</family>
-        </os>
-      </activation>
-      <properties>
-        <os.type>win32</os.type>
-      </properties>
-    </profile>
-    <profile>
-      <id>mac</id>
-      <activation>
-        <os>
-          <family>mac</family>
-        </os>
-      </activation>
-      <properties>
-        <os.type>mac64</os.type>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
+++ b/spring-boot-starter/starter-qa/integration-test-webapp/runtime/pom.xml
@@ -147,24 +147,6 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
-            <groupId>com.googlecode.maven-download-plugin</groupId>
-            <artifactId>download-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>wget</goal>
-                </goals>
-                <configuration>
-                  <url>https://chromedriver.storage.googleapis.com/${version.chromedriver}/chromedriver_${os.type}.zip</url>
-                  <outputFileName>chromedriver.zip</outputFileName>
-                  <unpack>true</unpack>
-                  <outputDirectory>${project.build.directory}/chromedriver</outputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
         <testResources>
           <testResource>


### PR DESCRIPTION
Verfies that #930 was fixed

Summary:
* Changed default context path for Web Apps to `/operaton` from `/camunda`
* Added newest version of Maven Cargo plugin which is needed for the latest Wildfly container
* Added `operaton-commons-utils` as dependency to engine-rest, because it depends on the Collection Utils which were moved there
* Removed handling of Chromedriver versions from the build process 
* Increased logging details for Maven Cargo Plugin
* Added bash script to install Chrome and Chromedriver in the latest version in GitHub Actions