### PR TITLE
Backport(commit dcee0dbeab): add variable creation time support (#5377)

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/history/HistoricVariableInstanceQuery.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/history/HistoricVariableInstanceQuery.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.history;
 
+import java.util.Date;
+
 import org.operaton.bpm.engine.query.Query;
 
 
@@ -64,6 +66,11 @@ public interface HistoricVariableInstanceQuery extends Query<HistoricVariableIns
   HistoricVariableInstanceQuery orderByProcessInstanceId();
 
   HistoricVariableInstanceQuery orderByVariableName();
+
+  /**
+   * Order by the creation time (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
+  HistoricVariableInstanceQuery orderByCreationTime();
 
   /** Only select historic process variables with the given process instance ids. */
   HistoricVariableInstanceQuery processInstanceIdIn(String... processInstanceIds);
@@ -119,5 +126,10 @@ public interface HistoricVariableInstanceQuery extends Query<HistoricVariableIns
 
   /** Only select historic process variables with the given variable names. */
   HistoricVariableInstanceQuery variableNameIn(String... names);
+
+    /**
+   * Only select historic process variables that were created after the given date.
+   */
+  HistoricVariableInstanceQuery createdAfter(Date date);
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricVariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricVariableInstanceQueryImpl.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.impl;
 import java.io.Serial;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Date;
 
 import org.operaton.bpm.engine.history.HistoricVariableInstance;
 import org.operaton.bpm.engine.history.HistoricVariableInstanceQuery;
@@ -70,11 +71,19 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
   protected boolean isByteArrayFetchingEnabled = true;
   protected boolean isCustomObjectDeserializationEnabled = true;
 
+  protected Date createdAfter;
+
   public HistoricVariableInstanceQueryImpl() {
   }
 
   public HistoricVariableInstanceQueryImpl(CommandExecutor commandExecutor) {
     super(commandExecutor);
+  }
+
+  @Override
+  public HistoricVariableInstanceQuery createdAfter(Date date) {
+    createdAfter = date;
+    return this;
   }
 
   @Override
@@ -192,6 +201,7 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
     this.activityInstanceIds = activityInstanceIds;
     return this;
   }
+
 
   @Override
   public HistoricVariableInstanceQuery variableName(String variableName) {
@@ -312,6 +322,12 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
     return this;
   }
 
+  @Override
+  public HistoricVariableInstanceQuery orderByCreationTime() {
+    orderBy(HistoricVariableInstanceQueryProperty.CREATE_TIME);
+    return this;
+  }
+
   // getters and setters //////////////////////////////////////////////////////
 
   public String getProcessInstanceId() {
@@ -386,6 +402,10 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
 
   public List<String> getVariableNameIn() {
     return variableNameIn;
+  }
+
+   public Date getCreatedAfter() {
+    return createdAfter;
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricVariableInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricVariableInstanceQueryProperty.java
@@ -30,6 +30,7 @@ final class HistoricVariableInstanceQueryProperty {
   public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
   public static final QueryProperty VARIABLE_NAME = new QueryPropertyImpl("NAME_");
   public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty CREATE_TIME = new QueryPropertyImpl("CREATE_TIME_");
 
   private HistoricVariableInstanceQueryProperty() {}
 }

--- a/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/HistoricVariableInstance.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/HistoricVariableInstance.xml
@@ -439,6 +439,9 @@
       <if test="variableId != null">
         and RES.ID_ = #{variableId}
       </if>
+      <if test="createdAfter != null">
+        and CREATE_TIME_ &gt;= #{createdAfter}
+      </if>
       <if test="processInstanceId != null">
         and RES.PROC_INST_ID_ = #{processInstanceId}
       </if>

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricVariableInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricVariableInstanceTest.java
@@ -19,6 +19,7 @@ package org.operaton.bpm.engine.test.history;
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -49,11 +50,13 @@ import org.operaton.bpm.engine.history.HistoricTaskInstance;
 import org.operaton.bpm.engine.history.HistoricVariableInstance;
 import org.operaton.bpm.engine.history.HistoricVariableInstanceQuery;
 import org.operaton.bpm.engine.history.HistoricVariableUpdate;
+import org.operaton.bpm.engine.impl.calendar.DateTimeUtil;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.history.HistoryLevel;
 import org.operaton.bpm.engine.impl.history.event.HistoryEvent;
 import org.operaton.bpm.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
+import org.operaton.bpm.engine.impl.calendar.DateTimeUtil;
 import org.operaton.bpm.engine.runtime.CaseExecution;
 import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.runtime.Execution;
@@ -80,6 +83,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
+
 
 /**
  * @author Christian Lipphardt (Camunda)
@@ -2672,5 +2677,54 @@ class HistoricVariableInstanceTest {
         .isInstanceOf(NullValueException.class)
         .hasMessage("Variable names is null");
   }
+
+  @Deployment(resources = {
+    "org/operaton/bpm/engine/test/history/HistoricVariableInstanceTest.testCallSimpleSubProcess.bpmn20.xml",
+    "org/operaton/bpm/engine/test/history/simpleSubProcess.bpmn20.xml"
+})
+@Test
+public void shouldBeCorrectlySortedWhenSortingByVariableCreationTime() {
+  // given
+  runtimeService.startProcessInstanceByKey("callSimpleSubProcess");
+
+  // when
+  List<HistoricVariableInstance> historicVariableInstancesAsc =
+      historyService.createHistoricVariableInstanceQuery().orderByCreationTime().asc().list();
+  List<HistoricVariableInstance> historicVariableInstancesDesc =
+      historyService.createHistoricVariableInstanceQuery().orderByCreationTime().desc().list();
+
+  // then
+  assertThat(historicVariableInstancesAsc).hasSize(5);
+  assertThat(historicVariableInstancesDesc).hasSize(5);
+  verifySorting(historicVariableInstancesAsc, propertyComparator(HistoricVariableInstance::getCreateTime));
+  verifySorting(historicVariableInstancesDesc, inverted(propertyComparator(HistoricVariableInstance::getCreateTime)));
+}
+
+@Deployment(resources = {
+    "org/operaton/bpm/engine/test/history/HistoricVariableInstanceTest.testCallSimpleSubProcess.bpmn20.xml",
+    "org/operaton/bpm/engine/test/history/simpleSubProcess.bpmn20.xml"
+})
+@Test
+public void shouldQueryByCreatedAfter() {
+  // given
+  Calendar creationDate = Calendar.getInstance();
+  ClockUtil.setCurrentTime(creationDate.getTime());
+  runtimeService.startProcessInstanceByKey("callSimpleSubProcess");
+
+  creationDate.add(Calendar.HOUR, 1);
+  ClockUtil.setCurrentTime(creationDate.getTime());
+  runtimeService.startProcessInstanceByKey("callSimpleSubProcess");
+
+  // when
+  List<HistoricVariableInstance> variablesCreatedAfter = historyService.createHistoricVariableInstanceQuery()
+      .createdAfter(creationDate.getTime())
+      .list();
+  List<HistoricVariableInstance> allVariables = historyService.createHistoricVariableInstanceQuery().list();
+
+  // then
+  assertThat(variablesCreatedAfter).hasSize(5);
+  assertThat(allVariables).hasSize(10);
+}
+
 
 }


### PR DESCRIPTION
Backport of camunda/camunda-bpm-platform@dcee0dbeab  
Original author: @HeleneW-dot  
Related to: camunda/camunda-bpm-platform#5376

What I changed:
- Added support for ordering by variable creation time
- Added query filter 'createdAfter' for HistoricVariableInstanceQuery
- Updated HistoricVariableInstanceQueryImpl, HistoricVariableInstanceQueryProperty, XML mapping, and test cases
- Adapted namespace: org.camunda.bpm -> org.operaton.bpm
- Migrated JUnit 4 tests to JUnit 5 and replaced assertEquals with AssertJ assertions where needed

Verification:
- Compiled with `./mvnw clean install`
- Verified that changes only affect the variable query functionality
- CI should confirm correctness

I confirm that my contribution and following ones comply with the Apache License 2.0 and the Code of Conduct.
