### PR TITLE
Enable users to start integration build scripts with mvnd

### DIFF
--- a/.devenv/scripts/build/build-and-run-integration-tests.sh
+++ b/.devenv/scripts/build/build-and-run-integration-tests.sh
@@ -5,6 +5,8 @@ EXECUTE_TEST=true
 TEST_SUITE="engine"
 DATABASE="h2"
 DISTRO="tomcat"
+RUNNER="./mvnw"
+DAEMON=false
 VALID_TEST_SUITES=("engine" "webapps" "db-rolling-update")
 VALID_DISTROS=("operaton" "tomcat" "wildfly")
 VALID_DATABASES=("h2" "postgresql" "postgresql-xa" "mysql" "mariadb" "oracle" "db2" "sqlserver")
@@ -43,6 +45,9 @@ parse_args() {
       --no-test)
         EXECUTE_TEST=false
         ;;
+      --daemon)
+        RUNNER="mvnd"
+        ;;
     esac
     shift
   done
@@ -72,8 +77,8 @@ run_build () {
   fi
 
   echo "ℹ️ Building $TEST_SUITE integration tests for distro $DISTRO with $DATABASE database using profiles: [${PROFILES[*]}]"
-  echo "./mvnw -DskipTests -P$(IFS=,; echo "${PROFILES[*]}") clean install"
-  ./mvnw -DskipTests -P$(IFS=,; echo "${PROFILES[*]}") clean install
+  echo "$RUNNER -DskipTests -P$(IFS=,; echo "${PROFILES[*]}") clean install"
+  $RUNNER -DskipTests -P$(IFS=,; echo "${PROFILES[*]}") clean install
   if [[ $? -ne 0 ]]; then
     echo "❌ Error: Build failed"
     popd > /dev/null
@@ -113,8 +118,8 @@ run_tests () {
   PROFILES+=($DATABASE)
 
   echo "ℹ️ Running $TEST_SUITE integration tests for distro $DISTRO with $DATABASE database using profiles: [${PROFILES[*]}]"
-  echo "./mvnw -P$(IFS=,; echo "${PROFILES[*]}") $(echo "${MVN_ARGS[*]}")"
-  ./mvnw -P$(IFS=,; echo "${PROFILES[*]}") $(echo "${MVN_ARGS[*]}")
+  echo "$RUNNER -P$(IFS=,; echo "${PROFILES[*]}") $(echo "${MVN_ARGS[*]}")"
+  $RUNNER -P$(IFS=,; echo "${PROFILES[*]}") $(echo "${MVN_ARGS[*]}")
   if [[ $? -ne 0 ]]; then
     echo "❌ Error: Build failed"
     popd > /dev/null

--- a/.devenv/scripts/build/build-and-run-integration-tests.sh
+++ b/.devenv/scripts/build/build-and-run-integration-tests.sh
@@ -140,6 +140,12 @@ run_tests () {
 # main script
 parse_args "$@"
 
+# Check if RUNNER exists, fallback if not
+if ! command -v ${RUNNER} &> /dev/null; then
+  echo "⚠️  Warning: Runner '${RUNNER}' not found. Falling back to './mvnw'."
+  RUNNER="./mvnw"
+fi
+
 pushd $(pwd) > /dev/null
 cd $(git rev-parse --show-toplevel) || exit 1
 

--- a/.devenv/scripts/build/build-and-run-integration-tests.sh
+++ b/.devenv/scripts/build/build-and-run-integration-tests.sh
@@ -6,11 +6,10 @@ TEST_SUITE="engine"
 DATABASE="h2"
 DISTRO="tomcat"
 RUNNER="./mvnw"
-DAEMON=false
 VALID_TEST_SUITES=("engine" "webapps" "db-rolling-update")
 VALID_DISTROS=("operaton" "tomcat" "wildfly")
 VALID_DATABASES=("h2" "postgresql" "postgresql-xa" "mysql" "mariadb" "oracle" "db2" "sqlserver")
-
+VALID_RUNNERS=("mvn" "./mvnw" "mvnd")
 ##########################################################################
 check_valid_values() {
   local param_name=$1
@@ -45,16 +44,24 @@ parse_args() {
       --no-test)
         EXECUTE_TEST=false
         ;;
-      --daemon)
-        RUNNER="mvnd"
+      --runner=*)
+        runner_param="${1#*=}"
+        case "$runner_param" in
+          mvn|mvnd)
+            RUNNER="$runner_param"
+            ;;
+          mvnw)
+            RUNNER="./mvnw"
+            ;;
+        esac
         ;;
     esac
     shift
   done
-
   check_valid_values "testsuite" "$TEST_SUITE" "${VALID_TEST_SUITES[@]}"
   check_valid_values "distro" "$DISTRO" "${VALID_DISTROS[@]}"
   check_valid_values "db" "$DATABASE" "${VALID_DATABASES[@]}"
+  check_valid_values "runner" "$RUNNER" "${VALID_RUNNERS[@]}"
 }
 
 run_build () {

--- a/.devenv/scripts/build/build.sh
+++ b/.devenv/scripts/build/build.sh
@@ -63,6 +63,12 @@ parse_args() {
 # main script
 parse_args "$@"
 
+# Check if RUNNER exists, fallback if not
+if ! command -v ${RUNNER} &> /dev/null; then
+  echo "⚠️  Warning: Runner '${RUNNER}' not found. Falling back to './mvnw'."
+  RUNNER="./mvnw"
+fi
+
 pushd $(pwd) > /dev/null
 cd $(git rev-parse --show-toplevel) || exit 1
 PROJECT_ROOT=$(pwd)

--- a/.devenv/scripts/build/build.sh
+++ b/.devenv/scripts/build/build.sh
@@ -5,7 +5,9 @@ PROFILES=()
 BUILD_PROFILE="normal"
 SKIP_TESTS="false"
 REPORT_PLUGINS="false"
+RUNNER="./mvnw"
 VALID_BUILD_PROFILES=("fast" "normal" "max")
+VALID_RUNNERS=("mvn" "./mvnw" "mvnd")
 
 ##########################################################################
 check_valid_values() {
@@ -35,6 +37,17 @@ parse_args() {
       --reports)
         REPORT_PLUGINS="true"
         ;;
+      --runner=*)
+        runner_param="${1#*=}"
+        case "$runner_param" in
+          mvn|mvnd)
+            RUNNER="$runner_param"
+            ;;
+          mvnw)
+            RUNNER="./mvnw"
+            ;;
+        esac
+        ;;
       *)
         MVN_ARGS+=("$1")
         ;;
@@ -43,6 +56,7 @@ parse_args() {
   done
 
   check_valid_values "profile" "$BUILD_PROFILE" "${VALID_BUILD_PROFILES[@]}"
+  check_valid_values "runner" "$RUNNER" "${VALID_RUNNERS[@]}"
 }
 
 ##########################################################################
@@ -79,7 +93,7 @@ case "$BUILD_PROFILE" in
     ;;
 esac
 
-MVN_CMD="./mvnw -P$(IFS=,; echo "${PROFILES[*]}") $(echo "${MVN_ARGS[*]}")"
+MVN_CMD="$RUNNER -P$(IFS=,; echo "${PROFILES[*]}") $(echo "${MVN_ARGS[*]}")"
 echo "ℹ️ $MVN_CMD"
 $MVN_CMD
 


### PR DESCRIPTION
I'm using Maven Daemon locally on my machine to speed up builds for integration testing, often cutting the test times in half.

I added a parameter to the script, so developers can choose to use the existing scripts either with the maven wrapper (default) or with Maven daemon:

`.devenv/scripts/build/build-and-run-integration-tests.sh --testsuite=engine --distro=tomcat --db=h2 --daemon`


https://github.com/user-attachments/assets/a604bdfb-8e4e-422c-af6a-e364444d96a9

