### PR TITLE
Backport "feat(decisionInstanceQuery): add ordering by id for decision instances (#5375)"

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/history/HistoricDecisionInstanceQuery.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/history/HistoricDecisionInstanceQuery.java
@@ -134,6 +134,10 @@ public interface HistoricDecisionInstanceQuery extends Query<HistoricDecisionIns
   /** Only selects historic decision instances that have no tenant id. */
   HistoricDecisionInstanceQuery withoutTenantId();
 
+  /** Order by decision instance id
+   * (needs to be followed by {@link #asc()} or {@link #desc()}). */
+  HistoricDecisionInstanceQuery orderByDecisionInstanceId();
+
   /** Order by the time when the decisions was evaluated
    * (needs to be followed by {@link #asc()} or {@link #desc()}). */
   HistoricDecisionInstanceQuery orderByEvaluationTime();

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricDecisionInstanceQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricDecisionInstanceQueryImpl.java
@@ -246,6 +246,12 @@ public class HistoricDecisionInstanceQueryImpl extends AbstractQuery<HistoricDec
   }
 
   @Override
+  public HistoricDecisionInstanceQuery orderByDecisionInstanceId(){
+    orderBy(HistoricDecisionInstanceQueryProperty.DECISION_INSTANCE_ID);
+    return this;
+  }
+
+  @Override
   public long executeCount(CommandContext commandContext) {
     checkQueryOk();
     return commandContext

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricDecisionInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricDecisionInstanceQueryProperty.java
@@ -26,6 +26,7 @@ import org.operaton.bpm.engine.query.QueryProperty;
  */
 final class HistoricDecisionInstanceQueryProperty {
 
+  public static final QueryProperty DECISION_INSTANCE_ID = new QueryPropertyImpl("ID_");
   public static final QueryProperty EVALUATION_TIME = new QueryPropertyImpl("EVAL_TIME_");
   public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
@@ -51,6 +51,9 @@ import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
+import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.propertyComparator;
+import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
 import static org.assertj.core.api.Assertions.fail;
 
 /**
@@ -195,6 +198,28 @@ class HistoricDecisionInstanceQueryTest {
 
     List<HistoricDecisionInstance> orderDesc = historyService.createHistoricDecisionInstanceQuery().orderByEvaluationTime().desc().list();
     assertThat(orderDesc.get(0).getEvaluationTime().after(orderDesc.get(1).getEvaluationTime())).isTrue();
+  }
+
+  @Deployment(resources = {DECISION_PROCESS, DECISION_SINGLE_OUTPUT_DMN})
+  @Test
+  void testQuerySortByDecisionInstanceId() {
+    for (int i = 0; i < 5; i++) {
+      startProcessInstanceAndEvaluateDecision();
+    }
+
+    List<HistoricDecisionInstance> orderAsc = historyService.createHistoricDecisionInstanceQuery()
+        .orderByDecisionInstanceId()
+        .asc()
+        .list();
+    assertThat(orderAsc).hasSize(5);
+    verifySorting(orderAsc, propertyComparator(HistoricDecisionInstance::getId));
+
+    List<HistoricDecisionInstance> orderDesc = historyService.createHistoricDecisionInstanceQuery()
+        .orderByDecisionInstanceId()
+        .desc()
+        .list();
+    assertThat(orderDesc).hasSize(5);
+    verifySorting(orderDesc, inverted(propertyComparator(HistoricDecisionInstance::getId)));
   }
 
   @Deployment(resources = {DECISION_PROCESS, DECISION_SINGLE_OUTPUT_DMN})


### PR DESCRIPTION
## Description
- Resolves https://github.com/operaton/operaton/issues/1275
- Added support in `HistoricDecisionInstanceQuery` to order results by decision instance id.
- Created a dedicated JUnit test that verifies ascending/descending ordering by decision instance id.

## Changes from original commit
Fixed a couple of Sonar issues adhering to following rules;
 - java:S5838 - [Chained AssertJ assertions should be simplified to the corresponding dedicated assertion](https://rules.sonarsource.com/java/RSPEC-5838/)
 - java:S5786 - [JUnit5 test classes and methods should have default package visibility](https://rules.sonarsource.com/java/?search=JUnit5%20test%20classes%20and%20methods%20should%20have%20default%20package%20visibility)

## Verification
- The code compiled and tests passed locally; CI should confirm the result.
- Ran `./mvnw clean install`for  verification; the build completed without errors
- Executed `.devenv/scripts/build/build-and-run-integration-tests.sh`; the script completed without errors

## Attribution
Related to: https://github.com/camunda/camunda-bpm-platform/issues/5374
Backported commit: https://github.com/camunda/camunda-bpm-platform/commit/18960a156d
Original author: @HeleneW-dot

---
I confirm that my contribution complies with the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) and the [Code of Conduct](https://github.com/operaton/operaton/blob/main/CODE_OF_CONDUCT.md)