### PR TITLE
chore(build): Update Maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.5.3</version>
+          <version>3.5.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -292,7 +292,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.6.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -307,7 +307,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.5.3</version>
+          <version>3.5.4</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -322,7 +322,7 @@
         <plugin>
           <groupId>org.codehaus.cargo</groupId>
           <artifactId>cargo-maven3-plugin</artifactId>
-          <version>1.10.21</version>
+          <version>1.10.22</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -350,7 +350,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.18.0</version>
+          <version>2.19.0</version>
           <configuration>
             <onlyProjectDependencies>true</onlyProjectDependencies>
             <onlyUpgradable>true</onlyUpgradable>


### PR DESCRIPTION
- maven-failsafe-plugin 3.5.3 -> 3.5.4
- maven-shade-plugin    3.6.0 -> 3.6.1
- maven-surefire-plugin 3.5.3 -> 3.5.4
- cargo-maven3-plugin   1.10.21 -> 1.10.22
- versions-maven-plugin 2.18.0 -> 2.19.0