### PR TITLE
feat(engine): extend queries with afterId filter

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/history/HistoricVariableInstanceQuery.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/history/HistoricVariableInstanceQuery.java
@@ -103,6 +103,11 @@ public interface HistoricVariableInstanceQuery extends Query<HistoricVariableIns
   HistoricVariableInstanceQuery orderByTenantId();
 
   /**
+   * Order by id (needs to be followed by {@link #asc()} or {@link #desc()}).
+   */
+  HistoricVariableInstanceQuery orderByVariableId();
+
+  /**
    * Disable fetching of byte array and file values. By default, the query will fetch such values.
    * By calling this method you can prevent the values of (potentially large) blob data chunks
    * to be fetched. The variables themselves are nonetheless included in the query result.

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -96,8 +96,8 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   protected String[] executedActivityIds;
   protected String[] activeActivityIds;
   protected String[] activityIds;
-  protected Set<String> state = new HashSet<>();
   protected String[] incidentIds;
+  protected Set<String> state = new HashSet<>();
 
   protected String caseInstanceId;
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricVariableInstanceQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricVariableInstanceQueryImpl.java
@@ -70,7 +70,7 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
 
   protected boolean isByteArrayFetchingEnabled = true;
   protected boolean isCustomObjectDeserializationEnabled = true;
-
+  protected String variableIdAfter;
   protected Date createdAfter;
 
   public HistoricVariableInstanceQueryImpl() {
@@ -79,7 +79,16 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
   public HistoricVariableInstanceQueryImpl(CommandExecutor commandExecutor) {
     super(commandExecutor);
   }
-  
+
+  public HistoricVariableInstanceQuery idAfter(String id) {
+    variableIdAfter = id;
+    return this;
+  }
+
+  public String getVariableIdAfter() {
+    return variableIdAfter;
+  }
+
   @Override
   public HistoricVariableInstanceQuery createdAfter(Date date) {
     createdAfter = date;
@@ -318,6 +327,12 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
   @Override
   public HistoricVariableInstanceQuery orderByTenantId() {
     orderBy(HistoricVariableInstanceQueryProperty.TENANT_ID);
+    return this;
+  }
+
+  @Override
+  public HistoricVariableInstanceQuery orderByVariableId() {
+    orderBy(HistoricVariableInstanceQueryProperty.VARIABLE_ID);
     return this;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricVariableInstanceQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/HistoricVariableInstanceQueryProperty.java
@@ -30,6 +30,7 @@ final class HistoricVariableInstanceQueryProperty {
   public static final QueryProperty PROCESS_INSTANCE_ID = new QueryPropertyImpl("PROC_INST_ID_");
   public static final QueryProperty VARIABLE_NAME = new QueryPropertyImpl("NAME_");
   public static final QueryProperty TENANT_ID = new QueryPropertyImpl("TENANT_ID_");
+  public static final QueryProperty VARIABLE_ID = new QueryPropertyImpl("ID_");
   public static final QueryProperty CREATE_TIME = new QueryPropertyImpl("CREATE_TIME_");
   private HistoricVariableInstanceQueryProperty() {}
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetActivityInstanceCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/GetActivityInstanceCmd.java
@@ -210,6 +210,10 @@ public class GetActivityInstanceCmd implements Command<ActivityInstance> {
     actInst.setProcessDefinitionId(scopeExecution.getProcessDefinitionId());
     actInst.setBusinessKey(scopeExecution.getBusinessKey());
     actInst.setActivityId(scope.getId());
+    PvmExecutionImpl subProcessInstance = scopeExecution.getSubProcessInstance();
+    if (subProcessInstance != null) {
+      actInst.setSubProcessInstanceId(subProcessInstance.getId());
+    }
 
     String name = scope.getName();
     if (name == null) {
@@ -267,6 +271,10 @@ public class GetActivityInstanceCmd implements Command<ActivityInstance> {
     transitionInstance.setProcessDefinitionId(execution.getProcessDefinitionId());
     transitionInstance.setExecutionId(execution.getId());
     transitionInstance.setActivityId(execution.getActivityId());
+    PvmExecutionImpl subProcessInstance = execution.getSubProcessInstance();
+    if (subProcessInstance != null) {
+      transitionInstance.setSubProcessInstanceId(subProcessInstance.getId());
+    }
 
     ActivityImpl activity = execution.getActivity();
     if (activity != null) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ActivityInstanceImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/ActivityInstanceImpl.java
@@ -39,6 +39,7 @@ public class ActivityInstanceImpl extends ProcessElementInstanceImpl implements 
   protected String activityId;
   protected String activityName;
   protected String activityType;
+  protected String subProcessInstanceId;
 
   protected ActivityInstance[] childActivityInstances = NO_ACTIVITY_INSTANCES;
   protected TransitionInstance[] childTransitionInstances = NO_TRANSITION_INSTANCES;
@@ -214,6 +215,14 @@ public class ActivityInstanceImpl extends ProcessElementInstanceImpl implements 
         ((ActivityInstanceImpl) childActivityInstance).collectTransitionInstances(activityId, instances);
       }
     }
+  }
+
+  public void setSubProcessInstanceId(String id) {
+    subProcessInstanceId = id;
+  }
+
+  public String getSubProcessInstanceId() {
+    return subProcessInstanceId;
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TransitionInstanceImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TransitionInstanceImpl.java
@@ -31,6 +31,7 @@ public class TransitionInstanceImpl extends ProcessElementInstanceImpl implement
   protected String activityId;
   protected String activityName;
   protected String activityType;
+  protected String subProcessInstanceId;
 
   protected String[] incidentIds = NO_IDS;
   protected Incident[] incidents = new Incident[0];
@@ -92,6 +93,14 @@ public class TransitionInstanceImpl extends ProcessElementInstanceImpl implement
 
   public void setIncidents(Incident[] incidents) {
     this.incidents = incidents;
+  }
+
+  public void setSubProcessInstanceId(String subProcessInstanceId) {
+    this.subProcessInstanceId = subProcessInstanceId;
+  }
+
+  public String getSubProcessInstanceId() {
+    return subProcessInstanceId;
   }
 
   @Override

--- a/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/HistoricVariableInstance.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/HistoricVariableInstance.xml
@@ -436,6 +436,9 @@
         <bind name="fieldName" value="'RES.NAME_'" />
         <include refid="org.operaton.bpm.engine.impl.persistence.entity.Commons.applyInForPaginatedCollection" />
       </if>
+      <if test="variableIdAfter != null">
+        and RES.ID_ > #{variableIdAfter}
+      </if>
       <if test="variableId != null">
         and RES.ID_ = #{variableId}
       </if>

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/queries/QueryByIdAfterTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/queries/QueryByIdAfterTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.test.api.queries;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.operaton.bpm.engine.HistoryService;
+import org.operaton.bpm.engine.ProcessEngineConfiguration;
+import org.operaton.bpm.engine.RuntimeService;
+import org.operaton.bpm.engine.history.HistoricVariableInstance;
+import org.operaton.bpm.engine.impl.HistoricVariableInstanceQueryImpl;
+import org.operaton.bpm.engine.impl.persistence.StrongUuidGenerator;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.RequiredHistoryLevel;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
+class QueryByIdAfterTest {
+  @RegisterExtension
+  static ProcessEngineExtension engineExtension = ProcessEngineExtension.builder()
+          .configurator(config -> config.setIdGenerator(new StrongUuidGenerator()))
+          .build();
+
+  @RegisterExtension
+  ProcessEngineTestExtension testRule = new ProcessEngineTestExtension(engineExtension);
+
+  HistoryService historyService;
+  RuntimeService runtimeService;
+
+  @Test
+  @Deployment(resources = { "org/operaton/bpm/engine/test/history/HistoricVariableInstanceTest.testSimple.bpmn20.xml" })
+  void shouldVariableInstanceApiReturnOnlyAfterGivenId() {
+    // given
+    startProcessInstancesByKey("myProc", 10);
+
+    // when querying by idAfter then only expected results are returned
+    HistoricVariableInstanceQueryImpl historicVariableInstanceQuery = (HistoricVariableInstanceQueryImpl) historyService.createHistoricVariableInstanceQuery();
+    List<HistoricVariableInstance> historicVariableInstances = historicVariableInstanceQuery.orderByVariableId().asc().list();
+    String firstId = historicVariableInstances.get(0).getId();
+    String middleId = historicVariableInstances.get(9).getId();
+    String lastId = historicVariableInstances.get(historicVariableInstances.size() - 1).getId();
+    assertEquals(20, historicVariableInstances.size());
+    assertEquals(19, historicVariableInstanceQuery.idAfter(firstId).list().size());
+    assertEquals(0, historicVariableInstanceQuery.idAfter(lastId).list().size());
+
+    List<HistoricVariableInstance> secondHalf = historicVariableInstanceQuery.idAfter(middleId).list();
+    assertEquals(10, secondHalf.size());
+    assertTrue(secondHalf.stream().allMatch(variable -> isIdGreaterThan(variable.getId(), middleId)));
+  }
+
+  private void startProcessInstancesByKey(String key, int numberOfInstances) {
+    for (int i = 0; i < numberOfInstances; i++) {
+      Map<String, Object> variables = Collections.singletonMap("message", "exception" + i);
+
+      runtimeService.startProcessInstanceByKey(key, i + "", variables);
+    }
+    testRule.executeAvailableJobs();
+  }
+
+  /**
+   * Compares two ids
+   * @return true if id1 is greater than id2, false otherwise
+   */
+  private static boolean isIdGreaterThan(String id1, String id2) {
+    return id1.compareTo(id2) > 0;
+  }
+
+}

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/subprocess/SubProcessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/subprocess/SubProcessTest.java
@@ -26,6 +26,7 @@ import org.operaton.bpm.engine.ManagementService;
 import org.operaton.bpm.engine.RepositoryService;
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.TaskService;
+import org.operaton.bpm.engine.impl.persistence.entity.ActivityInstanceImpl;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.engine.runtime.ActivityInstance;
 import org.operaton.bpm.engine.runtime.Job;
@@ -40,7 +41,6 @@ import org.operaton.bpm.engine.test.util.ActivityInstanceAssert;
 import org.operaton.commons.utils.CollectionUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 
 /**
  * @author Joram Barrez
@@ -507,6 +507,23 @@ class SubProcessTest {
   void testNestedSubProcessesWithoutEndEvents() {
     ProcessInstance pi = runtimeService.startProcessInstanceByKey("testNestedSubProcessesWithoutEndEvents");
     testRule.assertProcessEnded(pi.getId());
+  }
+
+  @Deployment(resources = {"org/operaton/bpm/engine/test/api/runtime/nestedSubProcess.bpmn20.xml", "org/operaton/bpm/engine/test/bpmn/callactivity/simpleSubProcess.bpmn20.xml"})
+  @Test
+  void testInstanceSubProcessInstanceIdSet() {
+    // given
+    ProcessInstance pi = runtimeService.startProcessInstanceByKey("nestedSimpleSubProcess");
+    ActivityInstance rootActivityInstance = runtimeService.getActivityInstance(pi.getProcessInstanceId());
+    ActivityInstance subProcessInstance = rootActivityInstance.getChildActivityInstances()[0];
+
+    // when
+    String subProcessInstanceId = ((ActivityInstanceImpl) subProcessInstance).getSubProcessInstanceId();
+
+    // then
+    assertThat(subProcessInstanceId).isNotNull();
+    ProcessInstance subProcess = runtimeService.createProcessInstanceQuery().processDefinitionKey("simpleSubProcess").singleResult();
+    assertThat(subProcess.getId()).isEqualTo(subProcessInstanceId);
   }
 
   @Deployment

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricVariableInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricVariableInstanceTest.java
@@ -265,6 +265,10 @@ class HistoricVariableInstanceTest {
     assertThat(historyService.createHistoricVariableInstanceQuery().orderByProcessInstanceId().asc().list()).hasSize(5);
     assertThat(historyService.createHistoricVariableInstanceQuery().orderByVariableName().asc().count()).isEqualTo(5);
     assertThat(historyService.createHistoricVariableInstanceQuery().orderByVariableName().asc().list()).hasSize(5);
+    assertThat(historyService.createHistoricVariableInstanceQuery().orderByTenantId().asc().count()).isEqualTo(5);
+    assertThat(historyService.createHistoricVariableInstanceQuery().orderByTenantId().asc().list()).hasSize(5);
+    assertThat(historyService.createHistoricVariableInstanceQuery().orderByVariableId().asc().count()).isEqualTo(5);
+    assertThat(historyService.createHistoricVariableInstanceQuery().orderByVariableId().asc().list()).hasSize(5);
 
     assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).count()).isEqualTo(2);
     assertThat(historyService.createHistoricVariableInstanceQuery().processInstanceId(processInstance.getId()).list()).hasSize(2);


### PR DESCRIPTION
* add HistoricVariableInstanceQuery orderByVariableId
* add TransitionInstanceImpl set/getSubProcessInstanceId

closes #1167

---

Related to https://github.com/camunda/camunda-bpm-platform/issues/4993
originally-authored-by: Tassilo Weidner <3015690+tasso94@users.noreply.github.com>
originally-authored-by: joaquinfelici
Backported commit https://github.com/camunda/camunda-bpm-platform/commit/1d054cf757 Backported commit https://github.com/camunda/camunda-bpm-platform/commit/320e9f6dd9