### PR TITLE
Add GitHub Actions workflow to greet first-time PR contributors

### DIFF
--- a/.github/workflows/check-for-new-contributor.yml
+++ b/.github/workflows/check-for-new-contributor.yml
@@ -1,0 +1,69 @@
+name: First-time Contributor Check
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  greet-first-time-pr:
+    name: Greet First-Time PR Contributors
+    runs-on: ubuntu-latest
+    if: github.event.action == 'opened' && github.event.pull_request.head.repo.fork
+    steps:
+      - name: Check for first-time PR contributor
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const author = context.actor;
+            const { owner, repo } = context.repo;
+            
+            const prTitle = context.payload.pull_request.title;
+
+            console.log(`Checking for past PRs from ${author}...`);
+            const allIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              creator: author,
+              state: 'all'
+            });
+
+            const prs = allIssues.filter(issue => issue.pull_request);
+            const prCount = prs.length;
+
+            console.log(`Found ${prCount} PR(s) from ${author}.`);
+            console.log(`PR Title is: "${prTitle}"`);
+
+            if (prCount === 1 || prTitle.includes('[FORCE GREETING]')) {
+              if (prTitle.includes('[FORCE GREETING]')) {
+                console.log('Forcing greeting due to "[FORCE GREETING]" in title.');
+              } else {
+                console.log('This is the first PR. Posting a welcome comment.');
+              }
+            
+              const prMessage = `
+              ### Hey @${author}! 🎉
+            
+              Thanks for opening your first pull request. We really appreciate it.
+            
+              👉 Please confirm by writing this comment that your contribution and following ones comply with the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) and the [Code of Conduct](https://github.com/operaton/operaton/blob/main/CODE_OF_CONDUCT.md):
+              \`\`\`
+              I confirm that my contribution and following ones comply with the Apache License 2.0 and the Code of Conduct.
+              \`\`\`
+              Consider adding a star ⭐️ to the [repository](https://github.com/operaton/operaton) if you like it, we appreciate that.
+            
+              Contributors will be added to the release notes of the next release.
+              `;
+
+              await github.rest.issues.createComment({
+                owner: owner,
+                repo: repo,
+                issue_number: context.issue.number,
+                body: prMessage
+              });
+            }


### PR DESCRIPTION
### Automate First-Time Contributor Check

**What was done?**

This pull request introduces a new GitHub Actions workflow to automate the process for first-time contributors. The goal is to ensure that new contributors explicitly agree to our contribution guidelines and the Apache 2.0 license before their contribution is merged.

The workflow implements the first part of the requirements from issue #1034:

1.  **Detects First-Time Contributors:** When a user opens their very first pull request, the workflow automatically identifies them.
2.  **Posts an Automated Comment:** The workflow posts a comment in the PR, welcoming the new contributor and asking them to read the contribution guidelines.
3.  **Requests Confirmation:** The comment includes an explicit instruction to copy and paste a confirmation statement as a reply. This confirms that their contribution complies with the Apache 2.0 license.

**Why was this approach chosen?**

The original requirement was to block the PR until the confirmation comment was posted and then automatically unblock the build process. However, during implementation, a fundamental security restriction in GitHub Actions was encountered:

Workflows triggered by a comment (`issue_comment`) from a first-time contributor run with highly restricted permissions. This is a security measure by GitHub to prevent abuse of Actions resources and the potential leaking of secrets. For this reason, it is not possible for the workflow to change a status check from "blocked" to "successful" or to re-run the workflow after the user posts their comment.

**The Implemented Solution:**

This workflow pragmatically solves the problem by automating the process as much as possible, leaving the final step as a manual check for maintainers:

* **Automated Notification:** The contributor is clearly and immediately informed of what is expected of them upon creating the PR. This eliminates the need for initial manual interaction from a maintainer.
* **Clear Visibility:** The comment posted by the bot and the contributor's reply are clearly visible in the PR for the maintainer to review.
* **Manual Merge:** A maintainer verifies that the confirmation comment is present and correct before merging the PR. This ensures compliance with our guidelines without trying to bypass GitHub's security constraints.

This approach is a compromise that significantly improves the process and reduces manual effort, even if 100% automation is not feasible.

**How to Test:**

You can see the message in a repository I've created for testing: https://github.com/Mojito060/operaton-github-actions-automatic-message-test/pull/12

Or to test the workflow for yourself without creating a new GitHub account, you can create a pull request with the string `[FORCE GREETING]` in its title. This will force the welcome comment to be posted, even if the author has made previous contributions.