### PR TITLE
feat(build): Build & deploy Javadoc

### DIFF
--- a/.devenv/scripts/build/javadoc.sh
+++ b/.devenv/scripts/build/javadoc.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+CMD="./mvnw package javadoc:javadoc javadoc:aggregate -Pdistro,distro-wildfly,distro-webjar,javadocs \
+ -pl '!distro/wildfly/modules,!engine-rest/engine-rest-openapi' \
+ -DskipTests=true -Dskip.frontend.build=true"
+
+# -pl '!distro/wildfly/modules,!engine-rest/engine-rest-openapi' \
+echo $CMD
+
+
+eval $CMD
+
+# The aggregated javadocs are in target/javadoc/operaton/<version>/apidocs, but we want them in target/javadoc/operaton/<version>
+APIDOC_BASEDIR=$(find target -type d -name apidocs | sed -e 's|/apidocs||')
+mv $APIDOC_BASEDIR/apidocs/* $APIDOC_BASEDIR
+rm -rf $APIDOC_BASEDIR/apidocs

--- a/.github/workflows/reports-and-docs.yml
+++ b/.github/workflows/reports-and-docs.yml
@@ -49,13 +49,14 @@ jobs:
           echo "version=$RELEASE_VERSION"
           #./mvnw -Psonatype-oss-release install javadoc:javadoc versions:dependency-updates-aggregate-report versions:plugin-updates-aggregate-report -Dsave=true -Ddisplay=false io.github.orhankupusoglu:sloc-maven-plugin:sloc -Dbuildplan.appendOutput=true -Dbuildplan.outputFile=/workspaces/operaton/target/reports/buildplan.txt fr.jcgay.maven.plugins:buildplan-maven-plugin:list -DskipTests
           ./mvnw versions:dependency-updates-aggregate-report versions:plugin-updates-aggregate-report
+          .devenv/scripts/build/javadoc.sh
       - name: Cache build artifacts
         uses: actions/cache/save@v4
         with:
           path: |
             **/target/reports/**
+            **/target/javadoc/**
           key: ${{ github.run_id }}-build-artifacts
-
 
   deploy:
     # allowed to deploy only from 'main' to github-pages due to environment protection rules
@@ -71,6 +72,7 @@ jobs:
         with:
           path: |
             **/target/reports/**
+            **/target/javadoc/**
           key: ${{ github.run_id }}-build-artifacts
           fail-on-cache-miss: true
       - name: Setup Pages
@@ -78,8 +80,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: 'target/reports'
+          path: 'target'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,22 @@
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>parse-current-version</id>
+            <goals>
+              <goal>parse-version</goal>
+            </goals>
+            <configuration>
+              <propertyPrefix>operaton.version</propertyPrefix>
+              <versionString>${project.version}</versionString>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
           <acceptPomPackaging>true</acceptPomPackaging>
@@ -273,6 +289,17 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.11.3</version>
+          <configuration>
+            <outputDirectory>${project.build.directory}/javadoc/operaton/${operaton.version.majorVersion}.${operaton.version.minorVersion}</outputDirectory>
+            <failOnError>false</failOnError>
+            <additionalJOptions>
+              <additionalJOption>-Xdoclint:none</additionalJOption>
+              <additionalJOption>--ignore-source-errors</additionalJOption>
+            </additionalJOptions>
+            <doctitle>Operaton XXXJavadocs ${operaton.version.majorVersion}.${operaton.version.minorVersion} API</doctitle>
+            <windowtitle>Operaton XXXJavadocs ${operaton.version.majorVersion}.${operaton.version.minorVersion} API</windowtitle>
+            <excludePackageNames>*.impl:*.impl.*</excludePackageNames>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -637,15 +664,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <configuration>
-              <failOnError>false</failOnError>
-              <additionalJOptions>
-                <additionalJOption>-Xdoclint:none</additionalJOption>
-                <additionalJOption>--ignore-source-errors</additionalJOption>
-              </additionalJOptions>
-              <doctitle>Operaton Javadocs ${project.version}</doctitle>
-              <windowtitle>Operaton Javadocs ${project.version}</windowtitle>
-            </configuration>
             <executions>
               <execution>
                 <id>attach-javadocs</id>


### PR DESCRIPTION
This change is adding a helper shell script `javadoc.sh` to create the Operaton Javadocs.

The script is invoked by the `reports-and-docs.yml` to create nightly Javadoc builds.

Note the handling of the target directory: The target folder for Javadocs is `javadoc/operaton/{major}.{minor}`. The Javadocs are produced into a subfolder `apidocs`, which is removed by the script.

Changes to /pom.xml are done to do the required configuration outside of the `sonatype-oss-release` profile.