### PR TITLE
chore(deps): Upgrade Spring to 6.2.11

### DIFF
--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -29,7 +29,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-framework-bom</artifactId>
-        <version>6.2.10</version>
+        <version>${version.spring}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <version.feel-scala>1.19.3</version.feel-scala>
     <version.quarkus>3.26.3</version.quarkus>
     <version.java>17</version.java>
+    <version.spring>6.2.11</version.spring>
     <version.spring-boot>3.5.5</version.spring-boot>
     <version.liquibase>4.33.0</version.liquibase>
     <maven.compiler.source>17</maven.compiler.source>


### PR DESCRIPTION
Updates `org.springframework:spring-framework-bom` from 6.2.10 to 6.2.11

Release notes: https://github.com/spring-projects/spring-framework/releases/tag/v6.2.11