### PR TITLE
feat(engine): variable and process definition queries for external tasks (#5335)

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/external-task-query-params.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/lib/commons/external-task-query-params.ftl
@@ -136,6 +136,72 @@
       location = "query"
       type = "integer"
       format = "int64"
-      last = last
       desc = "Only include jobs with a priority lower than or equal to the given value.
               Value must be a valid `long` value." />
+
+  <@lib.parameter
+      name = "processDefinitionKey"
+      location = "query"
+      type = "string"
+      desc = "Restrict to tasks that belong to a process definition with the given key." />
+
+  <@lib.parameter
+      name = "processDefinitionKeyIn"
+      location = "query"
+      type = "string"
+      desc = "Restrict to tasks that belong to a process definition with one of the given keys. The
+              keys need to be in a comma-separated list." />
+
+  <@lib.parameter
+      name = "processDefinitionName"
+      location = "query"
+      type = "string"
+      desc = "Restrict to tasks that belong to a process definition with the given name." />
+
+  <@lib.parameter
+      name = "processDefinitionNameLike"
+      location = "query"
+      type = "string"
+      desc = "Restrict to tasks that have a process definition name that has the parameter value as
+              a substring." />
+
+  <@lib.parameter
+      name = "variableNamesIgnoreCase"
+      location = "query"
+      type = "boolean"
+      defaultValue = "false"
+      desc = "Match all variable names in this query case-insensitively. If set
+              `variableName` and `variablename` are treated as equal." />
+
+  <@lib.parameter
+      name = "variableValuesIgnoreCase"
+      location = "query"
+      type = "boolean"
+      defaultValue = "false"
+      desc = "Match all variable values in this query case-insensitively. If set
+              `variableValue` and `variablevalue` are treated as equal." />
+
+  <@lib.parameter
+      name = "processVariables"
+      location = "query"
+      type = "string"
+      last = last
+      desc = "Only include tasks that belong to process instances that have variables with certain
+              values. Variable filtering expressions are comma-separated and are structured as
+              follows:
+
+              A valid parameter value has the form `key_operator_value`. `key` is the variable name,
+              `operator` is the comparison operator to be used and `value` the variable value.
+
+              **Note**: Values are always treated as String objects on server side.
+
+              Valid `operator` values are:
+              `eq` - equal to;
+              `neq` - not equal to;
+              `gt` - greater than;
+              `gteq` - greater than or equal to;
+              `lt` - lower than;
+              `lteq` - lower than or equal to;
+              `like`;
+              `notLike`.
+              `key` and `value` may not contain underscore or comma characters." />

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/externaltask/ExternalTaskQueryDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/externaltask/ExternalTaskQueryDto.ftl
@@ -127,6 +127,64 @@
       desc = "Only include jobs with a priority lower than or equal to the given value.
               Value must be a valid `long` value." />
 
+  <@lib.property
+      name = "processDefinitionKey"
+      type = "string"
+      desc = "Restrict to tasks that belong to a process definition with the given key." />
+
+  <@lib.property
+      name = "processDefinitionKeyIn"
+      type = "array"
+      itemType = "string"
+      desc = "Restrict to tasks that belong to a process definition with one of the given keys. The
+                keys need to be in a comma-separated list." />
+
+  <@lib.property
+      name = "processDefinitionName"
+      type = "string"
+      desc = "Restrict to tasks that belong to a process definition with the given name." />
+
+  <@lib.property
+      name = "processDefinitionNameLike"
+      type = "string"
+      desc = "Restrict to tasks that have a process definition name that has the parameter value as
+                a substring." />
+
+  <@lib.property
+      name = "variableNamesIgnoreCase"
+      type = "boolean"
+      defaultValue = "false"
+      desc = "Match all variable names in this query case-insensitively. If set
+                `variableName` and `variablename` are treated as equal." />
+
+  <@lib.property
+      name = "variableValuesIgnoreCase"
+      type = "boolean"
+      defaultValue = "false"
+      desc = "Match all variable values in this query case-insensitively. If set
+                `variableValue` and `variablevalue` are treated as equal." />
+
+  <@lib.property
+      name = "processVariables"
+      type = "array"
+      dto = "VariableQueryParameterDto"
+      desc = "A JSON array to only include tasks that belong to a process instance with variables
+              with certain values. The array consists of JSON objects with three properties
+              `name`, `operator` and `value`. `name` is the variable name, `operator` is the
+              comparison operator to be used and `value` the variable value. `value` may be of
+              type `String`, `Number` or `Boolean`.
+
+              Valid `operator` values are:
+              `eq` - equal to;
+              `neq` - not equal to;
+              `gt` - greater than;
+              `gteq` - greater than or equal to;
+              `lt` - lower than;
+              `lteq` - lower than or equal to;
+              `like`;
+              `notLike`.
+              `key` and `value` may not contain underscore or comma characters." />
+
   "sorting": {
     "type": "array",
     "nullable": true,

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/externaltask/ExternalTaskQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/externaltask/ExternalTaskQueryDto.java
@@ -22,8 +22,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.externaltask.ExternalTaskQuery;
@@ -34,6 +36,10 @@ import org.operaton.bpm.engine.rest.dto.converter.DateConverter;
 import org.operaton.bpm.engine.rest.dto.converter.LongConverter;
 import org.operaton.bpm.engine.rest.dto.converter.StringListConverter;
 import org.operaton.bpm.engine.rest.dto.converter.StringSetConverter;
+import org.operaton.bpm.engine.rest.dto.VariableQueryParameterDto;
+import org.operaton.bpm.engine.rest.dto.converter.*;
+import org.operaton.bpm.engine.rest.exception.InvalidRequestException;
+
 
 /**
  * @author Thorben Lindhauer
@@ -64,7 +70,11 @@ public class ExternalTaskQueryDto extends AbstractQueryDto<ExternalTaskQuery> {
   protected String executionId;
   protected String processInstanceId;
   protected List<String> processInstanceIdIn;
+  protected String processDefinitionKey;
+  protected String[] processDefinitionKeyIn;
   protected String processDefinitionId;
+  protected String processDefinitionName;
+  protected String processDefinitionNameLike;
   protected Boolean active;
   protected Boolean suspended;
   protected Boolean withRetriesLeft;
@@ -73,6 +83,10 @@ public class ExternalTaskQueryDto extends AbstractQueryDto<ExternalTaskQuery> {
   protected List<String> tenantIds;
   protected Long priorityHigherThanOrEquals;
   protected Long priorityLowerThanOrEquals;
+  protected Boolean variableNamesIgnoreCase;
+  protected Boolean variableValuesIgnoreCase;
+
+  private List<VariableQueryParameterDto> processVariables;
 
   public ExternalTaskQueryDto() {
   }
@@ -145,9 +159,29 @@ public class ExternalTaskQueryDto extends AbstractQueryDto<ExternalTaskQuery> {
     return processDefinitionId;
   }
 
+  @OperatonQueryParam("processDefinitionKey")
+  public void setProcessDefinitionKey(String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  @OperatonQueryParam(value = "processDefinitionKeyIn", converter = StringArrayConverter.class)
+  public void setProcessDefinitionKeyIn(String[] processDefinitionKeyIn) {
+    this.processDefinitionKeyIn = processDefinitionKeyIn;
+  }
+
   @OperatonQueryParam("processDefinitionId")
   public void setProcessDefinitionId(String processDefinitionId) {
     this.processDefinitionId = processDefinitionId;
+  }
+
+  @OperatonQueryParam("processDefinitionName")
+  public void setProcessDefinitionName(String processDefinitionName) {
+    this.processDefinitionName = processDefinitionName;
+  }
+
+  @OperatonQueryParam("processDefinitionNameLike")
+  public void setProcessDefinitionNameLike(String processDefinitionNameLike) {
+    this.processDefinitionNameLike = processDefinitionNameLike;
   }
 
   @OperatonQueryParam(value = "active", converter = BooleanConverter.class)
@@ -182,6 +216,21 @@ public class ExternalTaskQueryDto extends AbstractQueryDto<ExternalTaskQuery> {
   @OperatonQueryParam(value="priorityHigherThanOrEquals", converter = LongConverter.class)
   public void setPriorityHigherThanOrEquals(Long priorityHigherThanOrEquals) {
     this.priorityHigherThanOrEquals = priorityHigherThanOrEquals;
+  }
+
+  @OperatonQueryParam(value = "variableNamesIgnoreCase", converter = BooleanConverter.class)
+  public void setVariableNamesIgnoreCase(Boolean variableNamesCaseInsensitive) {
+    this.variableNamesIgnoreCase = variableNamesCaseInsensitive;
+  }
+
+  @OperatonQueryParam(value ="variableValuesIgnoreCase", converter = BooleanConverter.class)
+  public void setVariableValuesIgnoreCase(Boolean variableValuesCaseInsensitive) {
+    this.variableValuesIgnoreCase = variableValuesCaseInsensitive;
+  }
+
+  @OperatonQueryParam(value = "processVariables", converter = VariableListConverter.class)
+  public void setProcessVariables(List<VariableQueryParameterDto> processVariables) {
+    this.processVariables = processVariables;
   }
 
   @OperatonQueryParam(value="priorityLowerThanOrEquals", converter = LongConverter.class)
@@ -237,8 +286,20 @@ public class ExternalTaskQueryDto extends AbstractQueryDto<ExternalTaskQuery> {
     if (processInstanceIdIn != null && !processInstanceIdIn.isEmpty()) {
       query.processInstanceIdIn(processInstanceIdIn.toArray(new String[0]));
     }
+    if (processDefinitionKey != null) {
+      query.processDefinitionKey(processDefinitionKey);
+    }
+    if (processDefinitionKeyIn != null && processDefinitionKeyIn.length > 0) {
+      query.processDefinitionKeyIn(processDefinitionKeyIn);
+    }
     if (processDefinitionId != null) {
       query.processDefinitionId(processDefinitionId);
+    }
+    if (processDefinitionName != null) {
+      query.processDefinitionName(processDefinitionName);
+    }
+    if (processDefinitionNameLike != null) {
+      query.processDefinitionNameLike(processDefinitionNameLike);
     }
     if (active != null && active) {
       query.active();
@@ -257,6 +318,38 @@ public class ExternalTaskQueryDto extends AbstractQueryDto<ExternalTaskQuery> {
     }
     if (noRetriesLeft != null && noRetriesLeft) {
       query.noRetriesLeft();
+    }
+    if(variableValuesIgnoreCase != null && variableValuesIgnoreCase) {
+      query.matchVariableValuesIgnoreCase();
+    }
+    if(variableNamesIgnoreCase != null && variableNamesIgnoreCase) {
+      query.matchVariableNamesIgnoreCase();
+    }
+    if (processVariables != null) {
+      for (VariableQueryParameterDto variableQueryParam : processVariables) {
+        String variableName = variableQueryParam.getName();
+        String op = variableQueryParam.getOperator();
+        Object variableValue = variableQueryParam.resolveValue(objectMapper);
+        if (op.equals(VariableQueryParameterDto.EQUALS_OPERATOR_NAME)) {
+          query.processVariableValueEquals(variableName, variableValue);
+        } else if (op.equals(VariableQueryParameterDto.NOT_EQUALS_OPERATOR_NAME)) {
+          query.processVariableValueNotEquals(variableName, variableValue);
+        } else if (op.equals(VariableQueryParameterDto.GREATER_THAN_OPERATOR_NAME)) {
+          query.processVariableValueGreaterThan(variableName, variableValue);
+        } else if (op.equals(VariableQueryParameterDto.GREATER_THAN_OR_EQUALS_OPERATOR_NAME)) {
+          query.processVariableValueGreaterThanOrEquals(variableName, variableValue);
+        } else if (op.equals(VariableQueryParameterDto.LESS_THAN_OPERATOR_NAME)) {
+          query.processVariableValueLessThan(variableName, variableValue);
+        } else if (op.equals(VariableQueryParameterDto.LESS_THAN_OR_EQUALS_OPERATOR_NAME)) {
+          query.processVariableValueLessThanOrEquals(variableName, variableValue);
+        } else if (op.equals(VariableQueryParameterDto.LIKE_OPERATOR_NAME)) {
+          query.processVariableValueLike(variableName, String.valueOf(variableValue));
+        } else if (op.equals(VariableQueryParameterDto.NOT_LIKE_OPERATOR_NAME)) {
+          query.processVariableValueNotLike(variableName, String.valueOf(variableValue));
+        } else {
+          throw new InvalidRequestException(Response.Status.BAD_REQUEST, "Invalid process variable comparator specified: " + op);
+        }
+      }
     }
     if (workerId != null) {
       query.workerId(workerId);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExternalTaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExternalTaskRestServiceQueryTest.java
@@ -16,23 +16,9 @@
  */
 package org.operaton.bpm.engine.rest;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response.Status;
-
-import io.restassured.http.ContentType;
-import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
 
 import org.operaton.bpm.engine.externaltask.ExternalTask;
 import org.operaton.bpm.engine.externaltask.ExternalTaskQuery;
@@ -42,14 +28,24 @@ import org.operaton.bpm.engine.rest.helper.MockProvider;
 import org.operaton.bpm.engine.rest.util.OrderingBuilder;
 import org.operaton.bpm.engine.rest.util.container.TestContainerExtension;
 
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
 import static org.operaton.bpm.engine.rest.util.DateTimeUtils.withTimezone;
-import static io.restassured.RestAssured.given;
-import static io.restassured.path.json.JsonPath.from;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.reset;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static io.restassured.RestAssured.given;
+import static io.restassured.path.json.JsonPath.from;
+
 
 /**
  * @author Thorben Lindhauer
@@ -64,6 +60,9 @@ public class ExternalTaskRestServiceQueryTest extends AbstractRestServiceTest {
   protected static final String EXTERNAL_TASK_COUNT_QUERY_URL = EXTERNAL_TASK_QUERY_URL + "/count";
   public static final long EXTERNAL_TASK_LOW_BOUND_PRIORITY = 3L;
   public static final long EXTERNAL_TASK_HIGH_BOUND_PRIORITY = 4L;
+
+  private static final String SAMPLE_VAR_NAME = "varName";
+  private static final String SAMPLE_VAR_VALUE = "varValue";
 
   protected ExternalTaskQuery mockQuery;
 
@@ -181,6 +180,10 @@ public class ExternalTaskRestServiceQueryTest extends AbstractRestServiceTest {
     parameters.put("processInstanceIdIn", "aProcessInstanceId,anotherProcessInstanceId");
     parameters.put("processDefinitionId", "someProcessDefinitionId");
     parameters.put("processDefinitionVersionTag", "someProcessDefinitionVersionTag");
+    parameters.put("processDefinitionKey", "procDefKey");
+    parameters.put("processDefinitionKeyIn", "procDefKey2,procDefKey3");
+    parameters.put("processDefinitionName", "procDefName");
+    parameters.put("processDefinitionNameLike", "procDefName%");
     parameters.put("active", "true");
     parameters.put("suspended", "true");
     parameters.put("withRetriesLeft", "true");
@@ -206,7 +209,10 @@ public class ExternalTaskRestServiceQueryTest extends AbstractRestServiceTest {
     verify(mockQuery).processInstanceId("someProcessInstanceId");
     verify(mockQuery).processInstanceIdIn("aProcessInstanceId", "anotherProcessInstanceId");
     verify(mockQuery).processDefinitionId("someProcessDefinitionId");
-    verify(mockQuery).processDefinitionId("someProcessDefinitionId");
+    verify(mockQuery).processDefinitionKey("procDefKey");
+    verify(mockQuery).processDefinitionKeyIn("procDefKey2", "procDefKey3");
+    verify(mockQuery).processDefinitionName("procDefName");
+    verify(mockQuery).processDefinitionNameLike("procDefName%");
     verify(mockQuery).active();
     verify(mockQuery).suspended();
     verify(mockQuery).withRetriesLeft();
@@ -667,6 +673,341 @@ public class ExternalTaskRestServiceQueryTest extends AbstractRestServiceTest {
     assertThat(returnedId1).isEqualTo(MockProvider.EXTERNAL_TASK_ID);
     assertThat(returnedId2).isEqualTo(MockProvider.EXTERNAL_TASK_ANOTHER_ID);
   }
+
+    @Test
+    void testProcessVariableParameters() {
+        // equals
+        String variableName = "varName";
+        String variableValue = "varValue";
+        String queryValue = variableName + "_eq_" + variableValue;
+
+        given()
+                .queryParam("processVariables", queryValue)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .then()
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .get(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).processVariableValueEquals(variableName, variableValue);
+        reset(mockQuery);
+
+        //equals case-insensitive
+        queryValue = variableName + "_eq_" + variableValue;
+
+        given()
+                .queryParam("processVariables", queryValue)
+                .queryParam("variableValuesIgnoreCase", true)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .then()
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .get(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).matchVariableValuesIgnoreCase();
+        verify(mockQuery).processVariableValueEquals(variableName, variableValue);
+        reset(mockQuery);
+
+        given()
+                .queryParam("processVariables", queryValue)
+                .queryParam("variableNamesIgnoreCase", true)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .then()
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .get(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).matchVariableNamesIgnoreCase();
+        verify(mockQuery).processVariableValueEquals(variableName, variableValue);
+        reset(mockQuery);
+
+        given()
+                .queryParam("processVariables", queryValue)
+                .queryParam("variableNamesIgnoreCase", true)
+                .queryParam("variableValuesIgnoreCase", true)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .then()
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .get(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).matchVariableNamesIgnoreCase();
+        verify(mockQuery).matchVariableValuesIgnoreCase();
+        verify(mockQuery).processVariableValueEquals(variableName, variableValue);
+
+        // greater than
+        queryValue = variableName + "_gt_" + variableValue;
+
+        given()
+                .queryParam("processVariables", queryValue)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .then()
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .get(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).processVariableValueGreaterThan(variableName, variableValue);
+
+        // greater than equals
+        queryValue = variableName + "_gteq_" + variableValue;
+
+        given()
+                .queryParam("processVariables", queryValue)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .then()
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .get(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).processVariableValueGreaterThanOrEquals(variableName, variableValue);
+
+        // lower than
+        queryValue = variableName + "_lt_" + variableValue;
+
+        given()
+                .queryParam("processVariables", queryValue)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .then()
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .get(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).processVariableValueLessThan(variableName, variableValue);
+
+        // lower than equals
+        queryValue = variableName + "_lteq_" + variableValue;
+
+        given()
+                .queryParam("processVariables", queryValue)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .then()
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .get(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).processVariableValueLessThanOrEquals(variableName, variableValue);
+
+        // like
+        queryValue = variableName + "_like_" + variableValue;
+
+        given()
+                .queryParam("processVariables", queryValue)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .then()
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .get(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).processVariableValueLike(variableName, variableValue);
+        reset(mockQuery);
+
+        // like case-insensitive
+        queryValue = variableName + "_like_" + variableValue;
+
+        given()
+                .queryParam("processVariables", queryValue)
+                .queryParam("variableValuesIgnoreCase", true)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .then()
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .get(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).matchVariableValuesIgnoreCase();
+        verify(mockQuery).processVariableValueLike(variableName, variableValue);
+
+        // not equals
+        queryValue = variableName + "_neq_" + variableValue;
+
+        given()
+                .queryParam("processVariables", queryValue)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .then()
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .get(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).processVariableValueNotEquals(variableName, variableValue);
+        reset(mockQuery);
+
+        // not equals case-insensitive
+        queryValue = variableName + "_neq_" + variableValue;
+
+        given()
+                .queryParam("processVariables", queryValue)
+                .queryParam("variableValuesIgnoreCase", true)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .then()
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .get(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).matchVariableValuesIgnoreCase();
+        verify(mockQuery).processVariableValueNotEquals(variableName, variableValue);
+    }
+
+    @Test
+    public void testProcessVariableValueEqualsIgnoreCaseAsPost() {
+        Map<String, Object> variableJson = new HashMap<>();
+        variableJson.put("name", SAMPLE_VAR_NAME);
+        variableJson.put("operator", "eq");
+        variableJson.put("value", SAMPLE_VAR_VALUE.toLowerCase());
+
+        List<Map<String, Object>> variables = new ArrayList<>();
+        variables.add(variableJson);
+
+        Map<String, Object> json = new HashMap<>();
+        json.put("processVariables", variables);
+        json.put("variableValuesIgnoreCase", true);
+
+        given()
+                .contentType(POST_JSON_CONTENT_TYPE)
+                .body(json)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .post(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).matchVariableValuesIgnoreCase();
+        verify(mockQuery).processVariableValueEquals(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
+    }
+
+    @Test
+    public void testProcessVariableNameEqualsIgnoreCaseAsPost() {
+        Map<String, Object> variableJson = new HashMap<>();
+        variableJson.put("name", SAMPLE_VAR_NAME.toLowerCase());
+        variableJson.put("operator", "eq");
+        variableJson.put("value", SAMPLE_VAR_VALUE);
+
+        List<Map<String, Object>> variables = new ArrayList<>();
+        variables.add(variableJson);
+
+        Map<String, Object> json = new HashMap<>();
+        json.put("processVariables", variables);
+        json.put("variableNamesIgnoreCase", true);
+
+        given()
+                .contentType(POST_JSON_CONTENT_TYPE)
+                .body(json)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .post(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).matchVariableNamesIgnoreCase();
+        verify(mockQuery).processVariableValueEquals(SAMPLE_VAR_NAME.toLowerCase(), SAMPLE_VAR_VALUE);
+        reset(mockQuery);
+
+        json.put("variableValuesIgnoreCase", true);
+        given()
+                .contentType(POST_JSON_CONTENT_TYPE)
+                .body(json)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .post(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).matchVariableNamesIgnoreCase();
+        verify(mockQuery).matchVariableValuesIgnoreCase();
+        verify(mockQuery).processVariableValueEquals(SAMPLE_VAR_NAME.toLowerCase(), SAMPLE_VAR_VALUE);
+
+    }
+
+    @Test
+    public void testProcessVariableValueNotEqualsIgnoreCaseAsPost() {
+        Map<String, Object> variableJson = new HashMap<>();
+        variableJson.put("name", SAMPLE_VAR_NAME);
+        variableJson.put("operator", "neq");
+        variableJson.put("value", SAMPLE_VAR_VALUE.toLowerCase());
+
+        List<Map<String, Object>> variables = new ArrayList<>();
+        variables.add(variableJson);
+
+        Map<String, Object> json = new HashMap<>();
+        json.put("processVariables", variables);
+        json.put("variableValuesIgnoreCase", true);
+
+        given()
+                .contentType(POST_JSON_CONTENT_TYPE)
+                .body(json)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .post(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).matchVariableValuesIgnoreCase();
+        verify(mockQuery).processVariableValueNotEquals(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
+    }
+
+    @Test
+    public void testProcessVariableValueLikeIgnoreCaseAsPost() {
+        Map<String, Object> variableJson = new HashMap<>();
+        variableJson.put("name", SAMPLE_VAR_NAME);
+        variableJson.put("operator", "like");
+        variableJson.put("value", SAMPLE_VAR_VALUE.toLowerCase());
+
+        List<Map<String, Object>> variables = new ArrayList<>();
+        variables.add(variableJson);
+
+        Map<String, Object> json = new HashMap<>();
+        json.put("processVariables", variables);
+        json.put("variableValuesIgnoreCase", true);
+
+        given()
+                .contentType(POST_JSON_CONTENT_TYPE)
+                .body(json)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .post(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).matchVariableValuesIgnoreCase();
+        verify(mockQuery).processVariableValueLike(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
+    }
+
+    @Test
+    public void testProcessVariableValueNotLikeIgnoreCaseAsPost() {
+        Map<String, Object> variableJson = new HashMap<>();
+        variableJson.put("name", SAMPLE_VAR_NAME);
+        variableJson.put("operator", "notLike");
+        variableJson.put("value", SAMPLE_VAR_VALUE.toLowerCase());
+
+        List<Map<String, Object>> variables = new ArrayList<>();
+        variables.add(variableJson);
+
+        Map<String, Object> json = new HashMap<>();
+        json.put("processVariables", variables);
+        json.put("variableValuesIgnoreCase", true);
+
+        given()
+                .contentType(POST_JSON_CONTENT_TYPE)
+                .body(json)
+                .header("accept", MediaType.APPLICATION_JSON)
+                .expect()
+                .statusCode(Status.OK.getStatusCode())
+                .when()
+                .post(EXTERNAL_TASK_QUERY_URL);
+
+        verify(mockQuery).matchVariableValuesIgnoreCase();
+        verify(mockQuery).processVariableValueNotLike(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
+    }
 
   private List<ExternalTask> createMockExternalTasksTwoIds() {
     return Arrays.asList(

--- a/engine/src/main/java/org/operaton/bpm/engine/externaltask/ExternalTaskQuery.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/externaltask/ExternalTaskQuery.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.externaltask;
 
+
+import java.io.Serializable;
 import java.util.Date;
 import java.util.Set;
 
@@ -85,9 +87,34 @@ public interface ExternalTaskQuery extends Query<ExternalTaskQuery, ExternalTask
   ExternalTaskQuery processInstanceIdIn(String... processInstanceIdIn);
 
   /**
+   * Only select tasks which are part of a process instance which has the given
+   * process definition key.
+   */
+  ExternalTaskQuery processDefinitionKey(String processDefinitionKey);
+
+  /**
+   * Only select tasks which are part of a process instance which has one of the
+   * given process definition keys.
+   */
+  ExternalTaskQuery processDefinitionKeyIn(String... processDefinitionKeys);
+
+  /**
    * Only select external tasks that belong to an instance of the given process definition
    */
   ExternalTaskQuery processDefinitionId(String processDefinitionId);
+
+  /**
+   * Only select tasks which are part of a process instance which has the given
+   * process definition name.
+   */
+  ExternalTaskQuery processDefinitionName(String processDefinitionName);
+
+  /**
+   * Only select tasks which are part of a process instance which process definition
+   * name  is like the given parameter.
+   * The syntax is that of SQL: for example usage: nameLike(%processDefinitionName%)
+   */
+  ExternalTaskQuery processDefinitionNameLike(String processDefinitionName);
 
   /**
    * Only select external tasks that belong to an instance of the given activity
@@ -116,6 +143,68 @@ public interface ExternalTaskQuery extends Query<ExternalTaskQuery, ExternalTask
    * @return the builded external task query
    */
   ExternalTaskQuery priorityLowerThanOrEquals(long priority);
+
+  /**
+   * Only select tasks which have are part of a process that have a variable
+   * with the given name set to the given value.
+   */
+  ExternalTaskQuery processVariableValueEquals(String variableName, Object variableValue);
+
+  /**
+   * Only select tasks which have a variable with the given name, but
+   * with a different value than the passed value.
+   * Byte-arrays and {@link Serializable} objects (which are not primitive type wrappers)
+   * are not supported.
+   */
+  ExternalTaskQuery processVariableValueNotEquals(String variableName, Object variableValue);
+
+  /**
+   * Only select tasks which are part of a process that have a variable
+   * with the given name and matching the given value.
+   * The syntax is that of SQL: for example usage: valueLike(%value%)
+   */
+  ExternalTaskQuery processVariableValueLike(String variableName, String variableValue);
+
+  /**
+   * Only select tasks which are part of a process that have a variable
+   * with the given name and not matching the given value.
+   * The syntax is that of SQL: for example usage: valueNotLike(%value%)
+   */
+  ExternalTaskQuery processVariableValueNotLike(String variableName, String variableValue);
+
+  /**
+   * Only select tasks which are part of a process that have a variable
+   * with the given name and a value greater than the given one.
+   */
+  ExternalTaskQuery processVariableValueGreaterThan(String variableName, Object variableValue);
+
+  /**
+   * Only select tasks which are part of a process that have a variable
+   * with the given name and a value greater than or equal to the given one.
+   */
+  ExternalTaskQuery processVariableValueGreaterThanOrEquals(String variableName, Object variableValue);
+
+  /**
+   * Only select tasks which are part of a process that have a variable
+   * with the given name and a value less than the given one.
+   */
+  ExternalTaskQuery processVariableValueLessThan(String variableName, Object variableValue);
+
+  /**
+   * Only select tasks which are part of a process that have a variable
+   * with the given name and a value greater than or equal to the given one.
+   */
+  ExternalTaskQuery processVariableValueLessThanOrEquals(String variableName, Object variableValue);
+
+  /**
+   * All queries for task-, process- and case-variables will match the variable names in a case-insensitive way.
+   */
+  ExternalTaskQuery matchVariableNamesIgnoreCase();
+
+  /**
+   * All queries for task-, process- and case-variables will match the variable values in a case-insensitive way.
+   */
+  ExternalTaskQuery matchVariableValuesIgnoreCase();
 
   /**
    * Only select external tasks that are currently suspended

--- a/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/ExternalTask.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/ExternalTask.xml
@@ -394,6 +394,22 @@
       <if test="processDefinitionId != null">
         and RES.PROC_DEF_ID_ = #{processDefinitionId}
       </if>
+      <if test="processDefinitionKey != null">
+        and PD.KEY_ = #{processDefinitionKey}
+      </if>
+      <if test="processDefinitionKeys != null &amp;&amp; processDefinitionKeys.length > 0">
+        and PD.KEY_ in
+        <foreach item="item" index="index" collection="processDefinitionKeys"
+                 open="(" separator="," close=")">
+            #{item}
+        </foreach>
+      </if>
+      <if test="processDefinitionName != null">
+        and PD.NAME_ = #{processDefinitionName}
+      </if>
+      <if test="processDefinitionNameLike != null">
+        and PD.NAME_ like #{processDefinitionNameLike} ESCAPE ${escapeChar}
+      </if>
       <if test="activityId != null">
         and RES.ACT_ID_ = #{activityId}
       </if>
@@ -433,6 +449,26 @@
           #{tenantId}
         </foreach>
       </if>
+      <!-- queryVariables -->
+      <foreach collection="variables" index="index" item="queryVariableValue">
+        and EXISTS (
+        select
+        ID_
+        from
+        ${prefix}ACT_RU_VARIABLE
+        WHERE
+        <bind name="varPrefix" value="''"/>
+        <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.variableNameEqualsCaseInsensitive" />
+        <!-- When process instance or case instance variable is queried for, taskId should be null -->
+        and TASK_ID_ is null
+        and RES.PROC_INST_ID_ = PROC_INST_ID_
+        <bind name="varTypeField" value="'TYPE_'"/>
+        <if test="queryVariableValue.valueConditions != null">
+            and
+            <include refid="org.camunda.bpm.engine.impl.persistence.entity.Commons.variableValueConditions"/>
+        </if>
+        )
+      </foreach>
       <include refid="org.operaton.bpm.engine.impl.persistence.entity.AuthorizationEntity.queryAuthorizationCheck" />
       <include refid="org.operaton.bpm.engine.impl.persistence.entity.TenantEntity.queryTenantCheck" />
     </where>

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskQueryTest.java
@@ -1,4 +1,5 @@
 /*
+
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
  * under one or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information regarding copyright
@@ -16,19 +17,6 @@
  */
 package org.operaton.bpm.engine.test.api.externaltask;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-
 import org.operaton.bpm.engine.ExternalTaskService;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.RepositoryService;
@@ -41,12 +29,9 @@ import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.runtime.ActivityInstance;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
-import org.operaton.bpm.engine.test.Deployment;
-import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
-import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.externalTaskById;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.externalTaskByLockExpirationTime;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.externalTaskByProcessDefinitionId;
@@ -54,18 +39,33 @@ import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.external
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.externalTaskByProcessInstanceId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
+import org.operaton.bpm.engine.test.Deployment;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
+import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+
+import java.util.*;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * @author Thorben Lindhauer
  *
  */
-class ExternalTaskQueryTest {
+public class ExternalTaskQueryTest{
 
   protected static final String WORKER_ID = "aWorkerId";
   protected static final String TOPIC_NAME = "externalTaskTopic";
   protected static final String ERROR_MESSAGE = "error";
+  // The range of Oracle's NUMBER field is limited to ~10e+125
+  // which is below Double.MAX_VALUE, so we only test with the following
+  // max value
+  protected static final double MAX_DOUBLE_VALUE = 10E+124;
 
   @RegisterExtension
   static ProcessEngineExtension engineRule = ProcessEngineExtension.builder().build();
@@ -670,6 +670,451 @@ class ExternalTaskQueryTest {
     ExternalTask task = externalTaskService.createExternalTaskQuery().singleResult();
 
     assertThat(task.getProcessDefinitionVersionTag()).isEqualTo("1.2.3.4");
+  }
+
+  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testProcessDefinitionKey() throws Exception {
+    assertThat(externalTaskService.createExternalTaskQuery().processDefinitionKey("oneExternalTaskProcess").count()).isEqualTo(0);
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess");
+    assertThat(externalTaskService.createExternalTaskQuery().processDefinitionKey("oneExternalTaskProcess").count()).isEqualTo(1);
+  }
+
+  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testProcessDefinitionKeyIn() throws Exception {
+      assertThat(externalTaskService.createExternalTaskQuery().processDefinitionKeyIn("oneExternalTaskProcess").count()).isEqualTo(0);
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess");
+      assertThat(externalTaskService.createExternalTaskQuery().processDefinitionKeyIn("oneExternalTaskProcess").count()).isEqualTo(1);
+  }
+
+  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testProcessDefinitionName() throws Exception {
+      assertThat(externalTaskService.createExternalTaskQuery().processDefinitionName("One external task process").count()).isEqualTo(0);
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess");
+      assertThat(externalTaskService.createExternalTaskQuery().processDefinitionName("One external task process").count()).isEqualTo(1);
+  }
+
+  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void processDefinitionNameLike() throws Exception {
+      assertThat(externalTaskService.createExternalTaskQuery().processDefinitionNameLike("One external task proc%").count()).isEqualTo(0);
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess");
+      assertThat(externalTaskService.createExternalTaskQuery().processDefinitionNameLike("One external task proc%").count()).isEqualTo(1);
+  }
+
+  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testProcessVariableValueEquals() throws Exception {
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("longVar", 928374L);
+    variables.put("shortVar", (short) 123);
+    variables.put("integerVar", 1234);
+    variables.put("stringVar", "stringValue");
+    variables.put("booleanVar", true);
+    Date date = Calendar.getInstance().getTime();
+    variables.put("dateVar", date);
+    variables.put("nullVar", null);
+
+    // Start process-instance with all types of variables
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneExternalTaskProcess", variables);
+
+    // Test query matches
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("longVar", 928374L).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("shortVar",  (short) 123).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("integerVar", 1234).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("stringVar", "stringValue").count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("booleanVar", true).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("dateVar", date).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("nullVar", null).count()).isEqualTo(1);
+
+    // Test query for other values on existing variables
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("longVar", 999L).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("shortVar",  (short) 999).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("integerVar", 999).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("stringVar", "999").count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("booleanVar", false).count()).isEqualTo(0);
+    Calendar otherDate = Calendar.getInstance();
+    otherDate.add(Calendar.YEAR, 1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("dateVar", otherDate.getTime()).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("nullVar", "999").count()).isEqualTo(0);
+
+    // Test querying for task variables not equals
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotEquals("longVar", 999L).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotEquals("shortVar",  (short) 999).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotEquals("integerVar", 999).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotEquals("stringVar", "999").count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotEquals("booleanVar", false).count()).isEqualTo(1);
+
+    // and query for the existing variable with NOT should result in nothing found:
+      assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotEquals("longVar", 928374L).count()).isEqualTo(0);
+  }
+
+  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testProcessVariableNameEqualsIgnoreCase() throws Exception {
+    String variableName = "someVariable";
+    String variableValue = "someCamelCaseValue";
+    Map<String, Object> variables = new HashMap<>();
+    variables.put(variableName, variableValue);
+
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess", variables);
+
+    // query for case-insensitive variable name should only return a result if case-insensitive search is used
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableNamesIgnoreCase().processVariableValueEquals(variableName.toLowerCase(), variableValue).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals(variableName.toLowerCase(), variableValue).count()).isEqualTo(0);
+
+    // query should treat all variables case-insensitively, even when flag is set after variable
+      assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals(variableName.toLowerCase(), variableValue).matchVariableNamesIgnoreCase().count()).isEqualTo(1);
+  }
+
+  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testProcessVariableValueEqualsIgnoreCase() throws Exception {
+    String variableName = "someVariable";
+    String variableValue = "someCamelCaseValue";
+    Map<String, Object> variables = new HashMap<>();
+    variables.put(variableName, variableValue);
+
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess", variables);
+
+    // query for existing variable should return one result
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals(variableName, variableValue).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueEquals(variableName, variableValue.toLowerCase()).count()).isEqualTo(1);
+
+    // query for non existing variable should return zero results
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("nonExistentVariable", variableValue.toLowerCase()).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueEquals("nonExistentVariable", variableValue.toLowerCase()).count()).isEqualTo(0);
+
+    // query for existing variable with different value should return zero results
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals(variableName, "nonExistentValue").count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueEquals(variableName, "nonExistentValue".toLowerCase()).count()).isEqualTo(0);
+
+    // query for case-insensitive variable value should only return a result when case-insensitive search is used
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals(variableName, variableValue.toLowerCase()).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueEquals(variableName, variableValue.toLowerCase()).count()).isEqualTo(1);
+
+    // query for case-insensitive variable with not equals operator should only return a result when case-sensitive search is used
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotEquals(variableName, variableValue.toLowerCase()).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotEquals(variableName, variableValue.toLowerCase()).count()).isEqualTo(0);
+  }
+
+  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testProcessVariableValueLike() throws Exception {
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("stringVar", "stringValue");
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess", variables);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLike("stringVar", "stringVal%").count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLike("stringVar", "%ngValue").count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLike("stringVar", "%ngVal%").count()).isEqualTo(1);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLike("stringVar", "stringVar%").count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLike("stringVar", "%ngVar").count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLike("stringVar", "%ngVar%").count()).isEqualTo(0);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLike("stringVar", "stringVal").count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLike("nonExistingVar", "string%").count()).isEqualTo(0);
+
+    // test with null value
+    assertThatExceptionOfType(ProcessEngineException.class).isThrownBy(() ->
+            externalTaskService.createExternalTaskQuery().processVariableValueLike("stringVar", null).count());
+  }
+
+  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testProcessVariableValueLikeIgnoreCase() throws Exception {
+
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("stringVar", "stringValue");
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess", variables);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLike("stringVar", "stringVal%".toLowerCase()).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueLike("stringVar", "stringVal%".toLowerCase()).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueLike("stringVar", "%ngValue".toLowerCase()).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueLike("stringVar", "%ngVal%".toLowerCase()).count()).isEqualTo(1);
+
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueLike("stringVar", "stringVar%".toLowerCase()).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueLike("stringVar", "%ngVar".toLowerCase()).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueLike("stringVar", "%ngVar%".toLowerCase()).count()).isEqualTo(0);
+
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueLike("stringVar", "stringVal".toLowerCase()).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueLike("nonExistingVar", "stringVal%".toLowerCase()).count()).isEqualTo(0);
+
+    // test with null value
+    assertThatExceptionOfType(ProcessEngineException.class).isThrownBy(()->
+            externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueLike("stringVar", null).count());
+  }
+
+  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testProcessVariableValueNotLike() throws Exception {
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("stringVar", "stringValue");
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess", variables);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotLike("stringVar", "stringVal%").count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotLike("stringVar", "%ngValue").count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotLike("stringVar", "%ngVal%").count()).isEqualTo(0);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotLike("stringVar", "stringVar%").count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotLike("stringVar", "%ngVar").count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotLike("stringVar", "%ngVar%").count()).isEqualTo(1);
+
+      assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotLike("stringVar", "stringVal").count()).isEqualTo(1);
+      assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotLike("nonExistingVar", "string%").count()).isEqualTo(0);
+
+    // test with null value
+      assertThatExceptionOfType(ProcessEngineException.class).isThrownBy(()->
+            externalTaskService.createExternalTaskQuery().processVariableValueNotLike("stringVar", null).count());
+  }
+
+  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testProcessVariableValueNotLikeIgnoreCase() throws Exception {
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("stringVar", "stringValue");
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess", variables);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotLike("stringVar", "stringVal%".toLowerCase()).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", "stringVal%".toLowerCase()).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", "%ngValue".toLowerCase()).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", "%ngVal%".toLowerCase()).count()).isEqualTo(0);
+
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", "stringVar%".toLowerCase()).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", "%ngVar".toLowerCase()).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", "%ngVar%".toLowerCase()).count()).isEqualTo(1);
+
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", "stringVal".toLowerCase()).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("nonExistingVar", "stringVal%".toLowerCase()).count()).isEqualTo(0);
+
+    // test with null value
+    assertThatExceptionOfType(ProcessEngineException.class).isThrownBy(()->
+            externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", null).count());
+  }
+
+  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testProcessVariableValueCompare() throws Exception {
+
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("numericVar", 928374);
+    Date date = new GregorianCalendar(2014, 2, 2, 2, 2, 2).getTime();
+    variables.put("dateVar", date);
+    variables.put("stringVar", "ab");
+    variables.put("nullVar", null);
+
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess", variables);
+
+    // test compare methods with numeric values
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThan("numericVar", 928373).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThan("numericVar", 928374).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThan("numericVar", 928375).count()).isEqualTo(0);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThanOrEquals("numericVar", 928373).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThanOrEquals("numericVar", 928374).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThanOrEquals("numericVar", 928375).count()).isEqualTo(0);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThan("numericVar", 928375).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThan("numericVar", 928374).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThan("numericVar", 928373).count()).isEqualTo(0);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThanOrEquals("numericVar", 928375).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThanOrEquals("numericVar", 928374).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThanOrEquals("numericVar", 928373).count()).isEqualTo(0);
+
+    // test compare methods with date values
+    Date before = new GregorianCalendar(2014, 2, 2, 2, 2, 1).getTime();
+    Date after = new GregorianCalendar(2014, 2, 2, 2, 2, 3).getTime();
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThan("dateVar", before).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThan("dateVar", date).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThan("dateVar", after).count()).isEqualTo(0);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThanOrEquals("dateVar", before).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThanOrEquals("dateVar", date).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThanOrEquals("dateVar", after).count()).isEqualTo(0);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThan("dateVar", after).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThan("dateVar", date).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThan("dateVar", before).count()).isEqualTo(0);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThanOrEquals("dateVar", after).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThanOrEquals("dateVar", date).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThanOrEquals("dateVar", before).count()).isEqualTo(0);
+
+    //test with string values
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThan("stringVar", "aa").count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThan("stringVar", "ab").count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThan("stringVar", "ba").count()).isEqualTo(0);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThanOrEquals("stringVar", "aa").count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThanOrEquals("stringVar", "ab").count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThanOrEquals("stringVar", "ba").count()).isEqualTo(0);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThan("stringVar", "ba").count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThan("stringVar", "ab").count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThan("stringVar", "aa").count()).isEqualTo(0);
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThanOrEquals("stringVar", "ba").count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThanOrEquals("stringVar", "ab").count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThanOrEquals("stringVar", "aa").count()).isEqualTo(0);
+
+    // test with null value
+    assertThatExceptionOfType(ProcessEngineException.class).isThrownBy(()->
+        externalTaskService.createExternalTaskQuery().processVariableValueGreaterThan("nullVar", null).count());
+
+    assertThatExceptionOfType(ProcessEngineException.class).isThrownBy(()->
+            externalTaskService.createExternalTaskQuery().processVariableValueGreaterThanOrEquals("nullVar", null).count());
+
+    assertThatExceptionOfType(ProcessEngineException.class).isThrownBy(()->
+        externalTaskService.createExternalTaskQuery().processVariableValueLessThan("nullVar", null).count());
+
+    assertThatExceptionOfType(ProcessEngineException.class).isThrownBy(()->
+            externalTaskService.createExternalTaskQuery().processVariableValueLessThanOrEquals("nullVar", null).count());
+
+    // test with boolean value
+    assertThatExceptionOfType(ProcessEngineException.class).isThrownBy(()->
+            externalTaskService.createExternalTaskQuery().processVariableValueGreaterThan("nullVar", true).count());
+
+    assertThatExceptionOfType(ProcessEngineException.class).isThrownBy(()->
+            externalTaskService.createExternalTaskQuery().processVariableValueGreaterThanOrEquals("nullVar", false).count());
+
+    assertThatExceptionOfType(ProcessEngineException.class).isThrownBy(()->
+        externalTaskService.createExternalTaskQuery().processVariableValueLessThan("nullVar", true).count());
+
+    assertThatExceptionOfType(ProcessEngineException.class).isThrownBy(()->
+            externalTaskService.createExternalTaskQuery().processVariableValueLessThanOrEquals("nullVar", false).count());
+
+    // test non existing variable
+      assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThanOrEquals("nonExisting", 123).count()).isEqualTo(0);
+  }
+
+  @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testProcessVariableValueEqualsNumber() throws Exception {
+    // long
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", 123L));
+
+    // non-matching long
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", 12345L));
+
+    // short
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", (short) 123));
+
+    // double
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", 123.0d));
+
+    // integer
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", 123));
+
+    // untyped null (should not match)
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", null));
+
+    // typed null (should not match)
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", Variables.longValue(null)));
+
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", "123"));
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("var", Variables.numberValue(123)).count()).isEqualTo(4);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("var", Variables.numberValue(123L)).count()).isEqualTo(4);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("var", Variables.numberValue(123.0d)).count()).isEqualTo(4);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("var", Variables.numberValue((short) 123)).count()).isEqualTo(4);
+
+      assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("var", Variables.numberValue(null)).count()).isEqualTo(1);
+  }
+
+  @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testProcessVariableValueNumberComparison() throws Exception {
+    // long
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", 123L));
+
+    // non-matching long
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", 12345L));
+
+    // short
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", (short) 123));
+
+    // double
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", 123.0d));
+
+    // integer
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", 123));
+
+    // untyped null
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", null));
+
+    // typed null
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", Variables.longValue(null)));
+
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", "123"));
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotEquals("var", Variables.numberValue(123)).count()).isEqualTo(4);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThan("var", Variables.numberValue(123)).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueGreaterThanOrEquals("var", Variables.numberValue(123)).count()).isEqualTo(5);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThan("var", Variables.numberValue(123)).count()).isEqualTo(0);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueLessThanOrEquals("var", Variables.numberValue(123)).count()).isEqualTo(4);
+  }
+
+  @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testVariableEqualsNumberMax() throws Exception {
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", MAX_DOUBLE_VALUE));
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", Long.MAX_VALUE));
+
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("var", Variables.numberValue(MAX_DOUBLE_VALUE)).count()).isEqualTo(1);
+    assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("var", Variables.numberValue(Long.MAX_VALUE)).count()).isEqualTo(1);
+  }
+
+  @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testVariableEqualsNumberLongValueOverflow() throws Exception {
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", MAX_DOUBLE_VALUE));
+
+    // this results in an overflow
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", (long) MAX_DOUBLE_VALUE));
+
+    // the query should not find the long variable
+      assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("var", Variables.numberValue(MAX_DOUBLE_VALUE)).count()).isEqualTo(1);
+  }
+
+  @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Test
+  public void testVariableEqualsNumberNonIntegerDoubleShouldNotMatchInteger() throws Exception {
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Variables.createVariables().putValue("var", 42).putValue("var2", 52.4d));
+
+    // querying by 42.4 should not match the integer variable 42
+      assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("var", Variables.numberValue(42.4d)).count()).isEqualTo(0);
+
+    runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
+            Collections.<String, Object>singletonMap("var", 42.4d));
+
+    // querying by 52 should not find the double variable 52.4
+      assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals("var", Variables.numberValue(52)).count()).isEqualTo(0);
   }
 
   protected List<ProcessInstance> startInstancesByKey(String processDefinitionKey, int number) {

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/external/ExternalTaskParseTest.testParseExternalTaskWithoutTopic.bpmn20.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/bpmn/external/ExternalTaskParseTest.testParseExternalTaskWithoutTopic.bpmn20.xml
@@ -4,7 +4,7 @@
   xmlns:operaton="http://operaton.org/schema/1.0/bpmn"
   targetNamespace="Examples">
 
-  <process id="oneExternalTaskProcess" isExecutable="true">
+  <process id="oneExternalTaskProcess" name="One external task process" isExecutable="true">
     <startEvent id="start" />
     <sequenceFlow id="flow1" sourceRef="start" targetRef="externalTask" />
     <serviceTask id="externalTask" operaton:type="external" />


### PR DESCRIPTION
feat(engine): variable and process definition queries for external tasks (#5335)

i have a test-problem in my fork

14:00:45,577 [ERROR] Errors: 
14:00:45,577 [ERROR]   ExpressionLanguageTest.executeJavascriptDmnEngineConfiguration:146 » DmnEvaluation DMN-01003 Unable to find script engine for expression language 'javascript'.
14:00:45,577 [ERROR]   ExpressionLanguageTest.javascriptEmptyExpressions:209->DmnEngineTest.assertThatDecisionTableResult:94->DmnEngineTest.evaluateDecisionTable:84 » DmnEvaluation DMN-01003 Unable to find script engine for expression language 'javascript'.
14:00:45,577 [INFO] 
14:00:45,577 [ERROR] Tests run: 429, Failures: 0, Errors: 2, Skipped: 5 

but in original repository i get same problem

14:03:57,874 [ERROR] Errors: 
14:03:57,874 [ERROR]   ExpressionLanguageTest.executeJavascriptDmnEngineConfiguration:146 » DmnEvaluation DMN-01003 Unable to find script engine for expression language 'javascript'.
14:03:57,874 [ERROR]   ExpressionLanguageTest.javascriptEmptyExpressions:209->DmnEngineTest.assertThatDecisionTableResult:94->DmnEngineTest.evaluateDecisionTable:84 » DmnEvaluation DMN-01003 Unable to find script engine for expression language 'javascript'.
14:03:57,874 [INFO] 
14:03:57,874 [ERROR] Tests run: 429, Failures: 0, Errors: 2, Skipped: 5 

so i think is ok