### PR TITLE
fix(deps): upgrade jackson to 2.20.0

### DIFF
--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -49,6 +49,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${version.jackson}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${version.spring-boot}</version>
@@ -101,13 +108,6 @@
         <version>${version.shrinkwrap.resolvers}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>2.20.0</version>
-        <scope>import</scope>
-        <type>pom</type>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>


### PR DESCRIPTION
**What was the issue?**
Despite having the Jackson BOM properly configured with version 2.20.0 in `bom/internal-dependencies/pom.xml` and the corresponding property set in `parent/pom.xml`, the dependency tree still showed Jackson artifacts resolving to version 2.19.2 instead of the intended 2.20.0.
> _Issue Link_ https://github.com/operaton/operaton/issues/1320

**Solution Implemented**
The root cause was Maven's BOM import ordering mechanism and its "first wins" rule for dependency management. When multiple BOMs manage the same artifacts, Maven processes them sequentially and keeps the version declarations from the first BOM that declares each artifact. In this case, other BOMs (such as Spring Boot's BOM) were being imported before the Jackson BOM in the <dependencyManagement> section, so their older Jackson version declarations (2.19.2) took precedence over the Jackson BOM's 2.20.0 declarations. The solution was simply reordering the BOM imports so that the Jackson BOM was imported first, allowing it to establish version 2.20.0 for all Jackson artifacts before any other BOM could override them.

**How was the fix tested?**
1. `./mvnw dependency:tree | grep "jackson"` outputs intended version 2.20.0 of all jackson related dependencies [dependencies_jackson-fix.txt](https://github.com/user-attachments/files/22413944/dependencies_jackson-fix.txt)
2. `./mvnw clean install` confirmed that the build is passing on local with no test failures.
3. CI workflows - Look good to me, a couple of integration test workflows failing on exec but it seems to be unrelated as I can see the same failures on the last merged PR in main.