### PR TITLE
fix(maven): upgrade unsecure URLs to HTTPS

### DIFF
--- a/bom/operaton-bom/pom.xml
+++ b/bom/operaton-bom/pom.xml
@@ -38,7 +38,7 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-  <url>http://operaton.org</url>
+  <url>https://operaton.org</url>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/bom/operaton-only-bom/pom.xml
+++ b/bom/operaton-only-bom/pom.xml
@@ -225,7 +225,7 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-  <url>http://operaton.org</url>
+  <url>https://operaton.org</url>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
   </dependencies>
   <scm>
-    <url>http://github.com/operaton/operaton-external-task-client-java</url>
+    <url>https://github.com/operaton/operaton-external-task-client-java</url>
     <connection>scm:git:git@github.com:operaton/operaton-external-task-client-java.git</connection>
     <developerConnection>scm:git:git@github.com:operaton/operaton-external-task-client-java.git</developerConnection>
     <tag>HEAD</tag>


### PR DESCRIPTION
Upgrade all non-HTTPS URLs in Maven pom.xml files to their secure HTTPS counterparts to improve security and follow modern web standards.

I confirm that my contribution and following ones comply with the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
and the [Code of Conduct](https://github.com/operaton/operaton/blob/main/CODE_OF_CONDUCT.md).

related to #1325 