### PR TITLE
refactor(engine): use ThreadLocal.withInitial for a cleaner codebase

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/context/ProcessEngineContextImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/context/ProcessEngineContextImpl.java
@@ -21,12 +21,7 @@ public final class ProcessEngineContextImpl {
   private ProcessEngineContextImpl() {
   }
 
-  protected static ThreadLocal<Boolean> commandContextNew = new ThreadLocal<>() {
-    @Override
-    protected Boolean initialValue() {
-      return Boolean.FALSE;
-    }
-  };
+  protected static ThreadLocal<Boolean> commandContextNew = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
   public static boolean get() {
     return commandContextNew.get();


### PR DESCRIPTION
refactor(engine): use ThreadLocal.withInitial for a cleaner codebase

- changed ThreadLocal anonymous initialization to withInital method

related to #1323 