### PR TITLE
chore(engine): rename OperatonIntegration constants and references

### DIFF
--- a/distro/run/core/src/main/java/org/operaton/bpm/run/OperatonBpmRunProcessEngineConfiguration.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/OperatonBpmRunProcessEngineConfiguration.java
@@ -61,7 +61,7 @@ public class OperatonBpmRunProcessEngineConfiguration extends SpringProcessEngin
   protected void initTelemetryData() {
     super.initTelemetryData();
     Set<String> operatonIntegration = telemetryData.getProduct().getInternals().getOperatonIntegration();
-    operatonIntegration.add(OperatonIntegration.CAMUNDA_BPM_RUN);
+    operatonIntegration.add(OperatonIntegration.OPERATON_BPM_RUN);
   }
 
   protected void configureProcessEnginePlugins(List<ProcessEnginePlugin> processEnginePluginsFromContext,

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/TelemetryDataTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/TelemetryDataTest.java
@@ -47,6 +47,6 @@ class TelemetryDataTest {
     TelemetryDataImpl telemetryData = processEngineConfiguration.getTelemetryData();
     Set<String> operatonIntegration = telemetryData.getProduct().getInternals().getOperatonIntegration();
     assertThat(operatonIntegration)
-      .containsExactlyInAnyOrder(OperatonIntegration.CAMUNDA_BPM_RUN, OperatonIntegration.SPRING_BOOT_STARTER);
+      .containsExactlyInAnyOrder(OperatonIntegration.OPERATON_BPM_RUN, OperatonIntegration.SPRING_BOOT_STARTER);
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/diagnostics/OperatonIntegration.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/diagnostics/OperatonIntegration.java
@@ -19,10 +19,10 @@ package org.operaton.bpm.engine.impl.diagnostics;
 public final class OperatonIntegration {
 
   public static final String SPRING_BOOT_STARTER = "spring-boot-starter";
-  public static final String CAMUNDA_BPM_RUN = "operaton-bpm-run";
+  public static final String OPERATON_BPM_RUN = "operaton-bpm-run";
   public static final String WILDFLY_SUBSYSTEM = "wildfly-subsystem";
   public static final String JBOSS_SUBSYSTEM = "jboss-subsystem";
-  public static final String CAMUNDA_EJB_SERVICE = "operaton-ejb-service";
+  public static final String OPERATON_EJB_SERVICE = "operaton-ejb-service";
 
   private OperatonIntegration() {
   }


### PR DESCRIPTION
This PR renames two constants to align them with the Operaton renaming and to remove the remaining CAMUNDA_* references:

•	CAMUNDA_EJB_SERVICE → OPERATON_EJB_SERVICE
•	CAMUNDA_BPM_RUN → OPERATON_BPM_RUN

These constants were previously only used in the telemetry code, so they are unlikely to be consumed externally. Renaming them ensures consistency with other changes where CAMUNDA_* identifiers were replaced by their OPERATON_* equivalents.
