### PR TITLE
Fix code cleanup workflow & perform cleanups

### DIFF
--- a/.devenv/scripts/README.md
+++ b/.devenv/scripts/README.md
@@ -85,6 +85,36 @@ Execute this script from the root of the repository:
 .devenv/scripts/maintenance/code-cleanup.sh
 ```
 
+### Options
+
+- `--cleanups=LIST`  
+  Comma-separated list of cleanups to run. Valid values: `imports`, `code`, `tests`.  
+  If not specified, all cleanups are run.
+- `--help`  
+  Show usage and exit.
+
+### Examples
+
+Run all cleanups (imports, code, tests):
+
+```bash
+.devenv/scripts/maintenance/code-cleanup.sh
+```
+
+Run only imports and code cleanups:
+
+```bash
+.devenv/scripts/maintenance/code-cleanup.sh --cleanups=imports,code
+```
+
+Show help:
+
+```bash
+.devenv/scripts/maintenance/code-cleanup.sh --help
+```
+
+If an invalid cleanup value is specified, the script prints an error and exits.
+
 ## `init-database-version.py` — Database Version Maintenance
 
 This script automates the process of initializing and updating the database version across all supported databases and related files.

--- a/.devenv/scripts/maintenance/code-cleanup.sh
+++ b/.devenv/scripts/maintenance/code-cleanup.sh
@@ -1,9 +1,95 @@
 #!/usr/bin/env bash
-./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run \
-  -Drewrite.activeRecipes=org.openrewrite.java.OrderImports \
-  -Drewrite.activeStyles=org.operaton.style.OperatonJavaStyle \
-  -Drewrite.exportDatatables=true \
-  -Dskip.frontend.build=true \
-  -Pdistro,distro-run,distro-tomcat,distro-wildfly,distro-webjar,distro-starter,distro-serverless
-./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run \
-  -Dskip.frontend.build=true
+
+set -e
+
+show_help() {
+  cat <<EOF
+Usage: $(basename "$0") [--cleanups=<list>] [--help]
+
+Options:
+  --cleanups=LIST   Comma-separated list of cleanups to run. Valid values:
+                    imports, code, tests
+                    If not specified, all cleanups are run.
+  --help            Show this help and exit.
+
+Examples:
+  $0
+      # Run all cleanups (imports, code, tests)
+  $0 --cleanups=imports,code
+      # Only run imports and code cleanups
+EOF
+}
+
+VALID_CLEANUPS=("imports" "code" "tests")
+CLEANUPS=("${VALID_CLEANUPS[@]}")
+
+for arg in "$@"; do
+  case $arg in
+    --cleanups=*)
+      IFS=',' read -ra REQ_CLEANUPS <<< "${arg#*=}"
+      CLEANUPS=()
+      for c in "${REQ_CLEANUPS[@]}"; do
+        found=0
+        for v in "${VALID_CLEANUPS[@]}"; do
+          if [[ "$c" == "$v" ]]; then
+            found=1
+            CLEANUPS+=("$c")
+            break
+          fi
+        done
+        if [[ $found -eq 0 ]]; then
+          echo "Error: Invalid cleanup value: '$c'" >&2
+          echo "Valid values: ${VALID_CLEANUPS[*]}" >&2
+          exit 1
+        fi
+      done
+      ;;
+    --help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg" >&2
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
+PROFILES=distro,distro-run,distro-wildfly,distro-starter,distro-serverless
+
+RECIPES=()
+RUN_IMPORTS=0
+
+# Run selected cleanups
+for cleanup in "${CLEANUPS[@]}"; do
+  case "$cleanup" in
+    imports)
+      RUN_IMPORTS=1
+      ;;
+    code)
+      RECIPES+=("org.operaton.recipe.CodeCleanup")
+      ;;
+    tests)
+      RECIPES+=("org.operaton.recipe.TestsCleanup")
+      ;;
+  esac
+done
+
+if [[ $RUN_IMPORTS -eq 1 ]]; then
+  echo "ℹ️  Running: ./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=org.openrewrite.java.OrderImports -Drewrite.activeStyles=org.operaton.style.OperatonJavaStyle -Drewrite.exportDatatables=true -Dskip.frontend.build=true -P$PROFILES"
+  ./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run \
+    -Drewrite.activeRecipes=org.openrewrite.java.OrderImports \
+    -Drewrite.activeStyles=org.operaton.style.OperatonJavaStyle \
+    -Drewrite.exportDatatables=true \
+    -Dskip.frontend.build=true \
+    -P$PROFILES
+fi
+
+if [[ ${#RECIPES[@]} -gt 0 ]]; then
+  echo "ℹ️  Running: ./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=$(IFS=,; echo "${RECIPES[*]}") -Dskip.frontend.build=true -P$PROFILES"
+  ./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run \
+    -Drewrite.activeRecipes="$(IFS=,; echo "${RECIPES[*]}")" \
+    -Dskip.frontend.build=true \
+    -P$PROFILES
+fi

--- a/.github/workflows/code-cleanup.yml
+++ b/.github/workflows/code-cleanup.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Build
         run: .devenv/scripts/build/build.sh --profile=max --skip-tests
       - name: Code Cleanup
-        run: .devenv/scripts/maintenance/code-cleanup.sh
+        run: |
+          .devenv/scripts/maintenance/code-cleanup.sh --cleanups=imports,code
+          .devenv/scripts/maintenance/code-cleanup.sh --cleanups=tests
       - name: Verification Build
         run: .devenv/scripts/build/build.sh --profile=max --skip-tests
       - name: Create Pull Request

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/util/LoggingInterceptor.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/util/LoggingInterceptor.java
@@ -44,12 +44,16 @@ public class LoggingInterceptor implements ClientHttpRequestInterceptor {
     }
   }
 
-  private void log(HttpMessage message) throws IOException {
+  private void log(HttpMessage message) {
     if(message instanceof HttpRequest request) {
       log.info("URI: {}", request.getURI());
       log.info("Method: {}", request.getMethod());
     } else if(message instanceof ClientHttpResponse response) {
-      log.info("Status code: {}", response.getStatusCode());
+        try {
+            log.info("Status code: {}", response.getStatusCode());
+        } catch (IOException ignored) {
+            // no-op
+        }
     } else {
       return;
     }

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebIT.java
@@ -69,11 +69,11 @@ public abstract class AbstractWebIT {
   }
 
   @BeforeEach
-  public void before() throws Exception {
+  public void before() {
     testProperties = new TestProperties(48080);
   }
 
-  public void createClient(String ctxPath) throws Exception {
+  public void createClient(String ctxPath) {
     // Initialize test properties
     testProperties = new TestProperties();
 
@@ -82,9 +82,13 @@ public abstract class AbstractWebIT {
     LOGGER.info("Connecting to application " + appBasePath);
   }
 
-  public void preventRaceConditions() throws InterruptedException {
+  public void preventRaceConditions() {
     // just wait some seconds before starting because of Wildfly / Cargo race conditions
-    Thread.sleep(6 * 1000);
+    try {
+      Thread.sleep(6 * 1000);
+    } catch (InterruptedException ignored) {
+      Thread.currentThread().interrupt();
+    }
   }
 
   protected String getWebappCtxPath() {

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
@@ -79,7 +79,7 @@ public abstract class AbstractWebappUiIT extends AbstractWebIT {
   }
 
   @BeforeEach
-  void createClient() throws Exception {
+  void createClient() {
     preventRaceConditions();
     createClient(getWebappCtxPath());
     appUrl = testProperties.getApplicationPath("/" + getWebappCtxPath());

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
@@ -16,10 +16,7 @@
  */
 package org.operaton.bpm.run.qa.webapps;
 
-import java.io.File;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Locale;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/AbstractWebappUiIT.java
@@ -66,8 +66,8 @@ public abstract class AbstractWebappUiIT extends AbstractWebIT {
 
     return webDriver -> {
       try {
-        return new URI(webDriver.getCurrentUrl()).equals(pageURI);
-      } catch (URISyntaxException e) {
+        return URI.create(webDriver.getCurrentUrl()).equals(pageURI);
+      } catch (IllegalArgumentException e) {
         return false;
       }
     };

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/LoginIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/LoginIT.java
@@ -126,15 +126,14 @@ class LoginIT extends AbstractWebappUiIT {
     }).doesNotThrowAnyException();
   }
 
-  void loginToCockpit() throws URISyntaxException {
+  void loginToCockpit() {
     String appName = "cockpit";
     login(appName);
     wait.until(textToBePresentInElementLocated(
         By.cssSelector(".deployed .processes .stats-label"),
         "Process Definitions"));
 
-    wait.until(currentURIIs(new URI(appUrl + "app/"
-        + appName + "/default/#/dashboard")));
+    wait.until(currentURIIs(URI.create(appUrl + "app/" + appName + "/default/#/dashboard")));
   }
 
   @MethodSource("commands")
@@ -175,15 +174,14 @@ class LoginIT extends AbstractWebappUiIT {
     }).doesNotThrowAnyException();
   }
 
-  void loginToAdmin() throws URISyntaxException {
+  void loginToAdmin() {
     String appName = "admin";
     login(appName);
     wait.until(textToBePresentInElementLocated(
         By.cssSelector("[ng-class=\"activeClass('#/authorization')\"] a"),
         "Authorizations"));
 
-    wait.until(currentURIIs(new URI(appUrl
-        + "app/" + appName + "/default/#/")));
+    wait.until(currentURIIs(URI.create(appUrl + "app/" + appName + "/default/#/")));
   }
 
   @MethodSource("commands")
@@ -199,15 +197,14 @@ class LoginIT extends AbstractWebappUiIT {
     }).doesNotThrowAnyException();
   }
 
-  void loginToWelcome() throws URISyntaxException {
+  void loginToWelcome() {
     String appName = "welcome";
     login(appName);
     wait.until(textToBePresentInElementLocated(
         By.cssSelector(".webapps .section-title"),
         "Applications"));
 
-    wait.until(currentURIIs(new URI(appUrl
-        + "app/" + appName + "/default/#!/welcome")));
+    wait.until(currentURIIs(URI.create(appUrl + "app/" + appName + "/default/#!/welcome")));
   }
 
   @BeforeEach

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/LoginIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/LoginIT.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.run.qa.webapps;
 
 import java.lang.reflect.Method;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;

--- a/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/PluginsRootResourceIT.java
+++ b/distro/run/qa/integration-tests/src/test/java/org/operaton/bpm/run/qa/webapps/PluginsRootResourceIT.java
@@ -42,7 +42,7 @@ class PluginsRootResourceIT extends AbstractWebIT {
   boolean assetAllowed;
 
   @BeforeEach
-  void createClient() throws Exception {
+  void createClient() {
     createClient(getWebappCtxPath());
   }
 

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/deployment/processor/ProcessApplicationProcessor.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/deployment/processor/ProcessApplicationProcessor.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import org.jboss.as.ee.component.Attachments;
 import org.jboss.as.ee.component.ComponentDescription;
@@ -147,7 +146,7 @@ public class ProcessApplicationProcessor implements DeploymentUnitProcessor {
         JBossWebMetaData mergedJBossWebMetaData = warMetaData.getMergedJBossWebMetaData();
         List<ListenerMetaData> listeners = mergedJBossWebMetaData.getListeners();
         if(listeners == null) {
-          listeners = new ArrayList<ListenerMetaData>();
+          listeners = new ArrayList<>();
           mergedJBossWebMetaData.setListeners(listeners);
         }
 

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/deployment/processor/ProcessEngineStartProcessor.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/deployment/processor/ProcessEngineStartProcessor.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
-import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
@@ -47,7 +46,7 @@ public class ProcessEngineStartProcessor implements DeploymentUnitProcessor {
   public static final int PRIORITY = 0x0000;
 
   @Override
-  public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+  public void deploy(DeploymentPhaseContext phaseContext) {
 
     final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
 
@@ -99,7 +98,7 @@ public class ProcessEngineStartProcessor implements DeploymentUnitProcessor {
    * into a {@link ManagedProcessEngineMetadata} */
   protected ManagedProcessEngineMetadata transformConfiguration(ProcessEngineXml processEngineXml) {
     return new ManagedProcessEngineMetadata(
-        processEngineXml.getName().equals("default"),
+        "default".equals(processEngineXml.getName()),
         processEngineXml.getName(),
         processEngineXml.getDatasource(),
         processEngineXml.getProperties().get("history"),

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/extension/Element.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/extension/Element.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.container.impl.jboss.extension;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +76,7 @@ public enum Element {
 
   Element(final List<AttributeDefinition> definitions) {
     this.definition = null;
-    this.definitions = new HashMap<String, AttributeDefinition>();
+    this.definitions = new HashMap<>();
     String ourName = null;
     for (AttributeDefinition def : definitions) {
       if (ourName == null) {
@@ -97,7 +96,7 @@ public enum Element {
 
   Element(final Map<String, AttributeDefinition> definitions) {
     this.definition = null;
-    this.definitions = new HashMap<String, AttributeDefinition>();
+    this.definitions = new HashMap<>();
     String ourName = null;
     for (Map.Entry<String, AttributeDefinition> def : definitions.entrySet()) {
       String xmlName = def.getValue().getXmlName();

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/extension/handler/JobExecutorAdd.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/extension/handler/JobExecutorAdd.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.container.impl.jboss.extension.handler;
 
-import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -28,7 +27,6 @@ import org.jboss.as.threads.ThreadFactoryService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceController.Mode;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.threads.EnhancedQueueExecutor;

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/ProcessApplicationDeploymentService.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/service/ProcessApplicationDeploymentService.java
@@ -103,7 +103,7 @@ public class ProcessApplicationDeploymentService implements Service<ProcessAppli
   public void start(final StartContext context) throws StartException {
     provider.accept(this);
     context.asynchronous();
-    executorSupplier.get().submit((Runnable) () -> {
+    executorSupplier.get().submit(() -> {
       try {
         performDeployment();
         context.complete();
@@ -119,7 +119,7 @@ public class ProcessApplicationDeploymentService implements Service<ProcessAppli
   public void stop(final StopContext context) {
     provider.accept(null);
     context.asynchronous();
-    executorSupplier.get().submit((Runnable) () -> {
+    executorSupplier.get().submit(() -> {
       try {
         performUndeployment();
       } finally {
@@ -241,7 +241,7 @@ public class ProcessApplicationDeploymentService implements Service<ProcessAppli
   }
 
   protected boolean isValidValueForResumePreviousBy(String resumePreviousBy) {
-    return resumePreviousBy.equals(ResumePreviousBy.RESUME_BY_DEPLOYMENT_NAME) || resumePreviousBy.equals(ResumePreviousBy.RESUME_BY_PROCESS_DEFINITION_KEY);
+    return ResumePreviousBy.RESUME_BY_DEPLOYMENT_NAME.equals(resumePreviousBy) || ResumePreviousBy.RESUME_BY_PROCESS_DEFINITION_KEY.equals(resumePreviousBy);
   }
 
   /**

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/util/PlatformServiceReferenceFactory.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/util/PlatformServiceReferenceFactory.java
@@ -35,12 +35,15 @@ public class PlatformServiceReferenceFactory implements ManagedReferenceFactory 
     this.service = service;
   }
 
+  @Override
   public ManagedReference getReference() {
     return new ManagedReference() {
 
+      @Override
       public void release() {
       }
 
+      @Override
       public Object getInstance() {
         return service;
       }

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/util/ProcessEngineManagedReferenceFactory.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/util/ProcessEngineManagedReferenceFactory.java
@@ -33,12 +33,15 @@ public class ProcessEngineManagedReferenceFactory implements ManagedReferenceFac
     this.processEngine = processEngine;
   }
 
+  @Override
   public ManagedReference getReference() {
     return new ManagedReference() {
 
+      @Override
       public void release() {
       }
 
+      @Override
       public Object getInstance() {
         return processEngine;
       }

--- a/distro/wildfly/subsystem/src/test/java/org/operaton/bpm/container/impl/jboss/test/JBossSubsystemXMLTest.java
+++ b/distro/wildfly/subsystem/src/test/java/org/operaton/bpm/container/impl/jboss/test/JBossSubsystemXMLTest.java
@@ -16,7 +16,6 @@
  */
 package org.operaton.bpm.container.impl.jboss.test;
 
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -52,7 +51,7 @@ import org.operaton.bpm.container.impl.plugin.BpmPlatformPlugins;
 import org.operaton.bpm.engine.impl.jobexecutor.JobExecutor;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -166,7 +165,7 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
 
     List<ModelNode> operations = parse(subsystemXml);
 
-    assertThat(operations.size()).isEqualTo(1);
+    assertThat(operations).hasSize(1);
     //The add subsystem operation will happen first
     ModelNode addSubsystem = operations.get(0);
     assertThat(addSubsystem.get(OP).asString()).isEqualTo(ADD);
@@ -182,7 +181,7 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
     String subsystemXml = FileUtils.readFile(SUBSYSTEM_WITH_ENGINES);
 
     List<ModelNode> operations = parse(subsystemXml);
-    assertThat(operations.size()).isEqualTo(3);
+    assertThat(operations).hasSize(3);
   }
 
   @Test
@@ -190,7 +189,7 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
     String subsystemXml = FileUtils.readFile(SUBSYSTEM_WITH_ENGINES_AND_PROPERTIES);
 
     List<ModelNode> operations = parse(subsystemXml);
-    assertThat(operations.size()).isEqualTo(5);
+    assertThat(operations).hasSize(5);
   }
 
   @Test
@@ -198,7 +197,7 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
     String subsystemXml = FileUtils.readFile(SUBSYSTEM_WITH_ENGINES_PROPERTIES_PLUGINS);
 
     List<ModelNode> operations = parse(subsystemXml);
-    assertThat(operations.size()).isEqualTo(3);
+    assertThat(operations).hasSize(3);
   }
 
   @Test
@@ -220,12 +219,12 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
 
     ManagedProcessEngineMetadata metadata = ((MscManagedProcessEngineController) defaultEngineService.getService()).getProcessEngineMetadata();
     Map<String, String> configurationProperties = metadata.getConfigurationProperties();
-    assertThat(configurationProperties.get("job-name")).isEqualTo("default");
-    assertThat(configurationProperties.get("job-acquisition")).isEqualTo("default");
-    assertThat(configurationProperties.get("job-acquisition-name")).isEqualTo("default");
+    assertThat(configurationProperties).containsEntry("job-name", "default");
+    assertThat(configurationProperties).containsEntry("job-acquisition", "default");
+    assertThat(configurationProperties).containsEntry("job-acquisition-name", "default");
 
     Map<String, String> foxLegacyProperties = metadata.getFoxLegacyProperties();
-    assertThat(foxLegacyProperties.isEmpty()).isTrue();
+    assertThat(foxLegacyProperties).isEmpty();
 
     assertThat(container.getRequiredService(ServiceNames.forManagedProcessEngine("__default"))).withFailMessage("process engine controller for engine __default is installed ").isNotNull();
     assertThat(container.getRequiredService(ServiceNames.forManagedProcessEngine("__test"))).withFailMessage("process engine controller for engine __test is installed ").isNotNull();
@@ -238,31 +237,21 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
     ProcessEnginePluginXml processEnginePluginXml = pluginConfigurations.get(0);
     assertThat(processEnginePluginXml.getPluginClass()).isEqualTo("org.operaton.bpm.identity.impl.ldap.plugin.LdapIdentityProviderPlugin");
     Map<String, String> processEnginePluginXmlProperties = processEnginePluginXml.getProperties();
-    assertThat(processEnginePluginXmlProperties.get("test")).isEqualTo("abc");
-    assertThat(processEnginePluginXmlProperties.get("number")).isEqualTo("123");
-    assertThat(processEnginePluginXmlProperties.get("bool")).isEqualTo("true");
+    assertThat(processEnginePluginXmlProperties).containsEntry("test", "abc");
+    assertThat(processEnginePluginXmlProperties).containsEntry("number", "123");
+    assertThat(processEnginePluginXmlProperties).containsEntry("bool", "true");
 
     processEnginePluginXml = pluginConfigurations.get(1);
     assertThat(processEnginePluginXml.getPluginClass()).isEqualTo("org.operaton.bpm.identity.impl.ldap.plugin.LdapIdentityProviderPlugin");
     processEnginePluginXmlProperties = processEnginePluginXml.getProperties();
-    assertThat(processEnginePluginXmlProperties.get("test")).isEqualTo("cba");
-    assertThat(processEnginePluginXmlProperties.get("number")).isEqualTo("321");
-    assertThat(processEnginePluginXmlProperties.get("bool")).isEqualTo("false");
+    assertThat(processEnginePluginXmlProperties).containsEntry("test", "cba");
+    assertThat(processEnginePluginXmlProperties).containsEntry("number", "321");
+    assertThat(processEnginePluginXmlProperties).containsEntry("bool", "false");
 
     // test correct subsystem removal
     assertRemoveSubsystemResources(services);
-    try {
-      ServiceController<?> service = container.getRequiredService(ServiceNames.forManagedProcessEngine("__default"));
-      fail("Service '" + service.getName() + "' should have been removed.");
-    } catch (Exception expected) {
-      // nop
-    }
-    try {
-      ServiceController<?> service = container.getRequiredService(ServiceNames.forManagedProcessEngine("__test"));
-      fail("Service '" + service.getName() + "' should have been removed.");
-    } catch (Exception expected) {
-      // nop
-    }
+    assertThatThrownBy(() -> container.getRequiredService(ServiceNames.forManagedProcessEngine("__default"))).isInstanceOf(Exception.class);
+    assertThatThrownBy(() -> container.getRequiredService(ServiceNames.forManagedProcessEngine("__test"))).isInstanceOf(Exception.class);
   }
 
   @Test
@@ -295,7 +284,7 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
     assertThat(platformPlugins).isNotNull();
     assertThat(platformPlugins instanceof BpmPlatformPlugins).isTrue();
     List<BpmPlatformPlugin> plugins = ((BpmPlatformPlugins) platformPlugins).getPlugins();
-    assertThat(plugins.size()).isEqualTo(1);
+    assertThat(plugins).hasSize(1);
     assertThat(plugins.get(0) instanceof ExampleBpmPlatformPlugin).isTrue();
   }
 
@@ -335,12 +324,12 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
 
     ManagedProcessEngineMetadata metadata = ((MscManagedProcessEngineController) defaultEngineService.getService()).getProcessEngineMetadata();
     Map<String, String> configurationProperties = metadata.getConfigurationProperties();
-    assertThat(configurationProperties.get("job-name")).isEqualTo("default");
-    assertThat(configurationProperties.get("job-acquisition")).isEqualTo("default");
-    assertThat(configurationProperties.get("job-acquisition-name")).isEqualTo("default");
+    assertThat(configurationProperties).containsEntry("job-name", "default");
+    assertThat(configurationProperties).containsEntry("job-acquisition", "default");
+    assertThat(configurationProperties).containsEntry("job-acquisition-name", "default");
 
     Map<String, String> foxLegacyProperties = metadata.getFoxLegacyProperties();
-    assertThat(foxLegacyProperties.isEmpty()).isTrue();
+    assertThat(foxLegacyProperties).isEmpty();
 
     assertThat(container.getService(ServiceNames.forManagedProcessEngine("__test"))).withFailMessage("process engine controller for engine __test is installed ").isNotNull();
     assertThat(container.getService(ServiceNames.forManagedProcessEngine("__emptyPropertiesTag"))).withFailMessage("process engine controller for engine __emptyPropertiesTag is installed ").isNotNull();
@@ -388,7 +377,7 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
 
     List<ModelNode> operations = parse(subsystemXml);
 //    System.out.println(operations);
-    assertThat(operations.size()).isEqualTo(4);
+    assertThat(operations).hasSize(4);
 
     ModelNode jobExecutor = operations.get(1);
     PathAddress pathAddress = PathAddress.pathAddress(jobExecutor.get(ModelDescriptionConstants.OP_ADDR));
@@ -429,7 +418,7 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
     String subsystemXml = FileUtils.readFile(SUBSYSTEM_WITH_JOB_EXECUTOR_AND_PROPERTIES);
 
     List<ModelNode> operations = parse(subsystemXml);
-    assertThat(operations.size()).isEqualTo(5);
+    assertThat(operations).hasSize(5);
 
     // "default" job acquisition ///////////////////////////////////////////////////////////
     ModelNode jobAcquisition = operations.get(2);
@@ -443,7 +432,7 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
     assertThat(jobAcquisition.hasDefined(Element.PROPERTIES.getLocalName())).isTrue();
 
     ModelNode properties = jobAcquisition.get(Element.PROPERTIES.getLocalName());
-    assertThat(properties.asPropertyList().size()).isEqualTo(3);
+    assertThat(properties.asPropertyList()).hasSize(3);
 
     assertThat(properties.has(LOCK_TIME_IN_MILLIS)).isTrue();
     assertThat(properties.hasDefined(LOCK_TIME_IN_MILLIS)).isTrue();
@@ -464,7 +453,7 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
     assertThat(jobAcquisition.hasDefined(Element.PROPERTIES.getLocalName())).isTrue();
 
     properties = jobAcquisition.get(Element.PROPERTIES.getLocalName());
-    assertThat(properties.asPropertyList().size()).isEqualTo(1);
+    assertThat(properties.asPropertyList()).hasSize(1);
 
     assertThat(properties.has(LOCK_TIME_IN_MILLIS)).isTrue();
     assertThat(properties.hasDefined(LOCK_TIME_IN_MILLIS)).isTrue();
@@ -567,7 +556,7 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
 
     List<ModelNode> operations = parse(subsystemXml);
     System.out.println(operations);
-    assertThat(operations.size()).isEqualTo(6);
+    assertThat(operations).hasSize(6);
   }
 
   @Test
@@ -615,7 +604,7 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
 
     List<ModelNode> operations = parse(subsystemXml);
 
-    assertThat(operations.size()).isEqualTo(4);
+    assertThat(operations).hasSize(4);
     // all elements with expression allowed should be an expression now
     assertExpressionType(operations.get(1), "default", "datasource", "history-level", "configuration");
     assertExpressionType(operations.get(1).get("properties"), "job-acquisition-name");
@@ -648,24 +637,24 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
 
       ManagedProcessEngineMetadata metadata = ((MscManagedProcessEngineController) defaultEngineService.getService()).getProcessEngineMetadata();
       Map<String, String> configurationProperties = metadata.getConfigurationProperties();
-      assertThat(configurationProperties.get("job-acquisition-name")).isEqualTo("default");
+      assertThat(configurationProperties).containsEntry("job-acquisition-name", "default");
 
       Map<String, String> foxLegacyProperties = metadata.getFoxLegacyProperties();
-      assertThat(foxLegacyProperties.isEmpty()).isTrue();
+      assertThat(foxLegacyProperties).isEmpty();
 
       assertThat(container.getRequiredService(ServiceNames.forManagedProcessEngine("__test"))).withFailMessage("process engine controller for engine __test is installed ").isNotNull();
 
       // check we have parsed the plugin configurations
       List<ProcessEnginePluginXml> pluginConfigurations = metadata.getPluginConfigurations();
 
-      assertThat(pluginConfigurations.size()).isEqualTo(1);
+      assertThat(pluginConfigurations).hasSize(1);
 
       ProcessEnginePluginXml processEnginePluginXml = pluginConfigurations.get(0);
       assertThat(processEnginePluginXml.getPluginClass()).isEqualTo("org.operaton.bpm.identity.impl.ldap.plugin.LdapIdentityProviderPlugin");
       Map<String, String> processEnginePluginXmlProperties = processEnginePluginXml.getProperties();
-      assertThat(processEnginePluginXmlProperties.get("test")).isEqualTo("abc");
-      assertThat(processEnginePluginXmlProperties.get("number")).isEqualTo("123");
-      assertThat(processEnginePluginXmlProperties.get("bool")).isEqualTo("true");
+      assertThat(processEnginePluginXmlProperties).containsEntry("test", "abc");
+      assertThat(processEnginePluginXmlProperties).containsEntry("number", "123");
+      assertThat(processEnginePluginXmlProperties).containsEntry("bool", "true");
     } finally {
       for (String key : EXPRESSION_PROPERTIES.keySet()) {
         System.clearProperty(key);

--- a/distro/wildfly/subsystem/src/test/java/org/operaton/bpm/container/impl/jboss/test/JBossSubsystemXMLTest.java
+++ b/distro/wildfly/subsystem/src/test/java/org/operaton/bpm/container/impl/jboss/test/JBossSubsystemXMLTest.java
@@ -219,9 +219,10 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
 
     ManagedProcessEngineMetadata metadata = ((MscManagedProcessEngineController) defaultEngineService.getService()).getProcessEngineMetadata();
     Map<String, String> configurationProperties = metadata.getConfigurationProperties();
-    assertThat(configurationProperties).containsEntry("job-name", "default");
-    assertThat(configurationProperties).containsEntry("job-acquisition", "default");
-    assertThat(configurationProperties).containsEntry("job-acquisition-name", "default");
+    assertThat(configurationProperties)
+            .containsEntry("job-name", "default")
+            .containsEntry("job-acquisition", "default")
+            .containsEntry("job-acquisition-name", "default");
 
     Map<String, String> foxLegacyProperties = metadata.getFoxLegacyProperties();
     assertThat(foxLegacyProperties).isEmpty();
@@ -237,16 +238,18 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
     ProcessEnginePluginXml processEnginePluginXml = pluginConfigurations.get(0);
     assertThat(processEnginePluginXml.getPluginClass()).isEqualTo("org.operaton.bpm.identity.impl.ldap.plugin.LdapIdentityProviderPlugin");
     Map<String, String> processEnginePluginXmlProperties = processEnginePluginXml.getProperties();
-    assertThat(processEnginePluginXmlProperties).containsEntry("test", "abc");
-    assertThat(processEnginePluginXmlProperties).containsEntry("number", "123");
-    assertThat(processEnginePluginXmlProperties).containsEntry("bool", "true");
+    assertThat(processEnginePluginXmlProperties)
+            .containsEntry("test", "abc")
+            .containsEntry("number", "123")
+            .containsEntry("bool", "true");
 
     processEnginePluginXml = pluginConfigurations.get(1);
     assertThat(processEnginePluginXml.getPluginClass()).isEqualTo("org.operaton.bpm.identity.impl.ldap.plugin.LdapIdentityProviderPlugin");
     processEnginePluginXmlProperties = processEnginePluginXml.getProperties();
-    assertThat(processEnginePluginXmlProperties).containsEntry("test", "cba");
-    assertThat(processEnginePluginXmlProperties).containsEntry("number", "321");
-    assertThat(processEnginePluginXmlProperties).containsEntry("bool", "false");
+    assertThat(processEnginePluginXmlProperties)
+            .containsEntry("test", "cba")
+            .containsEntry("number", "321")
+            .containsEntry("bool", "false");
 
     // test correct subsystem removal
     assertRemoveSubsystemResources(services);
@@ -324,9 +327,10 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
 
     ManagedProcessEngineMetadata metadata = ((MscManagedProcessEngineController) defaultEngineService.getService()).getProcessEngineMetadata();
     Map<String, String> configurationProperties = metadata.getConfigurationProperties();
-    assertThat(configurationProperties).containsEntry("job-name", "default");
-    assertThat(configurationProperties).containsEntry("job-acquisition", "default");
-    assertThat(configurationProperties).containsEntry("job-acquisition-name", "default");
+    assertThat(configurationProperties)
+            .containsEntry("job-name", "default")
+            .containsEntry("job-acquisition", "default")
+            .containsEntry("job-acquisition-name", "default");
 
     Map<String, String> foxLegacyProperties = metadata.getFoxLegacyProperties();
     assertThat(foxLegacyProperties).isEmpty();
@@ -652,9 +656,10 @@ public class JBossSubsystemXMLTest extends AbstractSubsystemTest {
       ProcessEnginePluginXml processEnginePluginXml = pluginConfigurations.get(0);
       assertThat(processEnginePluginXml.getPluginClass()).isEqualTo("org.operaton.bpm.identity.impl.ldap.plugin.LdapIdentityProviderPlugin");
       Map<String, String> processEnginePluginXmlProperties = processEnginePluginXml.getProperties();
-      assertThat(processEnginePluginXmlProperties).containsEntry("test", "abc");
-      assertThat(processEnginePluginXmlProperties).containsEntry("number", "123");
-      assertThat(processEnginePluginXmlProperties).containsEntry("bool", "true");
+      assertThat(processEnginePluginXmlProperties)
+              .containsEntry("test", "abc")
+              .containsEntry("number", "123")
+              .containsEntry("bool", "true");
     } finally {
       for (String key : EXPRESSION_PROPERTIES.keySet()) {
         System.clearProperty(key);

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/externaltask/ExternalTaskQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/externaltask/ExternalTaskQueryDto.java
@@ -324,21 +324,21 @@ public class ExternalTaskQueryDto extends AbstractQueryDto<ExternalTaskQuery> {
         String variableName = variableQueryParam.getName();
         String op = variableQueryParam.getOperator();
         Object variableValue = variableQueryParam.resolveValue(objectMapper);
-        if (op.equals(VariableQueryParameterDto.EQUALS_OPERATOR_NAME)) {
+        if (VariableQueryParameterDto.EQUALS_OPERATOR_NAME.equals(op)) {
           query.processVariableValueEquals(variableName, variableValue);
-        } else if (op.equals(VariableQueryParameterDto.NOT_EQUALS_OPERATOR_NAME)) {
+        } else if (VariableQueryParameterDto.NOT_EQUALS_OPERATOR_NAME.equals(op)) {
           query.processVariableValueNotEquals(variableName, variableValue);
-        } else if (op.equals(VariableQueryParameterDto.GREATER_THAN_OPERATOR_NAME)) {
+        } else if (VariableQueryParameterDto.GREATER_THAN_OPERATOR_NAME.equals(op)) {
           query.processVariableValueGreaterThan(variableName, variableValue);
-        } else if (op.equals(VariableQueryParameterDto.GREATER_THAN_OR_EQUALS_OPERATOR_NAME)) {
+        } else if (VariableQueryParameterDto.GREATER_THAN_OR_EQUALS_OPERATOR_NAME.equals(op)) {
           query.processVariableValueGreaterThanOrEquals(variableName, variableValue);
-        } else if (op.equals(VariableQueryParameterDto.LESS_THAN_OPERATOR_NAME)) {
+        } else if (VariableQueryParameterDto.LESS_THAN_OPERATOR_NAME.equals(op)) {
           query.processVariableValueLessThan(variableName, variableValue);
-        } else if (op.equals(VariableQueryParameterDto.LESS_THAN_OR_EQUALS_OPERATOR_NAME)) {
+        } else if (VariableQueryParameterDto.LESS_THAN_OR_EQUALS_OPERATOR_NAME.equals(op)) {
           query.processVariableValueLessThanOrEquals(variableName, variableValue);
-        } else if (op.equals(VariableQueryParameterDto.LIKE_OPERATOR_NAME)) {
+        } else if (VariableQueryParameterDto.LIKE_OPERATOR_NAME.equals(op)) {
           query.processVariableValueLike(variableName, String.valueOf(variableValue));
-        } else if (op.equals(VariableQueryParameterDto.NOT_LIKE_OPERATOR_NAME)) {
+        } else if (VariableQueryParameterDto.NOT_LIKE_OPERATOR_NAME.equals(op)) {
           query.processVariableValueNotLike(variableName, String.valueOf(variableValue));
         } else {
           throw new InvalidRequestException(Response.Status.BAD_REQUEST, "Invalid process variable comparator specified: " + op);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExternalTaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExternalTaskRestServiceQueryTest.java
@@ -858,8 +858,8 @@ public class ExternalTaskRestServiceQueryTest extends AbstractRestServiceTest {
         verify(mockQuery).processVariableValueNotEquals(variableName, variableValue);
     }
 
-    @Test
-    public void testProcessVariableValueEqualsIgnoreCaseAsPost() {
+  @Test
+  void testProcessVariableValueEqualsIgnoreCaseAsPost() {
         Map<String, Object> variableJson = new HashMap<>();
         variableJson.put("name", SAMPLE_VAR_NAME);
         variableJson.put("operator", "eq");
@@ -885,8 +885,8 @@ public class ExternalTaskRestServiceQueryTest extends AbstractRestServiceTest {
         verify(mockQuery).processVariableValueEquals(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
     }
 
-    @Test
-    public void testProcessVariableNameEqualsIgnoreCaseAsPost() {
+  @Test
+  void testProcessVariableNameEqualsIgnoreCaseAsPost() {
         Map<String, Object> variableJson = new HashMap<>();
         variableJson.put("name", SAMPLE_VAR_NAME.toLowerCase());
         variableJson.put("operator", "eq");
@@ -928,8 +928,8 @@ public class ExternalTaskRestServiceQueryTest extends AbstractRestServiceTest {
 
     }
 
-    @Test
-    public void testProcessVariableValueNotEqualsIgnoreCaseAsPost() {
+  @Test
+  void testProcessVariableValueNotEqualsIgnoreCaseAsPost() {
         Map<String, Object> variableJson = new HashMap<>();
         variableJson.put("name", SAMPLE_VAR_NAME);
         variableJson.put("operator", "neq");
@@ -955,8 +955,8 @@ public class ExternalTaskRestServiceQueryTest extends AbstractRestServiceTest {
         verify(mockQuery).processVariableValueNotEquals(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
     }
 
-    @Test
-    public void testProcessVariableValueLikeIgnoreCaseAsPost() {
+  @Test
+  void testProcessVariableValueLikeIgnoreCaseAsPost() {
         Map<String, Object> variableJson = new HashMap<>();
         variableJson.put("name", SAMPLE_VAR_NAME);
         variableJson.put("operator", "like");
@@ -982,8 +982,8 @@ public class ExternalTaskRestServiceQueryTest extends AbstractRestServiceTest {
         verify(mockQuery).processVariableValueLike(SAMPLE_VAR_NAME, SAMPLE_VAR_VALUE.toLowerCase());
     }
 
-    @Test
-    public void testProcessVariableValueNotLikeIgnoreCaseAsPost() {
+  @Test
+  void testProcessVariableValueNotLikeIgnoreCaseAsPost() {
         Map<String, Object> variableJson = new HashMap<>();
         variableJson.put("name", SAMPLE_VAR_NAME);
         variableJson.put("operator", "notLike");

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ExternalTaskQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ExternalTaskQueryImpl.java
@@ -168,6 +168,7 @@ public class ExternalTaskQueryImpl extends AbstractQuery<ExternalTaskQuery, Exte
     return this;
   }
 
+  @Override
   public ExternalTaskQuery processDefinitionId(String processDefinitionId) {
     ensureNotNull("processDefinitionId", processDefinitionId);
     this.processDefinitionId = processDefinitionId;
@@ -186,6 +187,7 @@ public class ExternalTaskQueryImpl extends AbstractQuery<ExternalTaskQuery, Exte
     return this;
   }
 
+  @Override
   public ExternalTaskQuery activityId(String activityId) {
     ensureNotNull("activityId", activityId);
     this.activityId = activityId;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cmmn/CaseServiceTest.java
@@ -1811,19 +1811,9 @@ class CaseServiceTest {
 
   @Test
   void testGetVariableInvalidCaseExecutionId() {
-    try {
-      caseService.getVariable("invalid", "aVariableName");
-      fail("The case execution should not be found.");
-    } catch (NotFoundException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> caseService.getVariable("invalid", "aVariableName")).isInstanceOf(NotFoundException.class);
 
-    try {
-      caseService.getVariable(null, "aVariableName");
-      fail("The case execution should not be found.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> caseService.getVariable(null, "aVariableName")).isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/externaltask/ExternalTaskQueryTest.java
@@ -58,7 +58,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Thorben Lindhauer
  *
  */
-public class ExternalTaskQueryTest {
+class ExternalTaskQueryTest {
 
   protected static final String WORKER_ID = "aWorkerId";
   protected static final String TOPIC_NAME = "externalTaskTopic";
@@ -710,7 +710,7 @@ public class ExternalTaskQueryTest {
 
   @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
   @Test
-  void testProcessVariableValueEquals() throws Exception {
+  void testProcessVariableValueEquals() {
     Map<String, Object> variables = new HashMap<>();
     variables.put("longVar", 928374L);
     variables.put("shortVar", (short) 123);
@@ -755,9 +755,9 @@ public class ExternalTaskQueryTest {
       assertThat(externalTaskService.createExternalTaskQuery().processVariableValueNotEquals("longVar", 928374L).count()).isEqualTo(0);
   }
 
-  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
   @Test
-  public void testProcessVariableNameEqualsIgnoreCase() throws Exception {
+  void testProcessVariableNameEqualsIgnoreCase() {
     String variableName = "someVariable";
     String variableValue = "someCamelCaseValue";
     Map<String, Object> variables = new HashMap<>();
@@ -773,9 +773,9 @@ public class ExternalTaskQueryTest {
       assertThat(externalTaskService.createExternalTaskQuery().processVariableValueEquals(variableName.toLowerCase(), variableValue).matchVariableNamesIgnoreCase().count()).isEqualTo(1);
   }
 
-  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
   @Test
-  public void testProcessVariableValueEqualsIgnoreCase() throws Exception {
+  void testProcessVariableValueEqualsIgnoreCase() {
     String variableName = "someVariable";
     String variableValue = "someCamelCaseValue";
     Map<String, Object> variables = new HashMap<>();
@@ -804,9 +804,9 @@ public class ExternalTaskQueryTest {
     assertThat(externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotEquals(variableName, variableValue.toLowerCase()).count()).isEqualTo(0);
   }
 
-  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
   @Test
-  public void testProcessVariableValueLike() throws Exception {
+  void testProcessVariableValueLike() {
     Map<String, Object> variables = new HashMap<>();
     variables.put("stringVar", "stringValue");
     runtimeService.startProcessInstanceByKey("oneExternalTaskProcess", variables);
@@ -827,9 +827,9 @@ public class ExternalTaskQueryTest {
             externalTaskService.createExternalTaskQuery().processVariableValueLike("stringVar", null).count());
   }
 
-  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
   @Test
-  public void testProcessVariableValueLikeIgnoreCase() throws Exception {
+  void testProcessVariableValueLikeIgnoreCase() {
 
     Map<String, Object> variables = new HashMap<>();
     variables.put("stringVar", "stringValue");
@@ -852,9 +852,9 @@ public class ExternalTaskQueryTest {
             externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueLike("stringVar", null).count());
   }
 
-  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
   @Test
-  public void testProcessVariableValueNotLike() throws Exception {
+  void testProcessVariableValueNotLike() {
     Map<String, Object> variables = new HashMap<>();
     variables.put("stringVar", "stringValue");
     runtimeService.startProcessInstanceByKey("oneExternalTaskProcess", variables);
@@ -875,9 +875,9 @@ public class ExternalTaskQueryTest {
             externalTaskService.createExternalTaskQuery().processVariableValueNotLike("stringVar", null).count());
   }
 
-  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
   @Test
-  public void testProcessVariableValueNotLikeIgnoreCase() throws Exception {
+  void testProcessVariableValueNotLikeIgnoreCase() {
     Map<String, Object> variables = new HashMap<>();
     variables.put("stringVar", "stringValue");
     runtimeService.startProcessInstanceByKey("oneExternalTaskProcess", variables);
@@ -899,9 +899,9 @@ public class ExternalTaskQueryTest {
             externalTaskService.createExternalTaskQuery().matchVariableValuesIgnoreCase().processVariableValueNotLike("stringVar", null).count());
   }
 
-  @Deployment(resources="org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
+  @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
   @Test
-  public void testProcessVariableValueCompare() throws Exception {
+  void testProcessVariableValueCompare() {
 
     Map<String, Object> variables = new HashMap<>();
     variables.put("numericVar", 928374);
@@ -998,7 +998,7 @@ public class ExternalTaskQueryTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
   @Test
-  public void testProcessVariableValueEqualsNumber() throws Exception {
+  void testProcessVariableValueEqualsNumber() {
     // long
     runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
             Collections.<String, Object>singletonMap("var", 123L));
@@ -1040,7 +1040,7 @@ public class ExternalTaskQueryTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
   @Test
-  public void testProcessVariableValueNumberComparison() throws Exception {
+  void testProcessVariableValueNumberComparison() {
     // long
     runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
             Collections.<String, Object>singletonMap("var", 123L));
@@ -1081,7 +1081,7 @@ public class ExternalTaskQueryTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
   @Test
-  public void testVariableEqualsNumberMax() throws Exception {
+  void testVariableEqualsNumberMax() {
     runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
             Collections.<String, Object>singletonMap("var", MAX_DOUBLE_VALUE));
     runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
@@ -1093,7 +1093,7 @@ public class ExternalTaskQueryTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
   @Test
-  public void testVariableEqualsNumberLongValueOverflow() throws Exception {
+  void testVariableEqualsNumberLongValueOverflow() {
     runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
             Collections.<String, Object>singletonMap("var", MAX_DOUBLE_VALUE));
 
@@ -1107,7 +1107,7 @@ public class ExternalTaskQueryTest {
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/externaltask/oneExternalTaskProcess.bpmn20.xml")
   @Test
-  public void testVariableEqualsNumberNonIntegerDoubleShouldNotMatchInteger() throws Exception {
+  void testVariableEqualsNumberNonIntegerDoubleShouldNotMatchInteger() {
     runtimeService.startProcessInstanceByKey("oneExternalTaskProcess",
             Variables.createVariables().putValue("var", 42).putValue("var2", 52.4d));
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoryServiceTest.java
@@ -857,13 +857,7 @@ public class HistoryServiceTest {
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
   @Test
   void testDeleteProcessInstancesWithNull() {
-    try {
-      //when
-      historyService.deleteHistoricProcessInstances(null);
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      //expected
-    }
+    assertThatThrownBy(() -> historyService.deleteHistoricProcessInstances(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AuthorizationServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AuthorizationServiceTest.java
@@ -293,12 +293,7 @@ class AuthorizationServiceTest {
     authorizationService.saveAuthorization(authorization1);
 
     // the second one cannot
-    try {
-      authorizationService.saveAuthorization(authorization2);
-      fail("exception expected");
-    } catch(ProcessEngineException e) {
-      //expected
-    }
+    assertThatThrownBy(() -> authorizationService.saveAuthorization(authorization2)).isInstanceOf(ProcessEngineException.class);
 
     // but I can add a AUTH_TYPE_REVOKE auth
 
@@ -318,12 +313,7 @@ class AuthorizationServiceTest {
     authorization4.setResourceId("someId");
     authorization4.setUserId("someUser");
 
-    try {
-      authorizationService.saveAuthorization(authorization4);
-      fail("exception expected");
-    } catch(Exception e) {
-      //expected
-    }
+    assertThatThrownBy(() -> authorizationService.saveAuthorization(authorization4)).isInstanceOf(Exception.class);
   }
 
   @Test
@@ -346,12 +336,7 @@ class AuthorizationServiceTest {
     authorizationService.saveAuthorization(authorization1);
 
     // the second one cannot
-    try {
-      authorizationService.saveAuthorization(authorization2);
-      fail("exception expected");
-    } catch(Exception e) {
-      //expected
-    }
+    assertThatThrownBy(() -> authorizationService.saveAuthorization(authorization2)).isInstanceOf(Exception.class);
 
     // but I can add a AUTH_TYPE_REVOKE auth
 
@@ -371,12 +356,7 @@ class AuthorizationServiceTest {
     authorization4.setResourceId("someId");
     authorization4.setGroupId("someGroup");
 
-    try {
-      authorizationService.saveAuthorization(authorization4);
-      fail("exception expected");
-    } catch(Exception e) {
-      //expected
-    }
+    assertThatThrownBy(() -> authorizationService.saveAuthorization(authorization4)).isInstanceOf(Exception.class);
 
   }
 
@@ -398,12 +378,7 @@ class AuthorizationServiceTest {
     authorizationService.saveAuthorization(authorization1);
 
     // the second one cannot
-    try {
-      authorizationService.saveAuthorization(authorization2);
-      fail("exception expected");
-    } catch(Exception e) {
-      //expected
-    }
+    assertThatThrownBy(() -> authorizationService.saveAuthorization(authorization2)).isInstanceOf(Exception.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/UserQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/UserQueryTest.java
@@ -126,7 +126,7 @@ class UserQueryTest {
     verifyQueryResults(query, 0);
     var userQuery = identityService.createUserQuery().userFirstName(null);
 
-    assertThatThrownBy(() -> userQuery.singleResult()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(userQuery::singleResult).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -165,7 +165,7 @@ class UserQueryTest {
     verifyQueryResults(query, 0);
     var userQuery = identityService.createUserQuery().userLastName(null);
 
-    assertThatThrownBy(() -> userQuery.singleResult()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(userQuery::singleResult).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -198,7 +198,7 @@ class UserQueryTest {
     verifyQueryResults(query, 0);
     var userQuery = identityService.createUserQuery().userEmail(null);
 
-    assertThatThrownBy(() -> userQuery.singleResult()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(userQuery::singleResult).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -244,10 +244,10 @@ class UserQueryTest {
   @Test
   void testQueryInvalidSortingUsage() {
     var userQuery1 = identityService.createUserQuery().orderByUserId();
-    assertThatThrownBy(() -> userQuery1.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(userQuery1::list).isInstanceOf(ProcessEngineException.class);
 
     var userQuery2 = identityService.createUserQuery().orderByUserId().orderByUserEmail();
-    assertThatThrownBy(() -> userQuery2.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(userQuery2::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/UserQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/UserQueryTest.java
@@ -33,8 +33,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.UserEntity;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 
 import static org.operaton.bpm.engine.test.util.QueryTestHelper.verifyQueryResults;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 
 /**
@@ -109,12 +108,7 @@ class UserQueryTest {
     verifyQueryResults(query, 0);
     var userQuery = identityService.createUserQuery();
 
-    try {
-      userQuery.userId(null);
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> userQuery.userId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -132,12 +126,7 @@ class UserQueryTest {
     verifyQueryResults(query, 0);
     var userQuery = identityService.createUserQuery().userFirstName(null);
 
-    try {
-      userQuery.singleResult();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> userQuery.singleResult()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -158,12 +147,7 @@ class UserQueryTest {
     verifyQueryResults(query, 0);
     var userQuery = identityService.createUserQuery();
 
-    try {
-      userQuery.userFirstNameLike(null);
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> userQuery.userFirstNameLike(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -181,12 +165,7 @@ class UserQueryTest {
     verifyQueryResults(query, 0);
     var userQuery = identityService.createUserQuery().userLastName(null);
 
-    try {
-      userQuery.singleResult();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> userQuery.singleResult()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -204,12 +183,7 @@ class UserQueryTest {
     verifyQueryResults(query, 0);
     var userQuery = identityService.createUserQuery();
 
-    try {
-      userQuery.userLastNameLike(null);
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> userQuery.userLastNameLike(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -224,12 +198,7 @@ class UserQueryTest {
     verifyQueryResults(query, 0);
     var userQuery = identityService.createUserQuery().userEmail(null);
 
-    try {
-      userQuery.singleResult();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> userQuery.singleResult()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -247,12 +216,7 @@ class UserQueryTest {
     verifyQueryResults(query, 0);
     var userQuery = identityService.createUserQuery();
 
-    try {
-      userQuery.userEmailLike(null);
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> userQuery.userEmailLike(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -280,20 +244,10 @@ class UserQueryTest {
   @Test
   void testQueryInvalidSortingUsage() {
     var userQuery1 = identityService.createUserQuery().orderByUserId();
-    try {
-      userQuery1.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> userQuery1.list()).isInstanceOf(ProcessEngineException.class);
 
     var userQuery2 = identityService.createUserQuery().orderByUserId().orderByUserEmail();
-    try {
-      userQuery2.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> userQuery2.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -314,12 +268,7 @@ class UserQueryTest {
     verifyQueryResults(query, 0);
     var userQuery = identityService.createUserQuery();
 
-    try {
-      userQuery.memberOfGroup(null);
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> userQuery.memberOfGroup(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ActivateJobDefinitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ActivateJobDefinitionTest.java
@@ -42,7 +42,7 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.variable.Variables;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ProcessEngineExtension.class)
 class ActivateJobDefinitionTest {
@@ -65,61 +65,26 @@ class ActivateJobDefinitionTest {
 
   @Test
   void testActivationById_shouldThrowProcessEngineException() {
-    try {
-      managementService.activateJobDefinitionById(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionById(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testActivationByIdAndActivateJobsFlag_shouldThrowProcessEngineException() {
-    try {
-      managementService.activateJobDefinitionById(null, false);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionById(null, false)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.activateJobDefinitionById(null, true);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionById(null, true)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testActivationByIdAndActivateJobsFlagAndExecutionDate_shouldThrowProcessEngineException() {
     Date activationDate = new Date();
-    try {
-      managementService.activateJobDefinitionById(null, false, null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionById(null, false, null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.activateJobDefinitionById(null, true, null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionById(null, true, null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.activateJobDefinitionById(null, false, activationDate);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionById(null, false, activationDate)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.activateJobDefinitionById(null, true, activationDate);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionById(null, true, activationDate)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -468,61 +433,26 @@ class ActivateJobDefinitionTest {
 
   @Test
   void testActivationByProcessDefinitionId_shouldThrowProcessEngineException() {
-    try {
-      managementService.activateJobDefinitionByProcessDefinitionId(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testActivationByProcessDefinitionIdAndActivateJobsFlag_shouldThrowProcessEngineException() {
-    try {
-      managementService.activateJobDefinitionByProcessDefinitionId(null, false);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionId(null, false)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.activateJobDefinitionByProcessDefinitionId(null, true);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionId(null, true)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testActivationByProcessDefinitionIdAndActivateJobsFlagAndExecutionDate_shouldThrowProcessEngineException() {
     Date activationDate = new Date();
-    try {
-      managementService.activateJobDefinitionByProcessDefinitionId(null, false, null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionId(null, false, null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.activateJobDefinitionByProcessDefinitionId(null, true, null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionId(null, true, null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.activateJobDefinitionByProcessDefinitionId(null, false, activationDate);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionId(null, false, activationDate)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.activateJobDefinitionByProcessDefinitionId(null, true, activationDate);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionId(null, true, activationDate)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -872,61 +802,26 @@ class ActivateJobDefinitionTest {
 
   @Test
   void testActivationByProcessDefinitionKey_shouldThrowProcessEngineException() {
-    try {
-      managementService.activateJobDefinitionByProcessDefinitionKey(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionKey(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testActivationByProcessDefinitionKeyAndActivateJobsFlag_shouldThrowProcessEngineException() {
-    try {
-      managementService.activateJobDefinitionByProcessDefinitionKey(null, false);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionKey(null, false)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.activateJobDefinitionByProcessDefinitionKey(null, true);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionKey(null, true)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testActivationByProcessDefinitionKeyAndActivateJobsFlagAndExecutionDate_shouldThrowProcessEngineException() {
     Date activationDate = new Date();
-    try {
-      managementService.activateJobDefinitionByProcessDefinitionKey(null, false, null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionKey(null, false, null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.activateJobDefinitionByProcessDefinitionKey(null, true, null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionKey(null, true, null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.activateJobDefinitionByProcessDefinitionKey(null, false, activationDate);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionKey(null, false, activationDate)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.activateJobDefinitionByProcessDefinitionKey(null, true, activationDate);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.activateJobDefinitionByProcessDefinitionKey(null, true, activationDate)).isInstanceOf(ProcessEngineException.class);
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ActivityStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ActivityStatisticsQueryTest.java
@@ -401,7 +401,7 @@ class ActivityStatisticsQueryTest {
   @Test
   void testNullProcessDefinitionParameter() {
     var activityStatisticsQuery = managementService.createActivityStatisticsQuery(null);
-    assertThatThrownBy(() -> activityStatisticsQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(activityStatisticsQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ActivityStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ActivityStatisticsQueryTest.java
@@ -39,7 +39,7 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ActivityStatisticsQueryTest {
 
@@ -401,12 +401,7 @@ class ActivityStatisticsQueryTest {
   @Test
   void testNullProcessDefinitionParameter() {
     var activityStatisticsQuery = managementService.createActivityStatisticsQuery(null);
-    try {
-      activityStatisticsQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> activityStatisticsQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/IncidentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/IncidentTest.java
@@ -54,7 +54,6 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import static org.operaton.bpm.engine.impl.test.TestHelper.executeJobExpectingException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 class IncidentTest {
 
@@ -557,13 +556,7 @@ class IncidentTest {
     // it should not be possible to set the retries to a negative number with the management service
     executeJobExpectingException(managementService, jobId);
 
-    try {
-      managementService.setJobRetriesByJobDefinitionId(jobDefinitionId, -300);
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.setJobRetriesByJobDefinitionId(jobDefinitionId, -300)).isInstanceOf(ProcessEngineException.class);
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/ManagementServiceTest.java
@@ -382,14 +382,7 @@ class ManagementServiceTest {
 
     List<String> allJobIds = getAllJobIds();
     allJobIds.add("aFake");
-    try {
-      //when
-      managementService.setJobRetries(allJobIds, 5);
-      fail("exception expected");
-      //then
-    } catch (ProcessEngineException e) {
-      //expected
-    }
+    assertThatThrownBy(() -> managementService.setJobRetries(allJobIds, 5)).isInstanceOf(ProcessEngineException.class);
 
     assertRetries(getAllJobIds(), JobEntity.DEFAULT_RETRIES);
   }
@@ -680,12 +673,7 @@ class ManagementServiceTest {
     commandExecutor.execute(acquireJobsCmd);
 
     // Try to delete the job. This should fail.
-    try {
-      managementService.deleteJob(timerJobId);
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // Exception is expected
-    }
+    assertThatThrownBy(() -> managementService.deleteJob(timerJobId)).isInstanceOf(ProcessEngineException.class);
 
     // Clean up
     managementService.executeJob(timerJob.getId());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/SuspendJobDefinitionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/SuspendJobDefinitionTest.java
@@ -42,7 +42,7 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.variable.Variables;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author roman.smirnov
@@ -69,61 +69,26 @@ class SuspendJobDefinitionTest {
 
   @Test
   void testSuspensionById_shouldThrowProcessEngineException() {
-    try {
-      managementService.suspendJobDefinitionById(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionById(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testSuspensionByIdAndSuspendJobsFlag_shouldThrowProcessEngineException() {
-    try {
-      managementService.suspendJobDefinitionById(null, false);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionById(null, false)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.suspendJobDefinitionById(null, true);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionById(null, true)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testSuspensionByIdAndSuspendJobsFlagAndExecutionDate_shouldThrowProcessEngineException() {
-    try {
-      managementService.suspendJobDefinitionById(null, false, null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionById(null, false, null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.suspendJobDefinitionById(null, true, null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionById(null, true, null)).isInstanceOf(ProcessEngineException.class);
 
     Date suspensionDate = new Date();
-    try {
-      managementService.suspendJobDefinitionById(null, false, suspensionDate);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionById(null, false, suspensionDate)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.suspendJobDefinitionById(null, true, suspensionDate);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionById(null, true, suspensionDate)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -463,62 +428,27 @@ class SuspendJobDefinitionTest {
 
   @Test
   void testSuspensionByProcessDefinitionId_shouldThrowProcessEngineException() {
-    try {
-      managementService.suspendJobDefinitionByProcessDefinitionId(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testSuspensionByProcessDefinitionIdAndSuspendJobsFlag_shouldThrowProcessEngineException() {
-    try {
-      managementService.suspendJobDefinitionByProcessDefinitionId(null, false);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionId(null, false)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.suspendJobDefinitionByProcessDefinitionId(null, true);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionId(null, true)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testSuspensionByProcessDefinitionIdAndSuspendJobsFlagAndExecutionDate_shouldThrowProcessEngineException() {
     Date suspensionDate = new Date();
 
-    try {
-      managementService.suspendJobDefinitionByProcessDefinitionId(null, false, null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionId(null, false, null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.suspendJobDefinitionByProcessDefinitionId(null, true, null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionId(null, true, null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.suspendJobDefinitionByProcessDefinitionId(null, false, suspensionDate);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionId(null, false, suspensionDate)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.suspendJobDefinitionByProcessDefinitionId(null, true, suspensionDate);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionId(null, true, suspensionDate)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -856,61 +786,26 @@ class SuspendJobDefinitionTest {
 
   @Test
   void testSuspensionByProcessDefinitionKey_shouldThrowProcessEngineException() {
-    try {
-      managementService.suspendJobDefinitionByProcessDefinitionKey(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testSuspensionByProcessDefinitionKeyAndSuspendJobsFlag_shouldThrowProcessEngineException() {
-    try {
-      managementService.suspendJobDefinitionByProcessDefinitionKey(null, false);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(null, false)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.suspendJobDefinitionByProcessDefinitionKey(null, true);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(null, true)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testSuspensionByProcessDefinitionKeyAndSuspendJobsFlagAndExecutionDate_shouldThrowProcessEngineException() {
     Date suspensionDate = new Date();
-    try {
-      managementService.suspendJobDefinitionByProcessDefinitionKey(null, false, null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(null, false, null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.suspendJobDefinitionByProcessDefinitionKey(null, true, null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(null, true, null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.suspendJobDefinitionByProcessDefinitionKey(null, false, suspensionDate);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(null, false, suspensionDate)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      managementService.suspendJobDefinitionByProcessDefinitionKey(null, true, suspensionDate);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> managementService.suspendJobDefinitionByProcessDefinitionKey(null, true, suspensionDate)).isInstanceOf(ProcessEngineException.class);
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyBatchQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyBatchQueryTest.java
@@ -36,14 +36,13 @@ import org.operaton.bpm.engine.test.api.runtime.migration.batch.BatchMigrationHe
 import org.operaton.bpm.engine.test.api.runtime.migration.models.ProcessModels;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
-
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.batchByTenantId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.batchStatisticsByTenantId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Thorben Lindhauer
@@ -218,13 +217,7 @@ class MultiTenancyBatchQueryTest {
 
     String[] tenantIds = null;
     var batchQuery = managementService.createBatchQuery();
-    try {
-      batchQuery.tenantIdIn(tenantIds);
-      fail("exception expected");
-    }
-    catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> batchQuery.tenantIdIn(tenantIds)).isInstanceOf(NullValueException.class);
   }
 
   @Test
@@ -232,13 +225,7 @@ class MultiTenancyBatchQueryTest {
 
     String[] tenantIds = new String[]{ null };
     var batchQuery = managementService.createBatchQuery();
-    try {
-      batchQuery.tenantIdIn(tenantIds);
-      fail("exception expected");
-    }
-    catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> batchQuery.tenantIdIn(tenantIds)).isInstanceOf(NullValueException.class);
   }
 
   @Test
@@ -301,13 +288,7 @@ class MultiTenancyBatchQueryTest {
 
     String[] tenantIds = null;
     var batchStatisticsQuery = managementService.createBatchStatisticsQuery();
-    try {
-      batchStatisticsQuery.tenantIdIn(tenantIds);
-      fail("exception expected");
-    }
-    catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> batchStatisticsQuery.tenantIdIn(tenantIds)).isInstanceOf(NullValueException.class);
   }
 
   @Test
@@ -315,13 +296,7 @@ class MultiTenancyBatchQueryTest {
 
     String[] tenantIds = new String[]{ null };
     var batchStatisticsQuery = managementService.createBatchStatisticsQuery();
-    try {
-      batchStatisticsQuery.tenantIdIn(tenantIds);
-      fail("exception expected");
-    }
-    catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> batchStatisticsQuery.tenantIdIn(tenantIds)).isInstanceOf(NullValueException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyBatchQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyBatchQueryTest.java
@@ -36,13 +36,14 @@ import org.operaton.bpm.engine.test.api.runtime.migration.batch.BatchMigrationHe
 import org.operaton.bpm.engine.test.api.runtime.migration.models.ProcessModels;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.batchByTenantId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.batchStatisticsByTenantId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Thorben Lindhauer

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyTaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/MultiTenancyTaskQueryTest.java
@@ -35,7 +35,7 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Daniel Meyer
@@ -131,14 +131,7 @@ class MultiTenancyTaskQueryTest {
   @Test
   void testQueryByTenantIdNullFails() {
     var taskQuery = taskService.createTaskQuery();
-    try {
-      taskQuery.tenantIdIn((String)null);
-
-      fail("Exception expected");
-    }
-    catch(NullValueException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.tenantIdIn((String) null)).isInstanceOf(NullValueException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricBatchQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricBatchQueryTest.java
@@ -44,8 +44,7 @@ import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historic
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
 import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Thorben Lindhauer
@@ -211,13 +210,7 @@ class MultiTenancyHistoricBatchQueryTest {
 
     String[] tenantIds = null;
     var historicBatchQuery = historyService.createHistoricBatchQuery();
-    try {
-      historicBatchQuery.tenantIdIn(tenantIds);
-      fail("exception expected");
-    }
-    catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> historicBatchQuery.tenantIdIn(tenantIds)).isInstanceOf(NullValueException.class);
   }
 
   @Test
@@ -225,13 +218,7 @@ class MultiTenancyHistoricBatchQueryTest {
 
     String[] tenantIds = new String[]{ null };
     var historicBatchQuery = historyService.createHistoricBatchQuery();
-    try {
-      historicBatchQuery.tenantIdIn(tenantIds);
-      fail("exception expected");
-    }
-    catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> historicBatchQuery.tenantIdIn(tenantIds)).isInstanceOf(NullValueException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailVariableUpdateQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailVariableUpdateQueryTest.java
@@ -40,11 +40,12 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicDetailByTenantId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 class MultiTenancyHistoricDetailVariableUpdateQueryTest {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailVariableUpdateQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricDetailVariableUpdateQueryTest.java
@@ -40,12 +40,11 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicDetailByTenantId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 class MultiTenancyHistoricDetailVariableUpdateQueryTest {
@@ -161,16 +160,7 @@ class MultiTenancyHistoricDetailVariableUpdateQueryTest {
   void shouldFailQueryByTenantIdNull() {
     var historicDetailQuery = historyService.createHistoricDetailQuery()
         .variableUpdates();
-    try {
-      // when
-      historicDetailQuery.tenantIdIn((String) null);
-
-      fail("expected exception");
-
-      // then
-    } catch (NullValueException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicDetailQuery.tenantIdIn((String) null)).isInstanceOf(NullValueException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricExternalTaskLogTest.java
@@ -44,8 +44,7 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 import static org.operaton.bpm.engine.test.api.runtime.migration.models.ExternalTaskModels.ONE_EXTERNAL_TASK_PROCESS;
 import static org.operaton.bpm.engine.test.api.runtime.migration.models.builder.DefaultExternalTaskModelBuilder.DEFAULT_PROCESS_KEY;
 import static org.operaton.bpm.engine.test.api.runtime.migration.models.builder.DefaultExternalTaskModelBuilder.DEFAULT_TOPIC;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_FULL)
 class MultiTenancyHistoricExternalTaskLogTest {
@@ -156,16 +155,7 @@ class MultiTenancyHistoricExternalTaskLogTest {
   @Test
   void shouldFailQueryByTenantIdNull() {
     var historicExternalTaskLogQuery = historyService.createHistoricExternalTaskLogQuery();
-    try {
-      // when
-      historicExternalTaskLogQuery.tenantIdIn((String) null);
-
-      fail("expected exception");
-
-      // then
-    } catch (NullValueException e) {
-      // test passed
-    }
+    assertThatThrownBy(() -> historicExternalTaskLogQuery.tenantIdIn((String) null)).isInstanceOf(NullValueException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricVariableInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricVariableInstanceQueryTest.java
@@ -37,12 +37,11 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicVariableInstanceByTenantId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_AUDIT)
 class MultiTenancyHistoricVariableInstanceQueryTest {
@@ -146,16 +145,7 @@ class MultiTenancyHistoricVariableInstanceQueryTest {
   @Test
   void shouldFailQueryByTenantIdNull() {
     var historicVariableInstanceQuery = historyService.createHistoricVariableInstanceQuery();
-    try {
-      // when
-      historicVariableInstanceQuery.tenantIdIn((String) null);
-
-      fail("expected exception");
-
-      // then
-    } catch (NullValueException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicVariableInstanceQuery.tenantIdIn((String) null)).isInstanceOf(NullValueException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricVariableInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/multitenancy/query/history/MultiTenancyHistoricVariableInstanceQueryTest.java
@@ -37,11 +37,12 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.historicVariableInstanceByTenantId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @RequiredHistoryLevel(ProcessEngineConfiguration.HISTORY_AUDIT)
 class MultiTenancyHistoricVariableInstanceQueryTest {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessApplicationDeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessApplicationDeploymentTest.java
@@ -100,9 +100,9 @@ class ProcessApplicationDeploymentTest {
   void testEmptyDeployment() {
     var deploymentBuilder = repositoryService.createDeployment(processApplication.getReference());
     var deploymentBuilder2 = repositoryService.createDeployment();
-    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotValidException.class);
+    assertThatThrownBy(deploymentBuilder::deploy).isInstanceOf(NotValidException.class);
 
-    assertThatThrownBy(() -> deploymentBuilder2.deploy()).isInstanceOf(NotValidException.class);
+    assertThatThrownBy(deploymentBuilder2::deploy).isInstanceOf(NotValidException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessApplicationDeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/ProcessApplicationDeploymentTest.java
@@ -50,7 +50,7 @@ import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assume.assumeNotNull;
 
 /**
@@ -100,19 +100,9 @@ class ProcessApplicationDeploymentTest {
   void testEmptyDeployment() {
     var deploymentBuilder = repositoryService.createDeployment(processApplication.getReference());
     var deploymentBuilder2 = repositoryService.createDeployment();
-    try {
-      deploymentBuilder.deploy();
-      fail("it should not be possible to deploy without deployment resources");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotValidException.class);
 
-    try {
-      deploymentBuilder2.deploy();
-      fail("it should not be possible to deploy without deployment resources");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder2.deploy()).isInstanceOf(NotValidException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RedeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RedeploymentTest.java
@@ -88,31 +88,31 @@ public class RedeploymentTest {
       .createDeployment()
       .name(DEPLOYMENT_NAME)
       .addDeploymentResources("not-existing");
-    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(deploymentBuilder::deploy).isInstanceOf(NotFoundException.class);
 
     var deploymentBuilder1 = repositoryService
       .createDeployment()
       .name(DEPLOYMENT_NAME)
       .addDeploymentResourceById("not-existing", "an-id");
-    assertThatThrownBy(() -> deploymentBuilder1.deploy()).isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(deploymentBuilder1::deploy).isInstanceOf(NotFoundException.class);
 
     var deploymentBuilder2 = repositoryService
       .createDeployment()
       .name(DEPLOYMENT_NAME)
       .addDeploymentResourcesById("not-existing", Collections.singletonList("an-id"));
-    assertThatThrownBy(() -> deploymentBuilder2.deploy()).isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(deploymentBuilder2::deploy).isInstanceOf(NotFoundException.class);
 
     var deploymentBuilder3 = repositoryService
       .createDeployment()
       .name(DEPLOYMENT_NAME)
       .addDeploymentResourceByName("not-existing", "a-name");
-    assertThatThrownBy(() -> deploymentBuilder3.deploy()).isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(deploymentBuilder3::deploy).isInstanceOf(NotFoundException.class);
 
     var deploymentBuilder4 = repositoryService
       .createDeployment()
       .name(DEPLOYMENT_NAME)
       .addDeploymentResourcesByName("not-existing", Collections.singletonList("a-name"));
-    assertThatThrownBy(() -> deploymentBuilder4.deploy()).isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(deploymentBuilder4::deploy).isInstanceOf(NotFoundException.class);
   }
 
   @Test
@@ -148,13 +148,13 @@ public class RedeploymentTest {
         .addDeploymentResourcesById(deployment.getId(), Collections.singletonList("not-existing" +
                                                                                       "-resource-id"));
 
-    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(deploymentBuilder::deploy).isInstanceOf(NotFoundException.class);
 
-    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(deploymentBuilder::deploy).isInstanceOf(NotFoundException.class);
 
-    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(deploymentBuilder::deploy).isInstanceOf(NotFoundException.class);
 
-    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(deploymentBuilder::deploy).isInstanceOf(NotFoundException.class);
   }
 
   @Test
@@ -1151,7 +1151,7 @@ public class RedeploymentTest {
           .addDeploymentResources(deployment2.getId());
 
     // when
-    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotValidException.class);
+    assertThatThrownBy(deploymentBuilder::deploy).isInstanceOf(NotValidException.class);
   }
 
   @Test
@@ -1172,7 +1172,7 @@ public class RedeploymentTest {
         .addModelInstance(RESOURCE_1_NAME, model2)
         .addDeploymentResourceByName(deployment1.getId(), RESOURCE_1_NAME);
 
-    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotValidException.class);
+    assertThatThrownBy(deploymentBuilder::deploy).isInstanceOf(NotValidException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RedeploymentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/repository/RedeploymentTest.java
@@ -45,7 +45,7 @@ import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 /**
@@ -88,56 +88,31 @@ public class RedeploymentTest {
       .createDeployment()
       .name(DEPLOYMENT_NAME)
       .addDeploymentResources("not-existing");
-    try {
-      deploymentBuilder.deploy();
-      fail("It should not be able to re-deploy an unexisting deployment");
-    } catch (NotFoundException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotFoundException.class);
 
     var deploymentBuilder1 = repositoryService
       .createDeployment()
       .name(DEPLOYMENT_NAME)
       .addDeploymentResourceById("not-existing", "an-id");
-    try {
-      deploymentBuilder1.deploy();
-      fail("It should not be able to re-deploy an unexisting deployment");
-    } catch (NotFoundException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder1.deploy()).isInstanceOf(NotFoundException.class);
 
     var deploymentBuilder2 = repositoryService
       .createDeployment()
       .name(DEPLOYMENT_NAME)
       .addDeploymentResourcesById("not-existing", Collections.singletonList("an-id"));
-    try {
-      deploymentBuilder2.deploy();
-      fail("It should not be able to re-deploy an unexisting deployment");
-    } catch (NotFoundException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder2.deploy()).isInstanceOf(NotFoundException.class);
 
     var deploymentBuilder3 = repositoryService
       .createDeployment()
       .name(DEPLOYMENT_NAME)
       .addDeploymentResourceByName("not-existing", "a-name");
-    try {
-      deploymentBuilder3.deploy();
-      fail("It should not be able to re-deploy an unexisting deployment");
-    } catch (NotFoundException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder3.deploy()).isInstanceOf(NotFoundException.class);
 
     var deploymentBuilder4 = repositoryService
       .createDeployment()
       .name(DEPLOYMENT_NAME)
       .addDeploymentResourcesByName("not-existing", Collections.singletonList("a-name"));
-    try {
-      deploymentBuilder4.deploy();
-      fail("It should not be able to re-deploy an unexisting deployment");
-    } catch (NotFoundException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder4.deploy()).isInstanceOf(NotFoundException.class);
   }
 
   @Test
@@ -147,40 +122,15 @@ public class RedeploymentTest {
         .name(DEPLOYMENT_NAME);
     var resourceIdList = Collections.singletonList("a-name");
 
-    try {
-      deploymentBuilder.addDeploymentResources(null);
-      fail("It should not be possible to pass a null deployment id");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.addDeploymentResources(null)).isInstanceOf(NotValidException.class);
 
-    try {
-      deploymentBuilder.addDeploymentResourceById(null, "an-id");
-      fail("It should not be possible to pass a null deployment id");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.addDeploymentResourceById(null, "an-id")).isInstanceOf(NotValidException.class);
 
-    try {
-      deploymentBuilder.addDeploymentResourcesById(null, resourceIdList);
-      fail("It should not be possible to pass a null deployment id");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.addDeploymentResourcesById(null, resourceIdList)).isInstanceOf(NotValidException.class);
 
-    try {
-      deploymentBuilder.addDeploymentResourceByName(null, "a-name");
-      fail("It should not be possible to pass a null deployment id");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.addDeploymentResourceByName(null, "a-name")).isInstanceOf(NotValidException.class);
 
-    try {
-      deploymentBuilder.addDeploymentResourcesByName(null, resourceIdList);
-      fail("It should not be possible to pass a null deployment id");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.addDeploymentResourcesByName(null, resourceIdList)).isInstanceOf(NotValidException.class);
   }
 
   @Test
@@ -198,41 +148,13 @@ public class RedeploymentTest {
         .addDeploymentResourcesById(deployment.getId(), Collections.singletonList("not-existing" +
                                                                                       "-resource-id"));
 
-    try {
-      // when
-      deploymentBuilder.deploy();
-      fail("It should not be possible to re-deploy a not existing deployment resource");
-    } catch (NotFoundException e) {
-      // then
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotFoundException.class);
 
-    try {
-      // when
-      deploymentBuilder.deploy();
-      fail("It should not be possible to re-deploy a not existing deployment resource");
-    } catch (NotFoundException e) {
-      // then
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotFoundException.class);
 
-    try {
-      // when
-      deploymentBuilder.deploy();
-      fail("It should not be possible to re-deploy a not existing deployment resource");
-    } catch (NotFoundException e) {
-      // then
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotFoundException.class);
 
-    try {
-      // when
-      deploymentBuilder.deploy();
-      fail("It should not be possible to re-deploy a not existing deployment resource");
-    } catch (NotFoundException e) {
-      // then
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotFoundException.class);
   }
 
   @Test
@@ -242,62 +164,22 @@ public class RedeploymentTest {
         .name(DEPLOYMENT_NAME);
     var listWithNullResourceId = Collections.<String>singletonList(null);
 
-    try {
-      deploymentBuilder.addDeploymentResourceById("an-id", null);
-      fail("It should not be possible to pass a null resource id");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.addDeploymentResourceById("an-id", null)).isInstanceOf(NotValidException.class);
 
-    try {
-      deploymentBuilder.addDeploymentResourcesById("an-id", null);
-      fail("It should not be possible to pass a null resource id");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.addDeploymentResourcesById("an-id", null)).isInstanceOf(NotValidException.class);
 
-    try {
-      deploymentBuilder.addDeploymentResourcesById("an-id", listWithNullResourceId);
-      fail("It should not be possible to pass a null resource id");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.addDeploymentResourcesById("an-id", listWithNullResourceId)).isInstanceOf(NotValidException.class);
 
     ArrayList<String> emptyResourceIds = new ArrayList<>();
-    try {
-      deploymentBuilder.addDeploymentResourcesById("an-id", emptyResourceIds);
-      fail("It should not be possible to pass a null resource id");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.addDeploymentResourcesById("an-id", emptyResourceIds)).isInstanceOf(NotValidException.class);
 
-    try {
-      deploymentBuilder.addDeploymentResourceByName("an-id", null);
-      fail("It should not be possible to pass a null resource name");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.addDeploymentResourceByName("an-id", null)).isInstanceOf(NotValidException.class);
 
-    try {
-      deploymentBuilder.addDeploymentResourcesByName("an-id", null);
-      fail("It should not be possible to pass a null resource name");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.addDeploymentResourcesByName("an-id", null)).isInstanceOf(NotValidException.class);
 
-    try {
-      deploymentBuilder.addDeploymentResourcesByName("an-id", listWithNullResourceId);
-      fail("It should not be possible to pass a null resource name");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.addDeploymentResourcesByName("an-id", listWithNullResourceId)).isInstanceOf(NotValidException.class);
 
-    try {
-      deploymentBuilder.addDeploymentResourcesByName("an-id", emptyResourceIds);
-      fail("It should not be possible to pass a null resource name");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.addDeploymentResourcesByName("an-id", emptyResourceIds)).isInstanceOf(NotValidException.class);
   }
 
   @Test
@@ -334,22 +216,12 @@ public class RedeploymentTest {
     var deploymentBuilder = repositoryService
       .createDeployment()
       .name(DEPLOYMENT_NAME);
-    try {
-      deploymentBuilder.nameFromDeployment("a-deployment-id");
-      fail("Cannot set name() and nameFromDeployment().");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.nameFromDeployment("a-deployment-id")).isInstanceOf(NotValidException.class);
 
     var deploymentBuilder2 = repositoryService
       .createDeployment()
       .nameFromDeployment("a-deployment-id");
-    try {
-      deploymentBuilder2.name(DEPLOYMENT_NAME);
-      fail("Cannot set name() and nameFromDeployment().");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder2.name(DEPLOYMENT_NAME)).isInstanceOf(NotValidException.class);
   }
 
   @Test
@@ -1279,12 +1151,7 @@ public class RedeploymentTest {
           .addDeploymentResources(deployment2.getId());
 
     // when
-    try {
-      deploymentBuilder.deploy();
-      fail("It should not be possible to deploy different resources with same name.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotValidException.class);
   }
 
   @Test
@@ -1305,12 +1172,7 @@ public class RedeploymentTest {
         .addModelInstance(RESOURCE_1_NAME, model2)
         .addDeploymentResourceByName(deployment1.getId(), RESOURCE_1_NAME);
 
-    try {
-      deploymentBuilder.deploy();
-      fail("It should not be possible to deploy different resources with same name.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(NotValidException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CaseInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CaseInstanceQueryTest.java
@@ -455,7 +455,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueEquals("aByteArrayValue", bytes);
 
-    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(caseInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -473,7 +473,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueEquals("aSerializableValue", serializable);
 
-    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(caseInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -590,7 +590,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueNotEquals("aByteArrayValue", bytes);
 
-    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(caseInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -608,7 +608,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueNotEquals("aSerializableValue", serializable);
 
-    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(caseInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -751,7 +751,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueGreaterThan("aByteArrayValue", bytes);
 
-    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(caseInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -769,7 +769,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueGreaterThan("aSerializableValue", serializable);
 
-    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(caseInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -948,7 +948,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueGreaterThanOrEqual("aByteArrayValue", bytes);
 
-    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(caseInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -966,7 +966,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueGreaterThanOrEqual("aSerializableValue", serializable);
 
-    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(caseInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1109,7 +1109,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueLessThan("aByteArrayValue", bytes);
 
-    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(caseInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1127,7 +1127,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueLessThan("aSerializableValue", serializable);
 
-    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(caseInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1306,7 +1306,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueLessThanOrEqual("aByteArrayValue", bytes);
 
-    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(caseInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1324,7 +1324,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueLessThanOrEqual("aSerializableValue", serializable);
 
-    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(caseInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CaseInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/CaseInstanceQueryTest.java
@@ -38,8 +38,7 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.variable.Variables;
 
 import static org.operaton.bpm.engine.test.util.QueryTestHelper.verifyQueryResults;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Roman Smirnov
@@ -145,10 +144,7 @@ class CaseInstanceQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseDefinitionKey(null);
-      fail("Exception expected");
-    } catch (NotValidException e) {}
+    assertThatThrownBy(() -> query.caseDefinitionKey(null)).isInstanceOf(NotValidException.class);
 
   }
 
@@ -175,10 +171,7 @@ class CaseInstanceQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseDefinitionId(null);
-      fail("Exception expected");
-    } catch (NotValidException e) {}
+    assertThatThrownBy(() -> query.caseDefinitionId(null)).isInstanceOf(NotValidException.class);
 
   }
 
@@ -273,10 +266,7 @@ class CaseInstanceQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseInstanceBusinessKey(null);
-      fail("Exception expected");
-    } catch (NotValidException e) {}
+    assertThatThrownBy(() -> query.caseInstanceBusinessKey(null)).isInstanceOf(NotValidException.class);
 
   }
 
@@ -336,10 +326,7 @@ class CaseInstanceQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseInstanceId(null);
-      fail("Exception expected");
-    } catch (NotValidException e) {}
+    assertThatThrownBy(() -> query.caseInstanceId(null)).isInstanceOf(NotValidException.class);
 
   }
 
@@ -468,10 +455,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueEquals("aByteArrayValue", bytes);
 
-    try {
-      caseInstanceQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -489,10 +473,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueEquals("aSerializableValue", serializable);
 
-    try {
-      caseInstanceQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -609,10 +590,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueNotEquals("aByteArrayValue", bytes);
 
-    try {
-      caseInstanceQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -630,10 +608,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueNotEquals("aSerializableValue", serializable);
 
-    try {
-      caseInstanceQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -776,10 +751,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueGreaterThan("aByteArrayValue", bytes);
 
-    try {
-      caseInstanceQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -797,10 +769,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueGreaterThan("aSerializableValue", serializable);
 
-    try {
-      caseInstanceQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -979,10 +948,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueGreaterThanOrEqual("aByteArrayValue", bytes);
 
-    try {
-      caseInstanceQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1000,10 +966,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueGreaterThanOrEqual("aSerializableValue", serializable);
 
-    try {
-      caseInstanceQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1146,10 +1109,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueLessThan("aByteArrayValue", bytes);
 
-    try {
-      caseInstanceQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1167,10 +1127,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueLessThan("aSerializableValue", serializable);
 
-    try {
-      caseInstanceQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1349,10 +1306,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueLessThanOrEqual("aByteArrayValue", bytes);
 
-    try {
-      caseInstanceQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1370,10 +1324,7 @@ class CaseInstanceQueryTest {
     CaseInstanceQuery query = caseService.createCaseInstanceQuery();
     var caseInstanceQuery = query.variableValueLessThanOrEqual("aSerializableValue", serializable);
 
-    try {
-      caseInstanceQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {}
+    assertThatThrownBy(() -> caseInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1611,10 +1562,7 @@ class CaseInstanceQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.superProcessInstanceId(null);
-      fail("");
-    } catch (NotValidException e) {}
+    assertThatThrownBy(() -> query.superProcessInstanceId(null)).isInstanceOf(NotValidException.class);
 
   }
 
@@ -1649,12 +1597,7 @@ class CaseInstanceQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.subProcessInstanceId(null);
-      fail("");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.subProcessInstanceId(null)).isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneCaseTaskCase.cmmn"})
@@ -1677,12 +1620,7 @@ class CaseInstanceQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.superCaseInstanceId(null);
-      fail("");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.superCaseInstanceId(null)).isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneCaseTaskCase.cmmn"})
@@ -1714,12 +1652,7 @@ class CaseInstanceQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.subCaseInstanceId(null);
-      fail("");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.subCaseInstanceId(null)).isInstanceOf(NotValidException.class);
   }
 
   @Test
@@ -1744,12 +1677,7 @@ class CaseInstanceQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.deploymentId(null);
-      fail("");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.deploymentId(null)).isInstanceOf(NotValidException.class);
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ExecutionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ExecutionQueryTest.java
@@ -55,8 +55,7 @@ import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.executio
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.hierarchical;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 
 /**
@@ -161,12 +160,7 @@ class ExecutionQueryTest {
     assertThat(query.list()).hasSize(4);
     assertThat(query.count()).isEqualTo(4);
 
-    try {
-      query.singleResult();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.singleResult()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -232,12 +226,7 @@ class ExecutionQueryTest {
   @Test
   void testQueryInvalidSorting() {
     var executionQuery = runtimeService.createExecutionQuery().orderByProcessDefinitionKey();
-    try {
-      executionQuery.list();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> executionQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1239,12 +1228,7 @@ class ExecutionQueryTest {
 
     assertThat(query.incidentId("invalid").count()).isZero();
 
-    try {
-      query.incidentId(null);
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.incidentId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/runtime/failingProcessCreateOneIncident.bpmn20.xml"})
@@ -1272,12 +1256,7 @@ class ExecutionQueryTest {
 
     assertThat(query.incidentType("invalid").count()).isZero();
 
-    try {
-      query.incidentType(null);
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.incidentType(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/runtime/failingProcessCreateOneIncident.bpmn20.xml"})
@@ -1305,12 +1284,7 @@ class ExecutionQueryTest {
 
     assertThat(query.incidentMessage("invalid").count()).isZero();
 
-    try {
-      query.incidentMessage(null);
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.incidentMessage(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/runtime/failingProcessCreateOneIncident.bpmn20.xml"})
@@ -1336,12 +1310,7 @@ class ExecutionQueryTest {
 
     assertThat(query.incidentMessageLike("invalid").count()).isZero();
 
-    try {
-      query.incidentMessageLike(null);
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.incidentMessageLike(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/runtime/failingSubProcessCreateOneIncident.bpmn20.xml"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ExecutionQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ExecutionQueryTest.java
@@ -160,7 +160,7 @@ class ExecutionQueryTest {
     assertThat(query.list()).hasSize(4);
     assertThat(query.count()).isEqualTo(4);
 
-    assertThatThrownBy(() -> query.singleResult()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -226,7 +226,7 @@ class ExecutionQueryTest {
   @Test
   void testQueryInvalidSorting() {
     var executionQuery = runtimeService.createExecutionQuery().orderByProcessDefinitionKey();
-    assertThatThrownBy(() -> executionQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(executionQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/IncidentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/IncidentQueryTest.java
@@ -490,12 +490,7 @@ public class IncidentQueryTest {
             .isNotEmpty()
             .hasSize(3);
 
-    try {
-      query.singleResult();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // Exception is expected
-    }
+    assertThatThrownBy(() -> query.singleResult()).isInstanceOf(ProcessEngineException.class);
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/IncidentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/IncidentQueryTest.java
@@ -490,7 +490,7 @@ public class IncidentQueryTest {
             .isNotEmpty()
             .hasSize(3);
 
-    assertThatThrownBy(() -> query.singleResult()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
 
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationTest.java
@@ -222,7 +222,7 @@ class ProcessInstanceModificationTest {
     var processInstanceModificationBuilder = runtimeService.createProcessInstanceModification(processInstance.getId()).startBeforeActivity("innerSubProcessTask");
 
     // when I start the inner subprocess task without explicit ancestor
-    assertThatThrownBy(() -> processInstanceModificationBuilder.execute()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(processInstanceModificationBuilder::execute).isInstanceOf(ProcessEngineException.class);
 
     // when I start the inner subprocess task with an explicit ancestor activity
     // instance id
@@ -409,7 +409,7 @@ class ProcessInstanceModificationTest {
     var processInstanceModificationBuilder = runtimeService.createProcessInstanceModification(processInstance.getId()).startTransition("flow5");
 
     // when I start the inner subprocess task without explicit ancestor
-    assertThatThrownBy(() -> processInstanceModificationBuilder.execute()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(processInstanceModificationBuilder::execute).isInstanceOf(ProcessEngineException.class);
 
     // when I start the inner subprocess task with an explicit ancestor activity
     // instance id
@@ -596,7 +596,7 @@ class ProcessInstanceModificationTest {
     var processInstanceModificationBuilder = runtimeService.createProcessInstanceModification(processInstance.getId()).startAfterActivity("innerSubProcessStart");
 
     // when I start the inner subprocess task without explicit ancestor
-    assertThatThrownBy(() -> processInstanceModificationBuilder.execute()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(processInstanceModificationBuilder::execute).isInstanceOf(ProcessEngineException.class);
 
     // when I start the inner subprocess task with an explicit ancestor activity
     // instance id

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceModificationTest.java
@@ -19,7 +19,6 @@ package org.operaton.bpm.engine.test.api.runtime;
 import java.util.Collections;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -47,17 +46,16 @@ import org.operaton.bpm.engine.test.bpmn.tasklistener.util.RecorderTaskListener;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 import org.operaton.bpm.engine.test.standalone.deploy.SingleVariableListener;
+import org.operaton.bpm.engine.test.util.ActivityInstanceAssert;
+import org.operaton.bpm.engine.test.util.ExecutionAssert;
 import org.operaton.bpm.engine.test.util.ExecutionTree;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
-import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.assertThat;
 import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.describeActivityInstanceTree;
-import static org.operaton.bpm.engine.test.util.ExecutionAssert.assertThat;
 import static org.operaton.bpm.engine.test.util.ExecutionAssert.describeExecutionTree;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Thorben Lindhauer
@@ -110,14 +108,14 @@ class ProcessInstanceModificationTest {
     runtimeService.createProcessInstanceModification(processInstance.getId()).cancelActivityInstance(getInstanceIdForActivity(tree, "task1")).execute();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task2").done());
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task2").done());
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree).matches(describeExecutionTree("task2").scope().done());
+    ExecutionAssert.assertThat(executionTree).matches(describeExecutionTree("task2").scope().done());
 
     // complete the process
     completeTasksInOrder("task2");
@@ -168,14 +166,14 @@ class ProcessInstanceModificationTest {
     runtimeService.createProcessInstanceModification(processInstance.getId()).startBeforeActivity("task2").execute();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task2").done());
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task2").done());
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree)
+    ExecutionAssert.assertThat(executionTree)
         .matches(describeExecutionTree(null).scope().child("task1").concurrent().noScope().up().child("task2").concurrent().noScope().done());
 
     assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
@@ -196,14 +194,14 @@ class ProcessInstanceModificationTest {
     runtimeService.createProcessInstanceModification(processInstance.getId()).startBeforeActivity("task2", tree.getId()).execute();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task2").done());
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task2").done());
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree)
+    ExecutionAssert.assertThat(executionTree)
         .matches(describeExecutionTree(null).scope().child("task1").concurrent().noScope().up().child("task2").concurrent().noScope().done());
 
     assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
@@ -224,13 +222,7 @@ class ProcessInstanceModificationTest {
     var processInstanceModificationBuilder = runtimeService.createProcessInstanceModification(processInstance.getId()).startBeforeActivity("innerSubProcessTask");
 
     // when I start the inner subprocess task without explicit ancestor
-    try {
-      processInstanceModificationBuilder.execute();
-      // then the command fails
-      fail("should not succeed because the ancestors are ambiguous");
-    } catch (ProcessEngineException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> processInstanceModificationBuilder.execute()).isInstanceOf(ProcessEngineException.class);
 
     // when I start the inner subprocess task with an explicit ancestor activity
     // instance id
@@ -242,10 +234,10 @@ class ProcessInstanceModificationTest {
 
     // and the trees are correct
     updatedTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(updatedTree)
+    ActivityInstanceAssert.assertThat(updatedTree)
         .hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("subProcess").activity("subProcessTask").endScope()
             .beginScope("subProcess").activity("subProcessTask").beginScope("innerSubProcess").activity("innerSubProcessTask").done());
 
@@ -254,7 +246,7 @@ class ProcessInstanceModificationTest {
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree).matches(describeExecutionTree(null).scope().child(null).concurrent().noScope().child("subProcessTask").scope().up().up()
+    ExecutionAssert.assertThat(executionTree).matches(describeExecutionTree(null).scope().child(null).concurrent().noScope().child("subProcessTask").scope().up().up()
         .child(null).concurrent().noScope().child(null).scope().child("subProcessTask").concurrent().noScope().up().child(null).concurrent().noScope()
         .child("innerSubProcessTask").scope().done());
 
@@ -339,11 +331,11 @@ class ProcessInstanceModificationTest {
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
 
-    assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").done());
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").done());
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree).matches(describeExecutionTree("task1").scope().done());
+    ExecutionAssert.assertThat(executionTree).matches(describeExecutionTree("task1").scope().done());
 
     assertThat(taskService.createTaskQuery().count()).isEqualTo(1);
 
@@ -361,14 +353,14 @@ class ProcessInstanceModificationTest {
     runtimeService.createProcessInstanceModification(processInstance.getId()).startTransition("flow4").execute();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task2").done());
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task2").done());
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree)
+    ExecutionAssert.assertThat(executionTree)
         .matches(describeExecutionTree(null).scope().child("task1").concurrent().noScope().up().child("task2").concurrent().noScope().done());
 
     assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
@@ -389,14 +381,14 @@ class ProcessInstanceModificationTest {
     runtimeService.createProcessInstanceModification(processInstance.getId()).startTransition("flow4", tree.getId()).execute();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task2").done());
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task2").done());
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree)
+    ExecutionAssert.assertThat(executionTree)
         .matches(describeExecutionTree(null).scope().child("task1").concurrent().noScope().up().child("task2").concurrent().noScope().done());
 
     assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
@@ -417,13 +409,7 @@ class ProcessInstanceModificationTest {
     var processInstanceModificationBuilder = runtimeService.createProcessInstanceModification(processInstance.getId()).startTransition("flow5");
 
     // when I start the inner subprocess task without explicit ancestor
-    try {
-      processInstanceModificationBuilder.execute();
-      // then the command fails
-      fail("should not succeed because the ancestors are ambiguous");
-    } catch (ProcessEngineException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> processInstanceModificationBuilder.execute()).isInstanceOf(ProcessEngineException.class);
 
     // when I start the inner subprocess task with an explicit ancestor activity
     // instance id
@@ -435,10 +421,10 @@ class ProcessInstanceModificationTest {
 
     // and the trees are correct
     updatedTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(updatedTree)
+    ActivityInstanceAssert.assertThat(updatedTree)
         .hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("subProcess").activity("subProcessTask").endScope()
             .beginScope("subProcess").activity("subProcessTask").beginScope("innerSubProcess").activity("innerSubProcessTask").done());
 
@@ -447,7 +433,7 @@ class ProcessInstanceModificationTest {
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree).matches(describeExecutionTree(null).scope().child(null).concurrent().noScope().child("subProcessTask").scope().up().up()
+    ExecutionAssert.assertThat(executionTree).matches(describeExecutionTree(null).scope().child(null).concurrent().noScope().child("subProcessTask").scope().up().up()
         .child(null).concurrent().noScope().child(null).scope().child("subProcessTask").concurrent().noScope().up().child(null).concurrent().noScope()
         .child("innerSubProcessTask").scope().done());
 
@@ -509,14 +495,14 @@ class ProcessInstanceModificationTest {
     runtimeService.createProcessInstanceModification(processInstance.getId()).startTransition("flow2").execute();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task1").done());
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task1").done());
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree)
+    ExecutionAssert.assertThat(executionTree)
         .matches(describeExecutionTree(null).scope().child("task1").concurrent().noScope().up().child("task1").concurrent().noScope().done());
 
     assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
@@ -554,14 +540,14 @@ class ProcessInstanceModificationTest {
     runtimeService.createProcessInstanceModification(processInstance.getId()).startAfterActivity("theStart").execute();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task1").done());
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task1").done());
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree)
+    ExecutionAssert.assertThat(executionTree)
         .matches(describeExecutionTree(null).scope().child("task1").concurrent().noScope().up().child("task1").concurrent().noScope().done());
 
     assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
@@ -582,14 +568,14 @@ class ProcessInstanceModificationTest {
     runtimeService.createProcessInstanceModification(processInstance.getId()).startAfterActivity("theStart", tree.getId()).execute();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task1").done());
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task1").done());
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree)
+    ExecutionAssert.assertThat(executionTree)
         .matches(describeExecutionTree(null).scope().child("task1").concurrent().noScope().up().child("task1").concurrent().noScope().done());
 
     assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
@@ -610,13 +596,7 @@ class ProcessInstanceModificationTest {
     var processInstanceModificationBuilder = runtimeService.createProcessInstanceModification(processInstance.getId()).startAfterActivity("innerSubProcessStart");
 
     // when I start the inner subprocess task without explicit ancestor
-    try {
-      processInstanceModificationBuilder.execute();
-      // then the command fails
-      fail("should not succeed because the ancestors are ambiguous");
-    } catch (ProcessEngineException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> processInstanceModificationBuilder.execute()).isInstanceOf(ProcessEngineException.class);
 
     // when I start the inner subprocess task with an explicit ancestor activity
     // instance id
@@ -628,10 +608,10 @@ class ProcessInstanceModificationTest {
 
     // and the trees are correct
     updatedTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(updatedTree)
+    ActivityInstanceAssert.assertThat(updatedTree)
         .hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("subProcess").activity("subProcessTask").endScope()
             .beginScope("subProcess").activity("subProcessTask").beginScope("innerSubProcess").activity("innerSubProcessTask").done());
 
@@ -640,7 +620,7 @@ class ProcessInstanceModificationTest {
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree).matches(describeExecutionTree(null).scope().child(null).concurrent().noScope().child("subProcessTask").scope().up().up()
+    ExecutionAssert.assertThat(executionTree).matches(describeExecutionTree(null).scope().child(null).concurrent().noScope().child("subProcessTask").scope().up().up()
         .child(null).concurrent().noScope().child(null).scope().child("subProcessTask").concurrent().noScope().up().child(null).concurrent().noScope()
         .child("innerSubProcessTask").scope().done());
 
@@ -758,14 +738,14 @@ class ProcessInstanceModificationTest {
     runtimeService.createProcessInstanceModification(processInstance.getId()).startBeforeActivity("theTask").execute();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("theTask").activity("theTask").done());
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("theTask").activity("theTask").done());
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree).matches(describeExecutionTree(null).scope().child(null).concurrent().noScope().child("theTask").scope().up().up().child(null)
+    ExecutionAssert.assertThat(executionTree).matches(describeExecutionTree(null).scope().child(null).concurrent().noScope().child("theTask").scope().up().up().child(null)
         .concurrent().noScope().child("theTask").scope().done());
 
     assertThat(taskService.createTaskQuery().count()).isEqualTo(2);
@@ -784,27 +764,27 @@ class ProcessInstanceModificationTest {
     runtimeService.createProcessInstanceModification(processInstance.getId()).startAfterActivity("theTask").execute();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("theTask").done());
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("theTask").done());
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree).matches(describeExecutionTree(null).scope().child("theTask").scope().done());
+    ExecutionAssert.assertThat(executionTree).matches(describeExecutionTree(null).scope().child("theTask").scope().done());
 
     // when starting after the start event, regular concurrency happens
     runtimeService.createProcessInstanceModification(processInstance.getId()).startAfterActivity("theStart").execute();
 
     updatedTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("theTask").activity("theTask").done());
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("theTask").activity("theTask").done());
 
     executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree).matches(describeExecutionTree(null).scope().child(null).concurrent().noScope().child("theTask").scope().up().up().child(null)
+    ExecutionAssert.assertThat(executionTree).matches(describeExecutionTree(null).scope().child(null).concurrent().noScope().child("theTask").scope().up().up().child(null)
         .concurrent().noScope().child("theTask").scope().done());
 
     completeTasksInOrder("theTask", "theTask");
@@ -856,10 +836,10 @@ class ProcessInstanceModificationTest {
 
     // assert activity instance tree
     ActivityInstance activityInstanceTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(activityInstanceTree).isNotNull();
+    assertThat(activityInstanceTree).isNotNull();
     assertThat(activityInstanceTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(activityInstanceTree).hasStructure(
+    ActivityInstanceAssert.assertThat(activityInstanceTree).hasStructure(
         describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("outerTask").beginScope("subProcess").activity("innerTask").done());
 
     // assert listener invocations
@@ -1101,14 +1081,14 @@ class ProcessInstanceModificationTest {
     RecorderExecutionListener.clear();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(instance.getId());
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(instance.getId());
 
-    assertThat(updatedTree).hasStructure(describeActivityInstanceTree(instance.getProcessDefinitionId()).activity("task1").activity("task2").done());
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(describeActivityInstanceTree(instance.getProcessDefinitionId()).activity("task1").activity("task2").done());
 
     ExecutionTree executionTree = ExecutionTree.forExecution(instance.getId(), processEngine);
 
-    assertThat(executionTree)
+    ExecutionAssert.assertThat(executionTree)
         .matches(describeExecutionTree(null).scope().child("task1").concurrent().noScope().up().child("task2").concurrent().noScope().done());
 
     completeTasksInOrder("task1", "task2", "task2");
@@ -1135,14 +1115,14 @@ class ProcessInstanceModificationTest {
     RecorderExecutionListener.clear();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(instance.getId());
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
     assertThat(updatedTree.getProcessInstanceId()).isEqualTo(instance.getId());
 
-    assertThat(updatedTree).hasStructure(describeActivityInstanceTree(instance.getProcessDefinitionId()).activity("task1").activity("task2").done());
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(describeActivityInstanceTree(instance.getProcessDefinitionId()).activity("task1").activity("task2").done());
 
     ExecutionTree executionTree = ExecutionTree.forExecution(instance.getId(), processEngine);
 
-    assertThat(executionTree)
+    ExecutionAssert.assertThat(executionTree)
         .matches(describeExecutionTree(null).scope().child("task1").concurrent().noScope().up().child("task2").concurrent().noScope().done());
 
     completeTasksInOrder("task1", "task2", "task2");
@@ -1159,11 +1139,11 @@ class ProcessInstanceModificationTest {
         .setVariablesLocal(Variables.createVariables().putValue("localMapVar", "localMapValue")).execute();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(processInstance.getId());
-    Assertions.assertThat(updatedTree).isNotNull();
-    assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task2").done());
+    assertThat(updatedTree).isNotNull();
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task1").activity("task2").done());
 
     ActivityInstance task2Instance = getChildInstanceForActivity(updatedTree, "task2");
-    Assertions.assertThat(task2Instance).isNotNull();
+    assertThat(task2Instance).isNotNull();
     assertThat(task2Instance.getExecutionIds()).hasSize(1);
     String task2ExecutionId = task2Instance.getExecutionIds()[0];
 
@@ -1189,14 +1169,14 @@ class ProcessInstanceModificationTest {
         .startBeforeActivity("task2").execute();
 
     ActivityInstance activityInstanceTree = runtimeService.getActivityInstance(processInstanceId);
-    Assertions.assertThat(activityInstanceTree).isNotNull();
+    assertThat(activityInstanceTree).isNotNull();
     assertThat(activityInstanceTree.getProcessInstanceId()).isEqualTo(processInstanceId);
 
-    assertThat(activityInstanceTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task2").done());
+    ActivityInstanceAssert.assertThat(activityInstanceTree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).activity("task2").done());
 
     ExecutionTree executionTree = ExecutionTree.forExecution(processInstanceId, processEngine);
 
-    assertThat(executionTree).matches(describeExecutionTree("task2").scope().done());
+    ExecutionAssert.assertThat(executionTree).matches(describeExecutionTree("task2").scope().done());
 
     completeTasksInOrder("task2");
     testRule.assertProcessEnded(processInstanceId);
@@ -1290,19 +1270,19 @@ class ProcessInstanceModificationTest {
     assertThat(task.getTaskDefinitionKey()).isEqualTo("undoTask");
 
     ActivityInstance tree = runtimeService.getActivityInstance(processInstance.getId());
-    assertThat(tree)
+    ActivityInstanceAssert.assertThat(tree)
         .hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("txEnd").activity("undoTask").done());
 
     runtimeService.createProcessInstanceModification(processInstance.getId()).startBeforeActivity("userTask").execute();
 
     tree = runtimeService.getActivityInstance(processInstance.getId());
-    assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("txEnd").activity("undoTask")
+    ActivityInstanceAssert.assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("txEnd").activity("undoTask")
         .activity("userTask").done());
 
     completeTasksInOrder("userTask");
 
     tree = runtimeService.getActivityInstance(processInstance.getId());
-    assertThat(tree)
+    ActivityInstanceAssert.assertThat(tree)
         .hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("txEnd").activity("undoTask").done());
 
     Task newTask = taskService.createTaskQuery().singleResult();
@@ -1323,7 +1303,7 @@ class ProcessInstanceModificationTest {
     assertThat(task.getTaskDefinitionKey()).isEqualTo("undoTask");
 
     ActivityInstance tree = runtimeService.getActivityInstance(processInstance.getId());
-    assertThat(tree)
+    ActivityInstanceAssert.assertThat(tree)
         .hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("txEnd").activity("undoTask").done());
 
     runtimeService.createProcessInstanceModification(processInstance.getId()).startBeforeActivity("userTask", processInstance.getId()).execute();
@@ -1331,7 +1311,7 @@ class ProcessInstanceModificationTest {
     completeTasksInOrder("userTask");
 
     tree = runtimeService.getActivityInstance(processInstance.getId());
-    assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("txEnd").activity("undoTask")
+    ActivityInstanceAssert.assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("txEnd").activity("undoTask")
         .endScope().beginScope("tx").activity("txEnd").activity("undoTask").done());
 
     completeTasksInOrder("undoTask", "undoTask", "afterCancel", "afterCancel");
@@ -1382,7 +1362,7 @@ class ProcessInstanceModificationTest {
         .startBeforeActivity("userTask").execute();
 
     tree = runtimeService.getActivityInstance(processInstance.getId());
-    assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("userTask").done());
+    ActivityInstanceAssert.assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("userTask").done());
 
     completeTasksInOrder("userTask", "undoTask", "afterCancel");
 
@@ -1401,7 +1381,7 @@ class ProcessInstanceModificationTest {
         .startBeforeActivity("userTask", processInstance.getId()).execute();
 
     tree = runtimeService.getActivityInstance(processInstance.getId());
-    assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("userTask").done());
+    ActivityInstanceAssert.assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("userTask").done());
 
     completeTasksInOrder("userTask", "undoTask", "afterCancel");
 
@@ -1420,7 +1400,7 @@ class ProcessInstanceModificationTest {
         .cancelActivityInstance(getInstanceIdForActivity(tree, "undoTask")).execute();
 
     tree = runtimeService.getActivityInstance(processInstance.getId());
-    assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("userTask").done());
+    ActivityInstanceAssert.assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("userTask").done());
 
     completeTasksInOrder("userTask", "undoTask", "afterCancel");
 
@@ -1455,7 +1435,7 @@ class ProcessInstanceModificationTest {
     runtimeService.createProcessInstanceModification(processInstance.getId()).startBeforeActivity("undoTask").execute();
 
     ActivityInstance tree = runtimeService.getActivityInstance(processInstance.getId());
-    assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("txEnd").activity("undoTask")
+    ActivityInstanceAssert.assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("txEnd").activity("undoTask")
         .activity("undoTask").done());
 
     taskService.complete(firstUndoTask.getId());
@@ -1479,7 +1459,7 @@ class ProcessInstanceModificationTest {
     runtimeService.createProcessInstanceModification(processInstance.getId()).startBeforeActivity("undoTask").setVariableLocal("new", true).execute();
 
     ActivityInstance tree = runtimeService.getActivityInstance(processInstance.getId());
-    assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("txEnd").activity("undoTask")
+    ActivityInstanceAssert.assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("txEnd").activity("undoTask")
         .activity("undoTask").done());
 
     String taskExecutionId = runtimeService.createExecutionQuery().variableValueEquals("new", true).singleResult().getId();
@@ -1490,7 +1470,7 @@ class ProcessInstanceModificationTest {
     taskService.complete(secondUndoTask.getId());
 
     tree = runtimeService.getActivityInstance(processInstance.getId());
-    assertThat(tree)
+    ActivityInstanceAssert.assertThat(tree)
         .hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("txEnd").activity("undoTask").done());
 
     completeTasksInOrder("undoTask", "afterCancel");
@@ -1566,7 +1546,7 @@ class ProcessInstanceModificationTest {
     runtimeService.createProcessInstanceModification(processInstance.getId()).startBeforeActivity("afterCancel").execute();
 
     ActivityInstance tree = runtimeService.getActivityInstance(processInstance.getId());
-    assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("txEnd").activity("undoTask")
+    ActivityInstanceAssert.assertThat(tree).hasStructure(describeActivityInstanceTree(processInstance.getProcessDefinitionId()).beginScope("tx").activity("txEnd").activity("undoTask")
         .endScope().activity("afterCancel").done());
 
     completeTasksInOrder("afterCancel", "undoTask", "afterCancel");

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -187,7 +187,7 @@ public class ProcessInstanceQueryTest {
   @Test
   void testQueryNoSpecificsSingleResult() {
     ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery();
-    assertThatThrownBy(() -> query.singleResult()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -213,7 +213,7 @@ public class ProcessInstanceQueryTest {
     assertThat(query.count()).isEqualTo(4);
     assertThat(query.list()).hasSize(4);
 
-    assertThatThrownBy(() -> query.singleResult()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -480,7 +480,7 @@ public class ProcessInstanceQueryTest {
   @Test
   void testQueryInvalidSorting() {
     var processInstanceQuery = runtimeService.createProcessInstanceQuery().orderByProcessDefinitionId();
-    assertThatThrownBy(() -> processInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(processInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -61,8 +61,7 @@ import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.processI
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.processInstanceByProcessInstanceId;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
 import static java.util.Collections.emptySet;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Joram Barrez
@@ -188,12 +187,7 @@ public class ProcessInstanceQueryTest {
   @Test
   void testQueryNoSpecificsSingleResult() {
     ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery();
-    try {
-      query.singleResult();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // Exception is expected
-    }
+    assertThatThrownBy(() -> query.singleResult()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -219,12 +213,7 @@ public class ProcessInstanceQueryTest {
     assertThat(query.count()).isEqualTo(4);
     assertThat(query.list()).hasSize(4);
 
-    try {
-      query.singleResult();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // Exception is expected
-    }
+    assertThatThrownBy(() -> query.singleResult()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -287,25 +276,13 @@ public class ProcessInstanceQueryTest {
   @Test
   void testQueryByOneInvalidProcessDefinitionKeyIn() {
     var processInstanceQuery = runtimeService.createProcessInstanceQuery();
-    try {
-      // when
-      processInstanceQuery.processDefinitionKeyIn((String) null);
-      fail("Exception expected");
-    } catch(ProcessEngineException expected) {
-      // then Exception is expected
-    }
+    assertThatThrownBy(() -> processInstanceQuery.processDefinitionKeyIn((String) null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testQueryByMultipleInvalidProcessDefinitionKeyIn() {
     var processInstanceQuery = runtimeService.createProcessInstanceQuery();
-    try {
-      // when
-      processInstanceQuery.processDefinitionKeyIn(PROCESS_DEFINITION_KEY, null);
-      fail("Exception expected");
-    } catch(ProcessEngineException expected) {
-      // Exception is expected
-    }
+    assertThatThrownBy(() -> processInstanceQuery.processDefinitionKeyIn(PROCESS_DEFINITION_KEY, null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -343,25 +320,13 @@ public class ProcessInstanceQueryTest {
   @Test
   void testQueryByOneInvalidProcessDefinitionKeyNotIn() {
     var processInstanceQuery = runtimeService.createProcessInstanceQuery();
-    try {
-      // when
-      processInstanceQuery.processDefinitionKeyNotIn((String) null);
-      fail("Exception expected");
-    } catch(ProcessEngineException expected) {
-      // then Exception is expected
-    }
+    assertThatThrownBy(() -> processInstanceQuery.processDefinitionKeyNotIn((String) null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testQueryByMultipleInvalidProcessDefinitionKeyNotIn() {
     var processInstanceQuery = runtimeService.createProcessInstanceQuery();
-    try {
-      // when
-      processInstanceQuery.processDefinitionKeyNotIn(PROCESS_DEFINITION_KEY, null);
-      fail("Exception expected");
-    } catch(ProcessEngineException expected) {
-      // then Exception is expected
-    }
+    assertThatThrownBy(() -> processInstanceQuery.processDefinitionKeyNotIn(PROCESS_DEFINITION_KEY, null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -515,12 +480,7 @@ public class ProcessInstanceQueryTest {
   @Test
   void testQueryInvalidSorting() {
     var processInstanceQuery = runtimeService.createProcessInstanceQuery().orderByProcessDefinitionId();
-    try {
-      processInstanceQuery.list(); // asc - desc not called -> exception
-      fail("Exception expected");
-    }catch (ProcessEngineException ignored) {
-      // expected
-    }
+    assertThatThrownBy(() -> processInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1501,12 +1461,7 @@ public class ProcessInstanceQueryTest {
 
     assertThat(query.incidentId("invalid").count()).isZero();
 
-    try {
-      query.incidentId(null);
-      fail("Exception expected");
-    } catch (ProcessEngineException ignored) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.incidentId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1534,12 +1489,7 @@ public class ProcessInstanceQueryTest {
 
     assertThat(query.incidentType("invalid").count()).isZero();
 
-    try {
-      query.incidentType(null);
-      fail("Exception expected");
-    } catch (ProcessEngineException ignored) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.incidentType(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1567,12 +1517,7 @@ public class ProcessInstanceQueryTest {
 
     assertThat(query.incidentMessage("invalid").count()).isZero();
 
-    try {
-      query.incidentMessage(null);
-      fail("Exception expected");
-    } catch (ProcessEngineException ignored) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.incidentMessage(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1598,12 +1543,7 @@ public class ProcessInstanceQueryTest {
 
     assertThat(query.incidentMessageLike("invalid").count()).isZero();
 
-    try {
-      query.incidentMessageLike(null);
-      fail("Exception expected");
-    } catch (ProcessEngineException ignored) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.incidentMessageLike(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1716,12 +1656,7 @@ public class ProcessInstanceQueryTest {
 
     assertThat(query.count()).isZero();
 
-    try {
-      query.caseInstanceId(null);
-      fail("The passed case instance should not be null.");
-    } catch (Exception ignored) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.caseInstanceId(null)).isInstanceOf(Exception.class);
 
   }
 
@@ -1860,12 +1795,7 @@ public class ProcessInstanceQueryTest {
     assertThat(query.superProcessInstanceId("invalid").singleResult()).isNull();
     assertThat(query.superProcessInstanceId("invalid").list()).isEmpty();
 
-    try {
-      query.superCaseInstanceId(null);
-      fail("Exception expected");
-    } catch (NullValueException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.superCaseInstanceId(null)).isInstanceOf(NullValueException.class);
   }
 
   @Test
@@ -1925,12 +1855,7 @@ public class ProcessInstanceQueryTest {
     assertThat(query.subProcessInstanceId("invalid").singleResult()).isNull();
     assertThat(query.subProcessInstanceId("invalid").list()).isEmpty();
 
-    try {
-      query.subCaseInstanceId(null);
-      fail("Exception expected");
-    } catch (NullValueException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.subCaseInstanceId(null)).isInstanceOf(NullValueException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceSuspensionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstanceSuspensionTest.java
@@ -50,8 +50,7 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 
 import static java.util.Collections.emptyMap;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Daniel Meyer
@@ -757,12 +756,7 @@ class ProcessInstanceSuspensionTest {
     runtimeService.suspendProcessInstanceById(processInstance.getId());
     var taskQuery = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId();
 
-    try {
-      formService.submitTaskFormData(taskQuery, emptyProperties);
-      fail("Exception expected");
-    } catch(SuspendedEntityInteractionException e) {
-      // This is expected
-    }
+    assertThatThrownBy(() -> formService.submitTaskFormData(taskQuery, emptyProperties)).isInstanceOf(SuspendedEntityInteractionException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
@@ -773,12 +767,7 @@ class ProcessInstanceSuspensionTest {
     runtimeService.suspendProcessInstanceByProcessDefinitionId(processDefinition.getId());
     var taskQuery = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId();
 
-    try {
-      formService.submitTaskFormData(taskQuery, emptyProperties);
-      fail("");
-    } catch(SuspendedEntityInteractionException e) {
-      // This is expected
-    }
+    assertThatThrownBy(() -> formService.submitTaskFormData(taskQuery, emptyProperties)).isInstanceOf(SuspendedEntityInteractionException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
@@ -789,12 +778,7 @@ class ProcessInstanceSuspensionTest {
     runtimeService.suspendProcessInstanceByProcessDefinitionKey(processDefinition.getKey());
     var taskQuery = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult().getId();
 
-    try {
-      formService.submitTaskFormData(taskQuery, emptyProperties);
-      fail("");
-    } catch(SuspendedEntityInteractionException e) {
-      // This is expected
-    }
+    assertThatThrownBy(() -> formService.submitTaskFormData(taskQuery, emptyProperties)).isInstanceOf(SuspendedEntityInteractionException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
@@ -1108,103 +1092,42 @@ class ProcessInstanceSuspensionTest {
     runtimeService.suspendProcessInstanceById(processInstance.getId());
 
     // Completing the task should fail
-    try {
-      taskService.complete(taskId);
-      fail("It is not allowed to complete a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.complete(taskId)).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Claiming the task should fail
-    try {
-      taskService.claim(taskId, "jos");
-      fail("It is not allowed to claim a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
-
+    assertThatThrownBy(() -> taskService.claim(taskId, "jos")).isInstanceOf(SuspendedEntityInteractionException.class);
 
 
     // Adding candidate groups on the task should fail
-    try {
-      taskService.addCandidateGroup(taskId, "blahGroup");
-      fail("It is not allowed to add a candidate group on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.addCandidateGroup(taskId, "blahGroup")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Adding candidate users on the task should fail
-    try {
-      taskService.addCandidateUser(taskId, "blahUser");
-      fail("It is not allowed to add a candidate user on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.addCandidateUser(taskId, "blahUser")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Adding group identity links on the task should fail
-    try {
-      taskService.addGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE);
-      fail("It is not allowed to add a candidate user on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.addGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE)).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Adding an identity link on the task should fail
-    try {
-      taskService.addUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER);
-      fail("It is not allowed to add an identityLink on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.addUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER)).isInstanceOf(SuspendedEntityInteractionException.class);
 
 
     // Set an assignee on the task should fail
-    try {
-      taskService.setAssignee(taskId, "mispiggy");
-      fail("It is not allowed to set an assignee on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.setAssignee(taskId, "mispiggy")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Set an owner on the task should fail
-    try {
-      taskService.setOwner(taskId, "kermit");
-      fail("It is not allowed to set an owner on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.setOwner(taskId, "kermit")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Removing candidate groups on the task should fail
-    try {
-      taskService.deleteCandidateGroup(taskId, "blahGroup");
-      fail("It is not allowed to remove a candidate group on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.deleteCandidateGroup(taskId, "blahGroup")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Removing candidate users on the task should fail
-    try {
-      taskService.deleteCandidateUser(taskId, "blahUser");
-      fail("It is not allowed to remove a candidate user on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.deleteCandidateUser(taskId, "blahUser")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Removing group identity links on the task should fail
-    try {
-      taskService.deleteGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE);
-      fail("It is not allowed to remove a candidate user on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.deleteGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE)).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Removing an identity link on the task should fail
-    try {
-      taskService.deleteUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER);
-      fail("It is not allowed to remove an identityLink on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.deleteUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER)).isInstanceOf(SuspendedEntityInteractionException.class);
 
   }
 
@@ -1223,103 +1146,42 @@ class ProcessInstanceSuspensionTest {
     runtimeService.suspendProcessInstanceByProcessDefinitionId(processDefinition.getId());
 
     // Completing the task should fail
-    try {
-      taskService.complete(taskId);
-      fail("It is not allowed to complete a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.complete(taskId)).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Claiming the task should fail
-    try {
-      taskService.claim(taskId, "jos");
-      fail("It is not allowed to claim a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
-
+    assertThatThrownBy(() -> taskService.claim(taskId, "jos")).isInstanceOf(SuspendedEntityInteractionException.class);
 
 
     // Adding candidate groups on the task should fail
-    try {
-      taskService.addCandidateGroup(taskId, "blahGroup");
-      fail("It is not allowed to add a candidate group on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.addCandidateGroup(taskId, "blahGroup")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Adding candidate users on the task should fail
-    try {
-      taskService.addCandidateUser(taskId, "blahUser");
-      fail("It is not allowed to add a candidate user on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.addCandidateUser(taskId, "blahUser")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Adding group identity links on the task should fail
-    try {
-      taskService.addGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE);
-      fail("It is not allowed to add a candidate user on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.addGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE)).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Adding an identity link on the task should fail
-    try {
-      taskService.addUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER);
-      fail("It is not allowed to add an identityLink on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.addUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER)).isInstanceOf(SuspendedEntityInteractionException.class);
 
 
     // Set an assignee on the task should fail
-    try {
-      taskService.setAssignee(taskId, "mispiggy");
-      fail("It is not allowed to set an assignee on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.setAssignee(taskId, "mispiggy")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Set an owner on the task should fail
-    try {
-      taskService.setOwner(taskId, "kermit");
-      fail("It is not allowed to set an owner on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.setOwner(taskId, "kermit")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Removing candidate groups on the task should fail
-    try {
-      taskService.deleteCandidateGroup(taskId, "blahGroup");
-      fail("It is not allowed to remove a candidate group on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.deleteCandidateGroup(taskId, "blahGroup")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Removing candidate users on the task should fail
-    try {
-      taskService.deleteCandidateUser(taskId, "blahUser");
-      fail("It is not allowed to remove a candidate user on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.deleteCandidateUser(taskId, "blahUser")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Removing group identity links on the task should fail
-    try {
-      taskService.deleteGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE);
-      fail("It is not allowed to remove a candidate user on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.deleteGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE)).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Removing an identity link on the task should fail
-    try {
-      taskService.deleteUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER);
-      fail("It is not allowed to remove an identityLink on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.deleteUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER)).isInstanceOf(SuspendedEntityInteractionException.class);
 
   }
 
@@ -1338,103 +1200,42 @@ class ProcessInstanceSuspensionTest {
     runtimeService.suspendProcessInstanceByProcessDefinitionKey(processDefinition.getKey());
 
     // Completing the task should fail
-    try {
-      taskService.complete(taskId);
-      fail("It is not allowed to complete a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.complete(taskId)).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Claiming the task should fail
-    try {
-      taskService.claim(taskId, "jos");
-      fail("It is not allowed to claim a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
-
+    assertThatThrownBy(() -> taskService.claim(taskId, "jos")).isInstanceOf(SuspendedEntityInteractionException.class);
 
 
     // Adding candidate groups on the task should fail
-    try {
-      taskService.addCandidateGroup(taskId, "blahGroup");
-      fail("It is not allowed to add a candidate group on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.addCandidateGroup(taskId, "blahGroup")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Adding candidate users on the task should fail
-    try {
-      taskService.addCandidateUser(taskId, "blahUser");
-      fail("It is not allowed to add a candidate user on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.addCandidateUser(taskId, "blahUser")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Adding group identity links on the task should fail
-    try {
-      taskService.addGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE);
-      fail("It is not allowed to add a candidate user on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.addGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE)).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Adding an identity link on the task should fail
-    try {
-      taskService.addUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER);
-      fail("It is not allowed to add an identityLink on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.addUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER)).isInstanceOf(SuspendedEntityInteractionException.class);
 
 
     // Set an assignee on the task should fail
-    try {
-      taskService.setAssignee(taskId, "mispiggy");
-      fail("It is not allowed to set an assignee on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.setAssignee(taskId, "mispiggy")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Set an owner on the task should fail
-    try {
-      taskService.setOwner(taskId, "kermit");
-      fail("It is not allowed to set an owner on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.setOwner(taskId, "kermit")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Removing candidate groups on the task should fail
-    try {
-      taskService.deleteCandidateGroup(taskId, "blahGroup");
-      fail("It is not allowed to remove a candidate group on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.deleteCandidateGroup(taskId, "blahGroup")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Removing candidate users on the task should fail
-    try {
-      taskService.deleteCandidateUser(taskId, "blahUser");
-      fail("It is not allowed to remove a candidate user on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.deleteCandidateUser(taskId, "blahUser")).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Removing group identity links on the task should fail
-    try {
-      taskService.deleteGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE);
-      fail("It is not allowed to remove a candidate user on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.deleteGroupIdentityLink(taskId, "blahGroup", IdentityLinkType.CANDIDATE)).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // Removing an identity link on the task should fail
-    try {
-      taskService.deleteUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER);
-      fail("It is not allowed to remove an identityLink on a task of a suspended process instance");
-    } catch (SuspendedEntityInteractionException e) {
-      // This is good
-    }
+    assertThatThrownBy(() -> taskService.deleteUserIdentityLink(taskId, "blahUser", IdentityLinkType.OWNER)).isInstanceOf(SuspendedEntityInteractionException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
@@ -1448,12 +1249,7 @@ class ProcessInstanceSuspensionTest {
     Task subTask = taskService.newTask("someTaskId");
     subTask.setParentTaskId(task.getId());
 
-    try {
-      taskService.saveTask(subTask);
-      fail("Creating sub tasks for suspended task should not be possible");
-    } catch (SuspendedEntityInteractionException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskService.saveTask(subTask)).isInstanceOf(SuspendedEntityInteractionException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
@@ -1467,12 +1263,7 @@ class ProcessInstanceSuspensionTest {
     Task subTask = taskService.newTask("someTaskId");
     subTask.setParentTaskId(task.getId());
 
-    try {
-      taskService.saveTask(subTask);
-      fail("Creating sub tasks for suspended task should not be possible");
-    } catch (SuspendedEntityInteractionException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskService.saveTask(subTask)).isInstanceOf(SuspendedEntityInteractionException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
@@ -1486,12 +1277,7 @@ class ProcessInstanceSuspensionTest {
     Task subTask = taskService.newTask("someTaskId");
     subTask.setParentTaskId(task.getId());
 
-    try {
-      taskService.saveTask(subTask);
-      fail("Creating sub tasks for suspended task should not be possible");
-    } catch (SuspendedEntityInteractionException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskService.saveTask(subTask)).isInstanceOf(SuspendedEntityInteractionException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})
@@ -1849,12 +1635,7 @@ class ProcessInstanceSuspensionTest {
     Task task = taskService.createTaskQuery().singleResult();
     var taskId = task.getId();
 
-    try {
-      taskService.complete(taskId);
-      fail("this should not be successful, as the execution of a suspended instance is resumed");
-    } catch (SuspendedEntityInteractionException e) {
-      // this is expected to fail
-    }
+    assertThatThrownBy(() -> taskService.complete(taskId)).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // should be successful after reactivation
     runtimeService.activateProcessInstanceById(instance.getId());
@@ -1873,12 +1654,7 @@ class ProcessInstanceSuspensionTest {
     Task task = taskService.createTaskQuery().singleResult();
     var taskId = task.getId();
 
-    try {
-      taskService.complete(taskId);
-      fail("this should not be successful, as the execution of a suspended instance is resumed");
-    } catch (SuspendedEntityInteractionException e) {
-      // this is expected to fail
-    }
+    assertThatThrownBy(() -> taskService.complete(taskId)).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // should be successful after reactivation
     runtimeService.activateProcessInstanceByProcessDefinitionId(instance.getProcessDefinitionId());
@@ -1902,12 +1678,7 @@ class ProcessInstanceSuspensionTest {
     Task task = taskService.createTaskQuery().singleResult();
     var taskId = task.getId();
 
-    try {
-      taskService.complete(taskId);
-      fail("this should not be successful, as the execution of a suspended instance is resumed");
-    } catch (SuspendedEntityInteractionException e) {
-      // this is expected to fail
-    }
+    assertThatThrownBy(() -> taskService.complete(taskId)).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // should be successful after reactivation
     runtimeService.activateProcessInstanceByProcessDefinitionKey(processDefinition.getKey());
@@ -1929,19 +1700,9 @@ class ProcessInstanceSuspensionTest {
     String task1Id = task1.getId();
     String task2Id = task2.getId();
 
-    try {
-      taskService.complete(task1Id);
-      fail("this should not be successful, as the execution of a suspended instance is resumed");
-    } catch (SuspendedEntityInteractionException e) {
-      // this is expected to fail
-    }
+    assertThatThrownBy(() -> taskService.complete(task1Id)).isInstanceOf(SuspendedEntityInteractionException.class);
 
-    try {
-      taskService.complete(task2Id);
-      fail("this should not be successful, as the execution of a suspended instance is resumed");
-    } catch (SuspendedEntityInteractionException e) {
-      // this is expected to fail
-    }
+    assertThatThrownBy(() -> taskService.complete(task2Id)).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // should be successful after reactivation
     runtimeService.activateProcessInstanceById(instance.getId());
@@ -1964,19 +1725,9 @@ class ProcessInstanceSuspensionTest {
     String task1Id = task1.getId();
     String task2Id = task2.getId();
 
-    try {
-      taskService.complete(task1Id);
-      fail("this should not be successful, as the execution of a suspended instance is resumed");
-    } catch (SuspendedEntityInteractionException e) {
-      // this is expected to fail
-    }
+    assertThatThrownBy(() -> taskService.complete(task1Id)).isInstanceOf(SuspendedEntityInteractionException.class);
 
-    try {
-      taskService.complete(task2Id);
-      fail("this should not be successful, as the execution of a suspended instance is resumed");
-    } catch (SuspendedEntityInteractionException e) {
-      // this is expected to fail
-    }
+    assertThatThrownBy(() -> taskService.complete(task2Id)).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // should be successful after reactivation
     runtimeService.activateProcessInstanceByProcessDefinitionId(instance.getProcessDefinitionId());
@@ -2003,19 +1754,9 @@ class ProcessInstanceSuspensionTest {
     String task1Id = task1.getId();
     String task2Id = task2.getId();
 
-    try {
-      taskService.complete(task1Id);
-      fail("this should not be successful, as the execution of a suspended instance is resumed");
-    } catch (SuspendedEntityInteractionException e) {
-      // this is expected to fail
-    }
+    assertThatThrownBy(() -> taskService.complete(task1Id)).isInstanceOf(SuspendedEntityInteractionException.class);
 
-    try {
-      taskService.complete(task2Id);
-      fail("this should not be successful, as the execution of a suspended instance is resumed");
-    } catch (SuspendedEntityInteractionException e) {
-      // this is expected to fail
-    }
+    assertThatThrownBy(() -> taskService.complete(task2Id)).isInstanceOf(SuspendedEntityInteractionException.class);
 
     // should be successful after reactivation
     runtimeService.activateProcessInstanceByProcessDefinitionKey(processDefinition.getKey());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstantiationAtActivitiesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstantiationAtActivitiesTest.java
@@ -325,10 +325,10 @@ class ProcessInstantiationAtActivitiesTest {
   @Test
   void testStartNullProcessDefinition() {
     var processInstantiationBuilder1 = runtimeService.createProcessInstanceById(null).startBeforeActivity("start");
-    assertThatThrownBy(() -> processInstantiationBuilder1.execute()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(processInstantiationBuilder1::execute).isInstanceOf(ProcessEngineException.class);
 
     var processInstantiationBuilder2 = runtimeService.createProcessInstanceByKey(null).startBeforeActivity("start");
-    assertThatThrownBy(() -> processInstantiationBuilder2.execute()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(processInstantiationBuilder2::execute).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = LISTENERS_PROCESS)

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstantiationAtActivitiesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/ProcessInstantiationAtActivitiesTest.java
@@ -18,7 +18,6 @@ package org.operaton.bpm.engine.test.api.runtime;
 
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -42,12 +41,11 @@ import org.operaton.bpm.engine.test.bpmn.executionlistener.RecorderExecutionList
 import org.operaton.bpm.engine.test.bpmn.executionlistener.RecorderExecutionListener.RecordedEvent;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.test.util.ActivityInstanceAssert;
 import org.operaton.bpm.engine.variable.Variables;
 
-import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.assertThat;
 import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.describeActivityInstanceTree;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Thorben Lindhauer
@@ -87,9 +85,9 @@ class ProcessInstantiationAtActivitiesTest {
     assertThat(instance).isNotNull();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(instance.getId());
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
 
-    assertThat(updatedTree).hasStructure(
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(instance.getProcessDefinitionId())
         .activity("task1")
       .done());
@@ -115,9 +113,9 @@ class ProcessInstantiationAtActivitiesTest {
     assertThat(instance).isNotNull();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(instance.getId());
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
 
-    assertThat(updatedTree).hasStructure(
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(instance.getProcessDefinitionId())
         .activity("task1")
       .done());
@@ -170,9 +168,9 @@ class ProcessInstantiationAtActivitiesTest {
     assertThat(instance).isNotNull();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(instance.getId());
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
 
-    assertThat(updatedTree).hasStructure(
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(instance.getProcessDefinitionId())
         .activity("task1")
       .done());
@@ -230,9 +228,9 @@ class ProcessInstantiationAtActivitiesTest {
     assertThat(instance).isNotNull();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(instance.getId());
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
 
-    assertThat(updatedTree).hasStructure(
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(instance.getProcessDefinitionId())
         .activity("task1")
         .activity("task2")
@@ -290,9 +288,9 @@ class ProcessInstantiationAtActivitiesTest {
     assertThat(instance).isNotNull();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(instance.getId());
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
 
-    assertThat(updatedTree).hasStructure(
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(instance.getProcessDefinitionId())
         .activity("outerTask")
         .beginScope("subProcess")
@@ -327,20 +325,10 @@ class ProcessInstantiationAtActivitiesTest {
   @Test
   void testStartNullProcessDefinition() {
     var processInstantiationBuilder1 = runtimeService.createProcessInstanceById(null).startBeforeActivity("start");
-    try {
-      processInstantiationBuilder1.execute();
-      fail("exception expected");
-    } catch (ProcessEngineException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> processInstantiationBuilder1.execute()).isInstanceOf(ProcessEngineException.class);
 
     var processInstantiationBuilder2 = runtimeService.createProcessInstanceByKey(null).startBeforeActivity("start");
-    try {
-      processInstantiationBuilder2.execute();
-      fail("exception expected");
-    } catch (ProcessEngineException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> processInstantiationBuilder2.execute()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = LISTENERS_PROCESS)
@@ -356,9 +344,9 @@ class ProcessInstantiationAtActivitiesTest {
 
     // then
     ActivityInstance updatedTree = runtimeService.getActivityInstance(instance.getId());
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
 
-    assertThat(updatedTree).hasStructure(
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(instance.getProcessDefinitionId())
         .beginScope("subProcess")
           .activity("innerTask")
@@ -394,9 +382,9 @@ class ProcessInstantiationAtActivitiesTest {
 
     // then
     ActivityInstance updatedTree = runtimeService.getActivityInstance(instance.getId());
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
 
-    assertThat(updatedTree).hasStructure(
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(instance.getProcessDefinitionId())
         .beginScope("subProcess")
           .activity("innerTask")
@@ -494,9 +482,9 @@ class ProcessInstantiationAtActivitiesTest {
     assertThat(instance).isNotNull();
 
     ActivityInstance updatedTree = runtimeService.getActivityInstance(instance.getId());
-    Assertions.assertThat(updatedTree).isNotNull();
+    assertThat(updatedTree).isNotNull();
 
-    assertThat(updatedTree).hasStructure(
+    ActivityInstanceAssert.assertThat(updatedTree).hasStructure(
       describeActivityInstanceTree(instance.getProcessDefinitionId())
         .transition("task2")
       .done());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.java
@@ -123,12 +123,7 @@ public class RuntimeServiceTest {
 
   @Test
   void testStartProcessInstanceByKeyNullKey() {
-    try {
-      runtimeService.startProcessInstanceByKey(null);
-      fail("ProcessEngineException expected");
-    } catch (ProcessEngineException e) {
-      // Expected exception
-    }
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -143,12 +138,7 @@ public class RuntimeServiceTest {
 
   @Test
   void testStartProcessInstanceByIdNullId() {
-    try {
-      runtimeService.startProcessInstanceById(null);
-      fail("ProcessEngineException expected");
-    } catch (ProcessEngineException e) {
-      // Expected exception
-    }
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceById(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1736,12 +1726,7 @@ public class RuntimeServiceTest {
 
     ActivityInstance tree = runtimeService.getActivityInstance(instance.getId());
 
-    try {
-      tree.getActivityInstances(null);
-      fail("exception expected");
-    } catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> tree.getActivityInstances(null)).isInstanceOf(NullValueException.class);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.testGetActivityInstancesForActivity.bpmn20.xml")
@@ -1791,12 +1776,7 @@ public class RuntimeServiceTest {
 
     ActivityInstance tree = runtimeService.getActivityInstance(instance.getId());
 
-    try {
-      tree.getTransitionInstances(null);
-      fail("exception expected");
-    } catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> tree.getTransitionInstances(null)).isInstanceOf(NullValueException.class);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/runtime/RuntimeServiceTest.testGetTransitionInstancesForActivity.bpmn20.xml")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/VariableInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/VariableInstanceQueryTest.java
@@ -1368,7 +1368,7 @@ class VariableInstanceQueryTest {
     VariableInstanceQuery query = runtimeService.createVariableInstanceQuery().variableValueEquals("bytesVar", bytes);
 
     // then
-    assertThatThrownBy(() -> query.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(query::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/VariableInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/VariableInstanceQueryTest.java
@@ -53,8 +53,7 @@ import org.operaton.bpm.engine.variable.type.ValueType;
 import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.groups.Tuple.tuple;
 
 /**
@@ -1369,12 +1368,7 @@ class VariableInstanceQueryTest {
     VariableInstanceQuery query = runtimeService.createVariableInstanceQuery().variableValueEquals("bytesVar", bytes);
 
     // then
-    try {
-      query.list();
-      fail("A ProcessEngineException was expected: Variables of type ByteArray cannot be used to query.");
-    } catch (ProcessEngineException e) {
-      // expected exception
-    }
+    assertThatThrownBy(() -> query.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationTest.java
@@ -1307,7 +1307,7 @@ class MessageCorrelationTest {
   void testCorrelationWithoutMessageDoesNotMatchStartEvent() {
     var messageCorrelationBuilder = runtimeService.createMessageCorrelation(null)
         .processInstanceVariableEquals("variable", "value2");
-    assertThatThrownBy(() -> messageCorrelationBuilder.correlate()).isInstanceOf(MismatchingMessageCorrelationException.class);
+    assertThatThrownBy(messageCorrelationBuilder::correlate).isInstanceOf(MismatchingMessageCorrelationException.class);
 
     List<Execution> correlatedExecutions = runtimeService
       .createExecutionQuery()

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationTest.java
@@ -1307,12 +1307,7 @@ class MessageCorrelationTest {
   void testCorrelationWithoutMessageDoesNotMatchStartEvent() {
     var messageCorrelationBuilder = runtimeService.createMessageCorrelation(null)
         .processInstanceVariableEquals("variable", "value2");
-    try {
-      messageCorrelationBuilder.correlate();
-      fail("exception expected");
-    } catch (MismatchingMessageCorrelationException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> messageCorrelationBuilder.correlate()).isInstanceOf(MismatchingMessageCorrelationException.class);
 
     List<Execution> correlatedExecutions = runtimeService
       .createExecutionQuery()
@@ -1380,12 +1375,7 @@ class MessageCorrelationTest {
     Map<String, Object> correlationKeys = new HashMap<>();
     correlationKeys.put("aKey", "aValue");
 
-    try {
-      runtimeService.correlateMessage(messageName, correlationKeys);
-      fail("It should not be possible to correlate a message to a suspended process instance.");
-    } catch (MismatchingMessageCorrelationException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> runtimeService.correlateMessage(messageName, correlationKeys)).isInstanceOf(MismatchingMessageCorrelationException.class);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/runtime/message/MessageCorrelationTest.testCatchingMessageEventCorrelation.bpmn20.xml")
@@ -1442,12 +1432,7 @@ class MessageCorrelationTest {
     variables.put("aKey", "aValue");
     var processVariables = new HashMap<String, Object>();
 
-    try {
-      runtimeService.correlateMessage("newInvoiceMessage", processVariables, variables);
-      fail("It should not be possible to correlate a message to a suspended process definition.");
-    } catch (MismatchingMessageCorrelationException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> runtimeService.correlateMessage("newInvoiceMessage", processVariables, variables)).isInstanceOf(MismatchingMessageCorrelationException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/StandaloneTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/StandaloneTaskTest.java
@@ -33,8 +33,7 @@ import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Joram Barrez
@@ -118,12 +117,7 @@ class StandaloneTaskTest {
 
     // second modification on the initial instance
     task2.setDescription("second modification");
-    try {
-      taskService.saveTask(task2);
-      fail("should get an exception here as the task was modified by someone else.");
-    } catch (OptimisticLockingException expected) {
-      //  exception was thrown as expected
-    }
+    assertThatThrownBy(() -> taskService.saveTask(task2)).isInstanceOf(OptimisticLockingException.class);
   }
 
   // See http://jira.codehaus.org/browse/ACT-1290

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryExpressionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryExpressionTest.java
@@ -185,7 +185,7 @@ class TaskQueryExpressionTest {
 
     setCurrentUser(userWithoutGroups);
     var taskQuery = taskQuery().taskCandidateGroupInExpression("${currentUserGroups()}");
-    assertThatThrownBy(() -> taskQuery.count()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::count).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryExpressionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryExpressionTest.java
@@ -46,7 +46,6 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Sebastian Menski
@@ -186,13 +185,7 @@ class TaskQueryExpressionTest {
 
     setCurrentUser(userWithoutGroups);
     var taskQuery = taskQuery().taskCandidateGroupInExpression("${currentUserGroups()}");
-    try {
-      taskQuery.count();
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected because currentUserGroups will return null
-    }
+    assertThatThrownBy(() -> taskQuery.count()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
@@ -147,7 +147,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     assertThat(query.count()).isEqualTo(12);
     assertThat(query.list()).hasSize(12);
-    assertThatThrownBy(() -> query.singleResult()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -191,7 +191,7 @@ class TaskQueryTest {
     assertThat(query.list()).hasSize(6);
     assertThat(query.count()).isEqualTo(6);
 
-    assertThatThrownBy(() -> query.singleResult()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -202,7 +202,7 @@ class TaskQueryTest {
     assertThat(query.count()).isZero();
     var taskQuery = taskService.createTaskQuery().taskName(null);
 
-    assertThatThrownBy(() -> taskQuery.singleResult()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::singleResult).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -221,7 +221,7 @@ class TaskQueryTest {
     assertThat(query.count()).isZero();
     var taskQuery = taskService.createTaskQuery().taskName(null);
 
-    assertThatThrownBy(() -> taskQuery.singleResult()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::singleResult).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -230,7 +230,7 @@ class TaskQueryTest {
     assertThat(query.list()).hasSize(6);
     assertThat(query.count()).isEqualTo(6);
 
-    assertThatThrownBy(() -> query.singleResult()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -566,7 +566,7 @@ class TaskQueryTest {
   @Test
   void testQueryByIncludeAssignedTasksWithMissingCandidateUserOrGroup() {
     var taskQuery = taskService.createTaskQuery();
-    assertThatThrownBy(() -> taskQuery.includeAssignedTasks()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::includeAssignedTasks).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -3015,7 +3015,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueEquals("aByteArrayValue", bytes);
 
-    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3036,7 +3036,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueEquals("aSerializableValue", serializable);
 
-    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3279,7 +3279,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueNotEquals("aSerializableValue", serializable);
 
-    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3297,7 +3297,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueNotEquals("aByteArrayValue", bytes);
 
-    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3459,7 +3459,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueGreaterThan("aByteArrayValue", bytes);
 
-    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3480,7 +3480,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueGreaterThan("aSerializableValue", serializable);
 
-    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCaseWithManualActivation.cmmn"})
@@ -3697,7 +3697,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueGreaterThanOrEquals("aByteArrayValue", bytes);
 
-    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3718,7 +3718,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueGreaterThanOrEquals("aSerializableValue", serializable);
 
-    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3898,7 +3898,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueLessThan("aByteArrayValue", bytes);
 
-    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3919,7 +3919,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueLessThan("aSerializableValue", serializable);
 
-    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -4134,7 +4134,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueLessThanOrEquals("aByteArrayValue", bytes);
 
-    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -4155,7 +4155,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueLessThanOrEquals("aSerializableValue", serializable);
 
-    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -5301,7 +5301,7 @@ class TaskQueryTest {
     var taskQuery = taskService.createTaskQuery()
         .processInstanceId(processInstance.getId());
 
-    assertThatThrownBy(() -> taskQuery.includeAssignedTasks()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::includeAssignedTasks).isInstanceOf(ProcessEngineException.class);
   }
 
 
@@ -5321,7 +5321,7 @@ class TaskQueryTest {
     var taskQuery = taskService.createTaskQuery()
         .processInstanceId(processInstance.getId());
 
-    assertThatThrownBy(() -> taskQuery.includeAssignedTasks()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(taskQuery::includeAssignedTasks).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
@@ -147,12 +147,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     assertThat(query.count()).isEqualTo(12);
     assertThat(query.list()).hasSize(12);
-    try {
-      query.singleResult();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> query.singleResult()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -187,12 +182,7 @@ class TaskQueryTest {
     assertThat(query.count()).isZero();
     var taskQuery = taskService.createTaskQuery();
 
-    try {
-      taskQuery.taskId(null);
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> taskQuery.taskId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -201,12 +191,7 @@ class TaskQueryTest {
     assertThat(query.list()).hasSize(6);
     assertThat(query.count()).isEqualTo(6);
 
-    try {
-      query.singleResult();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> query.singleResult()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -217,12 +202,7 @@ class TaskQueryTest {
     assertThat(query.count()).isZero();
     var taskQuery = taskService.createTaskQuery().taskName(null);
 
-    try {
-      taskQuery.singleResult();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> taskQuery.singleResult()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -241,12 +221,7 @@ class TaskQueryTest {
     assertThat(query.count()).isZero();
     var taskQuery = taskService.createTaskQuery().taskName(null);
 
-    try {
-      taskQuery.singleResult();
-      fail("Exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.singleResult()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -255,12 +230,7 @@ class TaskQueryTest {
     assertThat(query.list()).hasSize(6);
     assertThat(query.count()).isEqualTo(6);
 
-    try {
-      query.singleResult();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.singleResult()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -271,12 +241,7 @@ class TaskQueryTest {
     assertThat(query.count()).isZero();
     var taskQuery = taskService.createTaskQuery();
 
-    try {
-      taskQuery.taskDescription(null);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.taskDescription(null)).isInstanceOf(ProcessEngineException.class);
   }
 
 
@@ -348,12 +313,7 @@ class TaskQueryTest {
     assertThat(query.count()).isZero();
     var taskQuery = taskService.createTaskQuery();
 
-    try {
-      taskQuery.taskDescriptionLike(null);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.taskDescriptionLike(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -362,12 +322,7 @@ class TaskQueryTest {
     assertThat(query.list()).hasSize(2);
     assertThat(query.count()).isEqualTo(2);
 
-    try {
-      query.singleResult();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
 
     query = taskService.createTaskQuery().taskPriority(100);
     assertThat(query.singleResult()).isNull();
@@ -402,12 +357,7 @@ class TaskQueryTest {
   @Test
   void testQueryByInvalidPriority() {
     var taskQuery = taskService.createTaskQuery();
-    try {
-      taskQuery.taskPriority(null);
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> taskQuery.taskPriority(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -439,12 +389,7 @@ class TaskQueryTest {
   @Test
   void testQueryByNullAssignee() {
     var taskQuery = taskService.createTaskQuery();
-    try {
-      taskQuery.taskAssignee(null);
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> taskQuery.taskAssignee(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -583,12 +528,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery().taskCandidateUser("kermit");
     assertThat(query.count()).isEqualTo(10);
     assertThat(query.list()).hasSize(10);
-    try {
-      query.singleResult();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
 
     // test including assigned tasks
     query = taskService.createTaskQuery().taskCandidateUser("kermit").includeAssignedTasks();
@@ -599,12 +539,7 @@ class TaskQueryTest {
     query = taskService.createTaskQuery().taskCandidateUser("fozzie");
     assertThat(query.count()).isEqualTo(2);
     assertThat(query.list()).hasSize(2);
-    try {
-      query.singleResult();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
 
     // test including assigned tasks
     query = taskService.createTaskQuery().taskCandidateUser("fozzie").includeAssignedTasks();
@@ -625,23 +560,13 @@ class TaskQueryTest {
   @Test
   void testQueryByNullCandidateUser() {
     var taskQuery = taskService.createTaskQuery();
-    try {
-      taskQuery.taskCandidateUser(null);
-      fail("");
-    } catch(ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.taskCandidateUser(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testQueryByIncludeAssignedTasksWithMissingCandidateUserOrGroup() {
     var taskQuery = taskService.createTaskQuery();
-    try {
-      taskQuery.includeAssignedTasks();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> taskQuery.includeAssignedTasks()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -714,12 +639,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery().taskCandidateGroup("management");
     assertThat(query.count()).isEqualTo(2);
     assertThat(query.list()).hasSize(2);
-    try {
-      query.singleResult();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
 
     // test including assigned tasks
     query = taskService.createTaskQuery().taskCandidateGroup("management").includeAssignedTasks();
@@ -841,12 +761,7 @@ class TaskQueryTest {
   @Test
   void testQueryByNullCandidateGroup() {
     var taskQuery = taskService.createTaskQuery();
-    try {
-      taskQuery.taskCandidateGroup(null);
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> taskQuery.taskCandidateGroup(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -855,12 +770,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery().taskCandidateGroupIn(groups);
     assertThat(query.count()).isEqualTo(4);
     assertThat(query.list()).hasSize(4);
-    try {
-      query.singleResult();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
 
     // test including assigned tasks
     query = taskService.createTaskQuery().taskCandidateGroupIn(groups).includeAssignedTasks();
@@ -886,12 +796,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery().taskCandidateGroupIn(groups).taskCandidateGroup(candidateGroup);
     assertThat(query.count()).isEqualTo(2);
     assertThat(query.list()).hasSize(2);
-    try {
-      query.singleResult();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
 
     // test including assigned tasks
     query = taskService.createTaskQuery().taskCandidateGroupIn(groups).taskCandidateGroup(candidateGroup).includeAssignedTasks();
@@ -903,12 +808,7 @@ class TaskQueryTest {
     query = taskService.createTaskQuery().taskCandidateGroupIn(groups).taskCandidateGroup(candidateGroup);
     assertThat(query.count()).isEqualTo(2);
     assertThat(query.list()).hasSize(2);
-    try {
-      query.singleResult();
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(query::singleResult).isInstanceOf(ProcessEngineException.class);
 
     // test including assigned tasks
     query = taskService.createTaskQuery().taskCandidateGroupIn(groups).taskCandidateGroup(candidateGroup).includeAssignedTasks();
@@ -938,19 +838,9 @@ class TaskQueryTest {
   @Test
   void testQueryByNullCandidateGroupIn() {
     var taskQuery = taskService.createTaskQuery();
-    try {
-      taskQuery.taskCandidateGroupIn(null);
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> taskQuery.taskCandidateGroupIn(null)).isInstanceOf(ProcessEngineException.class);
     List<String> emptyGroupIds = emptyList();
-    try {
-      taskQuery.taskCandidateGroupIn(emptyGroupIds);
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> taskQuery.taskCandidateGroupIn(emptyGroupIds)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1385,10 +1275,7 @@ class TaskQueryTest {
     var taskQuery = taskService.createTaskQuery();
 
     // test with null value
-    try {
-      taskQuery.taskVariableValueLike("stringVar", null);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
+    assertThatThrownBy(() -> taskQuery.taskVariableValueLike("stringVar", null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/task/TaskQueryTest.testTaskVariableValueEquals.bpmn20.xml")
@@ -1417,10 +1304,7 @@ class TaskQueryTest {
     var taskQuery = taskService.createTaskQuery();
 
     // test with null value
-    try {
-      taskQuery.taskVariableValueLike("stringVar", null);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
+    assertThatThrownBy(() -> taskQuery.taskVariableValueLike("stringVar", null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/task/TaskQueryTest.testTaskVariableValueEquals.bpmn20.xml")
@@ -1505,42 +1389,18 @@ class TaskQueryTest {
     assertThat(taskQuery.taskVariableValueLessThanOrEquals("stringVar", "ab").count()).isEqualTo(1);
     assertThat(taskQuery.taskVariableValueLessThanOrEquals("stringVar", "aa").count()).isZero();
 
-    taskQuery = taskService.createTaskQuery();
+    var taskQuery2 = taskService.createTaskQuery();
     // test with null value
-    try {
-      taskQuery.taskVariableValueGreaterThan("nullVar", null);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
-    try {
-      taskQuery.taskVariableValueGreaterThanOrEquals("nullVar", null);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
-    try {
-  	  taskQuery.taskVariableValueLessThan("nullVar", null);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
-    try {
-  	  taskQuery.taskVariableValueLessThanOrEquals("nullVar", null);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
+    assertThatThrownBy(() -> taskQuery2.taskVariableValueGreaterThan("nullVar", null)).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(() -> taskQuery2.taskVariableValueGreaterThanOrEquals("nullVar", null)).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(() -> taskQuery2.taskVariableValueLessThan("nullVar", null)).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(() -> taskQuery2.taskVariableValueLessThanOrEquals("nullVar", null)).isInstanceOf(ProcessEngineException.class);
 
     // test with boolean value
-    try {
-      taskQuery.taskVariableValueGreaterThan("nullVar", true);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
-    try {
-  	  taskQuery.taskVariableValueGreaterThanOrEquals("nullVar", false);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
-    try {
-  	  taskQuery.taskVariableValueLessThan("nullVar", true);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
-    try {
-  	  taskQuery.taskVariableValueLessThanOrEquals("nullVar", false);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
+    assertThatThrownBy(() -> taskQuery2.taskVariableValueGreaterThan("nullVar", true)).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(() -> taskQuery2.taskVariableValueGreaterThanOrEquals("nullVar", false)).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(() -> taskQuery2.taskVariableValueLessThan("nullVar", true)).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(() -> taskQuery2.taskVariableValueLessThanOrEquals("nullVar", false)).isInstanceOf(ProcessEngineException.class);
 
     // test non existing variable
     assertThat(taskQuery.taskVariableValueLessThanOrEquals("nonExisting", 123).count()).isZero();
@@ -1687,10 +1547,7 @@ class TaskQueryTest {
     var taskQuery = taskService.createTaskQuery();
 
     // test with null value
-    try {
-      taskQuery.processVariableValueLike("stringVar", null);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
+    assertThatThrownBy(() -> taskQuery.processVariableValueLike("stringVar", null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/task/TaskQueryTest.testProcessVariableValueEquals.bpmn20.xml")
@@ -1715,10 +1572,7 @@ class TaskQueryTest {
     var taskQuery = taskService.createTaskQuery().matchVariableValuesIgnoreCase();
 
     // test with null value
-    try {
-      taskQuery.processVariableValueLike("stringVar", null);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
+    assertThatThrownBy(() -> taskQuery.processVariableValueLike("stringVar", null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/task/TaskQueryTest.testProcessVariableValueEquals.bpmn20.xml")
@@ -1854,42 +1708,18 @@ class TaskQueryTest {
     assertThat(taskQuery.processVariableValueLessThanOrEquals("stringVar", "ab").count()).isEqualTo(1);
     assertThat(taskQuery.processVariableValueLessThanOrEquals("stringVar", "aa").count()).isZero();
 
-    taskQuery = taskService.createTaskQuery();
+    var taskQuery2 = taskService.createTaskQuery();
     // test with null value
-    try {
-      taskQuery.processVariableValueGreaterThan("nullVar", null);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
-    try {
-  	  taskQuery.processVariableValueGreaterThanOrEquals("nullVar", null);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
-    try {
-  	  taskQuery.processVariableValueLessThan("nullVar", null);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
-    try {
-  	  taskQuery.processVariableValueLessThanOrEquals("nullVar", null);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
+    assertThatThrownBy(() -> taskQuery2.processVariableValueGreaterThan("nullVar", null)).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(() -> taskQuery2.processVariableValueGreaterThanOrEquals("nullVar", null)).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(() -> taskQuery2.processVariableValueLessThan("nullVar", null)).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(() -> taskQuery2.processVariableValueLessThanOrEquals("nullVar", null)).isInstanceOf(ProcessEngineException.class);
 
     // test with boolean value
-    try {
-      taskQuery.processVariableValueGreaterThan("nullVar", true);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
-    try {
-  	  taskQuery.processVariableValueGreaterThanOrEquals("nullVar", false);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
-    try {
-  	  taskQuery.processVariableValueLessThan("nullVar", true);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
-    try {
-  	  taskQuery.processVariableValueLessThanOrEquals("nullVar", false);
-      fail("expected exception");
-    } catch (final ProcessEngineException e) {/*OK*/}
+    assertThatThrownBy(() -> taskQuery2.processVariableValueGreaterThan("nullVar", true)).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(() -> taskQuery2.processVariableValueGreaterThanOrEquals("nullVar", false)).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(() -> taskQuery2.processVariableValueLessThan("nullVar", true)).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(() -> taskQuery2.processVariableValueLessThanOrEquals("nullVar", false)).isInstanceOf(ProcessEngineException.class);
 
     // test non existing variable
     assertThat(taskQuery.processVariableValueLessThanOrEquals("nonExisting", 123).count()).isZero();
@@ -2711,12 +2541,7 @@ class TaskQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseDefinitionId(null);
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> query.caseDefinitionId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -2746,12 +2571,7 @@ class TaskQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseDefinitionKey(null);
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> query.caseDefinitionKey(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -2783,12 +2603,7 @@ class TaskQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseDefinitionName(null);
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> query.caseDefinitionName(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn", "org/operaton/bpm/engine/test/api/repository/three_.cmmn"})
@@ -2824,12 +2639,7 @@ class TaskQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseDefinitionNameLike(null);
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> query.caseDefinitionNameLike(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -2898,12 +2708,7 @@ class TaskQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseInstanceId(null);
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> query.caseInstanceId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -2933,12 +2738,7 @@ class TaskQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseInstanceBusinessKey(null);
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> query.caseInstanceBusinessKey(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -2976,12 +2776,7 @@ class TaskQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseInstanceBusinessKeyLike(null);
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> query.caseInstanceBusinessKeyLike(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCaseWithManualActivation.cmmn"})
@@ -3010,12 +2805,7 @@ class TaskQueryTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.caseExecutionId(null);
-      fail("expected exception");
-    } catch (ProcessEngineException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> query.caseExecutionId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3225,12 +3015,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueEquals("aByteArrayValue", bytes);
 
-    try {
-      taskQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3251,12 +3036,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueEquals("aSerializableValue", serializable);
 
-    try {
-      taskQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3499,12 +3279,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueNotEquals("aSerializableValue", serializable);
 
-    try {
-      taskQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3522,12 +3297,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueNotEquals("aByteArrayValue", bytes);
 
-    try {
-      taskQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3542,12 +3312,7 @@ class TaskQueryTest {
 
     var taskQuery = taskService.createTaskQuery();
 
-    try {
-      taskQuery.caseInstanceVariableValueGreaterThan("aNullValue", null);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.caseInstanceVariableValueGreaterThan("aNullValue", null)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -3581,12 +3346,7 @@ class TaskQueryTest {
 
     var taskQuery = taskService.createTaskQuery();
 
-    try {
-      taskQuery.caseInstanceVariableValueGreaterThan("aBooleanValue", false);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.caseInstanceVariableValueGreaterThan("aBooleanValue", false)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -3699,12 +3459,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueGreaterThan("aByteArrayValue", bytes);
 
-    try {
-      taskQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3725,12 +3480,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueGreaterThan("aSerializableValue", serializable);
 
-    try {
-      taskQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCaseWithManualActivation.cmmn"})
@@ -3764,12 +3514,7 @@ class TaskQueryTest {
 
     var taskQuery = taskService.createTaskQuery();
 
-    try {
-      taskQuery.caseInstanceVariableValueGreaterThanOrEquals("aNullValue", null);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.caseInstanceVariableValueGreaterThanOrEquals("aNullValue", null)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -3809,12 +3554,7 @@ class TaskQueryTest {
 
     TaskQuery taskQuery = taskService.createTaskQuery();
 
-    try {
-      taskQuery.caseInstanceVariableValueGreaterThanOrEquals("aBooleanValue", false);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.caseInstanceVariableValueGreaterThanOrEquals("aBooleanValue", false)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -3957,12 +3697,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueGreaterThanOrEquals("aByteArrayValue", bytes);
 
-    try {
-      taskQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -3983,12 +3718,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueGreaterThanOrEquals("aSerializableValue", serializable);
 
-    try {
-      taskQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -4021,12 +3751,7 @@ class TaskQueryTest {
 
     var taskQuery = taskService.createTaskQuery();
 
-    try {
-      taskQuery.caseInstanceVariableValueLessThan("aNullValue", null);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.caseInstanceVariableValueLessThan("aNullValue", null)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -4060,12 +3785,7 @@ class TaskQueryTest {
 
     var taskQuery = taskService.createTaskQuery();
 
-    try {
-      taskQuery.caseInstanceVariableValueLessThan("aBooleanValue", false);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.caseInstanceVariableValueLessThan("aBooleanValue", false)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -4178,12 +3898,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueLessThan("aByteArrayValue", bytes);
 
-    try {
-      taskQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -4204,12 +3919,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueLessThan("aSerializableValue", serializable);
 
-    try {
-      taskQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -4241,12 +3951,7 @@ class TaskQueryTest {
 
     var taskQuery = taskService.createTaskQuery();
 
-    try {
-      taskQuery.caseInstanceVariableValueLessThanOrEquals("aNullValue", null);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.caseInstanceVariableValueLessThanOrEquals("aNullValue", null)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -4286,12 +3991,7 @@ class TaskQueryTest {
 
     var taskQuery = taskService.createTaskQuery();
 
-    try {
-      taskQuery.caseInstanceVariableValueLessThanOrEquals("aBooleanValue", false);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.caseInstanceVariableValueLessThanOrEquals("aBooleanValue", false)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -4434,12 +4134,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueLessThanOrEquals("aByteArrayValue", bytes);
 
-    try {
-      taskQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -4460,12 +4155,7 @@ class TaskQueryTest {
     TaskQuery query = taskService.createTaskQuery();
     var taskQuery = query.caseInstanceVariableValueLessThanOrEquals("aSerializableValue", serializable);
 
-    try {
-      taskQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -4497,12 +4187,7 @@ class TaskQueryTest {
 
     var taskQuery = taskService.createTaskQuery();
 
-    try {
-      taskQuery.caseInstanceVariableValueLike("aNullValue", null);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.caseInstanceVariableValueLike("aNullValue", null)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -4518,12 +4203,7 @@ class TaskQueryTest {
 
     var taskQuery = taskService.createTaskQuery();
 
-    try {
-      taskQuery.caseInstanceVariableValueNotLike("aNullValue", null);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.caseInstanceVariableValueNotLike("aNullValue", null)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -5253,75 +4933,25 @@ class TaskQueryTest {
   @Test
   void testQueryResultOrderingWithInvalidParameters() {
     var taskQuery = taskService.createTaskQuery();
-    try {
-      taskQuery.orderByProcessVariable(null, ValueType.STRING);
-      fail("should not succeed");
-    } catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> taskQuery.orderByProcessVariable(null, ValueType.STRING)).isInstanceOf(NullValueException.class);
 
-    try {
-      taskQuery.orderByProcessVariable("var", null);
-      fail("should not succeed");
-    } catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> taskQuery.orderByProcessVariable("var", null)).isInstanceOf(NullValueException.class);
 
-    try {
-      taskQuery.orderByExecutionVariable(null, ValueType.STRING);
-      fail("should not succeed");
-    } catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> taskQuery.orderByExecutionVariable(null, ValueType.STRING)).isInstanceOf(NullValueException.class);
 
-    try {
-      taskQuery.orderByExecutionVariable("var", null);
-      fail("should not succeed");
-    } catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> taskQuery.orderByExecutionVariable("var", null)).isInstanceOf(NullValueException.class);
 
-    try {
-      taskQuery.orderByTaskVariable(null, ValueType.STRING);
-      fail("should not succeed");
-    } catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> taskQuery.orderByTaskVariable(null, ValueType.STRING)).isInstanceOf(NullValueException.class);
 
-    try {
-      taskQuery.orderByTaskVariable("var", null);
-      fail("should not succeed");
-    } catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> taskQuery.orderByTaskVariable("var", null)).isInstanceOf(NullValueException.class);
 
-    try {
-      taskQuery.orderByCaseInstanceVariable(null, ValueType.STRING);
-      fail("should not succeed");
-    } catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> taskQuery.orderByCaseInstanceVariable(null, ValueType.STRING)).isInstanceOf(NullValueException.class);
 
-    try {
-      taskQuery.orderByCaseInstanceVariable("var", null);
-      fail("should not succeed");
-    } catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> taskQuery.orderByCaseInstanceVariable("var", null)).isInstanceOf(NullValueException.class);
 
-    try {
-      taskQuery.orderByCaseExecutionVariable(null, ValueType.STRING);
-      fail("should not succeed");
-    } catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> taskQuery.orderByCaseExecutionVariable(null, ValueType.STRING)).isInstanceOf(NullValueException.class);
 
-    try {
-      taskQuery.orderByCaseExecutionVariable("var", null);
-      fail("should not succeed");
-    } catch (NullValueException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> taskQuery.orderByCaseExecutionVariable("var", null)).isInstanceOf(NullValueException.class);
   }
 
   protected void verifyTasksSortedByProcessInstanceId(List<ProcessInstance> expectedProcessInstances,
@@ -5671,12 +5301,7 @@ class TaskQueryTest {
     var taskQuery = taskService.createTaskQuery()
         .processInstanceId(processInstance.getId());
 
-    try{
-      taskQuery.includeAssignedTasks();
-      fail("exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.includeAssignedTasks()).isInstanceOf(ProcessEngineException.class);
   }
 
 
@@ -5696,12 +5321,7 @@ class TaskQueryTest {
     var taskQuery = taskService.createTaskQuery()
         .processInstanceId(processInstance.getId());
 
-    try{
-       taskQuery.includeAssignedTasks();
-      fail("exception expected");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskQuery.includeAssignedTasks()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskServiceTest.java
@@ -237,12 +237,7 @@ class TaskServiceTest {
     task.setParentTaskId("non-existing");
 
     // then
-    try {
-      taskService.saveTask(task);
-      fail("It should not be possible to save a task with a non existing parent task.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskService.saveTask(task)).isInstanceOf(NotValidException.class);
   }
 
   @Test
@@ -813,13 +808,7 @@ class TaskServiceTest {
   void testAddTaskNullComment() {
     int historyLevel = processEngineConfiguration.getHistoryLevel().getId();
     if (historyLevel> ProcessEngineConfigurationImpl.HISTORYLEVEL_NONE) {
-      try {
-        taskService.createComment(null, null, "test");
-        fail("Expected process engine exception");
-      }
-      catch (ProcessEngineException e){
-        // expected
-      }
+      assertThatThrownBy(() -> taskService.createComment(null, null, "test")).isInstanceOf(ProcessEngineException.class);
     }
   }
 
@@ -1037,12 +1026,7 @@ class TaskServiceTest {
 
   @Test
   void testDeleteTaskNullTaskId() {
-    try {
-      taskService.deleteTask(null);
-      fail("ProcessEngineException expected");
-    } catch (ProcessEngineException ae) {
-      // Expected exception
-    }
+    assertThatThrownBy(() -> taskService.deleteTask(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1054,12 +1038,7 @@ class TaskServiceTest {
 
   @Test
   void testDeleteTasksNullTaskIds() {
-    try {
-      taskService.deleteTasks(null);
-      fail("ProcessEngineException expected");
-    } catch (ProcessEngineException ae) {
-      // Expected exception
-    }
+    assertThatThrownBy(() -> taskService.deleteTasks(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -2394,13 +2373,7 @@ class TaskServiceTest {
     taskService.saveTask(task1);
     task2.setDescription("test description two");
 
-    try {
-      taskService.saveTask(task2);
-
-      fail("Expecting exception");
-    } catch(OptimisticLockingException e) {
-      // Expected exception
-    }
+    assertThatThrownBy(() -> taskService.saveTask(task2)).isInstanceOf(OptimisticLockingException.class);
   }
 
   @Test
@@ -2656,12 +2629,7 @@ class TaskServiceTest {
   @Test
   void testCreateTaskAttachmentWithNullTaskAndProcessInstance() {
     var content = new ByteArrayInputStream("someContent".getBytes());
-    try {
-      taskService.createAttachment("web page", null, null, "weatherforcast", "temperatures and more", content);
-      fail("expected process engine exception");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> taskService.createAttachment("web page", null, null, "weatherforcast", "temperatures and more", content)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {
@@ -2685,12 +2653,7 @@ class TaskServiceTest {
   void testDeleteTaskAttachmentWithNullParameter() {
     int historyLevel = processEngineConfiguration.getHistoryLevel().getId();
     if (historyLevel> ProcessEngineConfigurationImpl.HISTORYLEVEL_NONE) {
-      try {
-        taskService.deleteAttachment(null);
-        fail("expected process engine exception");
-      } catch (ProcessEngineException e) {
-        // expected
-      }
+      assertThatThrownBy(() -> taskService.deleteAttachment(null)).isInstanceOf(ProcessEngineException.class);
     }
   }
 
@@ -2717,12 +2680,7 @@ class TaskServiceTest {
   void testDeleteTaskAttachmentWithNullParameters() {
     int historyLevel = processEngineConfiguration.getHistoryLevel().getId();
     if (historyLevel> ProcessEngineConfigurationImpl.HISTORYLEVEL_NONE) {
-      try {
-        taskService.deleteTaskAttachment(null, null);
-        fail("expected process engine exception");
-      } catch (ProcessEngineException e) {
-        // expected
-      }
+      assertThatThrownBy(() -> taskService.deleteTaskAttachment(null, null)).isInstanceOf(ProcessEngineException.class);
     }
   }
 
@@ -2730,12 +2688,7 @@ class TaskServiceTest {
   void testDeleteTaskAttachmentWithTaskIdNull() {
     int historyLevel = processEngineConfiguration.getHistoryLevel().getId();
     if (historyLevel> ProcessEngineConfigurationImpl.HISTORYLEVEL_NONE) {
-      try {
-        taskService.deleteTaskAttachment(null, "myAttachmentId");
-        fail("expected process engine exception");
-      } catch(ProcessEngineException e) {
-        // expected
-      }
+      assertThatThrownBy(() -> taskService.deleteTaskAttachment(null, "myAttachmentId")).isInstanceOf(ProcessEngineException.class);
     }
   }
 
@@ -2790,12 +2743,7 @@ class TaskServiceTest {
     deletions.add("variable3");
     deletions.add("variable4");
 
-    try {
-      ((TaskServiceImpl) taskService).updateVariablesLocal("nonExistingId", modifications, deletions);
-      fail("expected process engine exception");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> ((TaskServiceImpl) taskService).updateVariablesLocal("nonExistingId", modifications, deletions)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -2809,12 +2757,7 @@ class TaskServiceTest {
     deletions.add("variable3");
     deletions.add("variable4");
 
-    try {
-      ((TaskServiceImpl) taskService).updateVariablesLocal(null, modifications, deletions);
-      fail("expected process engine exception");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> ((TaskServiceImpl) taskService).updateVariablesLocal(null, modifications, deletions)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {
@@ -2860,12 +2803,7 @@ class TaskServiceTest {
     deletions.add("variable3");
     deletions.add("variable4");
 
-    try {
-      ((TaskServiceImpl) taskService).updateVariables("nonExistingId", modifications, deletions);
-      fail("expected process engine exception");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> ((TaskServiceImpl) taskService).updateVariables("nonExistingId", modifications, deletions)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -2879,12 +2817,7 @@ class TaskServiceTest {
     deletions.add("variable3");
     deletions.add("variable4");
 
-    try {
-      ((TaskServiceImpl) taskService).updateVariables(null, modifications, deletions);
-      fail("expected process engine exception");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> ((TaskServiceImpl) taskService).updateVariables(null, modifications, deletions)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskVariablesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskVariablesTest.java
@@ -32,8 +32,7 @@ import org.operaton.bpm.engine.variable.value.ObjectValue;
 import org.operaton.bpm.engine.variable.value.StringValue;
 
 import static org.operaton.bpm.engine.variable.Variables.objectValue;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 
 /**
@@ -160,13 +159,7 @@ class TaskVariablesTest {
     ObjectValue serializedValueLocal = taskService.getVariableLocalTyped(taskId, "objectVariableLocal", false);
     assertThat(serializedValueLocal.isDeserialized()).isFalse();
 
-    try {
-      StringValue val = taskService.getVariableTyped(taskId, "objectVariable");
-      fail("expected exception");
-    }
-    catch(ClassCastException e) {
-      //happy path
-    }
+    assertThatThrownBy(() -> taskService.getVariableTyped(taskId, "objectVariable")).isInstanceOf(ClassCastException.class);
 
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskVariablesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskVariablesTest.java
@@ -159,7 +159,9 @@ class TaskVariablesTest {
     ObjectValue serializedValueLocal = taskService.getVariableLocalTyped(taskId, "objectVariableLocal", false);
     assertThat(serializedValueLocal.isDeserialized()).isFalse();
 
-    assertThatThrownBy(() -> taskService.getVariableTyped(taskId, "objectVariable")).isInstanceOf(ClassCastException.class);
+    assertThatThrownBy(() -> {
+      @SuppressWarnings("unused") StringValue val = taskService.getVariableTyped(taskId, "objectVariable");
+    }).isInstanceOf(ClassCastException.class);
 
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CaseCallActivityTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/callactivity/CaseCallActivityTest.java
@@ -33,8 +33,7 @@ import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Roman Smirnov
@@ -362,12 +361,7 @@ class CaseCallActivityTest extends CmmnTest {
   void testCaseNotFound() {
     // given
 
-    try {
-      // when
-      startProcessInstanceByKey(PROCESS_DEFINITION_KEY);
-      fail("It should not be possible to start a not existing case instance.");
-    } catch (CaseDefinitionNotFoundException e) {
-    }
+    assertThatThrownBy(() -> startProcessInstanceByKey(PROCESS_DEFINITION_KEY)).isInstanceOf(CaseDefinitionNotFoundException.class);
   }
 
   @Deployment(resources = {
@@ -1264,13 +1258,7 @@ class CaseCallActivityTest extends CmmnTest {
     assertThat(subCaseInstance).isNotNull();
     assertThat(subCaseInstance.isActive()).isTrue();
 
-    try {
-      // when
-      complete(humanTaskId);
-      fail("The super process instance is suspended.");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> complete(humanTaskId)).isInstanceOf(Exception.class);
 
     // complete ////////////////////////////////////////////////////////
     runtimeService.activateProcessInstanceById(superProcessInstanceId);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/conditional/EventSubProcessStartConditionalEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/conditional/EventSubProcessStartConditionalEventTest.java
@@ -31,10 +31,9 @@ import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 /**
  *
@@ -1065,12 +1064,7 @@ class EventSubProcessStartConditionalEventTest extends AbstractConditionalEventT
 
     //when variable which triggers condition is set
     //then exception is expected
-    try {
-      runtimeService.setVariable(processInstanceId, VARIABLE_NAME, 1);
-      fail("Should fail!");
-    } catch (SuspendedEntityInteractionException seie) {
-      //expected
-    }
+    assertThatThrownBy(() -> runtimeService.setVariable(processInstanceId, VARIABLE_NAME, 1)).isInstanceOf(SuspendedEntityInteractionException.class);
     runtimeService.activateProcessInstanceById(processInstanceId);
     tasksAfterVariableIsSet = taskService.createTaskQuery().list();
   }
@@ -1099,12 +1093,7 @@ class EventSubProcessStartConditionalEventTest extends AbstractConditionalEventT
 
     //when variable which triggers condition is set
     //then exception is expected
-    try {
-      runtimeService.setVariable(processInstanceId, VARIABLE_NAME, 1);
-      fail("Should fail!");
-    } catch (SuspendedEntityInteractionException seie) {
-      //expected
-    }
+    assertThatThrownBy(() -> runtimeService.setVariable(processInstanceId, VARIABLE_NAME, 1)).isInstanceOf(SuspendedEntityInteractionException.class);
     runtimeService.activateProcessInstanceById(processInstanceId);
     tasksAfterVariableIsSet = taskService.createTaskQuery().list();
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/conditional/EventSubProcessStartConditionalEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/conditional/EventSubProcessStartConditionalEventTest.java
@@ -31,9 +31,10 @@ import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  *

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/conditional/IntermediateConditionalEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/conditional/IntermediateConditionalEventTest.java
@@ -31,7 +31,7 @@ import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  *
@@ -494,12 +494,7 @@ class IntermediateConditionalEventTest extends AbstractConditionalEventTestCase 
 
     //when variable which triggers condition is set
     //then exception is expected
-    try {
-      runtimeService.setVariable(processInstanceId, VARIABLE_NAME, 1);
-      fail("Should fail!");
-    } catch (SuspendedEntityInteractionException seie) {
-      //expected
-    }
+    assertThatThrownBy(() -> runtimeService.setVariable(processInstanceId, VARIABLE_NAME, 1)).isInstanceOf(SuspendedEntityInteractionException.class);
     runtimeService.activateProcessInstanceById(procInst.getId());
     tasksAfterVariableIsSet = taskService.createTaskQuery().list();
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/error/BoundaryErrorEventTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/event/error/BoundaryErrorEventTest.java
@@ -49,8 +49,7 @@ import org.operaton.commons.utils.CollectionUtil;
 
 import static org.operaton.bpm.engine.test.bpmn.event.error.ThrowErrorDelegate.throwError;
 import static org.operaton.bpm.engine.test.bpmn.event.error.ThrowErrorDelegate.throwException;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 
@@ -561,12 +560,7 @@ class BoundaryErrorEventTest {
   @Test
   void testCatchExceptionExpressionThrownByFollowUpTask() {
     Map<String, Object> vars = throwException();
-    try {
-      runtimeService.startProcessInstanceByKey("testProcess", vars);
-      fail("should fail and not catch the error on the first task");
-    } catch (ProcessEngineException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testProcess", vars)).isInstanceOf(ProcessEngineException.class);
 
     assertThat(taskService.createTaskQuery().singleResult()).isNull();
   }
@@ -575,12 +569,7 @@ class BoundaryErrorEventTest {
   @Test
   void testCatchExceptionClassDelegateThrownByFollowUpTask() {
     Map<String, Object> vars = throwException();
-    try {
-      runtimeService.startProcessInstanceByKey("testProcess", vars);
-      fail("should fail");
-    } catch (ProcessEngineException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testProcess", vars)).isInstanceOf(ProcessEngineException.class);
 
     assertThat(taskService.createTaskQuery().singleResult()).isNull();
   }
@@ -589,12 +578,7 @@ class BoundaryErrorEventTest {
   @Test
   void testCatchExceptionExpressionThrownByFollowUpScopeTask() {
     Map<String, Object> vars = throwException();
-    try {
-      runtimeService.startProcessInstanceByKey("testProcess", vars);
-      fail("should fail and not catch the error on the first task");
-    } catch (ProcessEngineException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("testProcess", vars)).isInstanceOf(ProcessEngineException.class);
     assertThat(taskService.createTaskQuery().singleResult()).isNull();
   }
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/ExclusiveGatewayTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/ExclusiveGatewayTest.java
@@ -39,9 +39,7 @@ import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.commons.utils.CollectionUtil;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Joram Barrez
@@ -336,12 +334,7 @@ class ExclusiveGatewayTest {
 
     // Test with input == 4
     variables.put("input", 4);
-    try {
-      runtimeService.startProcessInstanceByKey("exclusiveGateway", variables);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // Exception is expected since no outgoing sequence flow matches
-    }
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("exclusiveGateway", variables)).isInstanceOf(ProcessEngineException.class);
 
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/InclusiveGatewayTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/gateway/InclusiveGatewayTest.java
@@ -39,13 +39,12 @@ import org.operaton.bpm.engine.task.TaskQuery;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
+import org.operaton.bpm.engine.test.util.ActivityInstanceAssert;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.commons.utils.CollectionUtil;
 
-import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.assertThat;
 import static org.operaton.bpm.engine.test.util.ActivityInstanceAssert.describeActivityInstanceTree;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
@@ -250,12 +249,7 @@ class InclusiveGatewayTest {
 
     ProcessInstance pi;
     var variables = CollectionUtil.singletonMap("orders", orders);
-    try {
-      runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnListOrArrayOfBeans", variables);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expect an exception to be thrown here
-    }
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnListOrArrayOfBeans", variables)).isInstanceOf(ProcessEngineException.class);
 
     orders.set(1, new InclusiveGatewayTestOrder(175));
     pi = runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnListOrArrayOfBeans", variables);
@@ -317,12 +311,7 @@ class InclusiveGatewayTest {
     assertThat(expectedNames).isEmpty();
     var variables = CollectionUtil.singletonMap("order", new InclusiveGatewayTestOrder(300));
 
-    try {
-      runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnBeanMethod", variables);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // Should get an exception indicating that no path could be taken
-    }
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("inclusiveDecisionBasedOnBeanMethod", variables)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -598,12 +587,7 @@ class InclusiveGatewayTest {
 
     // Test with input == 4
     variables.put("input", 4);
-    try {
-      runtimeService.startProcessInstanceByKey("inclusiveGateway", variables);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // Exception is expected since no outgoing sequence flow matches
-    }
+    assertThatThrownBy(() -> runtimeService.startProcessInstanceByKey("inclusiveGateway", variables)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -685,7 +669,7 @@ class InclusiveGatewayTest {
     // then
     ActivityInstance activityInstance = runtimeService.getActivityInstance(processInstance.getId());
 
-    assertThat(activityInstance).hasStructure(
+    ActivityInstanceAssert.assertThat(activityInstance).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
         .activity("beforeTask")
         .activity("afterTask")
@@ -702,7 +686,7 @@ class InclusiveGatewayTest {
     ActivityInstance activityInstance = runtimeService.getActivityInstance(processInstance.getId());
 
     // then
-    assertThat(activityInstance).hasStructure(
+    ActivityInstanceAssert.assertThat(activityInstance).hasStructure(
       describeActivityInstanceTree(processInstance.getProcessDefinitionId())
         .activity("task1")
         .activity("task2")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/receivetask/ReceiveTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/receivetask/ReceiveTaskTest.java
@@ -34,7 +34,7 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * see https://app.camunda.com/jira/browse/CAM-1612
@@ -356,12 +356,7 @@ class ReceiveTaskTest {
     var eventSubscription = subscriptions.get(0).getEventName();
 
     // then: we can not correlate an event
-    try {
-      runtimeService.correlateMessage(eventSubscription);
-      fail("should throw a mismatch");
-    } catch (MismatchingMessageCorrelationException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> runtimeService.correlateMessage(eventSubscription)).isInstanceOf(MismatchingMessageCorrelationException.class);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/bpmn/receivetask/ReceiveTaskTest.multiParallelReceiveTaskCompensate.bpmn20.xml")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/scripttask/ScriptTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/scripttask/ScriptTaskTest.java
@@ -572,13 +572,7 @@ class ScriptTaskTest extends AbstractScriptTaskTest {
         .userTask()
         .endEvent()
       .done();
-    try {
-      deployProcess(processBuilder);
-
-      fail("this process should not be deployable");
-    } catch (ProcessEngineException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> deployProcess(processBuilder)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/subprocess/InterruptingEventSubProcessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/subprocess/InterruptingEventSubProcessTest.java
@@ -37,7 +37,7 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Roman Smirnov
@@ -77,12 +77,7 @@ class InterruptingEventSubProcessTest {
     assertThat(eventSubscriptionQuery.count()).isZero();
     var processInstanceId = pi.getId();
 
-    try {
-      runtimeService.signalEventReceived("newSignal", processInstanceId);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected exception;
-    }
+    assertThatThrownBy(() -> runtimeService.signalEventReceived("newSignal", processInstanceId)).isInstanceOf(ProcessEngineException.class);
 
     taskService.complete(task.getId());
 
@@ -113,12 +108,7 @@ class InterruptingEventSubProcessTest {
     assertThat(eventSubscriptionQuery.count()).isZero();
     var processInstanceId = pi.getId();
 
-    try {
-      runtimeService.messageEventReceived("newMessage", processInstanceId);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected exception;
-    }
+    assertThatThrownBy(() -> runtimeService.messageEventReceived("newMessage", processInstanceId)).isInstanceOf(ProcessEngineException.class);
 
     taskService.complete(task.getId());
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/usertask/TaskAssignmentExtensionsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/usertask/TaskAssignmentExtensionsTest.java
@@ -36,7 +36,7 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Testcase for the non-spec extensions to the task candidate use case.
@@ -94,12 +94,7 @@ class TaskAssignmentExtensionsTest {
   void testDuplicateAssigneeDeclaration() {
     String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testDuplicateAssigneeDeclaration");
     var deploymentBuilder = repositoryService.createDeployment().addClasspathResource(resource);
-    try {
-      deploymentBuilder.deploy();
-      fail("Invalid BPMN 2.0 process should not parse, but it gets parsed sucessfully");
-    } catch (ProcessEngineException e) {
-      // Exception is to be expected
-    }
+    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/usertask/TaskAssignmentExtensionsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/usertask/TaskAssignmentExtensionsTest.java
@@ -94,7 +94,7 @@ class TaskAssignmentExtensionsTest {
   void testDuplicateAssigneeDeclaration() {
     String resource = TestHelper.getBpmnProcessDefinitionResource(getClass(), "testDuplicateAssigneeDeclaration");
     var deploymentBuilder = repositoryService.createDeployment().addClasspathResource(resource);
-    assertThatThrownBy(() -> deploymentBuilder.deploy()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(deploymentBuilder::deploy).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/casetask/CaseTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/casetask/CaseTaskTest.java
@@ -845,7 +845,7 @@ class CaseTaskTest extends CmmnTest {
     var caseExecutionCommandBuilder = caseService
         .withCaseExecution(caseTaskId);
 
-    assertThatThrownBy(() -> caseExecutionCommandBuilder.manualStart()).isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(caseExecutionCommandBuilder::manualStart).isInstanceOf(NotFoundException.class);
 
     // complete //////////////////////////////////////////////////////////
 
@@ -1346,7 +1346,7 @@ class CaseTaskTest extends CmmnTest {
     var caseExecutionCommandBuilder = caseService
         .withCaseExecution(caseTaskId);
 
-    assertThatThrownBy(() -> caseExecutionCommandBuilder.complete()).isInstanceOf(NotAllowedException.class);
+    assertThatThrownBy(caseExecutionCommandBuilder::complete).isInstanceOf(NotAllowedException.class);
 
 
     // complete ////////////////////////////////////////////////////////

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/casetask/CaseTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/casetask/CaseTaskTest.java
@@ -33,8 +33,7 @@ import org.operaton.bpm.engine.test.cmmn.CmmnTest;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.impl.VariableMapImpl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Roman Smirnov
@@ -846,11 +845,7 @@ class CaseTaskTest extends CmmnTest {
     var caseExecutionCommandBuilder = caseService
         .withCaseExecution(caseTaskId);
 
-    try {
-      // when
-      caseExecutionCommandBuilder.manualStart();
-      fail("It should not be possible to start a not existing case instance.");
-    } catch (NotFoundException e) {}
+    assertThatThrownBy(() -> caseExecutionCommandBuilder.manualStart()).isInstanceOf(NotFoundException.class);
 
     // complete //////////////////////////////////////////////////////////
 
@@ -1351,11 +1346,7 @@ class CaseTaskTest extends CmmnTest {
     var caseExecutionCommandBuilder = caseService
         .withCaseExecution(caseTaskId);
 
-    try {
-      // when
-      caseExecutionCommandBuilder.complete();
-      fail("It should not be possible to complete a case task, while the case instance is active.");
-    } catch (NotAllowedException e) {}
+    assertThatThrownBy(() -> caseExecutionCommandBuilder.complete()).isInstanceOf(NotAllowedException.class);
 
 
     // complete ////////////////////////////////////////////////////////

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/cmmn10/Cmmn10CompatibilityTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/cmmn10/Cmmn10CompatibilityTest.java
@@ -28,7 +28,7 @@ import org.operaton.bpm.engine.test.cmmn.CmmnTest;
 import org.operaton.bpm.engine.variable.Variables;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Roman Smirnov
@@ -48,12 +48,7 @@ class Cmmn10CompatibilityTest extends CmmnTest {
     assertThat(taskExecution).isNotNull();
     assertThat(taskExecution.isRequired()).isTrue();
 
-    try {
-      caseService.completeCaseExecution(caseInstanceId);
-      fail("completing the containing stage should not be allowed");
-    } catch (NotAllowedException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> caseService.completeCaseExecution(caseInstanceId)).isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/cmmn/cmm10/Cmmn10CompatibilityTest.testManualActivationRule.cmmn")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/listener/VariableListenerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/listener/VariableListenerTest.java
@@ -458,7 +458,7 @@ class VariableListenerTest extends CmmnTest {
         .withCaseExecution(taskExecution.getId())
         .setVariableLocal("aTaskVariable", "aTaskValue");
 
-    assertThatThrownBy(() -> caseExecutionCommandBuilder.execute()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(caseExecutionCommandBuilder::execute).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment
@@ -475,7 +475,7 @@ class VariableListenerTest extends CmmnTest {
         .withCaseExecution(taskExecution.getId())
         .setVariableLocal("aTaskVariable", "aTaskValue");
 
-    assertThatThrownBy(() -> caseExecutionCommandBuilder.execute()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(caseExecutionCommandBuilder::execute).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/listener/VariableListenerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/listener/VariableListenerTest.java
@@ -37,8 +37,7 @@ import org.operaton.bpm.engine.runtime.CaseInstance;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.cmmn.CmmnTest;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Thorben Lindhauer
@@ -459,13 +458,7 @@ class VariableListenerTest extends CmmnTest {
         .withCaseExecution(taskExecution.getId())
         .setVariableLocal("aTaskVariable", "aTaskValue");
 
-    try {
-      caseExecutionCommandBuilder.execute();
-
-      fail("expected exception during variable listener invocation");
-    } catch (ProcessEngineException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> caseExecutionCommandBuilder.execute()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment
@@ -482,13 +475,7 @@ class VariableListenerTest extends CmmnTest {
         .withCaseExecution(taskExecution.getId())
         .setVariableLocal("aTaskVariable", "aTaskValue");
 
-    try {
-      caseExecutionCommandBuilder.execute();
-
-      fail("expected exception during variable listener invocation");
-    } catch (ProcessEngineException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> caseExecutionCommandBuilder.execute()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/operation/CaseInstanceCloseTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/operation/CaseInstanceCloseTest.java
@@ -282,7 +282,7 @@ class CaseInstanceCloseTest {
 
     CmmnActivityExecution taskA = caseInstance.findCaseExecution("A");
 
-    assertThatThrownBy(() -> taskA.close()).isInstanceOf(CaseIllegalStateTransitionException.class);
+    assertThatThrownBy(taskA::close).isInstanceOf(CaseIllegalStateTransitionException.class);
 
     // then
     assertThat(stateTransitionCollector.stateTransitions).isEmpty();
@@ -334,7 +334,7 @@ class CaseInstanceCloseTest {
 
     CmmnActivityExecution stageX = caseInstance.findCaseExecution("X");
 
-    assertThatThrownBy(() -> stageX.close()).isInstanceOf(CaseIllegalStateTransitionException.class);
+    assertThatThrownBy(stageX::close).isInstanceOf(CaseIllegalStateTransitionException.class);
 
     // then
     assertThat(stateTransitionCollector.stateTransitions).isEmpty();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/operation/CaseInstanceCloseTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/operation/CaseInstanceCloseTest.java
@@ -31,7 +31,7 @@ import org.operaton.bpm.engine.impl.cmmn.model.CmmnCaseDefinition;
 import org.operaton.bpm.engine.impl.test.TestHelper;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Roman Smirnov
@@ -282,13 +282,7 @@ class CaseInstanceCloseTest {
 
     CmmnActivityExecution taskA = caseInstance.findCaseExecution("A");
 
-    try {
-      // when
-      taskA.close();
-      fail("It should not be possible to close a task.");
-    } catch (CaseIllegalStateTransitionException e) {
-
-    }
+    assertThatThrownBy(() -> taskA.close()).isInstanceOf(CaseIllegalStateTransitionException.class);
 
     // then
     assertThat(stateTransitionCollector.stateTransitions).isEmpty();
@@ -340,13 +334,7 @@ class CaseInstanceCloseTest {
 
     CmmnActivityExecution stageX = caseInstance.findCaseExecution("X");
 
-    try {
-      // when
-      stageX.close();
-      fail("It should not be possible to close a stage.");
-    } catch (CaseIllegalStateTransitionException e) {
-
-    }
+    assertThatThrownBy(() -> stageX.close()).isInstanceOf(CaseIllegalStateTransitionException.class);
 
     // then
     assertThat(stateTransitionCollector.stateTransitions).isEmpty();

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/processtask/ProcessTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/processtask/ProcessTaskTest.java
@@ -904,7 +904,7 @@ class ProcessTaskTest extends CmmnTest {
     var caseExecutionCommandBuilder = caseService
         .withCaseExecution(processTaskId);
 
-    assertThatThrownBy(() -> caseExecutionCommandBuilder.manualStart()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(caseExecutionCommandBuilder::manualStart).isInstanceOf(ProcessEngineException.class);
 
     // complete //////////////////////////////////////////////////////////
 
@@ -1456,7 +1456,7 @@ class ProcessTaskTest extends CmmnTest {
     var caseExecutionCommandBuilder = caseService
         .withCaseExecution(processTaskId);
 
-    assertThatThrownBy(() -> caseExecutionCommandBuilder.complete()).isInstanceOf(NotAllowedException.class);
+    assertThatThrownBy(caseExecutionCommandBuilder::complete).isInstanceOf(NotAllowedException.class);
 
     // complete ////////////////////////////////////////////////////////
 
@@ -1491,7 +1491,7 @@ class ProcessTaskTest extends CmmnTest {
     var caseExecutionCommandBuilder = caseService
         .withCaseExecution(processTaskId);
 
-    assertThatThrownBy(() -> caseExecutionCommandBuilder.complete()).isInstanceOf(Exception.class);
+    assertThatThrownBy(caseExecutionCommandBuilder::complete).isInstanceOf(Exception.class);
 
     // complete ////////////////////////////////////////////////////////
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/processtask/ProcessTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/processtask/ProcessTaskTest.java
@@ -31,8 +31,7 @@ import org.operaton.bpm.engine.test.cmmn.CmmnTest;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Roman Smirnov
@@ -905,13 +904,7 @@ class ProcessTaskTest extends CmmnTest {
     var caseExecutionCommandBuilder = caseService
         .withCaseExecution(processTaskId);
 
-    try {
-      // when
-      caseExecutionCommandBuilder.manualStart();
-      fail("It should not be possible to start a process instance.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> caseExecutionCommandBuilder.manualStart()).isInstanceOf(ProcessEngineException.class);
 
     // complete //////////////////////////////////////////////////////////
 
@@ -1463,13 +1456,7 @@ class ProcessTaskTest extends CmmnTest {
     var caseExecutionCommandBuilder = caseService
         .withCaseExecution(processTaskId);
 
-    try {
-      // when
-      caseExecutionCommandBuilder.complete();
-      fail("It should not be possible to complete a process task, while the process instance is running.");
-    } catch (NotAllowedException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> caseExecutionCommandBuilder.complete()).isInstanceOf(NotAllowedException.class);
 
     // complete ////////////////////////////////////////////////////////
 
@@ -1504,13 +1491,7 @@ class ProcessTaskTest extends CmmnTest {
     var caseExecutionCommandBuilder = caseService
         .withCaseExecution(processTaskId);
 
-    try {
-      // when
-      caseExecutionCommandBuilder.complete();
-      fail("It should not be possible to complete a process task");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> caseExecutionCommandBuilder.complete()).isInstanceOf(Exception.class);
 
     // complete ////////////////////////////////////////////////////////
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/required/RequiredRuleTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/cmmn/required/RequiredRuleTest.java
@@ -27,7 +27,7 @@ import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.cmmn.CmmnTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Roman Smirnov
@@ -49,12 +49,7 @@ class RequiredRuleTest extends CmmnTest {
     assertThat(taskExecution).isNotNull();
     assertThat(taskExecution.isRequired()).isTrue();
 
-    try {
-      caseService.completeCaseExecution(caseInstanceId);
-      fail("completing the containing stage should not be allowed");
-    } catch (NotAllowedException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> caseService.completeCaseExecution(caseInstanceId)).isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/cmmn/required/RequiredRuleTest.testVariableBasedRule.cmmn")
@@ -90,12 +85,7 @@ class RequiredRuleTest extends CmmnTest {
     assertThat(taskExecution).isNotNull();
     assertThat(taskExecution.isRequired()).isTrue();
 
-    try {
-      caseService.completeCaseExecution(caseInstanceId);
-      fail("completing the containing stage should not be allowed");
-    } catch (NotAllowedException e) {
-      // happy path
-    }
+    assertThatThrownBy(() -> caseService.completeCaseExecution(caseInstanceId)).isInstanceOf(NotAllowedException.class);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/cmmn/required/RequiredRuleTest.testDefaultVariableBasedRule.cmmn")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricActivityInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricActivityInstanceTest.java
@@ -50,8 +50,7 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Tom Baeyens
@@ -356,26 +355,11 @@ class HistoricActivityInstanceTest {
   @Test
   void testInvalidSorting() {
     var historicActivityInstanceQuery = historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceDuration();
-    try {
-      historicActivityInstanceQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicActivityInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      historicActivityInstanceQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicActivityInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      historicActivityInstanceQuery.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicActivityInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
@@ -465,12 +449,7 @@ class HistoricActivityInstanceTest {
     var historicActivityInstanceQuery = historyService
           .createHistoricActivityInstanceQuery()
           .completeScope();
-    try {
-      historicActivityInstanceQuery.canceled();
-      fail("It should not be possible to query by completeScope and canceled.");
-    } catch (ProcessEngineException e) {
-      // exception expected
-    }
+    assertThatThrownBy(() -> historicActivityInstanceQuery.canceled()).isInstanceOf(ProcessEngineException.class);
   }
 
   /**

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricActivityInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricActivityInstanceTest.java
@@ -355,11 +355,11 @@ class HistoricActivityInstanceTest {
   @Test
   void testInvalidSorting() {
     var historicActivityInstanceQuery = historyService.createHistoricActivityInstanceQuery().orderByHistoricActivityInstanceDuration();
-    assertThatThrownBy(() -> historicActivityInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(historicActivityInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
 
-    assertThatThrownBy(() -> historicActivityInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(historicActivityInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
 
-    assertThatThrownBy(() -> historicActivityInstanceQuery.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(historicActivityInstanceQuery::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})
@@ -449,7 +449,7 @@ class HistoricActivityInstanceTest {
     var historicActivityInstanceQuery = historyService
           .createHistoricActivityInstanceQuery()
           .completeScope();
-    assertThatThrownBy(() -> historicActivityInstanceQuery.canceled()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(historicActivityInstanceQuery::canceled).isInstanceOf(ProcessEngineException.class);
   }
 
   /**

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
@@ -50,7 +50,7 @@ import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.cmmn.CmmnTest;
 import org.operaton.bpm.engine.variable.Variables;
-
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.ACTIVE;
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.AVAILABLE;
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.COMPLETED;
@@ -59,7 +59,6 @@ import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.ENA
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.SUSPENDED;
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.TERMINATED;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Sebastian Menski
@@ -580,30 +579,12 @@ class HistoricCaseActivityInstanceTest extends CmmnTest {
   @Test
   void testInvalidSorting() {
     var historicCaseActivityInstanceQuery = historicQuery();
-    try {
-      historicCaseActivityInstanceQuery.asc();
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicCaseActivityInstanceQuery.asc()).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      historicCaseActivityInstanceQuery.desc();
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicCaseActivityInstanceQuery.desc()).isInstanceOf(ProcessEngineException.class);
 
     var historicCaseActivityInstanceQuery1 = historicQuery().orderByHistoricCaseActivityInstanceId();
-    try {
-      historicCaseActivityInstanceQuery1.count();
-      fail("Exception expected");
-    }
-    catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicCaseActivityInstanceQuery1.count()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})
@@ -904,19 +885,9 @@ class HistoricCaseActivityInstanceTest extends CmmnTest {
     assertCount(0, query);
     var historicCaseActivityInstanceQuery = historicQuery();
 
-    try {
-      historicCaseActivityInstanceQuery.caseActivityInstanceIdIn((String[])null);
-      fail("A NotValidException was expected.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicCaseActivityInstanceQuery.caseActivityInstanceIdIn((String[]) null)).isInstanceOf(NotValidException.class);
 
-    try {
-      historicCaseActivityInstanceQuery.caseActivityInstanceIdIn((String)null);
-      fail("A NotValidException was expected.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicCaseActivityInstanceQuery.caseActivityInstanceIdIn((String) null)).isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources = {
@@ -947,19 +918,9 @@ class HistoricCaseActivityInstanceTest extends CmmnTest {
     assertCount(0, query);
     var historicCaseActivityInstanceQuery = historicQuery();
 
-    try {
-      historicCaseActivityInstanceQuery.caseActivityIdIn((String[])null);
-      fail("A NotValidException was expected.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicCaseActivityInstanceQuery.caseActivityIdIn((String[]) null)).isInstanceOf(NotValidException.class);
 
-    try {
-      historicCaseActivityInstanceQuery.caseActivityIdIn((String)null);
-      fail("A NotValidException was expected.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicCaseActivityInstanceQuery.caseActivityIdIn((String) null)).isInstanceOf(NotValidException.class);
   }
 
   protected HistoricCaseActivityInstanceQuery historicQuery() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
@@ -579,12 +579,12 @@ class HistoricCaseActivityInstanceTest extends CmmnTest {
   @Test
   void testInvalidSorting() {
     var historicCaseActivityInstanceQuery = historicQuery();
-    assertThatThrownBy(() -> historicCaseActivityInstanceQuery.asc()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(historicCaseActivityInstanceQuery::asc).isInstanceOf(ProcessEngineException.class);
 
-    assertThatThrownBy(() -> historicCaseActivityInstanceQuery.desc()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(historicCaseActivityInstanceQuery::desc).isInstanceOf(ProcessEngineException.class);
 
     var historicCaseActivityInstanceQuery1 = historicQuery().orderByHistoricCaseActivityInstanceId();
-    assertThatThrownBy(() -> historicCaseActivityInstanceQuery1.count()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(historicCaseActivityInstanceQuery1::count).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityInstanceTest.java
@@ -50,7 +50,7 @@ import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.cmmn.CmmnTest;
 import org.operaton.bpm.engine.variable.Variables;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.ACTIVE;
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.AVAILABLE;
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.COMPLETED;
@@ -59,6 +59,7 @@ import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.ENA
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.SUSPENDED;
 import static org.operaton.bpm.engine.impl.cmmn.execution.CaseExecutionState.TERMINATED;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Sebastian Menski

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityStatisticsQueryTest.java
@@ -35,7 +35,7 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Roman Smirnov
@@ -56,12 +56,7 @@ class HistoricCaseActivityStatisticsQueryTest {
     // given
 
     // when
-    try {
-      historicCaseActivityStatisticsQuery.list();
-      fail("It should not be possible to query for statistics by null.");
-    } catch (NullValueException exception) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicCaseActivityStatisticsQuery.list()).isInstanceOf(NullValueException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityStatisticsQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseActivityStatisticsQueryTest.java
@@ -56,7 +56,7 @@ class HistoricCaseActivityStatisticsQueryTest {
     // given
 
     // when
-    assertThatThrownBy(() -> historicCaseActivityStatisticsQuery.list()).isInstanceOf(NullValueException.class);
+    assertThatThrownBy(historicCaseActivityStatisticsQuery::list).isInstanceOf(NullValueException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricCaseInstanceTest.java
@@ -43,8 +43,7 @@ import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.cmmn.CmmnTest;
 import org.operaton.bpm.engine.variable.Variables;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Sebastian Menski
@@ -243,14 +242,7 @@ class HistoricCaseInstanceTest extends CmmnTest {
     var historicCaseInstanceQuery = historicQuery();
 
 
-    try {
-      // oracle handles empty string like null which seems to lead to undefined behavior of the LIKE comparison
-      historicCaseInstanceQuery.caseDefinitionKeyNotIn(emptyCaseDefinitionKeys);
-      fail("Exception expected");
-    }
-    catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicCaseInstanceQuery.caseDefinitionKeyNotIn(emptyCaseDefinitionKeys)).isInstanceOf(NotValidException.class);
 
 
     assertCount(1, historicQuery().caseDefinitionName("One Task Case"));
@@ -546,14 +538,7 @@ class HistoricCaseInstanceTest extends CmmnTest {
     assertThat(historicInstance).isNotNull();
     var historicInstanceId = historicInstance.getId();
 
-    try {
-      // should not be able to delete historic case instance cause the case instance is still running
-      historyService.deleteHistoricCaseInstance(historicInstanceId);
-      fail("Exception expected");
-    }
-    catch (NullValueException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historyService.deleteHistoricCaseInstance(historicInstanceId)).isInstanceOf(NullValueException.class);
 
     terminate(caseInstanceId);
     close(caseInstanceId);
@@ -802,13 +787,7 @@ class HistoricCaseInstanceTest extends CmmnTest {
   @Test
   void testFailQueryByCaseActivityIdNull() {
     var historicCaseInstanceQuery = historyService.createHistoricCaseInstanceQuery();
-    try {
-      historicCaseInstanceQuery.caseActivityIdIn((String) null);
-
-      fail("expected exception");
-    } catch (NullValueException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicCaseInstanceQuery.caseActivityIdIn((String) null)).isInstanceOf(NullValueException.class);
   }
 
   @Deployment(resources = "org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn")

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricDetailQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricDetailQueryTest.java
@@ -144,10 +144,7 @@ class HistoricDetailQueryTest {
     assertThat(query.list()).isEmpty();
     assertThat(query.count()).isZero();
 
-    try {
-      query.userOperationId(null);
-      fail("It was possible to set a null value as userOperationId.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> query.userOperationId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -315,21 +312,9 @@ class HistoricDetailQueryTest {
     // then
     assertThat(query.count()).isZero();
 
-    try {
-      // when
-      query.variableTypeIn(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // then fails
-    }
+    assertThatThrownBy(() -> query.variableTypeIn(null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      // when
-      query.variableTypeIn((String)null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // then fails
-    }
+    assertThatThrownBy(() -> query.variableTypeIn((String) null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -601,21 +586,9 @@ class HistoricDetailQueryTest {
     HistoricDetailQuery query =
       historyService.createHistoricDetailQuery();
 
-    try {
-      // when
-      query.processInstanceIdIn(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // then fails
-    }
+    assertThatThrownBy(() -> query.processInstanceIdIn(null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      // when
-      query.processInstanceIdIn((String)null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // then fails
-    }
+    assertThatThrownBy(() -> query.processInstanceIdIn((String) null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -708,13 +681,7 @@ class HistoricDetailQueryTest {
     HistoricDetailQuery query =
       historyService.createHistoricDetailQuery();
 
-    try {
-      // when
-      query.occurredBefore(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // then fails
-    }
+    assertThatThrownBy(() -> query.occurredBefore(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -729,13 +696,7 @@ class HistoricDetailQueryTest {
     HistoricDetailQuery query =
       historyService.createHistoricDetailQuery();
 
-    try {
-      // when
-      query.occurredAfter(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // then fails
-    }
+    assertThatThrownBy(() -> query.occurredAfter(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIncidentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIncidentQueryTest.java
@@ -133,10 +133,7 @@ public class HistoricIncidentQueryTest {
     assertThat(query.incidentId("invalid").list()).isEmpty();
     assertThat(query.incidentId("invalid").count()).isZero();
 
-    try {
-      query.incidentId(null);
-      fail("It was possible to set a null value as incidentId.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> query.incidentId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -158,10 +155,7 @@ public class HistoricIncidentQueryTest {
     assertThat(query.incidentType("invalid").list()).isEmpty();
     assertThat(query.incidentType("invalid").count()).isZero();
 
-    try {
-      query.incidentType(null);
-      fail("It was possible to set a null value as incidentType.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> query.incidentType(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -183,10 +177,7 @@ public class HistoricIncidentQueryTest {
     assertThat(query.incidentMessage("invalid").list()).isEmpty();
     assertThat(query.incidentMessage("invalid").count()).isZero();
 
-    try {
-      query.incidentMessage(null);
-      fail("It was possible to set a null value as incidentMessage.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> query.incidentMessage(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -223,10 +214,7 @@ public class HistoricIncidentQueryTest {
     assertThat(query.processDefinitionId("invalid").list()).isEmpty();
     assertThat(query.processDefinitionId("invalid").count()).isZero();
 
-    try {
-      query.processDefinitionId(null);
-      fail("It was possible to set a null value as processDefinitionId.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> query.processDefinitionId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -303,10 +291,7 @@ public class HistoricIncidentQueryTest {
     assertThat(query.processInstanceId("invalid").list()).isEmpty();
     assertThat(query.processInstanceId("invalid").count()).isZero();
 
-    try {
-      query.processInstanceId(null);
-      fail("It was possible to set a null value as processInstanceId.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> query.processInstanceId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -330,10 +315,7 @@ public class HistoricIncidentQueryTest {
     assertThat(query.executionId("invalid").list()).isEmpty();
     assertThat(query.executionId("invalid").count()).isZero();
 
-    try {
-      query.executionId(null);
-      fail("It was possible to set a null value as executionId.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> query.executionId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -358,10 +340,7 @@ public class HistoricIncidentQueryTest {
     assertThat(query.activityId("invalid").list()).isEmpty();
     assertThat(query.activityId("invalid").count()).isZero();
 
-    try {
-      query.activityId(null);
-      fail("It was possible to set a null value as activityId.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> query.activityId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -386,10 +365,7 @@ public class HistoricIncidentQueryTest {
     assertThat(query.failedActivityId("invalid").list()).isEmpty();
     assertThat(query.failedActivityId("invalid").count()).isZero();
 
-    try {
-      query.failedActivityId(null);
-      fail("It was possible to set a null value as failedActivityId.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> query.failedActivityId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -421,10 +397,7 @@ public class HistoricIncidentQueryTest {
     assertThat(query.causeIncidentId("invalid").list()).isEmpty();
     assertThat(query.causeIncidentId("invalid").count()).isZero();
 
-    try {
-      query.causeIncidentId(null);
-      fail("It was possible to set a null value as causeIncidentId.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> query.causeIncidentId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -456,10 +429,7 @@ public class HistoricIncidentQueryTest {
     assertThat(query.rootCauseIncidentId("invalid").list()).isEmpty();
     assertThat(query.rootCauseIncidentId("invalid").count()).isZero();
 
-    try {
-      query.rootCauseIncidentId(null);
-      fail("It was possible to set a null value as rootCauseIncidentId.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> query.rootCauseIncidentId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -483,10 +453,7 @@ public class HistoricIncidentQueryTest {
     assertThat(query.configuration("invalid").list()).isEmpty();
     assertThat(query.configuration("invalid").count()).isZero();
 
-    try {
-      query.configuration(null);
-      fail("It was possible to set a null value as configuration.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> query.configuration(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -527,10 +494,7 @@ public class HistoricIncidentQueryTest {
     assertThat(query.historyConfiguration("invalid").list()).isEmpty();
     assertThat(query.historyConfiguration("invalid").count()).isZero();
 
-    try {
-      query.historyConfiguration(null);
-      fail("It was possible to set a null value as history configuration.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> query.historyConfiguration(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -550,10 +514,7 @@ public class HistoricIncidentQueryTest {
     HistoricIncidentQuery query = historyService.createHistoricIncidentQuery();
     var historicIncidentQuery = query.open();
 
-    try {
-      historicIncidentQuery.open();
-      fail("It was possible to set a the open flag twice.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> historicIncidentQuery.open()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -576,10 +537,7 @@ public class HistoricIncidentQueryTest {
     HistoricIncidentQuery query = historyService.createHistoricIncidentQuery();
     var historicIncidentQuery = query.resolved();
 
-    try {
-      historicIncidentQuery.resolved();
-      fail("It was possible to set a the resolved flag twice.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> historicIncidentQuery.resolved()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -602,10 +560,7 @@ public class HistoricIncidentQueryTest {
     HistoricIncidentQuery query = historyService.createHistoricIncidentQuery();
     var historicIncidentQuery = query.deleted();
 
-    try {
-      historicIncidentQuery.deleted();
-      fail("It was possible to set a the deleted flag twice.");
-    } catch (ProcessEngineException e) { }
+    assertThatThrownBy(() -> historicIncidentQuery.deleted()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIncidentQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricIncidentQueryTest.java
@@ -514,7 +514,7 @@ public class HistoricIncidentQueryTest {
     HistoricIncidentQuery query = historyService.createHistoricIncidentQuery();
     var historicIncidentQuery = query.open();
 
-    assertThatThrownBy(() -> historicIncidentQuery.open()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(historicIncidentQuery::open).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -537,7 +537,7 @@ public class HistoricIncidentQueryTest {
     HistoricIncidentQuery query = historyService.createHistoricIncidentQuery();
     var historicIncidentQuery = query.resolved();
 
-    assertThatThrownBy(() -> historicIncidentQuery.resolved()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(historicIncidentQuery::resolved).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -560,7 +560,7 @@ public class HistoricIncidentQueryTest {
     HistoricIncidentQuery query = historyService.createHistoricIncidentQuery();
     var historicIncidentQuery = query.deleted();
 
-    assertThatThrownBy(() -> historicIncidentQuery.deleted()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(historicIncidentQuery::deleted).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceDurationReportTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceDurationReportTest.java
@@ -51,7 +51,6 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import static org.operaton.bpm.engine.query.PeriodUnit.MONTH;
 import static org.operaton.bpm.engine.query.PeriodUnit.QUARTER;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 /**
@@ -276,12 +275,7 @@ class HistoricProcessInstanceDurationReportTest {
   void testReportByInvalidPeriodUnit() {
     HistoricProcessInstanceReport report = historyService.createHistoricProcessInstanceReport();
 
-    try {
-      report.duration(null);
-      fail("Exception expected");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> report.duration(null)).isInstanceOf(NotValidException.class);
   }
 
   @Test
@@ -348,12 +342,7 @@ class HistoricProcessInstanceDurationReportTest {
   void testReportByInvalidStartedBefore() {
     HistoricProcessInstanceReport report = historyService.createHistoricProcessInstanceReport();
 
-    try {
-      report.startedBefore(null);
-      fail("Exception expected");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> report.startedBefore(null)).isInstanceOf(NotValidException.class);
   }
 
   @Test
@@ -414,12 +403,7 @@ class HistoricProcessInstanceDurationReportTest {
   void testReportByInvalidStartedAfter() {
     HistoricProcessInstanceReport report = historyService.createHistoricProcessInstanceReport();
 
-    try {
-      report.startedAfter(null);
-      fail("Exception expected");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> report.startedAfter(null)).isInstanceOf(NotValidException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricProcessInstanceTest.java
@@ -2213,25 +2213,13 @@ class HistoricProcessInstanceTest {
   @Test
   void testQueryByOneInvalidProcessDefinitionKeyIn() {
     var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
-    try {
-      // when
-      historicProcessInstanceQuery.processDefinitionKeyIn((String) null);
-      fail("Exception expected");
-    } catch(ProcessEngineException expected) {
-      // then Exception is expected
-    }
+    assertThatThrownBy(() -> historicProcessInstanceQuery.processDefinitionKeyIn((String) null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
   void testQueryByMultipleInvalidProcessDefinitionKeyIn() {
     var historicProcessInstanceQuery = historyService.createHistoricProcessInstanceQuery();
-    try {
-      // when
-      historicProcessInstanceQuery.processDefinitionKeyIn(ProcessModels.PROCESS_KEY, null);
-      fail("Exception expected");
-    } catch(ProcessEngineException expected) {
-      // then Exception is expected
-    }
+    assertThatThrownBy(() -> historicProcessInstanceQuery.processDefinitionKeyIn(ProcessModels.PROCESS_KEY, null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricTaskInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricTaskInstanceTest.java
@@ -48,9 +48,7 @@ import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.RequiredHistoryLevel;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 
 /**
@@ -580,26 +578,11 @@ class HistoricTaskInstanceTest {
     assertThat(query.count()).isZero();
     String[] values = { "a", null, "b" };
 
-    try {
-      query.activityInstanceIdIn(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.activityInstanceIdIn(null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      query.activityInstanceIdIn((String)null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.activityInstanceIdIn((String) null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      query.activityInstanceIdIn(values);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.activityInstanceIdIn(values)).isInstanceOf(ProcessEngineException.class);
 
   }
 
@@ -1055,26 +1038,11 @@ class HistoricTaskInstanceTest {
     assertThat(query.count()).isZero();
     String[] values = { "a", null, "b" };
 
-    try {
-      query.taskDefinitionKeyIn(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.taskDefinitionKeyIn(null)).isInstanceOf(NotValidException.class);
 
-    try {
-      query.taskDefinitionKeyIn((String)null);
-      fail("A ProcessEngineException was expected.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.taskDefinitionKeyIn((String) null)).isInstanceOf(NotValidException.class);
 
-    try {
-      query.taskDefinitionKeyIn(values);
-      fail("A ProcessEngineException was expected.");
-    } catch (NotValidException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.taskDefinitionKeyIn(values)).isInstanceOf(NotValidException.class);
 
   }
 
@@ -1119,26 +1087,11 @@ class HistoricTaskInstanceTest {
     assertThat(query.count()).isZero();
     String[] values = { "a", null, "b" };
 
-    try {
-      query.processInstanceBusinessKeyIn(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.processInstanceBusinessKeyIn(null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      query.processInstanceBusinessKeyIn((String)null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.processInstanceBusinessKeyIn((String) null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      query.processInstanceBusinessKeyIn(values);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.processInstanceBusinessKeyIn(values)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/oneTaskProcess.bpmn20.xml"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricVariableInstanceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricVariableInstanceTest.java
@@ -82,7 +82,6 @@ import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.property
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.tuple;
 
 /**
@@ -480,19 +479,9 @@ class HistoricVariableInstanceTest {
     var processInstanceId = processInstance.getProcessInstanceId();
 
     // check existing variables for task ID
-    try {
-      historicVariableInstanceQuery.processInstanceIdIn(processInstanceId, null);
-      fail("Search by process instance ID was finished");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicVariableInstanceQuery.processInstanceIdIn(processInstanceId, null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      historicVariableInstanceQuery.processInstanceIdIn(null, processInstanceId);
-      fail("Search by process instance ID was finished");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicVariableInstanceQuery.processInstanceIdIn(null, processInstanceId)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
@@ -527,19 +516,9 @@ class HistoricVariableInstanceTest {
     assertThat(query.count()).isZero();
     var historicVariableInstanceQuery = historyService.createHistoricVariableInstanceQuery();
 
-    try {
-      historicVariableInstanceQuery.executionIdIn((String[])null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicVariableInstanceQuery.executionIdIn((String[]) null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      historicVariableInstanceQuery.executionIdIn((String)null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicVariableInstanceQuery.executionIdIn((String) null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -548,19 +527,9 @@ class HistoricVariableInstanceTest {
     assertThat(query.count()).isZero();
     var historicVariableInstanceQuery = historyService.createHistoricVariableInstanceQuery();
 
-    try {
-      historicVariableInstanceQuery.taskIdIn((String[])null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicVariableInstanceQuery.taskIdIn((String[]) null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      historicVariableInstanceQuery.taskIdIn((String)null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicVariableInstanceQuery.taskIdIn((String) null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
@@ -596,19 +565,9 @@ class HistoricVariableInstanceTest {
     query.taskIdIn("invalid");
     assertThat(query.count()).isZero();
 
-    try {
-      query.taskIdIn((String[])null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.taskIdIn((String[]) null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      query.taskIdIn((String)null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.taskIdIn((String) null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/runtime/oneTaskProcess.bpmn20.xml"})
@@ -680,21 +639,9 @@ class HistoricVariableInstanceTest {
     // then
     assertThat(query.count()).isZero();
 
-    try {
-      // when
-      query.variableTypeIn((String[])null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // then fails
-    }
+    assertThatThrownBy(() -> query.variableTypeIn((String[]) null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      // when
-      query.variableTypeIn((String)null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // then fails
-    }
+    assertThatThrownBy(() -> query.variableTypeIn((String) null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1955,26 +1902,11 @@ class HistoricVariableInstanceTest {
     assertThat(query.count()).isZero();
     String[] values = { "a", null, "b" };
 
-    try {
-      query.caseActivityIdIn((String[])null);
-      fail("A ProcessEngineException was expected.");
-    } catch (NullValueException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.caseActivityIdIn((String[]) null)).isInstanceOf(NullValueException.class);
 
-    try {
-      query.caseActivityIdIn((String)null);
-      fail("A ProcessEngineException was expected.");
-    } catch (NullValueException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.caseActivityIdIn((String) null)).isInstanceOf(NullValueException.class);
 
-    try {
-      query.caseActivityIdIn(values);
-      fail("A ProcessEngineException was expected.");
-    } catch (NullValueException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.caseActivityIdIn(values)).isInstanceOf(NullValueException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
@@ -53,8 +53,7 @@ import org.operaton.bpm.engine.variable.Variables;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.inverted;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.propertyComparator;
 import static org.operaton.bpm.engine.test.api.runtime.TestOrderingUtil.verifySorting;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Philipp Ossler
@@ -129,12 +128,7 @@ class HistoricDecisionInstanceQueryTest {
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
     var historicDecisionInstance = query.singleResult();
 
-    try {
-      historicDecisionInstance.getOutputs();
-      fail("expected exception: output not fetched");
-    } catch (ProcessEngineException e) {
-      // should throw exception if output is not fetched
-    }
+    assertThatThrownBy(() -> historicDecisionInstance.getOutputs()).isInstanceOf(ProcessEngineException.class);
 
     assertThat(query.includeOutputs().singleResult().getOutputs()).hasSize(1);
   }
@@ -378,12 +372,7 @@ class HistoricDecisionInstanceQueryTest {
 
     assertThat(query.decisionDefinitionNameLike("%invalid%").count()).isZero();
 
-    try {
-      query.decisionDefinitionNameLike(null);
-      fail("");
-    } catch (NotValidException e) {
-      // Expected exception
-    }
+    assertThatThrownBy(() -> query.decisionDefinitionNameLike(null)).isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources = {DECISION_PROCESS, DECISION_SINGLE_OUTPUT_DMN})
@@ -505,11 +494,7 @@ class HistoricDecisionInstanceQueryTest {
 
     assertThat(query.caseDefinitionKey("invalid").count()).isZero();
 
-    try {
-      query.caseDefinitionKey(null);
-      fail("exception expected");
-    } catch (ProcessEngineException e) {
-    }
+    assertThatThrownBy(() -> query.caseDefinitionKey(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {DECISION_CASE, DECISION_SINGLE_OUTPUT_DMN})
@@ -528,11 +513,7 @@ class HistoricDecisionInstanceQueryTest {
 
     assertThat(query.caseDefinitionId("invalid").count()).isZero();
 
-    try {
-      query.caseDefinitionId(null);
-      fail("exception expected");
-    } catch (ProcessEngineException e) {
-    }
+    assertThatThrownBy(() -> query.caseDefinitionId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {DECISION_CASE, DECISION_SINGLE_OUTPUT_DMN})
@@ -551,11 +532,7 @@ class HistoricDecisionInstanceQueryTest {
 
     assertThat(query.caseInstanceId("invalid").count()).isZero();
 
-    try {
-      query.caseInstanceId(null);
-      fail("exception expected");
-    } catch (ProcessEngineException e) {
-    }
+    assertThatThrownBy(() -> query.caseInstanceId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {DECISION_SINGLE_OUTPUT_DMN})
@@ -577,11 +554,7 @@ class HistoricDecisionInstanceQueryTest {
 
     assertThat(query.userId("dem1").count()).isZero();
 
-    try {
-      query.userId(null);
-      fail("exception expected");
-    } catch (ProcessEngineException e) {
-    }
+    assertThatThrownBy(() -> query.userId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {DRG_DMN})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/dmn/HistoricDecisionInstanceQueryTest.java
@@ -128,7 +128,7 @@ class HistoricDecisionInstanceQueryTest {
     HistoricDecisionInstanceQuery query = historyService.createHistoricDecisionInstanceQuery();
     var historicDecisionInstance = query.singleResult();
 
-    assertThatThrownBy(() -> historicDecisionInstance.getOutputs()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(historicDecisionInstance::getOutputs).isInstanceOf(ProcessEngineException.class);
 
     assertThat(query.includeOutputs().singleResult().getOutputs()).hasSize(1);
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/UserOperationLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/UserOperationLogQueryTest.java
@@ -51,7 +51,7 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Attachment;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.EntityTypes.ATTACHMENT;
 import static org.operaton.bpm.engine.EntityTypes.IDENTITY_LINK;
 import static org.operaton.bpm.engine.EntityTypes.JOB;
@@ -66,7 +66,6 @@ import static org.operaton.bpm.engine.impl.persistence.entity.TaskEntity.ASSIGNE
 import static org.operaton.bpm.engine.impl.persistence.entity.TaskEntity.OWNER;
 import static org.operaton.bpm.engine.test.util.QueryTestHelper.verifyQueryResults;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Danny Gräf
@@ -1239,19 +1238,9 @@ class UserOperationLogQueryTest extends AbstractUserOperationLogTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.entityTypeIn((String[]) null);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.entityTypeIn((String[]) null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      query.entityTypeIn(TASK, null, EntityTypes.VARIABLE);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.entityTypeIn(TASK, null, EntityTypes.VARIABLE)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Deployment(resources = {ONE_TASK_PROCESS})
@@ -1301,26 +1290,12 @@ class UserOperationLogQueryTest extends AbstractUserOperationLogTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.category(null);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    var query2 = query;
+    assertThatThrownBy(() -> query2.category(null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      query.categoryIn((String[]) null);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query2.categoryIn((String[]) null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      query.categoryIn(UserOperationLogEntry.CATEGORY_ADMIN, null, UserOperationLogEntry.CATEGORY_TASK_WORKER);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query2.categoryIn(UserOperationLogEntry.CATEGORY_ADMIN, null, UserOperationLogEntry.CATEGORY_TASK_WORKER)).isInstanceOf(ProcessEngineException.class);
   }
 
   // ----- DELETE VARIABLE HISTORY -----
@@ -1685,12 +1660,7 @@ class UserOperationLogQueryTest extends AbstractUserOperationLogTest {
 
     verifyQueryResults(query, 0);
 
-    try {
-      query.deploymentId(null);
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.deploymentId(null)).isInstanceOf(ProcessEngineException.class);
   }
 
   private Map<String, Object> createMapForVariableAddition() {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/UserOperationLogQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/UserOperationLogQueryTest.java
@@ -51,7 +51,7 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.Attachment;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import static org.operaton.bpm.engine.EntityTypes.ATTACHMENT;
 import static org.operaton.bpm.engine.EntityTypes.IDENTITY_LINK;
 import static org.operaton.bpm.engine.EntityTypes.JOB;
@@ -66,6 +66,7 @@ import static org.operaton.bpm.engine.impl.persistence.entity.TaskEntity.ASSIGNE
 import static org.operaton.bpm.engine.impl.persistence.entity.TaskEntity.OWNER;
 import static org.operaton.bpm.engine.test.util.QueryTestHelper.verifyQueryResults;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Danny Gräf

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/UserOperationLogTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/UserOperationLogTaskTest.java
@@ -34,7 +34,7 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.DelegationState;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.operaton.bpm.engine.history.UserOperationLogEntry.*;
 import static org.operaton.bpm.engine.impl.persistence.entity.TaskEntity.ASSIGNEE;
 import static org.operaton.bpm.engine.impl.persistence.entity.TaskEntity.DELEGATION;
@@ -42,7 +42,6 @@ import static org.operaton.bpm.engine.impl.persistence.entity.TaskEntity.DELETE;
 import static org.operaton.bpm.engine.impl.persistence.entity.TaskEntity.OWNER;
 import static org.operaton.bpm.engine.impl.persistence.entity.TaskEntity.PRIORITY;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Danny Gräf
@@ -512,12 +511,7 @@ class UserOperationLogTaskTest extends AbstractUserOperationLogTest {
     taskService.resolveTask(task.getId());
 
     // when null is used as deletion parameter
-    try {
-      historyService.deleteUserOperationLogEntry(null);
-      fail("exception expected");
-    } catch (NotValidException e) {
-      // then there should be an exception that signals an illegal input
-    }
+    assertThatThrownBy(() -> historyService.deleteUserOperationLogEntry(null)).isInstanceOf(NotValidException.class);
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/history/oneTaskProcess.bpmn20.xml"})

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/UserOperationLogTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/useroperationlog/UserOperationLogTaskTest.java
@@ -34,7 +34,7 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
 import org.operaton.bpm.engine.task.DelegationState;
 import org.operaton.bpm.engine.task.Task;
 import org.operaton.bpm.engine.test.Deployment;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import static org.operaton.bpm.engine.history.UserOperationLogEntry.*;
 import static org.operaton.bpm.engine.impl.persistence.entity.TaskEntity.ASSIGNEE;
 import static org.operaton.bpm.engine.impl.persistence.entity.TaskEntity.DELEGATION;
@@ -42,6 +42,7 @@ import static org.operaton.bpm.engine.impl.persistence.entity.TaskEntity.DELETE;
 import static org.operaton.bpm.engine.impl.persistence.entity.TaskEntity.OWNER;
 import static org.operaton.bpm.engine.impl.persistence.entity.TaskEntity.PRIORITY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Danny Gräf

--- a/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
@@ -52,7 +52,7 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import org.operaton.commons.logging.MdcAccess;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ProcessDataLoggingContextTest {
 
@@ -407,12 +407,7 @@ class ProcessDataLoggingContextTest {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
     var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
-    try {
-      taskService.complete(taskQuery);
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the task listener that is not caught
-    }
+    assertThatThrownBy(() -> taskService.complete(taskQuery)).isInstanceOf(Exception.class);
     // then
     assertFailureLogPresent(instance, "failingTask");
   }
@@ -433,12 +428,7 @@ class ProcessDataLoggingContextTest {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
     var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
-    try {
-      taskService.complete(taskQuery);
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the task listener that is not caught
-    }
+    assertThatThrownBy(() -> taskService.complete(taskQuery)).isInstanceOf(Exception.class);
     // then
     assertFailureLogPresent(instance, LOG_IDENT_FAILURE, "failingTask", null, B_KEY2, 1);
   }
@@ -457,12 +447,7 @@ class ProcessDataLoggingContextTest {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
     var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
-    try {
-      taskService.complete(taskQuery);
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the task listener that is not caught
-    }
+    assertThatThrownBy(() -> taskService.complete(taskQuery)).isInstanceOf(Exception.class);
     assertFailureLogPresent(instance, "failingTask");
   }
 
@@ -479,12 +464,7 @@ class ProcessDataLoggingContextTest {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
     var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
-    try {
-      taskService.setAssignee(taskQuery, "testUser");
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the task listener that is not caught
-    }
+    assertThatThrownBy(() -> taskService.setAssignee(taskQuery, "testUser")).isInstanceOf(Exception.class);
     assertFailureLogPresent(instance, "failingTask");
   }
 
@@ -501,12 +481,7 @@ class ProcessDataLoggingContextTest {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
     var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
-    try {
-      taskService.complete(taskQuery);
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the task listener that is not caught
-    }
+    assertThatThrownBy(() -> taskService.complete(taskQuery)).isInstanceOf(Exception.class);
     assertFailureLogPresent(instance, "failingTask");
   }
 
@@ -523,12 +498,7 @@ class ProcessDataLoggingContextTest {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
     var instanceId = instance.getId();
     // when
-    try {
-      runtimeService.deleteProcessInstance(instanceId, "cancel it");
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the task listener that is not caught
-    }
+    assertThatThrownBy(() -> runtimeService.deleteProcessInstance(instanceId, "cancel it")).isInstanceOf(Exception.class);
     assertFailureLogPresent(instance, "failingTask");
   }
 
@@ -540,12 +510,7 @@ class ProcessDataLoggingContextTest {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
     var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
-    try {
-      taskService.complete(taskQuery);
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the execution listener that is not caught
-    }
+    assertThatThrownBy(() -> taskService.complete(taskQuery)).isInstanceOf(Exception.class);
     // then
     assertFailureLogPresent(instance, "failingTask");
   }
@@ -588,12 +553,7 @@ class ProcessDataLoggingContextTest {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
     var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
-    try {
-      taskService.complete(taskQuery);
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the service task that is not caught
-    }
+    assertThatThrownBy(() -> taskService.complete(taskQuery)).isInstanceOf(Exception.class);
     // then
     assertFailureLogPresent(instance, "failingTask");
   }
@@ -618,12 +578,7 @@ class ProcessDataLoggingContextTest {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
     var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
-    try {
-      taskService.complete(taskQuery);
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the nested delegate that is not caught
-    }
+    assertThatThrownBy(() -> taskService.complete(taskQuery)).isInstanceOf(Exception.class);
     // then
     assertFailureLogPresent(instance, "startProcess");
     assertBpmnStacktraceLogPresent(instance);
@@ -650,12 +605,7 @@ class ProcessDataLoggingContextTest {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
     var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
-    try {
-      taskService.complete(taskQuery);
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the nested delegate that is not caught
-    }
+    assertThatThrownBy(() -> taskService.complete(taskQuery)).isInstanceOf(Exception.class);
     // then
     assertFailureLogPresent(instance, "startProcess");
     assertBpmnStacktraceLogPresent(instance);
@@ -674,12 +624,7 @@ class ProcessDataLoggingContextTest {
         .done());
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
     // when
-    try {
-      runtimeService.correlateMessage("testMessage");
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the task listener that is not caught
-    }
+    assertThatThrownBy(() -> runtimeService.correlateMessage("testMessage")).isInstanceOf(Exception.class);
     // then
     assertFailureLogPresent(instance, "message");
   }
@@ -691,12 +636,7 @@ class ProcessDataLoggingContextTest {
     testRule.deployForTenant(TENANT_ID, "org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextTest.shouldLogFailureFromEventSubprocessInSubprocessTaskContext.bpmn20.xml");
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS);
     // when
-    try {
-      runtimeService.correlateMessage("testMessage");
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the delegate that is not caught
-    }
+    assertThatThrownBy(() -> runtimeService.correlateMessage("testMessage")).isInstanceOf(Exception.class);
     // then
     assertFailureLogPresent(instance, "sub_failingTask");
   }
@@ -715,12 +655,7 @@ class ProcessDataLoggingContextTest {
     ProcessInstance pi = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
     var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
-    try {
-      taskService.complete(taskQuery);
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the delegate resolution that is not caught
-    }
+    assertThatThrownBy(() -> taskService.complete(taskQuery)).isInstanceOf(Exception.class);
     // then
     assertFailureLogPresent(pi, "failingTask");
   }
@@ -740,12 +675,7 @@ class ProcessDataLoggingContextTest {
     ProcessInstance pi = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
     var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
-    try {
-      taskService.complete(taskQuery);
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the delegate resolution that is not caught
-    }
+    assertThatThrownBy(() -> taskService.complete(taskQuery)).isInstanceOf(Exception.class);
     // then
     assertFailureLogPresent(pi, "failingTask");
   }
@@ -765,12 +695,7 @@ class ProcessDataLoggingContextTest {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
     var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
-    try {
-      taskService.complete(taskQuery);
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the task listener that is not caught
-    }
+    assertThatThrownBy(() -> taskService.complete(taskQuery)).isInstanceOf(Exception.class);
     application.undeploy();
     assertFailureLogInApplication(instance, "failingTask", application.getName());
   }
@@ -790,12 +715,7 @@ class ProcessDataLoggingContextTest {
     ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
     var taskQuery = taskService.createTaskQuery().singleResult().getId();
     // when
-    try {
-      taskService.complete(taskQuery);
-      fail("Exception expected");
-    } catch (Exception e) {
-      // expected exception in the execution listener that is not caught
-    }
+    assertThatThrownBy(() -> taskService.complete(taskQuery)).isInstanceOf(Exception.class);
     application.undeploy();
     // then
     assertFailureLogInApplication(instance, "failingTask", application.getName());

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/FullHistoryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/FullHistoryTest.java
@@ -716,24 +716,24 @@ class FullHistoryTest {
   @Test
   void testHistoricDetailQueryInvalidSorting() {
     var historicDetailQuery = historyService.createHistoricDetailQuery();
-    assertThatThrownBy(() -> historicDetailQuery.asc()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(historicDetailQuery::asc).isInstanceOf(ProcessEngineException.class);
 
-    assertThatThrownBy(() -> historicDetailQuery.desc()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(historicDetailQuery::desc).isInstanceOf(ProcessEngineException.class);
 
     HistoricDetailQuery queryOrderByProcessInstanceId = historicDetailQuery.orderByProcessInstanceId();
-    assertThatThrownBy(() -> queryOrderByProcessInstanceId.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(queryOrderByProcessInstanceId::list).isInstanceOf(ProcessEngineException.class);
 
     HistoricDetailQuery queryOrderByTime = historicDetailQuery.orderByTime();
-    assertThatThrownBy(() -> queryOrderByTime.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(queryOrderByTime::list).isInstanceOf(ProcessEngineException.class);
 
     HistoricDetailQuery queryOrderByVariableName = historicDetailQuery.orderByVariableName();
-    assertThatThrownBy(() -> queryOrderByVariableName.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(queryOrderByVariableName::list).isInstanceOf(ProcessEngineException.class);
 
     HistoricDetailQuery queryOrderByVariableRevision = historicDetailQuery.orderByVariableRevision();
-    assertThatThrownBy(() -> queryOrderByVariableRevision.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(queryOrderByVariableRevision::list).isInstanceOf(ProcessEngineException.class);
 
     HistoricDetailQuery queryByVariableType = historicDetailQuery.orderByVariableType();
-    assertThatThrownBy(() -> queryByVariableType.list()).isInstanceOf(ProcessEngineException.class);
+    assertThatThrownBy(queryByVariableType::list).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/FullHistoryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/FullHistoryTest.java
@@ -64,8 +64,7 @@ import org.operaton.bpm.engine.variable.type.ValueType;
 import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
@@ -717,59 +716,24 @@ class FullHistoryTest {
   @Test
   void testHistoricDetailQueryInvalidSorting() {
     var historicDetailQuery = historyService.createHistoricDetailQuery();
-    try {
-      historicDetailQuery.asc();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicDetailQuery.asc()).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      historicDetailQuery.desc();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> historicDetailQuery.desc()).isInstanceOf(ProcessEngineException.class);
 
     HistoricDetailQuery queryOrderByProcessInstanceId = historicDetailQuery.orderByProcessInstanceId();
-    try {
-      queryOrderByProcessInstanceId.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> queryOrderByProcessInstanceId.list()).isInstanceOf(ProcessEngineException.class);
 
     HistoricDetailQuery queryOrderByTime = historicDetailQuery.orderByTime();
-    try {
-      queryOrderByTime.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> queryOrderByTime.list()).isInstanceOf(ProcessEngineException.class);
 
     HistoricDetailQuery queryOrderByVariableName = historicDetailQuery.orderByVariableName();
-    try {
-      queryOrderByVariableName.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> queryOrderByVariableName.list()).isInstanceOf(ProcessEngineException.class);
 
     HistoricDetailQuery queryOrderByVariableRevision = historicDetailQuery.orderByVariableRevision();
-    try {
-      queryOrderByVariableRevision.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> queryOrderByVariableRevision.list()).isInstanceOf(ProcessEngineException.class);
 
     HistoricDetailQuery queryByVariableType = historicDetailQuery.orderByVariableType();
-    try {
-      queryByVariableType.list();
-      fail("");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> queryByVariableType.list()).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test
@@ -1297,19 +1261,9 @@ class FullHistoryTest {
     query.variableInstanceId("invalid");
     assertThat(query.count()).isZero();
 
-    try {
-      query.variableInstanceId(null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.variableInstanceId(null)).isInstanceOf(ProcessEngineException.class);
 
-    try {
-      query.variableInstanceId((String)null);
-      fail("A ProcessEngineException was expected.");
-    } catch (ProcessEngineException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> query.variableInstanceId((String) null)).isInstanceOf(ProcessEngineException.class);
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/interceptor/CommandContextInterceptorTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/interceptor/CommandContextInterceptorTest.java
@@ -33,8 +33,7 @@ import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * @author Tom Baeyens
@@ -53,15 +52,9 @@ class CommandContextInterceptorTest {
   @Test
   void testCommandContextGetCurrentAfterException() {
     var commandExecutor = processEngineConfiguration.getCommandExecutorTxRequired();
-    try {
-      commandExecutor.execute(commandContext -> {
-        throw new IllegalStateException("here i come!");
-      });
-
-      fail("expected exception");
-    } catch (IllegalStateException e) {
-      // OK
-    }
+    assertThatThrownBy(() -> commandExecutor.execute(commandContext -> {
+      throw new IllegalStateException("here i come!");
+    })).isInstanceOf(IllegalStateException.class);
 
     assertThat(Context.getCommandContext()).isNull();
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/util/SingleConsumerConditionTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/util/SingleConsumerConditionTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Timeout;
 
 import org.operaton.bpm.engine.impl.util.SingleConsumerCondition;
 
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SingleConsumerConditionTest {
 
@@ -65,24 +65,12 @@ class SingleConsumerConditionTest {
     SingleConsumerCondition condition = new SingleConsumerCondition(new Thread());
 
     // when then
-    try {
-      condition.await(0);
-      fail("expected exception");
-    }
-    catch (RuntimeException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> condition.await(0)).isInstanceOf(RuntimeException.class);
   }
 
   @Test
   void cannotCreateWithNull() {
-    try {
-      new SingleConsumerCondition(null);
-      fail("expected exception");
-    }
-    catch (IllegalArgumentException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> new SingleConsumerCondition(null)).isInstanceOf(IllegalArgumentException.class);
   }
 
 }

--- a/freemarker-template-engine/src/test/java/org/operaton/templateengines/engine/FreeMarkerScriptEngineTest.java
+++ b/freemarker-template-engine/src/test/java/org/operaton/templateengines/engine/FreeMarkerScriptEngineTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.operaton.templateengines.engine.util.Greeter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Sebastian Menski
@@ -127,13 +127,10 @@ class FreeMarkerScriptEngineTest {
 
   @Test
   void failingEvaluation() {
-    try {
+    assertThatThrownBy(() -> {
       String invalidTemplate = "${}";
       evaluate(invalidTemplate);
-      fail("Expected a ScriptException");
-    } catch (ScriptException e) {
-      // happy path
-    }
+    }).isInstanceOf(ScriptException.class);
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,8 @@
             <exclusion>**/DomXmlDataFormatWriterTest.java</exclusion>
             <exclusion>**/JerseyServerBootstrap.java</exclusion>
             <exclusion>**/ProcessApplicationStartService.java</exclusion>
+            <exclusion>**/AbstractWebIT.java</exclusion>
+            <exclusion>**/AbstractWebappUiIT.java</exclusion>
             <!-- org.openrewrite.java.RemoveUnusedImports -->
             <exclusion>**/TestConstants.java</exclusion>
             <!-- org.openrewrite.java.testing.cleanup.SimplifyTestThrows -->

--- a/pom.xml
+++ b/pom.xml
@@ -125,8 +125,6 @@
             <exclusion>**/DomXmlDataFormatWriterTest.java</exclusion>
             <exclusion>**/JerseyServerBootstrap.java</exclusion>
             <exclusion>**/ProcessApplicationStartService.java</exclusion>
-            <exclusion>**/AbstractWebIT.java</exclusion>
-            <exclusion>**/AbstractWebappUiIT.java</exclusion>
             <!-- org.openrewrite.java.RemoveUnusedImports -->
             <exclusion>**/TestConstants.java</exclusion>
             <!-- org.openrewrite.java.testing.cleanup.SimplifyTestThrows -->

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/TestPostDeployFailure_JBOSS.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/callbacks/TestPostDeployFailure_JBOSS.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.operaton.bpm.integrationtest.deployment.callbacks.apps.PostDeployFailureApp;
 
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Daniel Meyer
@@ -54,12 +54,7 @@ public class TestPostDeployFailure_JBOSS {
   @Test
   void test() {
 
-    try {
-      deployer.deploy(DEPLOYMENT);
-      fail("failure expected");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deployer.deploy(DEPLOYMENT)).isInstanceOf(Exception.class);
 
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithBrokenBpmnXml.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithBrokenBpmnXml.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.operaton.bpm.integrationtest.util.TestContainer;
 
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 /**
@@ -60,12 +60,7 @@ public class TestWarDeploymentWithBrokenBpmnXml {
 
   @Test
   void testXmlInvalid() {
-    try {
-      deployer.deploy(DEPLOYMENT);
-      fail("exception expected");
-    }catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deployer.deploy(DEPLOYMENT)).isInstanceOf(Exception.class);
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithNonExistingDS_JBOSS.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/deployment/war/TestWarDeploymentWithNonExistingDS_JBOSS.java
@@ -31,7 +31,7 @@ import org.operaton.bpm.integrationtest.deployment.war.apps.CustomServletPA;
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 /**
@@ -78,19 +78,9 @@ public class TestWarDeploymentWithNonExistingDS_JBOSS {
   @RunAsClient
   void testDeploymentFails(){
 
-    try {
-      deployer.deploy(DEPLOYMENT_WITH_EJB_PA);
-      fail("Deployment exception expected");
-    } catch(Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deployer.deploy(DEPLOYMENT_WITH_EJB_PA)).isInstanceOf(Exception.class);
 
-    try {
-      deployer.deploy(DEPLOYMENT_WITH_SERVLET_PA);
-      fail("Deployment exception expected");
-    } catch(Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deployer.deploy(DEPLOYMENT_WITH_SERVLET_PA)).isInstanceOf(Exception.class);
 
   }
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/ear/TestJavaDelegateResolution_ClientAsLibInWebModule.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/ear/TestJavaDelegateResolution_ClientAsLibInWebModule.java
@@ -32,7 +32,7 @@ import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 /**
@@ -75,12 +75,7 @@ public class TestJavaDelegateResolution_ClientAsLibInWebModule extends AbstractF
   @OperateOnDeployment("clientDeployment")
   void testResolveClass() {
     // assert that we cannot load the delegate here:
-    try {
-      Class.forName("org.operaton.bpm.integrationtest.functional.classloading.ExampleDelegate");
-      fail("CNFE expected");
-    }catch (ClassNotFoundException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> Class.forName("org.operaton.bpm.integrationtest.functional.classloading.ExampleDelegate")).isInstanceOf(ClassNotFoundException.class);
 
     // but the process can since it performs context switch to the process archive vor execution
     runtimeService.startProcessInstanceByKey("testResolveClass");

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseExecutionListenerResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseExecutionListenerResolutionTest.java
@@ -31,7 +31,7 @@ import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Roman Smirnov
@@ -63,12 +63,7 @@ public class CaseExecutionListenerResolutionTest extends AbstractFoxPlatformInte
   @OperateOnDeployment("clientDeployment")
   void testResolveCaseExecutionListenerClass() {
     // assert that we cannot load the delegate here:
-    try {
-      Class.forName("org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleCaseExecutionListener");
-      fail("CNFE expected");
-    }catch (ClassNotFoundException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> Class.forName("org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleCaseExecutionListener")).isInstanceOf(ClassNotFoundException.class);
 
     String caseInstanceId = caseService
         .withCaseDefinitionByKey("case")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseVariableListenerResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/CaseVariableListenerResolutionTest.java
@@ -31,7 +31,7 @@ import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Roman Smirnov
@@ -63,12 +63,7 @@ public class CaseVariableListenerResolutionTest extends AbstractFoxPlatformInteg
   @OperateOnDeployment("clientDeployment")
   void testResolveCaseExecutionListenerClass() {
     // assert that we cannot load the delegate here:
-    try {
-      Class.forName("org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleCaseVariableListener");
-      fail("CNFE expected");
-    }catch (ClassNotFoundException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> Class.forName("org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleCaseVariableListener")).isInstanceOf(ClassNotFoundException.class);
 
     String caseInstanceId = caseService
         .withCaseDefinitionByKey("case")

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/JavaDelegateResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/JavaDelegateResolutionTest.java
@@ -31,7 +31,7 @@ import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 /**
@@ -72,12 +72,7 @@ public class JavaDelegateResolutionTest extends AbstractFoxPlatformIntegrationTe
   @OperateOnDeployment("clientDeployment")
   void testResolveClass() {
     // assert that we cannot load the delegate here:
-    try {
-      Class.forName("org.operaton.bpm.integrationtest.functional.classloading.ExampleDelegate");
-      fail("CNFE expected");
-    }catch (ClassNotFoundException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> Class.forName("org.operaton.bpm.integrationtest.functional.classloading.ExampleDelegate")).isInstanceOf(ClassNotFoundException.class);
 
     // but the process can since it performs context switch to the process archive for execution
     runtimeService.startProcessInstanceByKey("testResolveClass");

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/SignallableActivityBehaviorResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/SignallableActivityBehaviorResolutionTest.java
@@ -32,7 +32,7 @@ import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  *
@@ -68,12 +68,7 @@ public class SignallableActivityBehaviorResolutionTest extends AbstractFoxPlatfo
   @OperateOnDeployment("clientDeployment")
   void testResolveClass() {
     // assert that we cannot load the delegate here:
-    try {
-      Class.forName("org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleSignallableActivityBehavior");
-      fail("CNFE expected");
-    }catch (ClassNotFoundException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> Class.forName("org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleSignallableActivityBehavior")).isInstanceOf(ClassNotFoundException.class);
 
     // but the process can since it performs context switch to the process archive for execution
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testResolveClass");

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/TaskListenerResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/classloading/war/TaskListenerResolutionTest.java
@@ -33,7 +33,7 @@ import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 import org.operaton.bpm.integrationtest.util.TestContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ArquillianExtension.class)
 public class TaskListenerResolutionTest extends AbstractFoxPlatformIntegrationTest {
@@ -61,12 +61,7 @@ public class TaskListenerResolutionTest extends AbstractFoxPlatformIntegrationTe
   @OperateOnDeployment("clientDeployment")
   void testResolveClassOnTaskComplete() {
     // assert that we cannot load the delegate here:
-    try {
-      Class.forName("org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleTaskListener");
-      fail("CNFE expected");
-    }catch (ClassNotFoundException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> Class.forName("org.operaton.bpm.integrationtest.functional.classloading.beans.ExampleTaskListener")).isInstanceOf(ClassNotFoundException.class);
 
     ProcessInstance pi = runtimeService.startProcessInstanceByKey("testTaskListenerProcess");
 

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/CallActivityContextSwitchTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/CallActivityContextSwitchTest.java
@@ -82,7 +82,7 @@ public class CallActivityContextSwitchTest extends AbstractFoxPlatformIntegratio
     // this test makes sure the delegate invoked by the called process can be resolved (context switch necessary).
 
     // we cannot load the class
-    assertThatThrownBy(() -> new CalledProcessDelegate()).isInstanceOf(NoClassDefFoundError.class);
+    assertThatThrownBy(CalledProcessDelegate::new).isInstanceOf(NoClassDefFoundError.class);
 
     // our bean manager does not know this bean
     Set<Bean< ? >> beans = beanManager.getBeans("calledProcessDelegate");

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/CallActivityContextSwitchTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/CallActivityContextSwitchTest.java
@@ -37,7 +37,7 @@ import org.operaton.bpm.integrationtest.functional.context.beans.DelegateBefore;
 import org.operaton.bpm.integrationtest.util.AbstractFoxPlatformIntegrationTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 /**
@@ -82,12 +82,7 @@ public class CallActivityContextSwitchTest extends AbstractFoxPlatformIntegratio
     // this test makes sure the delegate invoked by the called process can be resolved (context switch necessary).
 
     // we cannot load the class
-    try {
-      new CalledProcessDelegate();
-      fail("exception expected");
-    }catch (NoClassDefFoundError e) {
-      // expected
-    }
+    assertThatThrownBy(() -> new CalledProcessDelegate()).isInstanceOf(NoClassDefFoundError.class);
 
     // our bean manager does not know this bean
     Set<Bean< ? >> beans = beanManager.getBeans("calledProcessDelegate");

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/drools/TestDeploymentWithDroolsTaskFails.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/drools/TestDeploymentWithDroolsTaskFails.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 /**
@@ -57,12 +57,7 @@ public class TestDeploymentWithDroolsTaskFails {
   @Test
   @RunAsClient
   void testDeployDroolsFails() {
-    try {
-      deployer.deploy("deployment");
-      fail("exception expected");
-    }catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deployer.deploy("deployment")).isInstanceOf(Exception.class);
   }
 
 }

--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/metadata/engine/TestProcessEnginesXmlFails.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/metadata/engine/TestProcessEnginesXmlFails.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.operaton.bpm.integrationtest.util.DeploymentHelper;
 
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 /**
@@ -62,12 +62,7 @@ public class TestProcessEnginesXmlFails {
   @Test
   @RunAsClient
   void testDeployProcessArchive() {
-    try {
-      deployer.deploy("deployment");
-      fail("exception expected");
-    }catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> deployer.deploy("deployment")).isInstanceOf(Exception.class);
   }
 
 }

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebIntegrationTest.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebIntegrationTest.java
@@ -81,11 +81,11 @@ public abstract class AbstractWebIntegrationTest {
   }
 
   @BeforeEach
-  public void before() throws Exception {
+  public void before() {
     testProperties = new TestProperties(48080);
   }
 
-  public void createClient(String ctxPath) throws Exception {
+  public void createClient(String ctxPath) {
     testProperties = new TestProperties();
 
     appBasePath = testProperties.getApplicationPath("/" + ctxPath);

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebappUiIntegrationTest.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebappUiIntegrationTest.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -76,7 +75,7 @@ public class AbstractWebappUiIntegrationTest extends AbstractWebIntegrationTest 
   }
 
   @BeforeEach
-  void createClient() throws Exception {
+  void createClient() {
     preventRaceConditions();
     createClient(getWebappCtxPath());
     appUrl = testProperties.getApplicationPath("/" + getWebappCtxPath());

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebappUiIntegrationTest.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/AbstractWebappUiIntegrationTest.java
@@ -61,8 +61,8 @@ public class AbstractWebappUiIntegrationTest extends AbstractWebIntegrationTest 
 
     return webDriver -> {
       try {
-        return new URI(webDriver.getCurrentUrl()).equals(pageURI);
-      } catch (URISyntaxException e) {
+        return URI.create(webDriver.getCurrentUrl()).equals(pageURI);
+      } catch (IllegalArgumentException e) {
         return false;
       }
     };

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/CsrfPreventionIT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/CsrfPreventionIT.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CsrfPreventionIT extends AbstractWebIntegrationTest {
 
   @BeforeEach
-  void createClient() throws Exception {
+  void createClient() {
     preventRaceConditions();
     createClient(getWebappCtxPath());
   }

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/DateSerializationIT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/DateSerializationIT.java
@@ -37,7 +37,7 @@ class DateSerializationIT extends AbstractWebIntegrationTest {
   private static final String SCHEMA_LOG_PATH = "api/engine/engine/default/schema/log";
 
   @BeforeEach
-  void createClient() throws Exception {
+  void createClient() {
     preventRaceConditions();
     createClient(getWebappCtxPath());
     getTokens();

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/ErrorPageIT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/ErrorPageIT.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ErrorPageIT extends AbstractWebIntegrationTest {
 
   @BeforeEach
-  void createClient() throws Exception {
+  void createClient() {
     createClient(getWebappCtxPath());
   }
 

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/ExceptionLoggerIT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/ExceptionLoggerIT.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ExceptionLoggerIT extends AbstractWebIntegrationTest {
 
   @BeforeEach
-  void createClient() throws Exception {
+  void createClient() {
     createClient(getWebappCtxPath());
   }
 

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/HttpHeaderSecurityIT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/HttpHeaderSecurityIT.java
@@ -35,7 +35,7 @@ public class HttpHeaderSecurityIT extends AbstractWebIntegrationTest {
   public static final String CSP_VALUE = "base-uri 'self';script-src 'nonce-([-_a-zA-Z\\d]*)' 'strict-dynamic' 'unsafe-eval' https: 'self' 'unsafe-inline';style-src 'unsafe-inline' 'self';default-src 'self';img-src 'self' data:;block-all-mixed-content;form-action 'self';frame-ancestors 'none';object-src 'none';sandbox allow-forms allow-scripts allow-same-origin allow-popups allow-downloads";
 
   @BeforeEach
-  void createClient() throws Exception {
+  void createClient() {
     preventRaceConditions();
     createClient(getWebappCtxPath());
   }

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/LoginIT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/LoginIT.java
@@ -17,7 +17,6 @@
 package org.operaton.bpm;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.Arrays;
 

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/LoginIT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/LoginIT.java
@@ -68,15 +68,14 @@ public class LoginIT extends AbstractWebappUiIntegrationTest {
     }).doesNotThrowAnyException();
   }
 
-  public void loginToCockpit() throws URISyntaxException {
+  public void loginToCockpit() {
     String appName = "cockpit";
     login(appName);
     wait.until(textToBePresentInElementLocated(
         By.cssSelector(".deployed .processes .stats-label"),
         "Process Definitions"));
 
-    wait.until(currentURIIs(new URI(appUrl + "app/"
-        + appName + "/default/#/dashboard")));
+    wait.until(currentURIIs(URI.create(appUrl + "app/" + appName + "/default/#/dashboard")));
   }
 
   @Test
@@ -112,15 +111,14 @@ public class LoginIT extends AbstractWebappUiIntegrationTest {
     }).doesNotThrowAnyException();
   }
 
-  public void loginToAdmin() throws URISyntaxException {
+  public void loginToAdmin() {
     String appName = "admin";
     login(appName);
     wait.until(textToBePresentInElementLocated(
         By.cssSelector("[ng-class=\"activeClass('#/authorization')\"] a"),
         "Authorizations"));
 
-    wait.until(currentURIIs(new URI(appUrl
-        + "app/" + appName + "/default/#/")));
+    wait.until(currentURIIs(URI.create(appUrl + "app/" + appName + "/default/#/")));
   }
 
   @Test
@@ -134,15 +132,14 @@ public class LoginIT extends AbstractWebappUiIntegrationTest {
     }).doesNotThrowAnyException();
   }
 
-  public void loginToWelcome() throws URISyntaxException {
+  public void loginToWelcome() {
     String appName = "welcome";
     login(appName);
     wait.until(textToBePresentInElementLocated(
         By.cssSelector(".webapps .section-title"),
         "Applications"));
 
-    wait.until(currentURIIs(new URI(appUrl
-        + "app/" + appName + "/default/#!/welcome")));
+    wait.until(currentURIIs(URI.create(appUrl + "app/" + appName + "/default/#!/welcome")));
   }
 
 }

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/PluginsRootResourceIT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/PluginsRootResourceIT.java
@@ -43,7 +43,7 @@ public class PluginsRootResourceIT extends AbstractWebIntegrationTest {
   public boolean assetAllowed;
 
   @BeforeEach
-  void createClient() throws Exception {
+  void createClient() {
     createClient(getWebappCtxPath());
   }
 

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/SessionCookieSameSiteIT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/SessionCookieSameSiteIT.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SessionCookieSameSiteIT extends AbstractWebIntegrationTest {
 
   @BeforeEach
-  void createClient() throws Exception {
+  void createClient() {
     preventRaceConditions();
     createClient(getWebappCtxPath());
   }

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/SessionCookieSecurityIT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/SessionCookieSecurityIT.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SessionCookieSecurityIT extends AbstractWebIntegrationTest {
 
   @BeforeEach
-  void createClient() throws Exception {
+  void createClient() {
     preventRaceConditions();
     createClient(getWebappCtxPath());
   }

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/TestProperties.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/TestProperties.java
@@ -35,11 +35,11 @@ public class TestProperties {
   private final Properties properties;
   private final int defaultPort;
 
-  public TestProperties() throws IOException {
+  public TestProperties() {
     this(8080);
   }
 
-  public TestProperties(int defaultPort) throws IOException {
+  public TestProperties(int defaultPort) {
 
     this.defaultPort = defaultPort;
 
@@ -80,21 +80,13 @@ public class TestProperties {
     return getStringProperty("rest.ctx.path", "engine-rest/");
   }
 
-  public static Properties getTestProperties() throws IOException {
+  public static Properties getTestProperties() {
     Properties properties = new Properties();
 
-    InputStream propertiesStream = null;
-    try {
-      propertiesStream = TestProperties.class.getResourceAsStream(TESTCONFIG_PROPERTIES_FILE);
+    try (InputStream propertiesStream = TestProperties.class.getResourceAsStream(TESTCONFIG_PROPERTIES_FILE)) {
       properties.load(propertiesStream);
-    } finally {
-      try {
-        if (propertiesStream != null) {
-          propertiesStream.close();
-        }
-      } catch(Exception e) {
-        // nop
-      }
+    } catch (IOException e) {
+      throw new RuntimeException("Could not load test properties from " + TESTCONFIG_PROPERTIES_FILE, e);
     }
     Stream.of(HTTP_PORT, HTTP_CTX_PATH_WEBAPP, HTTP_CTX_PATH_REST).forEach(prop -> {
       if (System.getProperty(prop) != null) {

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/rest/RestIT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/rest/RestIT.java
@@ -62,7 +62,7 @@ class RestIT extends AbstractWebIntegrationTest {
   private static final Logger log = Logger.getLogger(RestIT.class.getName());
 
   @BeforeEach
-  void createClient() throws Exception {
+  void createClient() {
     preventRaceConditions();
     createClient(getRestCtxPath());
   }

--- a/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/rest/RestJaxRs2IT.java
+++ b/qa/integration-tests-webapps/integration-tests/src/main/java/org/operaton/bpm/rest/RestJaxRs2IT.java
@@ -47,7 +47,7 @@ class RestJaxRs2IT extends AbstractWebIntegrationTest {
   private static final String FETCH_AND_LOCK_PATH = ENGINE_DEFAULT_PATH + "/external-task/fetchAndLock";
 
   @BeforeEach
-  void createClient() throws Exception {
+  void createClient() {
     preventRaceConditions();
     createClient(getRestCtxPath());
   }

--- a/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/org/operaton/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.java
@@ -54,8 +54,7 @@ import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
 
 import static org.operaton.bpm.engine.test.util.JobExecutorWaitUtils.waitForJobExecutorToProcessAllJobs;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 
 class TransactionIntegrationTest {
 
@@ -129,13 +128,7 @@ class TransactionIntegrationTest {
         }
 
         String taskId = taskService.createTaskQuery().singleResult().getId();
-        try {
-          // when
-          userBean.completeTask(taskId);
-          fail("");
-        } catch (ProcessEngineException ignored) {
-          // expected
-        }
+        assertThatThrownBy(() -> userBean.completeTask(taskId)).isInstanceOf(ProcessEngineException.class);
 
         // then
         assertThat(taskService.createTaskQuery().singleResult().getName()).isEqualTo("My Task");

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -27,7 +27,7 @@ name: org.operaton.AddLicenseHeader
 displayName: Add Operaton ASL2 header
 recipeList:
   - org.openrewrite.java.AddLicenseHeader:
-      licenseText: |        
+      licenseText: |
         Copyright ${CURRENT_YEAR} the Operaton contributors.
         
         Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,6 +64,16 @@ recipeList:
   - org.openrewrite.java.migrate.lang.StringFormatted
   - org.openrewrite.java.migrate.UpgradeToJava17
   - org.openrewrite.java.migrate.DeprecatedLogRecordThreadID
+  # Logging
+  - org.openrewrite.java.logging.slf4j.ParameterizedLogging
+  - org.operaton.AddLicenseHeader
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.operaton.recipe.TestsCleanup
+displayName: Tests cleanup
+description: Automatically cleanup test code, use best practices for JUnit 5, AssertJ, and Mockito.
+recipeList:
+  - org.openrewrite.java.RemoveUnusedImports
   # Testing
   - org.openrewrite.java.testing.assertj.AssertJShortRulesRecipes$AbstractShortAssertIsZeroRecipe
   - org.openrewrite.java.testing.assertj.CollapseConsecutiveAssertThatStatements
@@ -109,6 +119,3 @@ recipeList:
   - org.openrewrite.java.testing.assertj.AssertJShortRulesRecipes
   # Very slow:
   #- tech.picnic.errorprone.refasterrules.AssertJObjectRulesRecipes
-  # Logging
-  - org.openrewrite.java.logging.slf4j.ParameterizedLogging
-  - org.operaton.AddLicenseHeader

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/engine/EnginesFilterTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/engine/EnginesFilterTest.java
@@ -31,7 +31,7 @@ import org.operaton.bpm.engine.rest.spi.ProcessEngineProvider;
 import org.operaton.bpm.webapp.impl.IllegalWebAppConfigurationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  *
@@ -135,12 +135,7 @@ class EnginesFilterTest {
       }
     });
 
-    try {
-      defaultEngineName = processEnginesFilter.getDefaultEngineName();
-      fail("");
-    } catch(IllegalWebAppConfigurationException e) {
-      // expected
-    }
+    assertThatThrownBy(processEnginesFilter::getDefaultEngineName).isInstanceOf(IllegalWebAppConfigurationException.class);
 
   }
 


### PR DESCRIPTION
The Code Cleanup workflow broke due to OOM errors. The amount of recipes excecuted on the large codebase is too much,

The PR changes the workflow to split the cleanup between code test recipes.

The code changed by the cleanups is added via separate commits.