### PR TITLE
fix(tests): Revert refactoring lambda -> method reference

### DIFF
--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/CallActivityContextSwitchTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/context/CallActivityContextSwitchTest.java
@@ -77,12 +77,14 @@ public class CallActivityContextSwitchTest extends AbstractFoxPlatformIntegratio
 
   @Test
   @OperateOnDeployment("mainDeployment")
+  // we cannot refactor to a method reference, this makes the test fail with NoClassDefFoundError without executing the lambda
+  @SuppressWarnings("java:S1612")
   void testNoWaitState() {
 
     // this test makes sure the delegate invoked by the called process can be resolved (context switch necessary).
 
     // we cannot load the class
-    assertThatThrownBy(CalledProcessDelegate::new).isInstanceOf(NoClassDefFoundError.class);
+    assertThatThrownBy(() -> new CalledProcessDelegate()).isInstanceOf(NoClassDefFoundError.class);
 
     // our bean manager does not know this bean
     Set<Bean< ? >> beans = beanManager.getBeans("calledProcessDelegate");


### PR DESCRIPTION
This reverts the change from #2a00dccd, because it broke the build with NoClassDefFoundError

fixes #1362