### PR TITLE
fix: remove unnecessary jetty plugin

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -68,7 +68,7 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>org.mortbay.jetty</groupId>
+          <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-maven-plugin</artifactId>
           <configuration>
             <webAppConfig>

--- a/pom.xml
+++ b/pom.xml
@@ -439,14 +439,9 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>org.mortbay.jetty</groupId>
-          <artifactId>jetty-maven-plugin</artifactId>
-          <version>8.1.16.v20140903</version>
-        </plugin>
-        <plugin>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-maven-plugin</artifactId>
-          <version>${version.jetty}</version>
+          <version>11.0.26</version>
         </plugin>
         <plugin>
           <groupId>org.eclipse.transformer</groupId>


### PR DESCRIPTION
fix: remove unnecessary jetty plugin

- remove unnecessary jetty plugin
- replaced use of mortbay maven-jetty-plugin to eclipse maven-jetty-plugin
- fixed version of eclipse maven-jetty-plugin

related to #1353 