### PR TITLE
fix(queryAPI): correct TenantQueryProperty class visibility. Replaced `GROUP_ID` with `TENANT_ID` for consistency.

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/TenantQueryImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/TenantQueryImpl.java
@@ -94,7 +94,7 @@ public abstract class TenantQueryImpl extends AbstractQuery<TenantQuery, Tenant>
 
   @Override
   public TenantQuery orderByTenantId() {
-    return orderBy(TenantQueryProperty.GROUP_ID);
+    return orderBy(TenantQueryProperty.TENANT_ID);
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/TenantQueryProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/TenantQueryProperty.java
@@ -22,9 +22,9 @@ import org.operaton.bpm.engine.query.QueryProperty;
 /**
  * Contains the possible properties that can be used by the {@link TenantQuery}.
  */
-final class TenantQueryProperty {
+public final class TenantQueryProperty {
 
-  public static final QueryProperty GROUP_ID = new QueryPropertyImpl("ID_");
+  public static final QueryProperty TENANT_ID = new QueryPropertyImpl("ID_");
   public static final QueryProperty NAME = new QueryPropertyImpl("NAME_");
 
   private TenantQueryProperty() {}


### PR DESCRIPTION
The keycloak plugin needs to be able to access to the `TenantQueryProperty` class, like it does with the `GroupQueryProperty` class. I also noticed that the TENANT_ID was erroneously named GROUP_ID in `TenantQueryProperty` which seems to be a copy & paste fail when it was initially created.