### PR TITLE
refactor(tests): Replacing org.junit.jupiter.api.Assertions

### DIFF
--- a/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/ldap/util/LdapTestUtilities.java
+++ b/engine-plugins/identity-ldap/src/test/java/org/operaton/bpm/identity/ldap/util/LdapTestUtilities.java
@@ -25,7 +25,6 @@ import org.operaton.bpm.engine.identity.Group;
 import org.operaton.bpm.engine.identity.User;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * Contains some test utilities to test the Ldap plugin.
@@ -35,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 public final class LdapTestUtilities {
 
   public static void checkPagingResults(Set<String> results, String result1, String result2) {
-    assertNotSame(result1, result2);
+    assertThat(result1).isNotSameAs(result2);
     assertThat(results).doesNotContain(result1);
     results.add(result1);
     assertThat(results).doesNotContain(result2);

--- a/engine-spring/src/test/java/org/operaton/bpm/engine/spring/test/components/scope/ScopingTest.java
+++ b/engine-spring/src/test/java/org/operaton/bpm/engine/spring/test/components/scope/ScopingTest.java
@@ -39,7 +39,6 @@ import org.operaton.bpm.engine.spring.test.components.ProcessInitiatingPojo;
 import org.operaton.bpm.engine.task.Task;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * tests the scoped beans
@@ -136,7 +135,7 @@ public class ScopingTest {
 		LOGGER.info("Running 'component-waiter' process instance with scoped beans.");
 		StatefulObject one = run();
 		StatefulObject two = run();
-		assertNotSame(one.getName(), two.getName());
+		assertThat(one.getName()).isNotSameAs(two.getName());
     assertThat(two.getVisitedCount()).isEqualTo(one.getVisitedCount());
 	}
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/IncidentAuthorizationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/authorization/IncidentAuthorizationTest.java
@@ -45,7 +45,6 @@ import static org.operaton.bpm.engine.test.util.QueryTestHelper.verifyQueryResul
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 /**
  * @author Roman Smirnov
@@ -394,9 +393,9 @@ class IncidentAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
 
-    // when
-    assertAll(() -> runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation"));
-    // then no error is thrown
+    assertThatCode(() ->
+            runtimeService.setAnnotationForIncidentById(incident.getId(),"my annotation"))
+            .doesNotThrowAnyException();
   }
 
   @Test
@@ -409,9 +408,9 @@ class IncidentAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_INSTANCE, instance.getId(), userId, UPDATE);
 
-    // when
-    assertAll(() -> runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation"));
-    // then no error is thrown
+    assertThatCode(() ->
+            runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation"))
+            .doesNotThrowAnyException();
   }
 
   @Test
@@ -424,9 +423,9 @@ class IncidentAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
 
-    // when
-    assertAll(() -> runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation"));
-    // then no error is thrown
+    assertThatCode(() ->
+            runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation"))
+            .doesNotThrowAnyException();
   }
 
   @Test
@@ -439,9 +438,9 @@ class IncidentAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_DEFINITION, ONE_INCIDENT_PROCESS_KEY, userId, UPDATE_INSTANCE);
 
-    // when
-    assertAll(() -> runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation"));
-    // then no error is thrown
+    assertThatCode(() ->
+            runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation"))
+            .doesNotThrowAnyException();
   }
 
   @Test
@@ -470,9 +469,9 @@ class IncidentAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_INSTANCE, ANY, userId, UPDATE);
 
-    // when
-    assertAll(() -> runtimeService.clearAnnotationForIncidentById(incident.getId()));
-    // then no error is thrown
+    assertThatCode(() ->
+            runtimeService.clearAnnotationForIncidentById(incident.getId()))
+            .doesNotThrowAnyException();
   }
 
   @Test
@@ -486,8 +485,9 @@ class IncidentAuthorizationTest extends AuthorizationTest {
     createGrantAuthorization(PROCESS_INSTANCE, instance.getId(), userId, UPDATE);
 
     // when
-    assertAll(() -> runtimeService.clearAnnotationForIncidentById(incident.getId()));
-    // then no error is thrown
+    assertThatCode(() ->
+            runtimeService.clearAnnotationForIncidentById(incident.getId()))
+            .doesNotThrowAnyException();
   }
 
   @Test
@@ -500,9 +500,9 @@ class IncidentAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_DEFINITION, ANY, userId, UPDATE_INSTANCE);
 
-    // when
-    assertAll(() -> runtimeService.clearAnnotationForIncidentById(incident.getId()));
-    // then no error is thrown
+    assertThatCode(() ->
+            runtimeService.clearAnnotationForIncidentById(incident.getId()))
+            .doesNotThrowAnyException();
   }
 
   @Test
@@ -515,9 +515,9 @@ class IncidentAuthorizationTest extends AuthorizationTest {
 
     createGrantAuthorization(PROCESS_DEFINITION, ONE_INCIDENT_PROCESS_KEY, userId, UPDATE_INSTANCE);
 
-    // when
-    assertAll(() -> runtimeService.clearAnnotationForIncidentById(incident.getId()));
-    // then no error is thrown
+    assertThatCode(() ->
+            runtimeService.clearAnnotationForIncidentById(incident.getId()))
+            .doesNotThrowAnyException();
   }
 
   @Test
@@ -528,7 +528,6 @@ class IncidentAuthorizationTest extends AuthorizationTest {
     Incident incident = runtimeService.createIncidentQuery().singleResult();
     enableAuthorization();
 
-    // when
     assertThatCode(() -> runtimeService.setAnnotationForIncidentById(incident.getId(), "my annotation"))
         .doesNotThrowAnyException();
 
@@ -544,9 +543,9 @@ class IncidentAuthorizationTest extends AuthorizationTest {
     Incident incident = runtimeService.createIncidentQuery().singleResult();
     enableAuthorization();
 
-    // when
-    // then no error is thrown
-    assertAll(() -> runtimeService.clearAnnotationForIncidentById(incident.getId()));
+    assertThatCode(() ->
+            runtimeService.clearAnnotationForIncidentById(incident.getId()))
+            .doesNotThrowAnyException();
 
     // cleanup
     cleanupStandalonIncident(jobId);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseTableSchemaTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/cfg/DatabaseTableSchemaTest.java
@@ -36,7 +36,7 @@ import org.operaton.bpm.engine.impl.util.ReflectUtil;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 /**
  * @author Ronny Bräunlich
@@ -87,9 +87,13 @@ class DatabaseTableSchemaTest {
     // session should tell us that the tables are already present and
     // databaseSchemaUpdate is set to noop
     final Connection connection3 = pooledDataSource.getConnection();
-    assertAll(() -> {
-      connection3.createStatement().execute("set schema " + SCHEMA_NAME);
-      engine1.getManagementService().databaseSchemaUpgrade(connection3, "", SCHEMA_NAME);
+
+    final boolean schemaSet = connection3.createStatement().execute("set schema " + SCHEMA_NAME);
+    assertSoftly(softly -> {
+      softly.assertThat(schemaSet).isFalse();
+      softly.assertThatCode(() ->
+              engine1.getManagementService().databaseSchemaUpgrade(connection3, "", SCHEMA_NAME)
+      ).doesNotThrowAnyException();
     });
     engine1.close();
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AdminGroupsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/AdminGroupsTest.java
@@ -32,12 +32,11 @@ import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineExtension;
 import org.operaton.bpm.engine.test.junit5.ProcessEngineTestExtension;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.operaton.bpm.engine.authorization.Authorization.ANY;
 import static org.operaton.bpm.engine.authorization.Authorization.AUTH_TYPE_GRANT;
 import static org.operaton.bpm.engine.authorization.Permissions.READ;
 import static org.operaton.bpm.engine.authorization.Resources.USER;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @ExtendWith(ProcessEngineExtension.class)
 @ExtendWith(ProcessEngineTestExtension.class)
@@ -95,8 +94,8 @@ class AdminGroupsTest {
     authorizationService.saveAuthorization(userAuth);
     processEngineConfiguration.setAuthorizationEnabled(true);
 
-    // when
-    assertAll(() -> identityService.unlockUser("jonny1"));
-    // then no exception
+    // when/then no exception
+    assertThatCode(() -> identityService.unlockUser("jonny1"))
+            .doesNotThrowAnyException();
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationVariablesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationVariablesTest.java
@@ -47,7 +47,6 @@ import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 import static org.operaton.bpm.engine.test.api.runtime.migration.ModifiableBpmnModelInstance.modify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * @author Thorben Lindhauer
@@ -506,8 +505,7 @@ class MigrationVariablesTest {
 
     VariableInstance variableAfterExpansion = runtimeService.createVariableInstanceQuery().singleResult();
     assertThat(variableAfterExpansion).isNotNull();
-    assertNotSame(processInstance.getId(), variableAfterExpansion.getExecutionId());
-
+    assertThat(processInstance.getId()).isNotSameAs(variableAfterExpansion.getExecutionId());
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/FullHistoryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/history/FullHistoryTest.java
@@ -65,7 +65,6 @@ import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * @author Tom Baeyens
@@ -909,7 +908,7 @@ class FullHistoryTest {
             .hasSize(2);
 
     // Should have 2 different historic activity instance ID's, with the same activityId
-    assertNotSame(details.get(0).getActivityInstanceId(), details.get(1).getActivityInstanceId());
+    assertThat(details.get(0).getActivityInstanceId()).isNotSameAs(details.get(1).getActivityInstanceId());
 
     HistoricActivityInstance historicActInst1 = historyService.createHistoricActivityInstanceQuery()
       .activityInstanceId(details.get(0).getActivityInstanceId())


### PR DESCRIPTION
- replaced remaining org.junit.jupiter.api.Assertions by AssertJ

related to #1408

I confirm that my contribution and following ones comply with the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
and the [Code of Conduct](https://github.com/operaton/operaton/blob/main/CODE_OF_CONDUCT.md).
