### PR TITLE
fix(engine): add support for retrieving deployed forms for the legacy namepsace

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractGetDeployedFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractGetDeployedFormCmd.java
@@ -35,9 +35,11 @@ import org.operaton.bpm.engine.repository.OperatonFormDefinition;
 public abstract class AbstractGetDeployedFormCmd implements Command<InputStream> {
 
   protected static final String EMBEDDED_KEY = "embedded:";
-  protected static final String CAMUNDA_FORMS_KEY = "operaton-forms:";
+  protected static final String OPERATON_FORMS_KEY = "operaton-forms:";
+  protected static final String CAMUNDA_FORMS_KEY = "camunda-forms:";
   protected static final int EMBEDDED_KEY_LENGTH = EMBEDDED_KEY.length();
   protected static final int CAMUNDA_FORMS_KEY_LENGTH = CAMUNDA_FORMS_KEY.length();
+  protected static final int OPERATON_FORMS_KEY_LENGTH = OPERATON_FORMS_KEY.length();
 
   protected static final String DEPLOYMENT_KEY = "deployment:";
   protected static final int DEPLOYMENT_KEY_LENGTH = DEPLOYMENT_KEY.length();
@@ -67,6 +69,8 @@ public abstract class AbstractGetDeployedFormCmd implements Command<InputStream>
 
     if (resourceName.startsWith(EMBEDDED_KEY)) {
       resourceName = resourceName.substring(EMBEDDED_KEY_LENGTH, resourceName.length());
+    } else if (resourceName.startsWith(OPERATON_FORMS_KEY)) {
+      resourceName = resourceName.substring(OPERATON_FORMS_KEY_LENGTH, resourceName.length());
     } else if (resourceName.startsWith(CAMUNDA_FORMS_KEY)) {
       resourceName = resourceName.substring(CAMUNDA_FORMS_KEY_LENGTH, resourceName.length());
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/form/FormServiceTest.java
@@ -1440,6 +1440,24 @@ class FormServiceTest {
     assertThat(fileAsString).isEqualTo(deployedStartFormAsString);
   }
 
+  @Deployment(resources = {"org/operaton/bpm/engine/test/api/form/DeployedCamundaFormsProcess.bpmn20.xml",
+      "org/operaton/bpm/engine/test/api/form/start.html",
+      "org/operaton/bpm/engine/test/api/form/task.html"})
+  @Test
+  void testGetDeployedCamundaStartForm() {
+    // given
+    String procDefId = repositoryService.createProcessDefinitionQuery().singleResult().getId();
+
+    // when
+    InputStream deployedStartForm = formService.getDeployedStartForm(procDefId);
+
+    // then
+    assertThat(deployedStartForm).isNotNull();
+    String fileAsString = IoUtil.fileAsString("org/operaton/bpm/engine/test/api/form/start.html");
+    String deployedStartFormAsString = IoUtil.inputStreamAsString(deployedStartForm);
+    assertThat(fileAsString).isEqualTo(deployedStartFormAsString);
+  }
+
   @Test
   void testGetDeployedStartFormWithNullProcDefId() {
     assertThatThrownBy(() -> formService.getDeployedStartForm(null))

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/api/form/DeployedCamundaFormsProcess.bpmn20.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/api/form/DeployedCamundaFormsProcess.bpmn20.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<definitions id="definitions"
+             targetNamespace="http://camunda.org/schema/1.0/bpmn20"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:camunda="http://camunda.org/schema/1.0/bpmn">
+  
+  <process id="FormsProcess" isExecutable="true">
+  
+    <startEvent id="start" camunda:formKey="camunda-forms:deployment:org/operaton/bpm/engine/test/api/form/start.html" />
+
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="task" />
+    
+    <userTask id="task"
+              camunda:formKey="camunda-forms:deployment:org/operaton/bpm/engine/test/api/form/task.html"
+              camunda:assignee="kermit" />
+
+    <sequenceFlow id="flow2" sourceRef="task" targetRef="wait" />
+    
+    <receiveTask id="wait" />
+
+  </process>
+  
+</definitions>


### PR DESCRIPTION
We’ve renamed the `camunda-forms:` prefix for embedded deployed forms to `operaton-forms:`.

Since this change breaks compatibility with existing models, I’ve added a fallback. Now both `operaton-forms:` and `camunda-forms:` are supported again for backward compatibility. 
