### PR TITLE
refactor(style): capitalize generic type params for Sonar S119 (#1415)

### DIFF
--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/spi/transform/DmnElementTransformHandler.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/spi/transform/DmnElementTransformHandler.java
@@ -23,10 +23,10 @@ import org.operaton.bpm.model.dmn.instance.DmnModelElementInstance;
  * stored by the static context of DefaultElementTransformHandlerRegistry & can be shared across different
  * DmnEngineConfigurations or ProcessEngineConfiguration.
  *
- * @param <Source> the type of the transformation input
- * @param <Target> the type of the transformation output
+ * @param <SOURCE> the type of the transformation input
+ * @param <TARGET> the type of the transformation output
  */
-public interface DmnElementTransformHandler<Source extends DmnModelElementInstance, Target> {
+public interface DmnElementTransformHandler<SOURCE extends DmnModelElementInstance, TARGET> {
 
   /**
    * Transform a DMN model element
@@ -35,6 +35,6 @@ public interface DmnElementTransformHandler<Source extends DmnModelElementInstan
    * @param element the source element
    * @return the transformed element
    */
-  Target handleElement(DmnElementTransformContext context, Source element);
+  TARGET handleElement(DmnElementTransformContext context, SOURCE element);
 
 }

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/spi/transform/DmnElementTransformHandlerRegistry.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/spi/transform/DmnElementTransformHandlerRegistry.java
@@ -27,20 +27,20 @@ public interface DmnElementTransformHandlerRegistry {
    * Get the transformer for a source type
    *
    * @param sourceClass the class of the source type
-   * @param <Source> the type of the transformation input
-   * @param <Target> the type of the transformation output
+   * @param <SOURCE> the type of the transformation input
+   * @param <TARGET> the type of the transformation output
    * @return the {@link DmnElementTransformHandler} or null if none is registered for this source type
    */
-  <Source extends DmnModelElementInstance, Target> DmnElementTransformHandler<Source, Target> getHandler(Class<Source> sourceClass);
+  <SOURCE extends DmnModelElementInstance, TARGET> DmnElementTransformHandler<SOURCE, TARGET> getHandler(Class<SOURCE> sourceClass);
 
   /**
    * Register a {@link DmnElementTransformHandler} for a source type
    *
    * @param sourceClass the class of the source type
    * @param handler the handler to register
-   * @param <Source> the type of the transformation input
-   * @param <Target> the type of the transformation output
+   * @param <SOURCE> the type of the transformation input
+   * @param <TARGET> the type of the transformation output
    */
-  <Source extends DmnModelElementInstance, Target> void addHandler(Class<Source> sourceClass, DmnElementTransformHandler<Source, Target> handler);
+  <SOURCE extends DmnModelElementInstance, TARGET> void addHandler(Class<SOURCE> sourceClass, DmnElementTransformHandler<SOURCE, TARGET> handler);
 
 }

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/transform/DefaultElementTransformHandlerRegistry.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/transform/DefaultElementTransformHandlerRegistry.java
@@ -48,14 +48,14 @@ public class DefaultElementTransformHandlerRegistry implements DmnElementTransfo
   }
 
   @Override
-  public <Source extends DmnModelElementInstance, Target> void addHandler(Class<Source> sourceClass, DmnElementTransformHandler<Source, Target> handler) {
+  public <SOURCE extends DmnModelElementInstance, TARGET> void addHandler(Class<SOURCE> sourceClass, DmnElementTransformHandler<SOURCE, TARGET> handler) {
     handlers.put(sourceClass, handler);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public <Source extends DmnModelElementInstance, Target> DmnElementTransformHandler<Source, Target> getHandler(Class<Source> sourceClass) {
-    return (DmnElementTransformHandler<Source, Target>) handlers.get(sourceClass);
+  public <SOURCE extends DmnModelElementInstance, TARGET> DmnElementTransformHandler<SOURCE, TARGET> getHandler(Class<SOURCE> sourceClass) {
+    return (DmnElementTransformHandler<SOURCE, TARGET>) handlers.get(sourceClass);
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/deploy/cache/ModelInstanceCache.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/deploy/cache/ModelInstanceCache.java
@@ -32,42 +32,42 @@ import org.operaton.commons.utils.cache.Cache;
 /**
  * @author: Johannes Heinemann
  */
-public abstract class ModelInstanceCache<InstanceType extends ModelInstance, DefinitionType extends ResourceDefinitionEntity> {
+public abstract class ModelInstanceCache<INSTANCE_TYPE extends ModelInstance, DEFINITION_TYPE extends ResourceDefinitionEntity> {
 
   protected static final EnginePersistenceLogger LOG = ProcessEngineLogger.PERSISTENCE_LOGGER;
 
-  protected Cache<String, InstanceType> instanceCache;
-  protected ResourceDefinitionCache<DefinitionType> definitionCache;
+  protected Cache<String, INSTANCE_TYPE> instanceCache;
+  protected ResourceDefinitionCache<DEFINITION_TYPE> definitionCache;
 
-  protected ModelInstanceCache(CacheFactory factory, int cacheCapacity, ResourceDefinitionCache<DefinitionType> definitionCache) {
+  protected ModelInstanceCache(CacheFactory factory, int cacheCapacity, ResourceDefinitionCache<DEFINITION_TYPE> definitionCache) {
     this.instanceCache = factory.createCache(cacheCapacity);
     this.definitionCache = definitionCache;
   }
 
-  public InstanceType findBpmnModelInstanceForDefinition(DefinitionType definitionEntity) {
-    InstanceType bpmnModelInstance = instanceCache.get(definitionEntity.getId());
+  public INSTANCE_TYPE findBpmnModelInstanceForDefinition(DEFINITION_TYPE definitionEntity) {
+    INSTANCE_TYPE bpmnModelInstance = instanceCache.get(definitionEntity.getId());
     if (bpmnModelInstance == null) {
       bpmnModelInstance = loadAndCacheBpmnModelInstance(definitionEntity);
     }
     return bpmnModelInstance;
   }
 
-  public InstanceType findBpmnModelInstanceForDefinition(String definitionId) {
-    InstanceType bpmnModelInstance = instanceCache.get(definitionId);
+  public INSTANCE_TYPE findBpmnModelInstanceForDefinition(String definitionId) {
+    INSTANCE_TYPE bpmnModelInstance = instanceCache.get(definitionId);
     if (bpmnModelInstance == null) {
-      DefinitionType definition = definitionCache.findDeployedDefinitionById(definitionId);
+      DEFINITION_TYPE definition = definitionCache.findDeployedDefinitionById(definitionId);
       bpmnModelInstance = loadAndCacheBpmnModelInstance(definition);
     }
     return bpmnModelInstance;
   }
 
-  protected InstanceType loadAndCacheBpmnModelInstance(final DefinitionType definitionEntity) {
+  protected INSTANCE_TYPE loadAndCacheBpmnModelInstance(final DEFINITION_TYPE definitionEntity) {
     final CommandContext commandContext = Context.getCommandContext();
     InputStream bpmnResourceInputStream = commandContext.runWithoutAuthorization(
         new GetDeploymentResourceCmd(definitionEntity.getDeploymentId(), definitionEntity.getResourceName()));
 
     try {
-      InstanceType bpmnModelInstance = readModelFromStream(bpmnResourceInputStream);
+      INSTANCE_TYPE bpmnModelInstance = readModelFromStream(bpmnResourceInputStream);
       instanceCache.put(definitionEntity.getId(), bpmnModelInstance);
       return bpmnModelInstance;
     } catch (Exception e) {
@@ -98,7 +98,7 @@ public abstract class ModelInstanceCache<InstanceType extends ModelInstance, Def
     instanceCache.clear();
   }
 
-  public Cache<String, InstanceType> getCache() {
+  public Cache<String, INSTANCE_TYPE> getCache() {
     return instanceCache;
   }
 
@@ -106,7 +106,7 @@ public abstract class ModelInstanceCache<InstanceType extends ModelInstance, Def
 
   protected abstract void logRemoveEntryFromDeploymentCacheFailure(String definitionId, Exception e);
 
-  protected abstract InstanceType readModelFromStream(InputStream stream);
+  protected abstract INSTANCE_TYPE readModelFromStream(InputStream stream);
 
   protected abstract List<? extends ResourceDefinition> getAllDefinitionsForDeployment(String deploymentId);
 }

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/ElementReferenceBuilderImpl.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/ElementReferenceBuilderImpl.java
@@ -24,17 +24,17 @@ import org.operaton.bpm.model.xml.type.reference.ElementReferenceBuilder;
 /**
  * @author Sebastian Menski
  */
-public class ElementReferenceBuilderImpl<Target extends ModelElementInstance, Source extends ModelElementInstance> extends ElementReferenceCollectionBuilderImpl<Target,Source> implements ElementReferenceBuilder<Target, Source> {
+public class ElementReferenceBuilderImpl<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> extends ElementReferenceCollectionBuilderImpl<TARGET, SOURCE> implements ElementReferenceBuilder<TARGET, SOURCE> {
 
-  public ElementReferenceBuilderImpl(Class<Source> childElementType, Class<Target> referenceTargetClass, ChildElementImpl<Source> child) {
+  public ElementReferenceBuilderImpl(Class<SOURCE> childElementType, Class<TARGET> referenceTargetClass, ChildElementImpl<SOURCE> child) {
     super(childElementType, referenceTargetClass, child);
     this.elementReferenceCollectionImpl = new ElementReferenceImpl<>(child);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public ElementReference<Target, Source> build() {
-    return (ElementReference<Target, Source>) elementReferenceCollectionImpl;
+  public ElementReference<TARGET, SOURCE> build() {
+    return (ElementReference<TARGET, SOURCE>) elementReferenceCollectionImpl;
   }
 
 }

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/ElementReferenceCollectionBuilderImpl.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/ElementReferenceCollectionBuilderImpl.java
@@ -28,20 +28,20 @@ import org.operaton.bpm.model.xml.type.reference.ElementReferenceCollectionBuild
 /**
  * @author Sebastian Menski
  */
-public class ElementReferenceCollectionBuilderImpl<Target extends ModelElementInstance, Source extends ModelElementInstance> implements ElementReferenceCollectionBuilder<Target, Source> {
+public class ElementReferenceCollectionBuilderImpl<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> implements ElementReferenceCollectionBuilder<TARGET, SOURCE> {
 
-  private final Class<Source> childElementType;
-  private final Class<Target> referenceTargetClass;
-  protected ElementReferenceCollectionImpl<Target, Source> elementReferenceCollectionImpl;
+  private final Class<SOURCE> childElementType;
+  private final Class<TARGET> referenceTargetClass;
+  protected ElementReferenceCollectionImpl<TARGET, SOURCE> elementReferenceCollectionImpl;
 
-  public ElementReferenceCollectionBuilderImpl(Class<Source> childElementType, Class<Target> referenceTargetClass, ChildElementCollectionImpl<Source> collection) {
+  public ElementReferenceCollectionBuilderImpl(Class<SOURCE> childElementType, Class<TARGET> referenceTargetClass, ChildElementCollectionImpl<SOURCE> collection) {
     this.childElementType = childElementType;
     this.referenceTargetClass = referenceTargetClass;
     this.elementReferenceCollectionImpl = new ElementReferenceCollectionImpl<>(collection);
   }
 
   @Override
-  public ElementReferenceCollection<Target, Source> build() {
+  public ElementReferenceCollection<TARGET, SOURCE> build() {
     return elementReferenceCollectionImpl;
   }
 

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/ElementReferenceCollectionImpl.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/ElementReferenceCollectionImpl.java
@@ -37,17 +37,17 @@ import org.operaton.bpm.model.xml.type.reference.ElementReferenceCollection;
 /**
  * @author Sebastian Menski
  */
-public class ElementReferenceCollectionImpl<Target extends ModelElementInstance, Source extends ModelElementInstance> extends  ReferenceImpl<Target> implements ElementReferenceCollection<Target, Source> {
+public class ElementReferenceCollectionImpl<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> extends  ReferenceImpl<TARGET> implements ElementReferenceCollection<TARGET, SOURCE> {
 
-  private final ChildElementCollection<Source> referenceSourceCollection;
+  private final ChildElementCollection<SOURCE> referenceSourceCollection;
   private ModelElementTypeImpl referenceSourceType;
 
-  public ElementReferenceCollectionImpl(ChildElementCollection<Source> referenceSourceCollection) {
+  public ElementReferenceCollectionImpl(ChildElementCollection<SOURCE> referenceSourceCollection) {
     this.referenceSourceCollection = referenceSourceCollection;
   }
 
   @Override
-  public ChildElementCollection<Source> getReferenceSourceCollection() {
+  public ChildElementCollection<SOURCE> getReferenceSourceCollection() {
     return referenceSourceCollection;
   }
 
@@ -56,7 +56,7 @@ public class ElementReferenceCollectionImpl<Target extends ModelElementInstance,
     referenceSourceElement.setTextContent(referenceIdentifier);
   }
 
-  protected void performAddOperation(ModelElementInstanceImpl referenceSourceParentElement, Target referenceTargetElement) {
+  protected void performAddOperation(ModelElementInstanceImpl referenceSourceParentElement, TARGET referenceTargetElement) {
     ModelInstanceImpl modelInstance = referenceSourceParentElement.getModelInstance();
     String referenceTargetIdentifier = referenceTargetAttribute.getValue(referenceTargetElement);
     ModelElementInstance existingElement = modelInstance.getModelElementById(referenceTargetIdentifier);
@@ -66,8 +66,8 @@ public class ElementReferenceCollectionImpl<Target extends ModelElementInstance,
         +": element is not part of model. Please connect element to the model first.");
     }
     else {
-      Collection<Source> referenceSourceElements = referenceSourceCollection.get(referenceSourceParentElement);
-      Source referenceSourceElement = modelInstance.newInstance(referenceSourceType);
+      Collection<SOURCE> referenceSourceElements = referenceSourceCollection.get(referenceSourceParentElement);
+      SOURCE referenceSourceElement = modelInstance.newInstance(referenceSourceType);
       referenceSourceElements.add(referenceSourceElement);
       setReferenceIdentifier(referenceSourceElement, referenceTargetIdentifier);
     }
@@ -104,7 +104,7 @@ public class ElementReferenceCollectionImpl<Target extends ModelElementInstance,
   @Override
   protected void removeReference(ModelElementInstance referenceSourceElement, ModelElementInstance referenceTargetElement) {
     ModelElementInstance parentElement = referenceSourceElement.getParentElement();
-    Collection<Source> childElementCollection = referenceSourceCollection.get(parentElement);
+    Collection<SOURCE> childElementCollection = referenceSourceCollection.get(parentElement);
     childElementCollection.remove(referenceSourceElement);
   }
 
@@ -119,9 +119,9 @@ public class ElementReferenceCollectionImpl<Target extends ModelElementInstance,
 
   protected Collection<DomElement> getView(ModelElementInstanceImpl referenceSourceParentElement) {
     DomDocument document = referenceSourceParentElement.getModelInstance().getDocument();
-    Collection<Source> referenceSourceElements = referenceSourceCollection.get(referenceSourceParentElement);
+    Collection<SOURCE> referenceSourceElements = referenceSourceCollection.get(referenceSourceParentElement);
     Collection<DomElement> referenceTargetElements = new ArrayList<>();
-    for (Source referenceSourceElement : referenceSourceElements) {
+    for (SOURCE referenceSourceElement : referenceSourceElements) {
       String identifier = getReferenceIdentifier(referenceSourceElement);
       DomElement referenceTargetElement = document.getElementById(identifier);
       if (referenceTargetElement != null) {
@@ -135,7 +135,7 @@ public class ElementReferenceCollectionImpl<Target extends ModelElementInstance,
   }
 
   @Override
-  public Collection<Target> getReferenceTargetElements(final ModelElementInstanceImpl referenceSourceParentElement) {
+  public Collection<TARGET> getReferenceTargetElements(final ModelElementInstanceImpl referenceSourceParentElement) {
 
     return new Collection<>() {
 
@@ -163,24 +163,24 @@ public class ElementReferenceCollectionImpl<Target extends ModelElementInstance,
       }
 
       @Override
-      public Iterator<Target> iterator() {
-        Collection<Target> modelElementCollection = ModelUtil.getModelElementCollection(getView(referenceSourceParentElement), referenceSourceParentElement.getModelInstance());
+      public Iterator<TARGET> iterator() {
+        Collection<TARGET> modelElementCollection = ModelUtil.getModelElementCollection(getView(referenceSourceParentElement), referenceSourceParentElement.getModelInstance());
         return modelElementCollection.iterator();
       }
 
       @Override
       public Object[] toArray() {
-        Collection<Target> modelElementCollection = ModelUtil.getModelElementCollection(getView(referenceSourceParentElement), referenceSourceParentElement.getModelInstance());
+        Collection<TARGET> modelElementCollection = ModelUtil.getModelElementCollection(getView(referenceSourceParentElement), referenceSourceParentElement.getModelInstance());
         return modelElementCollection.toArray();
       }
 
       public <T1> T1[] toArray(T1[] a) {
-        Collection<Target> modelElementCollection = ModelUtil.getModelElementCollection(getView(referenceSourceParentElement), referenceSourceParentElement.getModelInstance());
+        Collection<TARGET> modelElementCollection = ModelUtil.getModelElementCollection(getView(referenceSourceParentElement), referenceSourceParentElement.getModelInstance());
         return modelElementCollection.toArray(a);
       }
 
       @Override
-      public boolean add(Target t) {
+      public boolean add(TARGET t) {
         if (referenceSourceCollection.isImmutable()) {
           throw new UnsupportedModelOperationException("add()", "collection is immutable");
         }
@@ -206,17 +206,17 @@ public class ElementReferenceCollectionImpl<Target extends ModelElementInstance,
 
       @Override
       public boolean containsAll(Collection<?> c) {
-        Collection<Target> modelElementCollection = ModelUtil.getModelElementCollection(getView(referenceSourceParentElement), referenceSourceParentElement.getModelInstance());
+        Collection<TARGET> modelElementCollection = ModelUtil.getModelElementCollection(getView(referenceSourceParentElement), referenceSourceParentElement.getModelInstance());
         return modelElementCollection.containsAll(c);
       }
 
-      public boolean addAll(Collection<? extends Target> c) {
+      public boolean addAll(Collection<? extends TARGET> c) {
         if (referenceSourceCollection.isImmutable()) {
           throw new UnsupportedModelOperationException("addAll()", "collection is immutable");
         }
         else {
           boolean result = false;
-          for (Target o: c) {
+          for (TARGET o: c) {
             result |= add(o);
           }
           return result;
@@ -250,7 +250,7 @@ public class ElementReferenceCollectionImpl<Target extends ModelElementInstance,
         }
         else {
           Collection<DomElement> view = new ArrayList<>();
-          for (Source referenceSourceElement : referenceSourceCollection.get(referenceSourceParentElement)) {
+          for (SOURCE referenceSourceElement : referenceSourceCollection.get(referenceSourceParentElement)) {
             view.add(referenceSourceElement.getDomElement());
           }
           performClearOperation(referenceSourceParentElement, view);

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/ElementReferenceImpl.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/ElementReferenceImpl.java
@@ -27,35 +27,35 @@ import org.operaton.bpm.model.xml.type.reference.ElementReference;
 /**
  * @author Sebastian Menski
  */
-public class ElementReferenceImpl<Target extends ModelElementInstance, Source extends ModelElementInstance>  extends ElementReferenceCollectionImpl<Target,Source> implements ElementReference<Target, Source> {
+public class ElementReferenceImpl<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance>  extends ElementReferenceCollectionImpl<TARGET, SOURCE> implements ElementReference<TARGET, SOURCE> {
 
 
-  public ElementReferenceImpl(ChildElement<Source> referenceSourceCollection) {
+  public ElementReferenceImpl(ChildElement<SOURCE> referenceSourceCollection) {
     super(referenceSourceCollection);
   }
 
-  private ChildElement<Source> getReferenceSourceChild() {
-    return (ChildElement<Source>) getReferenceSourceCollection();
+  private ChildElement<SOURCE> getReferenceSourceChild() {
+    return (ChildElement<SOURCE>) getReferenceSourceCollection();
   }
 
   @Override
-  public Source getReferenceSource(ModelElementInstance referenceSourceParent) {
+  public SOURCE getReferenceSource(ModelElementInstance referenceSourceParent) {
     return getReferenceSourceChild().getChild(referenceSourceParent);
   }
 
-  private void setReferenceSource(ModelElementInstance referenceSourceParent, Source referenceSource) {
+  private void setReferenceSource(ModelElementInstance referenceSourceParent, SOURCE referenceSource) {
     getReferenceSourceChild().setChild(referenceSourceParent, referenceSource);
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public Target getReferenceTargetElement(ModelElementInstanceImpl referenceSourceParentElement) {
-    Source referenceSource = getReferenceSource(referenceSourceParentElement);
+  public TARGET getReferenceTargetElement(ModelElementInstanceImpl referenceSourceParentElement) {
+    SOURCE referenceSource = getReferenceSource(referenceSourceParentElement);
     if (referenceSource != null) {
       String identifier = getReferenceIdentifier(referenceSource);
       ModelElementInstance referenceTargetElement = referenceSourceParentElement.getModelInstance().getModelElementById(identifier);
       if (referenceTargetElement != null) {
-        return (Target) referenceTargetElement;
+        return (TARGET) referenceTargetElement;
       }
       else {
         throw new ModelException("Unable to find a model element instance for id " + identifier);
@@ -67,7 +67,7 @@ public class ElementReferenceImpl<Target extends ModelElementInstance, Source ex
   }
 
   @Override
-  public void setReferenceTargetElement(ModelElementInstanceImpl referenceSourceParentElement, Target referenceTargetElement) {
+  public void setReferenceTargetElement(ModelElementInstanceImpl referenceSourceParentElement, TARGET referenceTargetElement) {
     ModelInstanceImpl modelInstance = referenceSourceParentElement.getModelInstance();
     String identifier = referenceTargetAttribute.getValue(referenceTargetElement);
     ModelElementInstance existingElement = modelInstance.getModelElementById(identifier);
@@ -77,7 +77,7 @@ public class ElementReferenceImpl<Target extends ModelElementInstance, Source ex
         +": element is not part of model. Please connect element to the model first.");
     }
     else {
-      Source referenceSourceElement = modelInstance.newInstance(getReferenceSourceElementType());
+      SOURCE referenceSourceElement = modelInstance.newInstance(getReferenceSourceElementType());
       setReferenceSource(referenceSourceParentElement, referenceSourceElement);
       setReferenceIdentifier(referenceSourceElement, identifier);
     }

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/IdsElementReferenceCollectionBuilderImpl.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/IdsElementReferenceCollectionBuilderImpl.java
@@ -22,9 +22,9 @@ import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 /**
  * @author Sebastian Menski
  */
-public class IdsElementReferenceCollectionBuilderImpl<Target extends ModelElementInstance, Source extends ModelElementInstance> extends ElementReferenceCollectionBuilderImpl<Target, Source> {
+public class IdsElementReferenceCollectionBuilderImpl<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> extends ElementReferenceCollectionBuilderImpl<TARGET, SOURCE> {
 
-  public IdsElementReferenceCollectionBuilderImpl(Class<Source> childElementType, Class<Target> referenceTargetClass, ChildElementCollectionImpl<Source> collection) {
+  public IdsElementReferenceCollectionBuilderImpl(Class<SOURCE> childElementType, Class<TARGET> referenceTargetClass, ChildElementCollectionImpl<SOURCE> collection) {
     super(childElementType, referenceTargetClass, collection);
     this.elementReferenceCollectionImpl = new IdsElementReferenceCollectionImpl<>(collection);
   }

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/IdsElementReferenceCollectionImpl.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/IdsElementReferenceCollectionImpl.java
@@ -28,11 +28,11 @@ import org.operaton.bpm.model.xml.instance.DomElement;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 import org.operaton.bpm.model.xml.type.child.ChildElementCollection;
 
-public class IdsElementReferenceCollectionImpl<Target extends ModelElementInstance, Source extends ModelElementInstance> extends ElementReferenceCollectionImpl<Target, Source> {
+public class IdsElementReferenceCollectionImpl<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> extends ElementReferenceCollectionImpl<TARGET, SOURCE> {
 
   protected String separator = " ";
 
-  public IdsElementReferenceCollectionImpl(ChildElementCollection<Source> referenceSourceCollection) {
+  public IdsElementReferenceCollectionImpl(ChildElementCollection<SOURCE> referenceSourceCollection) {
     super(referenceSourceCollection);
   }
 
@@ -49,9 +49,9 @@ public class IdsElementReferenceCollectionImpl<Target extends ModelElementInstan
   @Override
   protected Collection<DomElement> getView(ModelElementInstanceImpl referenceSourceParentElement) {
     DomDocument document = referenceSourceParentElement.getModelInstance().getDocument();
-    Collection<Source> referenceSourceElements = getReferenceSourceCollection().get(referenceSourceParentElement);
+    Collection<SOURCE> referenceSourceElements = getReferenceSourceCollection().get(referenceSourceParentElement);
     Collection<DomElement> referenceTargetElements = new ArrayList<>();
-    for (Source referenceSourceElement : referenceSourceElements) {
+    for (SOURCE referenceSourceElement : referenceSourceElements) {
       List<String> identifiers = getReferenceIdentifiers(referenceSourceElement);
       for (String identifier : identifiers) {
         DomElement referenceTargetElement = document.getElementById(identifier);

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/QNameElementReferenceBuilderImpl.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/QNameElementReferenceBuilderImpl.java
@@ -22,9 +22,9 @@ import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 /**
  * @author Sebastian Menski
  */
-public class QNameElementReferenceBuilderImpl<Target extends ModelElementInstance, Source extends ModelElementInstance> extends ElementReferenceBuilderImpl<Target,Source> {
+public class QNameElementReferenceBuilderImpl<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> extends ElementReferenceBuilderImpl<TARGET, SOURCE> {
 
-  public QNameElementReferenceBuilderImpl(Class<Source> childElementType, Class<Target> referenceTargetClass, ChildElementImpl<Source> child) {
+  public QNameElementReferenceBuilderImpl(Class<SOURCE> childElementType, Class<TARGET> referenceTargetClass, ChildElementImpl<SOURCE> child) {
     super(childElementType, referenceTargetClass, child);
     this.elementReferenceCollectionImpl = new QNameElementReferenceImpl<>(child);
   }

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/QNameElementReferenceCollectionBuilderImpl.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/QNameElementReferenceCollectionBuilderImpl.java
@@ -22,9 +22,9 @@ import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 /**
  * @author Sebastian Menski
  */
-public class QNameElementReferenceCollectionBuilderImpl<Target extends ModelElementInstance, Source extends ModelElementInstance> extends ElementReferenceCollectionBuilderImpl<Target, Source> {
+public class QNameElementReferenceCollectionBuilderImpl<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> extends ElementReferenceCollectionBuilderImpl<TARGET, SOURCE> {
 
-  public QNameElementReferenceCollectionBuilderImpl(Class<Source> childElementType, Class<Target> referenceTargetClass, ChildElementCollectionImpl<Source> collection) {
+  public QNameElementReferenceCollectionBuilderImpl(Class<SOURCE> childElementType, Class<TARGET> referenceTargetClass, ChildElementCollectionImpl<SOURCE> collection) {
     super(childElementType, referenceTargetClass, collection);
     this.elementReferenceCollectionImpl = new QNameElementReferenceCollectionImpl<>(collection);
   }

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/QNameElementReferenceCollectionImpl.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/QNameElementReferenceCollectionImpl.java
@@ -23,9 +23,9 @@ import org.operaton.bpm.model.xml.type.child.ChildElementCollection;
 /**
  * @author Sebastian Menski
  */
-public class QNameElementReferenceCollectionImpl<Target extends ModelElementInstance, Source extends ModelElementInstance> extends ElementReferenceCollectionImpl<Target, Source> {
+public class QNameElementReferenceCollectionImpl<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> extends ElementReferenceCollectionImpl<TARGET, SOURCE> {
 
-  public QNameElementReferenceCollectionImpl(ChildElementCollection<Source> referenceSourceCollection) {
+  public QNameElementReferenceCollectionImpl(ChildElementCollection<SOURCE> referenceSourceCollection) {
     super(referenceSourceCollection);
   }
 

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/QNameElementReferenceImpl.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/QNameElementReferenceImpl.java
@@ -23,9 +23,9 @@ import org.operaton.bpm.model.xml.type.child.ChildElement;
 /**
  * @author Sebastian Menski
  */
-public class QNameElementReferenceImpl<Target extends ModelElementInstance, Source extends ModelElementInstance> extends ElementReferenceImpl<Target,Source> {
+public class QNameElementReferenceImpl<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> extends ElementReferenceImpl<TARGET, SOURCE> {
 
-  public QNameElementReferenceImpl(ChildElement<Source> referenceSourceCollection) {
+  public QNameElementReferenceImpl(ChildElement<SOURCE> referenceSourceCollection) {
     super(referenceSourceCollection);
   }
 

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/UriElementReferenceBuilderImpl.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/UriElementReferenceBuilderImpl.java
@@ -19,9 +19,9 @@ package org.operaton.bpm.model.xml.impl.type.reference;
 import org.operaton.bpm.model.xml.impl.type.child.ChildElementImpl;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 
-public class UriElementReferenceBuilderImpl<Target extends ModelElementInstance, Source extends ModelElementInstance> extends ElementReferenceBuilderImpl<Target, Source> {
+public class UriElementReferenceBuilderImpl<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> extends ElementReferenceBuilderImpl<TARGET, SOURCE> {
 
-  public UriElementReferenceBuilderImpl(Class<Source> childElementType, Class<Target> referenceTargetClass, ChildElementImpl<Source> child) {
+  public UriElementReferenceBuilderImpl(Class<SOURCE> childElementType, Class<TARGET> referenceTargetClass, ChildElementImpl<SOURCE> child) {
     super(childElementType, referenceTargetClass, child);
     this.elementReferenceCollectionImpl = new UriElementReferenceImpl<>(child);
   }

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/UriElementReferenceCollectionBuilderImpl.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/UriElementReferenceCollectionBuilderImpl.java
@@ -19,9 +19,9 @@ package org.operaton.bpm.model.xml.impl.type.reference;
 import org.operaton.bpm.model.xml.impl.type.child.ChildElementCollectionImpl;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 
-public class UriElementReferenceCollectionBuilderImpl<Target extends ModelElementInstance, Source extends ModelElementInstance> extends ElementReferenceCollectionBuilderImpl<Target, Source> {
+public class UriElementReferenceCollectionBuilderImpl<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> extends ElementReferenceCollectionBuilderImpl<TARGET, SOURCE> {
 
-  public UriElementReferenceCollectionBuilderImpl(Class<Source> childElementType, Class<Target> referenceTargetClass, ChildElementCollectionImpl<Source> collection) {
+  public UriElementReferenceCollectionBuilderImpl(Class<SOURCE> childElementType, Class<TARGET> referenceTargetClass, ChildElementCollectionImpl<SOURCE> collection) {
     super(childElementType, referenceTargetClass, collection);
     this.elementReferenceCollectionImpl = new UriElementReferenceCollectionImpl<>(collection);
   }

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/UriElementReferenceCollectionImpl.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/UriElementReferenceCollectionImpl.java
@@ -19,9 +19,9 @@ package org.operaton.bpm.model.xml.impl.type.reference;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 import org.operaton.bpm.model.xml.type.child.ChildElementCollection;
 
-public class UriElementReferenceCollectionImpl<Target extends ModelElementInstance, Source extends ModelElementInstance> extends ElementReferenceCollectionImpl<Target, Source> {
+public class UriElementReferenceCollectionImpl<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> extends ElementReferenceCollectionImpl<TARGET, SOURCE> {
 
-  public UriElementReferenceCollectionImpl(ChildElementCollection<Source> referenceSourceCollection) {
+  public UriElementReferenceCollectionImpl(ChildElementCollection<SOURCE> referenceSourceCollection) {
     super(referenceSourceCollection);
   }
 

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/UriElementReferenceImpl.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/UriElementReferenceImpl.java
@@ -19,9 +19,9 @@ package org.operaton.bpm.model.xml.impl.type.reference;
 import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 import org.operaton.bpm.model.xml.type.child.ChildElement;
 
-public class UriElementReferenceImpl<Target extends ModelElementInstance, Source extends ModelElementInstance> extends ElementReferenceImpl<Target, Source> {
+public class UriElementReferenceImpl<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> extends ElementReferenceImpl<TARGET, SOURCE> {
 
-  public UriElementReferenceImpl(ChildElement<Source> referenceSourceCollection) {
+  public UriElementReferenceImpl(ChildElement<SOURCE> referenceSourceCollection) {
     super(referenceSourceCollection);
   }
 

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/type/reference/ElementReference.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/type/reference/ElementReference.java
@@ -22,13 +22,13 @@ import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 /**
  * @author Sebastian Menski
  */
-public interface ElementReference<Target extends ModelElementInstance, Source extends ModelElementInstance> extends ElementReferenceCollection<Target, Source> {
+public interface ElementReference<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> extends ElementReferenceCollection<TARGET, SOURCE> {
 
-  Source getReferenceSource(ModelElementInstance referenceSourceParent);
+  SOURCE getReferenceSource(ModelElementInstance referenceSourceParent);
 
-  Target getReferenceTargetElement(ModelElementInstanceImpl referenceSourceParentElement);
+  TARGET getReferenceTargetElement(ModelElementInstanceImpl referenceSourceParentElement);
 
-  void setReferenceTargetElement(ModelElementInstanceImpl referenceSourceParentElement, Target referenceTargetElement);
+  void setReferenceTargetElement(ModelElementInstanceImpl referenceSourceParentElement, TARGET referenceTargetElement);
 
   void clearReferenceTargetElement(ModelElementInstanceImpl referenceSourceParentElement);
 

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/type/reference/ElementReferenceCollection.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/type/reference/ElementReferenceCollection.java
@@ -25,9 +25,9 @@ import org.operaton.bpm.model.xml.type.child.ChildElementCollection;
 /**
  * @author Sebastian Menski
  */
-public interface ElementReferenceCollection<Target extends ModelElementInstance, Source extends ModelElementInstance> extends Reference<Target> {
+public interface ElementReferenceCollection<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> extends Reference<TARGET> {
 
-  ChildElementCollection<Source> getReferenceSourceCollection();
+  ChildElementCollection<SOURCE> getReferenceSourceCollection();
 
-  Collection<Target> getReferenceTargetElements(ModelElementInstanceImpl referenceSourceElement);
+  Collection<TARGET> getReferenceTargetElements(ModelElementInstanceImpl referenceSourceElement);
 }

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/type/reference/ElementReferenceCollectionBuilder.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/type/reference/ElementReferenceCollectionBuilder.java
@@ -22,8 +22,8 @@ import org.operaton.bpm.model.xml.instance.ModelElementInstance;
 /**
  * @author Sebastian Menski
  */
-public interface ElementReferenceCollectionBuilder<Target extends ModelElementInstance, Source extends ModelElementInstance> extends ModelBuildOperation {
+public interface ElementReferenceCollectionBuilder<TARGET extends ModelElementInstance, SOURCE extends ModelElementInstance> extends ModelBuildOperation {
 
-  ElementReferenceCollection<Target, Source> build();
+  ElementReferenceCollection<TARGET, SOURCE> build();
 
 }

--- a/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/mapping/CustomerList.java
+++ b/spin/dataformat-json-jackson/src/test/java/org/operaton/spin/json/mapping/CustomerList.java
@@ -58,7 +58,7 @@ public class CustomerList<T> implements List<Customer> {
   }
 
   @Override
-  public <Customer> Customer[] toArray(Customer[] a) {
+  public <CUSTOMER> CUSTOMER[] toArray(CUSTOMER[] a) {
     return innerList.toArray(a);
   }
 


### PR DESCRIPTION
- Changes the generic type parameter naming convention from Pascal case to screaming snake case
- Does not fully address Sonar S119, requires manual intervention in SonarQube to mark issues as accepted

related to #1415