### PR TITLE
chore: removed redundant /modules folder definition in WildFly assembly.xml

### DIFF
--- a/distro/wildfly/assembly/assembly.xml
+++ b/distro/wildfly/assembly/assembly.xml
@@ -41,10 +41,6 @@
   <fileSets>
     <fileSet>
       <directory>../modules/target/modules</directory>
-      <outputDirectory>modules</outputDirectory>
-    </fileSet>
-    <fileSet>
-      <directory>../modules/target/modules</directory>
       <outputDirectory>server/wildfly-${version.wildfly}/modules</outputDirectory>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
Removed redundant top-level modules assembly.xml instruction

The fix was verified with build, static analysis and visual inspection.
Only the correct `server/wildfly-{VERSION}/modules` path and its usage remains.

Fixes #1423