### PR TITLE
fix(workflow): Avoid double posting on issues

### DIFF
--- a/.github/workflows/check-for-new-contributor.yml
+++ b/.github/workflows/check-for-new-contributor.yml
@@ -130,6 +130,12 @@ jobs:
             const { owner, repo } = context.repo;
             const commentBody = context.payload.comment.body;
             
+            const issueAuthor = context.payload.issue.user.login;
+            if (author === issueAuthor) {
+              console.log(`${author} is the author of this issue/PR. Skipping greeting.`);
+              return;
+            }
+            
             console.log(`Checking for past comments from ${author}...`);
             const allComments = await github.paginate(github.rest.issues.listCommentsForRepo, {
               owner,


### PR DESCRIPTION
- new contributors receiving greeting message only once now

related to #1472, closes #1472