### PR TITLE
fix(build): Include SBOM files in build artifacts

### DIFF
--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -3,7 +3,6 @@ name: Integration Build
 on:
   schedule:
     - cron: "0 2 * * *"     # Runs at 2:00 AM UTC daily
-    - cron: "30 11 * * *"
   workflow_dispatch:        # Allows manual trigger
     inputs:
       java_version:
@@ -396,6 +395,7 @@ jobs:
         with:
           path: |
             target/*.zip
+            target/sbom/**
           key: ${{ github.run_id }}-documentation-artifacts
 
   release:
@@ -438,6 +438,7 @@ jobs:
         with:
           path: |
             target/*.zip
+            target/sbom/**
           key: ${{ github.run_id }}-documentation-artifacts
           fail-on-cache-miss: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
             ./*/staging-deploy/**
             **/target/reports/**
             **/target/surefire-reports/*.xml
+            target/sbom/**
             target/*.zip
           key: ${{ github.run_id }}-build-artifacts
 
@@ -128,6 +129,7 @@ jobs:
             ./*/staging-deploy/**
             **/target/reports/**
             **/target/surefire-reports/*.xml
+            target/sbom/**
             target/*.zip
           key: ${{ github.run_id }}-build-artifacts
           fail-on-cache-miss: true


### PR DESCRIPTION
This change adds the missing SBOM artifacts to the build results. They were missing in the release job.

related to #215 