### PR TITLE
feat(build): Improve license book generation

### DIFF
--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -402,7 +402,7 @@ jobs:
           path: |
             target/*.zip
             target/sbom/**
-            distro/license-book/src/main/resources/license-book.md
+            distro/license-book/src/main/resources/LICENSE_BOOK.md
           key: ${{ github.run_id }}-documentation-artifacts
 
   release:
@@ -446,7 +446,7 @@ jobs:
           path: |
             target/*.zip
             target/sbom/**
-            distro/license-book/src/main/resources/license-book.md
+            distro/license-book/src/main/resources/LICENSE_BOOK.md
           key: ${{ github.run_id }}-documentation-artifacts
           fail-on-cache-miss: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
             **/target/surefire-reports/*.xml
             target/sbom/**
             target/*.zip
-            distro/license-book/src/main/resources/license-book.md
+            distro/license-book/src/main/resources/LICENSE_BOOK.md
           key: ${{ github.run_id }}-build-artifacts
 
   release:
@@ -130,7 +130,7 @@ jobs:
             **/target/surefire-reports/*.xml
             target/sbom/**
             target/*.zip
-            distro/license-book/src/main/resources/license-book.md
+            distro/license-book/src/main/resources/LICENSE_BOOK.md
           key: ${{ github.run_id }}-build-artifacts
           fail-on-cache-miss: true
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Java 17 or higher is required. Operaton is tested and supported on Java 17, 21, 
 
 The source files in this repository are made available under the [Apache License Version 2.0](./LICENSE).
 
-Operaton uses and includes third-party dependencies published under various licenses. By downloading and using Operaton artifacts, you agree to their terms and conditions. Refer to our [license-book.txt](./distro/license-book/src/main/resources/license-book.md) for an overview of third-party libraries and particularly important third-party licenses we want to make you aware of.
+Operaton uses and includes third-party dependencies published under various licenses. By downloading and using Operaton artifacts, you agree to their terms and conditions. Refer to our [LICENSE_BOOK.md](./distro/license-book/src/main/resources/LICENSE_BOOK.md) for an overview of third-party libraries and particularly important third-party licenses we want to make you aware of.
 
 ## Security
 

--- a/distro/license-book/assembly.xml
+++ b/distro/license-book/assembly.xml
@@ -13,10 +13,11 @@
 
   <files>
     <file>
-      <source>src/main/resources/license-book.md</source>
+      <source>src/main/resources/LICENSE_BOOK.md</source>
       <lineEnding>crlf</lineEnding>
       <outputDirectory></outputDirectory>
-      <destName>LICENSE_BOOK-${project.version}.md</destName>
+      <destName>LICENSE_BOOK.md</destName>
+      <filtered>true</filtered>
     </file>
   </files>
 

--- a/distro/license-book/pom.xml
+++ b/distro/license-book/pom.xml
@@ -24,6 +24,27 @@
   </dependencyManagement>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-resources</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/resources</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/resources</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <!-- assemble zip artifact -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -48,29 +69,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- copy book to target directory -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-license-book</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target>
-                <copy todir="target/">
-                  <fileset dir="src/main/resources">
-                    <include name="**/*.txt"/>
-                  </fileset>
-                </copy>
-              </target>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <!-- attach artifact -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -85,7 +83,7 @@
             <configuration>
               <artifacts>
                 <artifact>
-                  <file>target/license-book.md</file>
+                  <file>src/main/resources/LICENSE_BOOK.md</file>
                   <type>txt</type>
                 </artifact>
               </artifacts>

--- a/distro/license-book/src/main/mustache/license-book.tpl
+++ b/distro/license-book/src/main/mustache/license-book.tpl
@@ -1,4 +1,4 @@
-# License Book for Operaton {{version}}
+# Operaton ${project.version} License Book
 
 {{>toc}}
 

--- a/distro/license-book/src/main/mustache/license-summary.tpl
+++ b/distro/license-book/src/main/mustache/license-summary.tpl
@@ -4,7 +4,7 @@ The following sections contain licensing information for third-party libraries t
 
 We are thankful to all individuals that have created these.
 
-The Libraries used within Operaton {{version}} are published under the following licenses:
+The Libraries used within Operaton ${project.version} are published under the following licenses:
 
 {{#license_ids}}
 * [{{id}}](#{{id_lower}}) 

--- a/distro/license-book/src/main/mustache/preamble.tpl
+++ b/distro/license-book/src/main/mustache/preamble.tpl
@@ -1,15 +1,15 @@
 This is a license book. It contains licensing information for third-party libraries which are used
-in this release of Operaton {{version}}.
+in this release of Operaton ${project.version}.
 
-_(Document generated on: {{date}})_
+_(Document generated on: ${build.date})_
 
 <a name="introduction"></a>
 ## Introduction
 This Licensing Information document is a part of the program documentation and is intended to help you understand the license terms and copyright for third-party libraries associated with the Operaton software.
 
 <a name="product_license"></a>
-## Product License - Operaton {{version}}
-This is a distribution of Operaton {{version}} (visit https://docs.operaton.org/) a Java-based framework.
+## Product License - Operaton
+This is a distribution of Operaton ${project.version} (visit https://docs.operaton.org/) a Java-based framework.
 The software is mainly published under the Apache License 2.0 and other open source licenses.
 Which components are published under an open source license is clearly stated in the license header
 of a source code file or a LICENSE file present in the root directory of the software code repository.

--- a/distro/license-book/src/main/python/license-book-generator.py
+++ b/distro/license-book/src/main/python/license-book-generator.py
@@ -230,7 +230,7 @@ def generate_license_book():
 
     # write output file
     os.makedirs('distro/license-book/target/generated-resources', exist_ok=True)
-    out_path = 'distro/license-book/src/main/resources/license-book.md'
+    out_path = 'distro/license-book/src/main/resources/LICENSE_BOOK.md'
     with open(out_path, 'w', encoding='utf-8') as out_file:
         out_file.write(output)
 

--- a/distro/license-book/src/main/resources/LICENSE_BOOK.md
+++ b/distro/license-book/src/main/resources/LICENSE_BOOK.md
@@ -1,4 +1,4 @@
-# License Book for Operaton 1.1.0-SNAPSHOT
+# Operaton ${project.version} License Book
 
 ## Table of contents
 
@@ -10,17 +10,17 @@
 4. [License Texts](#licenses)
 
 This is a license book. It contains licensing information for third-party libraries which are used
-in this release of Operaton 1.1.0-SNAPSHOT.
+in this release of Operaton ${project.version}.
 
-_(Document generated on: 2025-10-30)_
+_(Document generated on: ${build.date})_
 
 <a name="introduction"></a>
 ## Introduction
 This Licensing Information document is a part of the program documentation and is intended to help you understand the license terms and copyright for third-party libraries associated with the Operaton software.
 
 <a name="product_license"></a>
-## Product License - Operaton 1.1.0-SNAPSHOT
-This is a distribution of Operaton 1.1.0-SNAPSHOT (visit https://docs.operaton.org/) a Java-based framework.
+## Product License - Operaton
+This is a distribution of Operaton ${project.version} (visit https://docs.operaton.org/) a Java-based framework.
 The software is mainly published under the Apache License 2.0 and other open source licenses.
 Which components are published under an open source license is clearly stated in the license header
 of a source code file or a LICENSE file present in the root directory of the software code repository.
@@ -32,7 +32,7 @@ The following sections contain licensing information for third-party libraries t
 
 We are thankful to all individuals that have created these.
 
-The Libraries used within Operaton 1.1.0-SNAPSHOT are published under the following licenses:
+The Libraries used within Operaton ${project.version} are published under the following licenses:
 
 * [Apache-2.0](#apache-2.0) 
 * [Apache-2.0-with-LLVM-exception](#apache-2.0-with-llvm-exception) 

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -195,7 +195,7 @@ files:
     - path: 'distro/wildfly/distro/target/operaton-bpm-wildfly-{{projectVersion}}.zip'
     - path: 'distro/sql-script/target/operaton-sql-scripts-{{OPERATON_DATABASE_VERSION}}.tar.gz'
     - path: 'distro/webjar/target/operaton-webapp-webjar-{{projectVersion}}.jar'
-    - path: 'distro/license-book/src/main/resources/license-book.md'
+    - path: 'distro/license-book/src/main/resources/LICENSE_BOOK.md'
     - path: 'target/sbom/operaton-modules.cyclonedx-json.sbom'
     - path: 'target/sbom/operaton-webapps.cyclonedx-json.sbom'
     - path: 'target/project-reports.zip'

--- a/pom.xml
+++ b/pom.xml
@@ -79,9 +79,23 @@
             <goals>
               <goal>parse-version</goal>
             </goals>
+            <phase>initialize</phase>
             <configuration>
               <propertyPrefix>operaton.version</propertyPrefix>
               <versionString>${project.version}</versionString>
+            </configuration>
+          </execution>
+          <execution>
+            <id>build-date-property</id>
+            <goals>
+              <goal>timestamp-property</goal>
+            </goals>
+            <phase>initialize</phase>
+            <configuration>
+              <name>build.date</name>
+              <pattern>yyyy-MM-dd</pattern>
+              <timeZone>Europe/Zurich</timeZone>
+              <locale>en</locale>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
- /pom.xml: produce build property 'build.date'
- renamed license-book.md -> LICENSE_BOOK.md
- Use placeholders in mustache templates to generate LICENSE_BOOK.md with placeholders for the project version and build date
- Use Maven resource filtering to replace placeholders at build time