### PR TITLE
feat(ci): Add sonar-project.properties & define coverage exclusions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: bash
-        run: ./mvnw org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=operaton_operaton
+        run: ./mvnw org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
         continue-on-error: true
       - name: Cache build artifacts
         uses: actions/cache/save@v4

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=operaton_operaton
+sonar.coverage.exclusions=qa/performance-tests-engine/**,\
+    qa/integration-tests-webapps/**,\
+    qa/integration-tests-engine/**,\
+    webapps/**


### PR DESCRIPTION
Sonar should ignore certain paths that we do not need to cover by tests. These are tests themselves and the old webapps.
Added a `sonar-project.properties` file to perform the exclusions.