### PR TITLE
Fix: Rename method to comply with naming conventions

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetJobDefinitionStateCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/AbstractSetJobDefinitionStateCmd.java
@@ -132,7 +132,7 @@ public abstract class AbstractSetJobDefinitionStateCmd extends AbstractSetStateC
         return JobDefinitionSuspensionStateConfiguration.byProcessDefinitionKey(processDefinitionKey, isIncludeSubResources());
 
       } else {
-        return JobDefinitionSuspensionStateConfiguration.ByProcessDefinitionKeyAndTenantId(processDefinitionKey, processDefinitionTenantId, isIncludeSubResources());
+        return JobDefinitionSuspensionStateConfiguration.byProcessDefinitionKeyAndTenantId(processDefinitionKey, processDefinitionTenantId, isIncludeSubResources());
       }
     }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerChangeJobDefinitionSuspensionStateJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/TimerChangeJobDefinitionSuspensionStateJobHandler.java
@@ -173,7 +173,7 @@ public abstract class TimerChangeJobDefinitionSuspensionStateJobHandler implemen
       return configuration;
     }
 
-    public static JobDefinitionSuspensionStateConfiguration ByProcessDefinitionKeyAndTenantId(String processDefinitionKey, String tenantId, boolean includeProcessInstances) {
+    public static JobDefinitionSuspensionStateConfiguration byProcessDefinitionKeyAndTenantId(String processDefinitionKey, String tenantId, boolean includeProcessInstances) {
       JobDefinitionSuspensionStateConfiguration configuration = byProcessDefinitionKey(processDefinitionKey, includeProcessInstances);
 
       configuration.isTenantIdSet = true;


### PR DESCRIPTION
Fixed #1554

This pull request renames the method
org.operaton.bpm.engine.impl.jobexecutor.TimerChangeJobDefinitionSuspensionStateJobHandler.JobDefinitionSuspensionStateConfiguration#ByProcessDefinitionKeyAndTenantId
to
byProcessDefinitionKeyAndTenantId
in order to align with Java naming conventions.

I confirm that my contribution and following ones comply with the Apache License 2.0 and the Code of Conduct.