### PR TITLE
feat(build): Define profile 'github-ci' and produce license book when it is activated

### DIFF
--- a/distro/run/assembly/pom.xml
+++ b/distro/run/assembly/pom.xml
@@ -111,42 +111,26 @@
       <artifactId>groovy-datetime</artifactId>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
+        <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
-            <id>install-python-libs</id>
-            <phase>generate-sources</phase>
+            <id>license-book-placeholer</id>
+            <phase>initialize</phase>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
             <configuration>
-              <executable>pip</executable>
-              <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
-              <arguments>
-                <argument>install</argument>
-                <argument>pystache</argument>
-              </arguments>
-              <skip>false</skip>
-            </configuration>
-          </execution>
-          <execution>
-            <id>generate-license-book</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>python3</executable>
-              <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
-              <arguments>
-                <argument>distro/license-book/src/main/python/license-book-generator.py</argument>
-                <argument>--distro=operaton</argument>
-              </arguments>
-              <skip>false</skip>
+              <target>
+                <echo file="${project.build.directory}/generated-resources/LICENSE_BOOK.md">
+                  License book placeholder. The actual content is generated when the
+                  "github-ci" profile is active.
+                  Without this file the assembly would fail.
+                </echo>
+              </target>
             </configuration>
           </execution>
         </executions>
@@ -154,12 +138,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <configuration>
-          <appendAssemblyId>false</appendAssemblyId>
-          <outputDirectory>target/</outputDirectory>
-          <tarLongFileMode>gnu</tarLongFileMode>
-          <finalName>operaton-bpm-${project.version}</finalName>
-        </configuration>
         <executions>
           <execution>
             <id>assemble</id>
@@ -171,11 +149,70 @@
               <descriptors>
                 <descriptor>assembly.xml</descriptor>
               </descriptors>
+              <finalName>operaton-bpm-${project.version}</finalName>
+              <attach>true</attach>
+              <appendAssemblyId>false</appendAssemblyId>
+              <outputDirectory>target/</outputDirectory>
               <workDirectory>target/assembly/work</workDirectory>
+              <tarLongFileMode>gnu</tarLongFileMode>
             </configuration>
           </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>github-ci</id>
+      <activation>
+        <property>
+          <name>env.GITHUB_ACTIONS</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>install-python-libs</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>pip</executable>
+                  <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
+                  <arguments>
+                    <argument>install</argument>
+                    <argument>pystache</argument>
+                  </arguments>
+                  <skip>false</skip>
+                </configuration>
+              </execution>
+              <execution>
+                <id>generate-license-book</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>python3</executable>
+                  <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
+                  <arguments>
+                    <argument>distro/license-book/src/main/python/license-book-generator.py</argument>
+                    <argument>--distro=operaton</argument>
+                  </arguments>
+                  <skip>false</skip>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/distro/tomcat/assembly/pom.xml
+++ b/distro/tomcat/assembly/pom.xml
@@ -141,39 +141,22 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
+        <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
-            <id>install-python-libs</id>
-            <phase>generate-sources</phase>
+            <id>license-book-placeholer</id>
+            <phase>initialize</phase>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
             <configuration>
-              <executable>pip</executable>
-              <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
-              <arguments>
-                <argument>install</argument>
-                <argument>pystache</argument>
-              </arguments>
-              <skip>false</skip>
-            </configuration>
-          </execution>
-          <execution>
-            <id>generate-license-book</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>python3</executable>
-              <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
-              <arguments>
-                <argument>distro/license-book/src/main/python/license-book-generator.py</argument>
-                <argument>--distro=tomcat</argument>
-              </arguments>
-              <skip>false</skip>
+              <target>
+                <echo file="${project.build.directory}/generated-resources/LICENSE_BOOK.md">
+                  License book placeholder. The actual content is generated when the
+                  "github-ci" profile is active.
+                  Without this file the assembly would fail.
+                </echo>
+              </target>
             </configuration>
           </execution>
         </executions>
@@ -197,11 +180,64 @@
               <outputDirectory>target/</outputDirectory>
               <workDirectory>target/assembly/work</workDirectory>
               <tarLongFileMode>gnu</tarLongFileMode>
-              <attach>true</attach>
             </configuration>
           </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>github-ci</id>
+      <activation>
+        <property>
+          <name>env.GITHUB_ACTIONS</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>install-python-libs</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>pip</executable>
+                  <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
+                  <arguments>
+                    <argument>install</argument>
+                    <argument>pystache</argument>
+                  </arguments>
+                  <skip>false</skip>
+                </configuration>
+              </execution>
+              <execution>
+                <id>generate-license-book</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>python3</executable>
+                  <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
+                  <arguments>
+                    <argument>distro/license-book/src/main/python/license-book-generator.py</argument>
+                    <argument>--distro=tomcat</argument>
+                  </arguments>
+                  <skip>false</skip>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/distro/wildfly/assembly/pom.xml
+++ b/distro/wildfly/assembly/pom.xml
@@ -131,39 +131,22 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
+        <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
-            <id>install-python-libs</id>
-            <phase>generate-sources</phase>
+            <id>license-book-placeholer</id>
+            <phase>initialize</phase>
             <goals>
-              <goal>exec</goal>
+              <goal>run</goal>
             </goals>
             <configuration>
-              <executable>pip</executable>
-              <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
-              <arguments>
-                <argument>install</argument>
-                <argument>pystache</argument>
-              </arguments>
-              <skip>false</skip>
-            </configuration>
-          </execution>
-          <execution>
-            <id>generate-license-book</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <configuration>
-              <executable>python3</executable>
-              <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
-              <arguments>
-                <argument>distro/license-book/src/main/python/license-book-generator.py</argument>
-                <argument>--distro=wildfly</argument>
-              </arguments>
-              <skip>false</skip>
+              <target>
+                <echo file="${project.build.directory}/generated-resources/LICENSE_BOOK.md">
+                  License book placeholder. The actual content is generated when the
+                  "github-ci" profile is active.
+                  Without this file the assembly would fail.
+                </echo>
+              </target>
             </configuration>
           </execution>
         </executions>
@@ -171,7 +154,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.7.1</version>
         <executions>
           <execution>
             <id>assemble</id>
@@ -194,4 +176,58 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>github-ci</id>
+      <activation>
+        <property>
+          <name>env.GITHUB_ACTIONS</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>install-python-libs</id>
+                <phase>initialize</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>pip</executable>
+                  <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
+                  <arguments>
+                    <argument>install</argument>
+                    <argument>pystache</argument>
+                  </arguments>
+                  <skip>false</skip>
+                </configuration>
+              </execution>
+              <execution>
+                <id>generate-license-book</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>python3</executable>
+                  <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
+                  <arguments>
+                    <argument>distro/license-book/src/main/python/license-book-generator.py</argument>
+                    <argument>--distro=wildfly</argument>
+                  </arguments>
+                  <skip>false</skip>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
The build should not assume that Python is installed to generate the license book. In regular builds the license book is just a placeholder file. When the profile 'github-ci' is activated, the license book is generated.