### PR TITLE
fix(build): Remove unused JUnit import from OSGi manifest

### DIFF
--- a/model-api/xml-model/pom.xml
+++ b/model-api/xml-model/pom.xml
@@ -12,8 +12,7 @@
   <properties>
     <operaton.artifact>org.operaton.bpm.model.xml</operaton.artifact>
     <operaton.osgi.import.additional>
-      org.assertj.*;resolution:=optional,
-      org.junit.jupiter.api.*;resolution:=optional
+      org.assertj.*;resolution:=optional
     </operaton.osgi.import.additional>
   </properties>
   <dependencies>


### PR DESCRIPTION
## Summary

Fixes an OSGi bundle plugin warning in the `operaton-xml-model` module by removing an unused Import-Package instruction for `org.junit.jupiter.api.*`.

## Changes

- Removed `org.junit.jupiter.api.*;resolution:=optional` from the OSGi manifest configuration in `model-api/xml-model/pom.xml`
- JUnit Jupiter is only used in test artifacts (test-jar), not in the main artifact, making this import unnecessary

## Build Warning Eliminated

```
[WARNING] Manifest org.operaton.bpm.model:operaton-xml-model:jar:1.1.0-SNAPSHOT : 
Unused Import-Package instructions: [org.junit.jupiter.api.*]
```

## Verification

- Built the `xml-model` module successfully without the warning
- The `org.assertj.*` import remains as it's actually used in the main code (test helper classes)

## Context

This PR was created during a **[Cyberland OSS camp session](https://cyberland.ijug.eu/2025-11-open-source-camp/)** in collaboration with:
- [@sparsick](https://github.com/sparsick) (Sandra Parsick)
- [@jopsdev](https://github.com/jopsdev) (Tobias Frech)  
- [@javahippie ](https://github.com/javahippie) (Tim Zöller)

Related to #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)