### PR TITLE
fix(stale): relax stale rules for milestone and deferred issues (#1510)

### DIFF
--- a/database/pom.xml
+++ b/database/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>


### PR DESCRIPTION
- Added `exempt-issue-milestones: true` so milestone issues (e.g., #360) are not marked stale
- Increased inactivity threshold to 90 days
- Added label exemptions: backlog, later, do not stale

Fixes #1510