### PR TITLE
feat(health): add runtime‑agnostic Health SPI and Run /health endpoint

### DIFF
--- a/distro/run/core/src/main/java/org/operaton/bpm/run/health/HealthController.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/health/HealthController.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.run.health;
+
+import org.operaton.bpm.engine.health.HealthResult;
+import org.operaton.bpm.engine.health.HealthService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Health endpoint for Operaton Run.
+ * Provides a lightweight /health JSON suitable for load balancers and uptime checks.
+ * Note: This endpoint is specific to the Operaton Run distribution. When deploying
+ * Operaton on application servers like Tomcat or WildFly, those runtimes typically
+ * provide their own health endpoints (e.g., via vendor-specific tooling or
+ * Spring Boot actuator in custom apps), so this endpoint is not exposed there.
+ *
+ * @author <a href="mailto:tomnm77@gmail.com">Tomasz Korcz</a>
+ */
+@RestController
+@ConditionalOnProperty(prefix = "management.health.operaton", name = "enabled", matchIfMissing = true)
+public class HealthController {
+
+  private final HealthService healthService;
+
+  public HealthController(HealthService healthService) {
+    this.healthService = healthService;
+  }
+
+  @GetMapping(path = "/health", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<Map<String, Object>> health() {
+    Map<String, Object> body = new LinkedHashMap<>();
+
+    HealthResult result = healthService.check();
+    body.put("status", result.status());
+    body.put("timestamp", result.timestamp());
+    if (result.version() != null) {
+      body.put("version", result.version());
+    }
+    body.put("details", result.details());
+    return ResponseEntity.ok()
+      .header(HttpHeaders.CACHE_CONTROL, "no-store, no-cache, must-revalidate, max-age=0")
+      .body(body);
+  }
+}

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/test/health/HealthEndpointTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/test/health/HealthEndpointTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.run.test.health;
+
+import org.junit.jupiter.api.Test;
+import org.operaton.bpm.run.test.AbstractRestTest;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class HealthEndpointTest extends AbstractRestTest {
+
+  @Test
+  void shouldReturnHealthStatus() {
+    ResponseEntity<JsonNode> entity = testRestTemplate.getForEntity("/health", JsonNode.class);
+    assertThat(entity.getStatusCode().value()).isEqualTo(200);
+    JsonNode body = entity.getBody();
+    assertThat(body).isNotNull();
+    assertThat(body.has("status")).isTrue();
+    assertThat(body.get("status").isTextual()).isTrue();
+    assertThat(body.has("timestamp")).isTrue();
+    assertThat(body.get("timestamp").isTextual()).isTrue();
+    assertThat(body.has("details")).isTrue();
+  }
+}

--- a/engine/src/main/java/org/operaton/bpm/engine/health/FrontendHealthContributor.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/health/FrontendHealthContributor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.health;
+
+import java.util.Map;
+
+/**
+ * SPI to contribute frontend (webapps) related health information.
+ *
+ * @author <a href="mailto:tomnm77@gmail.com">Tomasz Korcz</a>
+ * @since 1.1
+ */
+public interface FrontendHealthContributor {
+
+  /**
+   * Provide frontend-related health details. Implementations should at minimum
+   * expose an "operational" flag indicating whether the frontend is available.
+   * Example keys:
+   * - operational: boolean
+   * - path: String (application path if applicable)
+   */
+  Map<String, Object> frontendDetails();
+}

--- a/engine/src/main/java/org/operaton/bpm/engine/health/HealthResult.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/health/HealthResult.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.health;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Immutable value object describing Operaton health.
+ *
+ * @author <a href="mailto:tomnm77@gmail.com">Tomasz Korcz</a>
+ * @since 1.1
+ */
+public record HealthResult(String status, String timestamp, String version, Map<String, Object> details) {
+
+    public HealthResult(String status, String timestamp, String version, Map<String, Object> details) {
+        this.status = status;
+        this.timestamp = timestamp != null ? timestamp : Instant.now().toString();
+        this.version = version;
+        this.details = details != null ? Collections.unmodifiableMap(new LinkedHashMap<>(details)) : Collections.emptyMap();
+    }
+}

--- a/engine/src/main/java/org/operaton/bpm/engine/health/HealthService.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/health/HealthService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.health;
+
+/**
+ * SPI for obtaining Operaton health information independent of the runtime.
+ *
+ * @author <a href="mailto:tomnm77@gmail.com">Tomasz Korcz</a>
+ * @since 1.1
+ */
+public interface HealthService {
+
+  /**
+   * Perform a health check and return a {@link HealthResult}.
+   */
+  HealthResult check();
+}

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/health/DefaultHealthService.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/health/DefaultHealthService.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.health;
+
+import org.operaton.bpm.engine.health.FrontendHealthContributor;
+import org.operaton.bpm.engine.health.HealthResult;
+import org.operaton.bpm.engine.health.HealthService;
+import org.operaton.bpm.engine.impl.jobexecutor.JobExecutor;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Default, runtime-agnostic implementation that inspects JobExecutor and database connectivity.
+ *
+ * @author <a href="mailto:tomnm77@gmail.com">Tomasz Korcz</a>
+ */
+public class DefaultHealthService implements HealthService {
+
+  private static final int DATASOURCE_CONNECTION_TIMEOUT_SECONDS = 2;
+
+  private final DataSource dataSource;
+  private final JobExecutor jobExecutor;
+  private final String version;
+  private final FrontendHealthContributor frontendHealthContributor;
+
+  public DefaultHealthService(DataSource dataSource, JobExecutor jobExecutor) {
+    this(dataSource, jobExecutor, null);
+  }
+
+  public DefaultHealthService(DataSource dataSource,
+                              JobExecutor jobExecutor,
+                              FrontendHealthContributor frontendHealthContributor) {
+    this.dataSource = dataSource;
+    this.jobExecutor = jobExecutor;
+    this.frontendHealthContributor = frontendHealthContributor;
+    this.version = DefaultHealthService.class.getPackage() != null
+      ? DefaultHealthService.class.getPackage().getImplementationVersion()
+      : null;
+  }
+
+  @Override
+  public HealthResult check() {
+    String timestamp = OffsetDateTime.now().toString();
+
+    Map<String, Object> details = new LinkedHashMap<>();
+
+    boolean jobExecutorActive = jobExecutor != null && jobExecutor.isActive();
+    boolean engineRegistered = jobExecutor != null && jobExecutor.engineIterator().hasNext();
+      Map<String, Object> jobExec = getStringObjectMap(jobExecutorActive, engineRegistered);
+      details.put("jobExecutor", jobExec);
+
+    boolean dbConnected = false;
+    String dbError = null;
+    if (dataSource != null) {
+      try (Connection c = dataSource.getConnection()) {
+        dbConnected = c != null && c.isValid(DATASOURCE_CONNECTION_TIMEOUT_SECONDS);
+      } catch (Exception e) {
+        dbConnected = false;
+        dbError = e.getClass().getSimpleName() + ": " + e.getMessage();
+      }
+    }
+    Map<String, Object> db = new LinkedHashMap<>();
+    db.put("connected", dbConnected);
+    if (dbError != null) {
+      db.put("error", dbError);
+    }
+    details.put("database", db);
+
+    Map<String, Object> queue = new LinkedHashMap<>();
+    queue.put("available", engineRegistered);
+    details.put("queue", queue);
+
+    Map<String, Object> frontend;
+    if (frontendHealthContributor != null) {
+      frontend = new LinkedHashMap<>(frontendHealthContributor.frontendDetails());
+    } else {
+      frontend = new LinkedHashMap<>();
+      frontend.put("operational", false);
+    }
+    details.put("frontend", frontend);
+
+    boolean dbOk = (dataSource == null) || dbConnected;
+    String status = dbOk ? "UP" : "DOWN";
+
+    return new HealthResult(status, timestamp, version, details);
+  }
+
+    private Map<String, Object> getStringObjectMap(boolean jobExecutorActive, boolean engineRegistered) {
+        Map<String, Object> jobExec = new LinkedHashMap<>();
+        if (jobExecutor != null) {
+          jobExec.put("name", jobExecutor.getName());
+          jobExec.put("lockOwner", jobExecutor.getLockOwner());
+          jobExec.put("lockTimeInMillis", jobExecutor.getLockTimeInMillis());
+          jobExec.put("maxJobsPerAcquisition", jobExecutor.getMaxJobsPerAcquisition());
+          jobExec.put("waitTimeInMillis", jobExecutor.getWaitTimeInMillis());
+        }
+        jobExec.put("active", jobExecutorActive);
+        jobExec.put("engineRegistered", engineRegistered);
+        return jobExec;
+    }
+}

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/health/DefaultHealthServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/health/DefaultHealthServiceTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.health;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.operaton.bpm.engine.health.FrontendHealthContributor;
+import org.operaton.bpm.engine.health.HealthResult;
+import org.operaton.bpm.engine.impl.ProcessEngineImpl;
+import org.operaton.bpm.engine.impl.jobexecutor.JobExecutor;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class DefaultHealthServiceTest {
+
+  @Test
+  void shouldBeUpWhenNoDataSourceProvided() throws Exception {
+    JobExecutor jobExecutor = mock(JobExecutor.class);
+    when(jobExecutor.isActive()).thenReturn(true);
+    @SuppressWarnings("unchecked")
+    Iterator<Object> it = (Iterator<Object>) Mockito.mock(Iterator.class);
+    when(it.hasNext()).thenReturn(true);
+    when(jobExecutor.engineIterator()).thenReturn((Iterator) it);
+
+    FrontendHealthContributor frontend = () -> Collections.singletonMap("operational", true);
+
+    DefaultHealthService service = new DefaultHealthService(null, jobExecutor, frontend);
+    HealthResult result = service.check();
+
+    assertThat(result.status()).isEqualTo("UP");
+    assertThat(result.details()).containsKey("database");
+    Map<String, Object> db = (Map<String, Object>) result.details().get("database");
+    assertThat(db.get("connected")).isEqualTo(false);
+    Map<String, Object> frontendDetails = (Map<String, Object>) result.details().get("frontend");
+    assertThat(frontendDetails.get("operational")).isEqualTo(true);
+  }
+
+    @Test
+    void shouldReportDatabaseUp() throws Exception {
+        DataSource ds = mock(DataSource.class);
+        Connection conn = mock(Connection.class);
+        when(ds.getConnection()).thenReturn(conn);
+        when(conn.isValid(anyInt())).thenReturn(true);
+
+        JobExecutor jobExecutor = mock(JobExecutor.class);
+
+        Iterator<?> iterator = Collections.emptyIterator();
+        when(jobExecutor.engineIterator()).thenReturn((Iterator<ProcessEngineImpl>) iterator);
+
+        DefaultHealthService service = new DefaultHealthService(ds, jobExecutor, null);
+        HealthResult result = service.check();
+
+        assertThat(result.status()).isEqualTo("UP");
+        Map<String, Object> db = (Map<String, Object>) result.details().get("database");
+        assertThat(db.get("connected")).isEqualTo(true);
+    }
+
+  @Test
+  void shouldReportDatabaseDownOnException() throws Exception {
+    DataSource ds = mock(DataSource.class);
+    when(ds.getConnection()).thenThrow(new RuntimeException("boom"));
+
+    DefaultHealthService service = new DefaultHealthService(ds, null, null);
+    HealthResult result = service.check();
+
+    assertThat(result.status()).isEqualTo("DOWN");
+    Map<String, Object> db = (Map<String, Object>) result.details().get("database");
+    assertThat(db.get("connected")).isEqualTo(false);
+    assertThat(db).containsKey("error");
+  }
+}

--- a/spring-boot-starter/starter-webapp-core/src/main/java/org/operaton/bpm/spring/boot/starter/webapp/SpringWebappFrontendHealthContributor.java
+++ b/spring-boot-starter/starter-webapp-core/src/main/java/org/operaton/bpm/spring/boot/starter/webapp/SpringWebappFrontendHealthContributor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.spring.boot.starter.webapp;
+
+import org.operaton.bpm.engine.health.FrontendHealthContributor;
+import org.operaton.bpm.spring.boot.starter.property.WebappProperty;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Spring Webapps contributor that reports whether the packaged webapp resources are available.
+ *
+ * @author <a href="mailto:tomnm77@gmail.com">Tomasz Korcz</a>
+ */
+class SpringWebappFrontendHealthContributor implements FrontendHealthContributor {
+
+  private final ResourceLoader resourceLoader;
+  private final WebappProperty webappProperty;
+
+  SpringWebappFrontendHealthContributor(ResourceLoader resourceLoader, WebappProperty webappProperty) {
+    this.resourceLoader = resourceLoader;
+    this.webappProperty = webappProperty;
+  }
+
+  @Override
+  public Map<String, Object> frontendDetails() {
+    String webjarClasspath = webappProperty != null ? webappProperty.getWebjarClasspath() : "/META-INF/resources/webjars/operaton";
+    String applicationPath = webappProperty != null ? webappProperty.getApplicationPath() : "/operaton";
+
+    String indexPath = "classpath:" + (webjarClasspath.endsWith("/") ? webjarClasspath : webjarClasspath + "/") + "app/index.html";
+    Resource index = resourceLoader.getResource(indexPath);
+    boolean operational = index.exists();
+
+    Map<String, Object> details = new LinkedHashMap<>();
+    details.put("operational", operational);
+    details.put("path", applicationPath);
+    return details;
+  }
+}

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/OperatonBpmHealthServiceConfiguration.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/OperatonBpmHealthServiceConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.spring.boot.starter;
+
+import org.operaton.bpm.engine.impl.jobexecutor.JobExecutor;
+import org.operaton.bpm.engine.impl.health.DefaultHealthService;
+import org.operaton.bpm.engine.health.FrontendHealthContributor;
+import org.operaton.bpm.engine.health.HealthService;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class OperatonBpmHealthServiceConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean(HealthService.class)
+  public HealthService operatonHealthService(ObjectProvider<DataSource> dataSourceProvider,
+                                             ObjectProvider<JobExecutor> jobExecutorProvider,
+                                             ObjectProvider<FrontendHealthContributor> frontendHealthContributorProvider) {
+    return new DefaultHealthService(
+      dataSourceProvider.getIfAvailable(),
+      jobExecutorProvider.getIfAvailable(),
+      frontendHealthContributorProvider.getIfAvailable()
+    );
+  }
+}


### PR DESCRIPTION
Introduce a lightweight, runtime-agnostic health surface and integrate it across modules so health checks work consistently in different deployment models.

- add HealthService (SPI) and HealthResult (value object)
- expose GET /health returning JSON
- HealthController delegates to HealthService and is outside REST auth
- new OperatonBpmHealthServiceConfiguration registers DefaultHealthService using optional DataSource, JobExecutor, FrontendHealthContributor
- implement SpringWebappFrontendHealthContributor to report webapp presence and configured application path
- no hard dependency on Actuator in Run; Actuator remains optional

related to #1245, closes #1245