### PR TITLE
fix(Error): Unable to locate enclosing class when executing clirr API 

### DIFF
--- a/model-api/xml-model/pom.xml
+++ b/model-api/xml-model/pom.xml
@@ -72,6 +72,7 @@
               <excludes>
                 <exclude>org/operaton/bpm/model/xml/impl/**</exclude>
                 <exclude>org/operaton/bpm/model/xml/test/AbstractModelElementInstanceTest</exclude>
+                <exclude>org/operaton/bpm/model/xml/test/AbstractModelElementInstanceTest$*</exclude>
               </excludes>
             </configuration>
             <executions>


### PR DESCRIPTION
 add exclusions for the nested classes in the clirr plugin configuration to fix error : Unable to locate enclosing class when executing clirr API checks. 
 
 update the pom.xml

Fixes  #1577