### PR TITLE
Remove Spring Boot Starter Dependencies from engine-spring

### DIFF
--- a/engine-spring/pom.xml
+++ b/engine-spring/pom.xml
@@ -34,14 +34,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-jpa</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-validation</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jakarta.validation</groupId>
       <artifactId>jakarta.validation-api</artifactId>
     </dependency>
@@ -129,8 +121,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>jakarta.persistence</groupId>
-      <artifactId>jakarta.persistence-api</artifactId>
+      <groupId>org.hibernate.orm</groupId>
+      <artifactId>hibernate-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
### Remove Spring Boot Starter Dependencies from engine-spring

The **engine-spring**  module should only depend on **spring-framework**, not **spring-boot**. Therefore I removed **spring-boot-starter-validation** and **spring-boot-starter-data-jpa**. Hibernate is needed in test scope only to support `SpringJobExecutorTest`. For reference, compare the camunda 7 original.

