### PR TITLE
fix(build): Remove SBOM as release artifacts

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -195,8 +195,6 @@ files:
     - path: 'distro/wildfly/distro/target/operaton-bpm-wildfly-{{projectVersion}}.zip'
     - path: 'distro/sql-script/target/operaton-sql-scripts-{{OPERATON_DATABASE_VERSION}}.tar.gz'
     - path: 'distro/webjar/target/operaton-webapp-webjar-{{projectVersion}}.jar'
-    - path: 'target/sbom/operaton-modules.cyclonedx-json.sbom'
-    - path: 'target/sbom/operaton-webapps.cyclonedx-json.sbom'
     - path: 'target/project-reports.zip'
     - path: 'target/javadoc.zip'
     - path: 'target/rest-api.zip'


### PR DESCRIPTION
The SBOMs are now published as part of the distributions. This is a leftover from the refactoring of SBOM creation.

related to #1528

Resolves error in [nightly publishing](https://github.com/operaton/operaton/actions/runs/19605358581/job/56144791845):
```
☕ java -jar jreleaser-cli.jar full-release -POPERATON_DATABASE_VERSION=7.24.0
jreleaser 1.21.0. Consider becoming a sponsor at https://opencollective.com/jreleaser
[INFO]  JReleaser 1.21.0
[INFO]  Configuring with jreleaser.yml
[INFO]    - basedir set to /home/runner/work/operaton/operaton
[INFO]    - outputdir set to /home/runner/work/operaton/operaton/out/jreleaser
[INFO]  Reading configuration
[INFO]  git-root-search set to false
[INFO]  Loading variables from /home/runner/.jreleaser/config.properties
[WARN]  Variables source /home/runner/.jreleaser/config.properties does not exist
[INFO]  Validating configuration
[INFO]  Strict mode set to false
[WARN]    [validation] Deployer mavenCentral.MavenCentral disabled because project is snapshot
Path does not exist.
configured: target/sbom/operaton-modules.cyclonedx-json.sbom
resolved: target/sbom/operaton-modules.cyclonedx-json.sbom
Error: Process completed with exit code 1.

```