### PR TITLE
chore(tests): Enable CdiBeanCaseTaskResolutionTest

### DIFF
--- a/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanCaseTaskResolutionTest.java
+++ b/qa/integration-tests-engine/src/test/java/org/operaton/bpm/integrationtest/functional/cdi/CdiBeanCaseTaskResolutionTest.java
@@ -40,7 +40,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  */
 @ExtendWith(ArquillianExtension.class)
-@Disabled("https://github.com/operaton/operaton/issues/616")
 public class CdiBeanCaseTaskResolutionTest extends AbstractFoxPlatformIntegrationTest {
 
   @Deployment(name="pa1")


### PR DESCRIPTION
The test was failing with an exception and therefore disabled. The exception does not occur anymore. The test is re-enabled again.

closes #616 