### PR TITLE
feat(build): Set up Node and dependency caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,14 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'npm'
+          # Use a glob pattern to include all package-lock.json files
+          # This ensures the cache is unique based on ANY lock file change
+          cache-dependency-path: '**/package-lock.json'
       - name: Maven Build
         id: maven-build
         shell: bash


### PR DESCRIPTION
- Use explicit Node version (recommended)
- Caching of NPM dependencies to speed up build

Speeds up the build by ~30s

The step "Maven Build" took on main the last 3 times
- [22m 55s](https://github.com/operaton/operaton/actions/runs/19815374235/job/56765391952)
- [22m 25s](https://github.com/operaton/operaton/actions/runs/19801608962/job/56729717511)
- [22m 33s](https://github.com/operaton/operaton/actions/runs/19797651862/job/56720308055)

For the PR branch it is
- [22m 2s](https://github.com/operaton/operaton/actions/runs/19840092825/job/56848586992)