### PR TITLE
Add workflow to automatically check Slack URL and create an issue

### DIFF
--- a/.github/workflows/slack-link-check.yml
+++ b/.github/workflows/slack-link-check.yml
@@ -48,11 +48,14 @@ jobs:
 
       - name: Check Slack invite status
         id: check
+        env:
+          SLACK_URL: ${{ steps.extract.outputs.url }}
+          CHROMIUM_PATH: ${{ steps.find_chromium.outputs.path }}
         run: |
           node - << 'EOF'
           const { chromium } = require("playwright");
-          const url = "${{ steps.extract.outputs.url }}";
-          const path = "${{ steps.find_chromium.outputs.path }}";
+          const url = process.env.SLACK_URL;
+          const path = process.env.CHROMIUM_PATH;
 
           (async () => {
             const browser = await chromium.launch({


### PR DESCRIPTION
This pull request adds a GitHub Action that checks whether the Slack invite link in the README is still valid.
Slack redirects differently for valid, expired, or incorrect invites, but this logic is executed via JavaScript in the browser. Because curl cannot evaluate these redirects, the workflow uses Playwright with system Chromium to determine the final URL.

The workflow will:
  - Extract the Slack invite link from the README
  - Open it in a headless browser
  - Detect whether it resolves to a valid /join/... page
  - Identify expired or invalid links (redirecting to /signup or /join/*/error)
  - Automatically create an issue if the link is no longer valid
  - Avoid duplicates by checking for an existing issue first
  - Assign the issue directly to @kthoms
  
  Here is the [link](https://github.com/aounhaider1/operaton/issues/7) to created issue.
  And here [a link](https://github.com/aounhaider1/operaton/actions/runs/19891756987/job/57012103640) to workflow run.
  Closes https://github.com/operaton/operaton.org/issues/39
  