### PR TITLE
chore(build): Execute npm build in development mode on local machine

### DIFF
--- a/engine-rest/docs/pom.xml
+++ b/engine-rest/docs/pom.xml
@@ -12,6 +12,7 @@
   <description>${project.name}</description>
   <properties>
     <skip-third-party-bom>true</skip-third-party-bom>
+    <npm.build.args>install</npm.build.args>
   </properties>
   <dependencies>
     <dependency>
@@ -60,13 +61,13 @@
             </goals>
           </execution>
           <execution>
-            <id>npm install</id>
+            <id>npm (clean) install</id>
             <goals>
               <goal>npm</goal>
             </goals>
             <phase>generate-resources</phase>
             <configuration>
-              <arguments>ci</arguments>
+              <arguments>${npm.build.args}</arguments>
             </configuration>
           </execution>
           <execution>
@@ -83,4 +84,18 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>github-ci</id>
+      <activation>
+        <property>
+          <name>env.GITHUB_ACTIONS</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <properties>
+        <npm.build.args>ci</npm.build.args>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/webapps/pom.xml
+++ b/webapps/pom.xml
@@ -27,6 +27,8 @@
     <!-- frontend-sources artifact is for internal use only.
     Artifact generation is skipped when it comes to maven central deployment -->
     <skip-zip-frontend-sources>false</skip-zip-frontend-sources>
+    <npm.build.args>install</npm.build.args>
+    <npm.webpack.args>--mode development --config webpack.dev.js</npm.webpack.args>
   </properties>
   <build>
     <plugins>
@@ -58,13 +60,13 @@
             </goals>
           </execution>
           <execution>
-            <id>npm ci</id>
+            <id>npm (clean) install</id>
             <goals>
               <goal>npm</goal>
             </goals>
             <phase>generate-resources</phase>
             <configuration>
-              <arguments>ci</arguments>
+              <arguments>${npm.build.args}</arguments>
             </configuration>
           </execution>
           <execution>
@@ -80,11 +82,11 @@
           <execution>
             <id>Build</id>
             <goals>
-              <goal>npm</goal>
+              <goal>webpack</goal>
             </goals>
             <phase>generate-resources</phase>
             <configuration>
-              <arguments>run build</arguments>
+              <arguments>${npm.webpack.args}</arguments>
             </configuration>
           </execution>
         </executions>
@@ -114,6 +116,19 @@
       <id>skipFrontendBuild</id>
       <properties>
         <skip.frontend.build>true</skip.frontend.build>
+      </properties>
+    </profile>
+    <profile>
+      <id>github-ci</id>
+      <activation>
+        <property>
+          <name>env.GITHUB_ACTIONS</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <properties>
+        <npm.build.args>ci</npm.build.args>
+        <npm.webpack.args>--mode production --config webpack.prod.js</npm.webpack.args>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
This change configures the npm builds for
- engine-rest/docs
- webapps to use "npm install" instead of "npm ci" on local machines, while using "npm ci" on GitHub actions. Further, configure webpack to use the "development" mode & configuration.

This speeds up local builds.