### PR TITLE
fix(build) Remove unvalid tags from qa/tomcat-runtime/pom.xml (#1775)

### DIFF
--- a/qa/tomcat-runtime/pom.xml
+++ b/qa/tomcat-runtime/pom.xml
@@ -283,9 +283,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <goals>
-              <goal>run</goal>
-            </goals>
             <executions>
               <execution>
                 <id>clean-webapps</id>


### PR DESCRIPTION
Removing misplaced goals tag, to allow building using Maven 4.0.0-rc5


Tested with
mvn clean install

which now builds fine using maven 4.0.0-rc5.

fixes #1775