### PR TITLE
feat(engine): Decouple ProcessEngineConfigurationImpl from implementation services by service loaders

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -16,30 +16,6 @@
  */
 package org.operaton.bpm.engine.impl.cfg;
 
-
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.nio.charset.Charset;
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.SQLException;
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-
-import javax.naming.InitialContext;
-import javax.sql.DataSource;
 import org.apache.ibatis.builder.xml.XMLConfigBuilder;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
 import org.apache.ibatis.mapping.Environment;
@@ -50,7 +26,6 @@ import org.apache.ibatis.session.defaults.DefaultSqlSessionFactory;
 import org.apache.ibatis.transaction.TransactionFactory;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.apache.ibatis.transaction.managed.ManagedTransactionFactory;
-
 import org.operaton.bpm.dmn.engine.DmnEngine;
 import org.operaton.bpm.dmn.engine.DmnEngineConfiguration;
 import org.operaton.bpm.dmn.engine.impl.DefaultDmnEngineConfiguration;
@@ -75,40 +50,20 @@ import org.operaton.bpm.engine.TaskService;
 import org.operaton.bpm.engine.authorization.Groups;
 import org.operaton.bpm.engine.authorization.Permission;
 import org.operaton.bpm.engine.authorization.Permissions;
-import org.operaton.bpm.engine.impl.AuthorizationServiceImpl;
-import org.operaton.bpm.engine.impl.DecisionServiceImpl;
-import org.operaton.bpm.engine.impl.DefaultArtifactFactory;
+import org.operaton.bpm.engine.identity.PasswordPolicy;
 import org.operaton.bpm.engine.impl.DefaultPriorityProvider;
-import org.operaton.bpm.engine.impl.ExternalTaskServiceImpl;
-import org.operaton.bpm.engine.impl.FilterServiceImpl;
-import org.operaton.bpm.engine.impl.FormServiceImpl;
-import org.operaton.bpm.engine.impl.HistoryServiceImpl;
-import org.operaton.bpm.engine.impl.IdentityServiceImpl;
 import org.operaton.bpm.engine.impl.ManagementServiceImpl;
-import org.operaton.bpm.engine.impl.ModificationBatchJobHandler;
 import org.operaton.bpm.engine.impl.OptimizeService;
 import org.operaton.bpm.engine.impl.PriorityProvider;
 import org.operaton.bpm.engine.impl.ProcessEngineImpl;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.RepositoryServiceImpl;
-import org.operaton.bpm.engine.impl.RestartProcessInstancesJobHandler;
-import org.operaton.bpm.engine.impl.RuntimeServiceImpl;
 import org.operaton.bpm.engine.impl.ServiceImpl;
-import org.operaton.bpm.engine.impl.TaskServiceImpl;
 import org.operaton.bpm.engine.impl.application.ProcessApplicationManager;
 import org.operaton.bpm.engine.impl.batch.BatchJobHandler;
 import org.operaton.bpm.engine.impl.batch.BatchMonitorJobHandler;
 import org.operaton.bpm.engine.impl.batch.BatchSeedJobHandler;
-import org.operaton.bpm.engine.impl.batch.deletion.DeleteHistoricProcessInstancesJobHandler;
-import org.operaton.bpm.engine.impl.batch.deletion.DeleteProcessInstancesJobHandler;
-import org.operaton.bpm.engine.impl.batch.externaltask.SetExternalTaskRetriesJobHandler;
-import org.operaton.bpm.engine.impl.batch.job.SetJobRetriesJobHandler;
-import org.operaton.bpm.engine.impl.batch.message.MessageCorrelationBatchJobHandler;
-import org.operaton.bpm.engine.impl.batch.removaltime.BatchSetRemovalTimeJobHandler;
-import org.operaton.bpm.engine.impl.batch.removaltime.DecisionSetRemovalTimeJobHandler;
 import org.operaton.bpm.engine.impl.batch.removaltime.ProcessSetRemovalTimeJobHandler;
-import org.operaton.bpm.engine.impl.batch.update.UpdateProcessInstancesSuspendStateJobHandler;
-import org.operaton.bpm.engine.impl.batch.variables.BatchSetVariablesHandler;
 import org.operaton.bpm.engine.impl.bpmn.behavior.ExternalTaskActivityBehavior;
 import org.operaton.bpm.engine.impl.bpmn.deployer.BpmnDeployer;
 import org.operaton.bpm.engine.impl.bpmn.parser.BpmnParseListener;
@@ -120,15 +75,12 @@ import org.operaton.bpm.engine.impl.calendar.DueDateBusinessCalendar;
 import org.operaton.bpm.engine.impl.calendar.DurationBusinessCalendar;
 import org.operaton.bpm.engine.impl.calendar.MapBusinessCalendarManager;
 import org.operaton.bpm.engine.impl.cfg.auth.AuthorizationCommandChecker;
-import org.operaton.bpm.engine.impl.cfg.auth.DefaultAuthorizationProvider;
-import org.operaton.bpm.engine.impl.cfg.auth.DefaultPermissionProvider;
 import org.operaton.bpm.engine.impl.cfg.auth.PermissionProvider;
 import org.operaton.bpm.engine.impl.cfg.auth.ResourceAuthorizationProvider;
 import org.operaton.bpm.engine.impl.cfg.multitenancy.TenantCommandChecker;
 import org.operaton.bpm.engine.impl.cfg.multitenancy.TenantIdProvider;
 import org.operaton.bpm.engine.impl.cfg.standalone.StandaloneTransactionContextFactory;
 import org.operaton.bpm.engine.impl.cmd.HistoryCleanupCmd;
-import org.operaton.bpm.engine.impl.cmmn.CaseServiceImpl;
 import org.operaton.bpm.engine.impl.cmmn.deployer.CmmnDeployer;
 import org.operaton.bpm.engine.impl.cmmn.entity.repository.CaseDefinitionManager;
 import org.operaton.bpm.engine.impl.cmmn.entity.runtime.CaseExecutionManager;
@@ -137,7 +89,6 @@ import org.operaton.bpm.engine.impl.cmmn.handler.DefaultCmmnElementHandlerRegist
 import org.operaton.bpm.engine.impl.cmmn.transformer.CmmnTransformFactory;
 import org.operaton.bpm.engine.impl.cmmn.transformer.CmmnTransformListener;
 import org.operaton.bpm.engine.impl.cmmn.transformer.CmmnTransformer;
-import org.operaton.bpm.engine.impl.cmmn.transformer.DefaultCmmnTransformFactory;
 import org.operaton.bpm.engine.impl.db.DbIdGenerator;
 import org.operaton.bpm.engine.impl.db.entitymanager.DbEntityManagerFactory;
 import org.operaton.bpm.engine.impl.db.entitymanager.cache.DbEntityCacheKeyMapping;
@@ -146,12 +97,9 @@ import org.operaton.bpm.engine.impl.db.sql.DbSqlSessionFactory;
 import org.operaton.bpm.engine.impl.delegate.DefaultDelegateInterceptor;
 import org.operaton.bpm.engine.impl.diagnostics.DiagnosticsCollector;
 import org.operaton.bpm.engine.impl.diagnostics.DiagnosticsRegistry;
-import org.operaton.bpm.engine.impl.digest.Default16ByteSaltGenerator;
 import org.operaton.bpm.engine.impl.digest.PasswordEncryptor;
 import org.operaton.bpm.engine.impl.digest.PasswordManager;
 import org.operaton.bpm.engine.impl.digest.SaltGenerator;
-import org.operaton.bpm.engine.impl.digest.Sha512HashDigest;
-import org.operaton.bpm.engine.impl.dmn.batch.DeleteHistoricDecisionInstancesJobHandler;
 import org.operaton.bpm.engine.impl.dmn.configuration.DmnEngineConfigurationBuilder;
 import org.operaton.bpm.engine.impl.dmn.deployer.DecisionDefinitionDeployer;
 import org.operaton.bpm.engine.impl.dmn.deployer.DecisionRequirementsDefinitionDeployer;
@@ -189,7 +137,6 @@ import org.operaton.bpm.engine.impl.form.validator.MinLengthValidator;
 import org.operaton.bpm.engine.impl.form.validator.MinValidator;
 import org.operaton.bpm.engine.impl.form.validator.ReadOnlyValidator;
 import org.operaton.bpm.engine.impl.form.validator.RequiredValidator;
-import org.operaton.bpm.engine.impl.history.DefaultHistoryRemovalTimeProvider;
 import org.operaton.bpm.engine.impl.history.HistoryLevel;
 import org.operaton.bpm.engine.impl.history.HistoryRemovalTimeProvider;
 import org.operaton.bpm.engine.impl.history.event.HistoricDecisionInstanceManager;
@@ -200,14 +147,10 @@ import org.operaton.bpm.engine.impl.history.handler.CompositeHistoryEventHandler
 import org.operaton.bpm.engine.impl.history.handler.DbHistoryEventHandler;
 import org.operaton.bpm.engine.impl.history.handler.HistoryEventHandler;
 import org.operaton.bpm.engine.impl.history.parser.HistoryParseListener;
-import org.operaton.bpm.engine.impl.history.producer.CacheAwareCmmnHistoryEventProducer;
-import org.operaton.bpm.engine.impl.history.producer.CacheAwareHistoryEventProducer;
 import org.operaton.bpm.engine.impl.history.producer.CmmnHistoryEventProducer;
-import org.operaton.bpm.engine.impl.history.producer.DefaultDmnHistoryEventProducer;
 import org.operaton.bpm.engine.impl.history.producer.DmnHistoryEventProducer;
 import org.operaton.bpm.engine.impl.history.producer.HistoryEventProducer;
 import org.operaton.bpm.engine.impl.history.transformer.CmmnHistoryTransformListener;
-import org.operaton.bpm.engine.impl.identity.DefaultPasswordPolicyImpl;
 import org.operaton.bpm.engine.impl.identity.ReadOnlyIdentityProvider;
 import org.operaton.bpm.engine.impl.identity.WritableIdentityProvider;
 import org.operaton.bpm.engine.impl.identity.db.DbIdentityServiceProvider;
@@ -221,9 +164,26 @@ import org.operaton.bpm.engine.impl.interceptor.CommandInterceptor;
 import org.operaton.bpm.engine.impl.interceptor.DelegateInterceptor;
 import org.operaton.bpm.engine.impl.interceptor.ExceptionCodeInterceptor;
 import org.operaton.bpm.engine.impl.interceptor.SessionFactory;
-import org.operaton.bpm.engine.impl.jobexecutor.*;
+import org.operaton.bpm.engine.impl.jobexecutor.AsyncContinuationJobHandler;
+import org.operaton.bpm.engine.impl.jobexecutor.DefaultJobExecutor;
+import org.operaton.bpm.engine.impl.jobexecutor.DefaultJobPriorityProvider;
+import org.operaton.bpm.engine.impl.jobexecutor.FailedJobCommandFactory;
+import org.operaton.bpm.engine.impl.jobexecutor.JobDeclaration;
+import org.operaton.bpm.engine.impl.jobexecutor.JobExecutor;
+import org.operaton.bpm.engine.impl.jobexecutor.JobHandler;
+import org.operaton.bpm.engine.impl.jobexecutor.NotifyAcquisitionRejectedJobsHandler;
+import org.operaton.bpm.engine.impl.jobexecutor.ProcessEventJobHandler;
+import org.operaton.bpm.engine.impl.jobexecutor.RejectedJobsHandler;
+import org.operaton.bpm.engine.impl.jobexecutor.TimerActivateJobDefinitionHandler;
+import org.operaton.bpm.engine.impl.jobexecutor.TimerActivateProcessDefinitionHandler;
+import org.operaton.bpm.engine.impl.jobexecutor.TimerCatchIntermediateEventJobHandler;
+import org.operaton.bpm.engine.impl.jobexecutor.TimerExecuteNestedActivityJobHandler;
+import org.operaton.bpm.engine.impl.jobexecutor.TimerStartEventJobHandler;
+import org.operaton.bpm.engine.impl.jobexecutor.TimerStartEventSubprocessJobHandler;
+import org.operaton.bpm.engine.impl.jobexecutor.TimerSuspendJobDefinitionHandler;
+import org.operaton.bpm.engine.impl.jobexecutor.TimerSuspendProcessDefinitionHandler;
+import org.operaton.bpm.engine.impl.jobexecutor.TimerTaskListenerJobHandler;
 import org.operaton.bpm.engine.impl.jobexecutor.historycleanup.BatchWindowManager;
-import org.operaton.bpm.engine.impl.jobexecutor.historycleanup.DefaultBatchWindowManager;
 import org.operaton.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupBatch;
 import org.operaton.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupHandler;
 import org.operaton.bpm.engine.impl.jobexecutor.historycleanup.HistoryCleanupHelper;
@@ -233,51 +193,68 @@ import org.operaton.bpm.engine.impl.metrics.MetricsReporterIdProvider;
 import org.operaton.bpm.engine.impl.metrics.parser.MetricsBpmnParseListener;
 import org.operaton.bpm.engine.impl.metrics.parser.MetricsCmmnTransformListener;
 import org.operaton.bpm.engine.impl.metrics.reporter.DbMetricsReporter;
-import org.operaton.bpm.engine.impl.migration.DefaultMigrationActivityMatcher;
 import org.operaton.bpm.engine.impl.migration.DefaultMigrationInstructionGenerator;
 import org.operaton.bpm.engine.impl.migration.MigrationActivityMatcher;
 import org.operaton.bpm.engine.impl.migration.MigrationInstructionGenerator;
-import org.operaton.bpm.engine.impl.migration.batch.MigrationBatchJobHandler;
 import org.operaton.bpm.engine.impl.migration.validation.activity.MigrationActivityValidator;
 import org.operaton.bpm.engine.impl.migration.validation.activity.NoCompensationHandlerActivityValidator;
 import org.operaton.bpm.engine.impl.migration.validation.activity.SupportedActivityValidator;
 import org.operaton.bpm.engine.impl.migration.validation.activity.SupportedPassiveEventTriggerActivityValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instance.AsyncAfterMigrationValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instance.AsyncMigrationValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instance.AsyncProcessStartMigrationValidator;
 import org.operaton.bpm.engine.impl.migration.validation.instance.MigratingActivityInstanceValidator;
 import org.operaton.bpm.engine.impl.migration.validation.instance.MigratingCompensationInstanceValidator;
 import org.operaton.bpm.engine.impl.migration.validation.instance.MigratingTransitionInstanceValidator;
 import org.operaton.bpm.engine.impl.migration.validation.instance.NoUnmappedCompensationStartEventValidator;
 import org.operaton.bpm.engine.impl.migration.validation.instance.NoUnmappedLeafInstanceValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instance.SupportedActivityInstanceValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instance.VariableConflictActivityInstanceValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instruction.AdditionalFlowScopeInstructionValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instruction.CannotAddMultiInstanceBodyValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instruction.CannotAddMultiInstanceInnerActivityValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instruction.CannotRemoveMultiInstanceInnerActivityValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instruction.ConditionalEventUpdateEventTriggerValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instruction.GatewayMappingValidator;
 import org.operaton.bpm.engine.impl.migration.validation.instruction.MigrationInstructionValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instruction.OnlyOnceMappedActivityInstructionValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instruction.SameBehaviorInstructionValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instruction.SameEventScopeInstructionValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instruction.SameEventTypeValidator;
-import org.operaton.bpm.engine.impl.migration.validation.instruction.UpdateEventTriggersValidator;
 import org.operaton.bpm.engine.impl.mock.MocksResolverFactory;
 import org.operaton.bpm.engine.impl.optimize.OptimizeManager;
 import org.operaton.bpm.engine.impl.persistence.GenericManagerFactory;
 import org.operaton.bpm.engine.impl.persistence.deploy.Deployer;
 import org.operaton.bpm.engine.impl.persistence.deploy.cache.CacheFactory;
-import org.operaton.bpm.engine.impl.persistence.deploy.cache.DefaultCacheFactory;
 import org.operaton.bpm.engine.impl.persistence.deploy.cache.DeploymentCache;
-import org.operaton.bpm.engine.impl.persistence.entity.*;
-import org.operaton.bpm.engine.impl.repository.DefaultDeploymentHandlerFactory;
+import org.operaton.bpm.engine.impl.persistence.entity.AttachmentManager;
+import org.operaton.bpm.engine.impl.persistence.entity.AuthorizationManager;
+import org.operaton.bpm.engine.impl.persistence.entity.BatchManager;
+import org.operaton.bpm.engine.impl.persistence.entity.ByteArrayManager;
+import org.operaton.bpm.engine.impl.persistence.entity.CommentManager;
+import org.operaton.bpm.engine.impl.persistence.entity.DeploymentManager;
+import org.operaton.bpm.engine.impl.persistence.entity.EventSubscriptionManager;
+import org.operaton.bpm.engine.impl.persistence.entity.ExecutionManager;
+import org.operaton.bpm.engine.impl.persistence.entity.ExternalTaskManager;
+import org.operaton.bpm.engine.impl.persistence.entity.FilterManager;
+import org.operaton.bpm.engine.impl.persistence.entity.HistoricActivityInstanceManager;
+import org.operaton.bpm.engine.impl.persistence.entity.HistoricBatchManager;
+import org.operaton.bpm.engine.impl.persistence.entity.HistoricCaseActivityInstanceManager;
+import org.operaton.bpm.engine.impl.persistence.entity.HistoricCaseInstanceManager;
+import org.operaton.bpm.engine.impl.persistence.entity.HistoricDetailManager;
+import org.operaton.bpm.engine.impl.persistence.entity.HistoricExternalTaskLogManager;
+import org.operaton.bpm.engine.impl.persistence.entity.HistoricIdentityLinkLogManager;
+import org.operaton.bpm.engine.impl.persistence.entity.HistoricIncidentManager;
+import org.operaton.bpm.engine.impl.persistence.entity.HistoricJobLogManager;
+import org.operaton.bpm.engine.impl.persistence.entity.HistoricProcessInstanceManager;
+import org.operaton.bpm.engine.impl.persistence.entity.HistoricStatisticsManager;
+import org.operaton.bpm.engine.impl.persistence.entity.HistoricTaskInstanceManager;
+import org.operaton.bpm.engine.impl.persistence.entity.HistoricVariableInstanceManager;
+import org.operaton.bpm.engine.impl.persistence.entity.IdentityInfoManager;
+import org.operaton.bpm.engine.impl.persistence.entity.IdentityLinkManager;
+import org.operaton.bpm.engine.impl.persistence.entity.IncidentManager;
+import org.operaton.bpm.engine.impl.persistence.entity.JobDefinitionManager;
+import org.operaton.bpm.engine.impl.persistence.entity.JobManager;
+import org.operaton.bpm.engine.impl.persistence.entity.MeterLogManager;
+import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionManager;
+import org.operaton.bpm.engine.impl.persistence.entity.PropertyManager;
+import org.operaton.bpm.engine.impl.persistence.entity.ReportManager;
+import org.operaton.bpm.engine.impl.persistence.entity.ResourceManager;
+import org.operaton.bpm.engine.impl.persistence.entity.SchemaLogManager;
+import org.operaton.bpm.engine.impl.persistence.entity.StatisticsManager;
+import org.operaton.bpm.engine.impl.persistence.entity.TableDataManager;
+import org.operaton.bpm.engine.impl.persistence.entity.TaskManager;
+import org.operaton.bpm.engine.impl.persistence.entity.TaskReportManager;
+import org.operaton.bpm.engine.impl.persistence.entity.TenantManager;
+import org.operaton.bpm.engine.impl.persistence.entity.UserOperationLogManager;
+import org.operaton.bpm.engine.impl.persistence.entity.VariableInstanceManager;
 import org.operaton.bpm.engine.impl.runtime.ConditionHandler;
 import org.operaton.bpm.engine.impl.runtime.CorrelationHandler;
-import org.operaton.bpm.engine.impl.runtime.DefaultConditionHandler;
-import org.operaton.bpm.engine.impl.runtime.DefaultCorrelationHandler;
-import org.operaton.bpm.engine.impl.runtime.DefaultDeserializationTypeValidator;
 import org.operaton.bpm.engine.impl.scripting.ScriptFactory;
 import org.operaton.bpm.engine.impl.scripting.engine.BeansResolverFactory;
 import org.operaton.bpm.engine.impl.scripting.engine.DefaultScriptEngineResolver;
@@ -299,21 +276,61 @@ import org.operaton.bpm.engine.impl.util.ParseUtil;
 import org.operaton.bpm.engine.impl.util.ProcessEngineDetails;
 import org.operaton.bpm.engine.impl.util.ReflectUtil;
 import org.operaton.bpm.engine.impl.variable.ValueTypeResolverImpl;
-import org.operaton.bpm.engine.impl.variable.serializer.*;
+import org.operaton.bpm.engine.impl.variable.serializer.BooleanValueSerializer;
+import org.operaton.bpm.engine.impl.variable.serializer.ByteArrayValueSerializer;
+import org.operaton.bpm.engine.impl.variable.serializer.DateValueSerializer;
+import org.operaton.bpm.engine.impl.variable.serializer.DefaultVariableSerializers;
+import org.operaton.bpm.engine.impl.variable.serializer.DoubleValueSerializer;
+import org.operaton.bpm.engine.impl.variable.serializer.FileValueSerializer;
+import org.operaton.bpm.engine.impl.variable.serializer.IntegerValueSerializer;
+import org.operaton.bpm.engine.impl.variable.serializer.JavaObjectSerializer;
+import org.operaton.bpm.engine.impl.variable.serializer.LongValueSerlializer;
+import org.operaton.bpm.engine.impl.variable.serializer.NullValueSerializer;
+import org.operaton.bpm.engine.impl.variable.serializer.ShortValueSerializer;
+import org.operaton.bpm.engine.impl.variable.serializer.StringValueSerializer;
+import org.operaton.bpm.engine.impl.variable.serializer.TypedValueSerializer;
+import org.operaton.bpm.engine.impl.variable.serializer.VariableSerializerFactory;
+import org.operaton.bpm.engine.impl.variable.serializer.VariableSerializers;
 import org.operaton.bpm.engine.management.Metrics;
 import org.operaton.bpm.engine.repository.CaseDefinition;
 import org.operaton.bpm.engine.repository.DecisionDefinition;
 import org.operaton.bpm.engine.repository.DecisionRequirementsDefinition;
 import org.operaton.bpm.engine.repository.DeploymentBuilder;
 import org.operaton.bpm.engine.repository.DeploymentHandlerFactory;
+import org.operaton.bpm.engine.runtime.DeserializationTypeValidator;
 import org.operaton.bpm.engine.runtime.Incident;
 import org.operaton.bpm.engine.runtime.WhitelistingDeserializationTypeValidator;
 import org.operaton.bpm.engine.task.TaskQuery;
 import org.operaton.bpm.engine.variable.Variables;
+import org.operaton.commons.utils.ServiceLoaderUtil;
 
+import javax.naming.InitialContext;
+import javax.sql.DataSource;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.operaton.bpm.engine.impl.cmd.HistoryCleanupCmd.MAX_THREADS_NUMBER;
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @author Tom Baeyens
@@ -346,26 +363,26 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   public static SqlSessionFactory cachedSqlSessionFactory;
 
   protected static final Map<Integer, String> ISOLATION_LEVEL_CONSTANT_NAMES = Map.of(
-      Connection.TRANSACTION_READ_COMMITTED, "READ_COMMITTED",
-      Connection.TRANSACTION_READ_UNCOMMITTED, "READ_UNCOMMITTED",
-      Connection.TRANSACTION_REPEATABLE_READ, "REPEATABLE_READ",
-      Connection.TRANSACTION_SERIALIZABLE, "SERIALIZABLE");
+          Connection.TRANSACTION_READ_COMMITTED, "READ_COMMITTED",
+          Connection.TRANSACTION_READ_UNCOMMITTED, "READ_UNCOMMITTED",
+          Connection.TRANSACTION_REPEATABLE_READ, "REPEATABLE_READ",
+          Connection.TRANSACTION_SERIALIZABLE, "SERIALIZABLE");
 
   // SERVICES /////////////////////////////////////////////////////////////////
 
-  protected RepositoryService repositoryService = new RepositoryServiceImpl();
-  protected RuntimeService runtimeService = new RuntimeServiceImpl();
-  protected HistoryService historyService = new HistoryServiceImpl();
-  protected IdentityService identityService = new IdentityServiceImpl();
-  protected TaskService taskService = new TaskServiceImpl();
-  protected FormService formService = new FormServiceImpl();
+  protected RepositoryService repositoryService = ServiceLoaderUtil.loadSingleService(RepositoryService.class);
+  protected RuntimeService runtimeService = ServiceLoaderUtil.loadSingleService(RuntimeService.class);
+  protected HistoryService historyService = ServiceLoaderUtil.loadSingleService(HistoryService.class);
+  protected IdentityService identityService = ServiceLoaderUtil.loadSingleService(IdentityService.class);
+  protected TaskService taskService = ServiceLoaderUtil.loadSingleService(TaskService.class);
+  protected FormService formService = ServiceLoaderUtil.loadSingleService(FormService.class);
   protected ManagementService managementService = new ManagementServiceImpl(this);
-  protected AuthorizationService authorizationService = new AuthorizationServiceImpl();
-  protected CaseService caseService = new CaseServiceImpl();
-  protected FilterService filterService = new FilterServiceImpl();
-  protected ExternalTaskService externalTaskService = new ExternalTaskServiceImpl();
-  protected DecisionService decisionService = new DecisionServiceImpl();
-  protected OptimizeService optimizeService = new OptimizeService();
+  protected AuthorizationService authorizationService = ServiceLoaderUtil.loadSingleService(AuthorizationService.class);
+  protected CaseService caseService = ServiceLoaderUtil.loadSingleService(CaseService.class);
+  protected FilterService filterService = ServiceLoaderUtil.loadSingleService(FilterService.class);
+  protected ExternalTaskService externalTaskService = ServiceLoaderUtil.loadSingleService(ExternalTaskService.class);
+  protected DecisionService decisionService = ServiceLoaderUtil.loadSingleService(DecisionService.class);
+  protected OptimizeService optimizeService = ServiceLoaderUtil.loadSingleService(OptimizeService.class);
 
   // COMMAND EXECUTORS ////////////////////////////////////////////////////////
 
@@ -458,7 +475,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected SqlSessionFactory sqlSessionFactory;
   protected TransactionFactory transactionFactory;
 
-
   // ID GENERATOR /////////////////////////////////////////////////////////////
   protected IdGenerator idGenerator;
   protected DataSource idGeneratorDataSource;
@@ -508,7 +524,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected FormValidators formValidators;
   protected Map<String, Class<? extends FormFieldValidator>> customFormFieldValidators;
 
-  /** don't throw parsing exceptions for Operaton Forms if set to true*/
+  /**
+   * don't throw parsing exceptions for Operaton Forms if set to true
+   */
   protected boolean disableStrictOperatonFormParsing;
 
   protected List<TypedValueSerializer<?>> customPreVariableSerializers;
@@ -551,7 +569,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    */
   protected boolean cmmnEnabled = true;
 
-    /**
+  /**
    * When set to false, the following behavior changes:
    * <ul>
    * <li>The automated schema maintenance (creating and dropping tables, see property <code>databaseSchemaUpdate</code>)
@@ -688,8 +706,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected HistoryEventHandler historyEventHandler;
 
   /**
-   *  Allows users to add additional {@link HistoryEventHandler}
-   *  instances to process history events.
+   * Allows users to add additional {@link HistoryEventHandler}
+   * instances to process history events.
    */
   protected List<HistoryEventHandler> customHistoryEventHandlers = new ArrayList<>();
 
@@ -880,7 +898,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected Map<String, Integer> parsedBatchOperationsForHistoryCleanup;
 
   /**
-   * Default priority for history cleanup jobs. */
+   * Default priority for history cleanup jobs.
+   */
   protected long historyCleanupJobPriority = DefaultPriorityProvider.DEFAULT_PRIORITY;
 
   /**
@@ -899,7 +918,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected String taskMetricsTimeToLive;
   protected Integer parsedTaskMetricsTimeToLive;
 
-  protected BatchWindowManager batchWindowManager = new DefaultBatchWindowManager();
+  protected BatchWindowManager batchWindowManager = ServiceLoaderUtil.loadSingleService(BatchWindowManager.class);
 
   protected HistoryRemovalTimeProvider historyRemovalTimeProvider;
 
@@ -989,7 +1008,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    */
   protected ExceptionCodeProvider builtinExceptionCodeProvider;
 
-  /** Controls whether the time cycle is re-evaluated when due. */
+  /**
+   * Controls whether the time cycle is re-evaluated when due.
+   */
   protected boolean reevaluateTimeCycleWhenDue;
 
   /**
@@ -1135,14 +1156,13 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public void initExceptionCodeProvider() {
     if (!isDisableBuiltinExceptionCodeProvider()) {
-      builtinExceptionCodeProvider = new ExceptionCodeProvider() {};
-
+      builtinExceptionCodeProvider = ServiceLoaderUtil.loadSingleService(ExceptionCodeProvider.class);
     }
   }
 
   protected void initTypeValidator() {
     if (deserializationTypeValidator == null) {
-      deserializationTypeValidator = new DefaultDeserializationTypeValidator();
+      deserializationTypeValidator = ServiceLoaderUtil.loadSingleService(DeserializationTypeValidator.class);
     }
     if (deserializationTypeValidator instanceof WhitelistingDeserializationTypeValidator validator) {
       validator.setAllowedClasses(deserializationAllowedClasses);
@@ -1161,16 +1181,17 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
 
     if (!HISTORY_REMOVAL_TIME_STRATEGY_START.equals(historyRemovalTimeStrategy) &&
-      !HISTORY_REMOVAL_TIME_STRATEGY_END.equals(historyRemovalTimeStrategy) &&
-      !HISTORY_REMOVAL_TIME_STRATEGY_NONE.equals(historyRemovalTimeStrategy)) {
+            !HISTORY_REMOVAL_TIME_STRATEGY_END.equals(historyRemovalTimeStrategy) &&
+            !HISTORY_REMOVAL_TIME_STRATEGY_NONE.equals(historyRemovalTimeStrategy)) {
       throw LOG.invalidPropertyValue("historyRemovalTimeStrategy", historyRemovalTimeStrategy,
-        "history removal time strategy must be set to '%s', '%s' or '%s'".formatted(HISTORY_REMOVAL_TIME_STRATEGY_START, HISTORY_REMOVAL_TIME_STRATEGY_END, HISTORY_REMOVAL_TIME_STRATEGY_NONE));
+              "history removal time strategy must be set to '%s', '%s' or '%s'".formatted(HISTORY_REMOVAL_TIME_STRATEGY_START,
+                      HISTORY_REMOVAL_TIME_STRATEGY_END, HISTORY_REMOVAL_TIME_STRATEGY_NONE));
     }
   }
 
   public void initHistoryRemovalTimeProvider() {
     if (historyRemovalTimeProvider == null) {
-      historyRemovalTimeProvider = new DefaultHistoryRemovalTimeProvider();
+      historyRemovalTimeProvider = ServiceLoaderUtil.loadSingleService(HistoryRemovalTimeProvider.class);
     }
   }
 
@@ -1180,7 +1201,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     //validate number of threads
     if (historyCleanupDegreeOfParallelism < 1 || historyCleanupDegreeOfParallelism > MAX_THREADS_NUMBER) {
       throw LOG.invalidPropertyValue("historyCleanupDegreeOfParallelism", String.valueOf(historyCleanupDegreeOfParallelism),
-        "value for number of threads for history cleanup should be between 1 and %s".formatted(HistoryCleanupCmd.MAX_THREADS_NUMBER));
+              "value for number of threads for history cleanup should be between 1 and %s".formatted(
+                      HistoryCleanupCmd.MAX_THREADS_NUMBER));
     }
 
     if (historyCleanupBatchWindowStartTime != null) {
@@ -1195,12 +1217,12 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     if (historyCleanupBatchSize > HistoryCleanupHandler.MAX_BATCH_SIZE || historyCleanupBatchSize <= 0) {
       throw LOG.invalidPropertyValue("historyCleanupBatchSize", String.valueOf(historyCleanupBatchSize),
-        "value for batch size should be between 1 and %s".formatted(HistoryCleanupHandler.MAX_BATCH_SIZE));
+              "value for batch size should be between 1 and %s".formatted(HistoryCleanupHandler.MAX_BATCH_SIZE));
     }
 
     if (historyCleanupBatchThreshold < 0) {
       throw LOG.invalidPropertyValue("historyCleanupBatchThreshold", String.valueOf(historyCleanupBatchThreshold),
-          "History cleanup batch threshold cannot be negative.");
+              "History cleanup batch threshold cannot be negative.");
     }
 
     initHistoryTimeToLive();
@@ -1218,45 +1240,54 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
 
     if (!HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED.equals(historyCleanupStrategy) &&
-      !HISTORY_CLEANUP_STRATEGY_END_TIME_BASED.equals(historyCleanupStrategy)) {
+            !HISTORY_CLEANUP_STRATEGY_END_TIME_BASED.equals(historyCleanupStrategy)) {
       throw LOG.invalidPropertyValue("historyCleanupStrategy", historyCleanupStrategy,
-        "history cleanup strategy must be either set to '%s' or '%s'".formatted(HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED, HISTORY_CLEANUP_STRATEGY_END_TIME_BASED));
+              "history cleanup strategy must be either set to '%s' or '%s'".formatted(HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED,
+                      HISTORY_CLEANUP_STRATEGY_END_TIME_BASED));
     }
 
     if (HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED.equals(historyCleanupStrategy) &&
-      HISTORY_REMOVAL_TIME_STRATEGY_NONE.equals(historyRemovalTimeStrategy)) {
+            HISTORY_REMOVAL_TIME_STRATEGY_NONE.equals(historyRemovalTimeStrategy)) {
       throw LOG.invalidPropertyValue("historyRemovalTimeStrategy", historyRemovalTimeStrategy,
-        "history removal time strategy cannot be set to '%s' in conjunction with '%s' history cleanup strategy".formatted(HISTORY_REMOVAL_TIME_STRATEGY_NONE, HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED));
+              "history removal time strategy cannot be set to '%s' in conjunction with '%s' history cleanup strategy".formatted(
+                      HISTORY_REMOVAL_TIME_STRATEGY_NONE, HISTORY_CLEANUP_STRATEGY_REMOVAL_TIME_BASED));
     }
   }
 
   private void initHistoryCleanupBatchWindowsMap() {
     if (mondayHistoryCleanupBatchWindowStartTime != null || mondayHistoryCleanupBatchWindowEndTime != null) {
-      historyCleanupBatchWindows.put(Calendar.MONDAY, new BatchWindowConfiguration(mondayHistoryCleanupBatchWindowStartTime, mondayHistoryCleanupBatchWindowEndTime));
+      historyCleanupBatchWindows.put(Calendar.MONDAY,
+              new BatchWindowConfiguration(mondayHistoryCleanupBatchWindowStartTime, mondayHistoryCleanupBatchWindowEndTime));
     }
 
     if (tuesdayHistoryCleanupBatchWindowStartTime != null || tuesdayHistoryCleanupBatchWindowEndTime != null) {
-      historyCleanupBatchWindows.put(Calendar.TUESDAY, new BatchWindowConfiguration(tuesdayHistoryCleanupBatchWindowStartTime, tuesdayHistoryCleanupBatchWindowEndTime));
+      historyCleanupBatchWindows.put(Calendar.TUESDAY,
+              new BatchWindowConfiguration(tuesdayHistoryCleanupBatchWindowStartTime, tuesdayHistoryCleanupBatchWindowEndTime));
     }
 
     if (wednesdayHistoryCleanupBatchWindowStartTime != null || wednesdayHistoryCleanupBatchWindowEndTime != null) {
-      historyCleanupBatchWindows.put(Calendar.WEDNESDAY, new BatchWindowConfiguration(wednesdayHistoryCleanupBatchWindowStartTime, wednesdayHistoryCleanupBatchWindowEndTime));
+      historyCleanupBatchWindows.put(Calendar.WEDNESDAY,
+              new BatchWindowConfiguration(wednesdayHistoryCleanupBatchWindowStartTime, wednesdayHistoryCleanupBatchWindowEndTime));
     }
 
     if (thursdayHistoryCleanupBatchWindowStartTime != null || thursdayHistoryCleanupBatchWindowEndTime != null) {
-      historyCleanupBatchWindows.put(Calendar.THURSDAY, new BatchWindowConfiguration(thursdayHistoryCleanupBatchWindowStartTime, thursdayHistoryCleanupBatchWindowEndTime));
+      historyCleanupBatchWindows.put(Calendar.THURSDAY,
+              new BatchWindowConfiguration(thursdayHistoryCleanupBatchWindowStartTime, thursdayHistoryCleanupBatchWindowEndTime));
     }
 
     if (fridayHistoryCleanupBatchWindowStartTime != null || fridayHistoryCleanupBatchWindowEndTime != null) {
-      historyCleanupBatchWindows.put(Calendar.FRIDAY, new BatchWindowConfiguration(fridayHistoryCleanupBatchWindowStartTime, fridayHistoryCleanupBatchWindowEndTime));
+      historyCleanupBatchWindows.put(Calendar.FRIDAY,
+              new BatchWindowConfiguration(fridayHistoryCleanupBatchWindowStartTime, fridayHistoryCleanupBatchWindowEndTime));
     }
 
-    if (saturdayHistoryCleanupBatchWindowStartTime != null ||saturdayHistoryCleanupBatchWindowEndTime != null) {
-      historyCleanupBatchWindows.put(Calendar.SATURDAY, new BatchWindowConfiguration(saturdayHistoryCleanupBatchWindowStartTime, saturdayHistoryCleanupBatchWindowEndTime));
+    if (saturdayHistoryCleanupBatchWindowStartTime != null || saturdayHistoryCleanupBatchWindowEndTime != null) {
+      historyCleanupBatchWindows.put(Calendar.SATURDAY,
+              new BatchWindowConfiguration(saturdayHistoryCleanupBatchWindowStartTime, saturdayHistoryCleanupBatchWindowEndTime));
     }
 
     if (sundayHistoryCleanupBatchWindowStartTime != null || sundayHistoryCleanupBatchWindowEndTime != null) {
-      historyCleanupBatchWindows.put(Calendar.SUNDAY, new BatchWindowConfiguration(sundayHistoryCleanupBatchWindowStartTime, sundayHistoryCleanupBatchWindowEndTime));
+      historyCleanupBatchWindows.put(Calendar.SUNDAY,
+              new BatchWindowConfiguration(sundayHistoryCleanupBatchWindowStartTime, sundayHistoryCleanupBatchWindowEndTime));
     }
   }
 
@@ -1267,9 +1298,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     } else {
       Set<String> batchTypes = invocationsPerBatchJobByBatchType.keySet();
       batchTypes.stream()
-          // batchHandlers contains custom & built-in batch handlers
-          .filter(batchType -> !batchHandlers.containsKey(batchType))
-          .forEach(LOG::invalidBatchTypeForInvocationsPerBatchJob);
+              // batchHandlers contains custom & built-in batch handlers
+              .filter(batchType -> !batchHandlers.containsKey(batchType))
+              .forEach(LOG::invalidBatchTypeForInvocationsPerBatchJob);
     }
   }
 
@@ -1291,7 +1322,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     if (batchOperationsForHistoryCleanup == null) {
       batchOperationsForHistoryCleanup = new HashMap<>();
     } else {
-      for (var batchOperationEntry: batchOperationsForHistoryCleanup.entrySet()) {
+      for (var batchOperationEntry : batchOperationsForHistoryCleanup.entrySet()) {
         String batchOperation = batchOperationEntry.getKey();
         String timeToLive = batchOperationEntry.getValue();
         if (!batchHandlers.containsKey(batchOperation)) {
@@ -1308,12 +1339,12 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     if (batchHandlers != null && batchOperationHistoryTimeToLive != null) {
       batchHandlers.keySet().forEach(batchOperation ->
-        batchOperationsForHistoryCleanup.computeIfAbsent(batchOperation, k -> batchOperationHistoryTimeToLive)
+              batchOperationsForHistoryCleanup.computeIfAbsent(batchOperation, k -> batchOperationHistoryTimeToLive)
       );
     }
 
     parsedBatchOperationsForHistoryCleanup = new HashMap<>();
-    for (var batchOperationEntry: batchOperationsForHistoryCleanup.entrySet()) {
+    for (var batchOperationEntry : batchOperationsForHistoryCleanup.entrySet()) {
       String operation = batchOperationEntry.getKey();
       Integer historyTTL = ParseUtil.parseHistoryTimeToLive(batchOperationEntry.getValue());
       parsedBatchOperationsForHistoryCleanup.put(operation, historyTTL);
@@ -1375,7 +1406,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initFailedJobCommandFactory() {
     if (failedJobCommandFactory == null) {
-      failedJobCommandFactory = new DefaultFailedJobCommandFactory();
+      failedJobCommandFactory = ServiceLoaderUtil.loadSingleService(FailedJobCommandFactory.class);
     }
     if (postParseListeners == null) {
       postParseListeners = new ArrayList<>();
@@ -1392,7 +1423,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
       DefaultIncidentHandler failedJobIncidentHandler = new DefaultIncidentHandler(Incident.FAILED_JOB_HANDLER_TYPE);
       DefaultIncidentHandler failedExternalTaskIncidentHandler = new DefaultIncidentHandler(
-          Incident.EXTERNAL_TASK_HANDLER_TYPE);
+              Incident.EXTERNAL_TASK_HANDLER_TYPE);
 
       if (isCompositeIncidentHandlersEnabled) {
         addIncidentHandler(new CompositeIncidentHandler(failedJobIncidentHandler));
@@ -1416,47 +1447,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     if (batchHandlers == null) {
       batchHandlers = new HashMap<>();
 
-      MigrationBatchJobHandler migrationHandler = new MigrationBatchJobHandler();
-      batchHandlers.put(migrationHandler.getType(), migrationHandler);
-
-      ModificationBatchJobHandler modificationHandler = new ModificationBatchJobHandler();
-      batchHandlers.put(modificationHandler.getType(), modificationHandler);
-
-      DeleteProcessInstancesJobHandler deleteProcessJobHandler = new DeleteProcessInstancesJobHandler();
-      batchHandlers.put(deleteProcessJobHandler.getType(), deleteProcessJobHandler);
-
-      DeleteHistoricProcessInstancesJobHandler deleteHistoricProcessInstancesJobHandler = new DeleteHistoricProcessInstancesJobHandler();
-      batchHandlers.put(deleteHistoricProcessInstancesJobHandler.getType(), deleteHistoricProcessInstancesJobHandler);
-
-      SetJobRetriesJobHandler setJobRetriesJobHandler = new SetJobRetriesJobHandler();
-      batchHandlers.put(setJobRetriesJobHandler.getType(), setJobRetriesJobHandler);
-
-      SetExternalTaskRetriesJobHandler setExternalTaskRetriesJobHandler = new SetExternalTaskRetriesJobHandler();
-      batchHandlers.put(setExternalTaskRetriesJobHandler.getType(), setExternalTaskRetriesJobHandler);
-
-      RestartProcessInstancesJobHandler restartProcessInstancesJobHandler = new RestartProcessInstancesJobHandler();
-      batchHandlers.put(restartProcessInstancesJobHandler.getType(), restartProcessInstancesJobHandler);
-
-      UpdateProcessInstancesSuspendStateJobHandler suspendProcessInstancesJobHandler = new UpdateProcessInstancesSuspendStateJobHandler();
-      batchHandlers.put(suspendProcessInstancesJobHandler.getType(), suspendProcessInstancesJobHandler);
-
-      DeleteHistoricDecisionInstancesJobHandler deleteHistoricDecisionInstancesJobHandler = new DeleteHistoricDecisionInstancesJobHandler();
-      batchHandlers.put(deleteHistoricDecisionInstancesJobHandler.getType(), deleteHistoricDecisionInstancesJobHandler);
-
-      ProcessSetRemovalTimeJobHandler processSetRemovalTimeJobHandler = new ProcessSetRemovalTimeJobHandler();
-      batchHandlers.put(processSetRemovalTimeJobHandler.getType(), processSetRemovalTimeJobHandler);
-
-      DecisionSetRemovalTimeJobHandler decisionSetRemovalTimeJobHandler = new DecisionSetRemovalTimeJobHandler();
-      batchHandlers.put(decisionSetRemovalTimeJobHandler.getType(), decisionSetRemovalTimeJobHandler);
-
-      BatchSetRemovalTimeJobHandler batchSetRemovalTimeJobHandler = new BatchSetRemovalTimeJobHandler();
-      batchHandlers.put(batchSetRemovalTimeJobHandler.getType(), batchSetRemovalTimeJobHandler);
-
-      BatchSetVariablesHandler batchSetVariablesHandler = new BatchSetVariablesHandler();
-      batchHandlers.put(batchSetVariablesHandler.getType(), batchSetVariablesHandler);
-
-      MessageCorrelationBatchJobHandler messageCorrelationJobHandler = new MessageCorrelationBatchJobHandler();
-      batchHandlers.put(messageCorrelationJobHandler.getType(), messageCorrelationJobHandler);
+      ServiceLoader.load(BatchJobHandler.class).forEach(handler -> batchHandlers.put(handler.getType(), handler));
     }
 
     if (customBatchJobHandlers != null) {
@@ -1467,7 +1458,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
     if (removalTimeUpdateChunkSize > ProcessSetRemovalTimeJobHandler.MAX_CHUNK_SIZE || removalTimeUpdateChunkSize <= 0) {
       throw LOG.invalidPropertyValue("removalTimeUpdateChunkSize", String.valueOf(removalTimeUpdateChunkSize),
-        "value for chunk size should be between 1 and %s".formatted(ProcessSetRemovalTimeJobHandler.MAX_CHUNK_SIZE));
+              "value for chunk size should be between 1 and %s".formatted(ProcessSetRemovalTimeJobHandler.MAX_CHUNK_SIZE));
     }
   }
 
@@ -1613,8 +1604,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       throw new ProcessEngineException("DataSource or JDBC properties have to be specified in a process engine configuration");
     }
 
-    PooledDataSource pooledDataSource =
-        new PooledDataSource(ReflectUtil.getClassLoader(), jdbcDriver, jdbcUrl, jdbcUsername, jdbcPassword);
+        PooledDataSource pooledDataSource =
+                new PooledDataSource(ReflectUtil.getClassLoader(), jdbcDriver, jdbcUrl, jdbcUsername, jdbcPassword);
 
     if (jdbcMaxActiveConnections > 0) {
       pooledDataSource.setPoolMaximumActiveConnections(jdbcMaxActiveConnections);
@@ -1716,7 +1707,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       }
       LOG.debugDatabaseproductName(databaseProductName);
       databaseType = databaseTypeMappings.getProperty(databaseProductName);
-      ensureNotNull("couldn't deduct database type from database product name '%s'".formatted(databaseProductName), "databaseType", databaseType);
+      ensureNotNull("couldn't deduct database type from database product name '%s'".formatted(databaseProductName), "databaseType",
+              databaseType);
       LOG.debugDatabaseType(databaseType);
 
       initDatabaseVendorAndVersion(databaseMetaData);
@@ -1802,7 +1794,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
           Properties properties = new Properties();
 
           if (isUseSharedSqlSessionFactory) {
-            properties.put("prefix", "${@org.operaton.bpm.engine.impl.context.Context@getProcessEngineConfiguration().databaseTablePrefix}");
+            properties.put("prefix",
+                    "${@org.operaton.bpm.engine.impl.context.Context@getProcessEngineConfiguration().databaseTablePrefix}");
           } else {
             properties.put("prefix", databaseTablePrefix);
           }
@@ -1826,7 +1819,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
             cachedSqlSessionFactory = sqlSessionFactory;
           }
 
-
         } catch (Exception e) {
           throw new ProcessEngineException("Error while building ibatis SqlSessionFactory: %s".formatted(e.getMessage()), e);
         }
@@ -1840,24 +1832,31 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     if (databaseType != null) {
       properties.put("limitBefore", DbSqlSessionFactory.getDatabaseSpecificLimitBeforeStatements().get(databaseType));
       properties.put("limitAfter", DbSqlSessionFactory.getDatabaseSpecificLimitAfterStatements().get(databaseType));
-      properties.put("limitBeforeWithoutOffset", DbSqlSessionFactory.getDatabaseSpecificLimitBeforeWithoutOffsetStatements().get(databaseType));
-      properties.put("limitAfterWithoutOffset", DbSqlSessionFactory.getDatabaseSpecificLimitAfterWithoutOffsetStatements().get(databaseType));
+      properties.put("limitBeforeWithoutOffset",
+              DbSqlSessionFactory.getDatabaseSpecificLimitBeforeWithoutOffsetStatements().get(databaseType));
+      properties.put("limitAfterWithoutOffset",
+              DbSqlSessionFactory.getDatabaseSpecificLimitAfterWithoutOffsetStatements().get(databaseType));
 
-      properties.put("optimizeLimitBeforeWithoutOffset", DbSqlSessionFactory.getOptimizeDatabaseSpecificLimitBeforeWithoutOffsetStatements().get(databaseType));
-      properties.put("optimizeLimitAfterWithoutOffset", DbSqlSessionFactory.getOptimizeDatabaseSpecificLimitAfterWithoutOffsetStatements().get(databaseType));
+      properties.put("optimizeLimitBeforeWithoutOffset",
+              DbSqlSessionFactory.getOptimizeDatabaseSpecificLimitBeforeWithoutOffsetStatements().get(databaseType));
+      properties.put("optimizeLimitAfterWithoutOffset",
+              DbSqlSessionFactory.getOptimizeDatabaseSpecificLimitAfterWithoutOffsetStatements().get(databaseType));
       properties.put("innerLimitAfter", DbSqlSessionFactory.getDatabaseSpecificInnerLimitAfterStatements().get(databaseType));
       properties.put("limitBetween", DbSqlSessionFactory.getDatabaseSpecificLimitBetweenStatements().get(databaseType));
       properties.put("limitBetweenFilter", DbSqlSessionFactory.getDatabaseSpecificLimitBetweenFilterStatements().get(databaseType));
-      properties.put("limitBetweenAcquisition", DbSqlSessionFactory.getDatabaseSpecificLimitBetweenAcquisitionStatements().get(databaseType));
+      properties.put("limitBetweenAcquisition",
+              DbSqlSessionFactory.getDatabaseSpecificLimitBetweenAcquisitionStatements().get(databaseType));
       properties.put("orderBy", DbSqlSessionFactory.getDatabaseSpecificOrderByStatements().get(databaseType));
-      properties.put("limitBeforeNativeQuery", DbSqlSessionFactory.getDatabaseSpecificLimitBeforeNativeQueryStatements().get(databaseType));
+      properties.put("limitBeforeNativeQuery",
+              DbSqlSessionFactory.getDatabaseSpecificLimitBeforeNativeQueryStatements().get(databaseType));
       properties.put("distinct", DbSqlSessionFactory.getDatabaseSpecificDistinct().get(databaseType));
       properties.put("numericCast", DbSqlSessionFactory.getDatabaseSpecificNumericCast().get(databaseType));
 
       properties.put("limitBeforeInUpdate", DbSqlSessionFactory.getDatabaseSpecificLimitBeforeInUpdate().get(databaseType));
       properties.put("limitAfterInUpdate", DbSqlSessionFactory.getDatabaseSpecificLimitAfterInUpdate().get(databaseType));
 
-      properties.put("countDistinctBeforeStart", DbSqlSessionFactory.getDatabaseSpecificCountDistinctBeforeStart().get(databaseType));
+      properties.put("countDistinctBeforeStart",
+              DbSqlSessionFactory.getDatabaseSpecificCountDistinctBeforeStart().get(databaseType));
       properties.put("countDistinctBeforeEnd", DbSqlSessionFactory.getDatabaseSpecificCountDistinctBeforeEnd().get(databaseType));
       properties.put("countDistinctAfterEnd", DbSqlSessionFactory.getDatabaseSpecificCountDistinctAfterEnd().get(databaseType));
 
@@ -1879,7 +1878,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
       properties.put("dayComparator", DbSqlSessionFactory.getDatabaseSpecificDaysComparator().get(databaseType));
 
-      properties.put("collationForCaseSensitivity", DbSqlSessionFactory.getDatabaseSpecificCollationForCaseSensitivity().get(databaseType));
+      properties.put("collationForCaseSensitivity",
+              DbSqlSessionFactory.getDatabaseSpecificCollationForCaseSensitivity().get(databaseType));
 
       properties.put("authJoinStart", DbSqlSessionFactory.getDatabaseSpecificAuthJoinStart().get(databaseType));
       properties.put("authJoinEnd", DbSqlSessionFactory.getDatabaseSpecificAuthJoinEnd().get(databaseType));
@@ -1890,7 +1890,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       properties.put("authJoin1Separator", DbSqlSessionFactory.getDatabaseSpecificAuth1JoinSeparator().get(databaseType));
 
       properties.put("extractTimeUnitFromDate", DbSqlSessionFactory.getDatabaseSpecificExtractTimeUnitFromDate().get(databaseType));
-      properties.put("authCheckMethodSuffix", DbSqlSessionFactory.getDatabaseSpecificAuthCheckMethodSuffix().getOrDefault(databaseType, ""));
+      properties.put("authCheckMethodSuffix",
+              DbSqlSessionFactory.getDatabaseSpecificAuthCheckMethodSuffix().getOrDefault(databaseType, ""));
 
       Map<String, String> constants = DbSqlSessionFactory.getDatabaseSpecificConstants().get(databaseType);
       for (Entry<String, String> entry : constants.entrySet()) {
@@ -2021,7 +2022,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initMigrationActivityMatcher() {
     if (migrationActivityMatcher == null) {
-      migrationActivityMatcher = new DefaultMigrationActivityMatcher();
+      migrationActivityMatcher = ServiceLoaderUtil.loadSingleService(MigrationActivityMatcher.class);
     }
   }
 
@@ -2039,8 +2040,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       migrationActivityValidators.addAll(customPostMigrationActivityValidators);
     }
     migrationInstructionGenerator = migrationInstructionGenerator
-        .migrationActivityValidators(migrationActivityValidators)
-        .migrationInstructionValidators(migrationInstructionValidators);
+            .migrationActivityValidators(migrationActivityValidators)
+            .migrationInstructionValidators(migrationInstructionValidators);
   }
 
   protected void initMigrationInstructionValidators() {
@@ -2086,7 +2087,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
   }
 
-
   /**
    * When providing a schema and a prefix  the prefix has to be the schema ending with a dot.
    */
@@ -2095,7 +2095,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       return;
     }
     if (prefix == null || !prefix.startsWith(schema + ".")) {
-      throw new ProcessEngineException("When setting a schema the prefix has to be schema + '.'. Received schema: %s prefix: %s".formatted(schema, prefix));
+      throw new ProcessEngineException(
+              "When setting a schema the prefix has to be schema + '.'. Received schema: %s prefix: %s".formatted(schema, prefix));
     }
   }
 
@@ -2162,7 +2163,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     bpmnDeployer.setIdGenerator(idGenerator);
 
     if (bpmnParseFactory == null) {
-      bpmnParseFactory = new DefaultBpmnParseFactory();
+      bpmnParseFactory = ServiceLoaderUtil.loadSingleService(BpmnParseFactory.class);
     }
 
     BpmnParser bpmnParser = new BpmnParser(expressionManager, bpmnParseFactory);
@@ -2203,7 +2204,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     cmmnDeployer.setIdGenerator(idGenerator);
 
     if (cmmnTransformFactory == null) {
-      cmmnTransformFactory = new DefaultCmmnTransformFactory();
+      cmmnTransformFactory = ServiceLoaderUtil.loadSingleService(CmmnTransformFactory.class);
     }
 
     if (cmmnElementHandlerRegistry == null) {
@@ -2334,7 +2335,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     // verify job executor priority range is configured correctly
     if (jobExecutorPriorityRangeMin > jobExecutorPriorityRangeMax) {
       throw ProcessEngineLogger.JOB_EXECUTOR_LOGGER.jobExecutorPriorityRangeException(
-          "jobExecutorPriorityRangeMin can not be greater than jobExecutorPriorityRangeMax");
+              "jobExecutorPriorityRangeMin can not be greater than jobExecutorPriorityRangeMax");
     }
 
     if (jobExecutorPriorityRangeMin > historyCleanupJobPriority || jobExecutorPriorityRangeMax < historyCleanupJobPriority) {
@@ -2612,11 +2613,11 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       }
 
       DmnEngineConfigurationBuilder dmnEngineConfigurationBuilder = new DmnEngineConfigurationBuilder(dmnEngineConfiguration)
-          .dmnHistoryEventProducer(dmnHistoryEventProducer)
-          .scriptEngineResolver(scriptingEngines)
-          .feelCustomFunctionProviders(dmnFeelCustomFunctionProviders)
-          .enableFeelLegacyBehavior(dmnFeelEnableLegacyBehavior)
-          .returnBlankTableOutputAsNull(dmnReturnBlankTableOutputAsNull);
+              .dmnHistoryEventProducer(dmnHistoryEventProducer)
+              .scriptEngineResolver(scriptingEngines)
+              .feelCustomFunctionProviders(dmnFeelCustomFunctionProviders)
+              .enableFeelLegacyBehavior(dmnFeelEnableLegacyBehavior)
+              .returnBlankTableOutputAsNull(dmnReturnBlankTableOutputAsNull);
 
       if (dmnElProvider != null) {
         dmnEngineConfigurationBuilder.elProvider(dmnElProvider);
@@ -2638,16 +2639,15 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       expressionManager = new JuelExpressionManager(beans);
     }
 
-
     expressionManager.addFunction(CommandContextFunctions.CURRENT_USER,
-        ReflectUtil.getMethod(CommandContextFunctions.class, CommandContextFunctions.CURRENT_USER));
+            ReflectUtil.getMethod(CommandContextFunctions.class, CommandContextFunctions.CURRENT_USER));
     expressionManager.addFunction(CommandContextFunctions.CURRENT_USER_GROUPS,
-        ReflectUtil.getMethod(CommandContextFunctions.class, CommandContextFunctions.CURRENT_USER_GROUPS));
+            ReflectUtil.getMethod(CommandContextFunctions.class, CommandContextFunctions.CURRENT_USER_GROUPS));
 
     expressionManager.addFunction(DateTimeFunctions.NOW,
-        ReflectUtil.getMethod(DateTimeFunctions.class, DateTimeFunctions.NOW));
+            ReflectUtil.getMethod(DateTimeFunctions.class, DateTimeFunctions.NOW));
     expressionManager.addFunction(DateTimeFunctions.DATE_TIME,
-        ReflectUtil.getMethod(DateTimeFunctions.class, DateTimeFunctions.DATE_TIME));
+            ReflectUtil.getMethod(DateTimeFunctions.class, DateTimeFunctions.DATE_TIME));
   }
 
   protected void initBusinessCalendarManager() {
@@ -2709,7 +2709,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initArtifactFactory() {
     if (artifactFactory == null) {
-      artifactFactory = new DefaultArtifactFactory();
+      artifactFactory = ServiceLoaderUtil.loadSingleService(ArtifactFactory.class);
     }
   }
 
@@ -2722,7 +2722,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   // correlation handler //////////////////////////////////////////////////////
   protected void initCorrelationHandler() {
     if (correlationHandler == null) {
-      correlationHandler = new DefaultCorrelationHandler();
+      correlationHandler = ServiceLoaderUtil.loadSingleService(CorrelationHandler.class);
     }
 
   }
@@ -2730,14 +2730,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   // condition handler //////////////////////////////////////////////////////
   protected void initConditionHandler() {
     if (conditionHandler == null) {
-      conditionHandler = new DefaultConditionHandler();
+      conditionHandler = ServiceLoaderUtil.loadSingleService(ConditionHandler.class);
     }
   }
 
   // deployment handler //////////////////////////////////////////////////////
   protected void initDeploymentHandlerFactory() {
     if (deploymentHandlerFactory == null) {
-      deploymentHandlerFactory = new DefaultDeploymentHandlerFactory();
+      deploymentHandlerFactory = ServiceLoaderUtil.loadSingleService(DeploymentHandlerFactory.class);
     }
   }
 
@@ -2745,19 +2745,19 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initHistoryEventProducer() {
     if (historyEventProducer == null) {
-      historyEventProducer = new CacheAwareHistoryEventProducer();
+      historyEventProducer = ServiceLoaderUtil.loadSingleService(HistoryEventProducer.class);
     }
   }
 
   protected void initCmmnHistoryEventProducer() {
     if (cmmnHistoryEventProducer == null) {
-      cmmnHistoryEventProducer = new CacheAwareCmmnHistoryEventProducer();
+      cmmnHistoryEventProducer = ServiceLoaderUtil.loadSingleService(CmmnHistoryEventProducer.class);
     }
   }
 
   protected void initDmnHistoryEventProducer() {
     if (dmnHistoryEventProducer == null) {
-      dmnHistoryEventProducer = new DefaultDmnHistoryEventProducer();
+      dmnHistoryEventProducer = ServiceLoaderUtil.loadSingleService(DmnHistoryEventProducer.class);
     }
   }
 
@@ -2774,23 +2774,23 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   // password digest //////////////////////////////////////////////////////////
 
   protected void initPasswordDigest() {
-    if(saltGenerator == null) {
-      saltGenerator = new Default16ByteSaltGenerator();
+    if (saltGenerator == null) {
+      saltGenerator = ServiceLoaderUtil.loadSingleService(SaltGenerator.class);
     }
     if (passwordEncryptor == null) {
-      passwordEncryptor = new Sha512HashDigest();
+      passwordEncryptor = ServiceLoaderUtil.loadSingleService(PasswordEncryptor.class);
     }
-    if(customPasswordChecker == null) {
+    if (customPasswordChecker == null) {
       customPasswordChecker = Collections.emptyList();
     }
-    if(passwordManager == null) {
+    if (passwordManager == null) {
       passwordManager = new PasswordManager(passwordEncryptor, customPasswordChecker);
     }
   }
 
   public void initPasswordPolicy() {
-    if(passwordPolicy == null && enablePasswordPolicy) {
-      passwordPolicy = new DefaultPasswordPolicyImpl();
+    if (passwordPolicy == null && enablePasswordPolicy) {
+      passwordPolicy = ServiceLoaderUtil.loadSingleService(PasswordPolicy.class);
     }
   }
 
@@ -2801,10 +2801,10 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   }
 
   protected void initOperationLog() {
-    if(logEntriesPerSyncOperationLimit < -1 || logEntriesPerSyncOperationLimit == 0) {
+    if (logEntriesPerSyncOperationLimit < -1 || logEntriesPerSyncOperationLimit == 0) {
       throw new ProcessEngineException(
-          "Invalid configuration for logEntriesPerSyncOperationLimit. Configured value needs to be either -1 or greater than 0 but was %s."
-              .formatted(logEntriesPerSyncOperationLimit));
+              "Invalid configuration for logEntriesPerSyncOperationLimit. Configured value needs to be either -1 or greater than 0 but was %s."
+                      .formatted(logEntriesPerSyncOperationLimit));
     }
   }
 
@@ -2812,7 +2812,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initCacheFactory() {
     if (cacheFactory == null) {
-      cacheFactory = new DefaultCacheFactory();
+      cacheFactory = ServiceLoaderUtil.loadSingleService(CacheFactory.class);
     }
   }
 
@@ -2820,13 +2820,13 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected void initResourceAuthorizationProvider() {
     if (resourceAuthorizationProvider == null) {
-      resourceAuthorizationProvider = new DefaultAuthorizationProvider();
+      resourceAuthorizationProvider = ServiceLoaderUtil.loadSingleService(ResourceAuthorizationProvider.class);
     }
   }
 
   protected void initPermissionProvider() {
     if (permissionProvider == null) {
-      permissionProvider = new DefaultPermissionProvider();
+      permissionProvider = ServiceLoaderUtil.loadSingleService(PermissionProvider.class);
     }
   }
 
@@ -2837,7 +2837,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       } else if (Permissions.TASK_WORK.getName().equals(defaultUserPermissionNameForTask)) {
         defaultUserPermissionForTask = Permissions.TASK_WORK;
       } else {
-        throw LOG.invalidConfigDefaultUserPermissionNameForTask(defaultUserPermissionNameForTask, new String[]{Permissions.UPDATE.getName(), Permissions.TASK_WORK.getName()});
+        throw LOG.invalidConfigDefaultUserPermissionNameForTask(defaultUserPermissionNameForTask,
+                new String[] { Permissions.UPDATE.getName(), Permissions.TASK_WORK.getName() });
       }
     }
   }
@@ -2883,7 +2884,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
 
     ProcessEngineDetails engineInfo = ParseUtil
-        .parseProcessEngineVersion(true);
+            .parseProcessEngineVersion(true);
 
     ProductImpl product = new ProductImpl(PRODUCT_NAME, engineInfo.getVersion(), engineInfo.getEdition(), internals);
 
@@ -2928,7 +2929,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return customPreCommandInterceptorsTxRequired;
   }
 
-  public ProcessEngineConfigurationImpl setCustomPreCommandInterceptorsTxRequired(List<CommandInterceptor> customPreCommandInterceptorsTxRequired) {
+  public ProcessEngineConfigurationImpl setCustomPreCommandInterceptorsTxRequired(
+          List<CommandInterceptor> customPreCommandInterceptorsTxRequired) {
     this.customPreCommandInterceptorsTxRequired = customPreCommandInterceptorsTxRequired;
     return this;
   }
@@ -2937,7 +2939,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return customPostCommandInterceptorsTxRequired;
   }
 
-  public ProcessEngineConfigurationImpl setCustomPostCommandInterceptorsTxRequired(List<CommandInterceptor> customPostCommandInterceptorsTxRequired) {
+  public ProcessEngineConfigurationImpl setCustomPostCommandInterceptorsTxRequired(
+          List<CommandInterceptor> customPostCommandInterceptorsTxRequired) {
     this.customPostCommandInterceptorsTxRequired = customPostCommandInterceptorsTxRequired;
     return this;
   }
@@ -2964,7 +2967,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return customPreCommandInterceptorsTxRequiresNew;
   }
 
-  public ProcessEngineConfigurationImpl setCustomPreCommandInterceptorsTxRequiresNew(List<CommandInterceptor> customPreCommandInterceptorsTxRequiresNew) {
+  public ProcessEngineConfigurationImpl setCustomPreCommandInterceptorsTxRequiresNew(
+          List<CommandInterceptor> customPreCommandInterceptorsTxRequiresNew) {
     this.customPreCommandInterceptorsTxRequiresNew = customPreCommandInterceptorsTxRequiresNew;
     return this;
   }
@@ -2973,7 +2977,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return customPostCommandInterceptorsTxRequiresNew;
   }
 
-  public ProcessEngineConfigurationImpl setCustomPostCommandInterceptorsTxRequiresNew(List<CommandInterceptor> customPostCommandInterceptorsTxRequiresNew) {
+  public ProcessEngineConfigurationImpl setCustomPostCommandInterceptorsTxRequiresNew(
+          List<CommandInterceptor> customPostCommandInterceptorsTxRequiresNew) {
     this.customPostCommandInterceptorsTxRequiresNew = customPostCommandInterceptorsTxRequiresNew;
     return this;
   }
@@ -2982,7 +2987,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return commandInterceptorsTxRequiresNew;
   }
 
-  public ProcessEngineConfigurationImpl setCommandInterceptorsTxRequiresNew(List<CommandInterceptor> commandInterceptorsTxRequiresNew) {
+  public ProcessEngineConfigurationImpl setCommandInterceptorsTxRequiresNew(
+          List<CommandInterceptor> commandInterceptorsTxRequiresNew) {
     this.commandInterceptorsTxRequiresNew = commandInterceptorsTxRequiresNew;
     return this;
   }
@@ -3288,22 +3294,18 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return this;
   }
 
-
   public List<Deployer> getCustomPreDeployers() {
     return customPreDeployers;
   }
-
 
   public ProcessEngineConfigurationImpl setCustomPreDeployers(List<Deployer> customPreDeployers) {
     this.customPreDeployers = customPreDeployers;
     return this;
   }
 
-
   public List<Deployer> getCustomPostDeployers() {
     return customPostDeployers;
   }
-
 
   public ProcessEngineConfigurationImpl setCustomPostDeployers(List<Deployer> customPostDeployers) {
     this.customPostDeployers = customPostDeployers;
@@ -3318,7 +3320,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     this.cacheCapacity = cacheCapacity;
   }
 
-  public void setEnableFetchProcessDefinitionDescription(boolean enableFetchProcessDefinitionDescription){
+  public void setEnableFetchProcessDefinitionDescription(boolean enableFetchProcessDefinitionDescription) {
     this.enableFetchProcessDefinitionDescription = enableFetchProcessDefinitionDescription;
   }
 
@@ -3348,23 +3350,19 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return jobHandlers;
   }
 
-
   public ProcessEngineConfigurationImpl setJobHandlers(Map<String, JobHandler<?>> jobHandlers) {
     this.jobHandlers = jobHandlers;
     return this;
   }
 
-
   public SqlSessionFactory getSqlSessionFactory() {
     return sqlSessionFactory;
   }
-
 
   public ProcessEngineConfigurationImpl setSqlSessionFactory(SqlSessionFactory sqlSessionFactory) {
     this.sqlSessionFactory = sqlSessionFactory;
     return this;
   }
-
 
   public DbSqlSessionFactory getDbSqlSessionFactory() {
     return dbSqlSessionFactory;
@@ -3415,7 +3413,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return customFormTypes;
   }
 
-
   public ProcessEngineConfigurationImpl setCustomFormTypes(List<AbstractFormFieldType> customFormTypes) {
     this.customFormTypes = customFormTypes;
     return this;
@@ -3425,17 +3422,14 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return customPreVariableSerializers;
   }
 
-
   public ProcessEngineConfigurationImpl setCustomPreVariableSerializers(List<TypedValueSerializer<?>> customPreVariableTypes) {
     this.customPreVariableSerializers = customPreVariableTypes;
     return this;
   }
 
-
   public List<TypedValueSerializer<?>> getCustomPostVariableSerializers() {
     return customPostVariableSerializers;
   }
-
 
   public ProcessEngineConfigurationImpl setCustomPostVariableSerializers(List<TypedValueSerializer<?>> customPostVariableTypes) {
     this.customPostVariableSerializers = customPostVariableTypes;
@@ -3676,7 +3670,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   public boolean isDbIdentityUsed() {
     return isDbIdentityUsed;
   }
-
 
   public void setDbIdentityUsed(boolean isDbIdentityUsed) {
     this.isDbIdentityUsed = isDbIdentityUsed;
@@ -3932,7 +3925,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return invocationsPerBatchJobByBatchType;
   }
 
-  public ProcessEngineConfigurationImpl setInvocationsPerBatchJobByBatchType(Map<String, Integer> invocationsPerBatchJobByBatchType) {
+  public ProcessEngineConfigurationImpl setInvocationsPerBatchJobByBatchType(
+          Map<String, Integer> invocationsPerBatchJobByBatchType) {
     this.invocationsPerBatchJobByBatchType = invocationsPerBatchJobByBatchType;
     return this;
   }
@@ -4188,8 +4182,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   /**
    * Sets if deployment processing must be synchronized.
+   *
    * @param deploymentSynchronized {@code true} when deployment must be synchronized,
-   * {@code false} when several depoloyments may be processed in parallel
+   *                               {@code false} when several depoloyments may be processed in parallel
    */
   public void setDeploymentSynchronized(boolean deploymentSynchronized) {
     isDeploymentSynchronized = deploymentSynchronized;
@@ -4463,7 +4458,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return enableScriptEngineLoadExternalResources;
   }
 
-  public ProcessEngineConfigurationImpl setEnableScriptEngineLoadExternalResources(boolean enableScriptEngineLoadExternalResources) {
+  public ProcessEngineConfigurationImpl setEnableScriptEngineLoadExternalResources(
+          boolean enableScriptEngineLoadExternalResources) {
     this.enableScriptEngineLoadExternalResources = enableScriptEngineLoadExternalResources;
     return this;
   }
@@ -4532,7 +4528,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return restrictUserOperationLogToAuthenticatedUsers;
   }
 
-  public ProcessEngineConfigurationImpl setRestrictUserOperationLogToAuthenticatedUsers(boolean restrictUserOperationLogToAuthenticatedUsers) {
+  public ProcessEngineConfigurationImpl setRestrictUserOperationLogToAuthenticatedUsers(
+          boolean restrictUserOperationLogToAuthenticatedUsers) {
     this.restrictUserOperationLogToAuthenticatedUsers = restrictUserOperationLogToAuthenticatedUsers;
     return this;
   }
@@ -4562,7 +4559,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   public MigrationActivityMatcher getMigrationActivityMatcher() {
     return migrationActivityMatcher;
   }
-
 
   public void setCustomPreMigrationActivityValidators(List<MigrationActivityValidator> customPreMigrationActivityValidators) {
     this.customPreMigrationActivityValidators = customPreMigrationActivityValidators;
@@ -4604,7 +4600,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return migrationInstructionValidators;
   }
 
-  public void setCustomPostMigrationInstructionValidators(List<MigrationInstructionValidator> customPostMigrationInstructionValidators) {
+  public void setCustomPostMigrationInstructionValidators(
+          List<MigrationInstructionValidator> customPostMigrationInstructionValidators) {
     this.customPostMigrationInstructionValidators = customPostMigrationInstructionValidators;
   }
 
@@ -4612,7 +4609,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return customPostMigrationInstructionValidators;
   }
 
-  public void setCustomPreMigrationInstructionValidators(List<MigrationInstructionValidator> customPreMigrationInstructionValidators) {
+  public void setCustomPreMigrationInstructionValidators(
+          List<MigrationInstructionValidator> customPreMigrationInstructionValidators) {
     this.customPreMigrationInstructionValidators = customPreMigrationInstructionValidators;
   }
 
@@ -4623,17 +4621,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public List<MigrationInstructionValidator> getDefaultMigrationInstructionValidators() {
     List<MigrationInstructionValidator> validators = new ArrayList<>();
-    validators.add(new SameBehaviorInstructionValidator());
-    validators.add(new SameEventTypeValidator());
-    validators.add(new OnlyOnceMappedActivityInstructionValidator());
-    validators.add(new CannotAddMultiInstanceBodyValidator());
-    validators.add(new CannotAddMultiInstanceInnerActivityValidator());
-    validators.add(new CannotRemoveMultiInstanceInnerActivityValidator());
-    validators.add(new GatewayMappingValidator());
-    validators.add(new SameEventScopeInstructionValidator());
-    validators.add(new UpdateEventTriggersValidator());
-    validators.add(new AdditionalFlowScopeInstructionValidator());
-    validators.add(new ConditionalEventUpdateEventTriggerValidator());
+    for (MigrationInstructionValidator validator : ServiceLoader.load(MigrationInstructionValidator.class)) {
+      validators.add(validator);
+    }
     return validators;
   }
 
@@ -4645,7 +4635,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return migratingActivityInstanceValidators;
   }
 
-  public void setCustomPostMigratingActivityInstanceValidators(List<MigratingActivityInstanceValidator> customPostMigratingActivityInstanceValidators) {
+  public void setCustomPostMigratingActivityInstanceValidators(
+          List<MigratingActivityInstanceValidator> customPostMigratingActivityInstanceValidators) {
     this.customPostMigratingActivityInstanceValidators = customPostMigratingActivityInstanceValidators;
   }
 
@@ -4653,7 +4644,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return customPostMigratingActivityInstanceValidators;
   }
 
-  public void setCustomPreMigratingActivityInstanceValidators(List<MigratingActivityInstanceValidator> customPreMigratingActivityInstanceValidators) {
+  public void setCustomPreMigratingActivityInstanceValidators(
+          List<MigratingActivityInstanceValidator> customPreMigratingActivityInstanceValidators) {
     this.customPreMigratingActivityInstanceValidators = customPreMigratingActivityInstanceValidators;
   }
 
@@ -4671,22 +4663,13 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public List<MigratingActivityInstanceValidator> getDefaultMigratingActivityInstanceValidators() {
     List<MigratingActivityInstanceValidator> validators = new ArrayList<>();
-
-    validators.add(new NoUnmappedLeafInstanceValidator());
-    validators.add(new VariableConflictActivityInstanceValidator());
-    validators.add(new SupportedActivityInstanceValidator());
-
+    ServiceLoader.load(MigratingActivityInstanceValidator.class).forEach(validators::add);
     return validators;
   }
 
   public List<MigratingTransitionInstanceValidator> getDefaultMigratingTransitionInstanceValidators() {
     List<MigratingTransitionInstanceValidator> validators = new ArrayList<>();
-
-    validators.add(new NoUnmappedLeafInstanceValidator());
-    validators.add(new AsyncAfterMigrationValidator());
-    validators.add(new AsyncProcessStartMigrationValidator());
-    validators.add(new AsyncMigrationValidator());
-
+    ServiceLoader.load(MigratingTransitionInstanceValidator.class).forEach(validators::add);
     return validators;
   }
 
@@ -4889,7 +4872,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    * {@code isMetricsEnabled} are true
    *
    * @return {@code true} if both history cleanup metrics and general metrics are enabled,
-   *         {@code false} otherwise.
+   * {@code false} otherwise.
    */
   public boolean isHistoryCleanupMetricsEnabled() {
     return historyCleanupMetricsEnabled && isMetricsEnabled;
@@ -4925,7 +4908,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return this;
   }
 
-  public ProcessEngineConfigurationImpl setJobExecutorAcquireExclusiveOverProcessHierarchies(boolean jobExecutorAcquireExclusiveOverProcessHierarchies) {
+  public ProcessEngineConfigurationImpl setJobExecutorAcquireExclusiveOverProcessHierarchies(
+          boolean jobExecutorAcquireExclusiveOverProcessHierarchies) {
     this.jobExecutorAcquireExclusiveOverProcessHierarchies = jobExecutorAcquireExclusiveOverProcessHierarchies;
     return this;
   }
@@ -5218,7 +5202,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return enableOptimisticLockingOnForeignKeyViolation;
   }
 
-  public ProcessEngineConfigurationImpl setEnableOptimisticLockingOnForeignKeyViolation(boolean enableOptimisticLockingOnForeignKeyViolation) {
+  public ProcessEngineConfigurationImpl setEnableOptimisticLockingOnForeignKeyViolation(
+          boolean enableOptimisticLockingOnForeignKeyViolation) {
     this.enableOptimisticLockingOnForeignKeyViolation = enableOptimisticLockingOnForeignKeyViolation;
     return this;
   }
@@ -5227,7 +5212,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return dmnFeelCustomFunctionProviders;
   }
 
-  public ProcessEngineConfigurationImpl setDmnFeelCustomFunctionProviders(List<FeelCustomFunctionProvider> dmnFeelCustomFunctionProviders) {
+  public ProcessEngineConfigurationImpl setDmnFeelCustomFunctionProviders(
+          List<FeelCustomFunctionProvider> dmnFeelCustomFunctionProviders) {
     this.dmnFeelCustomFunctionProviders = dmnFeelCustomFunctionProviders;
     return this;
   }
@@ -5253,6 +5239,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   public DiagnosticsCollector getDiagnosticsCollector() {
     return diagnosticsCollector;
   }
+
   public void setDiagnosticsCollector(DiagnosticsCollector diagnosticsCollector) {
     this.diagnosticsCollector = diagnosticsCollector;
   }
@@ -5304,7 +5291,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   public boolean isLegacyJobRetryBehaviorEnabled() {
     return legacyJobRetryBehaviorEnabled;
   }
-  
+
   public ProcessEngineConfiguration setLegacyJobRetryBehaviorEnabled(boolean legacyJobRetryBehaviorEnabled) {
     this.legacyJobRetryBehaviorEnabled = legacyJobRetryBehaviorEnabled;
     return this;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/errorcode/DefaultExceptionCodeProvider.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/errorcode/DefaultExceptionCodeProvider.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.errorcode;
+
+public class DefaultExceptionCodeProvider implements ExceptionCodeProvider {
+}

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/errorcode/ExceptionCodeProvider.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/errorcode/ExceptionCodeProvider.java
@@ -55,7 +55,6 @@ public interface ExceptionCodeProvider {
   default Integer provideCode(ProcessEngineException processEngineException) {
     if (processEngineException instanceof OptimisticLockingException) {
       return OPTIMISTIC_LOCKING.getCode();
-
     }
 
     return null;

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.ArtifactFactory
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.ArtifactFactory
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.DefaultArtifactFactory

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.AuthorizationService
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.AuthorizationService
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.AuthorizationServiceImpl

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.CaseService
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.CaseService
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.cmmn.CaseServiceImpl

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.DecisionService
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.DecisionService
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.DecisionServiceImpl

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.ExternalTaskService
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.ExternalTaskService
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.ExternalTaskServiceImpl

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.FilterService
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.FilterService
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.FilterServiceImpl

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.FormService
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.FormService
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.FormServiceImpl

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.HistoryService
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.HistoryService
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.HistoryServiceImpl

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.IdentityService
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.IdentityService
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.IdentityServiceImpl

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.RepositoryService
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.RepositoryService
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.RepositoryServiceImpl

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.RuntimeService
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.RuntimeService
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.RuntimeServiceImpl

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.TaskService
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.TaskService
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.TaskServiceImpl

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.identity.PasswordPolicy
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.identity.PasswordPolicy
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.identity.DefaultPasswordPolicyImpl

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.OptimizeService
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.OptimizeService
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.OptimizeService

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.batch.BatchJobHandler
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.batch.BatchJobHandler
@@ -1,0 +1,14 @@
+org.operaton.bpm.engine.impl.migration.batch.MigrationBatchJobHandler
+org.operaton.bpm.engine.impl.ModificationBatchJobHandler
+org.operaton.bpm.engine.impl.batch.deletion.DeleteProcessInstancesJobHandler
+org.operaton.bpm.engine.impl.batch.deletion.DeleteHistoricProcessInstancesJobHandler
+org.operaton.bpm.engine.impl.batch.job.SetJobRetriesJobHandler
+org.operaton.bpm.engine.impl.batch.externaltask.SetExternalTaskRetriesJobHandler
+org.operaton.bpm.engine.impl.RestartProcessInstancesJobHandler
+org.operaton.bpm.engine.impl.batch.update.UpdateProcessInstancesSuspendStateJobHandler
+org.operaton.bpm.engine.impl.dmn.batch.DeleteHistoricDecisionInstancesJobHandler
+org.operaton.bpm.engine.impl.batch.removaltime.ProcessSetRemovalTimeJobHandler
+org.operaton.bpm.engine.impl.batch.removaltime.DecisionSetRemovalTimeJobHandler
+org.operaton.bpm.engine.impl.batch.removaltime.BatchSetRemovalTimeJobHandler
+org.operaton.bpm.engine.impl.batch.variables.BatchSetVariablesHandler
+org.operaton.bpm.engine.impl.batch.message.MessageCorrelationBatchJobHandler

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.cfg.BpmnParseFactory
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.cfg.BpmnParseFactory
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.cfg.DefaultBpmnParseFactory

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.cfg.auth.PermissionProvider
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.cfg.auth.PermissionProvider
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.cfg.auth.DefaultPermissionProvider

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.cfg.auth.ResourceAuthorizationProvider
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.cfg.auth.ResourceAuthorizationProvider
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.cfg.auth.DefaultAuthorizationProvider

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.cmmn.transformer.CmmnTransformFactory
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.cmmn.transformer.CmmnTransformFactory
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.cmmn.transformer.DefaultCmmnTransformFactory

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.digest.PasswordEncryptor
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.digest.PasswordEncryptor
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.digest.Sha512HashDigest

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.digest.SaltGenerator
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.digest.SaltGenerator
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.digest.Default16ByteSaltGenerator

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.errorcode.ExceptionCodeProvider
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.errorcode.ExceptionCodeProvider
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.errorcode.DefaultExceptionCodeProvider

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.history.HistoryRemovalTimeProvider
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.history.HistoryRemovalTimeProvider
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.history.DefaultHistoryRemovalTimeProvider

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.history.producer.CmmnHistoryEventProducer
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.history.producer.CmmnHistoryEventProducer
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.history.producer.CacheAwareCmmnHistoryEventProducer

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.history.producer.DmnHistoryEventProducer
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.history.producer.DmnHistoryEventProducer
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.history.producer.DefaultDmnHistoryEventProducer

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.history.producer.HistoryEventProducer
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.history.producer.HistoryEventProducer
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.history.producer.CacheAwareHistoryEventProducer

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.jobexecutor.FailedJobCommandFactory
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.jobexecutor.FailedJobCommandFactory
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.jobexecutor.DefaultFailedJobCommandFactory

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.jobexecutor.historycleanup.BatchWindowManager
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.jobexecutor.historycleanup.BatchWindowManager
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.jobexecutor.historycleanup.DefaultBatchWindowManager

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.migration.MigrationActivityMatcher
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.migration.MigrationActivityMatcher
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.migration.DefaultMigrationActivityMatcher

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.migration.validation.instance.MigratingActivityInstanceValidator
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.migration.validation.instance.MigratingActivityInstanceValidator
@@ -1,0 +1,3 @@
+org.operaton.bpm.engine.impl.migration.validation.instance.NoUnmappedLeafInstanceValidator
+org.operaton.bpm.engine.impl.migration.validation.instance.VariableConflictActivityInstanceValidator
+org.operaton.bpm.engine.impl.migration.validation.instance.SupportedActivityInstanceValidator

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.migration.validation.instance.MigratingTransitionInstanceValidator
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.migration.validation.instance.MigratingTransitionInstanceValidator
@@ -1,0 +1,4 @@
+org.operaton.bpm.engine.impl.migration.validation.instance.NoUnmappedLeafInstanceValidator
+org.operaton.bpm.engine.impl.migration.validation.instance.AsyncAfterMigrationValidator
+org.operaton.bpm.engine.impl.migration.validation.instance.AsyncProcessStartMigrationValidator
+org.operaton.bpm.engine.impl.migration.validation.instance.AsyncMigrationValidator

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.migration.validation.instruction.MigrationInstructionValidator
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.migration.validation.instruction.MigrationInstructionValidator
@@ -1,0 +1,11 @@
+org.operaton.bpm.engine.impl.migration.validation.instruction.SameBehaviorInstructionValidator
+org.operaton.bpm.engine.impl.migration.validation.instruction.SameEventTypeValidator
+org.operaton.bpm.engine.impl.migration.validation.instruction.OnlyOnceMappedActivityInstructionValidator
+org.operaton.bpm.engine.impl.migration.validation.instruction.CannotAddMultiInstanceBodyValidator
+org.operaton.bpm.engine.impl.migration.validation.instruction.CannotAddMultiInstanceInnerActivityValidator
+org.operaton.bpm.engine.impl.migration.validation.instruction.CannotRemoveMultiInstanceInnerActivityValidator
+org.operaton.bpm.engine.impl.migration.validation.instruction.GatewayMappingValidator
+org.operaton.bpm.engine.impl.migration.validation.instruction.SameEventScopeInstructionValidator
+org.operaton.bpm.engine.impl.migration.validation.instruction.UpdateEventTriggersValidator
+org.operaton.bpm.engine.impl.migration.validation.instruction.AdditionalFlowScopeInstructionValidator
+org.operaton.bpm.engine.impl.migration.validation.instruction.ConditionalEventUpdateEventTriggerValidator

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.persistence.deploy.cache.CacheFactory
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.persistence.deploy.cache.CacheFactory
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.persistence.deploy.cache.DefaultCacheFactory

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.runtime.ConditionHandler
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.runtime.ConditionHandler
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.runtime.DefaultConditionHandler

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.runtime.CorrelationHandler
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.impl.runtime.CorrelationHandler
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.runtime.DefaultCorrelationHandler

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.repository.DeploymentHandlerFactory
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.repository.DeploymentHandlerFactory
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.repository.DefaultDeploymentHandlerFactory

--- a/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.runtime.DeserializationTypeValidator
+++ b/engine/src/main/resources/META-INF/services/org.operaton.bpm.engine.runtime.DeserializationTypeValidator
@@ -1,0 +1,1 @@
+org.operaton.bpm.engine.impl.runtime.DefaultDeserializationTypeValidator

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/errorcode/DefaultExceptionCodeProviderTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/errorcode/DefaultExceptionCodeProviderTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.errorcode;
+
+import org.junit.jupiter.api.Test;
+import org.operaton.bpm.engine.OptimisticLockingException;
+import org.operaton.bpm.engine.ProcessEngineException;
+import org.operaton.bpm.engine.impl.util.ExceptionUtil;
+import org.operaton.commons.utils.ServiceLoaderUtil;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+class DefaultExceptionCodeProviderTest {
+  /** @see BuiltinExceptionCode#OPTIMISTIC_LOCKING */
+  private static final int CODE_OPTIMISTIC_LOCKING = 1;
+  /** @see BuiltinExceptionCode#DEADLOCK */
+  private static final int CODE_DEADLOCK = 10_000;
+  /** @see BuiltinExceptionCode#FOREIGN_KEY_CONSTRAINT_VIOLATION */
+  private static final int CODE_FOREIGN_KEY_CONSTRAINT_VIOLATION = 10_001;
+  /** @see BuiltinExceptionCode#COLUMN_SIZE_TOO_SMALL */
+  private static final int CODE_COLUMN_SIZE_TOO_SMALL = 10_002;
+
+  DefaultExceptionCodeProvider exceptionCodeProvider = new DefaultExceptionCodeProvider();
+
+  @Test
+  void canBeLoadedViaServiceLoader () {
+    assertThat(ServiceLoaderUtil.loadSingleService(ExceptionCodeProvider.class)).isInstanceOf(DefaultExceptionCodeProvider.class);
+  }
+
+  @Test
+  void provideCode_returnsOptimisticLockingCode_whenCalledWithOptimisticLockingException () {
+    assertThat(exceptionCodeProvider.provideCode(mock(OptimisticLockingException.class))).isEqualTo(CODE_OPTIMISTIC_LOCKING);
+  }
+
+  @Test
+  void provideCode_returnsNull_whenCalledWithProcessEngineException () {
+    assertThat(exceptionCodeProvider.provideCode(mock(ProcessEngineException.class))).isNull();
+  }
+
+  @Test
+  void provideCode_returnsDeadlockCode_whenDetected () {
+    // given
+    try (var exceptionUtil = mockStatic(ExceptionUtil.class)) {
+      exceptionUtil.when(() -> ExceptionUtil.checkDeadlockException(any())).thenReturn(true);
+      var sqlException = mock(SQLException.class);
+
+      // when
+      Integer code = exceptionCodeProvider.provideCode(sqlException);
+
+      // then
+      assertThat(code).isEqualTo(CODE_DEADLOCK);
+    }
+  }
+
+  @Test
+  void provideCode_returnsForeignKeyViolationCode_whenDetected () {
+    // given
+    try (var exceptionUtil = mockStatic(ExceptionUtil.class)) {
+      exceptionUtil.when(() -> ExceptionUtil.checkForeignKeyConstraintViolation(any(SQLException.class))).thenReturn(true);
+      var sqlException = mock(SQLException.class);
+
+      // when
+      Integer code = exceptionCodeProvider.provideCode(sqlException);
+
+      // then
+      assertThat(code).isEqualTo(CODE_FOREIGN_KEY_CONSTRAINT_VIOLATION);
+    }
+  }
+
+  @Test
+  void provideCode_returnsColumnSizeTooSmallCode_whenValueTooLongDetected () {
+    // given
+    try (var exceptionUtil = mockStatic(ExceptionUtil.class)) {
+      exceptionUtil.when(() -> ExceptionUtil.checkValueTooLongException(any(SQLException.class))).thenReturn(true);
+      var sqlException = mock(SQLException.class);
+
+      // when
+      Integer code = exceptionCodeProvider.provideCode(sqlException);
+
+      // then
+      assertThat(code).isEqualTo(CODE_COLUMN_SIZE_TOO_SMALL);
+    }
+  }
+
+  @Test
+  void provideCode_returnsNull_whenOtherSQLException () {
+    // given
+    var sqlException = mock(SQLException.class);
+
+    // when
+    Integer code = exceptionCodeProvider.provideCode(sqlException);
+
+    // then
+    assertThat(code).isNull();
+  }
+}


### PR DESCRIPTION
Register services via service loader for simple services.

## Motivation

`ProcessEngineConfigurationImpl` has a tight coupling to implementation classes. Potential changes of SPI implementations have to be called in code via setters and requires knowledge to the ProcessEngineConfigurationImpl implementation class to achieve a different configuration.

This is a non-breaking change in order to decouple API/SPI from internal implementation.