### PR TITLE
chore(deps): Upgrade gson to 2.13.2

### DIFF
--- a/engine-rest/engine-rest-openapi/pom.xml
+++ b/engine-rest/engine-rest-openapi/pom.xml
@@ -18,7 +18,6 @@
     <gson-fire-version>1.9.0</gson-fire-version>
     <swagger-core-version>2.1.36</swagger-core-version>
     <okhttp-version>5.3.2</okhttp-version>
-    <gson-version>2.8.9</gson-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>
     <surefire.forkCount>1</surefire.forkCount>
   </properties>
@@ -93,7 +92,6 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>${gson-version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -29,7 +29,7 @@
     <version.json-smart>2.5.2</version.json-smart>
     <version.accessors-smart>2.5.2</version.accessors-smart>
     <version.commons-codec>1.19.0</version.commons-codec>
-    <version.gson>2.8.9</version.gson>
+    <version.gson>2.13.2</version.gson>
     <version.hibernate>6.6.10.Final</version.hibernate>
     <version.jackson>2.20.1</version.jackson>
     <version.httpclient>4.5.14</version.httpclient>


### PR DESCRIPTION
Upgrade gson to latest version 2.13.2. gson is shaded into the engine jar.

closes #1821 