### PR TITLE
feat(qa): Add JUnit 6 support with junit6 classifier artifact (#1751)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -8,8 +8,8 @@
 
 ## Best Practices for Writing Test Cases
 
-* **Use JUnit 5**, do not write JUnit 4 tests
-* **Leverage the `ProcessEngineExtension`**: In the `operaton-engine` project, if you need a process engine object, use the `org.operaton.bpm.engine.test.extension.ProcessEngineExtension`. This extension integrates seamlessly with JUnit 5 and ensures that the process engine object is reused across test cases and that certain integrity checks are performed after every test. Example:
+* **Use JUnit 6 or JUnit 5**, do not write JUnit 4 tests
+* **Leverage the `ProcessEngineExtension`**: In the `operaton-engine` project, if you need a process engine object, use the `org.operaton.bpm.engine.test.extension.ProcessEngineExtension`. This extension integrates seamlessly with JUnit 6/5 and ensures that the process engine object is reused across test cases and that certain integrity checks are performed after every test. Example:
 
   ```java
   public class MyProcessEngineTest {
@@ -32,8 +32,21 @@
   }
   ```
 
-* Use the JUnit 5 extensions in your `pom.xml`
+* Use the JUnit 6/5 extensions in your `pom.xml`
  
+  For JUnit 6 compatible artifacts:
+  
+  ```xml
+  <dependency>
+    <groupId>org.operaton.bpm</groupId>
+    <artifactId>operaton-engine</artifactId>
+    <classifier>junit6</classifier>
+    <scope>test</scope>
+  </dependency>
+  ```
+  
+  Or for JUnit 5:
+  
   ```xml
   <dependency>
     <groupId>org.operaton.bpm</groupId>
@@ -42,7 +55,7 @@
   </dependency>
   ```
 * **Custom ProcessEngine Configuration**: If you need a process engine with custom configuration, use the `ProcessEngineExtension.builder()` method to specify configuration options, as shown in the example above.
-* **Avoid Static Rules and Inheritance**: Instead of extending a base class, favor composition by leveraging ProcessEngineExtension and dependency injection. This approach is cleaner and more flexible in JUnit 5.
+* **Avoid Static Rules and Inheritance**: Instead of extending a base class, favor composition by leveraging ProcessEngineExtension and dependency injection. This approach is cleaner and more flexible in JUnit 6/5.
 * **Consider to use AssertJ**: AssertJ allows a fluent style for writing test assertions. You will find its usage in Operaton's tests as reference.  
 * **Mock when possible**: Use Mockito when you want to test your logic and you could mock away used services. Unit tests are much faster than tests that require a running engine. 
   Consider to make methods under test package-private, so that they can't be accessed outside, but a unit test which is located usually in the same package can do. 

--- a/bom/operaton-only-bom/pom.xml
+++ b/bom/operaton-only-bom/pom.xml
@@ -32,6 +32,12 @@
       </dependency>
       <dependency>
         <groupId>org.operaton.bpm</groupId>
+        <artifactId>operaton-engine</artifactId>
+        <version>${project.version}</version>
+        <classifier>junit6</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.operaton.bpm</groupId>
         <artifactId>operaton-engine-cdi</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/distro/run/qa/integration-tests/pom.xml
+++ b/distro/run/qa/integration-tests/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>test</scope>
       <version>${project.version}</version>
     </dependency>

--- a/engine-cdi/pom.xml
+++ b/engine-cdi/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>test</scope>
       <version>${project.version}</version>
     </dependency>

--- a/engine-dmn/engine/pom.xml
+++ b/engine-dmn/engine/pom.xml
@@ -199,6 +199,16 @@
               <classesDirectory>${project.build.directory}/classes-junit5</classesDirectory>
             </configuration>
           </execution>
+          <execution>
+            <id>junit6-jar</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>junit6</classifier>
+              <classesDirectory>${project.build.directory}/classes-junit6</classesDirectory>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -244,6 +254,22 @@
               </compileSourceRoots>
               <!-- Set its own output directory -->
               <outputDirectory>${project.build.directory}/classes-junit5</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>junit6-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <!-- Specify the extra test source folder -->
+              <compileSourceRoots>
+                <compileSourceRoot>${project.basedir}/src/main/junit-shared</compileSourceRoot>
+                <compileSourceRoot>${project.basedir}/src/main/junit5</compileSourceRoot>
+              </compileSourceRoots>
+              <!-- Set its own output directory -->
+              <outputDirectory>${project.build.directory}/classes-junit6</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/engine-plugins/connect-plugin/pom.xml
+++ b/engine-plugins/connect-plugin/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/engine-plugins/pom.xml
+++ b/engine-plugins/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/engine-plugins/spin-plugin/pom.xml
+++ b/engine-plugins/spin-plugin/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/engine-spring/pom.xml
+++ b/engine-spring/pom.xml
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>test</scope>
       <version>${project.version}</version>
     </dependency>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -544,6 +544,21 @@
               <classesDirectory>${project.build.directory}/classes-junit5</classesDirectory>
             </configuration>
           </execution>
+          <execution>
+            <id>junit6-jar</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>org/operaton/bpm/container/impl/jmx/deployment/Mock*.class</include>
+                <include>org/operaton/bpm/engine/impl/test/*TestCase.class</include>
+                <include>org/operaton/bpm/engine/test/**</include>
+              </includes>
+              <classifier>junit6</classifier>
+              <classesDirectory>${project.build.directory}/classes-junit6</classesDirectory>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -608,6 +623,20 @@
                 <compileSourceRoot>${project.basedir}/src/main/junit5</compileSourceRoot>
               </compileSourceRoots>
               <outputDirectory>${project.build.directory}/classes-junit5</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>junit6-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <compileSourceRoots>
+                <compileSourceRoot>${project.basedir}/src/main/junit-shared</compileSourceRoot>
+                <compileSourceRoot>${project.basedir}/src/main/junit5</compileSourceRoot>
+              </compileSourceRoots>
+              <outputDirectory>${project.build.directory}/classes-junit6</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -33,7 +33,7 @@
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
       <scope>test</scope>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -171,7 +171,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/qa/integration-tests-webapps/integration-tests/pom.xml
+++ b/qa/integration-tests-webapps/integration-tests/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/qa/large-data-tests/pom.xml
+++ b/qa/large-data-tests/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/qa/performance-tests-engine/pom.xml
+++ b/qa/performance-tests-engine/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat</groupId>

--- a/qa/test-db-util/pom.xml
+++ b/qa/test-db-util/pom.xml
@@ -31,7 +31,7 @@
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
       <version>${project.version}</version>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/quarkus-extension/engine/deployment/pom.xml
+++ b/quarkus-extension/engine/deployment/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>test</scope>
       <version>${project.version}</version>
     </dependency>

--- a/quarkus-extension/engine/qa/pom.xml
+++ b/quarkus-extension/engine/qa/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>test</scope>
       <version>${project.version}</version>
     </dependency>

--- a/spring-boot-starter/starter-test-junit5/pom.xml
+++ b/spring-boot-starter/starter-test-junit5/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/spring-boot-starter/starter-webapp-core/pom.xml
+++ b/spring-boot-starter/starter-webapp-core/pom.xml
@@ -31,7 +31,7 @@
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
       <scope>test</scope>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/spring-boot-starter/starter/pom.xml
+++ b/spring-boot-starter/starter/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>test</scope>
     </dependency>
     <!-- Spring dependencies required by operaton-engine-spring -->

--- a/test-utils/assert/core/pom.xml
+++ b/test-utils/assert/core/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test-utils/assert/qa/pom.xml
+++ b/test-utils/assert/qa/pom.xml
@@ -38,7 +38,7 @@
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
       <scope>test</scope>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
     </dependency>
     <dependency>
       <groupId>org.operaton.bpm</groupId>

--- a/test-utils/junit5-extension/README.md
+++ b/test-utils/junit5-extension/README.md
@@ -1,11 +1,30 @@
-# Operaton JUnit 5
+# Operaton JUnit 6 / JUnit 5
 
-JUnit 5 extension that allows you to inject a process engine into your test.
+JUnit 6 and JUnit 5 extension that allows you to inject a process engine into your test.
+
+## Compatibility
+
+This extension is compatible with both JUnit 6 and JUnit 5. Operaton provides separate artifacts with classifiers for each version:
+
+- **JUnit 6**: Use the `junit6` classifier artifact
+- **JUnit 5**: Use the `junit5` classifier artifact
 
 ## Usage
 
 ### Maven dependency
-Add the dependency to your pom.xml
+
+For JUnit 6 compatible engine test classes, use:
+
+```xml
+    <dependency>
+      <groupId>org.operaton.bpm</groupId>
+      <artifactId>operaton-engine</artifactId>
+      <classifier>junit6</classifier>
+      <scope>test</scope>
+    </dependency>
+```
+
+For JUnit 5, add the dependency to your pom.xml:
 
 ```xml
     <dependency>

--- a/webapps/assembly/pom.xml
+++ b/webapps/assembly/pom.xml
@@ -109,7 +109,7 @@
     <dependency>
       <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine</artifactId>
-      <classifier>junit5</classifier>
+      <classifier>junit6</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
- Upgrade JUnit version from 5.14.1 to 6.0.1
- Add junit6 classifier jar creation to engine and engine-dmn modules
- Add junit6 to BOM (keeping junit5 for backwards compatibility)
- Update all test dependencies to use junit6 classifier instead of junit5
-  Document JUnit 6 support in testing guidelines
- Update TESTING.md to mention JUnit 5/6 compatibility
- Update junit5-extension README with JUnit 6 usage examples
- Add maven dependency examples for junit6 classifier

Related to: #1729 

---------