### PR TITLE
normalize platform-dependent newlines and simplify assertions

### DIFF
--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/validation/ModelValidationTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/validation/ModelValidationTest.java
@@ -87,7 +87,9 @@ class ModelValidationTest {
     StringWriter stringWriter = new StringWriter();
     results.write(stringWriter, new TestResultFormatter());
 
-    assertThat(stringWriter).hasToString("tweety\n\tERROR (20): Bird tweety is illegal\n");
+    // Use platform-independent comparison by normalizing newlines
+    assertThat(stringWriter.toString())
+        .isEqualToNormalizingNewlines("tweety\n\tERROR (20): Bird tweety is illegal\n");
   }
 
   @Test

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/db/QuerySessionFactoryTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/db/QuerySessionFactoryTest.java
@@ -77,7 +77,8 @@ class QuerySessionFactoryTest {
     var document = builder.parse(new ByteArrayInputStream(mappings.getBytes()));
     assertThat(document.getDocumentElement().getNodeName()).isEqualTo("configuration");
 
-    assertThat(mappings)
+    // normalize newlines only for the assertion
+    assertThat(mappings.replace("\r\n", "\n"))
       .contains("<mapper resource=\"foo/mapping1.xml\" />\n")
       .contains("<mapper resource=\"bar/mapping2.xml\" />\n");
   }

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/filter/TemplateFilterTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/filter/TemplateFilterTest.java
@@ -61,15 +61,28 @@ class TemplateFilterTest {
       .thenReturn(getClass().getResourceAsStream("/WEB-INF/session/web.xml"));
 
     // when
-
     String contents = filter.getWebResourceContents("web.xml");
 
     // then
-    assertThat(contents).
-      isNotEmpty()
-      .startsWith("""
+    assertThat(contents)
+      .isNotEmpty()
+      .isEqualToNormalizingNewlines("""
         <?xml version="1.0" encoding="UTF-8"?>
         <web-app version="6.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns="https://jakarta.ee/xml/ns/jakartaee" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd">
+
+          <display-name>Operaton webapp</display-name>
+
+          <filter>
+            <filter-name>SessionCookieFilter</filter-name>
+            <filter-class>org.operaton.bpm.webapp.impl.security.filter.SessionCookieFilter</filter-class>
+          </filter>
+          <filter-mapping>
+            <filter-name>SessionCookieFilter</filter-name>
+            <url-pattern>/*</url-pattern>
+          </filter-mapping>
+
+        </web-app>
         """);
   }
 


### PR DESCRIPTION
### 📄 Summary

This PR fixes platform-dependent test failures on Windows by normalizing newlines in XML-based test assertions and simplifying related mappings assertions. The changes ensure tests behave consistently across operating systems.

### 🔗 Related Issues

Fixes #1801

### 📌 Motivation and Context

Some tests failed on Windows due to differences in line separators (CRLF vs. LF). The production code correctly uses platform-dependent newlines via `%n`, but test expectations were hardcoded to `\n`. This caused assertion mismatches on Windows systems. The goal of this change is to make tests platform-independent and more robust.

### 🧪 How Was This Tested?

- Ran affected unit tests on Windows and Unix-based systems.
- Executed `mvn clean test` to ensure no regressions were introduced.

### 🖼️ Screenshots or Logs (if applicable)

N/A

### 💥 Breaking Changes?

- [ ] Yes
- [x] No

---

### ✅ Pull Request Checklist

#### 📋 Administrative
- [x] I have read and followed the [contribution guidelines](https://github.com/operaton/operaton/blob/main/CONTRIBUTING.md)
- [x] I confirm that my contribution complies with the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) and the [Code of Conduct](https://github.com/operaton/operaton/blob/main/CODE_OF_CONDUCT.md)
- [x] I confirm that I own the copyright of the code submitted and I license it under the Apache License 2.0
- [x] This PR references an issue (e.g., `Fixes #123`)


#### 🧪 Testing
- [x] I have read and followed the [Testing Guidelines](https://github.com/operaton/operaton/blob/main/TESTING.md)
- [x] Unit tests were written or updated
- [x] `mvn clean test` passes all unit tests
---

### 🧭 Change Type

Please select the type of change this PR introduces:

- [x] 🐛 Bugfix
- [ ] ✨ Feature
- [ ] 💄 Code style update (formatting, renaming)
- [ ] 🔨 Refactoring (no functional or API changes)
- [ ] 🏗 Build-related changes
- [ ] 📝 Documentation content changes
- [ ] 🔧 Other (please describe):
