### PR TITLE
refactor(model-api): Deprecate clone() implememtation and replace by copy()

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrateEventSubProcessAndTriggerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrateEventSubProcessAndTriggerTest.java
@@ -75,7 +75,7 @@ public class MigrateEventSubProcessAndTriggerTest {
 
   @TestTemplate
   void testMigrateEventSubprocessSignalTrigger() {
-    BpmnModelInstance processModel = ProcessModels.ONE_TASK_PROCESS.clone();
+    BpmnModelInstance processModel = ProcessModels.ONE_TASK_PROCESS.copy();
     MigratingBpmnEventTrigger eventTrigger = eventFactory.addEventSubProcess(
         rule.getProcessEngine(),
         processModel,

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationActiveEventSubProcessTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationActiveEventSubProcessTest.java
@@ -74,7 +74,7 @@ public class MigrationActiveEventSubProcessTest {
   @TestTemplate
   void testMigrateActiveCompensationEventSubProcess() {
     // given
-    BpmnModelInstance processModel = ProcessModels.ONE_TASK_PROCESS.clone();
+    BpmnModelInstance processModel = ProcessModels.ONE_TASK_PROCESS.copy();
     MigratingBpmnEventTrigger eventTrigger = eventFactory.addEventSubProcess(
         rule.getProcessEngine(),
         processModel,

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationBoundaryEventsParameterizedTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/MigrationBoundaryEventsParameterizedTest.java
@@ -87,7 +87,7 @@ public class MigrationBoundaryEventsParameterizedTest {
   @TestTemplate
   void testMigrateBoundaryEventOnUserTask() {
     // given
-    BpmnModelInstance sourceProcess = ProcessModels.ONE_TASK_PROCESS.clone();
+    BpmnModelInstance sourceProcess = ProcessModels.ONE_TASK_PROCESS.copy();
     MigratingBpmnEventTrigger eventTrigger = eventFactory.addBoundaryEvent(
         rule.getProcessEngine(),
         sourceProcess,
@@ -122,7 +122,7 @@ public class MigrationBoundaryEventsParameterizedTest {
   @TestTemplate
   void testMigrateBoundaryEventOnUserTaskAndTriggerEvent() {
     // given
-    BpmnModelInstance sourceProcess = ProcessModels.ONE_TASK_PROCESS.clone();
+    BpmnModelInstance sourceProcess = ProcessModels.ONE_TASK_PROCESS.copy();
     MigratingBpmnEventTrigger eventTrigger = eventFactory.addBoundaryEvent(
         rule.getProcessEngine(),
         sourceProcess,
@@ -156,7 +156,7 @@ public class MigrationBoundaryEventsParameterizedTest {
   @TestTemplate
   void testMigrateBoundaryEventOnConcurrentUserTask() {
     // given
-    BpmnModelInstance sourceProcess = ProcessModels.PARALLEL_GATEWAY_PROCESS.clone();
+    BpmnModelInstance sourceProcess = ProcessModels.PARALLEL_GATEWAY_PROCESS.copy();
     MigratingBpmnEventTrigger eventTrigger = eventFactory.addBoundaryEvent(
         rule.getProcessEngine(),
         sourceProcess,
@@ -195,7 +195,7 @@ public class MigrationBoundaryEventsParameterizedTest {
   @TestTemplate
   void testMigrateBoundaryEventOnConcurrentUserTaskAndTriggerEvent() {
     // given
-    BpmnModelInstance sourceProcess = ProcessModels.PARALLEL_GATEWAY_PROCESS.clone();
+    BpmnModelInstance sourceProcess = ProcessModels.PARALLEL_GATEWAY_PROCESS.copy();
     MigratingBpmnEventTrigger eventTrigger = eventFactory.addBoundaryEvent(
         rule.getProcessEngine(),
         sourceProcess,
@@ -232,7 +232,7 @@ public class MigrationBoundaryEventsParameterizedTest {
   @TestTemplate
   void testMigrateBoundaryEventOnConcurrentScopeUserTask() {
     // given
-    BpmnModelInstance sourceProcess = ProcessModels.PARALLEL_SCOPE_TASKS.clone();
+    BpmnModelInstance sourceProcess = ProcessModels.PARALLEL_SCOPE_TASKS.copy();
     MigratingBpmnEventTrigger eventTrigger = eventFactory.addBoundaryEvent(
         rule.getProcessEngine(),
         sourceProcess,
@@ -271,7 +271,7 @@ public class MigrationBoundaryEventsParameterizedTest {
   @TestTemplate
   void testMigrateBoundaryEventOnConcurrentScopeUserTaskAndTriggerEvent() {
     // given
-    BpmnModelInstance sourceProcess = ProcessModels.PARALLEL_SCOPE_TASKS.clone();
+    BpmnModelInstance sourceProcess = ProcessModels.PARALLEL_SCOPE_TASKS.copy();
     MigratingBpmnEventTrigger eventTrigger = eventFactory.addBoundaryEvent(
         rule.getProcessEngine(),
         sourceProcess,
@@ -308,7 +308,7 @@ public class MigrationBoundaryEventsParameterizedTest {
   @TestTemplate
   void testMigrateBoundaryEventToSubProcess() {
     // given
-    BpmnModelInstance sourceProcess = ProcessModels.SUBPROCESS_PROCESS.clone();
+    BpmnModelInstance sourceProcess = ProcessModels.SUBPROCESS_PROCESS.copy();
     MigratingBpmnEventTrigger eventTrigger = eventFactory.addBoundaryEvent(
         rule.getProcessEngine(),
         sourceProcess,
@@ -344,7 +344,7 @@ public class MigrationBoundaryEventsParameterizedTest {
   @TestTemplate
   void testMigrateBoundaryEventToSubProcessAndTriggerEvent() {
     // given
-    BpmnModelInstance sourceProcess = ProcessModels.SUBPROCESS_PROCESS.clone();
+    BpmnModelInstance sourceProcess = ProcessModels.SUBPROCESS_PROCESS.copy();
     MigratingBpmnEventTrigger eventTrigger = eventFactory.addBoundaryEvent(
         rule.getProcessEngine(),
         sourceProcess,
@@ -378,7 +378,7 @@ public class MigrationBoundaryEventsParameterizedTest {
   @TestTemplate
   void testMigrateBoundaryEventToSubProcessWithScopeUserTask() {
     // given
-    BpmnModelInstance sourceProcess = ProcessModels.SCOPE_TASK_SUBPROCESS_PROCESS.clone();
+    BpmnModelInstance sourceProcess = ProcessModels.SCOPE_TASK_SUBPROCESS_PROCESS.copy();
     MigratingBpmnEventTrigger eventTrigger = eventFactory.addBoundaryEvent(
         rule.getProcessEngine(),
         sourceProcess,
@@ -414,7 +414,7 @@ public class MigrationBoundaryEventsParameterizedTest {
   @TestTemplate
   void testMigrateBoundaryEventToSubProcessWithScopeUserTaskAndTriggerEvent() {
     // given
-    BpmnModelInstance sourceProcess = ProcessModels.SCOPE_TASK_SUBPROCESS_PROCESS.clone();
+    BpmnModelInstance sourceProcess = ProcessModels.SCOPE_TASK_SUBPROCESS_PROCESS.copy();
     MigratingBpmnEventTrigger eventTrigger = eventFactory.addBoundaryEvent(
         rule.getProcessEngine(),
         sourceProcess,
@@ -448,7 +448,7 @@ public class MigrationBoundaryEventsParameterizedTest {
   @TestTemplate
   void testMigrateBoundaryEventToParallelSubProcess() {
     // given
-    BpmnModelInstance sourceProcess = ProcessModels.PARALLEL_SUBPROCESS_PROCESS.clone();
+    BpmnModelInstance sourceProcess = ProcessModels.PARALLEL_SUBPROCESS_PROCESS.copy();
     MigratingBpmnEventTrigger eventTrigger = eventFactory.addBoundaryEvent(
         rule.getProcessEngine(),
         sourceProcess,
@@ -487,7 +487,7 @@ public class MigrationBoundaryEventsParameterizedTest {
   @TestTemplate
   void testMigrateBoundaryEventToParallelSubProcessAndTriggerEvent() {
     // given
-    BpmnModelInstance sourceProcess = ProcessModels.PARALLEL_SUBPROCESS_PROCESS.clone();
+    BpmnModelInstance sourceProcess = ProcessModels.PARALLEL_SUBPROCESS_PROCESS.copy();
     MigratingBpmnEventTrigger eventTrigger = eventFactory.addBoundaryEvent(
         rule.getProcessEngine(),
         sourceProcess,

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/ModifiableBpmnModelInstance.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/runtime/migration/ModifiableBpmnModelInstance.java
@@ -64,7 +64,7 @@ public class ModifiableBpmnModelInstance implements BpmnModelInstance {
    * Copies the argument; following modifications are not applied to the original model instance
    */
   public static ModifiableBpmnModelInstance modify(BpmnModelInstance modelInstance) {
-    return new ModifiableBpmnModelInstance(modelInstance.clone());
+    return new ModifiableBpmnModelInstance(modelInstance.copy());
   }
 
   /**
@@ -86,7 +86,12 @@ public class ModifiableBpmnModelInstance implements BpmnModelInstance {
 
   @Override
   public BpmnModelInstance clone() {
-    return modelInstance.clone();
+    return copy();
+  }
+
+  @Override
+  public BpmnModelInstance copy() {
+    return modelInstance.copy();
   }
 
   @Override

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/BpmnModelInstance.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/BpmnModelInstance.java
@@ -43,7 +43,16 @@ public interface BpmnModelInstance extends ModelInstance {
    * Changes of the model are persistent between multiple model instances.
    *
    * @return the new BPMN model instance
+   * @deprecated Use {@link #copy()} instead
    */
+  @Deprecated(forRemoval = true, since = "1.1")
   BpmnModelInstance clone();
 
+  /**
+   * Copies the BPMN model instance but not the model. So only the wrapped DOM document is cloned.
+   * Changes of the model are persistent between multiple model instances.
+   *
+   * @return the new BPMN model instance
+   */
+  BpmnModelInstance copy();
 }

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/BpmnModelInstanceImpl.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/BpmnModelInstanceImpl.java
@@ -47,6 +47,11 @@ public class BpmnModelInstanceImpl extends ModelInstanceImpl implements BpmnMode
 
   @Override
   public BpmnModelInstance clone() {
+    return copy();
+  }
+
+  @Override
+  public BpmnModelInstance copy() {
     return new BpmnModelInstanceImpl(model, modelBuilder, document.clone());
   }
 

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnModelInstanceTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/BpmnModelInstanceTest.java
@@ -36,11 +36,11 @@ class BpmnModelInstanceTest {
     definitions.setId("TestId");
     modelInstance.setDefinitions(definitions);
 
-    BpmnModelInstance cloneInstance = modelInstance.clone();
-    cloneInstance.getDefinitions().setId("TestId2");
+    BpmnModelInstance copiedInstance = modelInstance.copy();
+    copiedInstance.getDefinitions().setId("TestId2");
 
     assertThat(modelInstance.getDefinitions().getId()).isEqualTo("TestId");
-    assertThat(cloneInstance.getDefinitions().getId()).isEqualTo("TestId2");
+    assertThat(copiedInstance.getDefinitions().getId()).isEqualTo("TestId2");
   }
 
 }

--- a/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
+++ b/model-api/bpmn-model/src/test/java/org/operaton/bpm/model/bpmn/OperatonExtensionsTest.java
@@ -72,7 +72,7 @@ public class OperatonExtensionsTest {
   }
 
   private void initModelElements() {
-    modelInstance = originalModelInstance.clone();
+    modelInstance = originalModelInstance.copy();
     process = modelInstance.getModelElementById(PROCESS_ID);
     startEvent = modelInstance.getModelElementById(START_EVENT_ID);
     sequenceFlow = modelInstance.getModelElementById(SEQUENCE_FLOW_ID);

--- a/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/CmmnModelInstance.java
+++ b/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/CmmnModelInstance.java
@@ -41,7 +41,16 @@ public interface CmmnModelInstance extends ModelInstance {
    * Changes of the model are persistent between multiple model instances.
    *
    * @return the new CMMN model instance
+   * @deprecated Use {@link #copy()} instead
    */
+  @Deprecated(forRemoval = true, since = "1.1")
   CmmnModelInstance clone();
 
+  /**
+   * Copies the CMMN model instance but not the model. So only the wrapped DOM document is cloned.
+   * Changes of the model are persistent between multiple model instances.
+   *
+   * @return the new CMMN model instance
+   */
+  CmmnModelInstance copy();
 }

--- a/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/impl/CmmnModelInstanceImpl.java
+++ b/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/impl/CmmnModelInstanceImpl.java
@@ -45,6 +45,11 @@ public class CmmnModelInstanceImpl extends ModelInstanceImpl implements CmmnMode
 
   @Override
   public CmmnModelInstance clone() {
+    return copy();
+  }
+
+  @Override
+  public CmmnModelInstance copy() {
     return new CmmnModelInstanceImpl(model, modelBuilder, document.clone());
   }
 

--- a/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnModelInstanceTest.java
+++ b/model-api/cmmn-model/src/test/java/org/operaton/bpm/model/cmmn/CmmnModelInstanceTest.java
@@ -36,11 +36,11 @@ class CmmnModelInstanceTest {
     definitions.setId("TestId");
     modelInstance.setDefinitions(definitions);
 
-    CmmnModelInstance cloneInstance = modelInstance.clone();
-    cloneInstance.getDefinitions().setId("TestId2");
+    CmmnModelInstance copiedInstance = modelInstance.copy();
+    copiedInstance.getDefinitions().setId("TestId2");
 
     assertThat(modelInstance.getDefinitions().getId()).isEqualTo("TestId");
-    assertThat(cloneInstance.getDefinitions().getId()).isEqualTo("TestId2");
+    assertThat(copiedInstance.getDefinitions().getId()).isEqualTo("TestId2");
   }
 
 }

--- a/model-api/dmn-model/src/main/java/org/operaton/bpm/model/dmn/DmnModelInstance.java
+++ b/model-api/dmn-model/src/main/java/org/operaton/bpm/model/dmn/DmnModelInstance.java
@@ -38,7 +38,16 @@ public interface DmnModelInstance extends ModelInstance {
    * Changes of the model are persistent between multiple model instances.
    *
    * @return the new DMN model instance
+   * @deprecated Use {@link #copy()} instead
    */
+  @Deprecated(forRemoval = true, since = "1.1")
   DmnModelInstance clone();
 
+  /**
+   * Copies the DMN model instance but not the model. So only the wrapped DOM document is cloned.
+   * Changes of the model are persistent between multiple model instances.
+   *
+   * @return the new DMN model instance
+   */
+  DmnModelInstance copy();
 }

--- a/model-api/dmn-model/src/main/java/org/operaton/bpm/model/dmn/impl/DmnModelInstanceImpl.java
+++ b/model-api/dmn-model/src/main/java/org/operaton/bpm/model/dmn/impl/DmnModelInstanceImpl.java
@@ -42,6 +42,11 @@ public class DmnModelInstanceImpl extends ModelInstanceImpl implements DmnModelI
 
   @Override
   public DmnModelInstance clone() {
+    return copy();
+  }
+
+  @Override
+  public DmnModelInstance copy() {
     return new DmnModelInstanceImpl(model, modelBuilder, document.clone());
   }
 

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnModelInstanceTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/DmnModelInstanceTest.java
@@ -37,11 +37,11 @@ class DmnModelInstanceTest {
     definitions.setId("TestId");
     modelInstance.setDefinitions(definitions);
 
-    DmnModelInstance cloneInstance = modelInstance.clone();
-    cloneInstance.getDefinitions().setId("TestId2");
+    DmnModelInstance copiedInstance = modelInstance.copy();
+    copiedInstance.getDefinitions().setId("TestId2");
 
     assertThat(modelInstance.getDefinitions().getId()).isEqualTo("TestId");
-    assertThat(cloneInstance.getDefinitions().getId()).isEqualTo("TestId2");
+    assertThat(copiedInstance.getDefinitions().getId()).isEqualTo("TestId2");
   }
 
   @Test

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ExampleCompatibilityTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/ExampleCompatibilityTest.java
@@ -66,7 +66,7 @@ public class ExampleCompatibilityTest extends DmnModelTest {
    }
 
   public void initExampleCompatibilityTest(DmnModelInstance originalModelInstance) {
-    this.modelInstance = originalModelInstance.clone();
+    this.modelInstance = originalModelInstance.copy();
   }
 
   @MethodSource("parameters")

--- a/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/OperatonExtensionsTest.java
+++ b/model-api/dmn-model/src/test/java/org/operaton/bpm/model/dmn/OperatonExtensionsTest.java
@@ -41,7 +41,7 @@ public class OperatonExtensionsTest {
    }
 
   public void initOperatonExtensionsTest(DmnModelInstance originalModelInstance) {
-    this.modelInstance = originalModelInstance.clone();
+    this.modelInstance = originalModelInstance.copy();
   }
 
   @MethodSource("parameters")

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/ModelInstance.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/ModelInstance.java
@@ -129,8 +129,19 @@ public interface ModelInstance {
    * Changes of the model are persistent between multiple model instances.
    *
    * @return the new model instance
+   * @deprecated Use {@link #copy()} instead
    */
+  @Deprecated(forRemoval = true, since = "1.1")
   ModelInstance clone();
+
+  /**
+   * Copies the model instance but not the model. So only the wrapped DOM document is cloned.
+   * Changes of the model are persistent between multiple model instances.
+   *
+   * @return the new model instance
+   * @since 1.1
+   */
+  ModelInstance copy();
 
   /**
    * Validate semantic properties of this model instance using a collection of validators.

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/ModelInstanceImpl.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/ModelInstanceImpl.java
@@ -157,6 +157,11 @@ public class ModelInstanceImpl implements ModelInstance {
 
   @Override
   public ModelInstance clone() {
+    return copy();
+  }
+
+  @Override
+  public ModelInstance copy() {
       return new ModelInstanceImpl(model, modelBuilder, document.clone());
   }
 

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelInstanceTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelInstanceTest.java
@@ -38,11 +38,11 @@ class TestModelInstanceTest {
     animal.setId("TestId");
     animals.addChildElement(animal);
 
-    ModelInstance cloneInstance = modelInstance.clone();
-    getFirstAnimal(cloneInstance).setId("TestId2");
+    ModelInstance copiedInstance = modelInstance.copy();
+    getFirstAnimal(copiedInstance).setId("TestId2");
 
     assertThat(getFirstAnimal(modelInstance).getId()).isEqualTo("TestId");
-    assertThat(getFirstAnimal(cloneInstance).getId()).isEqualTo("TestId2");
+    assertThat(getFirstAnimal(copiedInstance).getId()).isEqualTo("TestId2");
   }
 
   protected Animal getFirstAnimal(ModelInstance modelInstance) {

--- a/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelTest.java
+++ b/model-api/xml-model/src/test/java/org/operaton/bpm/model/xml/testmodel/TestModelTest.java
@@ -65,7 +65,7 @@ public abstract class TestModelTest {
   }
 
   protected void init (TestModelArgs args) {
-    this.modelInstance = args.modelInstance.clone();
+    this.modelInstance = args.modelInstance.copy();
     this.modelParser = args.modelParser;
   }
 


### PR DESCRIPTION
Resolves Sonar issues of type java:S2975
  "'clone' should not be overridden"

Related to #511