### PR TITLE
refactor(engine): Removed 'volatile' modifier from ProcessEngineConfgurationImpl fields

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -353,19 +353,19 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   // SERVICES /////////////////////////////////////////////////////////////////
 
-  protected volatile RepositoryService repositoryService = new RepositoryServiceImpl();
-  protected volatile RuntimeService runtimeService = new RuntimeServiceImpl();
-  protected volatile HistoryService historyService = new HistoryServiceImpl();
-  protected volatile IdentityService identityService = new IdentityServiceImpl();
-  protected volatile TaskService taskService = new TaskServiceImpl();
-  protected volatile FormService formService = new FormServiceImpl();
-  protected volatile ManagementService managementService = new ManagementServiceImpl(this);
-  protected volatile AuthorizationService authorizationService = new AuthorizationServiceImpl();
-  protected volatile CaseService caseService = new CaseServiceImpl();
-  protected volatile FilterService filterService = new FilterServiceImpl();
-  protected volatile ExternalTaskService externalTaskService = new ExternalTaskServiceImpl();
-  protected volatile DecisionService decisionService = new DecisionServiceImpl();
-  protected volatile OptimizeService optimizeService = new OptimizeService();
+  protected RepositoryService repositoryService = new RepositoryServiceImpl();
+  protected RuntimeService runtimeService = new RuntimeServiceImpl();
+  protected HistoryService historyService = new HistoryServiceImpl();
+  protected IdentityService identityService = new IdentityServiceImpl();
+  protected TaskService taskService = new TaskServiceImpl();
+  protected FormService formService = new FormServiceImpl();
+  protected ManagementService managementService = new ManagementServiceImpl(this);
+  protected AuthorizationService authorizationService = new AuthorizationServiceImpl();
+  protected CaseService caseService = new CaseServiceImpl();
+  protected FilterService filterService = new FilterServiceImpl();
+  protected ExternalTaskService externalTaskService = new ExternalTaskServiceImpl();
+  protected DecisionService decisionService = new DecisionServiceImpl();
+  protected OptimizeService optimizeService = new OptimizeService();
 
   // COMMAND EXECUTORS ////////////////////////////////////////////////////////
 
@@ -373,63 +373,63 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   /**
    * the configurable list which will be {@link #initInterceptorChain(java.util.List) processed} to build the {@link #commandExecutorTxRequired}
    */
-  protected volatile List<CommandInterceptor> customPreCommandInterceptorsTxRequired;
-  protected volatile List<CommandInterceptor> customPostCommandInterceptorsTxRequired;
+  protected List<CommandInterceptor> customPreCommandInterceptorsTxRequired;
+  protected List<CommandInterceptor> customPostCommandInterceptorsTxRequired;
 
-  protected volatile List<CommandInterceptor> commandInterceptorsTxRequired;
+  protected List<CommandInterceptor> commandInterceptorsTxRequired;
 
   /**
    * this will be initialized during the configurationComplete()
    */
-  protected volatile CommandExecutor commandExecutorTxRequired;
+  protected CommandExecutor commandExecutorTxRequired;
 
   /**
    * the configurable list which will be {@link #initInterceptorChain(List) processed} to build the {@link #commandExecutorTxRequiresNew}
    */
-  protected volatile List<CommandInterceptor> customPreCommandInterceptorsTxRequiresNew;
-  protected volatile List<CommandInterceptor> customPostCommandInterceptorsTxRequiresNew;
+  protected List<CommandInterceptor> customPreCommandInterceptorsTxRequiresNew;
+  protected List<CommandInterceptor> customPostCommandInterceptorsTxRequiresNew;
 
-  protected volatile List<CommandInterceptor> commandInterceptorsTxRequiresNew;
+  protected List<CommandInterceptor> commandInterceptorsTxRequiresNew;
 
   /**
    * this will be initialized during the configurationComplete()
    */
-  protected volatile CommandExecutor commandExecutorTxRequiresNew;
+  protected CommandExecutor commandExecutorTxRequiresNew;
 
   /**
    * Separate command executor to be used for db schema operations. Must always use NON-JTA transactions
    */
-  protected volatile CommandExecutor commandExecutorSchemaOperations;
+  protected CommandExecutor commandExecutorSchemaOperations;
 
   // SESSION FACTORIES ////////////////////////////////////////////////////////
 
-  protected volatile List<SessionFactory> customSessionFactories;
-  protected volatile DbSqlSessionFactory dbSqlSessionFactory;
-  protected volatile Map<Class<?>, SessionFactory> sessionFactories;
+  protected List<SessionFactory> customSessionFactories;
+  protected DbSqlSessionFactory dbSqlSessionFactory;
+  protected Map<Class<?>, SessionFactory> sessionFactories;
 
   // DEPLOYERS ////////////////////////////////////////////////////////////////
 
-  protected volatile List<Deployer> customPreDeployers;
-  protected volatile List<Deployer> customPostDeployers;
-  protected volatile List<Deployer> deployers;
-  protected volatile DeploymentCache deploymentCache;
+  protected List<Deployer> customPreDeployers;
+  protected List<Deployer> customPostDeployers;
+  protected List<Deployer> deployers;
+  protected DeploymentCache deploymentCache;
 
   // CACHE ////////////////////////////////////////////////////////////////////
 
-  protected volatile CacheFactory cacheFactory;
-  protected volatile int cacheCapacity = 1000;
-  protected volatile boolean enableFetchProcessDefinitionDescription = true;
+  protected CacheFactory cacheFactory;
+  protected int cacheCapacity = 1000;
+  protected boolean enableFetchProcessDefinitionDescription = true;
 
   // JOB EXECUTOR /////////////////////////////////////////////////////////////
 
-  protected volatile List<JobHandler<?>> customJobHandlers;
-  protected volatile Map<String, JobHandler<?>> jobHandlers;
-  protected volatile JobExecutor jobExecutor;
+  protected List<JobHandler<?>> customJobHandlers;
+  protected Map<String, JobHandler<?>> jobHandlers;
+  protected JobExecutor jobExecutor;
 
-  protected volatile PriorityProvider<JobDeclaration<?, ?>> jobPriorityProvider;
+  protected PriorityProvider<JobDeclaration<?, ?>> jobPriorityProvider;
 
-  protected volatile long jobExecutorPriorityRangeMin = Long.MIN_VALUE;
-  protected volatile long jobExecutorPriorityRangeMax = Long.MAX_VALUE;
+  protected long jobExecutorPriorityRangeMin = Long.MIN_VALUE;
+  protected long jobExecutorPriorityRangeMax = Long.MAX_VALUE;
 
   /**
    * When set to false, exclusivity (no parallel execution) of tasks is applied per process instance.
@@ -448,97 +448,97 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    * <p>
    * Default value: false; to keep the legacy behaviour backwards compatible.
    */
-  protected volatile boolean jobExecutorAcquireExclusiveOverProcessHierarchies;
+  protected boolean jobExecutorAcquireExclusiveOverProcessHierarchies;
 
   // EXTERNAL TASK /////////////////////////////////////////////////////////////
-  protected volatile PriorityProvider<ExternalTaskActivityBehavior> externalTaskPriorityProvider;
+  protected PriorityProvider<ExternalTaskActivityBehavior> externalTaskPriorityProvider;
 
   // MYBATIS SQL SESSION FACTORY //////////////////////////////////////////////
 
-  protected volatile SqlSessionFactory sqlSessionFactory;
-  protected volatile TransactionFactory transactionFactory;
+  protected SqlSessionFactory sqlSessionFactory;
+  protected TransactionFactory transactionFactory;
 
 
   // ID GENERATOR /////////////////////////////////////////////////////////////
-  protected volatile IdGenerator idGenerator;
-  protected volatile DataSource idGeneratorDataSource;
-  protected volatile String idGeneratorDataSourceJndiName;
+  protected IdGenerator idGenerator;
+  protected DataSource idGeneratorDataSource;
+  protected String idGeneratorDataSourceJndiName;
 
   // INCIDENT HANDLER /////////////////////////////////////////////////////////
 
-  protected volatile Map<String, IncidentHandler> incidentHandlers;
-  protected volatile List<IncidentHandler> customIncidentHandlers;
+  protected Map<String, IncidentHandler> incidentHandlers;
+  protected List<IncidentHandler> customIncidentHandlers;
 
   // BATCH ////////////////////////////////////////////////////////////////////
 
-  protected volatile Map<String, BatchJobHandler<?>> batchHandlers;
-  protected volatile List<BatchJobHandler<?>> customBatchJobHandlers;
+  protected Map<String, BatchJobHandler<?>> batchHandlers;
+  protected List<BatchJobHandler<?>> customBatchJobHandlers;
 
   /**
    * Number of jobs created by a batch seed job invocation
    */
-  protected volatile int batchJobsPerSeed = 100;
+  protected int batchJobsPerSeed = 100;
   /**
    * Number of invocations executed by a single batch job
    */
-  protected volatile int invocationsPerBatchJob = DEFAULT_INVOCATIONS_PER_BATCH_JOB;
+  protected int invocationsPerBatchJob = DEFAULT_INVOCATIONS_PER_BATCH_JOB;
 
   /**
    * Map to set an individual value for each batch type to
    * control the invocations per batch job. Unless specified
    * in this map, value of 'invocationsPerBatchJob' is used.
    */
-  protected volatile Map<String, Integer> invocationsPerBatchJobByBatchType;
+  protected Map<String, Integer> invocationsPerBatchJobByBatchType;
 
   /**
    * seconds to wait between polling for batch completion
    */
-  protected volatile int batchPollTime = 30;
+  protected int batchPollTime = 30;
   /**
    * default priority for batch jobs
    */
-  protected volatile long batchJobPriority = DefaultPriorityProvider.DEFAULT_PRIORITY;
+  protected long batchJobPriority = DefaultPriorityProvider.DEFAULT_PRIORITY;
 
   // OTHER ////////////////////////////////////////////////////////////////////
-  protected volatile List<FormEngine> customFormEngines;
-  protected volatile Map<String, FormEngine> formEngines;
+  protected List<FormEngine> customFormEngines;
+  protected Map<String, FormEngine> formEngines;
 
-  protected volatile List<AbstractFormFieldType> customFormTypes;
-  protected volatile FormTypes formTypes;
-  protected volatile FormValidators formValidators;
-  protected volatile Map<String, Class<? extends FormFieldValidator>> customFormFieldValidators;
+  protected List<AbstractFormFieldType> customFormTypes;
+  protected FormTypes formTypes;
+  protected FormValidators formValidators;
+  protected Map<String, Class<? extends FormFieldValidator>> customFormFieldValidators;
 
   /** don't throw parsing exceptions for Operaton Forms if set to true*/
-  protected volatile boolean disableStrictOperatonFormParsing;
+  protected boolean disableStrictOperatonFormParsing;
 
-  protected volatile List<TypedValueSerializer<?>> customPreVariableSerializers;
-  protected volatile List<TypedValueSerializer<?>> customPostVariableSerializers;
-  protected volatile VariableSerializers variableSerializers;
-  protected volatile VariableSerializerFactory fallbackSerializerFactory;
-  protected volatile boolean implicitVariableUpdateDetectionEnabled = true;
+  protected List<TypedValueSerializer<?>> customPreVariableSerializers;
+  protected List<TypedValueSerializer<?>> customPostVariableSerializers;
+  protected VariableSerializers variableSerializers;
+  protected VariableSerializerFactory fallbackSerializerFactory;
+  protected boolean implicitVariableUpdateDetectionEnabled = true;
 
-  protected volatile String defaultSerializationFormat = Variables.SerializationDataFormats.JAVA.getName();
-  protected volatile boolean javaSerializationFormatEnabled;
-  protected volatile String defaultCharsetName;
-  protected volatile Charset defaultCharset;
+  protected String defaultSerializationFormat = Variables.SerializationDataFormats.JAVA.getName();
+  protected boolean javaSerializationFormatEnabled;
+  protected String defaultCharsetName;
+  protected Charset defaultCharset;
 
-  protected volatile ExpressionManager expressionManager;
-  protected volatile ElProvider dmnElProvider;
-  protected volatile ScriptingEngines scriptingEngines;
-  protected volatile List<ResolverFactory> resolverFactories;
-  protected volatile ScriptingEnvironment scriptingEnvironment;
-  protected volatile List<ScriptEnvResolver> scriptEnvResolvers;
-  protected volatile ScriptFactory scriptFactory;
-  protected volatile ScriptEngineResolver scriptEngineResolver;
-  protected volatile String scriptEngineNameJavaScript;
-  protected volatile boolean autoStoreScriptVariables;
-  protected volatile boolean enableScriptCompilation = true;
-  protected volatile boolean enableScriptEngineCaching = true;
-  protected volatile boolean enableFetchScriptEngineFromProcessApplication = true;
-  protected volatile boolean enableScriptEngineLoadExternalResources;
-  protected volatile boolean enableScriptEngineNashornCompatibility;
-  protected volatile boolean configureScriptEngineHostAccess = true;
-  protected volatile boolean skipIsolationLevelCheck;
+  protected ExpressionManager expressionManager;
+  protected ElProvider dmnElProvider;
+  protected ScriptingEngines scriptingEngines;
+  protected List<ResolverFactory> resolverFactories;
+  protected ScriptingEnvironment scriptingEnvironment;
+  protected List<ScriptEnvResolver> scriptEnvResolvers;
+  protected ScriptFactory scriptFactory;
+  protected ScriptEngineResolver scriptEngineResolver;
+  protected String scriptEngineNameJavaScript;
+  protected boolean autoStoreScriptVariables;
+  protected boolean enableScriptCompilation = true;
+  protected boolean enableScriptEngineCaching = true;
+  protected boolean enableFetchScriptEngineFromProcessApplication = true;
+  protected boolean enableScriptEngineLoadExternalResources;
+  protected boolean enableScriptEngineNashornCompatibility;
+  protected boolean configureScriptEngineHostAccess = true;
+  protected boolean skipIsolationLevelCheck;
 
   /**
    * When set to false, the following behavior changes:
@@ -549,7 +549,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    * <li>Tasks from CMMN cases are not returned by the {@link TaskQuery}.</li>
    * </ul>
    */
-  protected volatile boolean cmmnEnabled = true;
+  protected boolean cmmnEnabled = true;
 
     /**
    * When set to false, the following behavior changes:
@@ -560,7 +560,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    *   {@link DecisionRequirementsDefinition} to the engine.</li>
    * </ul>
    */
-  protected volatile boolean dmnEnabled = true;
+  protected boolean dmnEnabled = true;
   /**
    * When set to <code>false</code>, the following behavior changes:
    * <ul>
@@ -568,42 +568,42 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    *   <li>Standalone tasks are not returned by the TaskQuery.</li>
    * </ul>
    */
-  protected volatile boolean standaloneTasksEnabled = true;
+  protected boolean standaloneTasksEnabled = true;
 
-  protected volatile boolean enableGracefulDegradationOnContextSwitchFailure = true;
+  protected boolean enableGracefulDegradationOnContextSwitchFailure = true;
 
-  protected volatile BusinessCalendarManager businessCalendarManager;
+  protected BusinessCalendarManager businessCalendarManager;
 
-  protected volatile String wsSyncFactoryClassName = DEFAULT_WS_SYNC_FACTORY;
+  protected String wsSyncFactoryClassName = DEFAULT_WS_SYNC_FACTORY;
 
-  protected volatile CommandContextFactory commandContextFactory;
-  protected volatile TransactionContextFactory transactionContextFactory;
-  protected volatile BpmnParseFactory bpmnParseFactory;
+  protected CommandContextFactory commandContextFactory;
+  protected TransactionContextFactory transactionContextFactory;
+  protected BpmnParseFactory bpmnParseFactory;
 
   // cmmn
-  protected volatile CmmnTransformFactory cmmnTransformFactory;
-  protected volatile DefaultCmmnElementHandlerRegistry cmmnElementHandlerRegistry;
+  protected CmmnTransformFactory cmmnTransformFactory;
+  protected DefaultCmmnElementHandlerRegistry cmmnElementHandlerRegistry;
 
   // dmn
-  protected volatile DefaultDmnEngineConfiguration dmnEngineConfiguration;
-  protected volatile DmnEngine dmnEngine;
+  protected DefaultDmnEngineConfiguration dmnEngineConfiguration;
+  protected DmnEngine dmnEngine;
 
   /**
    * a list of DMN FEEL custom function providers
    */
-  protected volatile List<FeelCustomFunctionProvider> dmnFeelCustomFunctionProviders;
+  protected List<FeelCustomFunctionProvider> dmnFeelCustomFunctionProviders;
 
   /**
    * Enable DMN FEEL legacy behavior
    */
-  protected volatile boolean dmnFeelEnableLegacyBehavior;
+  protected boolean dmnFeelEnableLegacyBehavior;
 
   /**
    * Controls whether blank DMN table outputs are swallowed or returned as {@code null}.
    */
-  protected volatile boolean dmnReturnBlankTableOutputAsNull;
+  protected boolean dmnReturnBlankTableOutputAsNull;
 
-  protected volatile HistoryLevel historyLevel;
+  protected HistoryLevel historyLevel;
 
   /**
    * a list of supported history levels
@@ -613,95 +613,95 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   /**
    * a list of supported custom history levels
    */
-  protected volatile List<HistoryLevel> customHistoryLevels;
+  protected List<HistoryLevel> customHistoryLevels;
 
-  protected volatile List<BpmnParseListener> preParseListeners;
-  protected volatile List<BpmnParseListener> postParseListeners;
+  protected List<BpmnParseListener> preParseListeners;
+  protected List<BpmnParseListener> postParseListeners;
 
-  protected volatile List<CmmnTransformListener> customPreCmmnTransformListeners;
-  protected volatile List<CmmnTransformListener> customPostCmmnTransformListeners;
+  protected List<CmmnTransformListener> customPreCmmnTransformListeners;
+  protected List<CmmnTransformListener> customPostCmmnTransformListeners;
 
-  protected volatile Map<Object, Object> beans;
+  protected Map<Object, Object> beans;
 
-  protected volatile boolean isDbIdentityUsed = true;
-  protected volatile boolean isDbHistoryUsed = true;
+  protected boolean isDbIdentityUsed = true;
+  protected boolean isDbHistoryUsed = true;
 
-  protected volatile DelegateInterceptor delegateInterceptor;
+  protected DelegateInterceptor delegateInterceptor;
 
-  protected volatile CommandInterceptor actualCommandExecutor;
+  protected CommandInterceptor actualCommandExecutor;
 
-  protected volatile RejectedJobsHandler customRejectedJobsHandler;
+  protected RejectedJobsHandler customRejectedJobsHandler;
 
-  protected volatile Map<String, EventHandler> eventHandlers;
-  protected volatile List<EventHandler> customEventHandlers;
+  protected Map<String, EventHandler> eventHandlers;
+  protected List<EventHandler> customEventHandlers;
 
-  protected volatile FailedJobCommandFactory failedJobCommandFactory;
+  protected FailedJobCommandFactory failedJobCommandFactory;
 
-  protected volatile String databaseTablePrefix = "";
+  protected String databaseTablePrefix = "";
 
   /**
    * In some situations you want to set the schema to use for table checks / generation if the database metadata
    * doesn't return that correctly, see https://jira.codehaus.org/browse/ACT-1220,
    * https://jira.codehaus.org/browse/ACT-1062
    */
-  protected volatile String databaseSchema;
+  protected String databaseSchema;
 
-  protected volatile boolean isCreateDiagramOnDeploy;
+  protected boolean isCreateDiagramOnDeploy;
 
-  protected volatile ProcessApplicationManager processApplicationManager;
+  protected ProcessApplicationManager processApplicationManager;
 
-  protected volatile CorrelationHandler correlationHandler;
+  protected CorrelationHandler correlationHandler;
 
-  protected volatile ConditionHandler conditionHandler;
+  protected ConditionHandler conditionHandler;
 
   /**
    * session factory to be used for obtaining identity provider sessions
    */
-  protected volatile SessionFactory identityProviderSessionFactory;
+  protected SessionFactory identityProviderSessionFactory;
 
-  protected volatile PasswordEncryptor passwordEncryptor;
+  protected PasswordEncryptor passwordEncryptor;
 
-  protected volatile List<PasswordEncryptor> customPasswordChecker;
+  protected List<PasswordEncryptor> customPasswordChecker;
 
-  protected volatile PasswordManager passwordManager;
+  protected PasswordManager passwordManager;
 
-  protected volatile SaltGenerator saltGenerator;
+  protected SaltGenerator saltGenerator;
 
-  protected volatile Set<String> registeredDeployments;
+  protected Set<String> registeredDeployments;
 
-  protected volatile DeploymentHandlerFactory deploymentHandlerFactory;
+  protected DeploymentHandlerFactory deploymentHandlerFactory;
 
-  protected volatile ResourceAuthorizationProvider resourceAuthorizationProvider;
+  protected ResourceAuthorizationProvider resourceAuthorizationProvider;
 
-  protected volatile List<ProcessEnginePlugin> processEnginePlugins = new ArrayList<>();
+  protected List<ProcessEnginePlugin> processEnginePlugins = new ArrayList<>();
 
-  protected volatile HistoryEventProducer historyEventProducer;
+  protected HistoryEventProducer historyEventProducer;
 
-  protected volatile CmmnHistoryEventProducer cmmnHistoryEventProducer;
+  protected CmmnHistoryEventProducer cmmnHistoryEventProducer;
 
-  protected volatile DmnHistoryEventProducer dmnHistoryEventProducer;
+  protected DmnHistoryEventProducer dmnHistoryEventProducer;
 
   /**
    * As an instance of {@link org.operaton.bpm.engine.impl.history.handler.CompositeHistoryEventHandler}
    * it contains all the provided history event handlers that process history events.
    */
-  protected volatile HistoryEventHandler historyEventHandler;
+  protected HistoryEventHandler historyEventHandler;
 
   /**
    *  Allows users to add additional {@link HistoryEventHandler}
    *  instances to process history events.
    */
-  protected volatile List<HistoryEventHandler> customHistoryEventHandlers = new ArrayList<>();
+  protected List<HistoryEventHandler> customHistoryEventHandlers = new ArrayList<>();
 
   /**
    * If true, the default {@link DbHistoryEventHandler} will be included in the list
    * of history event handlers.
    */
-  protected volatile boolean enableDefaultDbHistoryEventHandler = true;
+  protected boolean enableDefaultDbHistoryEventHandler = true;
 
-  protected volatile PermissionProvider permissionProvider;
+  protected PermissionProvider permissionProvider;
 
-  protected volatile boolean isExecutionTreePrefetchEnabled = true;
+  protected boolean isExecutionTreePrefetchEnabled = true;
 
   /**
    * If true, the incident handlers init as {@link CompositeIncidentHandler} and
@@ -717,76 +717,76 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    * @see CompositeIncidentHandler
    * @see #initIncidentHandlers
    */
-  protected volatile boolean isCompositeIncidentHandlersEnabled;
+  protected boolean isCompositeIncidentHandlersEnabled;
 
   /**
    * If true the process engine will attempt to acquire an exclusive lock before
    * creating a deployment.
    */
-  protected volatile boolean isDeploymentLockUsed = true;
+  protected boolean isDeploymentLockUsed = true;
 
   /**
    * If true then several deployments will be processed strictly sequentially. When false they may be processed in parallel.
    */
-  protected volatile boolean isDeploymentSynchronized = true;
+  protected boolean isDeploymentSynchronized = true;
 
   /**
    * Allows setting whether the process engine should try reusing the first level entity cache.
    * Default setting is false, enabling it improves performance of asynchronous continuations.
    */
-  protected volatile boolean isDbEntityCacheReuseEnabled;
+  protected boolean isDbEntityCacheReuseEnabled;
 
-  protected volatile boolean isInvokeCustomVariableListeners = true;
+  protected boolean isInvokeCustomVariableListeners = true;
 
   /**
    * The process engine created by this configuration.
    */
-  protected volatile ProcessEngineImpl processEngine;
+  protected ProcessEngineImpl processEngine;
 
   /**
    * used to create instances for listeners, JavaDelegates, etc
    */
-  protected volatile ArtifactFactory artifactFactory;
+  protected ArtifactFactory artifactFactory;
 
-  protected volatile DbEntityCacheKeyMapping dbEntityCacheKeyMapping = DbEntityCacheKeyMapping.defaultEntityCacheKeyMapping();
+  protected DbEntityCacheKeyMapping dbEntityCacheKeyMapping = DbEntityCacheKeyMapping.defaultEntityCacheKeyMapping();
 
   /**
    * the metrics registry
    */
-  protected volatile MetricsRegistry metricsRegistry;
+  protected MetricsRegistry metricsRegistry;
 
-  protected volatile DbMetricsReporter dbMetricsReporter;
+  protected DbMetricsReporter dbMetricsReporter;
 
-  protected volatile boolean isMetricsEnabled = true;
-  protected volatile boolean isDbMetricsReporterActivate = true;
+  protected boolean isMetricsEnabled = true;
+  protected boolean isDbMetricsReporterActivate = true;
 
-  protected volatile MetricsReporterIdProvider metricsReporterIdProvider;
+  protected MetricsReporterIdProvider metricsReporterIdProvider;
 
-  protected volatile boolean isTaskMetricsEnabled = true;
+  protected boolean isTaskMetricsEnabled = true;
 
   /**
    * the historic job log host name
    */
-  protected volatile String hostname;
-  protected volatile HostnameProvider hostnameProvider;
+  protected String hostname;
+  protected HostnameProvider hostnameProvider;
 
   /**
    * handling of expressions submitted via API; can be used as guards against remote code execution
    */
-  protected volatile boolean enableExpressionsInAdhocQueries;
-  protected volatile boolean enableExpressionsInStoredQueries = true;
+  protected boolean enableExpressionsInAdhocQueries;
+  protected boolean enableExpressionsInStoredQueries = true;
 
   /**
    * If false, disables XML eXternal Entity (XXE) Processing. This provides protection against XXE Processing attacks.
    */
-  protected volatile boolean enableXxeProcessing;
+  protected boolean enableXxeProcessing;
 
   /**
    * If true, user operation log entries are only written if there is an
    * authenticated user present in the context. If false, user operation log
    * entries are written regardless of authentication state.
    */
-  protected volatile boolean restrictUserOperationLogToAuthenticatedUsers = true;
+  protected boolean restrictUserOperationLogToAuthenticatedUsers = true;
 
   /**
    * Maximum number of operation log entries written per synchronous operation.
@@ -798,200 +798,200 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    *   <li>1<x<=Long.MAX_VALUE: Write at most x operation logs per synchronous operation. If an operation exceeds x, a {@link ProcessEngineException} is thrown.</li>
    * </ul>
    */
-  protected volatile long logEntriesPerSyncOperationLimit = 1L;
+  protected long logEntriesPerSyncOperationLimit = 1L;
 
-  protected volatile boolean disableStrictCallActivityValidation;
+  protected boolean disableStrictCallActivityValidation;
 
-  protected volatile boolean isBpmnStacktraceVerbose;
+  protected boolean isBpmnStacktraceVerbose;
 
-  protected volatile boolean forceCloseMybatisConnectionPool = true;
+  protected boolean forceCloseMybatisConnectionPool = true;
 
-  protected volatile TenantIdProvider tenantIdProvider;
+  protected TenantIdProvider tenantIdProvider;
 
-  protected volatile List<CommandChecker> commandCheckers;
+  protected List<CommandChecker> commandCheckers;
 
-  protected volatile List<String> adminGroups;
+  protected List<String> adminGroups;
 
-  protected volatile List<String> adminUsers;
+  protected List<String> adminUsers;
 
   // Migration
-  protected volatile MigrationActivityMatcher migrationActivityMatcher;
+  protected MigrationActivityMatcher migrationActivityMatcher;
 
-  protected volatile List<MigrationActivityValidator> customPreMigrationActivityValidators;
-  protected volatile List<MigrationActivityValidator> customPostMigrationActivityValidators;
-  protected volatile MigrationInstructionGenerator migrationInstructionGenerator;
+  protected List<MigrationActivityValidator> customPreMigrationActivityValidators;
+  protected List<MigrationActivityValidator> customPostMigrationActivityValidators;
+  protected MigrationInstructionGenerator migrationInstructionGenerator;
 
-  protected volatile List<MigrationInstructionValidator> customPreMigrationInstructionValidators;
-  protected volatile List<MigrationInstructionValidator> customPostMigrationInstructionValidators;
-  protected volatile List<MigrationInstructionValidator> migrationInstructionValidators;
+  protected List<MigrationInstructionValidator> customPreMigrationInstructionValidators;
+  protected List<MigrationInstructionValidator> customPostMigrationInstructionValidators;
+  protected List<MigrationInstructionValidator> migrationInstructionValidators;
 
-  protected volatile List<MigratingActivityInstanceValidator> customPreMigratingActivityInstanceValidators;
-  protected volatile List<MigratingActivityInstanceValidator> customPostMigratingActivityInstanceValidators;
-  protected volatile List<MigratingActivityInstanceValidator> migratingActivityInstanceValidators;
-  protected volatile List<MigratingTransitionInstanceValidator> migratingTransitionInstanceValidators;
-  protected volatile List<MigratingCompensationInstanceValidator> migratingCompensationInstanceValidators;
+  protected List<MigratingActivityInstanceValidator> customPreMigratingActivityInstanceValidators;
+  protected List<MigratingActivityInstanceValidator> customPostMigratingActivityInstanceValidators;
+  protected List<MigratingActivityInstanceValidator> migratingActivityInstanceValidators;
+  protected List<MigratingTransitionInstanceValidator> migratingTransitionInstanceValidators;
+  protected List<MigratingCompensationInstanceValidator> migratingCompensationInstanceValidators;
 
   // Default user permission for task
-  protected volatile Permission defaultUserPermissionForTask;
+  protected Permission defaultUserPermissionForTask;
 
   /**
    * Historic instance permissions are disabled by default
    */
-  protected volatile boolean enableHistoricInstancePermissions;
+  protected boolean enableHistoricInstancePermissions;
 
-  protected volatile boolean isUseSharedSqlSessionFactory;
+  protected boolean isUseSharedSqlSessionFactory;
 
   //History cleanup configuration
-  protected volatile String historyCleanupBatchWindowStartTime;
-  protected volatile String historyCleanupBatchWindowEndTime = "00:00";
+  protected String historyCleanupBatchWindowStartTime;
+  protected String historyCleanupBatchWindowEndTime = "00:00";
 
-  protected volatile Date historyCleanupBatchWindowStartTimeAsDate;
-  protected volatile Date historyCleanupBatchWindowEndTimeAsDate;
+  protected Date historyCleanupBatchWindowStartTimeAsDate;
+  protected Date historyCleanupBatchWindowEndTimeAsDate;
 
-  protected volatile Map<Integer, BatchWindowConfiguration> historyCleanupBatchWindows = new HashMap<>();
+  protected Map<Integer, BatchWindowConfiguration> historyCleanupBatchWindows = new HashMap<>();
 
   //shortcuts for batch windows configuration available to be configured from XML
-  protected volatile String mondayHistoryCleanupBatchWindowStartTime;
-  protected volatile String mondayHistoryCleanupBatchWindowEndTime;
-  protected volatile String tuesdayHistoryCleanupBatchWindowStartTime;
-  protected volatile String tuesdayHistoryCleanupBatchWindowEndTime;
-  protected volatile String wednesdayHistoryCleanupBatchWindowStartTime;
-  protected volatile String wednesdayHistoryCleanupBatchWindowEndTime;
-  protected volatile String thursdayHistoryCleanupBatchWindowStartTime;
-  protected volatile String thursdayHistoryCleanupBatchWindowEndTime;
-  protected volatile String fridayHistoryCleanupBatchWindowStartTime;
-  protected volatile String fridayHistoryCleanupBatchWindowEndTime;
-  protected volatile String saturdayHistoryCleanupBatchWindowStartTime;
-  protected volatile String saturdayHistoryCleanupBatchWindowEndTime;
-  protected volatile String sundayHistoryCleanupBatchWindowStartTime;
-  protected volatile String sundayHistoryCleanupBatchWindowEndTime;
+  protected String mondayHistoryCleanupBatchWindowStartTime;
+  protected String mondayHistoryCleanupBatchWindowEndTime;
+  protected String tuesdayHistoryCleanupBatchWindowStartTime;
+  protected String tuesdayHistoryCleanupBatchWindowEndTime;
+  protected String wednesdayHistoryCleanupBatchWindowStartTime;
+  protected String wednesdayHistoryCleanupBatchWindowEndTime;
+  protected String thursdayHistoryCleanupBatchWindowStartTime;
+  protected String thursdayHistoryCleanupBatchWindowEndTime;
+  protected String fridayHistoryCleanupBatchWindowStartTime;
+  protected String fridayHistoryCleanupBatchWindowEndTime;
+  protected String saturdayHistoryCleanupBatchWindowStartTime;
+  protected String saturdayHistoryCleanupBatchWindowEndTime;
+  protected String sundayHistoryCleanupBatchWindowStartTime;
+  protected String sundayHistoryCleanupBatchWindowEndTime;
 
-  protected volatile int historyCleanupDegreeOfParallelism = 1;
+  protected int historyCleanupDegreeOfParallelism = 1;
 
-  protected volatile String historyTimeToLive;
+  protected String historyTimeToLive;
 
   /**
    * Feature flag that fails the deployment of process, decision, and case resources if their historyTimeToLive is {@code null}.
    */
-  protected volatile boolean enforceHistoryTimeToLive = true;
+  protected boolean enforceHistoryTimeToLive = true;
 
-  protected volatile String batchOperationHistoryTimeToLive;
-  protected volatile Map<String, String> batchOperationsForHistoryCleanup;
-  protected volatile Map<String, Integer> parsedBatchOperationsForHistoryCleanup;
+  protected String batchOperationHistoryTimeToLive;
+  protected Map<String, String> batchOperationsForHistoryCleanup;
+  protected Map<String, Integer> parsedBatchOperationsForHistoryCleanup;
 
   /**
    * Default priority for history cleanup jobs. */
-  protected volatile long historyCleanupJobPriority = DefaultPriorityProvider.DEFAULT_PRIORITY;
+  protected long historyCleanupJobPriority = DefaultPriorityProvider.DEFAULT_PRIORITY;
 
   /**
    * Specifies how often a cleanup job will be executed before an incident is raised.
    * This property overrides the global {@code defaultNumberOfRetries} property which has a default value of {@code 3}.
    */
-  protected volatile int historyCleanupDefaultNumberOfRetries = Integer.MIN_VALUE;
+  protected int historyCleanupDefaultNumberOfRetries = Integer.MIN_VALUE;
 
   /**
    * Time to live for historic job log entries written by history cleanup jobs.
    * Must be an ISO-8601 conform String specifying only a number of days. Only
    * works in conjunction with removal-time-based cleanup strategy.
    */
-  protected volatile String historyCleanupJobLogTimeToLive;
+  protected String historyCleanupJobLogTimeToLive;
 
-  protected volatile String taskMetricsTimeToLive;
-  protected volatile Integer parsedTaskMetricsTimeToLive;
+  protected String taskMetricsTimeToLive;
+  protected Integer parsedTaskMetricsTimeToLive;
 
-  protected volatile BatchWindowManager batchWindowManager = new DefaultBatchWindowManager();
+  protected BatchWindowManager batchWindowManager = new DefaultBatchWindowManager();
 
-  protected volatile HistoryRemovalTimeProvider historyRemovalTimeProvider;
+  protected HistoryRemovalTimeProvider historyRemovalTimeProvider;
 
-  protected volatile String historyRemovalTimeStrategy;
+  protected String historyRemovalTimeStrategy;
 
-  protected volatile String historyCleanupStrategy;
+  protected String historyCleanupStrategy;
 
   /**
    * Size of batch in which history cleanup data will be deleted. {@link HistoryCleanupBatch#MAX_BATCH_SIZE} must be respected.
    */
-  private volatile int historyCleanupBatchSize = 500;
+  private int historyCleanupBatchSize = 500;
   /**
    * Indicates the minimal amount of data to trigger the history cleanup.
    */
-  private volatile int historyCleanupBatchThreshold = 10;
+  private int historyCleanupBatchThreshold = 10;
 
-  private volatile boolean historyCleanupMetricsEnabled = true;
+  private boolean historyCleanupMetricsEnabled = true;
 
   /**
    * Controls whether engine participates in history cleanup or not.
    */
-  protected volatile boolean historyCleanupEnabled = true;
+  protected boolean historyCleanupEnabled = true;
 
-  private volatile int failedJobListenerMaxRetries = DEFAULT_FAILED_JOB_LISTENER_MAX_RETRIES;
+  private int failedJobListenerMaxRetries = DEFAULT_FAILED_JOB_LISTENER_MAX_RETRIES;
 
-  protected volatile String failedJobRetryTimeCycle;
+  protected String failedJobRetryTimeCycle;
 
   // login attempts ///////////////////////////////////////////////////////
-  protected volatile int loginMaxAttempts = 10;
-  protected volatile int loginDelayFactor = 2;
-  protected volatile int loginDelayMaxTime = 60;
-  protected volatile int loginDelayBase = 3;
+  protected int loginMaxAttempts = 10;
+  protected int loginDelayFactor = 2;
+  protected int loginDelayMaxTime = 60;
+  protected int loginDelayBase = 3;
 
   // webapps logging
-  protected volatile boolean webappsAuthenticationLoggingEnabled;
+  protected boolean webappsAuthenticationLoggingEnabled;
 
   // max results limit
-  protected volatile int queryMaxResultsLimit = Integer.MAX_VALUE;
+  protected int queryMaxResultsLimit = Integer.MAX_VALUE;
 
   // logging context property names (with default values)
-  protected volatile String loggingContextActivityId = "activityId";
-  protected volatile String loggingContextActivityName = "activityName";
-  protected volatile String loggingContextApplicationName = "applicationName";
-  protected volatile String loggingContextBusinessKey;// default == null => disabled by default
-  protected volatile String loggingContextProcessDefinitionId = "processDefinitionId";
-  protected volatile String loggingContextProcessDefinitionKey;// default == null => disabled by default
-  protected volatile String loggingContextProcessInstanceId = "processInstanceId";
-  protected volatile String loggingContextTenantId = "tenantId";
-  protected volatile String loggingContextEngineName = "engineName";
+  protected String loggingContextActivityId = "activityId";
+  protected String loggingContextActivityName = "activityName";
+  protected String loggingContextApplicationName = "applicationName";
+  protected String loggingContextBusinessKey;// default == null => disabled by default
+  protected String loggingContextProcessDefinitionId = "processDefinitionId";
+  protected String loggingContextProcessDefinitionKey;// default == null => disabled by default
+  protected String loggingContextProcessInstanceId = "processInstanceId";
+  protected String loggingContextTenantId = "tenantId";
+  protected String loggingContextEngineName = "engineName";
 
   // logging levels (with default values)
-  protected volatile String logLevelBpmnStackTrace = "DEBUG";
+  protected String logLevelBpmnStackTrace = "DEBUG";
 
   // OLEs for foreign key constraint violations on databases that rollback on SQL exceptions, e.g. PostgreSQL
-  protected volatile boolean enableOptimisticLockingOnForeignKeyViolation = true;
+  protected boolean enableOptimisticLockingOnForeignKeyViolation = true;
 
-  protected volatile int telemetryRequestTimeout;
-  protected volatile TelemetryDataImpl telemetryData;
-  protected volatile DiagnosticsRegistry diagnosticsRegistry;
-  protected volatile DiagnosticsCollector diagnosticsCollector;
+  protected int telemetryRequestTimeout;
+  protected TelemetryDataImpl telemetryData;
+  protected DiagnosticsRegistry diagnosticsRegistry;
+  protected DiagnosticsCollector diagnosticsCollector;
 
   // Exception Codes ///////////////////////////////////////////////////////////////////////////////////////////////////
 
   /**
    * Disables the {@link ExceptionCodeInterceptor} and therefore the whole exception code feature.
    */
-  protected volatile boolean disableExceptionCode;
+  protected boolean disableExceptionCode;
 
   /**
    * Disables the default implementation of {@link ExceptionCodeProvider} which allows overriding the reserved
    * exception codes > {@link ExceptionCodeInterceptor#MAX_CUSTOM_CODE} or < {@link ExceptionCodeInterceptor#MIN_CUSTOM_CODE}.
    */
-  protected volatile boolean disableBuiltinExceptionCodeProvider;
+  protected boolean disableBuiltinExceptionCodeProvider;
 
   /**
    * Allows registering a custom implementation of a {@link ExceptionCodeProvider}
    * allowing to provide custom exception codes.
    */
-  protected volatile ExceptionCodeProvider customExceptionCodeProvider;
+  protected ExceptionCodeProvider customExceptionCodeProvider;
 
   /**
    * Holds the default implementation of {@link ExceptionCodeProvider}.
    */
-  protected volatile ExceptionCodeProvider builtinExceptionCodeProvider;
+  protected ExceptionCodeProvider builtinExceptionCodeProvider;
 
   /** Controls whether the time cycle is re-evaluated when due. */
-  protected volatile boolean reevaluateTimeCycleWhenDue;
+  protected boolean reevaluateTimeCycleWhenDue;
 
   /**
    * Size of batch in which removal time data will be updated. {@link ProcessSetRemovalTimeJobHandler#MAX_CHUNK_SIZE} must be respected.
    */
-  protected volatile int removalTimeUpdateChunkSize = 500;
+  protected int removalTimeUpdateChunkSize = 500;
 
   /**
    * This legacy behavior sets the retry counter to 3 in the context when running a job for the first time.


### PR DESCRIPTION
The fields have been made volatile due to flaky tests during the JUnit 5 migration. This PR removes the `volatile` modifiers from fields of `ProcessEngineConfgurationImpl`.