### PR TITLE
fix(engine-rest,test): Adopt to changes that services use empty maps instead of null

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/VariableValueDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/VariableValueDto.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.rest.dto;
 
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -158,6 +159,9 @@ public class VariableValueDto {
 
   public static Map<String, VariableValueDto> fromMap(VariableMap variables, boolean preferSerializedValue)
   {
+    if (variables == null) {
+      return Collections.emptyMap();
+    }
     Map<String, VariableValueDto> result = new HashMap<>();
     for (String variableName : variables.keySet()) {
       VariableValueDto valueDto = VariableValueDto.fromTypedValue(variables.getValueTyped(variableName), preferSerializedValue);

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseDefinitionRestServiceInteractionTest.java
@@ -54,6 +54,7 @@ import org.operaton.bpm.engine.runtime.CaseInstanceBuilder;
 import org.operaton.bpm.engine.variable.type.ValueType;
 
 import static io.restassured.RestAssured.given;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -314,7 +315,7 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
 
     verify(caseServiceMock).withCaseDefinition(MockProvider.EXAMPLE_CASE_DEFINITION_ID);
     verify(caseInstanceBuilder).businessKey(null);
-    verify(caseInstanceBuilder).setVariables(null);
+    verify(caseInstanceBuilder).setVariables(emptyMap());
     verify(caseInstanceBuilder).create();
 
   }
@@ -334,7 +335,7 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
 
     verify(caseServiceMock).withCaseDefinition(MockProvider.EXAMPLE_CASE_DEFINITION_ID);
     verify(caseInstanceBuilder).businessKey(null);
-    verify(caseInstanceBuilder).setVariables(null);
+    verify(caseInstanceBuilder).setVariables(emptyMap());
     verify(caseInstanceBuilder).create();
   }
 
@@ -356,7 +357,7 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
 
     verify(caseServiceMock).withCaseDefinition(MockProvider.EXAMPLE_CASE_DEFINITION_ID);
     verify(caseInstanceBuilder).businessKey(MockProvider.EXAMPLE_CASE_INSTANCE_BUSINESS_KEY);
-    verify(caseInstanceBuilder).setVariables(null);
+    verify(caseInstanceBuilder).setVariables(emptyMap());
     verify(caseInstanceBuilder).create();
 
   }
@@ -379,7 +380,7 @@ public class CaseDefinitionRestServiceInteractionTest extends AbstractRestServic
 
     verify(caseServiceMock).withCaseDefinition(MockProvider.EXAMPLE_CASE_DEFINITION_ID);
     verify(caseInstanceBuilder).businessKey(MockProvider.EXAMPLE_CASE_INSTANCE_BUSINESS_KEY);
-    verify(caseInstanceBuilder).setVariables(null);
+    verify(caseInstanceBuilder).setVariables(emptyMap());
     verify(caseInstanceBuilder).create();
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseExecutionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/CaseExecutionRestServiceInteractionTest.java
@@ -60,6 +60,8 @@ import org.operaton.bpm.engine.variable.value.BooleanValue;
 import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static org.operaton.bpm.engine.rest.util.DateTimeUtils.DATE_FORMAT_WITH_TIMEZONE;
 import static io.restassured.RestAssured.given;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -1778,7 +1780,7 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
 
     verify(caseServiceMock).withCaseExecution(MockProvider.EXAMPLE_CASE_EXECUTION_ID);
     verify(caseExecutionCommandBuilderMock).removeVariablesLocal(null);
-    verify(caseExecutionCommandBuilderMock).setVariablesLocal(null);
+    verify(caseExecutionCommandBuilderMock).setVariablesLocal(emptyMap());
     verify(caseExecutionCommandBuilderMock).execute();
   }
 
@@ -1796,7 +1798,7 @@ public class CaseExecutionRestServiceInteractionTest extends AbstractRestService
 
     verify(caseServiceMock).withCaseExecution(MockProvider.EXAMPLE_CASE_EXECUTION_ID);
     verify(caseExecutionCommandBuilderMock).removeVariables(null);
-    verify(caseExecutionCommandBuilderMock).setVariables(null);
+    verify(caseExecutionCommandBuilderMock).setVariables(emptyMap());
     verify(caseExecutionCommandBuilderMock).execute();
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExecutionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExecutionRestServiceInteractionTest.java
@@ -65,6 +65,7 @@ import org.operaton.bpm.engine.variable.value.BooleanValue;
 import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
 
+import static java.util.Collections.emptyMap;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_TASK_ID;
 import static org.operaton.bpm.engine.rest.util.DateTimeUtils.DATE_FORMAT_WITH_TIMEZONE;
 import static io.restassured.RestAssured.given;
@@ -1583,7 +1584,7 @@ public class ExecutionRestServiceInteractionTest extends AbstractRestServiceTest
       .when().post(TRIGGER_MESSAGE_SUBSCRIPTION_URL);
 
     verify(runtimeServiceMock).messageEventReceived(eq(messageName), eq(MockProvider.EXAMPLE_EXECUTION_ID),
-        argThat(new EqualsMap(null)));
+        argThat(new EqualsMap(emptyMap())));
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExternalTaskRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ExternalTaskRestServiceInteractionTest.java
@@ -68,6 +68,7 @@ import org.operaton.bpm.engine.rest.util.container.TestContainerExtension;
 import org.operaton.bpm.engine.runtime.ProcessInstanceQuery;
 import org.operaton.bpm.engine.variable.type.ValueType;
 
+import static java.util.Collections.emptyMap;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_PRIMITIVE_VARIABLE_VALUE;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_VARIABLE_INSTANCE_NAME;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.createMockBatch;
@@ -881,7 +882,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     .when()
       .post(COMPLETE_EXTERNAL_TASK_URL);
 
-    verify(externalTaskService).complete("anExternalTaskId", "aWorkerId", null, null);
+    verify(externalTaskService).complete("anExternalTaskId", "aWorkerId", emptyMap(), emptyMap());
     verifyNoMoreInteractions(externalTaskService);
   }
 
@@ -920,7 +921,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
                 .serializedValue("val3")
                 .serializationFormat("aFormat")
                 .objectTypeName("aRootType"))),
-        eq((Map<String, Object>) null));
+        eq(emptyMap()));
 
     verifyNoMoreInteractions(externalTaskService);
   }
@@ -951,7 +952,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     verify(externalTaskService).complete(
         eq("anExternalTaskId"),
         eq("aWorkerId"),
-        eq((Map<String, Object>) null),
+        eq(emptyMap()),
         argThat(EqualsVariableMap.matches()
           .matcher("var1", EqualsUntypedValue.matcher().value("val1"))
           .matcher("var2", EqualsPrimitiveValue.stringValue("val2"))
@@ -1149,7 +1150,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     .when()
       .post(HANDLE_EXTERNAL_TASK_FAILURE_URL);
 
-    verify(externalTaskService).handleFailure("anExternalTaskId", "aWorkerId", "anErrorMessage", null, 5, 12345, null, null);
+    verify(externalTaskService).handleFailure("anExternalTaskId", "aWorkerId", "anErrorMessage", null, 5, 12345, emptyMap(), emptyMap());
     verifyNoMoreInteractions(externalTaskService);
   }
 
@@ -1172,7 +1173,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
         .when()
         .post(HANDLE_EXTERNAL_TASK_FAILURE_URL);
 
-    verify(externalTaskService).handleFailure("anExternalTaskId", "aWorkerId", "anErrorMessage","aStackTrace", 5, 12345, null, null);
+    verify(externalTaskService).handleFailure("anExternalTaskId", "aWorkerId", "anErrorMessage","aStackTrace", 5, 12345, emptyMap(), emptyMap());
     verifyNoMoreInteractions(externalTaskService);
   }
 
@@ -1279,7 +1280,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
         eq(5),
         eq(12345L),
         argThat(EqualsVariableMap.matches().matcher("var1", EqualsUntypedValue.matcher().value("val1"))),
-        eq((Map<String, Object>) null));
+        eq(emptyMap()));
 
     verifyNoMoreInteractions(externalTaskService);
   }
@@ -1311,7 +1312,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
         eq(null),
         eq(5),
         eq(12345L),
-        eq((Map<String, Object>) null),
+        eq(emptyMap()),
         argThat(EqualsVariableMap.matches().matcher("var1", EqualsUntypedValue.matcher().value("val1"))));
 
     verifyNoMoreInteractions(externalTaskService);
@@ -1333,7 +1334,7 @@ public class ExternalTaskRestServiceInteractionTest extends AbstractRestServiceT
     .when()
       .post(HANDLE_EXTERNAL_TASK_BPMN_ERROR_URL);
 
-    verify(externalTaskService).handleBpmnError("anExternalTaskId", "aWorkerId", "anErrorCode", null, null);
+    verify(externalTaskService).handleBpmnError("anExternalTaskId", "aWorkerId", "anErrorCode", null, emptyMap());
     verifyNoMoreInteractions(externalTaskService);
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessDefinitionRestServiceInteractionTest.java
@@ -87,6 +87,7 @@ import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.impl.VariableMapImpl;
 import org.operaton.bpm.engine.variable.type.ValueType;
 
+import static java.util.Collections.emptyMap;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.createMockSerializedVariables;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -556,7 +557,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
       .body("suspended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED))
     .when().post(SUBMIT_FORM_URL);
 
-    verify(formServiceMock).submitStartForm(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, null);
+    verify(formServiceMock).submitStartForm(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, emptyMap());
   }
 
   @Test
@@ -666,7 +667,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
         .body("suspended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED))
       .when().post(SUBMIT_FORM_URL);
 
-    verify(formServiceMock).submitStartForm(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, "myBusinessKey", null);
+    verify(formServiceMock).submitStartForm(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, "myBusinessKey", emptyMap());
   }
 
   @Test
@@ -2878,7 +2879,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
       .body("suspended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED))
     .when().post(SUBMIT_FORM_BY_KEY_URL);
 
-    verify(formServiceMock).submitStartForm(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, null);
+    verify(formServiceMock).submitStartForm(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, emptyMap());
   }
 
   @Test
@@ -2926,7 +2927,7 @@ public class ProcessDefinitionRestServiceInteractionTest extends AbstractRestSer
         .body("suspended", equalTo(MockProvider.EXAMPLE_PROCESS_INSTANCE_IS_SUSPENDED))
       .when().post(SUBMIT_FORM_BY_KEY_URL);
 
-    verify(formServiceMock).submitStartForm(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, "myBusinessKey", null);
+    verify(formServiceMock).submitStartForm(MockProvider.EXAMPLE_PROCESS_DEFINITION_ID, "myBusinessKey", emptyMap());
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/ProcessInstanceRestServiceInteractionTest.java
@@ -101,6 +101,7 @@ import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.LongValue;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
 
+import static java.util.Collections.emptyMap;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_PROCESS_INSTANCE_COMMENT_FULL_MESSAGE;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_PROCESS_INSTANCE_COMMENT_ID;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.EXAMPLE_TASK_ID;
@@ -4495,7 +4496,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
         null,
         mockedProcessInstanceQuery,
         null,
-        null);
+      emptyMap());
 
     verifyBatchJson(response.asString());
   }
@@ -4536,7 +4537,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
         null,
         null,
         mockedHistoricProcessInstanceQuery,
-        null);
+      emptyMap());
 
     verifyBatchJson(response.asString());
   }
@@ -4567,7 +4568,7 @@ public class ProcessInstanceRestServiceInteractionTest extends AbstractRestServi
         processInstanceIds,
         null,
         null,
-        null);
+        emptyMap());
 
     verifyBatchJson(response.asString());
   }

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceInteractionTest.java
@@ -100,6 +100,7 @@ import org.operaton.bpm.engine.variable.type.ValueType;
 import org.operaton.bpm.engine.variable.value.FileValue;
 import org.operaton.bpm.engine.variable.value.ObjectValue;
 
+import static java.util.Collections.emptyMap;
 import static org.operaton.bpm.engine.rest.helper.MockProvider.*;
 import static org.operaton.bpm.engine.rest.util.DateTimeUtils.withTimezone;
 import static io.restassured.RestAssured.given;
@@ -916,13 +917,13 @@ public class TaskRestServiceInteractionTest extends
         .statusCode(Status.NO_CONTENT.getStatusCode())
       .when().post(SUBMIT_FORM_URL);
 
-    verify(formServiceMock).submitTaskForm(EXAMPLE_TASK_ID, null);
+    verify(formServiceMock).submitTaskForm(EXAMPLE_TASK_ID, emptyMap());
   }
 
   @Test
   void testSubmitFormWithVariablesInReturn() {
     VariableMap variables = MockProvider.createMockSerializedVariables();
-    when(formServiceMock.submitTaskFormWithVariablesInReturn(EXAMPLE_TASK_ID, null, false)).thenReturn(variables);
+    when(formServiceMock.submitTaskFormWithVariablesInReturn(EXAMPLE_TASK_ID, emptyMap(), false)).thenReturn(variables);
 
     Map<String, Object> queryParameters = new HashMap<>();
     queryParameters.put("withVariablesInReturn", true);
@@ -954,7 +955,7 @@ public class TaskRestServiceInteractionTest extends
               equalTo(MockProvider.FORMAT_APPLICATION_JSON))
     .when().post(SUBMIT_FORM_URL);
 
-    verify(formServiceMock).submitTaskFormWithVariablesInReturn(EXAMPLE_TASK_ID, null, false);
+    verify(formServiceMock).submitTaskFormWithVariablesInReturn(EXAMPLE_TASK_ID, emptyMap(), false);
   }
 
   @Test
@@ -1788,7 +1789,7 @@ public class TaskRestServiceInteractionTest extends
         .statusCode(Status.NO_CONTENT.getStatusCode())
       .when().post(COMPLETE_TASK_URL);
 
-    verify(taskServiceMock).complete(EXAMPLE_TASK_ID, null);
+    verify(taskServiceMock).complete(EXAMPLE_TASK_ID, emptyMap());
   }
 
   @Test
@@ -1819,7 +1820,7 @@ public class TaskRestServiceInteractionTest extends
   @Test
   void testCompleteTaskWithVariablesInReturn() {
     VariableMap variables = MockProvider.createMockSerializedVariables();
-    when(taskServiceMock.completeWithVariablesInReturn(EXAMPLE_TASK_ID, null, false)).thenReturn(variables);
+    when(taskServiceMock.completeWithVariablesInReturn(EXAMPLE_TASK_ID, emptyMap(), false)).thenReturn(variables);
 
     Map<String, Object> json = new HashMap<>();
     json.put("withVariablesInReturn", Boolean.TRUE);
@@ -2228,7 +2229,7 @@ public class TaskRestServiceInteractionTest extends
     given().pathParam("id", NON_EXISTING_ID)
       .header("accept", MediaType.APPLICATION_JSON)
       .then().expect().statusCode(Status.NOT_FOUND.getStatusCode()).contentType(ContentType.JSON)
-      .body("type", equalTo(InvalidRequestException.class.getSimpleName()))
+      .body("type", equalTo("TaskNotFoundException"))
       .body("message", equalTo("No matching task with id " + NON_EXISTING_ID))
       .when().get(SINGLE_TASK_URL);
   }
@@ -3402,7 +3403,7 @@ public class TaskRestServiceInteractionTest extends
     .expect()
       .statusCode(Status.NOT_FOUND.getStatusCode())
       .contentType(ContentType.JSON)
-      .body("type", equalTo(InvalidRequestException.class.getSimpleName()))
+      .body("type", equalTo("TaskNotFoundException"))
       .body("message", containsString("No matching task with id "+EXAMPLE_TASK_ID))
     .when()
         .put(SINGLE_TASK_URL);
@@ -3647,7 +3648,7 @@ public class TaskRestServiceInteractionTest extends
     .when()
       .post(HANDLE_BPMN_ERROR_URL);
 
-    verify(taskServiceMock).handleBpmnError("aTaskId", "anErrorCode", "anErrorMessage", null);
+    verify(taskServiceMock).handleBpmnError("aTaskId", "anErrorCode", "anErrorMessage", emptyMap());
     verifyNoMoreInteractions(taskServiceMock);
   }
 
@@ -3789,7 +3790,7 @@ public class TaskRestServiceInteractionTest extends
     .when()
       .post(HANDLE_BPMN_ESCALATION_URL);
 
-    verify(taskServiceMock).handleEscalation("aTaskId", "anEscalationCode", null);
+    verify(taskServiceMock).handleEscalation("aTaskId", "anEscalationCode", emptyMap());
     verifyNoMoreInteractions(taskServiceMock);
   }
 

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/UserRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/UserRestServiceInteractionTest.java
@@ -329,7 +329,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
         .pathParam("id", "aNonExistingUser")
     .then()
         .statusCode(Status.NOT_FOUND.getStatusCode()).contentType(ContentType.JSON)
-        .body("type", equalTo(InvalidRequestException.class.getSimpleName()))
+        .body("type", equalTo("UserNotFoundException"))
         .body("message", equalTo(exceptionMessage))
     .when()
         .get(USER_PROFILE_URL);
@@ -627,7 +627,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
         .body(dto).contentType(ContentType.JSON)
     .then()
         .then().expect().statusCode(Status.NOT_FOUND.getStatusCode()).contentType(ContentType.JSON)
-        .body("type", equalTo(InvalidRequestException.class.getSimpleName()))
+        .body("type", equalTo("UserNotFoundException"))
         .body("message", equalTo(exceptionMessage))
     .when()
         .put(USER_CREDENTIALS_URL);
@@ -683,7 +683,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
         .body(updateDto).contentType(ContentType.JSON)
     .then()
         .then().expect().statusCode(Status.NOT_FOUND.getStatusCode()).contentType(ContentType.JSON)
-        .body("type", equalTo(InvalidRequestException.class.getSimpleName()))
+        .body("type", equalTo("UserNotFoundException"))
         .body("message", equalTo(exceptionMessage))
     .when()
         .put(USER_PROFILE_URL);

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CompleteTaskCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/CompleteTaskCmd.java
@@ -27,6 +27,7 @@ import org.operaton.bpm.engine.impl.persistence.entity.ExecutionVariableSnapshot
 import org.operaton.bpm.engine.impl.persistence.entity.TaskEntity;
 import org.operaton.bpm.engine.impl.persistence.entity.TaskManager;
 import org.operaton.bpm.engine.variable.VariableMap;
+import org.operaton.bpm.engine.variable.impl.VariableMapImpl;
 
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
@@ -34,6 +35,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Joram Barrez
  */
 public class CompleteTaskCmd implements Command<VariableMap> {
+  private static final VariableMapImpl EMPTY_VARIABLE_MAP = new VariableMapImpl();
   protected String taskId;
   protected Map<String, Object> variables;
 
@@ -82,12 +84,12 @@ public class CompleteTaskCmd implements Command<VariableMap> {
       if (variablesListener != null) {
         return variablesListener.getVariables();
       } else {
-        return task.getCaseDefinitionId() != null ? null : task.getVariablesTyped(false);
+        return task.getCaseDefinitionId() != null ? EMPTY_VARIABLE_MAP : task.getVariablesTyped(false);
       }
     }
     else
     {
-      return null;
+      return EMPTY_VARIABLE_MAP;
     }
 
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SubmitTaskFormCmd.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/SubmitTaskFormCmd.java
@@ -31,6 +31,7 @@ import org.operaton.bpm.engine.impl.task.TaskDefinition;
 import org.operaton.bpm.engine.task.DelegationState;
 import org.operaton.bpm.engine.variable.VariableMap;
 import org.operaton.bpm.engine.variable.Variables;
+import org.operaton.bpm.engine.variable.impl.VariableMapImpl;
 
 import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
 
@@ -39,6 +40,7 @@ import static org.operaton.bpm.engine.impl.util.EnsureUtil.ensureNotNull;
  * @author Joram Barrez
  */
 public class SubmitTaskFormCmd implements Command<VariableMap> {
+  private static final VariableMapImpl EMPTY_VARIABLE_MAP = new VariableMapImpl();
   protected String taskId;
   protected VariableMap properties;
 
@@ -95,12 +97,12 @@ public class SubmitTaskFormCmd implements Command<VariableMap> {
       if (variablesListener != null) {
         return variablesListener.getVariables();
       } else {
-        return task.getCaseDefinitionId() == null ? null : task.getVariablesTyped(false);
+        return task.getCaseDefinitionId() == null ? EMPTY_VARIABLE_MAP : task.getVariablesTyped(false);
       }
     }
     else
     {
-      return null;
+      return EMPTY_VARIABLE_MAP;
     }
   }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskServiceTest.java
@@ -1464,7 +1464,7 @@ class TaskServiceTest {
 
     taskService.setVariable(task1.getId(), taskVariableName, taskVariableValue);
     Map<String, Object> vars = taskService.completeWithVariablesInReturn(task1.getId(), null, true);
-    assertThat(vars).isNull();
+    assertThat(vars).isEmpty();
   }
 
   @Deployment(resources = {"org/operaton/bpm/engine/test/api/cmmn/oneTaskCase.cmmn"})


### PR DESCRIPTION
Adapt to change 8bb186d91aaca1eca6f8ce84576d5ad4c0573659 that changed VariableValueDto.toMap() returning now empty maps instead of null.