### PR TITLE
refactor(engine): Resolve singletons in AbstractBatchConfigurationObjectConverter subtypes

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ModificationBatchJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ModificationBatchJobHandler.java
@@ -34,6 +34,8 @@ import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 public class ModificationBatchJobHandler extends AbstractBatchJobHandler<ModificationBatchConfiguration>{
 
   public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(Batch.TYPE_PROCESS_INSTANCE_MODIFICATION);
+  private static final ModificationBatchConfigurationJsonConverter JSON_CONVERTER =
+      new ModificationBatchConfigurationJsonConverter();
 
   @Override
   public String getType() {
@@ -93,7 +95,7 @@ public class ModificationBatchJobHandler extends AbstractBatchJobHandler<Modific
 
   @Override
   protected ModificationBatchConfigurationJsonConverter getJsonConverterInstance() {
-    return ModificationBatchConfigurationJsonConverter.INSTANCE;
+    return JSON_CONVERTER;
   }
 
   protected ProcessDefinitionEntity getProcessDefinition(CommandContext commandContext, String processDefinitionId) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/RestartProcessInstancesBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/RestartProcessInstancesBatchConfigurationJsonConverter.java
@@ -30,8 +30,6 @@ import org.operaton.bpm.engine.impl.util.JsonUtil;
 public class RestartProcessInstancesBatchConfigurationJsonConverter
   extends AbstractBatchConfigurationObjectConverter<RestartProcessInstancesBatchConfiguration> {
 
-  public static final RestartProcessInstancesBatchConfigurationJsonConverter INSTANCE = new RestartProcessInstancesBatchConfigurationJsonConverter();
-
   public static final String PROCESS_INSTANCE_IDS = "processInstanceIds";
   public static final String PROCESS_INSTANCE_ID_MAPPINGS = "processInstanceIdMappings";
   public static final String INSTRUCTIONS = "instructions";

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/RestartProcessInstancesJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/RestartProcessInstancesJobHandler.java
@@ -40,6 +40,8 @@ import org.operaton.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity;
 public class RestartProcessInstancesJobHandler extends AbstractBatchJobHandler<RestartProcessInstancesBatchConfiguration>{
 
   public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(Batch.TYPE_PROCESS_INSTANCE_RESTART);
+  private static final RestartProcessInstancesBatchConfigurationJsonConverter JSON_CONVERTER =
+      new RestartProcessInstancesBatchConfigurationJsonConverter();
 
   @Override
   public String getType() {
@@ -107,7 +109,7 @@ public class RestartProcessInstancesJobHandler extends AbstractBatchJobHandler<R
 
   @Override
   protected RestartProcessInstancesBatchConfigurationJsonConverter getJsonConverterInstance() {
-    return RestartProcessInstancesBatchConfigurationJsonConverter.INSTANCE;
+    return JSON_CONVERTER;
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/deletion/DeleteHistoricProcessInstanceBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/deletion/DeleteHistoricProcessInstanceBatchConfigurationJsonConverter.java
@@ -32,8 +32,6 @@ import org.operaton.bpm.engine.impl.util.JsonUtil;
 public class DeleteHistoricProcessInstanceBatchConfigurationJsonConverter
   extends AbstractBatchConfigurationObjectConverter<BatchConfiguration> {
 
-  public static final DeleteHistoricProcessInstanceBatchConfigurationJsonConverter INSTANCE = new DeleteHistoricProcessInstanceBatchConfigurationJsonConverter();
-
   public static final String HISTORIC_PROCESS_INSTANCE_IDS = "historicProcessInstanceIds";
   public static final String HISTORIC_PROCESS_INSTANCE_ID_MAPPINGS = "historicProcessInstanceIdMappings";
   public static final String FAIL_IF_NOT_EXISTS = "failIfNotExists";

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/deletion/DeleteHistoricProcessInstancesJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/deletion/DeleteHistoricProcessInstancesJobHandler.java
@@ -35,6 +35,8 @@ import org.operaton.bpm.engine.impl.persistence.entity.MessageEntity;
 public class DeleteHistoricProcessInstancesJobHandler extends AbstractBatchJobHandler<BatchConfiguration> {
 
   public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(Batch.TYPE_HISTORIC_PROCESS_INSTANCE_DELETION);
+  private static final DeleteHistoricProcessInstanceBatchConfigurationJsonConverter JSON_CONVERTER =
+      new DeleteHistoricProcessInstanceBatchConfigurationJsonConverter();
 
   @Override
   public String getType() {
@@ -42,7 +44,7 @@ public class DeleteHistoricProcessInstancesJobHandler extends AbstractBatchJobHa
   }
 
   protected DeleteHistoricProcessInstanceBatchConfigurationJsonConverter getJsonConverterInstance() {
-    return DeleteHistoricProcessInstanceBatchConfigurationJsonConverter.INSTANCE;
+    return JSON_CONVERTER;
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/deletion/DeleteProcessInstanceBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/deletion/DeleteProcessInstanceBatchConfigurationJsonConverter.java
@@ -33,8 +33,6 @@ import org.operaton.bpm.engine.impl.util.JsonUtil;
 public class DeleteProcessInstanceBatchConfigurationJsonConverter
   extends AbstractBatchConfigurationObjectConverter<DeleteProcessInstanceBatchConfiguration> {
 
-  public static final DeleteProcessInstanceBatchConfigurationJsonConverter INSTANCE = new DeleteProcessInstanceBatchConfigurationJsonConverter();
-
   public static final String DELETE_REASON = "deleteReason";
   public static final String PROCESS_INSTANCE_IDS = "processInstanceIds";
   public static final String PROCESS_INSTANCE_ID_MAPPINGS = "processInstanceIdMappings";

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/deletion/DeleteProcessInstancesJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/deletion/DeleteProcessInstancesJobHandler.java
@@ -38,6 +38,8 @@ import org.operaton.bpm.engine.impl.persistence.entity.MessageEntity;
 public class DeleteProcessInstancesJobHandler extends AbstractBatchJobHandler<DeleteProcessInstanceBatchConfiguration> {
 
   public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(Batch.TYPE_PROCESS_INSTANCE_DELETION);
+  private static final DeleteProcessInstanceBatchConfigurationJsonConverter JSON_CONVERTER =
+      new DeleteProcessInstanceBatchConfigurationJsonConverter();
 
   @Override
   public String getType() {
@@ -45,7 +47,7 @@ public class DeleteProcessInstancesJobHandler extends AbstractBatchJobHandler<De
   }
 
   protected DeleteProcessInstanceBatchConfigurationJsonConverter getJsonConverterInstance() {
-    return DeleteProcessInstanceBatchConfigurationJsonConverter.INSTANCE;
+    return JSON_CONVERTER;
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/externaltask/SetExternalTaskRetriesBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/externaltask/SetExternalTaskRetriesBatchConfigurationJsonConverter.java
@@ -29,8 +29,6 @@ import org.operaton.bpm.engine.impl.util.JsonUtil;
 public class SetExternalTaskRetriesBatchConfigurationJsonConverter
   extends AbstractBatchConfigurationObjectConverter<SetRetriesBatchConfiguration> {
 
-  public static final SetExternalTaskRetriesBatchConfigurationJsonConverter INSTANCE = new SetExternalTaskRetriesBatchConfigurationJsonConverter();
-
   public static final String EXTERNAL_TASK_IDS = "externalTaskIds";
   public static final String EXTERNAL_TASK_ID_MAPPINGS = "externalTaskIdMappingss";
   public static final String RETRIES = "retries";

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/externaltask/SetExternalTaskRetriesJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/externaltask/SetExternalTaskRetriesJobHandler.java
@@ -33,6 +33,8 @@ import org.operaton.bpm.engine.impl.persistence.entity.MessageEntity;
 public class SetExternalTaskRetriesJobHandler extends AbstractBatchJobHandler<SetRetriesBatchConfiguration> {
 
   public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(Batch.TYPE_SET_EXTERNAL_TASK_RETRIES);
+  private static final SetExternalTaskRetriesBatchConfigurationJsonConverter JSON_CONVERTER =
+      new SetExternalTaskRetriesBatchConfigurationJsonConverter();
 
   @Override
   public String getType() {
@@ -65,7 +67,7 @@ public class SetExternalTaskRetriesJobHandler extends AbstractBatchJobHandler<Se
 
   @Override
   protected SetExternalTaskRetriesBatchConfigurationJsonConverter getJsonConverterInstance() {
-    return SetExternalTaskRetriesBatchConfigurationJsonConverter.INSTANCE;
+    return JSON_CONVERTER;
   }
 
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/job/SetJobRetriesBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/job/SetJobRetriesBatchConfigurationJsonConverter.java
@@ -33,8 +33,6 @@ import org.operaton.bpm.engine.impl.util.JsonUtil;
 public class SetJobRetriesBatchConfigurationJsonConverter
   extends AbstractBatchConfigurationObjectConverter<SetJobRetriesBatchConfiguration> {
 
-  public static final SetJobRetriesBatchConfigurationJsonConverter INSTANCE = new SetJobRetriesBatchConfigurationJsonConverter();
-
   public static final String JOB_IDS = "jobIds";
   public static final String JOB_ID_MAPPINGS = "jobIdMappings";
   public static final String RETRIES = "retries";

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/job/SetJobRetriesJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/job/SetJobRetriesJobHandler.java
@@ -35,6 +35,8 @@ import org.operaton.bpm.engine.impl.persistence.entity.MessageEntity;
  */
 public class SetJobRetriesJobHandler extends AbstractBatchJobHandler<SetJobRetriesBatchConfiguration> {
   public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(Batch.TYPE_SET_JOB_RETRIES);
+  private static final SetJobRetriesBatchConfigurationJsonConverter JSON_CONVERTER =
+      new SetJobRetriesBatchConfigurationJsonConverter();
 
   @Override
   public String getType() {
@@ -42,7 +44,7 @@ public class SetJobRetriesJobHandler extends AbstractBatchJobHandler<SetJobRetri
   }
 
   protected SetJobRetriesBatchConfigurationJsonConverter getJsonConverterInstance() {
-    return SetJobRetriesBatchConfigurationJsonConverter.INSTANCE;
+    return JSON_CONVERTER;
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/message/MessageCorrelationBatchJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/message/MessageCorrelationBatchJobHandler.java
@@ -43,6 +43,8 @@ import org.operaton.bpm.engine.variable.impl.VariableMapImpl;
 public class MessageCorrelationBatchJobHandler extends AbstractBatchJobHandler<MessageCorrelationBatchConfiguration> {
 
   public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(Batch.TYPE_CORRELATE_MESSAGE);
+  private static final MessageCorrelationBatchConfigurationJsonConverter JSON_CONVERTER =
+      new MessageCorrelationBatchConfigurationJsonConverter();
 
   @Override
   public String getType() {
@@ -55,7 +57,7 @@ public class MessageCorrelationBatchJobHandler extends AbstractBatchJobHandler<M
   }
 
   protected MessageCorrelationBatchConfigurationJsonConverter getJsonConverterInstance() {
-    return MessageCorrelationBatchConfigurationJsonConverter.INSTANCE;
+    return JSON_CONVERTER;
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/removaltime/BatchSetRemovalTimeJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/removaltime/BatchSetRemovalTimeJobHandler.java
@@ -39,6 +39,7 @@ import static org.operaton.bpm.engine.ProcessEngineConfiguration.HISTORY_REMOVAL
 public class BatchSetRemovalTimeJobHandler extends AbstractBatchJobHandler<SetRemovalTimeBatchConfiguration> {
 
   public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(Batch.TYPE_BATCH_SET_REMOVAL_TIME);
+  private static final SetRemovalTimeJsonConverter JSON_CONVERTER = new SetRemovalTimeJsonConverter();
 
   public void executeHandler(SetRemovalTimeBatchConfiguration batchConfiguration,
                              ExecutionEntity execution,
@@ -131,7 +132,7 @@ public class BatchSetRemovalTimeJobHandler extends AbstractBatchJobHandler<SetRe
   }
 
   protected SetRemovalTimeJsonConverter getJsonConverterInstance() {
-    return SetRemovalTimeJsonConverter.INSTANCE;
+    return JSON_CONVERTER;
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/removaltime/DecisionSetRemovalTimeJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/removaltime/DecisionSetRemovalTimeJobHandler.java
@@ -41,6 +41,7 @@ public class DecisionSetRemovalTimeJobHandler extends AbstractBatchJobHandler<Se
 
   public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(
       Batch.TYPE_DECISION_SET_REMOVAL_TIME);
+  private static final SetRemovalTimeJsonConverter JSON_CONVERTER = new SetRemovalTimeJsonConverter();
 
   public void executeHandler(SetRemovalTimeBatchConfiguration batchConfiguration,
       ExecutionEntity execution,
@@ -180,7 +181,7 @@ public class DecisionSetRemovalTimeJobHandler extends AbstractBatchJobHandler<Se
   }
 
   protected SetRemovalTimeJsonConverter getJsonConverterInstance() {
-    return SetRemovalTimeJsonConverter.INSTANCE;
+    return JSON_CONVERTER;
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/removaltime/ProcessSetRemovalTimeJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/removaltime/ProcessSetRemovalTimeJobHandler.java
@@ -49,6 +49,7 @@ public class ProcessSetRemovalTimeJobHandler extends AbstractBatchJobHandler<Set
 
   public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(Batch.TYPE_PROCESS_SET_REMOVAL_TIME);
   public static final int MAX_CHUNK_SIZE = 500;
+  private static final SetRemovalTimeJsonConverter JSON_CONVERTER = new SetRemovalTimeJsonConverter();
 
   @Override
   public void executeHandler(SetRemovalTimeBatchConfiguration configuration,
@@ -230,7 +231,7 @@ public class ProcessSetRemovalTimeJobHandler extends AbstractBatchJobHandler<Set
 
   @Override
   protected SetRemovalTimeJsonConverter getJsonConverterInstance() {
-    return SetRemovalTimeJsonConverter.INSTANCE;
+    return JSON_CONVERTER;
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/removaltime/SetRemovalTimeJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/removaltime/SetRemovalTimeJsonConverter.java
@@ -35,8 +35,6 @@ import org.operaton.bpm.engine.impl.util.JsonUtil;
 public class SetRemovalTimeJsonConverter
   extends AbstractBatchConfigurationObjectConverter<SetRemovalTimeBatchConfiguration> {
 
-  public static final SetRemovalTimeJsonConverter INSTANCE = new SetRemovalTimeJsonConverter();
-
   protected static final String IDS = "ids";
   protected static final String ID_MAPPINGS = "idMappings";
   protected static final String REMOVAL_TIME = "removalTime";

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/update/UpdateProcessInstancesSuspendStateBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/update/UpdateProcessInstancesSuspendStateBatchConfigurationJsonConverter.java
@@ -28,8 +28,6 @@ import org.operaton.bpm.engine.impl.util.JsonUtil;
 public class UpdateProcessInstancesSuspendStateBatchConfigurationJsonConverter
   extends AbstractBatchConfigurationObjectConverter<UpdateProcessInstancesSuspendStateBatchConfiguration> {
 
-  public static final UpdateProcessInstancesSuspendStateBatchConfigurationJsonConverter INSTANCE = new UpdateProcessInstancesSuspendStateBatchConfigurationJsonConverter();
-
   public static final String PROCESS_INSTANCE_IDS = "processInstanceIds";
   public static final String PROCESS_INSTANCE_ID_MAPPINGS = "processInstanceIdMappings";
   public static final String SUSPENDING = "suspended";

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/update/UpdateProcessInstancesSuspendStateJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/update/UpdateProcessInstancesSuspendStateJobHandler.java
@@ -33,6 +33,8 @@ import org.operaton.bpm.engine.impl.persistence.entity.MessageEntity;
 public class UpdateProcessInstancesSuspendStateJobHandler extends AbstractBatchJobHandler<UpdateProcessInstancesSuspendStateBatchConfiguration> {
 
   public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(Batch.TYPE_PROCESS_INSTANCE_UPDATE_SUSPENSION_STATE);
+  private static final UpdateProcessInstancesSuspendStateBatchConfigurationJsonConverter JSON_CONVERTER =
+      new UpdateProcessInstancesSuspendStateBatchConfigurationJsonConverter();
 
   @Override
   public String getType() {
@@ -40,7 +42,7 @@ public class UpdateProcessInstancesSuspendStateJobHandler extends AbstractBatchJ
   }
 
   protected UpdateProcessInstancesSuspendStateBatchConfigurationJsonConverter getJsonConverterInstance() {
-    return UpdateProcessInstancesSuspendStateBatchConfigurationJsonConverter.INSTANCE;
+    return JSON_CONVERTER;
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/variables/BatchSetVariablesHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/variables/BatchSetVariablesHandler.java
@@ -35,8 +35,8 @@ import org.operaton.bpm.engine.impl.persistence.entity.MessageEntity;
 
 public class BatchSetVariablesHandler extends AbstractBatchJobHandler<BatchConfiguration> {
 
-  public static final BatchJobDeclaration JOB_DECLARATION =
-      new BatchJobDeclaration(Batch.TYPE_SET_VARIABLES);
+  public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(Batch.TYPE_SET_VARIABLES);
+  private static final SetVariablesJsonConverter JSON_CONVERTER = new SetVariablesJsonConverter();
 
   @Override
   public void executeHandler(BatchConfiguration batchConfiguration,
@@ -68,7 +68,7 @@ public class BatchSetVariablesHandler extends AbstractBatchJobHandler<BatchConfi
 
   @Override
   protected SetVariablesJsonConverter getJsonConverterInstance() {
-    return SetVariablesJsonConverter.INSTANCE;
+    return JSON_CONVERTER;
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/variables/SetVariablesJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/variables/SetVariablesJsonConverter.java
@@ -28,8 +28,6 @@ import org.operaton.bpm.engine.impl.util.JsonUtil;
 
 public class SetVariablesJsonConverter extends AbstractBatchConfigurationObjectConverter<BatchConfiguration> {
 
-  public static final SetVariablesJsonConverter INSTANCE = new SetVariablesJsonConverter();
-
   protected static final String IDS = "ids";
   protected static final String ID_MAPPINGS = "idMappings";
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/batch/DeleteHistoricDecisionInstanceBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/batch/DeleteHistoricDecisionInstanceBatchConfigurationJsonConverter.java
@@ -28,8 +28,6 @@ import org.operaton.bpm.engine.impl.util.JsonUtil;
 
 public class DeleteHistoricDecisionInstanceBatchConfigurationJsonConverter extends AbstractBatchConfigurationObjectConverter<BatchConfiguration> {
 
-  public static final DeleteHistoricDecisionInstanceBatchConfigurationJsonConverter INSTANCE = new DeleteHistoricDecisionInstanceBatchConfigurationJsonConverter();
-
   public static final String HISTORIC_DECISION_INSTANCE_IDS = "historicDecisionInstanceIds";
   public static final String HISTORIC_DECISION_INSTANCE_ID_MAPPINGS = "historicDecisionInstanceIdMappingss";
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/batch/DeleteHistoricDecisionInstancesJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/batch/DeleteHistoricDecisionInstancesJobHandler.java
@@ -32,6 +32,8 @@ import org.operaton.bpm.engine.impl.persistence.entity.MessageEntity;
 public class DeleteHistoricDecisionInstancesJobHandler extends AbstractBatchJobHandler<BatchConfiguration> {
 
   public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(Batch.TYPE_HISTORIC_DECISION_INSTANCE_DELETION);
+  private static final DeleteHistoricDecisionInstanceBatchConfigurationJsonConverter JSON_CONVERTER =
+      new DeleteHistoricDecisionInstanceBatchConfigurationJsonConverter();
 
   @Override
   public String getType() {
@@ -39,7 +41,7 @@ public class DeleteHistoricDecisionInstancesJobHandler extends AbstractBatchJobH
   }
 
   protected DeleteHistoricDecisionInstanceBatchConfigurationJsonConverter getJsonConverterInstance() {
-    return DeleteHistoricDecisionInstanceBatchConfigurationJsonConverter.INSTANCE;
+    return JSON_CONVERTER;
   }
 
   @Override

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/json/MessageCorrelationBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/json/MessageCorrelationBatchConfigurationJsonConverter.java
@@ -29,8 +29,6 @@ import org.operaton.bpm.engine.impl.util.JsonUtil;
 public class MessageCorrelationBatchConfigurationJsonConverter
   extends AbstractBatchConfigurationObjectConverter<MessageCorrelationBatchConfiguration> {
 
-  public static final MessageCorrelationBatchConfigurationJsonConverter INSTANCE = new MessageCorrelationBatchConfigurationJsonConverter();
-
   public static final String MESSAGE_NAME = "messageName";
   public static final String PROCESS_INSTANCE_IDS = "processInstanceIds";
   public static final String PROCESS_INSTANCE_ID_MAPPINGS = "processInstanceIdMappings";

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/json/MigrationBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/json/MigrationBatchConfigurationJsonConverter.java
@@ -29,8 +29,6 @@ import org.operaton.bpm.engine.impl.util.JsonUtil;
 public class MigrationBatchConfigurationJsonConverter
   extends AbstractBatchConfigurationObjectConverter<MigrationBatchConfiguration> {
 
-  public static final MigrationBatchConfigurationJsonConverter INSTANCE = new MigrationBatchConfigurationJsonConverter();
-
   public static final String MIGRATION_PLAN = "migrationPlan";
   public static final String PROCESS_INSTANCE_IDS = "processInstanceIds";
   public static final String PROCESS_INSTANCE_ID_MAPPINGS = "processInstanceIdMappings";

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/json/ModificationBatchConfigurationJsonConverter.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/json/ModificationBatchConfigurationJsonConverter.java
@@ -30,7 +30,6 @@ import org.operaton.bpm.engine.impl.util.JsonUtil;
 public class ModificationBatchConfigurationJsonConverter
   extends AbstractBatchConfigurationObjectConverter<ModificationBatchConfiguration> {
 
-  public static final ModificationBatchConfigurationJsonConverter INSTANCE = new ModificationBatchConfigurationJsonConverter();
   public static final String INSTRUCTIONS = "instructions";
   public static final String PROCESS_INSTANCE_IDS = "processInstanceIds";
   public static final String PROCESS_INSTANCE_ID_MAPPINGS = "processInstanceIdMappings";

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/batch/MigrationBatchJobHandler.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/batch/MigrationBatchJobHandler.java
@@ -46,6 +46,8 @@ import org.operaton.bpm.engine.variable.impl.VariableMapImpl;
 public class MigrationBatchJobHandler extends AbstractBatchJobHandler<MigrationBatchConfiguration> {
 
   public static final BatchJobDeclaration JOB_DECLARATION = new BatchJobDeclaration(Batch.TYPE_PROCESS_INSTANCE_MIGRATION);
+  private static final MigrationBatchConfigurationJsonConverter JSON_CONVERTER =
+      new MigrationBatchConfigurationJsonConverter();
 
   @Override
   public String getType() {
@@ -58,7 +60,7 @@ public class MigrationBatchJobHandler extends AbstractBatchJobHandler<MigrationB
   }
 
   protected MigrationBatchConfigurationJsonConverter getJsonConverterInstance() {
-    return MigrationBatchConfigurationJsonConverter.INSTANCE;
+    return JSON_CONVERTER;
   }
 
   @Override


### PR DESCRIPTION
Instead of declaring a singleton in the converter classes themselves, the job handlers using them are declaring a constant internally.

This resolves unneeded singleton pattern usage.

Resolves Sonar issues of type java:S6548: "The Singleton design pattern should be used with care"

related to #511 