### PR TITLE
refactor(tests): Replace deprecated AssertJ isXmlEqualTo by XML Unit's XmlAssert

### DIFF
--- a/spin/dataformat-xml-dom/pom.xml
+++ b/spin/dataformat-xml-dom/pom.xml
@@ -90,6 +90,12 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-assertj</artifactId>
+      <version>2.11.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <profiles>
     <!-- check for api differences between latest minor release -->

--- a/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomElementTest.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomElementTest.java
@@ -29,6 +29,7 @@ import org.operaton.spin.xml.SpinXmlAttribute;
 import org.operaton.spin.xml.SpinXmlAttributeException;
 import org.operaton.spin.xml.SpinXmlElement;
 import org.operaton.spin.xml.SpinXmlElementException;
+import org.xmlunit.assertj.XmlAssert;
 
 import static org.operaton.spin.Spin.S;
 import static org.operaton.spin.Spin.XML;
@@ -676,7 +677,7 @@ class XmlDomElementTest {
 
   @Test
   void canWriteToString() {
-    assertThat(element.toString()).isXmlEqualTo(EXAMPLE_XML);
+    XmlAssert.assertThat(element.toString()).isEqualTo(EXAMPLE_XML);
   }
 
   @Test
@@ -684,7 +685,7 @@ class XmlDomElementTest {
     StringWriter writer = new StringWriter();
     element.writeToWriter(writer);
     String value = writer.toString();
-    assertThat(value).isXmlEqualTo(EXAMPLE_XML);
+    XmlAssert.assertThat(value).isEqualTo(EXAMPLE_XML);
   }
 
   // text content

--- a/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomMapJavaToXmlScriptTest.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomMapJavaToXmlScriptTest.java
@@ -22,6 +22,7 @@ import org.operaton.spin.impl.test.Script;
 import org.operaton.spin.impl.test.ScriptTest;
 import org.operaton.spin.xml.XmlTestUtil;
 import org.operaton.spin.xml.mapping.Order;
+import org.xmlunit.assertj.XmlAssert;
 
 import static org.operaton.spin.xml.XmlTestConstants.EXAMPLE_VALIDATION_XML;
 import static org.operaton.spin.xml.XmlTestConstants.createExampleOrder;
@@ -43,7 +44,7 @@ public abstract class XmlDomMapJavaToXmlScriptTest extends ScriptTest {
     //different timezone
     String exampleValidationXmlWoTimezone = XmlTestUtil.removeTimeZone(EXAMPLE_VALIDATION_XML);
     xml = XmlTestUtil.removeTimeZone(xml);
-    assertThat(xml).isXmlEqualTo(exampleValidationXmlWoTimezone);
+    XmlAssert.assertThat(xml).isEqualTo(exampleValidationXmlWoTimezone);
   }
 
   @Test

--- a/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomMapJavaToXmlTest.java
+++ b/spin/dataformat-xml-dom/src/test/java/org/operaton/spin/xml/dom/XmlDomMapJavaToXmlTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.operaton.spin.xml.XmlTestUtil;
 import org.operaton.spin.xml.mapping.NonXmlRootElementType;
 import org.operaton.spin.xml.mapping.Order;
+import org.xmlunit.assertj.XmlAssert;
 
 import static org.operaton.spin.Spin.XML;
 import static org.operaton.spin.xml.XmlTestConstants.EXAMPLE_VALIDATION_XML;
@@ -38,7 +39,7 @@ class XmlDomMapJavaToXmlTest {
     //different timezone
     String exampleValidationXmlWoTimezone = XmlTestUtil.removeTimeZone(EXAMPLE_VALIDATION_XML);
     orderAsString = XmlTestUtil.removeTimeZone(orderAsString);
-    assertThat(orderAsString).isXmlEqualTo(exampleValidationXmlWoTimezone);
+    XmlAssert.assertThat(orderAsString).isEqualTo(exampleValidationXmlWoTimezone);
   }
 
   @Test

--- a/spin/dataformat-xml-dom/src/test/resources/org/operaton/spin/xml/example.xml
+++ b/spin/dataformat-xml-dom/src/test/resources/org/operaton/spin/xml/example.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<customers xmlns="http://operaton.org/example" xmlns:ex="http://operaton.org/example" order="order1" ex:dueUntil="20150112">
-  <date name="20140512" />
+<?xml version="1.0" encoding="UTF-8"?><customers xmlns="http://operaton.org/example" xmlns:ex="http://operaton.org/example" ex:dueUntil="20150112" order="order1">
+  <date name="20140512"/>
   <file xmlns=""/>
   <customer id="customer1">
     <name>Kermit</name>


### PR DESCRIPTION
Resolves usage of deprecated code in tests.

Related to #144 