### PR TITLE
fix(webapps): Use ConcurretHashMap for commandExecutors map

### DIFF
--- a/webapps/assembly/src/main/java/org/operaton/bpm/admin/impl/DefaultAdminRuntimeDelegate.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/admin/impl/DefaultAdminRuntimeDelegate.java
@@ -16,10 +16,10 @@
  */
 package org.operaton.bpm.admin.impl;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import java.util.concurrent.ConcurrentHashMap;
 import org.operaton.bpm.admin.AdminRuntimeDelegate;
 import org.operaton.bpm.admin.plugin.spi.AdminPlugin;
 import org.operaton.bpm.engine.ProcessEngine;
@@ -46,7 +46,7 @@ public class DefaultAdminRuntimeDelegate extends AbstractAppRuntimeDelegate<Admi
 
   public DefaultAdminRuntimeDelegate() {
     super(AdminPlugin.class);
-    this.commandExecutors = new HashMap<>();
+    this.commandExecutors = new ConcurrentHashMap<>();
   }
 
   @Override

--- a/webapps/assembly/src/main/java/org/operaton/bpm/cockpit/impl/DefaultCockpitRuntimeDelegate.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/cockpit/impl/DefaultCockpitRuntimeDelegate.java
@@ -17,10 +17,10 @@
 package org.operaton.bpm.cockpit.impl;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import java.util.concurrent.ConcurrentHashMap;
 import org.operaton.bpm.cockpit.CockpitRuntimeDelegate;
 import org.operaton.bpm.cockpit.db.CommandExecutor;
 import org.operaton.bpm.cockpit.db.QueryService;
@@ -49,7 +49,7 @@ public class DefaultCockpitRuntimeDelegate extends AbstractAppRuntimeDelegate<Co
 
   public DefaultCockpitRuntimeDelegate() {
     super(CockpitPlugin.class);
-    this.commandExecutors = new HashMap<>();
+    this.commandExecutors = new ConcurrentHashMap<>();
   }
 
   @Override


### PR DESCRIPTION
These maps are potentially modified by different threads in parallel. Using a ConcurrentHashMap to avoid exceptions.

Fixes #2185