### PR TITLE
Upload server logs on integration test failure

### DIFF
--- a/.github/workflows/integration-build.yml
+++ b/.github/workflows/integration-build.yml
@@ -536,3 +536,13 @@ jobs:
             echo "Failed to notify Docker repository. HTTP response code: $response"
             exit 1
           fi
+      - name: Upload server logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-logs
+          path: |
+            qa/wildfly-runtime/target/server/wildfly-*.Final/standalone/log
+            qa/tomcat-runtime/target/server/apache-tomcat-*/logs
+          if-no-files-found: ignore
+


### PR DESCRIPTION
### What this PR does

- Uploads WildFly and Tomcat server logs as GitHub Actions artifacts
- Runs only when integration tests fail
- Helps diagnose CI failures faster without rerunning jobs

### Details

- Uses `actions/upload-artifact@v4`
- Safe guard added with `if-no-files-found: ignore`
- No impact on successful builds

Fixes: CI debugging improvement
