### PR TITLE
fix(tests): Skip email tests when Docker is not available

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/mail/EmailTestCase.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/mail/EmailTestCase.java
@@ -49,7 +49,7 @@ import static org.assertj.core.api.Assertions.fail;
 /**
  * @author Joram Barrez
  */
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 public abstract class EmailTestCase {
 
   @RegisterExtension


### PR DESCRIPTION
With b539967e4ee33f4b5b54af7c2848baa16b88f054 (#2235) the email tests have been refactored to use the mailpit testcontainer. This requires a running Docker environment for the test execution.

Set `disabledWithoutDocker = true` for the `@Testcontainers` annotation to skip these tests when Docker is unavailable.

fixes #2340