### PR TITLE
fix(engine-cdi): ensure CDI producers are discoverable with annotated bean discovery

### DIFF
--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/BusinessProcess.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/BusinessProcess.java
@@ -20,6 +20,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
 import jakarta.enterprise.context.Conversation;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -82,6 +83,7 @@ import org.operaton.bpm.engine.variable.value.TypedValue;
  * @author Daniel Meyer
  * @author Falko Menge
  */
+@Dependent
 @Named
 public class BusinessProcess implements Serializable {
 

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/CurrentProcessInstance.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/CurrentProcessInstance.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.cdi;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.Typed;
 import jakarta.inject.Inject;
@@ -40,6 +41,7 @@ import org.operaton.bpm.engine.task.Task;
  *
  * @author Falko Menge
  */
+@Dependent
 public class CurrentProcessInstance {
 
   @Inject

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/ProcessVariables.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/ProcessVariables.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.cdi;
 
 import java.util.Map;
 import java.util.logging.Logger;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.inject.Inject;
@@ -38,6 +39,7 @@ import org.operaton.bpm.engine.variable.value.TypedValue;
  *
  * @author Daniel Meyer
  */
+@Dependent
 public class ProcessVariables {
 
   private final Logger logger = Logger.getLogger(ProcessVariables.class.getName());

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/NamedProcessEngineServicesProducer.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/NamedProcessEngineServicesProducer.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.cdi.impl;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 
@@ -49,6 +50,7 @@ import org.operaton.bpm.engine.cdi.annotation.ProcessEngineName;
  *
  * @author Daniel Meyer
  */
+@Dependent
 public class NamedProcessEngineServicesProducer {
 
   @Produces @ProcessEngineName("")

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/ProcessEngineServicesProducer.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/ProcessEngineServicesProducer.java
@@ -18,6 +18,7 @@ package org.operaton.bpm.engine.cdi.impl;
 
 import java.util.List;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Named;
 
@@ -43,6 +44,7 @@ import org.operaton.bpm.engine.TaskService;
  * @author Daniel Meyer
  * @author Falko Menge
  */
+@Dependent
 public class ProcessEngineServicesProducer {
 
   @Produces

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/ProcessVariableLocalMap.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/ProcessVariableLocalMap.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.cdi.impl;
 
+import jakarta.enterprise.context.Dependent;
+
 import org.operaton.bpm.engine.cdi.BusinessProcess;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 
@@ -30,6 +32,7 @@ import org.operaton.bpm.engine.variable.value.TypedValue;
  *
  * @author Michael Scholz
  */
+@Dependent
 public class ProcessVariableLocalMap extends AbstractVariableMap {
 
   @Override

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/ProcessVariableMap.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/ProcessVariableMap.java
@@ -16,6 +16,8 @@
  */
 package org.operaton.bpm.engine.cdi.impl;
 
+import jakarta.enterprise.context.Dependent;
+
 import org.operaton.bpm.engine.cdi.BusinessProcess;
 import org.operaton.bpm.engine.variable.value.TypedValue;
 
@@ -30,6 +32,7 @@ import org.operaton.bpm.engine.variable.value.TypedValue;
  *
  * @author Daniel Meyer
  */
+@Dependent
 public class ProcessVariableMap extends AbstractVariableMap {
 
   @Override

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/annotation/BusinessKeyProducer.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/annotation/BusinessKeyProducer.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.cdi.impl.annotation;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Named;
 
@@ -27,6 +28,7 @@ import org.operaton.bpm.engine.runtime.ProcessInstance;
  *
  * @author Daniel Meyer
  */
+@Dependent
 public class BusinessKeyProducer {
 
   @Produces

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/context/DefaultContextAssociationManager.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/context/DefaultContextAssociationManager.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jakarta.enterprise.context.ContextNotActiveException;
+import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.inject.Inject;
 import jakarta.inject.Scope;
@@ -49,6 +50,7 @@ import org.operaton.bpm.engine.variable.value.TypedValue;
  * @author Daniel Meyer
  */
 @SuppressWarnings("serial")
+@Dependent
 public class DefaultContextAssociationManager implements ContextAssociationManager, Serializable {
 
   protected static final Logger log = Logger.getLogger(DefaultContextAssociationManager.class.getName());


### PR DESCRIPTION
Add explicit `@Dependent` bean-defining annotations to engine-cdi producer/support classes that previously relied on archive-wide discovery, and add a regression test that deploys with bean-discovery-mode="annotated".

This hardens CDI 4.x/container compatibility and prevents unsatisfied dependency errors caused by missing producer beans.

This was reported in this forum thread: https://forum.operaton.org/t/weld-001408-unsatisfied-dependencies-for-engine-services/402