### PR TITLE
fix(wildfly): provide operaton-engine-cdi as default module dependency

### DIFF
--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -55,6 +55,10 @@
     </dependency>
     <dependency>
       <groupId>org.operaton.bpm</groupId>
+      <artifactId>operaton-engine-cdi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.operaton.bpm</groupId>
       <artifactId>operaton-engine-plugin-spin</artifactId>
     </dependency>
     <dependency>

--- a/distro/wildfly/modules/src/main/modules/org/operaton/bpm/operaton-engine-cdi/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/operaton/bpm/operaton-engine-cdi/main/module.xml
@@ -1,0 +1,37 @@
+<!--
+  Copyright 2026 the Operaton contributors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at:
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<module xmlns="urn:jboss:module:1.0" name="org.operaton.bpm.operaton-engine-cdi">
+  <resources>
+    <resource-root path="operaton-engine-cdi-@project.version@.jar" />
+  </resources>
+
+  <dependencies>
+
+    <module name="java.base" />
+    <module name="java.logging" />
+    <module name="java.naming" />
+    <module name="jakarta.transaction.api" />
+    <module name="jakarta.enterprise.api" />
+    <module name="jakarta.enterprise.concurrent.api" />
+    <module name="jakarta.inject.api" />
+    <module name="jakarta.interceptor.api" />
+    <module name="jakarta.el.api" />
+    <module name="jakarta.faces.api" />
+
+    <module name="org.operaton.bpm.operaton-engine" />
+
+  </dependencies>
+</module>

--- a/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/deployment/processor/ModuleDependencyProcessor.java
+++ b/distro/wildfly/subsystem/src/main/java/org/operaton/bpm/container/impl/jboss/deployment/processor/ModuleDependencyProcessor.java
@@ -31,6 +31,7 @@ import org.jboss.as.server.deployment.module.ModuleSpecification;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
+import org.jboss.modules.filter.PathFilters;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController.Mode;
 import org.jboss.msc.service.ServiceName;
@@ -62,6 +63,7 @@ public class ModuleDependencyProcessor implements DeploymentUnitProcessor {
   public static String MODULE_IDENTIFIER_DMN_MODEL = "org.operaton.bpm.model.operaton-dmn-model";
   public static String MODULE_IDENTIFIER_SPIN = "org.operaton.spin.operaton-spin-core";
   public static String MODULE_IDENTIFIER_CONNECT = "org.operaton.connect.operaton-connect-core";
+  public static String MODULE_IDENTIFIER_ENGINE_CDI = "org.operaton.bpm.operaton-engine-cdi";
   public static String MODULE_IDENTIFIER_ENGINE_DMN = "org.operaton.bpm.dmn.operaton-engine-dmn";
   public static String MODULE_IDENTIFIER_GRAAL_JS = "org.graalvm.js.js-all";
   public static String MODULE_IDENTIFIER_JUEL = "org.operaton.bpm.juel.operaton-juel";
@@ -151,6 +153,9 @@ public class ModuleDependencyProcessor implements DeploymentUnitProcessor {
     addSystemDependency(moduleLoader, moduleSpecification, MODULE_IDENTIFIER_ENGINE_DMN);
     addSystemDependency(moduleLoader, moduleSpecification, MODULE_IDENTIFIER_GRAAL_JS, true);
     addSystemDependency(moduleLoader, moduleSpecification, MODULE_IDENTIFIER_JUEL, true);
+    // Keep the CDI dependency as the last addition because it is the only module
+    // dependency with custom META-INF import filters for Weld bean discovery.
+    addEngineCdiSystemDependency(moduleLoader, moduleSpecification);
   }
 
   private void addSystemDependency(ModuleLoader moduleLoader, final ModuleSpecification moduleSpecification, String identifier) {
@@ -159,6 +164,23 @@ public class ModuleDependencyProcessor implements DeploymentUnitProcessor {
 
   private void addSystemDependency(ModuleLoader moduleLoader, final ModuleSpecification moduleSpecification, String identifier, boolean importServices) {
     moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, identifier, false, false, importServices, false));
+  }
+
+  private void addEngineCdiSystemDependency(ModuleLoader moduleLoader, final ModuleSpecification moduleSpecification) {
+    // engine-cdi is a special case: for Weld discovery we need services plus META-INF
+    // from the module (in particular beans.xml), otherwise injections can fail with WELD-001408.
+    ModuleDependency dependency = ModuleDependency.Builder.of(moduleLoader, MODULE_IDENTIFIER_ENGINE_CDI)
+      .setOptional(false)
+      .setExport(false)
+      .setImportServices(true)
+      .setUserSpecified(false)
+      .build();
+    // Required for server-provided CDI producers from operaton-engine-cdi:
+    // services="import" alone does not import META-INF/beans.xml and leads to WELD-001408.
+    // These filters are equivalent to jboss-deployment-structure meta-inf="import".
+    dependency.addImportFilter(PathFilters.getMetaInfSubdirectoriesFilter(), true);
+    dependency.addImportFilter(PathFilters.getMetaInfFilter(), true);
+    moduleSpecification.addSystemDependency(dependency);
   }
 
 }

--- a/qa/integration-tests-engine/pom.xml
+++ b/qa/integration-tests-engine/pom.xml
@@ -66,6 +66,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
       <scope>provided</scope>
@@ -435,6 +440,7 @@
                 <!-- See Relevant issue: https://github.com/camunda/camunda-bpm-platform/issues/4434 -->
                 <exclude>**/CallActivityContextSwitchTest.java</exclude>
                 <exclude>**/CdiBeanCallActivityResolutionTest.java</exclude>
+                <exclude>**/CdiServletInjectionTest.java</exclude>
                 <!-- TODO and weld-servlet-shaded is resolved with integration-tests-engine -->
               </excludes>
               <redirectTestOutputToFile>${redirect.test.output}</redirectTestOutputToFile>
@@ -509,6 +515,7 @@
             <configuration>
               <systemPropertyVariables>
                 <databaseType>${database.type}</databaseType>
+                <jboss.http.port>${jboss.http.port}</jboss.http.port>
               </systemPropertyVariables>
               <excludes>
                 <!-- HEMERA-2453 -->

--- a/qa/integration-tests-engine/src/test/java-wildfly/org/operaton/bpm/integrationtest/functional/cdi/CdiServletInjectionTest.java
+++ b/qa/integration-tests-engine/src/test/java-wildfly/org/operaton/bpm/integrationtest/functional/cdi/CdiServletInjectionTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.integrationtest.functional.cdi;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.operaton.bpm.integrationtest.functional.cdi.beans.IdentityServiceInjectingProcessApplication;
+import org.operaton.bpm.integrationtest.functional.cdi.beans.IdentityServiceInjectingServlet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Regression test for WELD-001408 when injecting IdentityService into a Servlet
+ * in a Process Application on WildFly.
+ */
+@ExtendWith(ArquillianExtension.class)
+public class CdiServletInjectionTest {
+
+  private static final String DEPLOYMENT_NAME = "cdi-identity-service-servlet-injection";
+  private static final String JBOSS_HTTP_PORT_PROPERTY = "jboss.http.port";
+  private static final Duration SERVLET_RESPONSE_TIMEOUT = Duration.ofSeconds(30);
+  private static final Duration SERVLET_RESPONSE_POLL_INTERVAL = Duration.ofMillis(250);
+
+  @ArquillianResource
+  private Deployer deployer;
+
+  @Deployment(name = DEPLOYMENT_NAME, managed = false)
+  public static WebArchive createDeployment() {
+    return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME + ".war")
+      .addAsWebInfResource("org/operaton/bpm/integrationtest/beans.xml", "beans.xml")
+      .addAsManifestResource("jboss-deployment-structure.xml")
+      .addAsResource("META-INF/processes.xml", "META-INF/processes.xml")
+      .addClass(IdentityServiceInjectingServlet.class)
+      .addClass(IdentityServiceInjectingProcessApplication.class);
+  }
+
+  @Test
+  @RunAsClient
+  void shouldDeployWithIdentityServiceServletInjectionUsingServerModule() throws Exception {
+    assertDeploymentSucceeds(DEPLOYMENT_NAME,
+      "Deployment should be successful with operaton-engine-cdi provided by WildFly module");
+  }
+
+  private void assertDeploymentSucceeds(String deploymentName, String failureMessage) throws Exception {
+    try {
+      try {
+        deployer.deploy(deploymentName);
+      } catch (Exception exception) {
+        throw new AssertionError(failureMessage
+          + System.lineSeparator()
+          + formatExceptionChain(exception), exception);
+      }
+
+      assertIdentityServiceServletResponse(deploymentName);
+    } finally {
+      try {
+        deployer.undeploy(deploymentName);
+      } catch (Exception ignored) {
+        // deployment may fail before being installed
+      }
+    }
+  }
+
+  private int resolveHttpPort() {
+    String httpPortProperty = System.getProperty(JBOSS_HTTP_PORT_PROPERTY);
+    if (httpPortProperty == null || httpPortProperty.isBlank()) {
+      throw new IllegalStateException("Missing system property '" + JBOSS_HTTP_PORT_PROPERTY + "'");
+    }
+
+    try {
+      return Integer.parseInt(httpPortProperty);
+    } catch (NumberFormatException exception) {
+      throw new IllegalStateException(
+        "System property '" + JBOSS_HTTP_PORT_PROPERTY + "' is not a valid integer: " + httpPortProperty,
+        exception);
+    }
+  }
+
+  private void assertIdentityServiceServletResponse(String deploymentName) throws Exception {
+    HttpClient client = HttpClient.newHttpClient();
+    int httpPort = resolveHttpPort();
+    URI servletUrl = URI.create("http://127.0.0.1:" + httpPort + "/" + deploymentName + "/identity-service-check");
+    HttpRequest request = HttpRequest.newBuilder(servletUrl).GET().build();
+    AtomicReference<HttpResponse<String>> responseReference = new AtomicReference<>();
+
+    try {
+      await()
+        .atMost(SERVLET_RESPONSE_TIMEOUT)
+        .pollInterval(SERVLET_RESPONSE_POLL_INTERVAL)
+        .ignoreExceptions()
+        .until(() -> {
+          HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+          responseReference.set(response);
+          return response.statusCode() == 200 && "identityService=ok".equals(response.body());
+        });
+    } catch (Exception exception) {
+      throw new AssertionError("Servlet check failed for URL " + servletUrl
+        + " within timeout " + SERVLET_RESPONSE_TIMEOUT
+        + ". Last observed response: " + formatResponse(responseReference.get())
+        + System.lineSeparator()
+        + formatExceptionChain(exception), exception);
+    }
+
+    HttpResponse<String> response = responseReference.get();
+    assertThat(response).isNotNull();
+    assertThat(response.statusCode()).isEqualTo(200);
+    assertThat(response.body()).isEqualTo("identityService=ok");
+  }
+
+  private String formatResponse(HttpResponse<String> response) {
+    if (response == null) {
+      return "<no response>";
+    }
+
+    return "status=" + response.statusCode() + ", body=\"" + response.body() + "\"";
+  }
+
+  private String formatExceptionChain(Throwable throwable) {
+    StringBuilder builder = new StringBuilder("Exception chain:");
+    Throwable current = throwable;
+    int depth = 0;
+
+    while (current != null && depth < 20) {
+      builder.append(System.lineSeparator())
+        .append("  [").append(depth).append("] ")
+        .append(current.getClass().getName())
+        .append(": ")
+        .append(current.getMessage() == null ? "<no message>" : current.getMessage());
+
+      current = current.getCause();
+      depth++;
+    }
+
+    return builder.toString();
+  }
+}

--- a/qa/integration-tests-engine/src/test/java-wildfly/org/operaton/bpm/integrationtest/functional/cdi/beans/IdentityServiceInjectingProcessApplication.java
+++ b/qa/integration-tests-engine/src/test/java-wildfly/org/operaton/bpm/integrationtest/functional/cdi/beans/IdentityServiceInjectingProcessApplication.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.integrationtest.functional.cdi.beans;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.operaton.bpm.application.ProcessApplication;
+import org.operaton.bpm.application.impl.JakartaServletProcessApplication;
+
+@ApplicationScoped
+@ProcessApplication("IdentityServiceInjectingProcessApplication")
+public class IdentityServiceInjectingProcessApplication extends JakartaServletProcessApplication {
+}

--- a/qa/integration-tests-engine/src/test/java-wildfly/org/operaton/bpm/integrationtest/functional/cdi/beans/IdentityServiceInjectingServlet.java
+++ b/qa/integration-tests-engine/src/test/java-wildfly/org/operaton/bpm/integrationtest/functional/cdi/beans/IdentityServiceInjectingServlet.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.integrationtest.functional.cdi.beans;
+
+import java.io.IOException;
+import jakarta.inject.Inject;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.operaton.bpm.engine.IdentityService;
+
+@WebServlet(urlPatterns = "/identity-service-check")
+public class IdentityServiceInjectingServlet extends HttpServlet {
+
+  private static final long serialVersionUID = 1L;
+
+  @Inject
+  private IdentityService identityService;
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    resp.setContentType("text/plain");
+    resp.getWriter().write(identityService == null ? "identityService=null" : "identityService=ok");
+  }
+}


### PR DESCRIPTION
Splitted this PR from #2448 

_Originally posted by @DieterMayerOSS in https://github.com/operaton/operaton/issues/2448#issuecomment-3982212360_

**`operaton-engine-cdi` is not packaged as a WildFly module in the distribution at all.**

Currently:
- `operaton-engine-cdi` is declared as a Maven dependency in `distro/wildfly/assembly/pom.xml`, but it is not referenced in `assembly.xml` and has no `module.xml` defined
- It does **not** appear under `modules/org/operaton/bpm/` in the WildFly distribution
- The `operaton-wildfly-subsystem` `module.xml` does not list it as a dependency

Related forum thread: https://forum.operaton.org/t/weld-001408-unsatisfied-dependencies-for-engine-services/402

Related issue #2473 