### PR TITLE
chore(deps): bump version.spring-boot from 4.0.3 to 4.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <version.quarkus>3.32.0</version.quarkus>
     <version.java>17</version.java>
     <version.spring>7.0.5</version.spring>
-    <version.spring-boot>4.0.3</version.spring-boot>
+    <version.spring-boot>4.0.4</version.spring-boot>
     <version.liquibase>4.33.0</version.liquibase>
     <maven.compiler.release>17</maven.compiler.release>
     <sonar.organization>operaton</sonar.organization>


### PR DESCRIPTION
Bumps `version.spring-boot` from 4.0.3 to 4.0.4.
Updates `org.springframework.boot:spring-boot-maven-plugin` from 4.0.3 to 4.0.4