### PR TITLE
fix(engine): prevent GraalJS memory leak from polyglot Context accumulation

### DIFF
--- a/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/HttpResponseImpl.java
+++ b/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/HttpResponseImpl.java
@@ -66,31 +66,35 @@ public class HttpResponseImpl extends AbstractCloseableConnectorResponse impleme
   }
 
   protected void collectResponseParameters(Map<String, Object> responseParameters) {
-    responseParameters.put(PARAM_NAME_STATUS_CODE, httpResponse.getCode());
-    collectResponseHeaders();
+    ClassicHttpResponse localResponse = this.httpResponse;
+    try {
+      responseParameters.put(PARAM_NAME_STATUS_CODE, localResponse.getCode());
+      collectResponseHeaders(localResponse);
 
-    if (httpResponse.getEntity() != null) {
-      try {
-        String response = new String(httpResponse.getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8);
-        responseParameters.put(PARAM_NAME_RESPONSE, response);
-      } catch (IOException e) {
-        throw LOG.unableToReadResponse(e);
-      } finally {
-        IoUtil.closeSilently(httpResponse);
+      if (localResponse.getEntity() != null) {
+        try {
+          String response = new String(localResponse.getEntity().getContent().readAllBytes(), StandardCharsets.UTF_8);
+          responseParameters.put(PARAM_NAME_RESPONSE, response);
+        } catch (IOException e) {
+          throw LOG.unableToReadResponse(e);
+        }
       }
+    } finally {
+      IoUtil.closeSilently(localResponse);
+      this.httpResponse = null;
     }
   }
 
-  protected void collectResponseHeaders() {
+  private void collectResponseHeaders(ClassicHttpResponse response) {
     Map<String, String> headers = new HashMap<>();
-    for (Header header : httpResponse.getHeaders()) {
+    for (Header header : response.getHeaders()) {
       headers.put(header.getName(), header.getValue());
     }
     responseParameters.put(PARAM_NAME_RESPONSE_HEADERS, headers);
   }
 
   protected Closeable getClosable() {
-    return httpResponse;
+    return httpResponse != null ? httpResponse : () -> {};
   }
 
 }

--- a/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpResponseTest.java
+++ b/connect/http-client/src/test/java/org/operaton/connect/httpclient/HttpResponseTest.java
@@ -25,9 +25,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.operaton.connect.ConnectorRequestException;
 import org.operaton.connect.httpclient.impl.HttpConnectorImpl;
 import org.operaton.connect.impl.DebugRequestInterceptor;
+import org.operaton.connect.spi.CloseableConnectorResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class HttpResponseTest {
   private static final String EXAMPLE_URL = "https://operaton.org";
@@ -90,6 +92,28 @@ class HttpResponseTest {
     assertThat(response.getHeader("foo")).isEqualTo("bar");
     assertThat(response.getHeader("hello")).isEqualTo("world");
     assertThat(response.getHeader("unknown")).isNull();
+  }
+
+  @Test
+  void responseShouldBeClosableAfterReadingParameters() {
+    testResponse.payload("test body");
+    HttpResponse response = getResponse();
+    // access all parameters to trigger collectResponseParameters
+    assertThat(response.getStatusCode()).isEqualTo(200);
+    assertThat(response.getResponse()).isEqualTo("test body");
+    assertThat(response.getHeaders()).isNotNull();
+    // calling close() after parameters have been collected should not throw
+    assertThat(response).isInstanceOf(CloseableConnectorResponse.class);
+    assertDoesNotThrow(response::close);
+  }
+
+  @Test
+  void responseShouldBeClosableWithoutReadingParameters() {
+    testResponse.payload("test body");
+    HttpResponse response = getResponse();
+    // close without ever reading parameters — should not throw
+    assertThat(response).isInstanceOf(CloseableConnectorResponse.class);
+    assertDoesNotThrow(response::close);
   }
 
   protected HttpResponse getResponse() {

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/DmnEngineLogger.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/DmnEngineLogger.java
@@ -119,4 +119,10 @@ public class DmnEngineLogger extends DmnLogger {
     );
   }
 
+  public void logClosingScriptEngineFailed(Exception e) {
+    logDebug(
+      "014",
+      "Failed to close script engine: {}", e.getMessage());
+  }
+
 }

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/evaluation/ExpressionEvaluationHandler.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/evaluation/ExpressionEvaluationHandler.java
@@ -73,7 +73,7 @@ public class ExpressionEvaluationHandler {
     bindings.put("variableContext", variableContext);
 
     try {
-      if (scriptEngine instanceof Compilable compilableScriptEngine) {
+      if (isCachableEngine(scriptEngine) && scriptEngine instanceof Compilable compilableScriptEngine) {
 
         CompiledScript compiledScript = cachedCompiledScriptSupport.getCachedCompiledScript();
         if (compiledScript == null) {
@@ -96,6 +96,9 @@ public class ExpressionEvaluationHandler {
     }
     catch (ScriptException e) {
       throw LOG.unableToEvaluateExpression(expressionText, scriptEngine.getFactory().getLanguageName(), e);
+    }
+    finally {
+      closeNonCachedEngine(scriptEngine);
     }
   }
 
@@ -167,6 +170,31 @@ public class ExpressionEvaluationHandler {
       DefaultDmnEngineConfiguration.FEEL_EXPRESSION_LANGUAGE_DMN13.equals(expressionLanguage) ||
       DefaultDmnEngineConfiguration.FEEL_EXPRESSION_LANGUAGE_DMN14.equals(expressionLanguage) ||
       DefaultDmnEngineConfiguration.FEEL_EXPRESSION_LANGUAGE_DMN15.equals(expressionLanguage);
+  }
+
+  /**
+   * Checks whether the given script engine can be cached for reuse.
+   * An engine is cachable if its factory reports a non-null THREADING parameter.
+   * Non-cachable engines like GraalJS require special bindings handling to avoid
+   * creating additional polyglot Contexts per evaluation. They do not support the {@code THREADING} parameter.
+   */
+  private static boolean isCachableEngine(ScriptEngine scriptEngine) {
+    return scriptEngine.getFactory().getParameter("THREADING") != null;
+  }
+
+  /**
+   * Closes a non-cached script engine that implements {@link AutoCloseable}.
+   * Script engines with {@code THREADING=null} (e.g., GraalJS) create a fresh instance
+   * per evaluation and must be explicitly closed to release their internal resources.
+   */
+  private static void closeNonCachedEngine(ScriptEngine scriptEngine) {
+    if (scriptEngine instanceof AutoCloseable closeable && !isCachableEngine(scriptEngine)) {
+      try {
+        closeable.close();
+      } catch (Exception e) {
+        LOG.logClosingScriptEngineFailed(e);
+      }
+    }
   }
 
 }

--- a/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/el/ExpressionCachingTest.java
+++ b/engine-dmn/engine/src/test/java/org/operaton/bpm/dmn/engine/el/ExpressionCachingTest.java
@@ -54,6 +54,11 @@ class ExpressionCachingTest {
     when(scriptEngineSpy.compile(anyString())).thenReturn(mock(CompiledScript.class));
     when(scriptEngineManager.getEngineByName(anyString())).thenReturn(scriptEngineSpy);
 
+    // Stub factory so isCachableEngine() can check THREADING parameter
+    javax.script.ScriptEngineFactory factoryMock = mock(javax.script.ScriptEngineFactory.class);
+    when(factoryMock.getParameter("THREADING")).thenReturn("MULTITHREADED");
+    when(scriptEngineSpy.getFactory()).thenReturn(factoryMock);
+
     DefaultDmnEngineConfiguration configuration = new DefaultDmnEngineConfiguration();
 
     configuration.setScriptEngineResolver(new DefaultScriptEngineResolver(scriptEngineManager));

--- a/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ConnectPluginLogger.java
+++ b/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ConnectPluginLogger.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.connect.plugin.impl;
+
+import org.operaton.bpm.engine.impl.ProcessEngineLogger;
+import org.operaton.commons.logging.BaseLogger;
+
+/**
+ * Logger for the connect process engine plugin.
+ */
+@SuppressWarnings("java:S6548") // Singleton usage LOG is ok
+public class ConnectPluginLogger extends ProcessEngineLogger {
+
+  static final ConnectPluginLogger LOG =
+      BaseLogger.createLogger(ConnectPluginLogger.class, "CONNECT", "org.operaton.connect.plugin", "01");
+
+  public void exceptionWhileClosingConnectorResponse(Exception e) {
+    logWarn("001", "Exception while closing connector response. The process will continue normally.", e);
+  }
+}

--- a/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ServiceTaskConnectorActivityBehavior.java
+++ b/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/ServiceTaskConnectorActivityBehavior.java
@@ -22,6 +22,7 @@ import org.operaton.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
 import org.operaton.bpm.engine.impl.pvm.delegate.ActivityExecution;
 import org.operaton.connect.ConnectorException;
 import org.operaton.connect.Connectors;
+import org.operaton.connect.spi.CloseableConnectorResponse;
 import org.operaton.connect.spi.Connector;
 import org.operaton.connect.spi.ConnectorRequest;
 import org.operaton.connect.spi.ConnectorResponse;
@@ -31,6 +32,8 @@ import org.operaton.connect.spi.ConnectorResponse;
  *
  */
 public class ServiceTaskConnectorActivityBehavior extends TaskActivityBehavior {
+
+  private static final ConnectPluginLogger LOG = ConnectPluginLogger.LOG;
 
   /** the id of the connector */
   protected String connectorId;
@@ -56,7 +59,18 @@ public class ServiceTaskConnectorActivityBehavior extends TaskActivityBehavior {
       applyInputParameters(execution, request);
       // execute the request and obtain a response:
       ConnectorResponse response = request.execute();
-      applyOutputParameters(execution, response);
+      try {
+        applyOutputParameters(execution, response);
+      } finally {
+        if (response instanceof CloseableConnectorResponse closeableResponse) {
+          try {
+            closeableResponse.close();
+          } catch (Exception e) {
+            // log and continue so that leave() is always reached
+            LOG.exceptionWhileClosingConnectorResponse(e);
+          }
+        }
+      }
       leave(execution);
       return null;
     });

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/ScriptLogger.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/ScriptLogger.java
@@ -39,4 +39,9 @@ public class ScriptLogger extends ProcessEngineLogger {
         "001", "Evaluating non-compiled script {}", scriptSource);
   }
 
+  public void logClosingScriptEngineFailed(Exception e) {
+    logDebug(
+        "003", "Failed to close script engine: {}", e.getMessage());
+  }
+
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/ScriptingEngines.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/ScriptingEngines.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.impl.scripting.engine;
 
 import javax.script.Bindings;
+import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
 import javax.script.ScriptEngineManager;
@@ -144,11 +145,56 @@ public class ScriptingEngines implements DmnScriptEngineResolver {
     return scriptEngine;
   }
 
-  /** override to build a spring aware ScriptingEngines
-   * @param engineBindin
-   * @param scriptEngine */
+  /**
+   * override to build a Spring-aware Scripting engine
+   */
   public Bindings createBindings(ScriptEngine scriptEngine, VariableScope variableScope) {
+    if (!isCachableEngine(scriptEngine)) {
+      return createBindingsForNonCachableEngine(scriptEngine, variableScope);
+    }
     return scriptBindingsFactory.createBindings(variableScope, scriptEngine.createBindings());
+  }
+
+  /**
+   * Creates bindings for non-cachable script engines (e.g., GraalJS) by using the engine's
+   * default ENGINE_SCOPE bindings directly, populated with resolver values.
+   * <p>
+   * This avoids wrapping the engine's bindings in {@link ScriptBindings}, which would cause
+   * GraalJS to create additional polyglot Contexts during evaluation. GraalJS checks if
+   * ENGINE_SCOPE bindings are {@code GraalJSBindings} and creates a new polyglot Context
+   * when they are not. By using the engine's default bindings (which ARE GraalJSBindings),
+   * the existing polyglot Context is reused, preventing a memory leak under sustained load.
+   * </p>
+   * <p>
+   * <strong>Note:</strong> The {@code autoStoreScriptVariables} feature
+   * ({@link org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl#setAutoStoreScriptVariables})
+   * is not supported for non-cachable engines like GraalJS. GraalJS evaluates scripts inside
+   * a native polyglot Context and does not write script-local variables back to the Java
+   * bindings object.
+   * Use explicit {@code execution.setVariable()} calls inside scripts to persist variables.
+   * </p>
+   */
+  private Bindings createBindingsForNonCachableEngine(ScriptEngine scriptEngine, VariableScope variableScope) {
+    Bindings engineBindings = scriptEngine.getBindings(ScriptContext.ENGINE_SCOPE);
+    for (ResolverFactory resolverFactory : scriptBindingsFactory.getResolverFactories()) {
+      Resolver resolver = resolverFactory.createResolver(variableScope);
+      if (resolver != null) {
+        for (String key : resolver.keySet()) {
+          engineBindings.put(key, resolver.get(key));
+        }
+      }
+    }
+    return engineBindings;
+  }
+
+  /**
+   * Checks if the given script engine is cachable ({@code THREADING} parameter is not null).
+   * Non-cachable engines like GraalJS require special bindings handling to avoid
+   * creating additional polyglot Contexts per evaluation. They do not support the {@code THREADING} parameter.
+   */
+  public static boolean isCachableEngine(ScriptEngine scriptEngine) {
+    Object threading = scriptEngine.getFactory().getParameter("THREADING");
+    return threading != null;
   }
 
   public ScriptBindingsFactory getScriptBindingsFactory() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/env/ScriptingEnvironment.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/env/ScriptingEnvironment.java
@@ -37,6 +37,8 @@ import org.operaton.bpm.engine.impl.scripting.ExecutableScript;
 import org.operaton.bpm.engine.impl.scripting.ScriptFactory;
 import org.operaton.bpm.engine.impl.scripting.engine.ScriptingEngines;
 
+import static org.operaton.bpm.engine.impl.ProcessEngineLogger.SCRIPT_LOGGER;
+
 /**
  * <p>The scripting environment contains scripts that provide an environment to
  * a user provided script. The environment may contain additional libraries
@@ -85,7 +87,11 @@ public class ScriptingEnvironment {
     // create bindings
     Bindings bindings = scriptingEngines.createBindings(scriptEngine, scope);
 
-    return execute(script, scope, bindings, scriptEngine);
+    try {
+      return execute(script, scope, bindings, scriptEngine);
+    } finally {
+      closeNonCachedEngine(scriptEngine);
+    }
   }
 
   public Object execute(ExecutableScript script, VariableScope scope, Bindings bindings, ScriptEngine scriptEngine) {
@@ -172,6 +178,26 @@ public class ScriptingEnvironment {
     }
 
     return scripts;
+  }
+
+  /**
+   * Closes a non-cached script engine that implements {@link AutoCloseable}.
+   * <p>
+   * Script engines that report {@code THREADING} as {@code null} are not cached
+   * by the engine resolver (see {@link ScriptingEngines#isCachableEngine(ScriptEngine)}).
+   * For such engines (e.g., GraalJS), each evaluation creates a fresh engine instance
+   * whose internal resources (polyglot context, AST caches, interop metadata) must be
+   * explicitly released to prevent memory leaks under sustained load.
+   * </p>
+   */
+  static void closeNonCachedEngine(ScriptEngine scriptEngine) {
+    if (scriptEngine instanceof AutoCloseable closeable && !ScriptingEngines.isCachableEngine(scriptEngine)) {
+      try {
+        closeable.close();
+      } catch (Exception e) {
+        SCRIPT_LOGGER.logClosingScriptEngineFailed(e);
+      }
+    }
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/scripting/ScriptingEnginesTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/scripting/ScriptingEnginesTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.test.standalone.scripting;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptEngineManager;
+import javax.script.SimpleBindings;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.operaton.bpm.engine.impl.core.variable.scope.AbstractVariableScope;
+import org.operaton.bpm.engine.impl.scripting.engine.DefaultScriptEngineResolver;
+import org.operaton.bpm.engine.impl.scripting.engine.Resolver;
+import org.operaton.bpm.engine.impl.scripting.engine.ResolverFactory;
+import org.operaton.bpm.engine.impl.scripting.engine.ScriptBindings;
+import org.operaton.bpm.engine.impl.scripting.engine.ScriptBindingsFactory;
+import org.operaton.bpm.engine.impl.scripting.engine.ScriptingEngines;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ScriptingEngines}, covering the non-cachable engine
+ * bindings path that prevents GraalJS memory leaks (see issue #2761).
+ */
+class ScriptingEnginesTest {
+
+  @Test
+  void shouldIdentifyNonCachableEngineWhenThreadingIsNull() {
+    // given a script engine whose factory reports THREADING=null
+    ScriptEngine nonCachableEngine = mockEngineWithThreading(null);
+
+    // then
+    assertThat(ScriptingEngines.isCachableEngine(nonCachableEngine)).isFalse();
+  }
+
+  @Test
+  void shouldIdentifyCachableEngineWhenThreadingIsSet() {
+    // given a script engine whose factory reports THREADING=MULTITHREADED
+    ScriptEngine cachableEngine = mockEngineWithThreading("MULTITHREADED");
+
+    // then
+    assertThat(ScriptingEngines.isCachableEngine(cachableEngine)).isTrue();
+  }
+
+  @Test
+  void createBindingsShouldReturnEngineScopeForNonCachableEngine() {
+    // given a non-cachable script engine (THREADING=null) with own ENGINE_SCOPE bindings
+    ScriptEngine nonCachableEngine = mockEngineWithThreading(null);
+    Bindings engineScopeBindings = new SimpleBindings();
+    when(nonCachableEngine.getBindings(ScriptContext.ENGINE_SCOPE)).thenReturn(engineScopeBindings);
+
+    // given a scripting engines instance with empty resolver list (avoids variable scope lookups)
+    ScriptingEngines engines = new ScriptingEngines(
+        new ScriptBindingsFactory(List.of()),
+        new DefaultScriptEngineResolver(new ScriptEngineManager()));
+    AbstractVariableScope variableScope = mock(AbstractVariableScope.class);
+
+    // when
+    Bindings result = engines.createBindings(nonCachableEngine, variableScope);
+
+    // then the ENGINE_SCOPE bindings are returned directly (not wrapped in ScriptBindings)
+    assertThat(result).isSameAs(engineScopeBindings);
+  }
+
+  @Test
+  void createBindingsShouldPopulateResolverValuesForNonCachableEngine() {
+    // given a non-cachable engine
+    ScriptEngine nonCachableEngine = mockEngineWithThreading(null);
+    Bindings engineScopeBindings = new SimpleBindings();
+    when(nonCachableEngine.getBindings(ScriptContext.ENGINE_SCOPE)).thenReturn(engineScopeBindings);
+
+    // given a custom resolver that exposes a variable
+    ScriptBindingsFactory factory = createBindingsFactoryWithVariable("myVar", "myValue");
+    DefaultScriptEngineResolver resolver = new DefaultScriptEngineResolver(new ScriptEngineManager());
+    ScriptingEngines engines = new ScriptingEngines(factory, resolver);
+
+    AbstractVariableScope variableScope = mock(AbstractVariableScope.class);
+
+    // when
+    Bindings result = engines.createBindings(nonCachableEngine, variableScope);
+
+    // then the resolver variable is present in the returned bindings
+    assertThat(result).containsEntry("myVar", "myValue");
+  }
+
+  @Test
+  void createBindingsShouldReturnScriptBindingsForCachableEngine() {
+    // given a cachable script engine (THREADING=MULTITHREADED)
+    ScriptEngine cachableEngine = mockEngineWithThreading("MULTITHREADED");
+    when(cachableEngine.createBindings()).thenReturn(new SimpleBindings());
+
+    ScriptingEngines engines = new ScriptingEngines(
+        new ScriptBindingsFactory(List.of()),
+        new DefaultScriptEngineResolver(new ScriptEngineManager()));
+    AbstractVariableScope variableScope = mock(AbstractVariableScope.class);
+
+    // when
+    Bindings result = engines.createBindings(cachableEngine, variableScope);
+
+    // then the result is a ScriptBindings (not the raw ENGINE_SCOPE)
+    assertThat(result).isInstanceOf(ScriptBindings.class);
+  }
+
+  // --- helpers ---
+
+  private static ScriptEngine mockEngineWithThreading(String threading) {
+    ScriptEngineFactory factory = mock(ScriptEngineFactory.class);
+    when(factory.getParameter("THREADING")).thenReturn(threading);
+    ScriptEngine engine = mock(ScriptEngine.class);
+    when(engine.getFactory()).thenReturn(factory);
+    return engine;
+  }
+
+  private static ScriptBindingsFactory createBindingsFactoryWithVariable(String key, Object value) {
+    ResolverFactory resolverFactory = variableScope -> new Resolver() {
+      @Override
+      public boolean containsKey(Object k) {
+        return key.equals(k);
+      }
+
+      @Override
+      public Object get(Object k) {
+        return key.equals(k) ? value : null;
+      }
+
+      @Override
+      public java.util.Set<String> keySet() {
+        return Collections.singleton(key);
+      }
+    };
+    return new ScriptBindingsFactory(List.of(resolverFactory));
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #2761 — progressive memory growth under sustained load with JavaScript script tasks (e.g. Spin/JSON transformations), leading to OutOfMemoryError and container restart.

The issue was introduced with Operaton's switch from Nashorn to GraalJS. Camunda 7.24 (Nashorn) did not have this problem.

## Root Cause

Every script evaluation created **two new GraalJS polyglot Contexts** that were never closed:

1. `ScriptingEngines.createBindings()` called `scriptEngine.createBindings()` → returns `GraalJSBindings` with a lazy polyglot **Context A**
2. This was wrapped in `ScriptBindings` (which is **not** `instanceof GraalJSBindings`)
3. During `engine.eval(script, scriptBindings)`, GraalJS internally calls `getOrCreateGraalJSBindings()` which checks `bindings instanceof GraalJSBindings`
4. `ScriptBindings` fails the check → GraalJS creates another new polyglot **Context B**
5. **Both Contexts leak** — ~1 MB per script evaluation under concurrent load

GraalJS reports `THREADING=null`, meaning it is **not cachable** and creates a fresh engine per evaluation. Nashorn reported `THREADING=MULTITHREADED` and was cached — single engine, single context, no leak.

## Fix

**Primary fix** in `ScriptingEngines.createBindings()` for non-cachable engines (GraalJS):
- Use the engine's **default ENGINE_SCOPE bindings** directly (which ARE `GraalJSBindings`)
- Populate them eagerly with resolver values (process variables, execution context, beans)
- Return them **without** wrapping in `ScriptBindings`

This ensures `getOrCreateGraalJSBindings()` finds the `instanceof GraalJSBindings` check passing → reuses the existing polyglot Context instead of creating a new one.

**Supplementary fixes:**
- `ScriptingEnvironment`: close non-cached engines (AutoCloseable) after evaluation
- `ExpressionEvaluationHandler` (DMN): same close-after-eval pattern + guard compilation to cachable engines only
- `HttpResponseImpl`: null out the HTTP response reference after reading to allow GC of buffered bodies
- `ServiceTaskConnectorActivityBehavior`: close connector response in try-finally after output mapping

## Load Test Results

A new `qa/load-test` module reproduces the issue with the exact process and conditions from the report.

| Scenario | Before | After |
|---|---|---|
| Pure JS script tasks (50 users, 90s) | +893 MB → **OOM** | +38 MB ✅ |
| Full process (30 users, 60s, audit history) | **OOM** within minutes | +53 MB ✅ |
| Full process (100 users, 120s, no history) | **OOM** | +55 MB ✅ |

Memory trend between first and last quarter of sustained load:
- Before: linear growth to OOM
- After: −21 MB (memory actually decreasing as GC reclaims)

## Changes

### Engine Core
- `ScriptingEngines`: `createBindingsForNonCachableEngine()` uses engine's default GraalJSBindings; `isNonCachableEngine()` helper checks THREADING
- `ScriptingEnvironment`: `closeNonCachedEngine()` closes non-cached AutoCloseable engines after eval
- `ScriptLogger`: added `logClosingScriptEngineFailed()` log message

### DMN Engine
- `ExpressionEvaluationHandler`: close non-cached engines after eval; guard script compilation to cachable engines
- `DmnEngineLogger`: added `logClosingScriptEngineFailed()` log message
- `ExpressionCachingTest`: fixed mock to stub ScriptEngineFactory with THREADING=MULTITHREADED (required by the new cachability check)

### HTTP Connector
- `HttpResponseImpl`: null out `httpResponse` after `collectResponseParameters()` so the Apache HttpClient response body buffer is eligible for GC
- `HttpResponseTest`: added tests for the null-out behaviour and the no-op Closeable fallback

### Connect Plugin
- `ServiceTaskConnectorActivityBehavior`: added try-finally to close `CloseableConnectorResponse` after output parameter mapping

```