### PR TITLE
fix(wildfly): Add module dependencies for connect plugin module

### DIFF
--- a/distro/wildfly/modules/src/main/modules/org/operaton/bpm/operaton-engine-plugin-connect/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/operaton/bpm/operaton-engine-plugin-connect/main/module.xml
@@ -7,6 +7,7 @@
 
     <module name="java.base" />
 
+    <module name="org.operaton.commons.operaton-commons-logging" />
     <module name="org.operaton.bpm.operaton-engine" />
 
     <module name="org.operaton.connect.operaton-connect-core" />

--- a/distro/wildfly/modules/src/main/modules/org/operaton/bpm/operaton-engine/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/operaton/bpm/operaton-engine/main/module.xml
@@ -35,8 +35,8 @@
     <module name="org.operaton.bpm.model.operaton-cmmn-model" />
     <module name="org.operaton.bpm.model.operaton-dmn-model" />
 
-    <module name="org.operaton.commons.operaton-commons-logging" />
-    <module name="org.operaton.commons.operaton-commons-utils" />
+    <module name="org.operaton.commons.operaton-commons-logging" export="true"/>
+    <module name="org.operaton.commons.operaton-commons-utils" export="true"/>
     <module name="org.operaton.commons.operaton-commons-typed-values" export="true" />
     <module name="org.operaton.template-engines.operaton-template-engines-freemarker" services="import" />
     <module name="org.operaton.spin.operaton-spin-core" services="import"/>


### PR DESCRIPTION
Make connect plugin module dependent on commons-logging module. This makes the BaseLogger class accessible from downstream modules.

fixes #2812 