### PR TITLE
Adjust minimum database compatibility for Operaton 2.1

### DIFF
--- a/database/pom.xml
+++ b/database/pom.xml
@@ -301,7 +301,7 @@
         <database.type>mysql</database.type>
         <database.driver>com.mysql.cj.jdbc.Driver</database.driver>
         <database.datasource.class>com.mysql.cj.jdbc.MysqlDataSource</database.datasource.class>
-        <database.tc.url>operatonmysql:9.7</database.tc.url>
+        <database.tc.url>operatonmysql:8.4</database.tc.url>
         <jboss.datasource.filename>mysql-ds.xml</jboss.datasource.filename>
         <database.tc.params>/${database.name}?sendFractionalSeconds=false&amp;amp;user=${database.username}&amp;amp;password=${database.password}</database.tc.params>
         <database.url>jdbc:tc:${database.tc.url}://localhost:${database.port}${database.tc.params}</database.url>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -586,7 +586,7 @@
         <database.datasource.class>org.postgresql.ds.PGSimpleDataSource</database.datasource.class>
         <jboss.datasource.filename>postgresql-ds.xml</jboss.datasource.filename>
         <hibernate.dialect>org.hibernate.dialect.PostgreSQLDialect</hibernate.dialect>
-        <database.tc.url>operatonpostgresql:13.2</database.tc.url>
+        <database.tc.url>operatonpostgresql:14</database.tc.url>
         <database.url>jdbc:tc:${database.tc.url}:///${database.name}/${database.tc.params}</database.url>
       </properties>
 

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -263,7 +263,7 @@
         <database.driver>org.mariadb.jdbc.Driver</database.driver>
         <hibernate.dialect>org.hibernate.dialect.MariaDBDialect</hibernate.dialect>
         <database.datasource.class>org.mariadb.jdbc.MariaDbDataSource</database.datasource.class>
-        <database.tc.url>operatonmariadb:10.6</database.tc.url>
+        <database.tc.url>operatonmariadb:10.11</database.tc.url>
         <jboss.datasource.filename>mariadb-ds.xml</jboss.datasource.filename>
         <database.tc.params>/${database.name}</database.tc.params>
         <database.url>jdbc:tc:${database.tc.url}://localhost:${database.port}${database.tc.params}</database.url>
@@ -301,7 +301,7 @@
         <database.type>mysql</database.type>
         <database.driver>com.mysql.cj.jdbc.Driver</database.driver>
         <database.datasource.class>com.mysql.cj.jdbc.MysqlDataSource</database.datasource.class>
-        <database.tc.url>operatonmysql:9.2.0</database.tc.url>
+        <database.tc.url>operatonmysql:9.7</database.tc.url>
         <jboss.datasource.filename>mysql-ds.xml</jboss.datasource.filename>
         <database.tc.params>/${database.name}?sendFractionalSeconds=false&amp;amp;user=${database.username}&amp;amp;password=${database.password}</database.tc.params>
         <database.url>jdbc:tc:${database.tc.url}://localhost:${database.port}${database.tc.params}</database.url>

--- a/qa/arquillian-extensions/src/main/java/org/operaton/bpm/integrationtest/ArquillianEventObserver.java
+++ b/qa/arquillian-extensions/src/main/java/org/operaton/bpm/integrationtest/ArquillianEventObserver.java
@@ -37,7 +37,7 @@ import java.util.Map;
 public class ArquillianEventObserver {
 
   private static final String POSTGRES = "postgres";
-  private static final String POSTGRES_VERSION = "13.2";
+  private static final String POSTGRES_VERSION = "14.22";
 
   private static final String SQLSERVER = "sqlserver";
   private static final String SQLSERVER_VERSION = "2022-latest";

--- a/qa/arquillian-extensions/src/main/java/org/operaton/bpm/integrationtest/ArquillianEventObserver.java
+++ b/qa/arquillian-extensions/src/main/java/org/operaton/bpm/integrationtest/ArquillianEventObserver.java
@@ -30,20 +30,20 @@ import java.util.Map;
 
 /**
  * {@link org.jboss.arquillian.core.api.annotation.Observer} for Arquillian lifecycle events.
- * Observes {@link ContainerRegistry} event and facilitates ability to start jdbc database
+ * Observes {@link ContainerRegistry} event and facilitates the ability to start jdbc database
  * container before and provide connection information to Arquillian container.
  */
 @SuppressWarnings("rawtypes")
 public class ArquillianEventObserver {
 
   private static final String POSTGRES = "postgres";
-  private static final String POSTGRES_VERSION = "14.22";
+  private static final String POSTGRES_VERSION = "14";
 
   private static final String SQLSERVER = "sqlserver";
   private static final String SQLSERVER_VERSION = "2022-latest";
 
   private static final String MARIADB = "mariadb";
-  private static final String MARIADB_VERSION = "10.0";
+  private static final String MARIADB_VERSION = "10.11";
 
   private static final String ORACLE = "oracle";
   private static final String ORACLE_VERSION = "21-faststart";
@@ -52,7 +52,7 @@ public class ArquillianEventObserver {
   private static final String DB2_VERSION = "12.1.2.0";
 
   private static final String MYSQL = "mysql";
-  private static final String MYSQL_VERSION = "9.2.0";
+  private static final String MYSQL_VERSION = "9.7";
 
   // Initialized with providers, so we do not start all containers at the same time here statically upon initialization
   private static final Map<String, JdbcDatabaseContainer> AVAILABLE_DB_CONTAINERS = Map.of(

--- a/qa/arquillian-extensions/src/main/java/org/operaton/bpm/integrationtest/ArquillianEventObserver.java
+++ b/qa/arquillian-extensions/src/main/java/org/operaton/bpm/integrationtest/ArquillianEventObserver.java
@@ -52,7 +52,7 @@ public class ArquillianEventObserver {
   private static final String DB2_VERSION = "12.1.2.0";
 
   private static final String MYSQL = "mysql";
-  private static final String MYSQL_VERSION = "9.7";
+  private static final String MYSQL_VERSION = "8.4";
 
   // Initialized with providers, so we do not start all containers at the same time here statically upon initialization
   private static final Map<String, JdbcDatabaseContainer> AVAILABLE_DB_CONTAINERS = Map.of(

--- a/qa/test-database-container/docker-compose.yaml
+++ b/qa/test-database-container/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:9.2.0
+    image: mysql:9.7
     container_name: mysql
     ports:
       - "${MT_MYSQL_HOST_PORT:-33060}:3306"
@@ -11,7 +11,7 @@ services:
       - ./my.cnf:/etc/mysql/conf.d/my.cnf
 
   mariadb:
-    image: mariadb:11.8
+    image: mariadb:10.11
     container_name: mariadb
     ports:
       - "${MT_MARIADB_HOST_PORT:-33070}:3306"

--- a/qa/test-database-container/docker-compose.yaml
+++ b/qa/test-database-container/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:9.7
+    image: mysql:8.4
     container_name: mysql
     ports:
       - "${MT_MYSQL_HOST_PORT:-33060}:3306"

--- a/qa/test-database-container/docker-compose.yaml
+++ b/qa/test-database-container/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
       - ORACLE_DATABASE=${MT_ORACLE_DATABASE:-SYSTEM}
 
   postgres:
-    image: postgres:17
+    image: postgres:14
     container_name: postgres
     ports:
       - "${MT_POSTGRES_HOST_PORT:-54320}:5432"

--- a/test-utils/testcontainers/pom.xml
+++ b/test-utils/testcontainers/pom.xml
@@ -49,6 +49,10 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-oracle-free</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-db2</artifactId>
     </dependency>
 

--- a/test-utils/testcontainers/src/main/java/org/operaton/impl/test/utils/testcontainers/OperatonOracleContainerProvider.java
+++ b/test-utils/testcontainers/src/main/java/org/operaton/impl/test/utils/testcontainers/OperatonOracleContainerProvider.java
@@ -20,9 +20,14 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.JdbcDatabaseContainerProvider;
 import org.testcontainers.utility.DockerImageName;
 
+import java.util.List;
+import java.util.Objects;
+
 public class OperatonOracleContainerProvider extends JdbcDatabaseContainerProvider {
 
   private static final String NAME = "operatonoracle";
+
+  private static final List<String> XE_VERSIONS = List.of("21", "18", "11");
 
   @Override
   public boolean supports(String databaseType) {
@@ -31,16 +36,17 @@ public class OperatonOracleContainerProvider extends JdbcDatabaseContainerProvid
 
   @Override
   public JdbcDatabaseContainer<?> newInstance(String tag) {
-    if (tag != null && tag.startsWith("21")) {
+    Objects.requireNonNull(tag);
+    // tags starting with 21, 18, or 11 are routed to gvenzl/oracle-xe.
+    if (XE_VERSIONS.stream().anyMatch(tag::startsWith)) {
       DockerImageName dockerImageName = TestcontainersHelper
               .resolveDockerImageName("oracle", tag, "gvenzl/oracle-xe");
       return new org.testcontainers.containers.OracleContainer(dockerImageName);
-    }
-    if (tag != null && tag.startsWith("23")) {
+      // anything else goes to gvenzl/oracle-free, including "latest", "slim" and "full".
+    } else {
       DockerImageName dockerImageName = TestcontainersHelper
               .resolveDockerImageName("oracle", tag, "gvenzl/oracle-free");
       return new org.testcontainers.oracle.OracleContainer(dockerImageName);
     }
-    throw new UnsupportedOperationException("Unsupported Oracle Testcontainer version %s".formatted(tag));
   }
 }

--- a/test-utils/testcontainers/src/main/java/org/operaton/impl/test/utils/testcontainers/OperatonOracleContainerProvider.java
+++ b/test-utils/testcontainers/src/main/java/org/operaton/impl/test/utils/testcontainers/OperatonOracleContainerProvider.java
@@ -17,11 +17,10 @@
 package org.operaton.impl.test.utils.testcontainers;
 
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.OracleContainer;
-import org.testcontainers.containers.OracleContainerProvider;
+import org.testcontainers.containers.JdbcDatabaseContainerProvider;
 import org.testcontainers.utility.DockerImageName;
 
-public class OperatonOracleContainerProvider extends OracleContainerProvider {
+public class OperatonOracleContainerProvider extends JdbcDatabaseContainerProvider {
 
   private static final String NAME = "operatonoracle";
 
@@ -32,8 +31,16 @@ public class OperatonOracleContainerProvider extends OracleContainerProvider {
 
   @Override
   public JdbcDatabaseContainer<?> newInstance(String tag) {
-    DockerImageName dockerImageName = TestcontainersHelper
-      .resolveDockerImageName("oracle", tag, "gvenzl/oracle-xe");
-    return new OracleContainer(dockerImageName);
+    if (tag != null && tag.startsWith("21")) {
+      DockerImageName dockerImageName = TestcontainersHelper
+              .resolveDockerImageName("oracle", tag, "gvenzl/oracle-xe");
+      return new org.testcontainers.containers.OracleContainer(dockerImageName);
+    }
+    if (tag != null && tag.startsWith("23")) {
+      DockerImageName dockerImageName = TestcontainersHelper
+              .resolveDockerImageName("oracle", tag, "gvenzl/oracle-free");
+      return new org.testcontainers.oracle.OracleContainer(dockerImageName);
+    }
+    throw new UnsupportedOperationException("Unsupported Oracle Testcontainer version %s".formatted(tag));
   }
 }

--- a/test-utils/testcontainers/src/test/java/org/operaton/impl/test/utils/testcontainers/DatabaseContainerProviderTest.java
+++ b/test-utils/testcontainers/src/test/java/org/operaton/impl/test/utils/testcontainers/DatabaseContainerProviderTest.java
@@ -43,7 +43,7 @@ class DatabaseContainerProviderTest {
    */
   @ParameterizedTest(name = "{3}:{2}")
   @CsvSource({
-    "jdbc:tc:operatonpostgresql:13.2:///process-engine, SELECT version();, 13.2, postgres",
+    "jdbc:tc:operatonpostgresql:14.22:///process-engine, SELECT version();, 14.22, postgres",
     "jdbc:tc:operatonmariadb:10.0://localhost:3306/process-engine, SELECT version();, 10.0, mariadb",
     "jdbc:tc:operatonmysql:5.7://localhost:3306/process-engine, SELECT version();, 5.7, mysql",
     "jdbc:tc:operatonmysql:8.0://localhost:3306/process-engine, SELECT version();, 8.0, mysql",

--- a/test-utils/testcontainers/src/test/java/org/operaton/impl/test/utils/testcontainers/DatabaseContainerProviderTest.java
+++ b/test-utils/testcontainers/src/test/java/org/operaton/impl/test/utils/testcontainers/DatabaseContainerProviderTest.java
@@ -53,6 +53,7 @@ class DatabaseContainerProviderTest {
     "jdbc:tc:operatonmysql:8.4://localhost:3306/process-engine, SELECT version();, 8.4, mysql",
     "jdbc:tc:operatonmysql:9.7://localhost:3306/process-engine, SELECT version();, 9.7, mysql",
     "jdbc:tc:operatonsqlserver:2022-latest://localhost:1433/process-engine, SELECT @@VERSION, 2022, sqlserver",
+    "jdbc:tc:operatonoracle:23-faststart://localhost:1521, SELECT * FROM v$version, 23.26, oracle",
     "jdbc:tc:operatonoracle:21-faststart://localhost:1521, SELECT * FROM v$version, 21c, oracle",
     "jdbc:tc:operatondb2:12.1.2.0://localhost:50000, SELECT SERVICE_LEVEL FROM TABLE(SYSPROC.ENV_GET_INST_INFO()), v12, db2"
   })

--- a/test-utils/testcontainers/src/test/java/org/operaton/impl/test/utils/testcontainers/DatabaseContainerProviderTest.java
+++ b/test-utils/testcontainers/src/test/java/org/operaton/impl/test/utils/testcontainers/DatabaseContainerProviderTest.java
@@ -43,11 +43,15 @@ class DatabaseContainerProviderTest {
    */
   @ParameterizedTest(name = "{3}:{2}")
   @CsvSource({
-    "jdbc:tc:operatonpostgresql:14.22:///process-engine, SELECT version();, 14.22, postgres",
-    "jdbc:tc:operatonmariadb:10.0://localhost:3306/process-engine, SELECT version();, 10.0, mariadb",
-    "jdbc:tc:operatonmysql:5.7://localhost:3306/process-engine, SELECT version();, 5.7, mysql",
-    "jdbc:tc:operatonmysql:8.0://localhost:3306/process-engine, SELECT version();, 8.0, mysql",
-    "jdbc:tc:operatonmysql:9.2.0://localhost:3306/process-engine, SELECT version();, 9.2.0, mysql",
+    "jdbc:tc:operatonpostgresql:14:///process-engine, SELECT version();, 14, postgres",
+    "jdbc:tc:operatonpostgresql:15:///process-engine, SELECT version();, 15, postgres",
+    "jdbc:tc:operatonpostgresql:16:///process-engine, SELECT version();, 16, postgres",
+    "jdbc:tc:operatonpostgresql:17:///process-engine, SELECT version();, 17, postgres",
+    "jdbc:tc:operatonpostgresql:18:///process-engine, SELECT version();, 18, postgres",
+    "jdbc:tc:operatonmariadb:10.6://localhost:3306/process-engine, SELECT version();, 10.6, mariadb",
+    "jdbc:tc:operatonmariadb:10.11://localhost:3306/process-engine, SELECT version();, 10.11, mariadb",
+    "jdbc:tc:operatonmysql:8.4://localhost:3306/process-engine, SELECT version();, 8.4, mysql",
+    "jdbc:tc:operatonmysql:9.7://localhost:3306/process-engine, SELECT version();, 9.7, mysql",
     "jdbc:tc:operatonsqlserver:2022-latest://localhost:1433/process-engine, SELECT @@VERSION, 2022, sqlserver",
     "jdbc:tc:operatonoracle:21-faststart://localhost:1521, SELECT * FROM v$version, 21c, oracle",
     "jdbc:tc:operatondb2:12.1.2.0://localhost:50000, SELECT SERVICE_LEVEL FROM TABLE(SYSPROC.ENV_GET_INST_INFO()), v12, db2"


### PR DESCRIPTION
### Adjust minimum database compatibility for Operaton 2.1

With every Minor Release we should check for minimum database compatibility in our test suite.

Databases versions which are declared  EOL or are without OSS support should be upgraded.

- PostgreSQL: 13 -> 14
- MariaDB: 10.6 -> 10.11 (LTS)
- MySQL: 9.2 -> 8.4 (LTS)

Researched Support Timelines

- MariaDB 10.6 LTS (EOL July 2026),  10.11 (LTS, Feb 2028).
- MySQL: Current supported LTS Versions: 8.4. (LTS) and (9.7 LTS). Operaton test use 8.4.
- Oracle: 19 (LTR) , 21 (Innovation Release), 26ai (LTR). Operaton test use 21 (xe).
- SQL Server 2022 January 11, 2028 (Mainstream) January 11, 2033 (Extended). Operaton test use 2022.
- SQL Server 2025 January 6, 2031	(Mainstream)  January 6, 2036 (Extended)