### PR TITLE
chore(ci): pin dependency versions to resolve Sonar security findings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
           .devenv/scripts/build/check-api-compatibility.sh
           .devenv/scripts/build/rest-api-doc.sh
           .devenv/scripts/build/build-sbom.sh
-          pip install pystache
+          pip install --only-binary :all: pystache==0.6.8
       - name: Commit changes
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         if: ${{github.event.inputs.dry_run == 'false' }}

--- a/.github/workflows/slack-link-check.yml
+++ b/.github/workflows/slack-link-check.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: 20
 
       - name: Install Playwright core only
-        run: npm install --ignore-scripts playwright
+        run: npm install --ignore-scripts playwright@1.59.1
       - name: Extract Slack link from README
         id: extract
         run: |

--- a/distro/run/assembly/pom.xml
+++ b/distro/run/assembly/pom.xml
@@ -188,7 +188,9 @@
                   <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
                   <arguments>
                     <argument>install</argument>
-                    <argument>pystache</argument>
+                    <argument>--only-binary</argument>
+                    <argument>:all:</argument>
+                    <argument>pystache==0.6.8</argument>
                   </arguments>
                   <skip>false</skip>
                 </configuration>

--- a/distro/tomcat/assembly/pom.xml
+++ b/distro/tomcat/assembly/pom.xml
@@ -213,7 +213,9 @@
                   <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
                   <arguments>
                     <argument>install</argument>
-                    <argument>pystache</argument>
+                    <argument>--only-binary</argument>
+                    <argument>:all:</argument>
+                    <argument>pystache==0.6.8</argument>
                   </arguments>
                   <skip>false</skip>
                 </configuration>

--- a/distro/wildfly/assembly/pom.xml
+++ b/distro/wildfly/assembly/pom.xml
@@ -203,7 +203,9 @@
                   <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
                   <arguments>
                     <argument>install</argument>
-                    <argument>pystache</argument>
+                    <argument>--only-binary</argument>
+                    <argument>:all:</argument>
+                    <argument>pystache==0.6.8</argument>
                   </arguments>
                   <skip>false</skip>
                 </configuration>


### PR DESCRIPTION
- Pin playwright to 1.59.1 in slack-link-check.yml (S8543)
- Pin pystache to 0.6.8 and add --only-binary :all: in release.yml (S8541, S8544)

related to #511 