### PR TITLE
feat: Harden first-time contributor workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners
+.github/  @javahippie @kthoms @cachescrubber

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# Default code owners
+# github actions code owners
 .github/  @javahippie @kthoms @cachescrubber

--- a/.github/workflows/check-for-new-contributor.yml
+++ b/.github/workflows/check-for-new-contributor.yml
@@ -1,3 +1,4 @@
+# HEADS-UP: pull_request_target runs a PR against the main branch and has access to secrets.
 name: First-time Contributor Check
 
 on:
@@ -20,8 +21,10 @@ jobs:
     name: Greet First-Time PR Contributors
     runs-on: ubuntu-slim
     permissions:
-      pull-requests: write
+      contents: read
       issues: write
+    # This job intentionally uses pull_request_target only for metadata reads and comments.
+    # Do not check out or execute PR code here.
     # Only run for PRs from forks (different repository) and not from operaton/operaton
     if: |
       github.event_name == 'pull_request_target' && 
@@ -29,7 +32,7 @@ jobs:
       github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Check for first-time PR contributor
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const author = context.actor;
@@ -38,7 +41,9 @@ jobs:
             const prBody = context.payload.pull_request.body || "";
 
             // Check if author is in the whitelist
-            const whitelist = process.env.CONTRIBUTOR_WHITELIST || '';
+            const whitelist = (process.env.CONTRIBUTOR_WHITELIST || '')
+              .split(/\s+/)
+              .filter(Boolean);
             if (whitelist.includes(author)) {
               console.log(`${author} is in the contributor whitelist. Skipping greeting.`);
               return;
@@ -86,14 +91,14 @@ jobs:
     name: Greet First-Time Issue Creators
     runs-on: ubuntu-slim
     permissions:
-      pull-requests: write
+      contents: read
       issues: write
     if: |
       github.event_name == 'issues' && 
       github.event.action == 'opened'
     steps:
       - name: Check for first-time Issue creator
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const author = context.actor;
@@ -101,7 +106,9 @@ jobs:
             const issueTitle = context.payload.issue.title;
 
             // Check if author is in the whitelist
-            const whitelist = process.env.CONTRIBUTOR_WHITELIST || '';
+            const whitelist = (process.env.CONTRIBUTOR_WHITELIST || '')
+              .split(/\s+/)
+              .filter(Boolean);
             if (whitelist.includes(author)) {
               console.log(`${author} is in the contributor whitelist. Skipping greeting.`);
               return;
@@ -142,13 +149,13 @@ jobs:
     name: Greet First-Time Issue Commenters
     runs-on: ubuntu-slim
     permissions:
-      pull-requests: write
+      contents: read
       issues: write
     if: |
       github.event_name == 'issue_comment' && 
       github.event.action == 'created'
     steps:
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const author = context.actor;
@@ -156,7 +163,9 @@ jobs:
             const commentBody = context.payload.comment.body;
             
             // Check if author is in the whitelist
-            const whitelist = process.env.CONTRIBUTOR_WHITELIST || '';
+            const whitelist = (process.env.CONTRIBUTOR_WHITELIST || '')
+              .split(/\s+/)
+              .filter(Boolean);
             if (whitelist.includes(author)) {
               console.log(`${author} is in the contributor whitelist. Skipping greeting.`);
               return;

--- a/.github/workflows/check-for-new-contributor.yml
+++ b/.github/workflows/check-for-new-contributor.yml
@@ -1,4 +1,4 @@
-# HEADS-UP: pull_request_target runs a PR against the main branch and has access to secrets.
+# HEADS-UP: pull_request_target runs in the context of the base repository and target branch and has access to secrets.
 name: First-time Contributor Check
 
 on:


### PR DESCRIPTION
### Harden first-time contributor workflow and add GitHub config ownership

In light of the recent supply chain issues I checked our repo for usages of `pull_request_target` event in github actions. `pull_request_target` becomes a security disaster the moment you explicitly check out and run untrusted PR code inside a privileged environment that holds your repository's write tokens and secrets.

The **check-for-new-contributor** workflow is okay in its current form. However, I decided to add a HEADS-UP and to harden it further.

### Changes

- pin all actions/github-script usages to a full commit SHA
- add explicit safety notes and HEADS-UP
- remove unnecessary permission: pull-requests: write
- fix contributor whitelist matching to use exact usernames instead of substring matches

For the time being, pinning of the `actions/github-script`  is in the context of this workflow, because it runs in the context of the `pull_request_target` event.

Further, I want to suggest require a codeowner review to changes to the action workflows. The list of reviewers is even smaller than the core maintainer list. I this requires further discussion, I'm happy to remove it from this PR.

To make this effective, we would need to add "Require code owner review" as a branch protection rule.

### Note

I only checked the `.github/workflows/check-for-new-contributor.yml` workflow. We should probably audit all workflows.