### PR TITLE
feat(build): Automate dependabot milestone updates after release

### DIFF
--- a/.github/scripts/update-dependabot-milestone.sh
+++ b/.github/scripts/update-dependabot-milestone.sh
@@ -52,3 +52,35 @@ PATCH="${BASH_REMATCH[3]}"
 
 echo "📦 Release version: $VERSION (MAJOR=$MAJOR, MINOR=$MINOR, PATCH=$PATCH)"
 echo "🌿 Release source branch: $RELEASE_TARGET_BRANCH"
+
+# --- Step 2: Determine target branch ---
+# COMPUTED_RELEASE_BRANCH is used only when the release comes from main (to find pre-existing entries)
+COMPUTED_RELEASE_BRANCH="release/${MAJOR}.${MINOR}.x"
+
+TARGET_BRANCH=""
+
+if [[ "$RELEASE_TARGET_BRANCH" == release/* ]]; then
+  # Patch release: use the actual source branch directly (not a computed value)
+  HAS_ENTRIES=$(yq '.updates[]."target-branch"' "$DEPENDABOT_FILE" | grep -Fcx "$RELEASE_TARGET_BRANCH" || true)
+  if [[ "$HAS_ENTRIES" -gt 0 ]]; then
+    TARGET_BRANCH="$RELEASE_TARGET_BRANCH"
+  else
+    echo "::error::Release was tagged from '$RELEASE_TARGET_BRANCH' but no entries for '$RELEASE_TARGET_BRANCH' found in $DEPENDABOT_FILE."
+    exit 1
+  fi
+elif [[ "$RELEASE_TARGET_BRANCH" == "main" ]]; then
+  # Minor/major release from main: prefer pre-existing release branch entries
+  HAS_RELEASE_BRANCH_ENTRIES=$(yq '.updates[]."target-branch"' "$DEPENDABOT_FILE" | grep -Fcx "$COMPUTED_RELEASE_BRANCH" || true)
+  if [[ "$HAS_RELEASE_BRANCH_ENTRIES" -gt 0 ]]; then
+    TARGET_BRANCH="$COMPUTED_RELEASE_BRANCH"
+    echo "ℹ️  Release from main — found entries for '$COMPUTED_RELEASE_BRANCH', updating those."
+  else
+    TARGET_BRANCH="main"
+    echo "ℹ️  Release from main — no '$COMPUTED_RELEASE_BRANCH' entries found, updating 'main'."
+  fi
+else
+  echo "::error::Unexpected release source branch: '$RELEASE_TARGET_BRANCH'"
+  exit 1
+fi
+
+echo "🎯 Target branch to update: $TARGET_BRANCH"

--- a/.github/scripts/update-dependabot-milestone.sh
+++ b/.github/scripts/update-dependabot-milestone.sh
@@ -123,3 +123,23 @@ if [[ -z "$MILESTONE_NUMBER" ]]; then
   echo "::error::No open milestone found matching any of: ${VERSION_CANDIDATES[*]}. Please create the milestone before releasing."
   exit 1
 fi
+
+# --- Step 5: Update dependabot.yml ---
+echo "📝 Updating milestone for target-branch '$TARGET_BRANCH' → $MILESTONE_NUMBER ($MILESTONE_TITLE)..."
+
+yq -i '(.updates[] | select(."target-branch" == "'"$TARGET_BRANCH"'") | .milestone) = '"$MILESTONE_NUMBER" "$DEPENDABOT_FILE"
+
+# Verify the update actually changed something
+if git diff --quiet "$DEPENDABOT_FILE"; then
+  echo "::error::yq produced no diff on $DEPENDABOT_FILE. No entries matched target-branch '$TARGET_BRANCH' or milestone was already $MILESTONE_NUMBER."
+  exit 1
+fi
+
+echo "✅ $DEPENDABOT_FILE updated."
+
+# --- Step 6: Export for workflow PR step ---
+export_env "TARGET_BRANCH"    "$TARGET_BRANCH"
+export_env "RELEASE_VERSION"  "$VERSION"
+export_env "MILESTONE_TITLE"  "$MILESTONE_TITLE"
+
+echo "📤 Exported: TARGET_BRANCH=$TARGET_BRANCH, RELEASE_VERSION=$VERSION, MILESTONE_TITLE=$MILESTONE_TITLE"

--- a/.github/scripts/update-dependabot-milestone.sh
+++ b/.github/scripts/update-dependabot-milestone.sh
@@ -69,15 +69,9 @@ if [[ "$RELEASE_TARGET_BRANCH" == release/* ]]; then
     exit 1
   fi
 elif [[ "$RELEASE_TARGET_BRANCH" == "main" ]]; then
-  # Minor/major release from main: prefer pre-existing release branch entries
-  HAS_RELEASE_BRANCH_ENTRIES=$(yq '.updates[]."target-branch"' "$DEPENDABOT_FILE" | grep -Fcx "$COMPUTED_RELEASE_BRANCH" || true)
-  if [[ "$HAS_RELEASE_BRANCH_ENTRIES" -gt 0 ]]; then
-    TARGET_BRANCH="$COMPUTED_RELEASE_BRANCH"
-    echo "ℹ️  Release from main — found entries for '$COMPUTED_RELEASE_BRANCH', updating those."
-  else
-    TARGET_BRANCH="main"
-    echo "ℹ️  Release from main — no '$COMPUTED_RELEASE_BRANCH' entries found, updating 'main'."
-  fi
+  # Minor/major release from main: update main entries to the next minor milestone
+  TARGET_BRANCH="main"
+  echo "ℹ️  Release from main — updating 'main'."
 else
   echo "::error::Unexpected release source branch: '$RELEASE_TARGET_BRANCH'"
   exit 1

--- a/.github/scripts/update-dependabot-milestone.sh
+++ b/.github/scripts/update-dependabot-milestone.sh
@@ -84,3 +84,42 @@ else
 fi
 
 echo "🎯 Target branch to update: $TARGET_BRANCH"
+
+# --- Step 3: Compute next version candidates ---
+NEXT_PATCH_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
+NEXT_MINOR_VERSION="${MAJOR}.$((MINOR + 1)).0"
+
+if [[ "$TARGET_BRANCH" == release/* ]]; then
+  VERSION_CANDIDATES=("$NEXT_PATCH_VERSION" "$NEXT_MINOR_VERSION")
+else
+  VERSION_CANDIDATES=("$NEXT_MINOR_VERSION")
+fi
+
+echo "🔍 Milestone candidates: ${VERSION_CANDIDATES[*]}"
+
+# --- Step 4: Milestone lookup via GitHub API ---
+OWNER="${GITHUB_REPOSITORY%%/*}"
+REPO="${GITHUB_REPOSITORY##*/}"
+
+ALL_MILESTONES=$(gh api --paginate "repos/${OWNER}/${REPO}/milestones?state=open&per_page=100") || {
+  echo "::error::GitHub API call failed. Check GITHUB_TOKEN is set and has repo access."
+  exit 1
+}
+
+MILESTONE_NUMBER=""
+MILESTONE_TITLE=""
+
+for CANDIDATE in "${VERSION_CANDIDATES[@]}"; do
+  FOUND_NUMBER=$(echo "$ALL_MILESTONES" | jq -r --arg title "$CANDIDATE" '.[] | select(.title == $title) | .number' | head -1)
+  if [[ -n "$FOUND_NUMBER" ]]; then
+    MILESTONE_NUMBER="$FOUND_NUMBER"
+    MILESTONE_TITLE="$CANDIDATE"
+    echo "✅ Found milestone '$CANDIDATE' (#$MILESTONE_NUMBER)"
+    break
+  fi
+done
+
+if [[ -z "$MILESTONE_NUMBER" ]]; then
+  echo "::error::No open milestone found matching any of: ${VERSION_CANDIDATES[*]}. Please create the milestone before releasing."
+  exit 1
+fi

--- a/.github/scripts/update-dependabot-milestone.sh
+++ b/.github/scripts/update-dependabot-milestone.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 the Operaton contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# --- Inputs ---
+RELEASE_TAG="${RELEASE_TAG:?RELEASE_TAG is required}"
+RELEASE_TARGET_BRANCH="${RELEASE_TARGET_BRANCH:?RELEASE_TARGET_BRANCH is required}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+# GITHUB_TOKEN is used implicitly by the gh CLI
+
+DEPENDABOT_FILE=".github/dependabot.yml"
+
+# --- Helper: write a key=value pair to GITHUB_ENV if available ---
+export_env() {
+  local key="$1" val="$2"
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    echo "$key=$val" >> "$GITHUB_ENV"
+  fi
+}
+
+# --- Step 1: Parse version ---
+VERSION="${RELEASE_TAG#v}"
+
+# Secondary guard: exit 0 (silent cancel) for preliminary qualifiers
+if [[ "$VERSION" =~ -M[0-9]+|-RC[0-9]+ ]]; then
+  echo "ℹ️  Preliminary release '$VERSION' detected — skipping."
+  exit 0
+fi
+
+if [[ ! "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  echo "::error::Unrecognized version format: '$VERSION'"
+  exit 1
+fi
+
+MAJOR="${BASH_REMATCH[1]}"
+MINOR="${BASH_REMATCH[2]}"
+PATCH="${BASH_REMATCH[3]}"
+
+echo "📦 Release version: $VERSION (MAJOR=$MAJOR, MINOR=$MINOR, PATCH=$PATCH)"
+echo "🌿 Release source branch: $RELEASE_TARGET_BRANCH"

--- a/.github/workflows/update-dependabot-milestone.yml
+++ b/.github/workflows/update-dependabot-milestone.yml
@@ -1,0 +1,61 @@
+# Copyright 2025 the Operaton contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Update Dependabot Milestone
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-dependabot-milestone:
+    name: Update Dependabot Milestone
+    runs-on: ubuntu-latest
+    if: github.event.release.prerelease == false
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Update dependabot milestone
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TARGET_BRANCH: ${{ github.event.release.target_commitish }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: .github/scripts/update-dependabot-milestone.sh
+
+      - name: Create Pull Request
+        if: env.RELEASE_VERSION != ''
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
+        with:
+          title: "chore(build): Update dependabot milestone after release ${{ env.RELEASE_VERSION }}"
+          commit-message: "chore(build): Update dependabot milestone after release ${{ env.RELEASE_VERSION }}"
+          branch: "chore/update-dependabot-milestone-after-${{ env.RELEASE_VERSION }}"
+          base: main
+          labels: scope:build
+          body: |
+            ## Update Dependabot Milestone
+
+            After the release of `${{ env.RELEASE_VERSION }}`, this PR updates the `milestone` field
+            for `${{ env.TARGET_BRANCH }}` entries in `.github/dependabot.yml` to point to
+            milestone **${{ env.MILESTONE_TITLE }}**.
+
+            This PR was created automatically by the
+            [Update Dependabot Milestone](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) workflow.


### PR DESCRIPTION
Closes #2841

## Summary

Adds a GitHub Actions workflow that automatically creates a PR updating the `milestone` field in `.github/dependabot.yml` after each non-preliminary release.

### What it does
- Triggers on `release: published` (skips prereleases via job condition `prerelease == false`)
- Determines the correct target branch using `target_commitish` + `dependabot.yml` content
- Looks up the next milestone via the GitHub API (with pagination and fallback candidates)
- Updates all matching entries in `.github/dependabot.yml` using `yq`
- Opens a PR targeting `main` with label `scope:build`

### Files
- `.github/scripts/update-dependabot-milestone.sh` — all automation logic
- `.github/workflows/update-dependabot-milestone.yml` — trigger + PR creation