### PR TITLE
Add package-info.java to all packages

### DIFF
--- a/clients/java/client/src/main/java/org/operaton/bpm/client/backoff/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/backoff/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Pluggable backoff strategies for handling task subscription failures and retries.
+ */
+package org.operaton.bpm.client.backoff;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/exception/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/exception/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Exception types specific to external task client communication and processing errors.
+ */
+package org.operaton.bpm.client.exception;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/impl/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation classes for the external task client. Not intended for direct use.
+ */
+package org.operaton.bpm.client.impl;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/interceptor/auth/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/interceptor/auth/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Authentication interceptor implementations for the external task client.
+ */
+package org.operaton.bpm.client.interceptor.auth;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/interceptor/impl/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/interceptor/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation classes for HTTP interceptors. Not intended for direct use.
+ */
+package org.operaton.bpm.client.interceptor.impl;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/interceptor/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/interceptor/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Request and response interceptors for HTTP communication with the Operaton engine.
+ */
+package org.operaton.bpm.client.interceptor;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Java client for subscribing to external tasks from an Operaton instance and communicating task results back.
+ * The {@link org.operaton.bpm.client.ExternalTaskClient} is the entry point for configuring and starting task subscriptions.
+ */
+package org.operaton.bpm.client;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/spi/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/spi/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Service provider interfaces for extending external task client behavior.
+ */
+package org.operaton.bpm.client.spi;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/task/impl/dto/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/task/impl/dto/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Data transfer objects for external task representations.
+ */
+package org.operaton.bpm.client.task.impl.dto;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/task/impl/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/task/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation classes for external task handling. Not intended for direct use.
+ */
+package org.operaton.bpm.client.task.impl;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/task/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/task/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * External task data transfer objects and handling interfaces.
+ */
+package org.operaton.bpm.client.task;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/topic/impl/dto/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/topic/impl/dto/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Data transfer objects for topic subscriptions.
+ */
+package org.operaton.bpm.client.topic.impl.dto;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/topic/impl/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/topic/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation classes for topic subscriptions. Not intended for direct use.
+ */
+package org.operaton.bpm.client.topic.impl;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/topic/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/topic/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Topic subscription management for external tasks.
+ */
+package org.operaton.bpm.client.topic;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/format/json/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/format/json/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * JSON variable format implementations.
+ */
+package org.operaton.bpm.client.variable.impl.format.json;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/format/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/format/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Variable format handlers for JSON, XML, and other serialization formats.
+ */
+package org.operaton.bpm.client.variable.impl.format;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/format/serializable/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/format/serializable/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Serializable variable format implementations.
+ */
+package org.operaton.bpm.client.variable.impl.format.serializable;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/format/xml/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/format/xml/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * XML variable format implementations.
+ */
+package org.operaton.bpm.client.variable.impl.format.xml;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/mapper/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/mapper/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Variable mappers for converting between Java types and serialized forms.
+ */
+package org.operaton.bpm.client.variable.impl.mapper;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation classes for variable serialization. Not intended for direct use.
+ */
+package org.operaton.bpm.client.variable.impl;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/type/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/type/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Variable type definitions for the external task client.
+ */
+package org.operaton.bpm.client.variable.impl.type;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/value/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/variable/impl/value/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal variable value implementations. Not intended for direct use.
+ */
+package org.operaton.bpm.client.variable.impl.value;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/variable/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/variable/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Variable serialization and format handling for external task variables.
+ */
+package org.operaton.bpm.client.variable;

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/variable/value/package-info.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/variable/value/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Variable value types for use with the external task client.
+ */
+package org.operaton.bpm.client.variable.value;

--- a/commons/logging/src/main/java/org/operaton/commons/logging/package-info.java
+++ b/commons/logging/src/main/java/org/operaton/commons/logging/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Logging abstraction backed by SLF4J, providing specialized logger classes via {@link org.operaton.commons.logging.BaseLogger}.
+ */
+package org.operaton.commons.logging;

--- a/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/context/package-info.java
+++ b/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/context/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Context access for variable resolution during process execution.
+ */
+package org.operaton.bpm.engine.variable.context;

--- a/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/context/package-info.java
+++ b/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/context/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of variable context.
+ */
+package org.operaton.bpm.engine.variable.impl.context;

--- a/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/package-info.java
+++ b/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of variable API.
+ */
+package org.operaton.bpm.engine.variable.impl;

--- a/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/type/package-info.java
+++ b/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/type/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementations of variable types.
+ */
+package org.operaton.bpm.engine.variable.impl.type;

--- a/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/value/builder/package-info.java
+++ b/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/value/builder/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Fluent builders for constructing complex variable values.
+ */
+package org.operaton.bpm.engine.variable.impl.value.builder;

--- a/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/value/package-info.java
+++ b/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/impl/value/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementations of variable value types.
+ */
+package org.operaton.bpm.engine.variable.impl.value;

--- a/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/package-info.java
+++ b/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Typed variable value API, providing factories ({@link org.operaton.bpm.engine.variable.Variables}) and value containers
+ * ({@link org.operaton.bpm.engine.variable.value.TypedValue}) for process variables.
+ */
+package org.operaton.bpm.engine.variable;

--- a/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/type/package-info.java
+++ b/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/type/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Variable type system for declaring and managing value types.
+ */
+package org.operaton.bpm.engine.variable.type;

--- a/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/value/builder/package-info.java
+++ b/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/value/builder/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API for fluent builders to construct complex variable values.
+ */
+package org.operaton.bpm.engine.variable.value.builder;

--- a/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/value/package-info.java
+++ b/commons/typed-values/src/main/java/org/operaton/bpm/engine/variable/value/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Public API for variable values, including {@link org.operaton.bpm.engine.variable.value.TypedValue}, specialized value types,
+ * and {@link org.operaton.bpm.engine.variable.value.ObjectValue} for complex objects.
+ */
+package org.operaton.bpm.engine.variable.value;

--- a/commons/utils/src/main/java/org/operaton/commons/utils/cache/package-info.java
+++ b/commons/utils/src/main/java/org/operaton/commons/utils/cache/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Caching utilities for improving performance of frequently accessed operations.
+ */
+package org.operaton.commons.utils.cache;

--- a/commons/utils/src/main/java/org/operaton/commons/utils/package-info.java
+++ b/commons/utils/src/main/java/org/operaton/commons/utils/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Shared utility classes for string, I/O, collection, and reflection operations across Operaton.
+ */
+package org.operaton.commons.utils;

--- a/connect/core/src/main/java/org/operaton/connect/impl/package-info.java
+++ b/connect/core/src/main/java/org/operaton/connect/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of the connector API.
+ */
+package org.operaton.connect.impl;

--- a/connect/core/src/main/java/org/operaton/connect/package-info.java
+++ b/connect/core/src/main/java/org/operaton/connect/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Connector public API, providing entry points ({@link org.operaton.connect.Connectors}) and core interfaces
+ * ({@link org.operaton.connect.ConnectorRequest}, {@link org.operaton.connect.ConnectorResponse}).
+ */
+package org.operaton.connect;

--- a/connect/core/src/main/java/org/operaton/connect/spi/package-info.java
+++ b/connect/core/src/main/java/org/operaton/connect/spi/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Connector SPI for implementing custom connectors via {@link org.operaton.connect.spi.Connector}, configuration,
+ * and provider interfaces.
+ */
+package org.operaton.connect.spi;

--- a/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/package-info.java
+++ b/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of the HTTP connector.
+ */
+package org.operaton.connect.httpclient.impl;

--- a/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/util/package-info.java
+++ b/connect/http-client/src/main/java/org/operaton/connect/httpclient/impl/util/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal utilities for HTTP connector implementation.
+ */
+package org.operaton.connect.httpclient.impl.util;

--- a/connect/http-client/src/main/java/org/operaton/connect/httpclient/package-info.java
+++ b/connect/http-client/src/main/java/org/operaton/connect/httpclient/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * HTTP connector public API using Apache HttpClient.
+ */
+package org.operaton.connect.httpclient;

--- a/connect/soap-http-client/src/main/java/org/operaton/connect/httpclient/soap/impl/package-info.java
+++ b/connect/soap-http-client/src/main/java/org/operaton/connect/httpclient/soap/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of the SOAP-over-HTTP connector.
+ */
+package org.operaton.connect.httpclient.soap.impl;

--- a/connect/soap-http-client/src/main/java/org/operaton/connect/httpclient/soap/package-info.java
+++ b/connect/soap-http-client/src/main/java/org/operaton/connect/httpclient/soap/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * SOAP-over-HTTP connector public API built on the HTTP connector.
+ */
+package org.operaton.connect.httpclient.soap;

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/annotation/event/package-info.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/annotation/event/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * CDI qualifiers for process engine event observation.
+ * Qualifiers are used to fire and observe process lifecycle events
+ * such as task creation, completion, and activity transitions.
+ */
+package org.operaton.bpm.engine.cdi.annotation.event;

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/annotation/package-info.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/annotation/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * CDI qualifiers and interceptor annotations for process engine integration.
+ * Enables process variable injection, process lifecycle hooks,
+ * and business process scoped bean management.
+ */
+package org.operaton.bpm.engine.cdi.annotation;

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/compat/package-info.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/compat/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Backward compatibility support for legacy process engine APIs in CDI environments.
+ * Provides legacy form handling and naming conventions for existing applications.
+ */
+package org.operaton.bpm.engine.cdi.compat;

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/annotation/package-info.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/annotation/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Internal implementation of annotation-based process integration.
+ * Contains bean post-processors and interceptors for
+ * {@code @StartProcess} and {@code @CompleteTask} lifecycle management.
+ */
+package org.operaton.bpm.engine.cdi.impl.annotation;

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/context/package-info.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/context/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Internal CDI scoping and context management for business processes.
+ * Manages association of executions and tasks with conversation, request,
+ * and job executor scopes.
+ */
+package org.operaton.bpm.engine.cdi.impl.context;

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/el/package-info.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/el/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * CDI-aware expression language resolution for process engine.
+ * Enables injection of process engine context into Jakarta EE expression evaluation.
+ */
+package org.operaton.bpm.engine.cdi.impl.el;

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/event/package-info.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/event/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Internal CDI event and listener infrastructure for process lifecycle events.
+ * Fires {@code BusinessProcessEvent} objects as CDI events, enabling
+ * event-driven integration with process engine lifecycle.
+ */
+package org.operaton.bpm.engine.cdi.impl.event;

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/package-info.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Implementation of CDI process engine integration.
+ * Internal classes supporting process variable scoping, bean production,
+ * and expression resolution in CDI managed environments.
+ */
+package org.operaton.bpm.engine.cdi.impl;

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/util/package-info.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/impl/util/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Utility classes for CDI integration with the process engine.
+ * Provides CDI container lookup, bean instantiation, and lifecycle management.
+ */
+package org.operaton.bpm.engine.cdi.impl.util;

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/jsf/package-info.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/jsf/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Jakarta Faces integration for process engine.
+ * Provides task form management in JSF web applications.
+ */
+package org.operaton.bpm.engine.cdi.jsf;

--- a/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/package-info.java
+++ b/engine-cdi/src/main/java/org/operaton/bpm/engine/cdi/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * CDI integration for the Operaton process engine.
+ * Provides the {@link org.operaton.bpm.engine.cdi.BusinessProcess} context bean,
+ * CDI-based process variable injection, and event producers for process lifecycle.
+ */
+package org.operaton.bpm.engine.cdi;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/delegate/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/delegate/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Listener and event interfaces for observing DMN decision evaluation progress.
+ * Enables custom handling of decision evaluation events and rule evaluation results.
+ */
+package org.operaton.bpm.dmn.engine.delegate;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/delegate/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/delegate/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementations of DMN decision evaluation listeners and event publishing.
+ */
+package org.operaton.bpm.dmn.engine.impl.delegate;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/el/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/el/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Integration with expression language providers for evaluating decision table expressions.
+ * Includes JUEL-based expression evaluation and variable context resolution.
+ */
+package org.operaton.bpm.dmn.engine.impl.el;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/evaluation/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/evaluation/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Core handlers for evaluating decision tables, literal expressions, and their logic.
+ * Processes inputs, rules, and outputs during decision evaluation.
+ */
+package org.operaton.bpm.dmn.engine.impl.evaluation;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/hitpolicy/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/hitpolicy/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Handlers for applying DMN hit policies (First, Unique, Any, Collect, Rule Order) to matched decision table rules.
+ */
+package org.operaton.bpm.dmn.engine.impl.hitpolicy;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/metrics/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/metrics/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Collects and tracks metrics during DMN decision evaluation for monitoring and performance analysis.
+ */
+package org.operaton.bpm.dmn.engine.impl.metrics;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Default implementation of the DMN engine configuration and decision evaluation logic.
+ * Includes {@link org.operaton.bpm.dmn.engine.impl.DefaultDmnEngine} and related support classes.
+ */
+package org.operaton.bpm.dmn.engine.impl;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/spi/el/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/spi/el/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * SPI for providing expression language implementations and resolving script engines for DMN evaluation.
+ */
+package org.operaton.bpm.dmn.engine.impl.spi.el;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/spi/hitpolicy/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/spi/hitpolicy/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * SPI for registering and providing custom hit policy handlers.
+ */
+package org.operaton.bpm.dmn.engine.impl.spi.hitpolicy;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/spi/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/spi/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Service Provider Interface (SPI) for extending the DMN engine with custom implementations.
+ * Defines extension points for element transformation, evaluation, and data type handling.
+ */
+package org.operaton.bpm.dmn.engine.impl.spi;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/spi/transform/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/spi/transform/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * SPI for registering and providing custom DMN element transformation handlers.
+ */
+package org.operaton.bpm.dmn.engine.impl.spi.transform;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/spi/type/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/spi/type/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * SPI for registering and providing custom data type transformers for DMN decision values.
+ */
+package org.operaton.bpm.dmn.engine.impl.spi.type;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/transform/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/transform/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Transformation of parsed DMN model elements into executable decision structures.
+ * Handles decision tables, literal expressions, inputs, outputs, rules, and variables.
+ */
+package org.operaton.bpm.dmn.engine.impl.transform;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/type/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/impl/type/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Data type transformers for converting values to and from DMN type definitions (String, Integer, Long, Double, Boolean, Date).
+ */
+package org.operaton.bpm.dmn.engine.impl.type;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Core DMN engine interfaces for parsing and evaluating DMN decision models and decisions.
+ * The {@link org.operaton.bpm.dmn.engine.DmnEngine} is the central interface for decision evaluation.
+ */
+package org.operaton.bpm.dmn.engine;

--- a/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/spi/package-info.java
+++ b/engine-dmn/engine/src/main/java/org/operaton/bpm/dmn/engine/spi/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public SPI for DMN engine extensions: configuration factory and metric collector interfaces.
+ */
+package org.operaton.bpm.dmn.engine.spi;

--- a/engine-dmn/feel-api/src/main/java/org/operaton/bpm/dmn/feel/impl/package-info.java
+++ b/engine-dmn/feel-api/src/main/java/org/operaton/bpm/dmn/feel/impl/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * FEEL (Friendly Enough Expression Language) engine API for evaluating DMN expressions.
+ * The {@link org.operaton.bpm.dmn.feel.impl.FeelEngine} is obtained through {@link org.operaton.bpm.dmn.feel.impl.FeelEngineFactory}.
+ */
+package org.operaton.bpm.dmn.feel.impl;

--- a/engine-dmn/feel-juel/src/main/java/org/operaton/bpm/dmn/feel/impl/juel/el/package-info.java
+++ b/engine-dmn/feel-juel/src/main/java/org/operaton/bpm/dmn/feel/impl/juel/el/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * JUEL expression language integration for FEEL evaluation, including context factories, function mappers, and type converters.
+ */
+package org.operaton.bpm.dmn.feel.impl.juel.el;

--- a/engine-dmn/feel-juel/src/main/java/org/operaton/bpm/dmn/feel/impl/juel/package-info.java
+++ b/engine-dmn/feel-juel/src/main/java/org/operaton/bpm/dmn/feel/impl/juel/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * JUEL-based FEEL engine implementation providing expression evaluation and error handling.
+ */
+package org.operaton.bpm.dmn.feel.impl.juel;

--- a/engine-dmn/feel-juel/src/main/java/org/operaton/bpm/dmn/feel/impl/juel/transform/package-info.java
+++ b/engine-dmn/feel-juel/src/main/java/org/operaton/bpm/dmn/feel/impl/juel/transform/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Transformation of FEEL expressions to JUEL syntax for evaluation via JUEL engine.
+ * Handles comparison, intervals, lists, functions, and other FEEL constructs.
+ */
+package org.operaton.bpm.dmn.feel.impl.juel.transform;

--- a/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/function/builder/package-info.java
+++ b/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/function/builder/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Builder for creating custom FEEL functions in Scala FEEL expressions.
+ */
+package org.operaton.bpm.dmn.feel.impl.scala.function.builder;

--- a/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/function/package-info.java
+++ b/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/function/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Custom function providers and transformers for Scala FEEL expressions.
+ */
+package org.operaton.bpm.dmn.feel.impl.scala.function;

--- a/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/package-info.java
+++ b/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Scala-based FEEL engine implementation providing native expression evaluation with Scala semantics.
+ */
+package org.operaton.bpm.dmn.feel.impl.scala;

--- a/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/spin/package-info.java
+++ b/engine-dmn/feel-scala/src/main/java/org/operaton/bpm/dmn/feel/impl/scala/spin/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Integration with Spin for mapping custom data types in Scala FEEL expressions.
+ */
+package org.operaton.bpm.dmn.feel.impl.scala.spin;

--- a/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/package-info.java
+++ b/engine-plugins/connect-plugin/src/main/java/org/operaton/connect/plugin/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of the Connect connector framework integration via {@link org.operaton.connect.plugin.impl.ConnectProcessEnginePlugin}.
+ */
+package org.operaton.connect.plugin.impl;

--- a/engine-plugins/identity-ldap/src/main/java/org/operaton/bpm/identity/impl/ldap/package-info.java
+++ b/engine-plugins/identity-ldap/src/main/java/org/operaton/bpm/identity/impl/ldap/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * LDAP-backed read-only identity provider implementation for user and group queries.
+ * Central types include {@link org.operaton.bpm.identity.impl.ldap.LdapIdentityProviderSession} and {@link org.operaton.bpm.identity.impl.ldap.LdapConfiguration}.
+ */
+package org.operaton.bpm.identity.impl.ldap;

--- a/engine-plugins/identity-ldap/src/main/java/org/operaton/bpm/identity/impl/ldap/plugin/package-info.java
+++ b/engine-plugins/identity-ldap/src/main/java/org/operaton/bpm/identity/impl/ldap/plugin/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Plugin integration for LDAP identity provider via {@link org.operaton.bpm.identity.impl.ldap.plugin.LdapIdentityProviderPlugin}.
+ */
+package org.operaton.bpm.identity.impl.ldap.plugin;

--- a/engine-plugins/identity-ldap/src/main/java/org/operaton/bpm/identity/impl/ldap/util/package-info.java
+++ b/engine-plugins/identity-ldap/src/main/java/org/operaton/bpm/identity/impl/ldap/util/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Utility classes for LDAP identity provider operations including certificate and logging support.
+ */
+package org.operaton.bpm.identity.impl.ldap.util;

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/impl/feel/integration/package-info.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/impl/feel/integration/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * FEEL expression language integration with Spin data format handling.
+ */
+package org.operaton.spin.plugin.impl.feel.integration;

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/impl/package-info.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/impl/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Implementation of Spin data format framework integration via {@link org.operaton.spin.plugin.impl.SpinProcessEnginePlugin}.
+ * Handles JSON and XML serialization for process engine variables.
+ */
+package org.operaton.spin.plugin.impl;

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/package-info.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Spin-based variable value types and builders for process engine variables.
+ * Entry point is {@link org.operaton.spin.plugin.variable.SpinValues} for creating JSON and XML values.
+ */
+package org.operaton.spin.plugin.variable;

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/type/impl/package-info.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/type/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of Spin variable types for JSON and XML serialization.
+ */
+package org.operaton.spin.plugin.variable.type.impl;

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/type/package-info.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/type/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Spin variable type definitions for JSON and XML data format handling.
+ */
+package org.operaton.spin.plugin.variable.type;

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/value/builder/package-info.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/value/builder/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Builder interfaces for constructing Spin variable values with JSON and XML data.
+ */
+package org.operaton.spin.plugin.variable.value.builder;

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/value/impl/builder/package-info.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/value/impl/builder/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Builder implementations for constructing Spin variable values.
+ */
+package org.operaton.spin.plugin.variable.value.impl.builder;

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/value/impl/package-info.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/value/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of Spin variable values for JSON and XML data handling.
+ */
+package org.operaton.spin.plugin.variable.value.impl;

--- a/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/value/package-info.java
+++ b/engine-plugins/spin-plugin/src/main/java/org/operaton/spin/plugin/variable/value/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Spin variable value interfaces for JSON and XML data formats.
+ */
+package org.operaton.spin.plugin.variable.value;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/cache/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/cache/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Caching infrastructure for REST resources and responses.
+ */
+package org.operaton.bpm.engine.rest.cache;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/authorization/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/authorization/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for authorization and access control resources.
+ */
+package org.operaton.bpm.engine.rest.dto.authorization;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/batch/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/batch/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for batch operation resources and responses.
+ */
+package org.operaton.bpm.engine.rest.dto.batch;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/condition/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/condition/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for condition evaluation resources.
+ */
+package org.operaton.bpm.engine.rest.dto.condition;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/converter/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/converter/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Converter classes for transforming between engine domain objects and REST DTOs.
+ */
+package org.operaton.bpm.engine.rest.dto.converter;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/dmn/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/dmn/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for DMN (Decision Model and Notation) decision definition and evaluation resources.
+ */
+package org.operaton.bpm.engine.rest.dto.dmn;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/externaltask/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/externaltask/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for external task and external task worker resources.
+ */
+package org.operaton.bpm.engine.rest.dto.externaltask;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/history/batch/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/history/batch/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for historic batch operation data.
+ */
+package org.operaton.bpm.engine.rest.dto.history.batch;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/history/batch/removaltime/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/history/batch/removaltime/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for historic batch removal time calculations.
+ */
+package org.operaton.bpm.engine.rest.dto.history.batch.removaltime;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/history/optimize/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/history/optimize/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for Optimize integration and historic process data analytics.
+ */
+package org.operaton.bpm.engine.rest.dto.history.optimize;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/history/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/history/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for historic engine data including completed process instances, tasks, and variables.
+ */
+package org.operaton.bpm.engine.rest.dto.history;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/identity/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/identity/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for identity and group management resources.
+ */
+package org.operaton.bpm.engine.rest.dto.identity;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/management/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/management/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for engine management and administration resources including jobs and metrics.
+ */
+package org.operaton.bpm.engine.rest.dto.management;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/message/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/message/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for message and signal correlation resources.
+ */
+package org.operaton.bpm.engine.rest.dto.message;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/metrics/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/metrics/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for engine metrics and monitoring data.
+ */
+package org.operaton.bpm.engine.rest.dto.metrics;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/migration/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/migration/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for process instance migration and plan generation resources.
+ */
+package org.operaton.bpm.engine.rest.dto.migration;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Data transfer objects (DTOs) for REST request and response payloads across the engine API.
+ * Provides serializable representations of engine domain objects for HTTP communication.
+ */
+package org.operaton.bpm.engine.rest.dto;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/repository/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/repository/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for repository resources including deployments, process definitions, and decision definitions.
+ */
+package org.operaton.bpm.engine.rest.dto.repository;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/batch/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/batch/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for async batch operation requests related to process instance runtime management.
+ */
+package org.operaton.bpm.engine.rest.dto.runtime.batch;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/modification/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/modification/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for process instance modification resources.
+ */
+package org.operaton.bpm.engine.rest.dto.runtime.modification;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/runtime/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for runtime engine data including process instances, tasks, and executions.
+ */
+package org.operaton.bpm.engine.rest.dto.runtime;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for user task resources and task-related operations.
+ */
+package org.operaton.bpm.engine.rest.dto.task;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/telemetry/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/telemetry/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs for telemetry and data collection resources.
+ */
+package org.operaton.bpm.engine.rest.dto.telemetry;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/exception/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/exception/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Exception mappers that translate engine exceptions into REST error responses.
+ */
+package org.operaton.bpm.engine.rest.exception;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/filter/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/filter/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * JAX-RS request and response filters for REST API processing.
+ */
+package org.operaton.bpm.engine.rest.filter;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/cache/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/cache/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * HAL link cache infrastructure for performance optimization.
+ */
+package org.operaton.bpm.engine.rest.hal.cache;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/casedefinition/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/casedefinition/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * HAL representation types for CMMN case definition resources.
+ */
+package org.operaton.bpm.engine.rest.hal.casedefinition;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/group/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/group/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * HAL representation types for group and identity resources.
+ */
+package org.operaton.bpm.engine.rest.hal.group;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/identitylink/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/identitylink/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * HAL representation types for identity link resources.
+ */
+package org.operaton.bpm.engine.rest.hal.identitylink;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Hypertext Application Language (HAL) representation types for HATEOAS REST responses.
+ * Provides hypermedia support with embedded resources and links.
+ */
+package org.operaton.bpm.engine.rest.hal;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/processdefinition/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/processdefinition/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * HAL representation types for process definition resources.
+ */
+package org.operaton.bpm.engine.rest.hal.processdefinition;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/task/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/task/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * HAL representation types for task resources.
+ */
+package org.operaton.bpm.engine.rest.hal.task;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/tenant/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/tenant/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * HAL representation types for tenant resources.
+ */
+package org.operaton.bpm.engine.rest.hal.tenant;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/user/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/hal/user/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * HAL representation types for user and identity resources.
+ */
+package org.operaton.bpm.engine.rest.hal.user;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/history/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/history/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST resource interfaces for historic engine data queries and analysis.
+ */
+package org.operaton.bpm.engine.rest.history;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/application/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/application/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * JAX-RS application configuration and setup for the REST API.
+ */
+package org.operaton.bpm.engine.rest.impl.application;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/history/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/history/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of historic data REST resources and queries.
+ */
+package org.operaton.bpm.engine.rest.impl.history;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/optimize/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/optimize/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Optimize integration implementation for process analytics and reporting.
+ */
+package org.operaton.bpm.engine.rest.impl.optimize;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation classes for REST resource interfaces, handling engine integration and request processing.
+ */
+package org.operaton.bpm.engine.rest.impl;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/web/bootstrap/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/impl/web/bootstrap/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Web application bootstrap and initialization configuration.
+ */
+package org.operaton.bpm.engine.rest.impl.web.bootstrap;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/mapper/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/mapper/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * JSON and HTTP response mappers for REST API serialization.
+ */
+package org.operaton.bpm.engine.rest.mapper;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * REST API resource interfaces that define the contract for accessing the Operaton engine via HTTP endpoints.
+ * Includes service interfaces for processes, tasks, deployments, and other engine operations.
+ */
+package org.operaton.bpm.engine.rest;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/impl/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of authentication and authorization providers.
+ */
+package org.operaton.bpm.engine.rest.security.auth.impl;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST resource interfaces for authentication and authorization.
+ */
+package org.operaton.bpm.engine.rest.security.auth;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/spi/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/spi/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Service provider interfaces for REST extension points and plugin mechanisms.
+ */
+package org.operaton.bpm.engine.rest.spi;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/authorization/impl/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/authorization/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of authorization sub-resource handlers.
+ */
+package org.operaton.bpm.engine.rest.sub.authorization.impl;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/authorization/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/authorization/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST resource interfaces for authorization sub-resources.
+ */
+package org.operaton.bpm.engine.rest.sub.authorization;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/batch/impl/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/batch/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of batch operation sub-resource handlers.
+ */
+package org.operaton.bpm.engine.rest.sub.batch.impl;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/batch/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/batch/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST resource interfaces for batch operation sub-resources.
+ */
+package org.operaton.bpm.engine.rest.sub.batch;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/externaltask/impl/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/externaltask/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of external task sub-resource handlers.
+ */
+package org.operaton.bpm.engine.rest.sub.externaltask.impl;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/externaltask/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/externaltask/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST resource interfaces for external task sub-resources.
+ */
+package org.operaton.bpm.engine.rest.sub.externaltask;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/history/impl/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/history/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of historic data sub-resource handlers.
+ */
+package org.operaton.bpm.engine.rest.sub.history.impl;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/history/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/history/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST resource interfaces for historic data sub-resources.
+ */
+package org.operaton.bpm.engine.rest.sub.history;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/identity/impl/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/identity/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of identity and group sub-resource handlers.
+ */
+package org.operaton.bpm.engine.rest.sub.identity.impl;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/identity/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/identity/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST resource interfaces for identity and group sub-resources.
+ */
+package org.operaton.bpm.engine.rest.sub.identity;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/impl/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Base implementation classes for sub-resource handlers.
+ */
+package org.operaton.bpm.engine.rest.sub.impl;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/management/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/management/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST resource interfaces for management and administration sub-resources.
+ */
+package org.operaton.bpm.engine.rest.sub.management;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/metrics/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/metrics/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST resource interfaces for metrics and monitoring sub-resources.
+ */
+package org.operaton.bpm.engine.rest.sub.metrics;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST resource interfaces for nested sub-resources within parent resources.
+ */
+package org.operaton.bpm.engine.rest.sub;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of repository and deployment sub-resource handlers.
+ */
+package org.operaton.bpm.engine.rest.sub.repository.impl;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/repository/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST resource interfaces for repository and deployment sub-resources.
+ */
+package org.operaton.bpm.engine.rest.sub.repository;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/impl/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of runtime process and execution sub-resource handlers.
+ */
+package org.operaton.bpm.engine.rest.sub.runtime.impl;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/runtime/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST resource interfaces for runtime process and execution sub-resources.
+ */
+package org.operaton.bpm.engine.rest.sub.runtime;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/task/impl/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/task/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of task sub-resource handlers.
+ */
+package org.operaton.bpm.engine.rest.sub.task.impl;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/task/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/task/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST resource interfaces for task sub-resources including variables, attachments, and identity links.
+ */
+package org.operaton.bpm.engine.rest.sub.task;

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/package-info.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/util/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Utility classes for REST API processing, conversion, and helper functions.
+ */
+package org.operaton.bpm.engine.rest.util;

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/annotations/package-info.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/annotations/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Spring annotations for process engine integration.
+ * Enables process variable injection, process lifecycle management,
+ * and business process scoped bean definitions.
+ */
+package org.operaton.bpm.engine.spring.annotations;

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/application/package-info.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/application/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Spring application context integration for the process engine.
+ * Provides process application implementations and expression language resolvers
+ * for Spring and servlet-based environments.
+ */
+package org.operaton.bpm.engine.spring.application;

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/aop/package-info.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/aop/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Spring AOP integration for process engine annotation handling.
+ * Provides method interceptors and bean post-processors for
+ * {@code @StartProcess} and {@code @State} annotations.
+ */
+package org.operaton.bpm.engine.spring.components.aop;

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/aop/util/package-info.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/aop/util/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Utility classes for Spring AOP pointcut and method matching.
+ * Provides meta-annotation matching and bean scoping support.
+ */
+package org.operaton.bpm.engine.spring.components.aop.util;

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/config/xml/package-info.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/config/xml/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Spring XML configuration namespace support for process engine.
+ * Provides bean definition parsing for activiti XML namespace declarations
+ * and custom annotation-driven bean configuration.
+ */
+package org.operaton.bpm.engine.spring.components.config.xml;

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/jobexecutor/package-info.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/jobexecutor/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Spring job executor implementation for asynchronous task processing.
+ * Provides Spring-managed job execution with thread pool integration.
+ */
+package org.operaton.bpm.engine.spring.components.jobexecutor;

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/package-info.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Spring component support for process engine integration.
+ * Provides utilities for process context management and initialization.
+ */
+package org.operaton.bpm.engine.spring.components;

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/registry/package-info.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/registry/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Spring registry for process engine state handlers.
+ * Manages registration and lookup of business process state handlers.
+ */
+package org.operaton.bpm.engine.spring.components.registry;

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/scope/package-info.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/components/scope/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Spring custom scope implementation for process instances.
+ * Enables Spring beans scoped to the lifetime of a business process.
+ */
+package org.operaton.bpm.engine.spring.components.scope;

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/container/package-info.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/container/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Spring container support for managed process engine instantiation.
+ * Provides factory beans for managed process engine lifecycle in containers.
+ */
+package org.operaton.bpm.engine.spring.container;

--- a/engine-spring/src/main/java/org/operaton/bpm/engine/spring/package-info.java
+++ b/engine-spring/src/main/java/org/operaton/bpm/engine/spring/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Spring Framework integration for the Operaton process engine.
+ * Provides {@link org.operaton.bpm.engine.spring.SpringProcessEngineConfiguration},
+ * transaction management, expression language resolution, and bean factory support.
+ */
+package org.operaton.bpm.engine.spring;

--- a/engine/src/main/java/org/operaton/bpm/application/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/application/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Process application registration and lifecycle management API.
+ * {@link org.operaton.bpm.application.AbstractProcessApplication} provides the base for
+ * deploying process definitions and managing engine integration within applications.
+ */
+package org.operaton.bpm.application;

--- a/engine/src/main/java/org/operaton/bpm/container/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/container/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Process engine container integration API for runtime environments.
+ * {@link org.operaton.bpm.container.RuntimeContainerDelegate} enables the process engine to
+ * integrate with various runtime containers like WildFly, JMX, and OSGi.
+ */
+package org.operaton.bpm.container;

--- a/engine/src/main/java/org/operaton/bpm/engine/authorization/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/authorization/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Resource-based authorization API for process engine access control. Provides types for defining
+ * {@link org.operaton.bpm.engine.authorization.Authorization authorizations}, {@link org.operaton.bpm.engine.authorization.Permission permissions},
+ * and resources to enforce fine-grained security policies.
+ */
+package org.operaton.bpm.engine.authorization;

--- a/engine/src/main/java/org/operaton/bpm/engine/batch/history/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/batch/history/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Historic query API for completed and ongoing batch operations. Provides {@link org.operaton.bpm.engine.batch.history.HistoricBatch HistoricBatch}
+ * and query interface to inspect historical batch data.
+ */
+package org.operaton.bpm.engine.batch.history;

--- a/engine/src/main/java/org/operaton/bpm/engine/batch/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/batch/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * API for managing long-running asynchronous batch operations. A {@link org.operaton.bpm.engine.batch.Batch batch}
+ * represents a set of jobs executed asynchronously by the job executor, with support for monitoring and controlling
+ * execution progress.
+ */
+package org.operaton.bpm.engine.batch;

--- a/engine/src/main/java/org/operaton/bpm/engine/context/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/context/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Utilities for propagating process engine context across thread boundaries. {@link org.operaton.bpm.engine.context.ProcessEngineContext ProcessEngineContext}
+ * controls context scoping and caching for database operations during nested engine API calls.
+ */
+package org.operaton.bpm.engine.context;

--- a/engine/src/main/java/org/operaton/bpm/engine/dmn/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/dmn/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Builder API for evaluating DMN decisions through the process engine. Fluent builders
+ * {@link org.operaton.bpm.engine.dmn.DecisionEvaluationBuilder DecisionEvaluationBuilder} and
+ * {@link org.operaton.bpm.engine.dmn.DecisionsEvaluationBuilder DecisionsEvaluationBuilder} provide the entry point for decision evaluation.
+ */
+package org.operaton.bpm.engine.dmn;

--- a/engine/src/main/java/org/operaton/bpm/engine/exception/cmmn/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/exception/cmmn/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * CMMN-specific runtime exceptions for case management errors.
+ * Covers missing case definitions and illegal state transitions in case execution.
+ */
+package org.operaton.bpm.engine.exception.cmmn;

--- a/engine/src/main/java/org/operaton/bpm/engine/exception/dmn/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/exception/dmn/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * DMN-specific runtime exceptions for decision evaluation errors.
+ * Covers missing decision definitions and evaluation failures.
+ */
+package org.operaton.bpm.engine.exception.dmn;

--- a/engine/src/main/java/org/operaton/bpm/engine/exception/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/exception/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Engine-specific runtime exceptions extending {@link org.operaton.bpm.engine.ProcessEngineException}.
+ * Covers typed exceptions for missing resources, invalid state, and null values.
+ */
+package org.operaton.bpm.engine.exception;

--- a/engine/src/main/java/org/operaton/bpm/engine/externaltask/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/externaltask/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * External task API for decoupled service task execution.
+ * Workers fetch and lock tasks via {@link org.operaton.bpm.engine.externaltask.ExternalTaskQueryBuilder}, execute work externally, then report completion or failure.
+ */
+package org.operaton.bpm.engine.externaltask;

--- a/engine/src/main/java/org/operaton/bpm/engine/filter/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/filter/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Saved query filter API.
+ * A {@link org.operaton.bpm.engine.filter.Filter} stores a named, reusable query (e.g. a task list) that can be shared across users.
+ */
+package org.operaton.bpm.engine.filter;

--- a/engine/src/main/java/org/operaton/bpm/engine/health/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/health/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Process engine health check API for monitoring engine status independent of runtime.
+ * Provides {@link org.operaton.bpm.engine.health.HealthService} to obtain engine health information
+ * and allows custom contributors via {@link org.operaton.bpm.engine.health.FrontendHealthContributor}.
+ */
+package org.operaton.bpm.engine.health;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/ant/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/ant/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Ant task support for schema creation and process deployment.
+ * Provides Ant tasks for engine management operations in build and deployment
+ * automation scripts.
+ */
+package org.operaton.bpm.engine.impl.ant;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/application/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/application/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Internal process application management implementation.
+ * Handles process application lifecycle, context propagation, and resource
+ * management within the engine.
+ */
+package org.operaton.bpm.engine.impl.application;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/builder/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/builder/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Builder infrastructure for constructing batch operations.
+ * Provides fluent APIs to configure and build typed batch job instances.
+ */
+package org.operaton.bpm.engine.impl.batch.builder;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/deletion/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/deletion/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Batch process and decision instance deletion handlers.
+ * Implements batch job logic for cascading deletion of process instances and their associated historic data.
+ */
+package org.operaton.bpm.engine.impl.batch.deletion;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/externaltask/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/externaltask/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Batch external task retry handler.
+ * Provides batch job processing for external task failures, enabling bulk retry operations.
+ */
+package org.operaton.bpm.engine.impl.batch.externaltask;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/history/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/history/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Batch historic instance cleanup handler.
+ * Manages batch-driven deletion of historic process and decision instances based on time-to-live policies.
+ */
+package org.operaton.bpm.engine.impl.batch.history;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/job/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/job/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Core batch job processing infrastructure.
+ * Defines the batch job execution model and handler contracts for type-specific batch operations.
+ */
+package org.operaton.bpm.engine.impl.batch.job;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/message/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/message/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Batch message correlation handler.
+ * Implements batch job processing for message-triggered process instance correlations at scale.
+ */
+package org.operaton.bpm.engine.impl.batch.message;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Internal batch processing infrastructure.
+ * Core types including {@link org.operaton.bpm.engine.impl.batch.BatchConfiguration} for configuration management and job handler abstraction.
+ */
+package org.operaton.bpm.engine.impl.batch;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/removaltime/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/removaltime/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Batch removal time update handlers.
+ * Manages batch-driven updates to the removal time (TTL) of historic process and decision instances.
+ */
+package org.operaton.bpm.engine.impl.batch.removaltime;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/update/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/update/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Batch process instance variable update handler.
+ * Implements batch job processing for bulk updates to process instance variables and state.
+ */
+package org.operaton.bpm.engine.impl.batch.update;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/batch/variables/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/batch/variables/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Batch variable set handler.
+ * Provides batch job processing for bulk variable assignments to process instances.
+ */
+package org.operaton.bpm.engine.impl.batch.variables;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/behavior/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Activity behavior implementations for BPMN constructs, including service tasks, gateways, events, and subprocess executions.
+ */
+package org.operaton.bpm.engine.impl.bpmn.behavior;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/delegate/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/delegate/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal delegate execution wrappers for invoking Java delegates and expression evaluations within the BPMN execution context.
+ */
+package org.operaton.bpm.engine.impl.bpmn.delegate;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/deployer/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/deployer/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * BPMN process definition deployer that parses BPMN 2.0 XML and persists process definitions into the engine's repository.
+ */
+package org.operaton.bpm.engine.impl.bpmn.deployer;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/diagram/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/diagram/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * BPMN diagram interchange (DI) processing for reading and interpreting graphical layout information from BPMN models.
+ */
+package org.operaton.bpm.engine.impl.bpmn.diagram;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/helper/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * BPMN helper utilities providing support for error boundary events, compensation, and escalation handling in process execution.
+ */
+package org.operaton.bpm.engine.impl.bpmn.helper;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/listener/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/listener/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Built-in execution and task listener implementations for responding to process and task lifecycle events.
+ */
+package org.operaton.bpm.engine.impl.bpmn.listener;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Top-level BPMN engine implementation package containing the core execution model and integration points for BPMN 2.0 processes.
+ */
+package org.operaton.bpm.engine.impl.bpmn;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/bpmn/parser/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * BPMN 2.0 XML parser that transforms BPMN process definitions into the engine's internal process definition model.
+ */
+package org.operaton.bpm.engine.impl.bpmn.parser;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Business calendar implementations for timer resolution and due date calculation.
+ * Provides various business calendar strategies including default, duration-based,
+ * and cycle-based calculations for BPMN timer events.
+ */
+package org.operaton.bpm.engine.impl.calendar;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/auth/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/auth/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Authorization configuration and checker implementations wired during engine startup.
+ * Provides mechanisms for enforcing authorization rules through command checkers
+ * and permission providers.
+ */
+package org.operaton.bpm.engine.impl.cfg.auth;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/jta/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/jta/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * JTA transaction manager integration for engine configuration.
+ * Provides transaction context implementations that bridge the engine
+ * with external JTA transaction coordinators.
+ */
+package org.operaton.bpm.engine.impl.cfg.jta;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/multitenancy/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/multitenancy/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Multi-tenancy configuration and tenant isolation implementations.
+ * Provides tenant check mechanisms and tenant ID providers wired during
+ * engine configuration to enforce tenant boundaries.
+ */
+package org.operaton.bpm.engine.impl.cfg.multitenancy;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Engine configuration infrastructure including core configuration classes and transaction handling.
+ * {@link org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl} is the central class
+ * that manages engine lifecycle and all subsystem configurations.
+ */
+package org.operaton.bpm.engine.impl.cfg;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/standalone/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/standalone/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Standalone (non-managed) transaction context configuration.
+ * Provides transaction context implementations for standalone engine deployments
+ * without external transaction coordinator integration.
+ */
+package org.operaton.bpm.engine.impl.cfg.standalone;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/batch/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/batch/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Commands for creating and managing batch operations.
+ * Handles batch creation, execution control, and lifecycle operations through the {@link org.operaton.bpm.engine.impl.cmd.batch.CreateBatchCmd} and related command classes.
+ */
+package org.operaton.bpm.engine.impl.cmd.batch;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/batch/removaltime/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/batch/removaltime/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Commands for setting removal times on batch historic data.
+ * Provides operations to update the removal time TTL for batch-managed historic instances and variables.
+ */
+package org.operaton.bpm.engine.impl.cmd.batch.removaltime;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/batch/variables/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/batch/variables/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Commands for batch variable updates.
+ * Provides operations to update process instance variables in bulk through batch processing.
+ */
+package org.operaton.bpm.engine.impl.cmd.batch.variables;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/optimize/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/optimize/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Commands for Optimize history export queries.
+ * Handles retrieval and transformation of historic process and decision data for export to the Optimize reporting platform.
+ */
+package org.operaton.bpm.engine.impl.cmd.optimize;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmd/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Command pattern implementations for all engine service operations.
+ * Each {@link org.operaton.bpm.engine.impl.cmd.Command} instance encapsulates a single operation, allowing
+ * consistent transaction management, audit logging, and authorization checks across the engine.
+ */
+package org.operaton.bpm.engine.impl.cmd;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/behavior/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/behavior/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Case plan item behavior implementations defining execution semantics for CMMN elements.
+ * Provides behavior classes for tasks, stages, milestones, event listeners, and other case plan items.
+ */
+package org.operaton.bpm.engine.impl.cmmn.behavior;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/cmd/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/cmd/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Command implementations for the CMMN service API, encapsulating operations on case instances,
+ * case plan items, and case definitions within the case engine service.
+ */
+package org.operaton.bpm.engine.impl.cmmn.cmd;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/delegate/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/delegate/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Delegate execution wrappers for CMMN case task invocations, providing interfaces for user tasks,
+ * service tasks, and human task implementations within a case context.
+ */
+package org.operaton.bpm.engine.impl.cmmn.delegate;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/deployer/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/deployer/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Case definition deployer that parses CMMN XML artifacts and transforms them into the executable
+ * internal case model representation stored in the repository.
+ */
+package org.operaton.bpm.engine.impl.cmmn.deployer;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Persistence entities for case instances, executions, and definitions.
+ * Provides the domain model entities for storing and retrieving case data.
+ */
+package org.operaton.bpm.engine.impl.cmmn.entity;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/repository/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/repository/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Persistence entities specific to case definition repository, managing deployed case definitions
+ * and their access from the repository.
+ */
+package org.operaton.bpm.engine.impl.cmmn.entity.repository;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/entity/runtime/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Runtime persistence entities for case execution state, tracking active case instances and plan item instances
+ * during case execution.
+ */
+package org.operaton.bpm.engine.impl.cmmn.entity.runtime;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/execution/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/execution/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * CMMN execution runtime providing the core case lifecycle management. {@link org.operaton.bpm.engine.impl.cmmn.execution.CmmnExecution}
+ * drives the case forward through state transitions and plan item lifecycle events.
+ */
+package org.operaton.bpm.engine.impl.cmmn.execution;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/handler/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/handler/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Element handlers used during CMMN XML parsing to construct the internal case model from CMMN XML artifacts.
+ * Each handler is responsible for parsing a specific CMMN element type.
+ */
+package org.operaton.bpm.engine.impl.cmmn.handler;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/listener/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/listener/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Built-in case execution listener implementations providing default behavior for case lifecycle events.
+ * Listeners respond to case execution state changes and plan item transitions.
+ */
+package org.operaton.bpm.engine.impl.cmmn.listener;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/model/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/model/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Internal CMMN model representation derived from parsed XML, providing the executable model
+ * of a case definition used by the case execution engine.
+ */
+package org.operaton.bpm.engine.impl.cmmn.model;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/operation/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Atomic CMMN operations applied during case lifecycle transitions, enabling step-by-step progression
+ * through case plan item state changes and case execution flow.
+ */
+package org.operaton.bpm.engine.impl.cmmn.operation;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Top-level CMMN (Case Management Model and Notation) implementation mirroring the BPMN impl structure
+ * for case management services. Provides core case service APIs and command builders for case lifecycle management.
+ */
+package org.operaton.bpm.engine.impl.cmmn;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/transformer/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cmmn/transformer/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Transformation logic that converts the parsed CMMN model into the executable internal case model,
+ * resolving references and preparing the model for runtime execution.
+ */
+package org.operaton.bpm.engine.impl.cmmn.transformer;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/context/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/context/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Thread-local engine context management providing access to the current command context,
+ * process application, and engine configuration. {@link org.operaton.bpm.engine.impl.context.Context}
+ * is the central access point for context information during command execution.
+ */
+package org.operaton.bpm.engine.impl.context;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/delegate/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/delegate/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Core delegate execution types shared between BPMN and CMMN engines.
+ */
+package org.operaton.bpm.engine.impl.core.delegate;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/handler/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/handler/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Element handler SPI for parsing model elements in BPMN and CMMN formats.
+ */
+package org.operaton.bpm.engine.impl.core.handler;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/instance/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/instance/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Base execution abstraction represented by {@link org.operaton.bpm.engine.impl.core.instance.CoreExecution}.
+ */
+package org.operaton.bpm.engine.impl.core.instance;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/model/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/model/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Base element model abstractions including {@link org.operaton.bpm.engine.impl.core.model.CoreModelElement}, properties, and property keys.
+ */
+package org.operaton.bpm.engine.impl.core.model;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/operation/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/operation/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Core execution operations shared between BPMN and CMMN engines.
+ */
+package org.operaton.bpm.engine.impl.core.operation;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Core model and execution abstractions shared by BPMN and CMMN engines.
+ */
+package org.operaton.bpm.engine.impl.core;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/transformer/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/transformer/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Core model transformer base classes for BPMN and CMMN.
+ */
+package org.operaton.bpm.engine.impl.core.transformer;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/event/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/event/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Variable event types and dispatching infrastructure.
+ */
+package org.operaton.bpm.engine.impl.core.variable.event;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/mapping/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/mapping/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Input and output variable mapping infrastructure.
+ */
+package org.operaton.bpm.engine.impl.core.variable.mapping;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/mapping/value/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/mapping/value/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Parameter value providers for input and output variable mappings.
+ */
+package org.operaton.bpm.engine.impl.core.variable.mapping.value;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Variable handling infrastructure for the core engine.
+ */
+package org.operaton.bpm.engine.impl.core.variable;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/scope/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/core/variable/scope/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Variable scope abstraction represented by {@link org.operaton.bpm.engine.impl.core.variable.scope.AbstractVariableScope}.
+ */
+package org.operaton.bpm.engine.impl.core.variable.scope;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/cache/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/cache/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * First-level entity cache (identity map) for the current command execution.
+ * Tracks loaded entities, detects changes, and coordinates dirty-checking during flush
+ * via {@link org.operaton.bpm.engine.impl.db.entitymanager.cache.DbEntityCache}.
+ */
+package org.operaton.bpm.engine.impl.db.entitymanager.cache;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/operation/comparator/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/operation/comparator/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Comparators for ordering database insert and update operations by entity type.
+ * Ensures correct execution order to satisfy foreign key constraints during flush.
+ */
+package org.operaton.bpm.engine.impl.db.entitymanager.operation.comparator;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/operation/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/operation/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Insert, update, and delete operation types applied during entity manager flush.
+ * Manages queuing and sequencing of {@link org.operaton.bpm.engine.impl.db.DbEntity} changes
+ * for batch execution through {@link org.operaton.bpm.engine.impl.db.sql.DbSqlSession}.
+ */
+package org.operaton.bpm.engine.impl.db.entitymanager.operation;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/entitymanager/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Entity manager coordinating flush and dirty-tracking of cached entities.
+ * {@link org.operaton.bpm.engine.impl.db.entitymanager.DbEntityManager} orchestrates
+ * the cache, dirty checks, and operation sequencing for database persistence.
+ */
+package org.operaton.bpm.engine.impl.db.entitymanager;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Database abstraction layer providing entity persistence and session management.
+ * {@link org.operaton.bpm.engine.impl.db.DbEntity} and {@link org.operaton.bpm.engine.impl.db.PersistenceSession}
+ * form the core contract for data access and command-scoped transactions.
+ */
+package org.operaton.bpm.engine.impl.db;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * MyBatis-backed SQL session implementation for entity persistence.
+ * {@link org.operaton.bpm.engine.impl.db.sql.DbSqlSession} executes operations
+ * against the database via MyBatis mapped statements.
+ */
+package org.operaton.bpm.engine.impl.db.sql;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/delegate/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/delegate/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal delegate execution infrastructure for BPMN task and listener execution.
+ */
+package org.operaton.bpm.engine.impl.delegate;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/diagnostics/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/diagnostics/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Engine diagnostic and introspection utilities for monitoring and debugging.
+ * Provides diagnostic collectors, registries, and support for engine telemetry
+ * and operational insights.
+ */
+package org.operaton.bpm.engine.impl.diagnostics;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/digest/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/digest/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Password hashing, digest utilities, and encryption infrastructure.
+ * Provides salt generators, hash digest implementations, and password encryption
+ * support for user credential management.
+ */
+package org.operaton.bpm.engine.impl.digest;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/batch/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/batch/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Batch processing for DMN decision reevaluation operations.
+ */
+package org.operaton.bpm.engine.impl.dmn.batch;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/cmd/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/cmd/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DMN decision evaluation command implementations.
+ */
+package org.operaton.bpm.engine.impl.dmn.cmd;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/configuration/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/configuration/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DMN engine configuration and initialization.
+ */
+package org.operaton.bpm.engine.impl.dmn.configuration;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/deployer/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/deployer/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DMN decision definition deployer for parsing and registering DMN models.
+ */
+package org.operaton.bpm.engine.impl.dmn.deployer;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/el/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/el/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Expression language support for DMN decision evaluation.
+ */
+package org.operaton.bpm.engine.impl.dmn.el;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/entity/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/entity/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DMN decision definition persistence entities.
+ */
+package org.operaton.bpm.engine.impl.dmn.entity;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/entity/repository/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/entity/repository/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DMN decision definition persistence repositories.
+ */
+package org.operaton.bpm.engine.impl.dmn.entity.repository;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/invocation/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/invocation/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DMN decision invocation and execution handling.
+ */
+package org.operaton.bpm.engine.impl.dmn.invocation;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DMN integration within the BPMN process engine.
+ */
+package org.operaton.bpm.engine.impl.dmn;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/result/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/result/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DMN decision evaluation result representation and handling.
+ */
+package org.operaton.bpm.engine.impl.dmn.result;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/transformer/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/dmn/transformer/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DMN model transformer for converting DMN definitions into engine-executable forms.
+ */
+package org.operaton.bpm.engine.impl.dmn.transformer;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/el/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/el/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Expression Language integration bridging JUEL and the process engine.
+ * Provides expression managers, EL resolvers, and expression condition evaluation
+ * for BPMN process variable and conditional expression support.
+ */
+package org.operaton.bpm.engine.impl.el;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/errorcode/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/errorcode/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Built-in error code constants and exception code infrastructure for engine exceptions.
+ * Provides standard error codes and a registry for exception code providers
+ * used throughout the engine.
+ */
+package org.operaton.bpm.engine.impl.errorcode;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/event/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/event/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Internal engine event dispatching and handling infrastructure.
+ * Provides event handlers for signal, compensation, and conditional events
+ * used during process execution.
+ */
+package org.operaton.bpm.engine.impl.event;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/externaltask/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/externaltask/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal external task service implementations for long-polling task workers.
+ */
+package org.operaton.bpm.engine.impl.externaltask;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/filter/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/filter/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal filter service implementations for creating and managing task and process instance filters.
+ */
+package org.operaton.bpm.engine.impl.filter;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/form/deployer/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/form/deployer/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Form deployment handling that detects and registers embedded and external form references during process deployment.
+ */
+package org.operaton.bpm.engine.impl.form.deployer;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/form/engine/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/form/engine/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Form rendering engines providing multiple template formats including HTML and Freemarker-based form generation.
+ */
+package org.operaton.bpm.engine.impl.form.engine;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/form/entity/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/form/entity/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Persistence entity implementations for storing Operaton form metadata including form keys and deployment associations.
+ */
+package org.operaton.bpm.engine.impl.form.entity;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/form/handler/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/form/handler/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Form field and form data handler implementations managing form processing for both start and user task forms.
+ */
+package org.operaton.bpm.engine.impl.form.handler;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/form/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/form/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal form service implementation coordinating form data retrieval, processing, and validation across the engine.
+ */
+package org.operaton.bpm.engine.impl.form;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/form/type/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/form/type/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Built-in form field type implementations including string, long, boolean, date, and enum field types.
+ */
+package org.operaton.bpm.engine.impl.form.type;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/form/validator/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/form/validator/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Built-in form field validator implementations including required, min, max, and other constraint validators.
+ */
+package org.operaton.bpm.engine.impl.form.validator;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/health/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/health/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal health service implementation for engine diagnostics and monitoring.
+ */
+package org.operaton.bpm.engine.impl.health;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/event/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/event/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * History event types and entity classes.
+ * Contains event class definitions for process, task, activity, and decision history entries.
+ */
+package org.operaton.bpm.engine.impl.history.event;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/handler/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/handler/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * History event handler implementations.
+ * Provides handlers for consuming and persisting history events to storage backends.
+ */
+package org.operaton.bpm.engine.impl.history.handler;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * History event infrastructure and processing.
+ * Defines {@link org.operaton.bpm.engine.impl.history.event.HistoryEvent}, {@link org.operaton.bpm.engine.impl.history.handler.HistoryEventHandler}, and history levels.
+ */
+package org.operaton.bpm.engine.impl.history;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/parser/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/parser/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * History event parsing and deserialization.
+ * Reconstructs history event objects from persisted or serialized representations.
+ */
+package org.operaton.bpm.engine.impl.history.parser;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/producer/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/producer/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * History event production.
+ * Generates {@link org.operaton.bpm.engine.impl.history.event.HistoryEvent} objects from engine operations.
+ */
+package org.operaton.bpm.engine.impl.history.producer;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/history/transformer/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/history/transformer/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * History event transformation.
+ * Transforms raw engine state into structured history event objects.
+ */
+package org.operaton.bpm.engine.impl.history.transformer;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/identity/db/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/identity/db/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Database-backed identity provider implementation.
+ * Provides concrete implementations for querying and managing users, groups, and tenants in a relational database.
+ */
+package org.operaton.bpm.engine.impl.identity.db;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/identity/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/identity/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Identity service implementation and read-only identity provider SPI.
+ * Provides access to user, group, and tenant information through pluggable identity providers.
+ */
+package org.operaton.bpm.engine.impl.identity;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/incident/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/incident/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Incident management implementations for handling and resolving business process incidents.
+ */
+package org.operaton.bpm.engine.impl.incident;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Command interceptor chain infrastructure for request processing.
+ * Core abstractions include {@link org.operaton.bpm.engine.impl.interceptor.Command},
+ * {@link org.operaton.bpm.engine.impl.interceptor.CommandInterceptor},
+ * {@link org.operaton.bpm.engine.impl.interceptor.CommandExecutor}, and
+ * {@link org.operaton.bpm.engine.impl.interceptor.CommandContext}.
+ */
+package org.operaton.bpm.engine.impl.interceptor;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/historycleanup/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Job executor support for automatic history cleanup operations.
+ */
+package org.operaton.bpm.engine.impl.jobexecutor.historycleanup;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/jobexecutor/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Job executor infrastructure for asynchronous job execution and timer handling.
+ */
+package org.operaton.bpm.engine.impl.jobexecutor;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/json/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/json/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * JSON serialization and conversion utilities used internally by the engine.
+ * Provides converters for queries, migrations, modifications, and other engine
+ * data structures to JSON representation.
+ */
+package org.operaton.bpm.engine.impl.json;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/management/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/management/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal management service implementations for job definitions, metrics queries, and resource monitoring.
+ */
+package org.operaton.bpm.engine.impl.management;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/metrics/dmn/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/metrics/dmn/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DMN-specific metrics collection for decision evaluation tracking.
+ */
+package org.operaton.bpm.engine.impl.metrics.dmn;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/metrics/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/metrics/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Metrics collection infrastructure for engine telemetry and monitoring.
+ */
+package org.operaton.bpm.engine.impl.metrics;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/metrics/parser/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/metrics/parser/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Metrics configuration parser for reading and processing metric definitions.
+ */
+package org.operaton.bpm.engine.impl.metrics.parser;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/metrics/reporter/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/metrics/reporter/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Metrics reporter implementations for publishing collected metrics.
+ */
+package org.operaton.bpm.engine.impl.metrics.reporter;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/metrics/util/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/metrics/util/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Metrics utility classes for collection and calculation.
+ */
+package org.operaton.bpm.engine.impl.metrics.util;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/batch/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/batch/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Batch migration execution.
+ * Manages asynchronous migration of multiple process instances as batch jobs.
+ */
+package org.operaton.bpm.engine.impl.migration.batch;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/instance/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/instance/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * In-memory representation of migrating process instances.
+ * Models the structure and state of process elements during migration execution.
+ */
+package org.operaton.bpm.engine.impl.migration.instance;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/instance/parser/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/instance/parser/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Parser for reconstructing migrating instance trees.
+ * Builds in-memory representation of process instances from persisted execution state.
+ */
+package org.operaton.bpm.engine.impl.migration.instance.parser;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Migration execution infrastructure.
+ * Orchestrates migration plan validation, process instance migration, and activity mapping.
+ */
+package org.operaton.bpm.engine.impl.migration;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/validation/activity/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/validation/activity/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Validators for migration plan activity mappings.
+ * Ensures activities in migration instructions are supported and properly mapped.
+ */
+package org.operaton.bpm.engine.impl.migration.validation.activity;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/validation/instance/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/validation/instance/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Validators for runtime instance state during migration.
+ * Validates that executing process instances can be safely migrated according to the plan.
+ */
+package org.operaton.bpm.engine.impl.migration.validation.instance;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/validation/instruction/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/validation/instruction/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Validators for individual migration instructions.
+ * Validates correctness and feasibility of specific activity mappings in a migration plan.
+ */
+package org.operaton.bpm.engine.impl.migration.validation.instruction;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/migration/validation/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/migration/validation/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Migration plan and instance validation.
+ * Validates migration plans against process definitions and running instances before execution.
+ */
+package org.operaton.bpm.engine.impl.migration.validation;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/mock/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/mock/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Mock infrastructure for test support within the engine.
+ * Provides mock expression managers, EL resolvers, and utilities for testing
+ * engine behavior in isolation.
+ */
+package org.operaton.bpm.engine.impl.mock;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/oplog/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/oplog/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Operation log producer for audit events.
+ * Records engine API calls as audit trail entries in the user operation log.
+ */
+package org.operaton.bpm.engine.impl.oplog;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/optimize/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/optimize/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal Optimize history export implementations for business process analytics.
+ */
+package org.operaton.bpm.engine.impl.optimize;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/deploy/cache/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/deploy/cache/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * In-memory cache of deployed process, case, and decision definitions and their parsed models.
+ * Provides fast lookup and prevents repeated deserialization of BPMN/CMMN/DMN resources.
+ */
+package org.operaton.bpm.engine.impl.persistence.deploy.cache;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/deploy/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/deploy/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Deployment cache and deployer SPI for process, case, and decision resources.
+ * Manages resource registration, parsing, and initialization during deployment.
+ */
+package org.operaton.bpm.engine.impl.persistence.deploy;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/optimize/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/optimize/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Query entities and mappers for Optimize history export.
+ * Provides specialized entity classes for business analytics and reporting.
+ */
+package org.operaton.bpm.engine.impl.persistence.entity.optimize;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * MyBatis entity classes mapping to engine database tables.
+ * Includes entity managers for core process and case entities, users, jobs, and variables.
+ */
+package org.operaton.bpm.engine.impl.persistence.entity;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/util/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/util/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Utility classes supporting persistence entity implementations.
+ * Provides helpers for byte arrays, typed values, and authentication integration.
+ */
+package org.operaton.bpm.engine.impl.persistence.entity.util;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Top-level persistence infrastructure shared across all entity types.
+ * Provides manager factories and abstract base classes for entity lifecycle management.
+ */
+package org.operaton.bpm.engine.impl.persistence;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/plugin/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/plugin/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Engine plugin implementations and infrastructure.
+ * Provides built-in plugins that hook into the process engine lifecycle
+ * during configuration initialization.
+ */
+package org.operaton.bpm.engine.impl.plugin;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/delegate/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/delegate/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Behavior interfaces and delegation patterns for PVM activity execution. {@link org.operaton.bpm.engine.impl.pvm.delegate.ActivityBehavior}
+ * defines execution semantics for process activities and is extended by concrete behavior implementations.
+ */
+package org.operaton.bpm.engine.impl.pvm.delegate;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Process Virtual Machine (PVM) — core execution engine abstraction providing process definition models
+ * and runtime representations. Central types include {@link org.operaton.bpm.engine.impl.pvm.PvmProcessDefinition},
+ * {@link org.operaton.bpm.engine.impl.pvm.PvmActivity}, and {@link org.operaton.bpm.engine.impl.pvm.PvmExecution}.
+ */
+package org.operaton.bpm.engine.impl.pvm;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/process/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/process/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Internal process definition model representing the parsed and validated structure of a BPMN process.
+ * {@link org.operaton.bpm.engine.impl.pvm.process.ProcessDefinitionImpl} and {@link org.operaton.bpm.engine.impl.pvm.process.ActivityImpl}
+ * form the core model elements used by the PVM for execution.
+ */
+package org.operaton.bpm.engine.impl.pvm.process;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/operation/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/operation/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Atomic PVM operations that advance execution state through the process model. Each {@link org.operaton.bpm.engine.impl.pvm.runtime.operation.PvmAtomicOperation}
+ * represents a single transition or lifecycle event such as activity start, activity end, or transition traversal.
+ */
+package org.operaton.bpm.engine.impl.pvm.runtime.operation;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/pvm/runtime/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Runtime state of executing PVM instances, capturing the execution path and variable scope at each step.
+ * {@link org.operaton.bpm.engine.impl.pvm.runtime.PvmExecutionImpl} is the central execution object
+ * that advances through the process model during instance execution.
+ */
+package org.operaton.bpm.engine.impl.pvm.runtime;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/repository/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/repository/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Internal repository service command implementations.
+ * Includes builders for deployments, process definition queries, and suspension state changes.
+ */
+package org.operaton.bpm.engine.impl.repository;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/runtime/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/runtime/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal runtime service command implementations for process execution and message correlation.
+ */
+package org.operaton.bpm.engine.impl.runtime;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Script engine resolution and caching infrastructure supporting multiple scripting languages and implementations.
+ */
+package org.operaton.bpm.engine.impl.scripting.engine;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/env/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/env/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Script environment providing process variables and execution context as script bindings for script evaluation.
+ */
+package org.operaton.bpm.engine.impl.scripting.env;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal scripting service implementation providing script execution and lifecycle management across the engine.
+ */
+package org.operaton.bpm.engine.impl.scripting;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/task/delegate/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/task/delegate/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Task delegate execution infrastructure.
+ */
+package org.operaton.bpm.engine.impl.task.delegate;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/task/listener/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/task/listener/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Task listener execution infrastructure.
+ */
+package org.operaton.bpm.engine.impl.task.listener;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/task/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/task/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal task service and task filter implementations.
+ */
+package org.operaton.bpm.engine.impl.task;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/telemetry/dto/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/telemetry/dto/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Telemetry data transfer objects for usage analytics reporting.
+ */
+package org.operaton.bpm.engine.impl.telemetry.dto;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/telemetry/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/telemetry/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal telemetry collection and reporting for process engine usage analytics.
+ */
+package org.operaton.bpm.engine.impl.telemetry;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/test/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/test/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Test support infrastructure for engine integration tests.
+ */
+package org.operaton.bpm.engine.impl.test;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/tree/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/tree/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Tree walker and visitor utilities for traversing activity instance hierarchies.
+ * Provides execution walkers, tree visitors, and collectors for analyzing
+ * and manipulating process execution trees.
+ */
+package org.operaton.bpm.engine.impl.tree;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/io/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/io/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * I/O utility classes for stream and file handling.
+ */
+package org.operaton.bpm.engine.impl.util.io;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * General-purpose utility classes for engine implementation.
+ */
+package org.operaton.bpm.engine.impl.util;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/xml/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/xml/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * XML utility classes for DOM and namespace handling.
+ */
+package org.operaton.bpm.engine.impl.util.xml;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/variable/listener/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/variable/listener/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Variable change event listener dispatching infrastructure notifying subscribers of variable lifecycle events.
+ */
+package org.operaton.bpm.engine.impl.variable.listener;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/variable/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/variable/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal variable service implementation managing variable storage, retrieval, and lifecycle throughout process execution.
+ */
+package org.operaton.bpm.engine.impl.variable;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/variable/serializer/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/variable/serializer/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Variable value serializer registry and built-in serializer implementations for persisting and deserializing variable values.
+ */
+package org.operaton.bpm.engine.impl.variable.serializer;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/xml/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/xml/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * XML parsing infrastructure using SAX for BPMN and process definition loading.
+ */
+package org.operaton.bpm.engine.impl.xml;

--- a/engine/src/main/java/org/operaton/bpm/engine/migration/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/migration/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Process instance migration API for moving running instances between process definitions.
+ * Build migration plans with {@link org.operaton.bpm.engine.migration.MigrationPlanBuilder},
+ * execute them, and validate migration instructions and plan outcomes.
+ */
+package org.operaton.bpm.engine.migration;

--- a/engine/src/main/java/org/operaton/bpm/engine/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/package-info.java
@@ -1,35 +1,7 @@
 /**
- * Public API of the Operaton engine.<br/><br/>
- * Typical usage of the API starts by the creation of a {@link org.operaton.bpm.engine.ProcessEngineConfiguration}
- * (typically based on a configuration file), from which a {@link org.operaton.bpm.engine.ProcessEngine} can be obtained.<br/><br/>
- * <p>
- * Through the services obtained from such a {@link org.operaton.bpm.engine.ProcessEngine}, BPM and workflow operation
- * can be executed:<br/><br/>
- *
- * <b>{@link org.operaton.bpm.engine.RepositoryService}:</b>
- * Manages {@link org.operaton.bpm.engine.repository.Deployment}s<br/>
- *
- * <b>{@link org.operaton.bpm.engine.RuntimeService}:</b>
- * For starting and searching {@link org.operaton.bpm.engine.runtime.ProcessInstance}s<br/>
- *
- * <b>{@link org.operaton.bpm.engine.TaskService}:</b>
- * Exposes operations to manage human (standalone) {@link org.operaton.bpm.engine.task.Task}s,
- * such as claiming, completing and assigning tasks<br/>
- *
- * <b>{@link org.operaton.bpm.engine.IdentityService}:</b>
- * Used for managing {@link org.operaton.bpm.engine.identity.User}s,
- * {@link org.operaton.bpm.engine.identity.Group}s and the relations between them<br/>
- *
- * <b>{@link org.operaton.bpm.engine.ManagementService}:</b>
- * Exposes engine admin and maintenance operations,
- * which have no relation to the runtime execution of business processes<br/>
- *
- * <b>{@link org.operaton.bpm.engine.HistoryService}:</b>
- * Exposes information about ongoing and past process instances.<br/>
- *
- * <b>{@link org.operaton.bpm.engine.FormService}:</b>
- * Access to form data and rendered forms for starting new process instances and completing tasks.<br/>
- *
- * @since 1.0
+ * Public API of the Operaton engine for BPM and workflow execution.
+ * Typical usage starts by creating a {@link org.operaton.bpm.engine.ProcessEngineConfiguration} and obtaining a
+ * {@link org.operaton.bpm.engine.ProcessEngine}, from which services like RepositoryService, RuntimeService, TaskService,
+ * IdentityService, ManagementService, HistoryService, and FormService can be accessed.
  */
 package org.operaton.bpm.engine;

--- a/engine/src/main/java/org/operaton/bpm/engine/spi/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/spi/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Service provider interfaces for process engine configuration and extension.
+ * {@link org.operaton.bpm.engine.spi.ProcessEngineConfigurationFactory} enables framework-specific
+ * engine initialization from configuration resources.
+ */
+package org.operaton.bpm.engine.spi;

--- a/engine/src/main/java/org/operaton/bpm/engine/telemetry/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/telemetry/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Data transfer objects for engine telemetry and usage reporting.
+ * Contains structured data about product information, metrics, internals, and commands
+ * collected by the engine for telemetry purposes.
+ */
+package org.operaton.bpm.engine.telemetry;

--- a/freemarker-template-engine/src/main/java/org/operaton/templateengines/package-info.java
+++ b/freemarker-template-engine/src/main/java/org/operaton/templateengines/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * FreeMarker-backed form and template engine for Operaton Forms.
+ */
+package org.operaton.templateengines;

--- a/juel/src/main/java/org/operaton/bpm/impl/juel/package-info.java
+++ b/juel/src/main/java/org/operaton/bpm/impl/juel/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * JUEL (Java Unified Expression Language) implementation for expression evaluation in Operaton processes.
+ */
+package org.operaton.bpm.impl.juel;

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/builder/package-info.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/builder/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Fluent builder API for programmatically constructing BPMN 2.0 process models.
+ */
+package org.operaton.bpm.model.bpmn.builder;

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/instance/bpmndi/package-info.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/instance/bpmndi/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of BPMN diagram interchange (BPMNDI) element types.
+ */
+package org.operaton.bpm.model.bpmn.impl.instance.bpmndi;

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/instance/dc/package-info.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/instance/dc/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of diagram common (DC) element types.
+ */
+package org.operaton.bpm.model.bpmn.impl.instance.dc;

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/instance/di/package-info.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/instance/di/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of diagram interchange (DI) element types.
+ */
+package org.operaton.bpm.model.bpmn.impl.instance.di;

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/instance/operaton/package-info.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/instance/operaton/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of Operaton-specific BPMN extensions.
+ */
+package org.operaton.bpm.model.bpmn.impl.instance.operaton;

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/instance/package-info.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/instance/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of BPMN element types.
+ */
+package org.operaton.bpm.model.bpmn.impl.instance;

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/package-info.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of the BPMN 2.0 model API.
+ */
+package org.operaton.bpm.model.bpmn.impl;

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/instance/bpmndi/package-info.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/instance/bpmndi/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API for BPMN diagram interchange (BPMNDI) element types.
+ */
+package org.operaton.bpm.model.bpmn.instance.bpmndi;

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/instance/dc/package-info.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/instance/dc/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API for diagram common (DC) element types.
+ */
+package org.operaton.bpm.model.bpmn.instance.dc;

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/instance/di/package-info.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/instance/di/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API for diagram interchange (DI) element types.
+ */
+package org.operaton.bpm.model.bpmn.instance.di;

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/instance/operaton/package-info.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/instance/operaton/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API for Operaton-specific BPMN extensions.
+ */
+package org.operaton.bpm.model.bpmn.instance.operaton;

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/instance/package-info.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/instance/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API for BPMN 2.0 element types.
+ */
+package org.operaton.bpm.model.bpmn.instance;

--- a/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/package-info.java
+++ b/model-api/bpmn-model/src/main/java/org/operaton/bpm/model/bpmn/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * BPMN 2.0 model API providing access to {@link BpmnModelInstance} and element interfaces for all BPMN element types.
+ */
+package org.operaton.bpm.model.bpmn;

--- a/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/impl/instance/operaton/package-info.java
+++ b/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/impl/instance/operaton/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of Operaton-specific CMMN extensions.
+ */
+package org.operaton.bpm.model.cmmn.impl.instance.operaton;

--- a/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/impl/instance/package-info.java
+++ b/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/impl/instance/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of CMMN element types.
+ */
+package org.operaton.bpm.model.cmmn.impl.instance;

--- a/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/impl/package-info.java
+++ b/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of the CMMN 1.1 model API.
+ */
+package org.operaton.bpm.model.cmmn.impl;

--- a/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/instance/operaton/package-info.java
+++ b/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/instance/operaton/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API for Operaton-specific CMMN extensions.
+ */
+package org.operaton.bpm.model.cmmn.instance.operaton;

--- a/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/instance/package-info.java
+++ b/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/instance/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API for CMMN 1.1 element types.
+ */
+package org.operaton.bpm.model.cmmn.instance;

--- a/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/package-info.java
+++ b/model-api/cmmn-model/src/main/java/org/operaton/bpm/model/cmmn/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * CMMN 1.1 model API providing access to {@link CmmnModelInstance} and element interfaces for all CMMN element types.
+ */
+package org.operaton.bpm.model.cmmn;

--- a/model-api/dmn-model/src/main/java/org/operaton/bpm/model/dmn/impl/instance/package-info.java
+++ b/model-api/dmn-model/src/main/java/org/operaton/bpm/model/dmn/impl/instance/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of DMN element types.
+ */
+package org.operaton.bpm.model.dmn.impl.instance;

--- a/model-api/dmn-model/src/main/java/org/operaton/bpm/model/dmn/impl/package-info.java
+++ b/model-api/dmn-model/src/main/java/org/operaton/bpm/model/dmn/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of the DMN 1.3 model API.
+ */
+package org.operaton.bpm.model.dmn.impl;

--- a/model-api/dmn-model/src/main/java/org/operaton/bpm/model/dmn/instance/package-info.java
+++ b/model-api/dmn-model/src/main/java/org/operaton/bpm/model/dmn/instance/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API for DMN 1.3 element types.
+ */
+package org.operaton.bpm.model.dmn.instance;

--- a/model-api/dmn-model/src/main/java/org/operaton/bpm/model/dmn/package-info.java
+++ b/model-api/dmn-model/src/main/java/org/operaton/bpm/model/dmn/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DMN 1.3 model API providing access to {@link DmnModelInstance} and element interfaces for all DMN element types.
+ */
+package org.operaton.bpm.model.dmn;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/instance/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/instance/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of model element instances and the DOM document abstraction layer.
+ */
+package org.operaton.bpm.model.xml.impl.instance;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of the generic XML model framework. Provides the default implementations for model creation, parsing, validation, and element management.
+ */
+package org.operaton.bpm.model.xml.impl;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/parser/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/parser/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * XML parsing infrastructure for loading and parsing model files.
+ */
+package org.operaton.bpm.model.xml.impl.parser;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/attribute/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/attribute/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of XML attribute handling and type conversion for model elements.
+ */
+package org.operaton.bpm.model.xml.impl.type.attribute;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/child/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/child/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of child element handling and containment relationships.
+ */
+package org.operaton.bpm.model.xml.impl.type.child;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of model element types and type metadata.
+ */
+package org.operaton.bpm.model.xml.impl.type;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/type/reference/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Implementation of element references and relationship resolution.
+ */
+package org.operaton.bpm.model.xml.impl.type.reference;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/util/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Utility classes and helper methods for XML model operations.
+ */
+package org.operaton.bpm.model.xml.impl.util;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/validation/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/impl/validation/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of model validation, including validation result aggregation and reporting.
+ */
+package org.operaton.bpm.model.xml.impl.validation;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/instance/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/instance/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API for model element instances and DOM document abstractions.
+ */
+package org.operaton.bpm.model.xml.instance;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Generic XML model framework providing core APIs for creating and manipulating XML-based model instances. Core types include {@link Model}, {@link ModelInstance}, and {@link ModelBuilder}.
+ */
+package org.operaton.bpm.model.xml;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/assertions/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/assertions/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Assertion helpers for model element and document validation in tests.
+ */
+package org.operaton.bpm.model.xml.test.assertions;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/test/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Test utilities and helper classes for XML model testing.
+ */
+package org.operaton.bpm.model.xml.test;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/type/attribute/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/type/attribute/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API for XML attribute definitions and type conversion.
+ */
+package org.operaton.bpm.model.xml.type.attribute;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/type/child/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/type/child/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API for child element definitions and containment relationships.
+ */
+package org.operaton.bpm.model.xml.type.child;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/type/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/type/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API for model element types, attributes, child elements, and references.
+ */
+package org.operaton.bpm.model.xml.type;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/type/reference/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/type/reference/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API for element reference definitions.
+ */
+package org.operaton.bpm.model.xml.type.reference;

--- a/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/validation/package-info.java
+++ b/model-api/xml-model/src/main/java/org/operaton/bpm/model/xml/validation/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Public API for model validation, including custom validators and validation results.
+ */
+package org.operaton.bpm.model.xml.validation;

--- a/quarkus-extension/engine/runtime/src/main/java/org/operaton/bpm/quarkus/engine/extension/event/package-info.java
+++ b/quarkus-extension/engine/runtime/src/main/java/org/operaton/bpm/quarkus/engine/extension/event/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Event handlers for the Quarkus Operaton extension.
+ */
+package org.operaton.bpm.quarkus.engine.extension.event;

--- a/quarkus-extension/engine/runtime/src/main/java/org/operaton/bpm/quarkus/engine/extension/impl/package-info.java
+++ b/quarkus-extension/engine/runtime/src/main/java/org/operaton/bpm/quarkus/engine/extension/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation classes for the Quarkus extension. Not intended for direct use.
+ */
+package org.operaton.bpm.quarkus.engine.extension.impl;

--- a/quarkus-extension/engine/runtime/src/main/java/org/operaton/bpm/quarkus/engine/extension/package-info.java
+++ b/quarkus-extension/engine/runtime/src/main/java/org/operaton/bpm/quarkus/engine/extension/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Quarkus extension for the Operaton process engine. Registers the process engine as a Quarkus bean and enables native image compilation.
+ */
+package org.operaton.bpm.quarkus.engine.extension;

--- a/spin/core/src/main/java/org/operaton/spin/impl/logging/package-info.java
+++ b/spin/core/src/main/java/org/operaton/spin/impl/logging/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Logging infrastructure for Spin data format implementation.
+ */
+package org.operaton.spin.impl.logging;

--- a/spin/core/src/main/java/org/operaton/spin/impl/package-info.java
+++ b/spin/core/src/main/java/org/operaton/spin/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation of the Spin data format API.
+ */
+package org.operaton.spin.impl;

--- a/spin/core/src/main/java/org/operaton/spin/impl/util/package-info.java
+++ b/spin/core/src/main/java/org/operaton/spin/impl/util/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal utilities for Spin data format implementation.
+ */
+package org.operaton.spin.impl.util;

--- a/spin/core/src/main/java/org/operaton/spin/json/package-info.java
+++ b/spin/core/src/main/java/org/operaton/spin/json/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * JSON data format API for processing JSON data.
+ */
+package org.operaton.spin.json;

--- a/spin/core/src/main/java/org/operaton/spin/package-info.java
+++ b/spin/core/src/main/java/org/operaton/spin/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Spin data format public API, providing {@link org.operaton.spin.Spin} and {@link org.operaton.spin.DataFormats}
+ * for JSON and XML processing.
+ */
+package org.operaton.spin;

--- a/spin/core/src/main/java/org/operaton/spin/scripting/package-info.java
+++ b/spin/core/src/main/java/org/operaton/spin/scripting/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Scripting support for Spin data formats.
+ */
+package org.operaton.spin.scripting;

--- a/spin/core/src/main/java/org/operaton/spin/spi/package-info.java
+++ b/spin/core/src/main/java/org/operaton/spin/spi/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Spin data format SPI for implementing custom data formats via {@link org.operaton.spin.spi.DataFormat},
+ * provider, and configuration interfaces.
+ */
+package org.operaton.spin.spi;

--- a/spin/core/src/main/java/org/operaton/spin/xml/package-info.java
+++ b/spin/core/src/main/java/org/operaton/spin/xml/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * XML data format API for processing XML data.
+ */
+package org.operaton.spin.xml;

--- a/spin/dataformat-json-jackson/src/main/java/org/operaton/spin/impl/json/jackson/format/package-info.java
+++ b/spin/dataformat-json-jackson/src/main/java/org/operaton/spin/impl/json/jackson/format/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Jackson JSON data format provider and reader/writer implementations.
+ */
+package org.operaton.spin.impl.json.jackson.format;

--- a/spin/dataformat-json-jackson/src/main/java/org/operaton/spin/impl/json/jackson/package-info.java
+++ b/spin/dataformat-json-jackson/src/main/java/org/operaton/spin/impl/json/jackson/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Jackson-based JSON data format implementation.
+ */
+package org.operaton.spin.impl.json.jackson;

--- a/spin/dataformat-json-jackson/src/main/java/org/operaton/spin/impl/json/jackson/query/package-info.java
+++ b/spin/dataformat-json-jackson/src/main/java/org/operaton/spin/impl/json/jackson/query/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * JSONPath query support for Jackson JSON data format.
+ */
+package org.operaton.spin.impl.json.jackson.query;

--- a/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/format/package-info.java
+++ b/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/format/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DOM XML data format provider and reader/writer implementations.
+ */
+package org.operaton.spin.impl.xml.dom.format;

--- a/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/format/spi/package-info.java
+++ b/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/format/spi/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * SPI for DOM XML data format customization.
+ */
+package org.operaton.spin.impl.xml.dom.format.spi;

--- a/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/package-info.java
+++ b/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DOM-based XML data format implementation.
+ */
+package org.operaton.spin.impl.xml.dom;

--- a/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/query/package-info.java
+++ b/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/query/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * XPath query support for DOM XML data format.
+ */
+package org.operaton.spin.impl.xml.dom.query;

--- a/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/util/package-info.java
+++ b/spin/dataformat-xml-dom/src/main/java/org/operaton/spin/impl/xml/dom/util/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal utilities for DOM XML data format implementation.
+ */
+package org.operaton.spin.impl.xml.dom.util;

--- a/spring-boot-starter/starter-rest/src/main/java/org/operaton/bpm/spring/boot/starter/rest/package-info.java
+++ b/spring-boot-starter/starter-rest/src/main/java/org/operaton/bpm/spring/boot/starter/rest/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Spring Boot auto-configuration for the Operaton REST API.
+ * The {@link org.operaton.bpm.spring.boot.starter.rest.OperatonBpmRestJerseyAutoConfiguration} class provides REST endpoint configuration.
+ */
+package org.operaton.bpm.spring.boot.starter.rest;

--- a/spring-boot-starter/starter-rest/src/main/java/org/operaton/bpm/spring/boot/starter/rest/spi/package-info.java
+++ b/spring-boot-starter/starter-rest/src/main/java/org/operaton/bpm/spring/boot/starter/rest/spi/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Service provider interfaces for extending the REST API configuration.
+ */
+package org.operaton.bpm.spring.boot.starter.rest.spi;

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/package-info.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation classes for OAuth 2 security. Not intended for direct use.
+ */
+package org.operaton.bpm.spring.boot.starter.security.oauth2.impl;

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/plugin/admin/package-info.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/plugin/admin/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * OAuth 2 security plugin for the Operaton Admin application.
+ */
+package org.operaton.bpm.spring.boot.starter.security.oauth2.impl.plugin.admin;

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/plugin/cockpit/package-info.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/plugin/cockpit/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * OAuth 2 security plugin for the Operaton Cockpit application.
+ */
+package org.operaton.bpm.spring.boot.starter.security.oauth2.impl.plugin.cockpit;

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/plugin/package-info.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/plugin/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * OAuth 2 security plugins for Operaton web applications.
+ */
+package org.operaton.bpm.spring.boot.starter.security.oauth2.impl.plugin;

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/plugin/tasklist/package-info.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/plugin/tasklist/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * OAuth 2 security plugin for the Operaton Tasklist application.
+ */
+package org.operaton.bpm.spring.boot.starter.security.oauth2.impl.plugin.tasklist;

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/plugin/welcome/package-info.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/plugin/welcome/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * OAuth 2 security plugin for the Operaton Welcome application.
+ */
+package org.operaton.bpm.spring.boot.starter.security.oauth2.impl.plugin.welcome;

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/package-info.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * OAuth 2 security integration for the Operaton REST API.
+ */
+package org.operaton.bpm.spring.boot.starter.security.oauth2;

--- a/spring-boot-starter/starter-webapp-core/src/main/java/org/operaton/bpm/spring/boot/starter/webapp/filter/package-info.java
+++ b/spring-boot-starter/starter-webapp-core/src/main/java/org/operaton/bpm/spring/boot/starter/webapp/filter/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * HTTP servlet filters for the Operaton web application.
+ */
+package org.operaton.bpm.spring.boot.starter.webapp.filter;

--- a/spring-boot-starter/starter-webapp-core/src/main/java/org/operaton/bpm/spring/boot/starter/webapp/package-info.java
+++ b/spring-boot-starter/starter-webapp-core/src/main/java/org/operaton/bpm/spring/boot/starter/webapp/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Spring Boot auto-configuration for the core Operaton web application.
+ */
+package org.operaton.bpm.spring.boot.starter.webapp;

--- a/spring-boot-starter/starter-webapp/src/main/java/org/operaton/bpm/spring/boot/starter/webapp/package-info.java
+++ b/spring-boot-starter/starter-webapp/src/main/java/org/operaton/bpm/spring/boot/starter/webapp/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Convenience aggregator for Spring Boot Operaton web application dependencies.
+ */
+package org.operaton.bpm.spring.boot.starter.webapp;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/actuator/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/actuator/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Spring Boot Actuator integration for Operaton health and metrics.
+ */
+package org.operaton.bpm.spring.boot.starter.actuator;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/annotation/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/annotation/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Spring Boot starter annotations for the Operaton process engine.
+ */
+package org.operaton.bpm.spring.boot.starter.annotation;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/condition/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/condition/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Spring Boot conditional configuration classes.
+ */
+package org.operaton.bpm.spring.boot.starter.configuration.condition;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/id/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/id/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * ID generator configuration for the Spring Boot Operaton starter.
+ */
+package org.operaton.bpm.spring.boot.starter.configuration.id;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/impl/custom/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/impl/custom/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Custom configuration implementations for the Operaton process engine.
+ */
+package org.operaton.bpm.spring.boot.starter.configuration.impl.custom;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/impl/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/impl/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Internal implementation classes for process engine configuration. Not intended for direct use.
+ */
+package org.operaton.bpm.spring.boot.starter.configuration.impl;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Spring Boot starter configuration classes for the Operaton process engine.
+ */
+package org.operaton.bpm.spring.boot.starter.configuration;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/event/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/event/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Spring application event classes for the Operaton process engine lifecycle.
+ */
+package org.operaton.bpm.spring.boot.starter.event;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/jdbc/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/jdbc/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * JDBC and database configuration for the Spring Boot Operaton starter.
+ */
+package org.operaton.bpm.spring.boot.starter.jdbc;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Spring Boot auto-configuration for the Operaton process engine.
+ * The {@link org.operaton.bpm.spring.boot.starter.OperatonBpmAutoConfiguration} class provides engine bean registration and configuration.
+ */
+package org.operaton.bpm.spring.boot.starter;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/plugin/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/plugin/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Plugin and extension registration for the Spring Boot Operaton starter.
+ */
+package org.operaton.bpm.spring.boot.starter.plugin;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/property/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/property/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Configuration properties classes for the Spring Boot Operaton starter.
+ */
+package org.operaton.bpm.spring.boot.starter.property;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/runlistener/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/runlistener/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Spring Boot ApplicationRunner integration for the Operaton process engine.
+ */
+package org.operaton.bpm.spring.boot.starter.runlistener;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/spin/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/spin/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Spin data format integration for the Spring Boot Operaton starter.
+ */
+package org.operaton.bpm.spring.boot.starter.spin;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/telemetry/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/telemetry/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Telemetry and monitoring integration for the Spring Boot Operaton starter.
+ */
+package org.operaton.bpm.spring.boot.starter.telemetry;

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/util/package-info.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/util/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Utility classes for the Spring Boot Operaton starter.
+ */
+package org.operaton.bpm.spring.boot.starter.util;


### PR DESCRIPTION
Adds `package-info.java` to all Java packages in order to have a brief summary in the Javadoc overview.