### PR TITLE
fix(engine-rest): correct tenant group membership delete docs

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/tenant/{id}/group-members/{groupId}/delete.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/tenant/{id}/group-members/{groupId}/delete.ftl
@@ -4,8 +4,8 @@
   <@lib.endpointInfo
       id = "deleteGroupMembership"
       tag = "Tenant"
-      summary = "Create Tenant Group Membership"
-      desc = "Creates a membership between a tenant and a group."
+      summary = "Delete Tenant Group Membership"
+      desc = "Deletes a membership between a tenant and a group."
   />
 
   "parameters" : [


### PR DESCRIPTION
Related to https://github.com/cibseven/cibseven/pull/48

Backported commit f7dd7a6fe0d3b86eabb028a65e564957f4723cf9 from the cibseven repository.

Original author: fernando-m-g <fernandom@cib.de>

Backport change unit: 819