### PR TITLE
fix(engine): accept date form values

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/form/type/DateFormType.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/form/type/DateFormType.java
@@ -99,6 +99,9 @@ public class DateFormType extends AbstractFormFieldType {
     if (propertyValue==null || "".equals(propertyValue)) {
       return null;
     }
+    if (propertyValue instanceof Date) {
+      return propertyValue;
+    }
     try {
       return dateFormat.parseObject(propertyValue.toString());
     } catch (ParseException e) {

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/form/DateFormTypeTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/form/DateFormTypeTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.test.api.form;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+
+import org.operaton.bpm.engine.impl.form.type.DateFormType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DateFormTypeTest {
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void shouldAcceptExistingDateAsLegacyFormValue() {
+    Date date = new Date(1_700_000_000_000L);
+
+    Object modelValue = new DateFormType("dd/MM/yyyy").convertFormValueToModelValue(date);
+
+    assertThat(modelValue).isSameAs(date);
+  }
+
+}


### PR DESCRIPTION
## Description

Backports the date form handling fix from CIBSeven.

The bug occurs in the deprecated `DateFormType.convertFormValueToModelValue(Object)` path. When a date is entered in one task and later reused as the default value of another task form field, the converter can receive an already typed `java.util.Date` instead of a string.

Previously, the method converted that `Date` via `propertyValue.toString()` and then tried to parse the localized output with the configured form date pattern. That caused a `ProcessEngineException` for a valid existing date value, which could surface as an unhandled REST/Tasklist error.

This change accepts existing `Date` values directly and returns them unchanged before falling back to string parsing.

## References

CIBSeven:
- PR: https://github.com/cibseven/cibseven/pull/330
- Commit: https://github.com/cibseven/cibseven/commit/29056bff5ba1374a11554bb27e08daddc766bf25

Original Camunda reference:
- PR: https://github.com/camunda/camunda-bpm-platform/pull/332
- Jira: https://app.camunda.com/jira/browse/CAM-10211

The Camunda PR was closed without merge due to inactivity. The CIBSeven PR later implemented the same fix and was merged.

## Attribution

Backported commit `29056bff5ba1374a11554bb27e08daddc766bf25` from the `cibseven` repository.

Original CIBSeven author: David Benes <dbenesj@users.noreply.github.com>  
Co-authored-by: David Benes <david.benes@cogniware.com>

Original Camunda proposal: Alan Sambol, camunda/camunda-bpm-platform#332

## Testing

Added a focused regression test for the legacy date form conversion path.

The test was also verified against the parent commit before the fix: it fails there with `ProcessEngineException: invalid date value


Backport change unit: 1118
