### PR TITLE
fix(engine-rest): handle task OR query candidates

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskQueryDto.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/dto/task/TaskQueryDto.java
@@ -1118,14 +1118,8 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
 
   @Override
   protected void applyFilters(TaskQuery query) {
-    if (orQueries != null) {
-      for (TaskQueryDto orQueryDto: orQueries) {
-        TaskQueryImpl orQuery = new TaskQueryImpl();
-        orQuery.setOrQueryActive();
-        orQueryDto.applyFilters(orQuery);
-        ((TaskQueryImpl) query).addOrQuery(orQuery);
-      }
-    }
+    applyOrQueries(query);
+
     if (processInstanceBusinessKey != null) {
       query.processInstanceBusinessKey(processInstanceBusinessKey);
     }
@@ -1489,6 +1483,168 @@ public class TaskQueryDto extends AbstractQueryDto<TaskQuery> {
     if (withCommentAttachmentInfo != null && withCommentAttachmentInfo) {
       query.withCommentAttachmentInfo();
     }
+  }
+
+  private void applyOrQueries(TaskQuery query) {
+    if (orQueries == null) {
+      return;
+    }
+
+    List<TaskQueryDto> nonEmptyOrQueries = orQueries.stream()
+      .filter(Objects::nonNull)
+      .filter(TaskQueryDto::hasFilterCriteria)
+      .toList();
+
+    if (nonEmptyOrQueries.isEmpty()) {
+      return;
+    }
+
+    TaskQuery orQuery = query.or();
+
+    for (TaskQueryDto orQueryDto : nonEmptyOrQueries) {
+      orQueryDto.applyFilters(orQuery);
+    }
+
+    orQuery.endOr();
+  }
+
+  private boolean hasFilterCriteria() {
+    return hasProcessFilters()
+      || hasAssignmentFilters()
+      || hasTaskFilters()
+      || hasCaseFilters()
+      || hasDateFilters()
+      || hasTenantFilters()
+      || hasVariableFilters()
+      || hasOtherFilters();
+  }
+
+  private boolean hasProcessFilters() {
+    return processInstanceBusinessKey != null
+      || processInstanceBusinessKeyExpression != null
+      || !isEmpty(processInstanceBusinessKeyIn)
+      || processInstanceBusinessKeyLike != null
+      || processInstanceBusinessKeyLikeExpression != null
+      || processDefinitionKey != null
+      || !isEmpty(processDefinitionKeyIn)
+      || processDefinitionId != null
+      || executionId != null
+      || !isEmpty(activityInstanceIdIn)
+      || processDefinitionName != null
+      || processDefinitionNameLike != null
+      || processInstanceId != null
+      || !isEmpty(processInstanceIdIn);
+  }
+
+  private boolean hasAssignmentFilters() {
+    return assignee != null
+      || assigneeExpression != null
+      || assigneeLike != null
+      || assigneeLikeExpression != null
+      || !isEmpty(assigneeIn)
+      || !isEmpty(assigneeNotIn)
+      || candidateGroup != null
+      || candidateGroupExpression != null
+      || candidateGroupLike != null
+      || candidateUser != null
+      || candidateUserExpression != null
+      || !isEmpty(candidateGroups)
+      || candidateGroupsExpression != null
+      || TRUE.equals(includeAssignedTasks)
+      || TRUE.equals(assigned)
+      || TRUE.equals(unassigned)
+      || TRUE.equals(withCandidateGroups)
+      || TRUE.equals(withoutCandidateGroups)
+      || TRUE.equals(withCandidateUsers)
+      || TRUE.equals(withoutCandidateUsers);
+  }
+
+  private boolean hasTaskFilters() {
+    return taskDefinitionKey != null
+      || !isEmpty(taskDefinitionKeyIn)
+      || !isEmpty(taskDefinitionKeyNotIn)
+      || taskDefinitionKeyLike != null
+      || taskId != null
+      || !isEmpty(taskIdIn)
+      || description != null
+      || descriptionLike != null
+      || involvedUser != null
+      || involvedUserExpression != null
+      || maxPriority != null
+      || minPriority != null
+      || name != null
+      || nameNotEqual != null
+      || nameLike != null
+      || nameNotLike != null
+      || owner != null
+      || ownerExpression != null
+      || priority != null
+      || parentTaskId != null
+      || TRUE.equals(active)
+      || TRUE.equals(suspended);
+  }
+
+  private boolean hasCaseFilters() {
+    return caseDefinitionKey != null
+      || caseDefinitionId != null
+      || caseDefinitionName != null
+      || caseDefinitionNameLike != null
+      || caseInstanceId != null
+      || caseInstanceBusinessKey != null
+      || caseInstanceBusinessKeyLike != null
+      || caseExecutionId != null;
+  }
+
+  private boolean hasDateFilters() {
+    return dueAfter != null
+      || dueAfterExpression != null
+      || dueBefore != null
+      || dueBeforeExpression != null
+      || dueDate != null
+      || dueDateExpression != null
+      || TRUE.equals(withoutDueDate)
+      || followUpAfter != null
+      || followUpAfterExpression != null
+      || followUpBefore != null
+      || followUpBeforeExpression != null
+      || followUpBeforeOrNotExistent != null
+      || followUpBeforeOrNotExistentExpression != null
+      || followUpDate != null
+      || followUpDateExpression != null
+      || createdAfter != null
+      || createdAfterExpression != null
+      || createdBefore != null
+      || createdBeforeExpression != null
+      || createdOn != null
+      || createdOnExpression != null
+      || updatedAfter != null
+      || updatedAfterExpression != null;
+  }
+
+  private boolean hasTenantFilters() {
+    return !isEmpty(tenantIdIn)
+      || TRUE.equals(withoutTenantId);
+  }
+
+  private boolean hasVariableFilters() {
+    return !isEmpty(taskVariables)
+      || !isEmpty(processVariables)
+      || !isEmpty(caseInstanceVariables)
+      || TRUE.equals(variableNamesIgnoreCase)
+      || TRUE.equals(variableValuesIgnoreCase);
+  }
+
+  private boolean hasOtherFilters() {
+    return delegationState != null
+      || TRUE.equals(withCommentAttachmentInfo);
+  }
+
+  private boolean isEmpty(Object[] values) {
+    return values == null || values.length == 0;
+  }
+
+  private boolean isEmpty(Collection<?> values) {
+    return values == null || values.isEmpty();
   }
 
   @Override

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/FilterRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/FilterRestServiceInteractionTest.java
@@ -945,8 +945,9 @@ public class FilterRestServiceInteractionTest extends AbstractRestServiceTest {
 
     ArgumentCaptor<TaskQueryImpl> argument = ArgumentCaptor.forClass(TaskQueryImpl.class);
     verify(filterServiceMock).singleResult(eq(EXAMPLE_FILTER_ID), argument.capture());
+    assertThat(argument.getValue().getQueries()).hasSize(2);
     assertThat(argument.getValue().getQueries().get(1).getDescription()).isEqualTo(MockProvider.EXAMPLE_TASK_DESCRIPTION);
-    assertThat(argument.getValue().getQueries().get(2).getName()).isEqualTo(MockProvider.EXAMPLE_TASK_NAME);
+    assertThat(argument.getValue().getQueries().get(1).getName()).isEqualTo(MockProvider.EXAMPLE_TASK_NAME);
   }
 
   @Test

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/TaskRestServiceQueryTest.java
@@ -96,7 +96,14 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     TaskQuery sampleTaskQuery = mock(TaskQueryImpl.class);
     when(sampleTaskQuery.list()).thenReturn(mockedTasks);
     when(sampleTaskQuery.count()).thenReturn((long) mockedTasks.size());
+    when(sampleTaskQuery.or()).thenReturn(sampleTaskQuery);
+    when(sampleTaskQuery.endOr()).thenReturn(sampleTaskQuery);
+    when(sampleTaskQuery.taskName(anyString())).thenReturn(sampleTaskQuery);
+    when(sampleTaskQuery.taskDescription(anyString())).thenReturn(sampleTaskQuery);
+    when(sampleTaskQuery.taskCandidateUser(anyString())).thenReturn(sampleTaskQuery);
     when(sampleTaskQuery.taskCandidateGroup(anyString())).thenReturn(sampleTaskQuery);
+    when(sampleTaskQuery.taskCandidateGroupIn(any())).thenReturn(sampleTaskQuery);
+    when(sampleTaskQuery.includeAssignedTasks()).thenReturn(sampleTaskQuery);
 
     when(processEngine.getTaskService().createTaskQuery()).thenReturn(sampleTaskQuery);
 
@@ -1933,10 +1940,82 @@ public class TaskRestServiceQueryTest extends AbstractRestServiceTest {
     .when()
       .post(TASK_QUERY_URL);
 
-    ArgumentCaptor<TaskQueryImpl> argument = ArgumentCaptor.forClass(TaskQueryImpl.class);
-    verify((TaskQueryImpl) mockQuery).addOrQuery(argument.capture());
-    assertEquals(MockProvider.EXAMPLE_TASK_NAME, argument.getValue().getName());
-    assertEquals(MockProvider.EXAMPLE_TASK_DESCRIPTION, argument.getValue().getDescription());
+    verify((TaskQueryImpl) mockQuery).or();
+    verify(mockQuery).taskName(MockProvider.EXAMPLE_TASK_NAME);
+    verify(mockQuery).taskDescription(MockProvider.EXAMPLE_TASK_DESCRIPTION);
+    verify((TaskQueryImpl) mockQuery).endOr();
+  }
+
+  @Test
+  void testOrQueryWithCandidateUserAndCandidateGroups() {
+    Map<String, Object> candidateGroupOrQuery = new HashMap<>();
+    candidateGroupOrQuery.put("candidateGroups", List.of("testGroup"));
+
+    Map<String, Object> candidateUserOrQuery = new HashMap<>();
+    candidateUserOrQuery.put("candidateUser", "testUser");
+
+    Map<String, Object> body = new HashMap<>();
+    body.put("orQueries", List.of(candidateGroupOrQuery, candidateUserOrQuery));
+
+    given()
+      .contentType(POST_JSON_CONTENT_TYPE)
+      .header(ACCEPT_JSON_HEADER)
+      .body(body)
+    .then().expect()
+      .statusCode(Status.OK.getStatusCode())
+    .when()
+      .post(TASK_QUERY_URL);
+
+    verify((TaskQueryImpl) mockQuery).or();
+    verify((TaskQueryImpl) mockQuery).endOr();
+
+    verify(mockQuery).taskCandidateGroupIn(argThat(new EqualsList(List.of("testGroup"))));
+    verify(mockQuery).taskCandidateUser("testUser");
+  }
+
+  @Test
+  void testOrQueryWithEmptyOrQueryAndCandidateUser() {
+    Map<String, Object> emptyOrQuery = new HashMap<>();
+
+    Map<String, Object> candidateUserOrQuery = new HashMap<>();
+    candidateUserOrQuery.put("candidateUser", "testUser");
+
+    Map<String, Object> body = new HashMap<>();
+    body.put("orQueries", List.of(emptyOrQuery, candidateUserOrQuery));
+
+    given()
+      .contentType(POST_JSON_CONTENT_TYPE)
+      .header(ACCEPT_JSON_HEADER)
+      .body(body)
+    .then().expect()
+      .statusCode(Status.OK.getStatusCode())
+    .when()
+      .post(TASK_QUERY_URL);
+
+    verify((TaskQueryImpl) mockQuery).or();
+    verify((TaskQueryImpl) mockQuery).endOr();
+    verify(mockQuery).taskCandidateUser("testUser");
+  }
+
+  @Test
+  void testOrQueryWithFalseOnlyFilterIsIgnored() {
+    Map<String, Object> falseOnlyOrQuery = new HashMap<>();
+    falseOnlyOrQuery.put("includeAssignedTasks", false);
+
+    Map<String, Object> body = new HashMap<>();
+    body.put("orQueries", List.of(falseOnlyOrQuery));
+
+    given()
+      .contentType(POST_JSON_CONTENT_TYPE)
+      .header(ACCEPT_JSON_HEADER)
+      .body(body)
+    .then().expect()
+      .statusCode(Status.OK.getStatusCode())
+    .when()
+      .post(TASK_QUERY_URL);
+
+    verify((TaskQueryImpl) mockQuery, never()).or();
+    verify(mockQuery, never()).includeAssignedTasks();
   }
 
 }


### PR DESCRIPTION
## Description

Backports the EximeeBPMS fix for REST task OR queries with candidate user and candidate group filters.

`TaskQueryDto` previously translated every REST `orQueries` entry into a detached `TaskQueryImpl` and attached it via `addOrQuery`. That bypasses the normal `query.or()` / `endOr()` path used by the engine query API and can mishandle combinations such as separate REST OR blocks for `candidateUser` and `candidateGroups`.

This change skips empty OR DTOs and applies all non-empty REST OR filters through the real `TaskQuery` by opening one `or()` block, applying the nested filters, and closing it with `endOr()`.

Operaton already has engine-level coverage for candidate-user/group OR query behavior in `TaskQueryOrTest`, so this backport keeps the focused REST-layer regression coverage and adapts the filter interaction test to the resulting single OR query structure.

## References

EximeeBPMS:
- PR: https://github.com/EximeeBPMS/eximeebpms/pull/116
- Commit: https://github.com/EximeeBPMS/eximeebpms/commit/d483358f8c1cbd3c72d2f8878777f3f5b78dc331
- Ticket reference: BPMS-151

## Attribution

Backported commit `d483358f8c1cbd3c72d2f8878777f3f5b78dc331` from the `eximeebpms` repository.

Original author: Robert Mastalerek <robert.mastalerek@gmail.com>

Backport change unit: 628

## Testing

```bash
./mvnw -pl engine-rest/engine-rest -Dskip.frontend.build=true -Dtest=TaskRestServiceQueryTest#testOrQuery+testOrQueryWithCandidateUserAndCandidateGroups+testOrQueryWithEmptyOrQueryAndCandidateUser,FilterRestServiceInteractionTest#testExecuteSingleResultWithExtendingOrQuery test
```

```bash
./mvnw -pl engine-rest/engine-rest -DskipTests -Dskip.frontend.build=true package
```