### PR TITLE
docs(engine-rest): fix task local variable OpenAPI examples

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/get.ftl
@@ -46,7 +46,7 @@
         additionalProperties = true
         desc = "Request successful."
         examples = ['"example-1": {
-                       "summary": "GET `/task/aTaskId/variables`",
+                       "summary": "GET `/task/aTaskId/localVariables`",
                        "value": {
                          "aVariableKey": {
                            "value": {
@@ -62,7 +62,7 @@
                        }
                      }',
                     '"example-2": {
-                       "summary": "GET `/task/aTaskId/variables?deserializeValue=false`",
+                       "summary": "GET `/task/aTaskId/localVariables?deserializeValue=false`",
                        "value": {
                          "aVariableKey": {
                            "value": "ab",

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/post.ftl
@@ -24,7 +24,7 @@
       mediaType = "application/json"
       dto = "PatchVariablesDto"
       examples = ['"example-1": {
-                     "summary": "POST `/task/aTaskId/variables`",
+                     "summary": "POST `/task/aTaskId/localVariables`",
                      "description": "Status 204 Response: No content.",
                      "value": {
                        "modifications": {

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/{varName}/data/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/{varName}/data/get.ftl
@@ -42,7 +42,7 @@
           },
           "examples": {
             "example-1": {
-              "summary": "GET /task/aTaskId/variables/aVarName/data",
+              "summary": "GET /task/aTaskId/localVariables/aVarName/data",
               "value": "binary variable: Status 200. Content-Type: application/octet-stream"
             }
           }
@@ -56,7 +56,7 @@
           },
           "examples": {
             "example-1": {
-              "summary": "GET /task/aTaskId/variables/aVarName/data",
+              "summary": "GET /task/aTaskId/localVariables/aVarName/data",
               "value": "file variable: Status 200. Content-Type: text/plain; charset=UTF-8. Content-Disposition: attachment; filename=\"someFile.txt\""
             }
           }

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/{varName}/data/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/{varName}/data/post.ftl
@@ -31,7 +31,7 @@
       dto = "MultiFormVariableBinaryDto"
       requestDesc = "For binary variables a multipart form submit with the following parts:"
       examples = [ '"example-1": {
-                      "summary": "POST `/task/aTaskId/variables/aVarName/data` (1)",
+                      "summary": "POST `/task/aTaskId/localVariables/aVarName/data` (1)",
                       "description": "Post binary content of a byte array variable.",
                       "value": "
                         ```
@@ -52,7 +52,7 @@
                       "
                     }',
                    '"example-2": {
-                      "summary": "POST `/task/aTaskId/variables/aVarName/data` (2)",
+                      "summary": "POST `/task/aTaskId/localVariables/aVarName/data` (2)",
                       "description": "Post the JSON serialization of a Java Class (**deprecated**).",
                       "value": "
                         ```
@@ -73,7 +73,7 @@
                       "
                     }',
                    '"example-3": {
-                      "summary": "POST `/task/aTaskId/variables/aVarName/data` (3)",
+                      "summary": "POST `/task/aTaskId/localVariables/aVarName/data` (3)",
                       "description": "Post a text file.",
                       "value": "
                         ```

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/{varName}/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/{varName}/get.ftl
@@ -52,7 +52,7 @@
         dto = "VariableValueDto"
         desc = "Request successful."
         examples = ['"example-1": {
-                       "summary": "GET `/task/aTaskId/variables/myObject123`",
+                       "summary": "GET `/task/aTaskId/localVariables/myObject123`",
                        "value": {
                          "value": {
                            "prop1": "a",
@@ -66,7 +66,7 @@
                        }
                      }',
                     '"example-2": {
-                       "summary": "GET `/task/aTaskId/variables/myObject123?deserializeValue=false`",
+                       "summary": "GET `/task/aTaskId/localVariables/myObject123?deserializeValue=false`",
                        "value": {
                          "value": "ab",
                          "type": "Object",

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/{varName}/put.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/task/{id}/localVariables/{varName}/put.ftl
@@ -30,7 +30,7 @@
       mediaType = "application/json"
       dto = "VariableValueDto"
       examples = [ '"example-1": {
-                      "summary": "PUT /task/aTaskId/variables/aVarName",
+                      "summary": "PUT /task/aTaskId/localVariables/aVarName",
                       "description": "Status 204. No content.",
                       "value": {
                         "value": "someValue",
@@ -38,7 +38,7 @@
                       }
                     }',
                    '"example-2": {
-                      "summary": "PUT /task/aTaskId/variables/aVarName",
+                      "summary": "PUT /task/aTaskId/localVariables/aVarName",
                       "description": "An Object Variable PUT Request. Status 204. No content.",
                       "value": {
                         "value": "ab",


### PR DESCRIPTION
## Description

Backports a small REST documentation fix from CIBSeven for the task local variable OpenAPI examples.

The affected templates describe endpoints under `/task/{id}/localVariables`, but several example summaries still used `/task/{id}/variables`. This makes the examples point to the regular task variable endpoints instead of the local task variable endpoints.

This PR updates only those example summaries so they consistently use `/task/aTaskId/localVariables` and `/task/aTaskId/localVariables/{varName}` in the task local variable documentation.

## Attribution

Backported from CIBSeven:

- Source commit: https://github.com/cibseven/cibseven/commit/f6da48f993de634eaf2ca9c06bd27b4977c7b2ea
- Original author: patrickCIB <patrick.fincke@cib.de>
- Backport change unit: 823

## Verification

- `git diff --check`
- `./mvnw -pl engine-rest/engine-rest-openapi -am -DskipTests -Dskip.frontend.build=true package`

The OpenAPI build generated and validated `openapi.json`, generated the Java client, and compiled the generated test sources with tests skipped.