### PR TITLE
fix(engine): use Operaton script engine manager for process applications

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/application/impl/ProcessApplicationScriptEnvironment.java
+++ b/engine/src/main/java/org/operaton/bpm/application/impl/ProcessApplicationScriptEnvironment.java
@@ -21,11 +21,11 @@ import java.util.List;
 import java.util.Map;
 
 import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
 
 import org.operaton.bpm.application.ProcessApplicationInterface;
 import org.operaton.bpm.engine.impl.scripting.ExecutableScript;
 import org.operaton.bpm.engine.impl.scripting.engine.DefaultScriptEngineResolver;
+import org.operaton.bpm.engine.impl.scripting.engine.OperatonScriptEngineManager;
 import org.operaton.bpm.engine.impl.scripting.engine.ScriptEngineResolver;
 
 /**
@@ -57,7 +57,8 @@ public class ProcessApplicationScriptEnvironment {
    */
   public synchronized ScriptEngine getScriptEngineForName(String scriptEngineName, boolean cache) {
     if(processApplicationScriptEngineResolver == null) {
-      processApplicationScriptEngineResolver = new DefaultScriptEngineResolver(new ScriptEngineManager(getProcessApplicationClassloader()));
+      processApplicationScriptEngineResolver =
+          new DefaultScriptEngineResolver(new OperatonScriptEngineManager(getProcessApplicationClassloader()));
     }
     return processApplicationScriptEngineResolver.getScriptEngine(scriptEngineName, cache);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/OperatonScriptEngineManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/OperatonScriptEngineManager.java
@@ -49,6 +49,11 @@ public class OperatonScriptEngineManager extends ScriptEngineManager {
     applyConfigOnEnginesAfterClasspathDiscovery();
   }
 
+  public OperatonScriptEngineManager(ClassLoader loader) {
+    super(loader);
+    applyConfigOnEnginesAfterClasspathDiscovery();
+  }
+
   protected void applyConfigOnEnginesAfterClasspathDiscovery() {
     var engineNames = getEngineNamesFoundInClasspath();
 

--- a/engine/src/test/java/org/operaton/bpm/application/impl/ProcessApplicationScriptEnvironmentTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/ProcessApplicationScriptEnvironmentTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.application.impl;
+
+import java.io.Reader;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import javax.script.AbstractScriptEngine;
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.SimpleBindings;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.operaton.bpm.application.ProcessApplicationInterface;
+import org.operaton.bpm.engine.impl.scripting.engine.DefaultScriptEngineResolver;
+import org.operaton.bpm.engine.impl.scripting.engine.OperatonScriptEngineManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ProcessApplicationScriptEnvironmentTest {
+
+  protected static final String PROCESS_APPLICATION_SCRIPT_ENGINE_NAME = "processApplicationScriptEngine";
+
+  @Test
+  void shouldUseOperatonScriptEngineManagerWithProcessApplicationClassloader(@TempDir Path serviceRoot)
+      throws Exception {
+    Path servicesDir = serviceRoot.resolve("META-INF/services");
+    Files.createDirectories(servicesDir);
+    Files.writeString(servicesDir.resolve(ScriptEngineFactory.class.getName()),
+        ProcessApplicationTestScriptEngineFactory.class.getName());
+
+    URL[] processApplicationClasspath = { serviceRoot.toUri().toURL() };
+    try (URLClassLoader processApplicationClassloader =
+        new URLClassLoader(processApplicationClasspath, getClass().getClassLoader())) {
+      ProcessApplicationInterface processApplication = mock(ProcessApplicationInterface.class);
+      when(processApplication.getProcessApplicationClassloader()).thenReturn(processApplicationClassloader);
+      ProcessApplicationScriptEnvironment scriptEnvironment =
+          new ProcessApplicationScriptEnvironment(processApplication);
+
+      ScriptEngine scriptEngine =
+          scriptEnvironment.getScriptEngineForName(PROCESS_APPLICATION_SCRIPT_ENGINE_NAME, false);
+
+      assertThat(scriptEngine).isInstanceOf(ProcessApplicationTestScriptEngine.class);
+      assertThat(scriptEnvironment.processApplicationScriptEngineResolver)
+          .isInstanceOf(DefaultScriptEngineResolver.class);
+      assertThat(scriptEnvironment.processApplicationScriptEngineResolver.getScriptEngineManager())
+          .isInstanceOf(OperatonScriptEngineManager.class);
+      verify(processApplication).getProcessApplicationClassloader();
+    }
+  }
+
+  public static class ProcessApplicationTestScriptEngineFactory implements ScriptEngineFactory {
+
+    @Override
+    public String getEngineName() {
+      return PROCESS_APPLICATION_SCRIPT_ENGINE_NAME;
+    }
+
+    @Override
+    public String getEngineVersion() {
+      return "1";
+    }
+
+    @Override
+    public List<String> getExtensions() {
+      return List.of();
+    }
+
+    @Override
+    public List<String> getMimeTypes() {
+      return List.of();
+    }
+
+    @Override
+    public List<String> getNames() {
+      return List.of(PROCESS_APPLICATION_SCRIPT_ENGINE_NAME);
+    }
+
+    @Override
+    public String getLanguageName() {
+      return PROCESS_APPLICATION_SCRIPT_ENGINE_NAME;
+    }
+
+    @Override
+    public String getLanguageVersion() {
+      return "1";
+    }
+
+    @Override
+    public Object getParameter(String key) {
+      return null;
+    }
+
+    @Override
+    public String getMethodCallSyntax(String obj, String m, String... args) {
+      return null;
+    }
+
+    @Override
+    public String getOutputStatement(String toDisplay) {
+      return null;
+    }
+
+    @Override
+    public String getProgram(String... statements) {
+      return null;
+    }
+
+    @Override
+    public ScriptEngine getScriptEngine() {
+      return new ProcessApplicationTestScriptEngine(this);
+    }
+
+  }
+
+  public static class ProcessApplicationTestScriptEngine extends AbstractScriptEngine {
+
+    protected final ScriptEngineFactory factory;
+
+    protected ProcessApplicationTestScriptEngine(ScriptEngineFactory factory) {
+      this.factory = factory;
+    }
+
+    @Override
+    public Object eval(String script, ScriptContext context) {
+      return null;
+    }
+
+    @Override
+    public Object eval(Reader reader, ScriptContext context) {
+      return null;
+    }
+
+    @Override
+    public Bindings createBindings() {
+      return new SimpleBindings();
+    }
+
+    @Override
+    public ScriptEngineFactory getFactory() {
+      return factory;
+    }
+
+  }
+
+}


### PR DESCRIPTION
## Description

This backports CIBSeven's fix for Process Application script engine resolution.

The regular process engine scripting path already initializes `DefaultScriptEngineResolver` with `OperatonScriptEngineManager` in `ProcessEngineConfigurationImpl#initScripting`. That manager performs Operaton-specific setup immediately after script engine discovery and before engines are created.

The Process Application-specific path in `ProcessApplicationScriptEnvironment` still used the plain JDK `ScriptEngineManager` with the Process Application classloader. As a result, script engines resolved through Process Applications could miss the same initialization that normal engine scripts receive.

## What This Fixes

The change keeps the Process Application classloader behavior intact, but creates the resolver with `OperatonScriptEngineManager` instead of the plain JDK manager.

That makes Process Application script resolution consistent with the main engine path. In particular, script engines discovered through a Process Application classloader now also get the Operaton manager's pre-creation setup, such as:

- disabling GraalJS interpreter-only warnings via `polyglot.engine.WarnInterpreterOnly=false`
- disabling Jython site import warnings via `python.import.site=false`

This is intentionally a narrow scripting infrastructure fix. It does not change script execution semantics or caching behavior; it aligns the manager used for Process Application scripts with the manager used by the process engine itself.

## Reviewer Notes

The new test builds a small ScriptEngine service registration in a temporary `META-INF/services/javax.script.ScriptEngineFactory` directory and exposes it only through a dedicated Process Application classloader. The test then verifies both relevant aspects:

- Process Application script engine lookup still uses the Process Application classloader.
- The resolver is backed by `OperatonScriptEngineManager`, not the plain JDK `ScriptEngineManager`.

This avoids a purely self-referential assertion: the test would fail if the Process Application classloader were no longer used to discover script engines.

## Attribution

Backported from CIBSeven:

- PR: https://github.com/cibseven/cibseven/pull/149
- Commit: https://github.com/cibseven/cibseven/commit/48f2ec3698c109717f81358f14ba7ef47fc58f40
- Original author: Fernando Mambrilla <fernandom@cib.de>

Backport tracking:

- Change unit: 932
- Branch: `backport/cibseven-932-process-application-script-engine-manager`

## Testing

- `git diff --check`
- `./mvnw -pl engine -Dskip.frontend.build=true -Dtest=ProcessApplicationScriptEnvironmentTest test`
- `./mvnw -pl engine -DskipTests -Dskip.frontend.build=true package`
