### PR TITLE
fix(webapps): recognize more license file names

### DIFF
--- a/webapps/frontend/scripts/license-header-loader.js
+++ b/webapps/frontend/scripts/license-header-loader.js
@@ -45,29 +45,34 @@ const addMissingLicenseHeaders = (filePath, source) => {
         packagePath = `${process.cwd()}/node_modules/operaton-bpm-webapp/node_modules/${pkg}`;
       }
 
+      const licenseFileNames = [
+        'LICENSE',
+        'LICENCE',
+        'license',
+        'LICENSE.md',
+        'LICENCE.md',
+        'LICENSE-MIT',
+        'LICENSE-MIT.txt',
+        'LICENSE.txt',
+      ];
+
       let licenseInfo = null;
-      try {
-        licenseInfo = fs.readFileSync(`${packagePath}/LICENSE`, 'utf8');
-      } catch (_e) {
-        try {
-          licenseInfo = fs.readFileSync(`${packagePath}/LICENSE.md`, 'utf8');
-        } catch (_e) {
+      for (const fileName of licenseFileNames) {
+        const pathName = `${packagePath}/${fileName}`;
+        if (fs.existsSync(pathName)) {
           try {
-            licenseInfo = fs.readFileSync(
-              `${packagePath}/LICENSE-MIT.txt`,
-              'utf8',
-            );
+            licenseInfo = fs.readFileSync(pathName, 'utf8');
           } catch (_e) {
-            try {
-              licenseInfo = fs.readFileSync(
-                `${packagePath}/LICENSE.txt`,
-                'utf8',
-              );
-            } catch (_e) {
-              console.log(`${pkg} has no license file. 🤷‍`); // eslint-disable-line
-            }
+            // Ignore unreadable license files and try the next known filename.
+          }
+          if (licenseInfo) {
+            break;
           }
         }
+      }
+
+      if (!licenseInfo) {
+        console.log(`${pkg} has no license file. 🤷‍`); // eslint-disable-line
       }
 
       let packageJsonPath = require.resolve(`${packagePath}/package.json`);
@@ -75,7 +80,7 @@ const addMissingLicenseHeaders = (filePath, source) => {
       if (licenseInfo) {
         return `/*!\n@license ${pkg}@${version}\n${licenseInfo}*/\n${source}`;
       } else if (license) {
-        console.log(`${pkg} has a "license" property. 🤷‍`);// eslint-disable-line
+        console.log(`${pkg} has a "license" property. 🤷‍`); // eslint-disable-line
         return `/*! @license ${pkg}@${version} (${license}) */\n${source}`;
       }
     }


### PR DESCRIPTION
## Description

This backports two small CIBSeven fixes for the frontend `license-header-loader`.

The loader adds license headers for bundled npm dependencies by reading a license file from the package directory. Until now, Operaton only checked a small set of filenames through nested `try/catch` blocks:

- `LICENSE`
- `LICENSE.md`
- `LICENSE-MIT.txt`
- `LICENSE.txt`

Some npm packages use other common variants, for example `LICENCE`, `LICENCE.md`, `LICENSE-MIT`, or lowercase `license`. In those cases the loader could miss an existing license file and fall back to the package.json `license` field or log that no license file exists.

## What This Fixes

The backport replaces the nested lookup with an explicit list of known license filenames and checks them in order. This makes the build-time license header generation more robust without changing runtime behavior.

The Operaton-specific package fallback remains unchanged:

- `node_modules/<pkg>`
- `node_modules/operaton-bpm-webapp/node_modules/<pkg>`

## Reviewer Notes

This is a build/compliance helper change only. It does not affect shipped application logic except for improving which license text can be embedded during frontend bundling.

The two CIBSeven commits are kept together because the second commit only extends the filename list introduced by the first one.

## Attribution

Backported from CIBSeven:

- Commit: https://github.com/cibseven/cibseven/commit/7a1eab0dda73c89533ca4cf4f63057fa5510f04b
- Commit: https://github.com/cibseven/cibseven/commit/411012a5ef95e4415cb120d2221a786eb58fb2c9
- Original author: Serge Krot <serge.krot@cib.de>

Backport tracking:

- Change units: 635, 663
- Branch: `backport/cibseven-635-663-license-header-filenames`

## Testing

- `git diff --check`
- `node --check webapps/frontend/scripts/license-header-loader.js`
- `npx --yes prettier@3.8.3 --check scripts/license-header-loader.js`
- Node smoke test with temporary packages using `LICENCE`, `license`, and `LICENSE-MIT` files
