### PR TITLE
fix(run): read production passwords from environment

### DIFF
--- a/distro/run/assembly/resources/production.yml
+++ b/distro/run/assembly/resources/production.yml
@@ -68,10 +68,10 @@ server:
 # do not use the provided certificate in production
   ssl:
     key-store: classpath:keystore.p12
-    key-store-password: operaton
+    key-store-password: ${KEY_STORE_PASSWORD}
     key-store-type: pkcs12
     key-alias: localhost
-    key-password: operaton
+    key-password: ${KEY_PASSWORD}
   port: 8443
 
 # https://docs.operaton.org/manual/latest/user-guide/security/#http-header-security-in-webapps
@@ -94,7 +94,7 @@ spring.datasource:
   url: jdbc:h2:./operaton-h2-test-production/process-engine;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE
   driver-class-name: org.h2.Driver
   username: sa
-  password: sa
+  password: ${H2_PASSWORD}
 
 # By default, Spring Boot serves static content from any directories called /static or /public or /resources or
 # /META-INF/resources in the classpath. To prevent users from accidentally sharing files, this is disabled here by setting static locations to NULL.


### PR DESCRIPTION
## Description

This backports two small Fluxnova security/configuration fixes for Operaton's Standalone production configuration.

Operaton is affected on `main`: `distro/run/assembly/resources/production.yml` still contains hardcoded password-like values in the production profile:

- `server.ssl.key-store-password: operaton`
- `server.ssl.key-password: operaton`
- `spring.datasource.password: sa`

The Fluxnova changes replace the equivalent static values with Spring property placeholders so deployments must provide the values from the environment/configuration source instead of inheriting repository defaults.

## What This Fixes

The production sample now reads these values from environment-backed placeholders:

- `KEY_STORE_PASSWORD`
- `KEY_PASSWORD`
- `H2_PASSWORD`

This keeps sensitive values out of the checked-in production configuration and addresses the same CodeQL-style finding that Fluxnova fixed. The change is limited to `production.yml`; test fixtures and default/local examples are intentionally unchanged.

## Reviewer Notes

I backported this as a small cluster rather than only change unit 511 because Fluxnova split the same problem across two adjacent commits:

- one commit replaces the keystore password
- the next commit replaces the key password and H2 datasource password

Operaton still had all three hardcoded values, so taking only the second commit would leave the production SSL keystore password hardcoded and make the security fix incomplete.

The placeholder names are kept aligned with Fluxnova (`KEY_STORE_PASSWORD`, `KEY_PASSWORD`, `H2_PASSWORD`) to minimize backport divergence. They can be renamed later if Operaton wants a more namespaced convention, but that would be a follow-up policy choice rather than part of this backport.

## Attribution

Backported from Fluxnova:

- Commit: https://github.com/finos/fluxnova-bpm-platform/commit/eaea144ef901c0650b18c30727ba4294fca14046
- Commit: https://github.com/finos/fluxnova-bpm-platform/commit/45c0f7310159316d320d6c2017429f4dc073a566
- Original author: Mannuru, ReddyKishore <ReddyKishore.Mannuru@fmr.com>

Backport tracking:

- Change units: 510, 511
- Branch: `backport/fluxnova-510-511-production-password-env`

## Testing

- `git diff --check`
- YAML parse of `distro/run/assembly/resources/production.yml`, verifying the three placeholders are parsed as strings
- `./mvnw -pl distro/run/assembly -DskipTests -Dskip.frontend.build=true package`
  - this direct module build fails before compiling because local `2.2.0-SNAPSHOT` Run module artifacts are not installed
- `./mvnw -pl distro/run/assembly -am -DskipTests -Dskip.frontend.build=true package`
  - builds the required reactor modules and packages the Run assembly successfully
