### PR TITLE
fix(engine): Stabilize rejected job metrics test

### DIFF
--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/metrics/JobExecutorMetricsTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/mgmt/metrics/JobExecutorMetricsTest.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.test.api.mgmt.metrics;
 
+import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
@@ -32,6 +33,7 @@ import org.operaton.bpm.engine.impl.jobexecutor.CallerRunsRejectedJobsHandler;
 import org.operaton.bpm.engine.impl.jobexecutor.DefaultJobExecutor;
 import org.operaton.bpm.engine.impl.jobexecutor.JobExecutor;
 import org.operaton.bpm.engine.management.Metrics;
+import org.operaton.bpm.engine.runtime.Job;
 import org.operaton.bpm.engine.test.Deployment;
 import org.operaton.bpm.engine.test.concurrency.ConcurrencyTestHelper.ThreadControl;
 import org.operaton.bpm.engine.test.jobexecutor.ControllableJobExecutor;
@@ -206,8 +208,16 @@ class JobExecutorMetricsTest extends AbstractMetricsTest {
       runtimeService.startProcessInstanceByKey("asyncServiceTaskProcess");
     }
 
-    // when executing the jobs
-    testRule.waitForJobExecutorToProcessAllJobs(5000L);
+    List<String> jobIds = managementService.createJobQuery()
+        .processDefinitionKey("asyncServiceTaskProcess")
+        .list()
+        .stream()
+        .map(Job::getId)
+        .toList();
+
+    // when executing only the three jobs using the RejectingJobExecutor
+    JobExecutor jobExecutor = processEngineConfiguration.getJobExecutor();
+    jobExecutor.executeJobs(jobIds, (ProcessEngineImpl) processEngine);
 
     // then all of them were rejected by the job executor which is reflected by the metric
     long numRejectedJobs = managementService.createMetricsQuery().name(Metrics.JOB_EXECUTION_REJECTED).sum();


### PR DESCRIPTION
## Summary

Backports the Camunda 7 test stabilization from camunda/camunda-bpm-platform#5048. This is a test-only change for `JobExecutorMetricsTest` and does not change production behavior.

## Why this is needed

Operaton `main` still uses `waitForJobExecutorToProcessAllJobs(5000L)` in `testJobRejectedExecutionMetricReporting`. That helper waits broadly for the job executor to process jobs instead of explicitly executing only the jobs created by this test case.

In larger or parallel test runs, that makes the test more sensitive to unrelated executable jobs in the same engine context and weakens the intent of the assertion: the metric should count the three jobs that were deliberately submitted to the rejecting executor.

## Fix

The test now queries the job IDs for the deployed `asyncServiceTaskProcess` instances and executes exactly those jobs through the currently configured `RejectingJobExecutor`. The final metric assertion remains the same: `JOB_EXECUTION_REJECTED` must be `3`.

I adapted the original patch to the current Operaton/JUnit 5 test style and reused the existing `processEngineConfiguration` field instead of adding an extra configuration cast.

## Attribution

Original Camunda change:

- Original PR: https://github.com/camunda/camunda-bpm-platform/pull/5048
- Original commit: https://github.com/camunda/camunda-bpm-platform/commit/3998bf59f1f61647f5515c17d96ad0ea66a35ec5
- Original author: Miklas Boskamp <miklas.boskamp@camunda.com>
- Related upstream issue: https://github.com/camunda/team-automation-platform/issues/304
- Backport change unit: 4789

## Verification

- `./mvnw -pl engine -Dtest=JobExecutorMetricsTest#testJobRejectedExecutionMetricReporting test`
- `./mvnw -pl engine -Dtest=JobExecutorMetricsTest test`
