### PR TITLE
fix(springboot): validate trailing slash redirect target

### DIFF
--- a/spring-boot-starter/starter-webapp-core/src/main/java/org/operaton/bpm/spring/boot/starter/webapp/filter/AppendTrailingSlashFilter.java
+++ b/spring-boot-starter/starter-webapp-core/src/main/java/org/operaton/bpm/spring/boot/starter/webapp/filter/AppendTrailingSlashFilter.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.spring.boot.starter.webapp.filter;
 
 import java.io.IOException;
+
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -26,10 +27,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
- * Servlet filter to ensure request paths always have a trailing slash. Before Spring Boot 3, missing trailing slashes were
- * handled automatically. This filter implements the Spring Boot 2 behavior for the registered request patterns.
+ * Servlet filter to ensure request paths always have a trailing slash. Transparent trailing slash matching was deprecated
+ * in Spring Framework 6 and removed in Spring Framework 7. This filter keeps the legacy webapp entry points working for
+ * the registered request patterns by redirecting them to their canonical trailing-slash URLs.
  *
- * @see https://github.com/spring-projects/spring-framework/issues/28552
+ * @see <a href="https://docs.spring.io/spring-framework/reference/web/webmvc/filters.html">Spring Framework URL Handler Filter</a>
  */
 public class AppendTrailingSlashFilter implements Filter {
 
@@ -37,7 +39,18 @@ public class AppendTrailingSlashFilter implements Filter {
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
       throws IOException, ServletException {
     String requestURI = ((HttpServletRequest) request).getRequestURI();
-    ((HttpServletResponse) response).sendRedirect(requestURI + "/");
+    if (isLocalPath(requestURI)) {
+      ((HttpServletResponse) response).sendRedirect(requestURI + "/");
+    } else {
+      chain.doFilter(request, response);
+    }
+  }
+
+  protected boolean isLocalPath(String requestURI) {
+    return requestURI != null
+        && requestURI.startsWith("/")
+        && !requestURI.startsWith("//")
+        && !requestURI.contains("://");
   }
 
 }

--- a/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/AppendTrailingSlashFilterTest.java
+++ b/spring-boot-starter/starter-webapp-core/src/test/java/org/operaton/bpm/spring/boot/starter/webapp/filter/AppendTrailingSlashFilterTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.spring.boot.starter.webapp.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class AppendTrailingSlashFilterTest {
+
+  private final AppendTrailingSlashFilter filter = new AppendTrailingSlashFilter();
+
+  @Test
+  void shouldRedirectLocalPathWithTrailingSlash() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    FilterChain chain = mock(FilterChain.class);
+
+    when(request.getRequestURI()).thenReturn("/operaton/app");
+
+    filter.doFilter(request, response, chain);
+
+    verify(response).sendRedirect("/operaton/app/");
+    verify(chain, never()).doFilter(request, response);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "https://example.org/app", "//example.org/app", "app" })
+  void shouldContinueFilterChainForUnsafeRedirectTargets(String requestURI) throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    FilterChain chain = mock(FilterChain.class);
+
+    when(request.getRequestURI()).thenReturn(requestURI);
+
+    filter.doFilter(request, response, chain);
+
+    verify(response, never()).sendRedirect(any());
+    verify(chain).doFilter(request, response);
+  }
+
+  @Test
+  void shouldContinueFilterChainForMissingRequestUri() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    FilterChain chain = mock(FilterChain.class);
+
+    when(request.getRequestURI()).thenReturn(null);
+
+    filter.doFilter(request, response, chain);
+
+    verify(response, never()).sendRedirect(any());
+    verify(chain).doFilter(request, response);
+  }
+
+}


### PR DESCRIPTION
## Summary
- Backports OrqueIO commit https://github.com/OrqueIO/OrqueIO/commit/5f12e717c13fa4b8638b758f7c2f345b16dd67d6 to harden `AppendTrailingSlashFilter`.
- Change unit: `4854`
- Keeps normal trailing-slash redirects for local absolute paths such as `/operaton/app`.
- Passes unsafe or non-local redirect targets down the filter chain instead of sending a redirect.
- Adds regression coverage for local paths, absolute URLs, scheme-relative URLs, relative paths, and missing request URIs.

## Reviewer Notes
Previously, `AppendTrailingSlashFilter` used `request.getRequestURI()` directly as the redirect target after appending `/`. If a servlet container or proxy exposed a non-local URI here, the filter could emit an external redirect. This change only redirects local paths and rejects values such as `https://example.org/app` and `//example.org/app`, while preserving the intended Spring Boot 2-style trailing-slash behavior for normal Operaton app routes.

No original OrqueIO PR was recorded for this change unit; the source attribution is the commit above.

## Tests
- `.devenv/scripts/maintenance/code-cleanup.sh`
- `git diff --check`
- `./mvnw -pl spring-boot-starter/starter-webapp-core -Dtest=AppendTrailingSlashFilterTest -Dskip.frontend.build=true test`
