### PR TITLE
fix(deps): Pin embedded Tomcat to patched version

### DIFF
--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -415,6 +415,23 @@
         <artifactId>tomcat-catalina</artifactId>
         <version>${version.tomcat}</version>
       </dependency>
+      <!-- Keep embedded Tomcat aligned with the patched standalone Tomcat version.
+           The Spring Boot BOM manages these artifacts independently from version.tomcat. -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.glassfish.jersey.core</groupId>

--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -412,11 +412,24 @@
 
       <dependency>
         <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-annotations-api</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
         <artifactId>tomcat-catalina</artifactId>
         <version>${version.tomcat}</version>
       </dependency>
-      <!-- Keep embedded Tomcat aligned with the patched standalone Tomcat version.
-           The Spring Boot BOM manages these artifacts independently from version.tomcat. -->
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-el-api</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-jsp-api</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-core</artifactId>

--- a/spring-boot-starter/starter/pom.xml
+++ b/spring-boot-starter/starter/pom.xml
@@ -27,6 +27,23 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+      <!-- Keep embedded Tomcat aligned with the patched standalone Tomcat version.
+           This module imports the Spring Boot BOM directly for Dependabot detection. -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.tomcat}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/spring-boot-starter/starter/pom.xml
+++ b/spring-boot-starter/starter/pom.xml
@@ -14,35 +14,18 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${version.spring-boot}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.operaton.bpm</groupId>
         <artifactId>operaton-core-internal-dependencies</artifactId>
         <version>${project.version}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
-      <!-- Keep embedded Tomcat aligned with the patched standalone Tomcat version.
-           This module imports the Spring Boot BOM directly for Dependabot detection. -->
       <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-core</artifactId>
-        <version>${version.tomcat}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-el</artifactId>
-        <version>${version.tomcat}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-websocket</artifactId>
-        <version>${version.tomcat}</version>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${version.spring-boot}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## What this backport fixes

Operaton already has the standalone Tomcat version property set to `11.0.22`, but Operaton Run uses embedded Tomcat through Spring Boot. Without an explicit override in `distro/run`, the Spring Boot BOM still manages the embedded Tomcat artifacts to `11.0.21`.

Before this change, `distro/run/core` resolved:

```text
org.apache.tomcat.embed:tomcat-embed-core:jar:11.0.21:compile
org.apache.tomcat.embed:tomcat-embed-el:jar:11.0.21:compile
org.apache.tomcat.embed:tomcat-embed-websocket:jar:11.0.21:compile
```

This PR pins the three embedded Tomcat artifacts in Operaton Run dependency management to `${version.tomcat}`, so the Run distribution follows the patched Tomcat line already defined in `parent/pom.xml`.

Note: the checked-in distro SBOM files are generated by the dedicated `build-sbom` / `update-sbom` workflow and are not included in this focused backport.

## Operaton adaptation

CIBSeven patched both `distro/run` and `distro/run4`. Operaton does not have a `distro/run4` distribution, so this backport only applies the `distro/run` part.

## Attribution

Backport of CIBSeven PR:

- CIBSeven PR: https://github.com/cibseven/cibseven/pull/351
- Backported commit: https://github.com/cibseven/cibseven/commit/5c7e909d2bd94374f735d7be2ccc3cae5a5befba
- Original author: Oleg Skrypnyuk `<oleg.skrypnyuk@cib.de>`

Backport tracking:

- Backport change unit: 1138

## Verification

Dependency tree after the change:

```text
org.operaton.bpm.run:operaton-bpm-run-core:jar:2.2.0-SNAPSHOT
+- org.apache.tomcat.embed:tomcat-embed-core:jar:11.0.22:compile
\- org.springframework.boot:spring-boot-starter-web:jar:4.1.0-RC1:compile
   \- org.springframework.boot:spring-boot-starter-tomcat:jar:4.1.0-RC1:compile
      \- org.springframework.boot:spring-boot-starter-tomcat-runtime:jar:4.1.0-RC1:compile
         +- org.apache.tomcat.embed:tomcat-embed-el:jar:11.0.22:compile
         \- org.apache.tomcat.embed:tomcat-embed-websocket:jar:11.0.22:compile
```

Repackaged Run core artifact contains:

```text
BOOT-INF/lib/tomcat-embed-core-11.0.22.jar
BOOT-INF/lib/tomcat-embed-el-11.0.22.jar
BOOT-INF/lib/tomcat-embed-websocket-11.0.22.jar
```

Commands run:

```bash
./mvnw -pl distro/run/core -DskipTests -Dskip.frontend.build=true dependency:tree -Dincludes=org.apache.tomcat.embed:tomcat-embed-core,org.apache.tomcat.embed:tomcat-embed-el,org.apache.tomcat.embed:tomcat-embed-websocket
./mvnw -pl distro/run/core -am -DskipTests -Dskip.frontend.build=true package
.devenv/scripts/build/build-and-run-integration-tests.sh --distro=operaton --testsuite=engine --db=h2
```

The official Run integration script completed successfully. The Run QA runtime suite reported `41` tests, `0` failures, `0` errors, and `4` skipped tests.
