### PR TITLE
fix(wildfly): Use managed ShrinkWrap Resolver version

### DIFF
--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -10,7 +10,6 @@
   <name>Operaton - Wildfly Modules</name>
   <description>${project.name}</description>
   <properties>
-    <org.jboss.shrinkwrap.resolver.version>1.0.0-beta-5</org.jboss.shrinkwrap.resolver.version>
     <!-- generate a bom of compile time dependencies for the license book.
     Note: Every compile time dependency will end up in the license book. Please
     declare only dependencies that are actually needed -->


### PR DESCRIPTION
## Summary

Backports the relevant part of cibseven/cibseven#307 to Operaton's WildFly distribution build.

CIBSeven updated its WildFly module build away from the old ShrinkWrap Resolver `1.0.0-beta-5` override while addressing CVE-2025-67030 in the test/build environment. Operaton already manages ShrinkWrap Resolver centrally at `3.3.7`, which resolves `org.codehaus.plexus:plexus-utils:3.6.1`. The remaining Operaton issue was the stale local override in `distro/wildfly/modules/pom.xml`.

This PR removes that local override so the WildFly modules build inherits the managed Operaton version.

## Source / Attribution

- Source PR: https://github.com/cibseven/cibseven/pull/307
- Source commit: https://github.com/cibseven/cibseven/commit/ea8637084d0f434311eb09392386299e0bcf44f0
- Source repository: https://github.com/cibseven/cibseven
- Original author: Vladimir Gribko <156691737+vladgrind@users.noreply.github.com>
- Backport change unit: 1105

## Operaton Adaptation

CIBSeven changed `parent/pom.xml`, `distro/wildfly/modules/pom.xml`, and `distro/wildfly28/modules/pom.xml`:

- CIBSeven raised `version.shrinkwrap.resolvers` from `2.2.2` to `2.2.7`.
- CIBSeven raised the local WildFly module property from `1.0.0-beta-5` to `2.2.7`.
- CIBSeven added an explicit `plexus-utils:3.6.1` plugin dependency.
- CIBSeven also patched `wildfly28`, which does not exist in Operaton.

Operaton differs from that source baseline:

- Operaton already manages ShrinkWrap Resolver globally at `3.3.7`, newer than the CIBSeven target version.
- The Operaton ShrinkWrap Resolver Maven plugin classpath already contains `plexus-utils:3.6.1`.
- Operaton has no `distro/wildfly28` distribution.

Because of that, the clean Operaton adaptation is to remove the stale local `org.jboss.shrinkwrap.resolver.version` override from `distro/wildfly/modules/pom.xml` instead of pinning an older `2.2.7` value or adding a redundant Plexus override.

## Reviewer Notes

The previous local property forced the WildFly modules build to use ShrinkWrap Resolver `1.0.0-beta-5`, bypassing Operaton's centrally managed dependency version. That made this module inconsistent with the rest of the build and could keep an obsolete plugin/runtime dependency path alive even though the parent build already manages a fixed version.

After this change, `distro/wildfly/modules` inherits the same managed ShrinkWrap Resolver version as the rest of Operaton. The effective POM no longer contains the stale local property, and the resolved ShrinkWrap Resolver Maven plugin classpath includes `plexus-utils:3.6.1`.

## Verification

```bash
./mvnw -Pdistro-wildfly -pl distro/wildfly/modules \
  -DskipTests -Dskip.frontend.build=true \
  help:effective-pom -Doutput=/tmp/operaton-1105-after-effective.xml
```

Confirmed in the generated effective POM:

- `org.jboss.shrinkwrap.resolver.version` is no longer locally defined.
- `version.shrinkwrap.resolvers` remains managed at `3.3.7`.
- `shrinkwrap-resolver-maven-plugin` resolves at `3.3.7`.

```bash
./mvnw -Pdistro-wildfly -pl distro/wildfly/modules \
  -DskipTests -Dskip.frontend.build=true \
  org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-maven-plugin:3.3.7:propagate-execution-context -X
```

Confirmed the plugin classpath contains:

- `org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-maven-plugin:jar:3.3.7`
- `org.codehaus.plexus:plexus-utils:jar:3.6.1`

```bash
./mvnw -Pdistro-wildfly -pl distro/wildfly/modules -am \
  -DskipTests -Dskip.frontend.build=true package
```

Result: `BUILD SUCCESS` for the WildFly reactor modules.
