### PR TITLE
fix(wildfly): Include httpcore5-h2 in httpcore5 module

### DIFF
--- a/distro/wildfly/modules/pom.xml
+++ b/distro/wildfly/modules/pom.xml
@@ -78,6 +78,11 @@
       <artifactId>operaton-connect-http-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5-h2</artifactId>
+      <version>${version.httpcore5-h2}</version>
+    </dependency>
+    <dependency>
       <groupId>org.operaton.connect</groupId>
       <artifactId>operaton-connect-soap-http-client</artifactId>
     </dependency>
@@ -250,6 +255,19 @@
                     </chainedmapper>
                   </mapper>
                 </copy>
+                <!-- Place httpcore5-h2 in the httpcore5 module. -->
+                <copy todir="target/modules" flatten="false">
+                  <fileset dir="target/modules">
+                    <include name="org/apache/httpcomponents/core5/httpcore5-h2/main/*.jar"/>
+                  </fileset>
+                  <chainedmapper>
+                    <regexpmapper
+                      from="^org/apache/httpcomponents/core5/httpcore5-h2/main/(.*)$$"
+                      to="org/apache/httpcomponents/core5/httpcore5/main/\1"
+                      handledirsep="yes"/>
+                  </chainedmapper>
+                </copy>
+                <delete dir="target/modules/org/apache/httpcomponents/core5/httpcore5-h2"/>
                 <!-- copy groovy dependencies to single dir -->
                 <delete dir="target/modules/org/apache/groovy"/>
                 <copy todir="target/modules" flatten="false">
@@ -292,6 +310,9 @@
                   <include name="**/module.xml"/>
                 </replace>
                 <replace dir="target/modules" token="@version.httpcore5@" value="${version.httpcore5}">
+                  <include name="**/module.xml"/>
+                </replace>
+                <replace dir="target/modules" token="@version.httpcore5-h2@" value="${version.httpcore5-h2}">
                   <include name="**/module.xml"/>
                 </replace>
                 <replace dir="target/modules" token="@version.jackson@" value="${version.jackson}">

--- a/distro/wildfly/modules/src/main/modules/org/apache/httpcomponents/core5/httpcore5/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/apache/httpcomponents/core5/httpcore5/main/module.xml
@@ -1,6 +1,7 @@
 <module xmlns="urn:jboss:module:1.0" name="org.apache.httpcomponents.core5.httpcore5">
   <resources>
     <resource-root path="httpcore5-@version.httpcore5@.jar" />
+    <resource-root path="httpcore5-h2-@version.httpcore5-h2@.jar" />
   </resources>
 
   <dependencies>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -35,6 +35,7 @@
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpclient5>5.6.1</version.httpclient5>
     <version.httpcore5>5.4</version.httpcore5>
+    <version.httpcore5-h2>5.4.2</version.httpcore5-h2>
     <version.cronutils>9.2.1</version.cronutils>
     <version.unirest-java>3.14.5</version.unirest-java>
     <version.junit5>6.0.3</version.junit5>


### PR DESCRIPTION
## Summary

Backports the applicable WildFly module packaging fix from cibseven/cibseven#245.

The WildFly `httpclient5` module depends on `org.apache.httpcomponents.core5.httpcore5`, and HTTP connector code can also require classes from `httpcore5-h2`. Before this change, Operaton copied `httpcore5-h2` as its own generated module directory, but the checked-in WildFly module descriptors only expose `httpcore5`. That leaves the HTTP/2 core jar unavailable through the `httpcore5` module used by `httpclient5`.

This PR places the generated `httpcore5-h2` jar into the existing `httpcore5` WildFly module and adds it as a `resource-root` there.

## Source / Attribution

- Source PR: https://github.com/cibseven/cibseven/pull/245
- Source commit: https://github.com/cibseven/cibseven/commit/567a0490f069c997a6c21bbda8e06c79bfcdff0e
- Source repository: https://github.com/cibseven/cibseven
- Original author: Fernando Mambrilla <fernandom@cib.de>
- Backport change unit: 1064

## Operaton Adaptation

CIBSeven changed both `distro/wildfly` and `distro/wildfly28`. Operaton has no `wildfly28` distribution, so this backport only adapts the `distro/wildfly` part.

There is one important Operaton-specific difference from the source patch: Operaton currently resolves:

- `httpcore5:5.4`
- `httpcore5-h2:5.4.2`
- `httpclient5:5.6.1`

The source patch could use the same version token for `httpcore5` and `httpcore5-h2`; doing that in Operaton would generate a broken `module.xml` referencing `httpcore5-h2-5.4.jar` while the actual jar is `httpcore5-h2-5.4.2.jar`.

For that reason this adaptation adds a dedicated `version.httpcore5-h2` property and replaces `@version.httpcore5-h2@` separately in the WildFly module descriptors. It also declares `httpcore5-h2` explicitly in `distro/wildfly/modules/pom.xml`, because the WildFly module now intentionally packages that artifact instead of relying on it only as a transitive dependency.

## Reviewer Notes

This is a runtime packaging fix rather than a Java code change. The important behavior is in the generated WildFly module tree:

```text
target/modules/org/apache/httpcomponents/core5/httpcore5/main/httpcore5-5.4.jar
target/modules/org/apache/httpcomponents/core5/httpcore5/main/httpcore5-h2-5.4.2.jar
target/modules/org/apache/httpcomponents/core5/httpcore5/main/module.xml
```

The separate generated `target/modules/org/apache/httpcomponents/core5/httpcore5-h2` directory is removed after the jar is copied into the `httpcore5` module. The generated `module.xml` now references both resource roots with the correct versions.

## Verification

```bash
./mvnw -Pdistro-wildfly -pl distro/wildfly/modules \
  -DskipTests -Dskip.frontend.build=true \
  dependency:tree -Dincludes=org.apache.httpcomponents.core5 -DoutputType=text
```

Confirmed `httpcore5-h2:5.4.2` is part of the WildFly modules dependency tree.

```bash
./mvnw -Pdistro-wildfly -pl distro/wildfly/modules -am \
  -DskipTests -Dskip.frontend.build=true clean package
```

Result: `BUILD SUCCESS`.

Checked generated module files after the build:

```text
httpcore5-5.4.jar
httpcore5-h2-5.4.2.jar
module.xml
```

and confirmed the generated `module.xml` contains:

```xml
<resource-root path="httpcore5-5.4.jar" />
<resource-root path="httpcore5-h2-5.4.2.jar" />
```

```bash
./mvnw -Pdistro-wildfly -pl distro/wildfly/modules -am \
  -DskipTests -Dskip.frontend.build=true verify
```

Result: `BUILD SUCCESS`; `validate-wildfly-modules` reported:

```text
Wildfly module.xml validation PASSED: All referenced resources found.
```
