### PR TITLE
docs(rest): Fix VariableInstanceDto batchId description

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/VariableInstanceDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/VariableInstanceDto.ftl
@@ -55,7 +55,7 @@
     <@lib.property
         name = "batchId"
         type = "string"
-        desc = "The id of the batch that this variable instance belongs to.<"
+        desc = "The id of the batch that this variable instance belongs to."
     />
     
     <@lib.property


### PR DESCRIPTION
## Summary

Backports the OpenAPI template typo fix from cibseven/cibseven#250.

The `batchId` property description in `VariableInstanceDto.ftl` ended with a stray `<` character:

```text
The id of the batch that this variable instance belongs to.<
```

This PR removes that extra character so the generated OpenAPI description is correct.

## Source / Attribution

- Source PR: https://github.com/cibseven/cibseven/pull/250
- Source commit: https://github.com/cibseven/cibseven/commit/fbbe4b6be68fa9fefd61402e87cdd2cce2d92961
- Source repository: https://github.com/cibseven/cibseven
- Original author: Oleg Skrypnyuk <oleg.skrypnyuk@cib.de>
- Backport change unit: 1076

## Operaton Adaptation

The source commit changed the CIBSeven template path:

```text
engine-rest/engine-rest-openapi/src/main/templates/models/org/cibseven/bpm/engine/rest/dto/runtime/VariableInstanceDto.ftl
```

Operaton has the same template under the Operaton namespace:

```text
engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/runtime/VariableInstanceDto.ftl
```

The actual text change is identical.

## Reviewer Notes

This is a generated OpenAPI documentation/spec cleanup only. It does not change REST runtime behavior or DTO serialization.

The typo was present in Operaton before this PR and appeared in generated `openapi.json` for `VariableInstanceDto.batchId`. After this change, the generated schema description no longer contains the stray `<`.

## Verification

```bash
./mvnw -pl engine-rest/engine-rest-openapi -am \
  -DskipTests -Dskip.frontend.build=true package
```

Result: `BUILD SUCCESS`. This runs OpenAPI JSON generation and schema validation.

Checked generated output:

```bash
rg -n "The id of the batch that this variable instance belongs to\." \
  engine-rest/engine-rest-openapi/target/generated-sources/openapi-json/openapi.json \
  engine-rest/engine-rest-openapi/target/classes/openapi.json
```

Found the corrected description in both generated files.

```bash
rg -n "The id of the batch that this variable instance belongs to\.<" \
  engine-rest/engine-rest-openapi/target/generated-sources/openapi-json/openapi.json \
  engine-rest/engine-rest-openapi/target/classes/openapi.json \
  engine-rest/engine-rest-openapi/src/main/templates
```

No matches.
