### PR TITLE
build(engine): Use commons-collections4 in tests

### DIFF
--- a/bom/internal-dependencies/pom.xml
+++ b/bom/internal-dependencies/pom.xml
@@ -175,9 +175,9 @@
         <version>${version.commons-codec}</version>
       </dependency>
       <dependency>
-        <groupId>commons-collections</groupId>
-        <artifactId>commons-collections</artifactId>
-        <version>3.2.2</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-collections4</artifactId>
+        <version>4.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -251,8 +251,8 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricInstanceForCleanupQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/history/HistoricInstanceForCleanupQueryTest.java
@@ -21,7 +21,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections.map.HashedMap;
+import org.apache.commons.collections4.map.HashedMap;
 import org.apache.commons.lang3.time.DateUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;

--- a/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricBatchManagerBatchesForCleanupTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/history/HistoricBatchManagerBatchesForCleanupTest.java
@@ -22,7 +22,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections.map.HashedMap;
+import org.apache.commons.collections4.map.HashedMap;
 import org.apache.commons.lang3.time.DateUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;


### PR DESCRIPTION
## Summary

Backports Fluxnova change unit 484 to replace the legacy test-scope Apache Commons Collections 3.x dependency with Commons Collections 4 in the engine test setup.

The change updates Operaton's internal dependency management from `commons-collections:commons-collections:3.2.2` to `org.apache.commons:commons-collections4:4.4`, switches the engine test dependency to the new artifact, and updates the two affected test imports from `org.apache.commons.collections.map.HashedMap` to `org.apache.commons.collections4.map.HashedMap`.

## Reviewer notes

This is a test-scope dependency modernization. The direct engine dependency is declared with `<scope>test</scope>`, so the change affects the engine test classpath and the internal BOM entry, not Operaton runtime behavior.

The only Java code changes are import migrations in two History Cleanup test classes. The tests still exercise the same query/setup logic; the map implementation is the Commons Collections 4 equivalent of the previous Commons Collections 3 `HashedMap` type.

Repo-wide follow-up check: `qa/test-old-engine/pom.xml` still contains `commons-collections:commons-collections` inside the `old-engine` profile. That is intentionally left unchanged here because this profile imports the historical Operaton BOM `1.0.0-beta-5` and resolves `commons-collections:3.2.2:test` for old-engine compatibility testing. It is not using the engine test dependency changed by this PR. The remaining root `pom.xml` reference is only a `versions-maven-plugin` rule for the old coordinate.

Operaton adaptation:

- Fluxnova's `internal-dependencies/pom.xml` maps to Operaton's `bom/internal-dependencies/pom.xml`.
- Fluxnova package paths were adapted to Operaton package paths.
- Operaton's tests are already JUnit 5, so no test framework migration was needed.

## Attribution

Backported from Fluxnova:

- Source repository: https://github.com/finos/fluxnova-bpm-platform
- Source commit: `3fea119d15143c364c078ec3c5cc0ea6ed44a3a6`
- Source title: `build: upgrade to commons-collections4 and update imports`
- Original author: Sowmya, HL `<Sowmya.HL@fmr.com>`
- Backport change unit: 484

## Verification

```bash
./mvnw -pl engine -am -Dskip.frontend.build=true -DskipTests dependency:tree -Dincludes=commons-collections:commons-collections,org.apache.commons:commons-collections4 -DoutputType=text
```

Result: `operaton-engine` resolves `org.apache.commons:commons-collections4:jar:4.4:test`.

```bash
./mvnw -pl engine -am -DskipTests -Dskip.frontend.build=true install
```

Result: `BUILD SUCCESS`.

```bash
./mvnw -pl engine -Dskip.frontend.build=true -Dtest=HistoricInstanceForCleanupQueryTest,HistoricBatchManagerBatchesForCleanupTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false test
```

Result: 5 tests run, 0 failures, 0 errors, 0 skipped.

```bash
./mvnw -f qa/test-old-engine/pom.xml -Pold-engine -Dskip.frontend.build=true -DskipTests dependency:tree -Dincludes=commons-collections:commons-collections,org.apache.commons:commons-collections4 -DoutputType=text
```

Result: `operaton-qa-old-engine` intentionally still resolves `commons-collections:commons-collections:jar:3.2.2:test` from the historical old-engine BOM.

```bash
git diff --check
```

Result: no whitespace issues.
