### PR TITLE
feat(engine-rest): Configure Jackson string constraints

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/mapper/JacksonConfigurator.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/mapper/JacksonConfigurator.java
@@ -1,10 +1,11 @@
 /*
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
- * under one or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information regarding copyright
- * ownership. Camunda licenses this file to you under the Apache License,
- * Version 2.0; you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * under one or more contributor license agreements.
+ * Modifications Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
  *
  *     https://www.apache.org/licenses/LICENSE-2.0
  *
@@ -16,25 +17,38 @@
  */
 package org.operaton.bpm.engine.rest.mapper;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.text.SimpleDateFormat;
+import java.util.Properties;
+
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.ContextResolver;
 import jakarta.ws.rs.ext.Provider;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
+import org.operaton.bpm.engine.impl.ProcessEngineLogger;
+import org.operaton.bpm.engine.impl.util.EngineUtilLogger;
 import org.operaton.bpm.engine.rest.hal.Hal;
 
 @Provider
 @Produces({MediaType.APPLICATION_JSON, Hal.APPLICATION_HAL_JSON})
 public class JacksonConfigurator implements ContextResolver<ObjectMapper> {
 
+  protected static final EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
+
   public static final String DEFAULT_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
   private static String dateFormatString = DEFAULT_DATE_FORMAT;
+
+  private static final String PROPERTIES_FILE = "jackson.properties";
+  private static final String LENGTH_PROPERTY = "jackson.maxStringLength";
+  private static final int maxStringLength = loadMaxStringLength();
 
   public static ObjectMapper configureObjectMapper(ObjectMapper mapper) {
     SimpleDateFormat dateFormat = new SimpleDateFormat(dateFormatString);
@@ -43,8 +57,39 @@ public class JacksonConfigurator implements ContextResolver<ObjectMapper> {
     mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 
     mapper.registerModule(new JavaTimeModule());
+    configureStreamReadConstraints(mapper);
 
     return mapper;
+  }
+
+  private static int loadMaxStringLength() {
+    int defaultMaxStringLength = StreamReadConstraints.DEFAULT_MAX_STRING_LEN;
+    Properties properties = new Properties();
+
+    try (InputStream inputStream = JacksonConfigurator.class.getClassLoader().getResourceAsStream(PROPERTIES_FILE)) {
+      if (inputStream != null) {
+        properties.load(inputStream);
+      }
+    } catch (IOException e) {
+      throw LOG.exceptionWhileReadingFile(PROPERTIES_FILE, e);
+    }
+
+    return Integer.parseInt(properties.getProperty(LENGTH_PROPERTY, String.valueOf(defaultMaxStringLength)));
+  }
+
+  /**
+   * Configures StreamReadConstraints on the ObjectMapper if the Jackson version supports it.
+   * StreamReadConstraints was added in Jackson 2.15.0.
+   */
+  private static void configureStreamReadConstraints(ObjectMapper mapper) {
+    try {
+      StreamReadConstraints streamReadConstraints = StreamReadConstraints.builder()
+          .maxStringLength(maxStringLength)
+          .build();
+      mapper.getFactory().setStreamReadConstraints(streamReadConstraints);
+    } catch (NoSuchMethodError e) {
+      // Can happen when an application server provides older Jackson modules.
+    }
   }
 
   @Override

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/mapper/JacksonConfiguratorTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/mapper/JacksonConfiguratorTest.java
@@ -1,5 +1,10 @@
 /*
- * Copyright 2026 the Operaton contributors.
+ * Copyright CIB software GmbH and/or licensed to CIB software GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. CIB software licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * Modifications Copyright 2026 the Operaton contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/mapper/JacksonConfiguratorTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/mapper/JacksonConfiguratorTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.mapper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JacksonConfiguratorTest {
+
+  private static final int DEFAULT_LIMIT = StreamReadConstraints.DEFAULT_MAX_STRING_LEN;
+  private static final int HIGHER_LIMIT = 50_000_000;
+
+  @Test
+  void shouldDeserializeStringBelowConfiguredLimit() throws JsonProcessingException {
+    assertStringRoundTrip(HIGHER_LIMIT - 1);
+  }
+
+  @Test
+  void shouldDeserializeStringAtConfiguredLimit() throws JsonProcessingException {
+    assertStringRoundTrip(HIGHER_LIMIT);
+  }
+
+  @Test
+  void shouldRejectStringAboveConfiguredLimit() {
+    assertThatThrownBy(() -> assertStringRoundTrip(HIGHER_LIMIT + 1))
+        .isInstanceOf(StreamConstraintsException.class);
+  }
+
+  @Test
+  void shouldDeserializeStringBelowDefaultLimit() throws JsonProcessingException {
+    assertStringRoundTrip(DEFAULT_LIMIT - 1);
+  }
+
+  @Test
+  void shouldDeserializeStringAtDefaultLimit() throws JsonProcessingException {
+    assertStringRoundTrip(DEFAULT_LIMIT);
+  }
+
+  @Test
+  void shouldDeserializeStringAboveDefaultLimit() throws JsonProcessingException {
+    assertStringRoundTrip(DEFAULT_LIMIT + 1);
+  }
+
+  private void assertStringRoundTrip(int dataLength) throws JsonProcessingException {
+    ObjectMapper objectMapper = new JacksonConfigurator().getContext(ObjectMapper.class);
+
+    StreamReadConstraints constraints = objectMapper.getFactory().streamReadConstraints();
+    assertThat(constraints.getMaxStringLength()).isEqualTo(HIGHER_LIMIT);
+
+    String longString = "x".repeat(dataLength);
+    String json = objectMapper.writeValueAsString(longString);
+    String deserializedString = objectMapper.readValue(json, String.class);
+
+    assertThat(deserializedString).isEqualTo(longString);
+  }
+
+}

--- a/engine-rest/engine-rest/src/test/resources/jackson.properties
+++ b/engine-rest/engine-rest/src/test/resources/jackson.properties
@@ -1,5 +1,10 @@
 #
-# Copyright 2026 the Operaton contributors.
+# Copyright CIB software GmbH and/or licensed to CIB software GmbH
+# under one or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information regarding copyright
+# ownership. CIB software licenses this file to you under the Apache License,
+# Version 2.0; you may not use this file except in compliance with the License.
+# Modifications Copyright 2026 the Operaton contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/engine-rest/engine-rest/src/test/resources/jackson.properties
+++ b/engine-rest/engine-rest/src/test/resources/jackson.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2026 the Operaton contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set the max string length to 50 MB.
+jackson.maxStringLength=50000000


### PR DESCRIPTION
## Summary

Backports the CIBSeven Jackson string-length configuration feature as one combined Operaton PR.

The REST `JacksonConfigurator` now applies Jackson `StreamReadConstraints` to the `ObjectMapper`. By default it keeps Jackson's own `DEFAULT_MAX_STRING_LEN`; deployments can override it by placing a `jackson.properties` file on the classpath with:

```properties
jackson.maxStringLength=<max string length>
```

The PR also adds a JUnit 5 test for the configured limit and folds in the CIBSeven follow-up that expects Jackson's `StreamConstraintsException` when a payload exceeds the configured limit.

## Identified CIBSeven commits

This PR intentionally combines these related CIBSeven commits:

- `c7296100ac81b394cb6e10a9b37496fb46ef4603` / change unit 801: introduces configurable Jackson max string length and the original test/resource.
- `1c4bcc64ea80c867ccf93dc35e7141d4f18f2ffa` / change unit 803: fixes the test to expect `StreamConstraintsException` instead of swallowing exceptions.
- `81a8d2b2074d596e1e441996482fe6fbcbc27311` / change unit 1026: guards `setStreamReadConstraints` for mixed/older Jackson runtime modules.

Related commits that were checked but not included as separate sources:

- `200764e3d0e61f99726cdcaa0c0e034439ad9530` only changes the file mode of `jackson.properties` and mostly restructures unrelated identity DB tests.
- `7e72cec8789a69b25860f3362b2bd4befe3dc39b` is a branch-only JUnit 5 migration. Operaton already uses JUnit 5, so the test was adapted directly to Operaton style instead of attributing that branch-only commit as a mainline source.

## Reviewer notes

Operaton adaptation:

- Applied the change to `org.operaton` package paths and the Jakarta REST module.
- Added an Operaton-header JUnit 5/AssertJ test instead of the source JUnit 4 test.
- Kept `jackson.properties` optional: if it is absent, Jackson's default max string length is used without a startup warning.
- If a present `jackson.properties` cannot be read, Operaton fails using the existing `EngineUtilLogger.exceptionWhileReadingFile` path instead of silently ignoring the configuration.

No production `jackson.properties` file is shipped by this PR. The file added here is test-only and sets `jackson.maxStringLength=50000000` so the test can verify both the default and configured limits.

## Attribution

Backported from CIBSeven:

- Source repository: https://github.com/cibseven/cibseven
- Original author: Oleg Skrypnyuk `<oleg.skrypnyuk@cib.de>`
- Co-authored source contribution: Serge Krot `<serge.krot@cib.de>`
- Backport change units: 801, 803, 1026

Source commits:

- `c7296100ac81b394cb6e10a9b37496fb46ef4603`
- `1c4bcc64ea80c867ccf93dc35e7141d4f18f2ffa`
- `81a8d2b2074d596e1e441996482fe6fbcbc27311`

## Verification

```bash
./mvnw -pl engine -am -DskipTests -Dskip.frontend.build=true install
```

Result: `BUILD SUCCESS`.

```bash
./mvnw -pl engine-rest/engine-rest -Dskip.frontend.build=true -Dtest=JacksonConfiguratorTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false test
```

Result: `BUILD SUCCESS`; `JacksonConfiguratorTest` ran twice through the module's Surefire executions, 12 total test invocations, 0 failures/errors.

```bash
git diff --check
```

Result: no whitespace issues.
