### PR TITLE
feat(engine): add fork class name compatibility mapping

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/application/impl/ProcessApplicationScriptEnvironment.java
+++ b/engine/src/main/java/org/operaton/bpm/application/impl/ProcessApplicationScriptEnvironment.java
@@ -21,11 +21,11 @@ import java.util.List;
 import java.util.Map;
 
 import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
 
 import org.operaton.bpm.application.ProcessApplicationInterface;
 import org.operaton.bpm.engine.impl.scripting.ExecutableScript;
 import org.operaton.bpm.engine.impl.scripting.engine.DefaultScriptEngineResolver;
+import org.operaton.bpm.engine.impl.scripting.engine.OperatonScriptEngineManager;
 import org.operaton.bpm.engine.impl.scripting.engine.ScriptEngineResolver;
 
 /**
@@ -57,7 +57,8 @@ public class ProcessApplicationScriptEnvironment {
    */
   public synchronized ScriptEngine getScriptEngineForName(String scriptEngineName, boolean cache) {
     if(processApplicationScriptEngineResolver == null) {
-      processApplicationScriptEngineResolver = new DefaultScriptEngineResolver(new ScriptEngineManager(getProcessApplicationClassloader()));
+      processApplicationScriptEngineResolver = new DefaultScriptEngineResolver(
+          new OperatonScriptEngineManager(getProcessApplicationClassloader()));
     }
     return processApplicationScriptEngineResolver.getScriptEngine(scriptEngineName, cache);
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/ProcessEngineConfiguration.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/ProcessEngineConfiguration.java
@@ -423,6 +423,11 @@ public abstract class ProcessEngineConfiguration {
    */
   protected boolean skipOutputMappingOnCanceledActivities;
 
+  /**
+   * Enables compatibility class name mapping from known Camunda 7 fork package prefixes to the Operaton package prefix.
+   */
+  protected boolean enableForkClassNameCompatibilityMapping;
+
   protected ProcessEngineConfiguration() {
   }
 
@@ -1052,5 +1057,15 @@ public abstract class ProcessEngineConfiguration {
 
   public void setSkipOutputMappingOnCanceledActivities(boolean skipOutputMappingOnCanceledActivities) {
     this.skipOutputMappingOnCanceledActivities = skipOutputMappingOnCanceledActivities;
+  }
+
+  public boolean isEnableForkClassNameCompatibilityMapping() {
+    return enableForkClassNameCompatibilityMapping;
+  }
+
+  public ProcessEngineConfiguration setEnableForkClassNameCompatibilityMapping(
+      boolean enableForkClassNameCompatibilityMapping) {
+    this.enableForkClassNameCompatibilityMapping = enableForkClassNameCompatibilityMapping;
+    return this;
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -4480,6 +4480,13 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return this;
   }
 
+  @Override
+  public ProcessEngineConfigurationImpl setEnableForkClassNameCompatibilityMapping(
+      boolean enableForkClassNameCompatibilityMapping) {
+    super.setEnableForkClassNameCompatibilityMapping(enableForkClassNameCompatibilityMapping);
+    return this;
+  }
+
   public boolean isEnableExpressionsInAdhocQueries() {
     return enableExpressionsInAdhocQueries;
   }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/SourceExecutableScript.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/SourceExecutableScript.java
@@ -29,6 +29,7 @@ import org.operaton.bpm.engine.delegate.VariableScope;
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.operaton.bpm.engine.impl.context.Context;
+import org.operaton.bpm.engine.impl.util.ClassNameUtil;
 
 /**
  * A script which is provided as source code.
@@ -101,7 +102,7 @@ public class SourceExecutableScript extends CompiledExecutableScript {
   public CompiledScript compile(ScriptEngine scriptEngine, String language, String src) {
     if (scriptEngine instanceof Compilable compilingEngine && !"ecmascript".equalsIgnoreCase(scriptEngine.getFactory().getLanguageName())) {
       try {
-        CompiledScript compiledScript = compilingEngine.compile(src);
+        CompiledScript compiledScript = compilingEngine.compile(mapKnownForkClassNamesToOperaton(src));
 
         LOG.debugCompiledScriptUsing(language);
 
@@ -121,7 +122,15 @@ public class SourceExecutableScript extends CompiledExecutableScript {
 
   protected Object evaluateScript(ScriptEngine engine, Bindings bindings) throws ScriptException {
     LOG.debugEvaluatingNonCompiledScript(scriptSource);
-    return engine.eval(scriptSource, bindings);
+    return engine.eval(mapKnownForkClassNamesToOperaton(scriptSource), bindings);
+  }
+
+  protected String mapKnownForkClassNamesToOperaton(String source) {
+    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    if (processEngineConfiguration != null && processEngineConfiguration.isEnableForkClassNameCompatibilityMapping()) {
+      return ClassNameUtil.mapKnownForkClassNamesInTextToOperaton(source);
+    }
+    return source;
   }
 
   public String getScriptSource() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/OperatonScriptEngineManager.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/scripting/engine/OperatonScriptEngineManager.java
@@ -18,9 +18,15 @@ package org.operaton.bpm.engine.impl.scripting.engine;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
+import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
 import javax.script.ScriptEngineManager;
+
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.operaton.bpm.engine.impl.context.Context;
+import org.operaton.bpm.engine.impl.util.ForkClassNameMappingClassLoader;
 
 import static org.operaton.bpm.engine.impl.scripting.engine.ScriptingEngines.GRAAL_JS_SCRIPT_ENGINE_NAME;
 import static org.operaton.bpm.engine.impl.scripting.engine.ScriptingEngines.JYTHON_SCRIPT_ENGINE_NAME;
@@ -47,6 +53,48 @@ public class OperatonScriptEngineManager extends ScriptEngineManager {
   public OperatonScriptEngineManager() {
     super(); // creates engine factories after classpath discovery
     applyConfigOnEnginesAfterClasspathDiscovery();
+  }
+
+  public OperatonScriptEngineManager(ClassLoader classLoader) {
+    super(classLoader); // creates engine factories after classpath discovery
+    applyConfigOnEnginesAfterClasspathDiscovery();
+  }
+
+  @Override
+  public ScriptEngine getEngineByName(String shortName) {
+    return withForkClassNameCompatibilityMapping(() -> super.getEngineByName(shortName));
+  }
+
+  @Override
+  public ScriptEngine getEngineByExtension(String extension) {
+    return withForkClassNameCompatibilityMapping(() -> super.getEngineByExtension(extension));
+  }
+
+  @Override
+  public ScriptEngine getEngineByMimeType(String mimeType) {
+    return withForkClassNameCompatibilityMapping(() -> super.getEngineByMimeType(mimeType));
+  }
+
+  protected ScriptEngine withForkClassNameCompatibilityMapping(Supplier<ScriptEngine> scriptEngineSupplier) {
+    if (!isForkClassNameCompatibilityMappingEnabled()) {
+      return scriptEngineSupplier.get();
+    }
+
+    Thread currentThread = Thread.currentThread();
+    ClassLoader originalClassLoader = currentThread.getContextClassLoader();
+    ClassLoader mappingClassLoader = new ForkClassNameMappingClassLoader(originalClassLoader);
+
+    try {
+      currentThread.setContextClassLoader(mappingClassLoader);
+      return scriptEngineSupplier.get();
+    } finally {
+      currentThread.setContextClassLoader(originalClassLoader);
+    }
+  }
+
+  protected boolean isForkClassNameCompatibilityMappingEnabled() {
+    ProcessEngineConfigurationImpl cfg = Context.getProcessEngineConfiguration();
+    return cfg != null && cfg.isEnableForkClassNameCompatibilityMapping();
   }
 
   protected void applyConfigOnEnginesAfterClasspathDiscovery() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ClassNameUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ClassNameUtil.java
@@ -16,6 +16,7 @@
  */
 package org.operaton.bpm.engine.impl.util;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -24,6 +25,15 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Tom Baeyens
  */
 public final class ClassNameUtil {
+
+  public static final String OPERATON_ENGINE_PACKAGE_PREFIX = "org.operaton.bpm";
+
+  protected static final List<Map.Entry<String, String>> FORK_ENGINE_PACKAGE_PREFIX_MAPPINGS = List.of(
+    Map.entry("org.camunda.bpm", OPERATON_ENGINE_PACKAGE_PREFIX),
+    Map.entry("org.cibseven.bpm", OPERATON_ENGINE_PACKAGE_PREFIX),
+    Map.entry("org.eximeebpms.bpm", OPERATON_ENGINE_PACKAGE_PREFIX),
+    Map.entry("org.finos.fluxnova.bpm", OPERATON_ENGINE_PACKAGE_PREFIX)
+  );
 
   protected static final Map<Class<?>, String> cachedNames = new ConcurrentHashMap<>();
 
@@ -40,5 +50,33 @@ public final class ClassNameUtil {
       String fullyQualifiedClassName = key.getName();
       return fullyQualifiedClassName.substring(fullyQualifiedClassName.lastIndexOf('.') + 1);
     });
+  }
+
+  public static String mapKnownForkClassNameToOperaton(String className) {
+    if (className == null) {
+      return null;
+    }
+
+    for (var mapping : FORK_ENGINE_PACKAGE_PREFIX_MAPPINGS) {
+      String sourcePrefix = mapping.getKey();
+      if (className.equals(sourcePrefix) || className.startsWith(sourcePrefix + ".")) {
+        return mapping.getValue() + className.substring(sourcePrefix.length());
+      }
+    }
+
+    return className;
+  }
+
+  public static String mapKnownForkClassNamesInTextToOperaton(String text) {
+    if (text == null) {
+      return null;
+    }
+
+    String mappedText = text;
+    for (var mapping : FORK_ENGINE_PACKAGE_PREFIX_MAPPINGS) {
+      mappedText = mappedText.replace(mapping.getKey() + ".", mapping.getValue() + ".");
+    }
+
+    return mappedText;
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ClassNameUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ClassNameUtil.java
@@ -32,7 +32,8 @@ public final class ClassNameUtil {
     Map.entry("org.camunda.bpm", OPERATON_ENGINE_PACKAGE_PREFIX),
     Map.entry("org.cibseven.bpm", OPERATON_ENGINE_PACKAGE_PREFIX),
     Map.entry("org.eximeebpms.bpm", OPERATON_ENGINE_PACKAGE_PREFIX),
-    Map.entry("org.finos.fluxnova.bpm", OPERATON_ENGINE_PACKAGE_PREFIX)
+    Map.entry("org.finos.fluxnova.bpm", OPERATON_ENGINE_PACKAGE_PREFIX),
+    Map.entry("io.orqueio.bpm", OPERATON_ENGINE_PACKAGE_PREFIX)
   );
 
   protected static final Map<Class<?>, String> cachedNames = new ConcurrentHashMap<>();
@@ -57,6 +58,15 @@ public final class ClassNameUtil {
       return null;
     }
 
+    String componentClassName = getObjectArrayComponentClassName(className);
+    if (componentClassName != null) {
+      String mappedComponentClassName = mapKnownForkClassNameToOperaton(componentClassName);
+      if (!mappedComponentClassName.equals(componentClassName)) {
+        return className.substring(0, className.indexOf('L') + 1) + mappedComponentClassName + ";";
+      }
+      return className;
+    }
+
     for (var mapping : FORK_ENGINE_PACKAGE_PREFIX_MAPPINGS) {
       String sourcePrefix = mapping.getKey();
       if (className.equals(sourcePrefix) || className.startsWith(sourcePrefix + ".")) {
@@ -65,6 +75,22 @@ public final class ClassNameUtil {
     }
 
     return className;
+  }
+
+  protected static String getObjectArrayComponentClassName(String className) {
+    int arrayPrefixLength = 0;
+    while (arrayPrefixLength < className.length() && className.charAt(arrayPrefixLength) == '[') {
+      arrayPrefixLength++;
+    }
+
+    if (arrayPrefixLength == 0
+        || arrayPrefixLength >= className.length()
+        || className.charAt(arrayPrefixLength) != 'L'
+        || !className.endsWith(";")) {
+      return null;
+    }
+
+    return className.substring(arrayPrefixLength + 1, className.length() - 1);
   }
 
   public static String mapKnownForkClassNamesInTextToOperaton(String text) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ForkClassNameMappingClassLoader.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ForkClassNameMappingClassLoader.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+
+public class ForkClassNameMappingClassLoader extends ClassLoader {
+
+  private static final String CLASS_RESOURCE_SUFFIX = ".class";
+
+  public ForkClassNameMappingClassLoader(ClassLoader parent) {
+    super(parent);
+  }
+
+  @Override
+  public Class<?> loadClass(String name) throws ClassNotFoundException {
+    try {
+      return super.loadClass(name);
+    } catch (ClassNotFoundException e) {
+      String mappedClassName = ClassNameUtil.mapKnownForkClassNameToOperaton(name);
+      if (mappedClassName.equals(name)) {
+        throw e;
+      }
+
+      try {
+        return super.loadClass(mappedClassName);
+      } catch (ClassNotFoundException mappedException) {
+        mappedException.addSuppressed(e);
+        throw mappedException;
+      }
+    }
+  }
+
+  @Override
+  public URL getResource(String name) {
+    URL resource = super.getResource(name);
+    if (resource != null) {
+      return resource;
+    }
+
+    String mappedResourceName = mapKnownForkResourceNameToOperaton(name);
+    if (mappedResourceName.equals(name)) {
+      return null;
+    }
+    return super.getResource(mappedResourceName);
+  }
+
+  @Override
+  public Enumeration<URL> getResources(String name) throws IOException {
+    Enumeration<URL> resources = super.getResources(name);
+    if (resources.hasMoreElements()) {
+      return resources;
+    }
+
+    String mappedResourceName = mapKnownForkResourceNameToOperaton(name);
+    if (mappedResourceName.equals(name)) {
+      return resources;
+    }
+    return super.getResources(mappedResourceName);
+  }
+
+  @Override
+  public InputStream getResourceAsStream(String name) {
+    InputStream resource = super.getResourceAsStream(name);
+    if (resource != null) {
+      return resource;
+    }
+
+    String mappedResourceName = mapKnownForkResourceNameToOperaton(name);
+    if (mappedResourceName.equals(name)) {
+      return null;
+    }
+    return super.getResourceAsStream(mappedResourceName);
+  }
+
+  protected String mapKnownForkResourceNameToOperaton(String resourceName) {
+    if (resourceName == null || !resourceName.endsWith(CLASS_RESOURCE_SUFFIX)) {
+      return resourceName;
+    }
+
+    String className = resourceName
+        .substring(0, resourceName.length() - CLASS_RESOURCE_SUFFIX.length())
+        .replace('/', '.');
+    String mappedClassName = ClassNameUtil.mapKnownForkClassNameToOperaton(className);
+    if (mappedClassName.equals(className)) {
+      return resourceName;
+    }
+    return mappedClassName.replace('.', '/') + CLASS_RESOURCE_SUFFIX;
+  }
+}

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/ReflectUtil.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/ReflectUtil.java
@@ -100,6 +100,19 @@ public final class ReflectUtil {
     }
 
     if (clazz == null) {
+      String mappedClassName = mapKnownForkClassNameToOperaton(className);
+      if (mappedClassName != null && !mappedClassName.equals(className)) {
+        try {
+          clazz = loadClass(mappedClassName);
+        } catch (Exception | LinkageError err) {
+          if (throwable == null) {
+            throwable = err;
+          }
+        }
+      }
+    }
+
+    if (clazz == null) {
       throw LOG.classLoadingException(className, throwable);
     }
     return clazz;
@@ -115,7 +128,21 @@ public final class ReflectUtil {
 
   public static <T> Class<? extends T> loadClass(String className, ClassLoader customClassloader) throws ClassNotFoundException, ClassCastException {
     if(customClassloader != null) {
-      return (Class<? extends T>) customClassloader.loadClass(className);
+      try {
+        return (Class<? extends T>) customClassloader.loadClass(className);
+      } catch (ClassNotFoundException e) {
+        String mappedClassName = mapKnownForkClassNameToOperaton(className);
+        if (mappedClassName == null || mappedClassName.equals(className)) {
+          throw e;
+        }
+
+        try {
+          return (Class<? extends T>) customClassloader.loadClass(mappedClassName);
+        } catch (ClassNotFoundException mappedException) {
+          mappedException.addSuppressed(e);
+          throw mappedException;
+        }
+      }
     } else {
       return (Class<? extends T>) loadClass(className);
     }
@@ -438,5 +465,13 @@ public final class ReflectUtil {
    */
   public static Method getMethod(Class<?> declaringType, String methodName, Class<?>... parameterTypes) {
     return findMethod(declaringType, methodName, parameterTypes);
+  }
+
+  public static String mapKnownForkClassNameToOperaton(String className) {
+    ProcessEngineConfigurationImpl cfg = Context.getProcessEngineConfiguration();
+    if (cfg != null && cfg.isEnableForkClassNameCompatibilityMapping()) {
+      return ClassNameUtil.mapKnownForkClassNameToOperaton(className);
+    }
+    return className;
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/variable/serializer/AbstractObjectValueSerializer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/variable/serializer/AbstractObjectValueSerializer.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.impl.variable.serializer;
 
 import org.operaton.bpm.engine.ProcessEngineException;
+import org.operaton.bpm.engine.impl.util.ReflectUtil;
 import org.operaton.bpm.engine.variable.Variables;
 import org.operaton.bpm.engine.variable.impl.value.ObjectValueImpl;
 import org.operaton.bpm.engine.variable.impl.value.UntypedValueImpl;
@@ -124,7 +125,15 @@ public abstract class AbstractObjectValueSerializer extends AbstractSerializable
   @Override
   protected Object deserializeFromByteArray(byte[] object, ValueFields valueFields) throws Exception {
     String objectTypeName = readObjectNameFromFields(valueFields);
-    return deserializeFromByteArray(object, objectTypeName);
+    try {
+      return deserializeFromByteArray(object, objectTypeName);
+    } catch (Exception e) {
+      String mappedObjectTypeName = ReflectUtil.mapKnownForkClassNameToOperaton(objectTypeName);
+      if (mappedObjectTypeName != null && !mappedObjectTypeName.equals(objectTypeName)) {
+        return deserializeFromByteArray(object, mappedObjectTypeName);
+      }
+      throw e;
+    }
   }
 
   /**

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/variable/serializer/JavaObjectSerializer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/variable/serializer/JavaObjectSerializer.java
@@ -24,7 +24,9 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
 import java.io.Serializable;
+import java.lang.reflect.Proxy;
 
+import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.impl.util.ReflectUtil;
 import org.operaton.bpm.engine.variable.Variables.SerializationDataFormats;
 
@@ -86,6 +88,28 @@ public class JavaObjectSerializer extends AbstractObjectValueSerializer {
     @Override
     protected Class<?> resolveClass(ObjectStreamClass desc) {
       return ReflectUtil.loadClass(desc.getName());
+    }
+
+    @Override
+    protected Class<?> resolveProxyClass(String[] interfaces) throws IOException, ClassNotFoundException {
+      Class<?>[] resolvedInterfaces = new Class<?>[interfaces.length];
+      for (int i = 0; i < interfaces.length; i++) {
+        resolvedInterfaces[i] = loadInterfaceClass(interfaces[i]);
+      }
+
+      try {
+        return Proxy.getProxyClass(ReflectUtil.getClassLoader(), resolvedInterfaces);
+      } catch (IllegalArgumentException e) {
+        throw new ClassNotFoundException(null, e);
+      }
+    }
+
+    protected Class<?> loadInterfaceClass(String interfaceName) throws ClassNotFoundException {
+      try {
+        return ReflectUtil.loadClass(interfaceName);
+      } catch (ProcessEngineException e) {
+        throw new ClassNotFoundException(interfaceName, e);
+      }
     }
 
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/scripting/engine/OperatonScriptEngineManagerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/scripting/engine/OperatonScriptEngineManagerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.scripting.engine;
+
+import java.io.Reader;
+import java.net.URL;
+import java.util.List;
+
+import javax.script.AbstractScriptEngine;
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptException;
+import javax.script.SimpleBindings;
+
+import org.junit.jupiter.api.Test;
+
+import org.operaton.bpm.engine.delegate.BpmnError;
+import org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
+import org.operaton.bpm.engine.impl.context.Context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OperatonScriptEngineManagerTest {
+
+  @Test
+  void shouldCreateScriptEngineWithForkClassNameMappingClassLoaderWhenCompatibilityMappingIsEnabled() {
+    Context.setProcessEngineConfiguration(new StandaloneInMemProcessEngineConfiguration()
+      .setEnableForkClassNameCompatibilityMapping(true));
+
+    try {
+      OperatonScriptEngineManager scriptEngineManager = new OperatonScriptEngineManager();
+      scriptEngineManager.registerEngineName("mapping-test", new RecordingScriptEngineFactory());
+
+      RecordingScriptEngine scriptEngine = (RecordingScriptEngine) scriptEngineManager.getEngineByName("mapping-test");
+
+      assertThat(scriptEngine.loadedClass).isEqualTo(BpmnError.class);
+      assertThat(scriptEngine.loadedClassResource).isNotNull();
+    } finally {
+      Context.removeProcessEngineConfiguration();
+    }
+  }
+
+  private static class RecordingScriptEngineFactory implements ScriptEngineFactory {
+
+    @Override
+    public String getEngineName() {
+      return "mapping-test";
+    }
+
+    @Override
+    public String getEngineVersion() {
+      return "1";
+    }
+
+    @Override
+    public List<String> getExtensions() {
+      return List.of();
+    }
+
+    @Override
+    public List<String> getMimeTypes() {
+      return List.of();
+    }
+
+    @Override
+    public List<String> getNames() {
+      return List.of("mapping-test");
+    }
+
+    @Override
+    public String getLanguageName() {
+      return "mapping-test";
+    }
+
+    @Override
+    public String getLanguageVersion() {
+      return "1";
+    }
+
+    @Override
+    public Object getParameter(String key) {
+      return null;
+    }
+
+    @Override
+    public String getMethodCallSyntax(String obj, String method, String... args) {
+      return null;
+    }
+
+    @Override
+    public String getOutputStatement(String toDisplay) {
+      return null;
+    }
+
+    @Override
+    public String getProgram(String... statements) {
+      return null;
+    }
+
+    @Override
+    public ScriptEngine getScriptEngine() {
+      try {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        Class<?> loadedClass = contextClassLoader
+            .loadClass("org.cibseven.bpm.engine.delegate.BpmnError");
+        URL loadedClassResource = contextClassLoader
+            .getResource("org/cibseven/bpm/engine/delegate/BpmnError.class");
+        return new RecordingScriptEngine(this, loadedClass, loadedClassResource);
+      } catch (ClassNotFoundException e) {
+        throw new AssertionError(e);
+      }
+    }
+  }
+
+  private static class RecordingScriptEngine extends AbstractScriptEngine {
+
+    private final ScriptEngineFactory factory;
+    private final Class<?> loadedClass;
+    private final URL loadedClassResource;
+
+    private RecordingScriptEngine(ScriptEngineFactory factory, Class<?> loadedClass, URL loadedClassResource) {
+      this.factory = factory;
+      this.loadedClass = loadedClass;
+      this.loadedClassResource = loadedClassResource;
+    }
+
+    @Override
+    public Object eval(String script, ScriptContext context) throws ScriptException {
+      return null;
+    }
+
+    @Override
+    public Object eval(Reader reader, ScriptContext context) throws ScriptException {
+      return null;
+    }
+
+    @Override
+    public Bindings createBindings() {
+      return new SimpleBindings();
+    }
+
+    @Override
+    public ScriptEngineFactory getFactory() {
+      return factory;
+    }
+  }
+}

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/util/ClassNameUtilTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/util/ClassNameUtilTest.java
@@ -67,9 +67,14 @@ class ClassNameUtilTest {
       arguments("org.cibseven.bpm.engine.delegate.BpmnError", "org.operaton.bpm.engine.delegate.BpmnError"),
       arguments("org.eximeebpms.bpm.engine.delegate.BpmnError", "org.operaton.bpm.engine.delegate.BpmnError"),
       arguments("org.finos.fluxnova.bpm.engine.delegate.BpmnError", "org.operaton.bpm.engine.delegate.BpmnError"),
+      arguments("io.orqueio.bpm.engine.delegate.BpmnError", "org.operaton.bpm.engine.delegate.BpmnError"),
+      arguments("[Lorg.cibseven.bpm.engine.delegate.BpmnError;", "[Lorg.operaton.bpm.engine.delegate.BpmnError;"),
+      arguments("[[Lio.orqueio.bpm.engine.delegate.BpmnError;", "[[Lorg.operaton.bpm.engine.delegate.BpmnError;"),
       arguments("org.operaton.bpm.engine.delegate.BpmnError", "org.operaton.bpm.engine.delegate.BpmnError"),
+      arguments("[I", "[I"),
       arguments("org.camunda.community.BpmnError", "org.camunda.community.BpmnError"),
       arguments("org.cibsevenx.bpm.engine.delegate.BpmnError", "org.cibsevenx.bpm.engine.delegate.BpmnError"),
+      arguments("io.orqueio.bpmfoo.engine.delegate.BpmnError", "io.orqueio.bpmfoo.engine.delegate.BpmnError"),
       arguments(null, null)
     );
   }
@@ -88,8 +93,12 @@ class ClassNameUtilTest {
       arguments(
         "Java.type('org.finos.fluxnova.bpm.engine.delegate.BpmnError')",
         "Java.type('org.operaton.bpm.engine.delegate.BpmnError')"),
+      arguments(
+        "Java.type('io.orqueio.bpm.engine.delegate.BpmnError')",
+        "Java.type('org.operaton.bpm.engine.delegate.BpmnError')"),
       arguments("org.camunda.community.BpmnError", "org.camunda.community.BpmnError"),
       arguments("org.cibseven.bpmfoo.engine.BpmnError", "org.cibseven.bpmfoo.engine.BpmnError"),
+      arguments("io.orqueio.bpmfoo.engine.BpmnError", "io.orqueio.bpmfoo.engine.BpmnError"),
       arguments(null, null)
     );
   }

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/util/ClassNameUtilTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/util/ClassNameUtilTest.java
@@ -54,4 +54,43 @@ class ClassNameUtilTest {
       arguments(new Object(),     "Object")
     );
   }
+
+  @ParameterizedTest
+  @MethodSource("forkClassNameArgs")
+  void mapKnownForkClassNameToOperaton_shouldOnlyMapKnownEnginePackagePrefixes(String className, String expected) {
+    assertThat(ClassNameUtil.mapKnownForkClassNameToOperaton(className)).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> forkClassNameArgs() {
+    return Stream.of(
+      arguments("org.camunda.bpm.engine.delegate.BpmnError", "org.operaton.bpm.engine.delegate.BpmnError"),
+      arguments("org.cibseven.bpm.engine.delegate.BpmnError", "org.operaton.bpm.engine.delegate.BpmnError"),
+      arguments("org.eximeebpms.bpm.engine.delegate.BpmnError", "org.operaton.bpm.engine.delegate.BpmnError"),
+      arguments("org.finos.fluxnova.bpm.engine.delegate.BpmnError", "org.operaton.bpm.engine.delegate.BpmnError"),
+      arguments("org.operaton.bpm.engine.delegate.BpmnError", "org.operaton.bpm.engine.delegate.BpmnError"),
+      arguments("org.camunda.community.BpmnError", "org.camunda.community.BpmnError"),
+      arguments("org.cibsevenx.bpm.engine.delegate.BpmnError", "org.cibsevenx.bpm.engine.delegate.BpmnError"),
+      arguments(null, null)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("forkClassNameTextArgs")
+  void mapKnownForkClassNamesInTextToOperaton_shouldOnlyMapKnownEnginePackagePrefixes(String text, String expected) {
+    assertThat(ClassNameUtil.mapKnownForkClassNamesInTextToOperaton(text)).isEqualTo(expected);
+  }
+
+  static Stream<Arguments> forkClassNameTextArgs() {
+    return Stream.of(
+      arguments(
+        "new org.cibseven.bpm.engine.delegate.BpmnError('x')",
+        "new org.operaton.bpm.engine.delegate.BpmnError('x')"),
+      arguments(
+        "Java.type('org.finos.fluxnova.bpm.engine.delegate.BpmnError')",
+        "Java.type('org.operaton.bpm.engine.delegate.BpmnError')"),
+      arguments("org.camunda.community.BpmnError", "org.camunda.community.BpmnError"),
+      arguments("org.cibseven.bpmfoo.engine.BpmnError", "org.cibseven.bpmfoo.engine.BpmnError"),
+      arguments(null, null)
+    );
+  }
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/util/ReflectUtilTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/util/ReflectUtilTest.java
@@ -22,6 +22,9 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 import org.operaton.bpm.engine.ProcessEngineException;
+import org.operaton.bpm.engine.delegate.BpmnError;
+import org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
+import org.operaton.bpm.engine.impl.context.Context;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -143,6 +146,42 @@ class ReflectUtilTest {
     Method m = ReflectUtil.getMethod(SetterClass.class, "setName", String.class);
     assertThat(m).isNotNull();
     assertThat(m.getName()).isEqualTo("setName");
+  }
+
+  @Test
+  void shouldNotMapKnownForkClassNameWhenCompatibilityMappingIsDisabled() {
+    assertThatThrownBy(() -> ReflectUtil.loadClass("org.cibseven.bpm.engine.delegate.BpmnError"))
+      .isInstanceOf(ProcessEngineException.class);
+  }
+
+  @Test
+  void shouldMapKnownForkClassNameWhenCompatibilityMappingIsEnabled() {
+    Context.setProcessEngineConfiguration(new StandaloneInMemProcessEngineConfiguration()
+      .setEnableForkClassNameCompatibilityMapping(true));
+
+    try {
+      Class<?> loadedClass = ReflectUtil.loadClass("org.cibseven.bpm.engine.delegate.BpmnError");
+
+      assertThat(loadedClass).isEqualTo(BpmnError.class);
+    } finally {
+      Context.removeProcessEngineConfiguration();
+    }
+  }
+
+  @Test
+  void shouldMapKnownForkClassNameWithCustomClassLoaderWhenCompatibilityMappingIsEnabled() throws Exception {
+    Context.setProcessEngineConfiguration(new StandaloneInMemProcessEngineConfiguration()
+      .setEnableForkClassNameCompatibilityMapping(true));
+
+    try {
+      Class<?> loadedClass = ReflectUtil.loadClass(
+          "org.eximeebpms.bpm.engine.delegate.BpmnError",
+          Thread.currentThread().getContextClassLoader());
+
+      assertThat(loadedClass).isEqualTo(BpmnError.class);
+    } finally {
+      Context.removeProcessEngineConfiguration();
+    }
   }
 
 }

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/variable/serializer/AbstractObjectValueSerializerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/variable/serializer/AbstractObjectValueSerializerTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.variable.serializer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.operaton.bpm.engine.delegate.BpmnError;
+import org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
+import org.operaton.bpm.engine.impl.context.Context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AbstractObjectValueSerializerTest {
+
+  @Test
+  void shouldRetryDeserializationWithMappedForkClassNameWhenCompatibilityMappingIsEnabled() throws Exception {
+    Context.setProcessEngineConfiguration(new StandaloneInMemProcessEngineConfiguration()
+      .setEnableForkClassNameCompatibilityMapping(true));
+
+    try {
+      RecordingObjectValueSerializer serializer = new RecordingObjectValueSerializer();
+      TestValueFields valueFields = new TestValueFields("org.cibseven.bpm.engine.delegate.BpmnError");
+
+      Object result = serializer.deserializeFromByteArray(new byte[0], valueFields);
+
+      assertThat(result).isEqualTo("mapped");
+      assertThat(serializer.attemptedObjectTypeNames)
+        .containsExactly("org.cibseven.bpm.engine.delegate.BpmnError", BpmnError.class.getName());
+    } finally {
+      Context.removeProcessEngineConfiguration();
+    }
+  }
+
+  @Test
+  void shouldNotRetryDeserializationWhenCompatibilityMappingIsDisabled() {
+    RecordingObjectValueSerializer serializer = new RecordingObjectValueSerializer();
+    TestValueFields valueFields = new TestValueFields("org.cibseven.bpm.engine.delegate.BpmnError");
+
+    assertThatThrownBy(() -> serializer.deserializeFromByteArray(new byte[0], valueFields))
+      .isInstanceOf(ClassNotFoundException.class);
+
+    assertThat(serializer.attemptedObjectTypeNames)
+      .containsExactly("org.cibseven.bpm.engine.delegate.BpmnError");
+  }
+
+  private static class RecordingObjectValueSerializer extends AbstractObjectValueSerializer {
+
+    private final List<String> attemptedObjectTypeNames = new ArrayList<>();
+
+    private RecordingObjectValueSerializer() {
+      super("test");
+    }
+
+    @Override
+    public String getName() {
+      return "test";
+    }
+
+    @Override
+    protected String getTypeNameForDeserialized(Object deserializedObject) {
+      return deserializedObject.getClass().getName();
+    }
+
+    @Override
+    protected byte[] serializeToByteArray(Object deserializedObject) {
+      return new byte[0];
+    }
+
+    @Override
+    protected Object deserializeFromByteArray(byte[] object, String objectTypeName) throws Exception {
+      attemptedObjectTypeNames.add(objectTypeName);
+      if (BpmnError.class.getName().equals(objectTypeName)) {
+        return "mapped";
+      }
+      throw new ClassNotFoundException(objectTypeName);
+    }
+
+    @Override
+    protected boolean isSerializationTextBased() {
+      return false;
+    }
+
+    @Override
+    protected boolean canSerializeValue(Object value) {
+      return true;
+    }
+  }
+
+  private static class TestValueFields implements ValueFields {
+
+    private final String textValue2;
+
+    private TestValueFields(String textValue2) {
+      this.textValue2 = textValue2;
+    }
+
+    @Override
+    public String getName() {
+      return "variable";
+    }
+
+    @Override
+    public String getTextValue() {
+      return null;
+    }
+
+    @Override
+    public void setTextValue(String textValue) {
+      // test stub
+    }
+
+    @Override
+    public String getTextValue2() {
+      return textValue2;
+    }
+
+    @Override
+    public void setTextValue2(String textValue2) {
+      // test stub
+    }
+
+    @Override
+    public Long getLongValue() {
+      return null;
+    }
+
+    @Override
+    public void setLongValue(Long longValue) {
+      // test stub
+    }
+
+    @Override
+    public Double getDoubleValue() {
+      return null;
+    }
+
+    @Override
+    public void setDoubleValue(Double doubleValue) {
+      // test stub
+    }
+
+    @Override
+    public byte[] getByteArrayValue() {
+      return new byte[0];
+    }
+
+    @Override
+    public void setByteArrayValue(byte[] bytes) {
+      // test stub
+    }
+  }
+}

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/variable/serializer/JavaObjectSerializerTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/variable/serializer/JavaObjectSerializerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.variable.serializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Proxy;
+
+import org.junit.jupiter.api.Test;
+
+import org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
+import org.operaton.bpm.engine.impl.context.Context;
+import org.operaton.bpm.engine.impl.util.ReflectUtil;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JavaObjectSerializerTest {
+
+  @Test
+  void shouldResolveProxyInterfaceWithMappedForkClassNameWhenCompatibilityMappingIsEnabled() throws Exception {
+    Context.setProcessEngineConfiguration(new StandaloneInMemProcessEngineConfiguration()
+      .setEnableForkClassNameCompatibilityMapping(true));
+
+    try (var objectInputStream = new JavaObjectSerializer.ClassloaderAwareObjectInputStream(
+        new ByteArrayInputStream(objectStreamHeader()))) {
+      Class<?> proxyClass = objectInputStream.resolveProxyClass(new String[] {
+          "io.orqueio.bpm.engine.impl.variable.serializer.JavaObjectSerializerTest$TestProxyInterface"
+      });
+
+      assertThat(Proxy.isProxyClass(proxyClass)).isTrue();
+      assertThat(proxyClass.getInterfaces()).containsExactly(TestProxyInterface.class);
+    } finally {
+      Context.removeProcessEngineConfiguration();
+    }
+  }
+
+  @Test
+  void shouldResolveArrayDescriptorWithMappedForkClassNameWhenCompatibilityMappingIsEnabled() {
+    Context.setProcessEngineConfiguration(new StandaloneInMemProcessEngineConfiguration()
+      .setEnableForkClassNameCompatibilityMapping(true));
+
+    try {
+      Class<?> arrayClass = ReflectUtil.loadClass(
+          "[Lio.orqueio.bpm.engine.impl.variable.serializer.JavaObjectSerializerTest$TestProxyInterface;");
+
+      assertThat(arrayClass).isEqualTo(TestProxyInterface[].class);
+    } finally {
+      Context.removeProcessEngineConfiguration();
+    }
+  }
+
+  private static byte[] objectStreamHeader() throws Exception {
+    try (var baos = new ByteArrayOutputStream(); var oos = new ObjectOutputStream(baos)) {
+      oos.flush();
+      return baos.toByteArray();
+    }
+  }
+
+  public interface TestProxyInterface {
+  }
+
+}

--- a/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/scripttask/ScriptTaskTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/bpmn/scripttask/ScriptTaskTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.operaton.bpm.engine.ProcessEngineException;
 import org.operaton.bpm.engine.ScriptCompilationException;
 import org.operaton.bpm.engine.ScriptEvaluationException;
+import org.operaton.bpm.engine.delegate.BpmnError;
 import org.operaton.bpm.engine.exception.NullValueException;
 import org.operaton.bpm.engine.repository.ProcessDefinition;
 import org.operaton.bpm.engine.runtime.ProcessInstance;
@@ -526,6 +527,33 @@ class ScriptTaskTest extends AbstractScriptTaskTest {
 
     MySerializable myVar = (MySerializable) runtimeService.getVariable(pi.getId(), "myVar");
     assertThat(myVar.getName()).isEqualTo("test");
+  }
+
+  @Test
+  void testGroovyCanUseKnownForkClassNameWhenCompatibilityMappingIsEnabled() {
+    boolean originalCompatibilityMapping = processEngineConfiguration.isEnableForkClassNameCompatibilityMapping();
+    boolean originalScriptEngineCaching = processEngineConfiguration
+      .getScriptingEngines()
+      .isEnableScriptEngineCaching();
+
+    try {
+      processEngineConfiguration.setEnableForkClassNameCompatibilityMapping(true);
+      processEngineConfiguration.getScriptingEngines().setEnableScriptEngineCaching(false);
+
+      deployProcess(GROOVY, """
+        def error = new org.cibseven.bpm.engine.delegate.BpmnError('migration-error')
+        execution.setVariable('errorCode', error.getErrorCode())
+        execution.setVariable('errorClass', error.getClass().getName())
+        """);
+
+      ProcessInstance pi = runtimeService.startProcessInstanceByKey("testProcess");
+
+      assertThat(runtimeService.getVariable(pi.getId(), "errorCode")).isEqualTo("migration-error");
+      assertThat(runtimeService.getVariable(pi.getId(), "errorClass")).isEqualTo(BpmnError.class.getName());
+    } finally {
+      processEngineConfiguration.setEnableForkClassNameCompatibilityMapping(originalCompatibilityMapping);
+      processEngineConfiguration.getScriptingEngines().setEnableScriptEngineCaching(originalScriptEngineCaching);
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds an opt-in compatibility mode for migrated process applications and runtime data that still reference Camunda 7 fork package names.

When `enableForkClassNameCompatibilityMapping` is enabled, Operaton maps known fork engine package prefixes to `org.operaton.bpm` in these paths:

- reflective class loading via `ReflectUtil`
- Java-serialized object type-name fallback in `AbstractObjectValueSerializer`
- Java serialization class descriptor loading, including object array descriptors
- Java serialization proxy interface resolution
- script source compile/eval in `SourceExecutableScript`
- script engine creation through a mapping context classloader
- process-application script engine lookup via `OperatonScriptEngineManager`

Known source prefixes covered by this PR:

- `org.camunda.bpm`
- `org.cibseven.bpm`
- `org.eximeebpms.bpm`
- `org.finos.fluxnova.bpm`
- `io.orqueio.bpm`

## Problem

After migrating from Camunda 7 or another fork, deployed processes, scripts, serialized variables, or process-application configuration can still contain class names from the previous namespace. Without a compatibility layer, these references fail even when the equivalent class exists in Operaton under `org.operaton.bpm`.

The CIBSeven implementation solved this for selected `org.camunda` to `org.cibseven` cases. Fluxnova added a Java serialization stream-level remapping helper for migrated serialized variables. This PR generalizes the useful parts for Operaton and keeps the behavior fork-neutral.

## Implementation Notes

The new behavior is disabled by default via `enableForkClassNameCompatibilityMapping = false` to avoid changing class loading semantics for existing installations.

The mapping is boundary-aware. For example, `org.cibseven.bpm.engine.delegate.BpmnError` maps to `org.operaton.bpm.engine.delegate.BpmnError`, but unrelated packages such as `org.camunda.community`, `org.cibseven.bpmfoo`, or `io.orqueio.bpmfoo` are left unchanged.

For Java serialization, `ClassloaderAwareObjectInputStream` continues to resolve through Operaton's class loading utility, but now also benefits from descriptor mapping for object arrays such as `[Lio.orqueio.bpm...;`. Serialized proxy interfaces are resolved through the same mapping path so migrated proxy descriptors can be loaded when their Operaton interface equivalent exists.

For scripting, Operaton normalizes known fork package prefixes in script source before compile/eval when the flag is enabled. This covers Groovy and also supports string-based class lookups such as `Java.type('org.cibseven.bpm...')` without adding production compile-time dependencies on Groovy or GraalJS internals.

## Validation

Executed:

```bash
./mvnw -pl engine -Dskip.frontend.build=true -Dtest='ClassNameUtilTest,ReflectUtilTest,AbstractObjectValueSerializerTest,JavaObjectSerializerTest,OperatonScriptEngineManagerTest,ScriptTaskTest#testGroovyCanUseKnownForkClassNameWhenCompatibilityMappingIsEnabled' test
```

Result: 43 tests passed.

Coverage added for:

- package-prefix boundary mapping
- OrqueIO `io.orqueio.bpm` prefix mapping
- object array descriptor mapping
- disabled/enabled `ReflectUtil` behavior
- custom classloader fallback
- serializer retry behavior with original then mapped object type name
- Java serialization proxy interface mapping
- script engine context classloader mapping
- real Groovy ScriptTask using `org.cibseven.bpm.engine.delegate.BpmnError`

## Attribution

Inspired by and generalized from these CIBSeven namespace compatibility commits:

- https://github.com/cibseven/cibseven/commit/73b3da20f1556512113bd6afcedf011586a6ab51
- https://github.com/cibseven/cibseven/commit/379d7c71537fc2a958118a68baecbe61d909e518
- https://github.com/cibseven/cibseven/commit/91d7b8641dbcb18fd1c95d5c56faa8bfff4e0b3c

Original CIBSeven authors include:

- vladimirg <vladimir.gribko@cib.de>
- Oleg Skrypnyuk <oleg.skrypnyuk@cib.de>

Serialization edge-case coverage is also inspired by Fluxnova change 355:

- https://github.com/finos/fluxnova-bpm-platform/commit/06f6bb0f5ba9213ea05e9f37f12bdd84d185133c
- https://github.com/finos/fluxnova-bpm-platform/commit/c7d53ababb98a48b435cff82650c7c3928c8af5e

Original Fluxnova author:

- Bhandari, Prajwol <prajwol.bhandari@fmr.com>

This is not a straight CIBSeven or Fluxnova backport. The implementation is adapted for Operaton and generalized from fork-specific mappings to known fork engine prefixes -> `org.operaton.bpm`.
