### PR TITLE
chore(webapps): remove CE EOL banner leftovers

### DIFF
--- a/distro/operaton-welcome/assets/css/welcome.css
+++ b/distro/operaton-welcome/assets/css/welcome.css
@@ -12,21 +12,6 @@ body.dashboard {
   display: flex;
   align-items: center;
 }
-[cam-widget-header] .ce-eol-banner {
-  background-color: #B5152BFF;
-  color: white;
-  text-align: center;
-  height: 20px;
-  font-size: 0.9em;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-}
-[cam-widget-header] .ce-eol-banner a {
-  color: white;
-  text-decoration: underline;
-}
-
 .navbar-brand .logo {
   margin-right: 5px;
   fill: #666;

--- a/webapps/frontend/operaton-commons-ui/lib/widgets/header/cam-widget-header.scss
+++ b/webapps/frontend/operaton-commons-ui/lib/widgets/header/cam-widget-header.scss
@@ -22,22 +22,6 @@ body {
 [cam-widget-header] {
   @include cam-corporate-header();
 
-  .ce-eol-banner {
-    background-color: $main-color;
-    color: white;
-    text-align: center;
-    height: $ce-banner-height;
-    font-size: 0.9em;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-
-    a {
-      color: white;
-      text-decoration: underline;
-    }
-  }
-
   .navbar-brand {
     display: flex;
     align-items: center;

--- a/webapps/frontend/operaton-commons-ui/resources/scss/sites/base.scss
+++ b/webapps/frontend/operaton-commons-ui/resources/scss/sites/base.scss
@@ -17,7 +17,7 @@ $headings-font-family:        $font-family-base;
 $link-hover-decoration:       none;
 
 // Header Math
-$header-height:               65px;
+$header-height:               45px;
 // Note: ensured $header-computed-height is defined in your variables or shared files
 $header-site-name-size:       calc($header-height / 3);
 $header-brand-logo-font-size: 33px;

--- a/webapps/frontend/ui/common/styles/_three-cols-layout.scss
+++ b/webapps/frontend/ui/common/styles/_three-cols-layout.scss
@@ -128,7 +128,7 @@ $active-link-hover-color: $link-hover-color
 
   .page-wrap {
     z-index: 1;
-    top: calc(#{$navbar-height} + #{$ce-banner-height});
+    top: $navbar-height;
     bottom: $footer-height;
   }
 

--- a/webapps/frontend/ui/welcome/client/styles/styles.scss
+++ b/webapps/frontend/ui/welcome/client/styles/styles.scss
@@ -25,7 +25,7 @@ form .btn {
 .welcome-page {
   background-color: $custom-gray-light;
   position: absolute;
-  min-height: calc(100% - ($header-height + $ce-banner-height + $footer-height));
+  min-height: calc(100% - ($header-height + $footer-height));
   width: 100%;
   // padding-top: @grid-gutter-width;
   // padding-bottom: @grid-gutter-width;

--- a/webapps/frontend/webpack.common.js
+++ b/webapps/frontend/webpack.common.js
@@ -132,7 +132,6 @@ module.exports = (_env, argv = {}) => {
               options: {
                 // Optional: helps sass-loader handle modern Sass features
                 implementation: require('sass'),
-                additionalData: `$ce-banner-height: ${eeBuild ? '0' : '20px'};`,
                 sassOptions: {
                   // Keep unicode escapes in generated CSS (e.g. "\f4da")
                   // so icon codepoints are not emitted as raw UTF-8 bytes.


### PR DESCRIPTION
## Summary

Removes leftover Camunda 7 CE EOL banner styling and layout offsets from the Operaton webapps frontend and welcome distribution.

The visible banner markup is already absent in Operaton's welcome page, but related CSS/Sass pieces were still present:

- `.ce-eol-banner` styles in the static welcome CSS
- `.ce-eol-banner` styles in the shared header widget
- `$ce-banner-height` offsets in common and welcome layouts
- Sass injection of `$ce-banner-height` from webpack
- the inflated shared header height that included the removed 20px banner space

## Reviewer Notes

This is a UI cleanup backport from Fluxnova. It removes dead Camunda 7 CE migration banner machinery and prevents the frontend layout from reserving space for a banner that Operaton should not show.

The patch is adapted to Operaton paths and SCSS naming:

- Fluxnova used `flowave-commons-ui` and LESS; Operaton uses `operaton-commons-ui` and SCSS.
- Fluxnova removed `@ce-banner-height`; Operaton removes the equivalent `$ce-banner-height` injection and usages.
- The shared header height is reduced from `65px` to `45px`, matching the upstream intent: the old 20px EOL banner height is no longer part of the header layout.

## Validation

Executed in `webapps/frontend`:

```bash
npm ci
npm run build
```

Result:

- `npm ci` completed successfully.
- `npm run build` completed successfully with existing Sass deprecation and bundle-size warnings.
- Verified there are no remaining `ce-banner-height` or `ce-eol-banner` references under `distro/` or `webapps/frontend/`.

## Attribution

Backported and adapted from Fluxnova:

- https://github.com/finos/fluxnova-bpm-platform/commit/fa5c82b2facc4cd63d2eb18068b649b2c4698ee3

Original author:

- Michael Scharp <michael.scharp@fmr.com>