### PR TITLE
fix(engine-rest): whitelist identity verification endpoint

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/ProcessEngineAuthenticationFilter.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/ProcessEngineAuthenticationFilter.java
@@ -69,7 +69,9 @@ public class ProcessEngineAuthenticationFilter implements Filter {
 
   // regexes for urls that may be accessed unauthorized
   protected static final Pattern[] WHITE_LISTED_URL_PATTERNS = new Pattern[] {
-    Pattern.compile("^" + NamedProcessEngineRestServiceImpl.PATH + "/?")
+    Pattern.compile("^" + NamedProcessEngineRestServiceImpl.PATH + "/?"),
+    Pattern.compile("^" + NamedProcessEngineRestServiceImpl.PATH + "/[^/]+/identity/verify$"),
+    Pattern.compile("^/identity/verify$")
   };
 
   protected static final Pattern ENGINE_REQUEST_URL_PATTERN = Pattern.compile("^" + NamedProcessEngineRestServiceImpl.PATH + "/(.*?)(/|$)");

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/AuthenticationFilterPathMatchingTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/standalone/AuthenticationFilterPathMatchingTest.java
@@ -109,6 +109,9 @@ public class AuthenticationFilterPathMatchingTest extends AbstractRestServiceTes
         {"", "/process-definition", "default", true},
         {"", "/engine", null, false},
         {"", "/engine/", null, false},
+        {"", "/identity/verify", null, false},
+        {"", "/engine/default/identity/verify", null, false},
+        {"", "/engine/someOther/identity/verify", null, false},
         {"", "/", "default", true},
         {"", "", "default", true},
         {"/someservlet", "/engine/someengine/process-definition", "someengine", true}


### PR DESCRIPTION
## Summary

Whitelists the REST identity verification endpoint in `ProcessEngineAuthenticationFilter`:

- `/identity/verify`
- `/engine/{engineName}/identity/verify`

This keeps the login/credential verification endpoint reachable without requiring the same REST authentication filter to authenticate the request first.

## Problem

`IdentityRestService#verifyUser` is the endpoint that checks submitted username/password credentials and returns an `AuthenticationResult`. If the global REST authentication filter treats that endpoint like a normal protected engine resource, the request can be challenged before the endpoint itself gets a chance to validate the submitted credentials.

CIBSeven fixed this as part of a larger REST filter configuration simplification. In Operaton, most of that larger diff is not applicable as-is:

- Operaton's assembly `web.xml` files already map the REST auth filter broadly with `/*`.
- Operaton Run registers the Jersey application URL mapping directly.
- The missing part is the narrow `identity/verify` whitelist and its path-matching coverage.

## Implementation Notes

The whitelist is intentionally exact:

- default-engine verification: `^/identity/verify$`
- named-engine verification: `^/engine/[^/]+/identity/verify$`

Other identity endpoints, such as `/identity/groups` or password-policy endpoints, continue to require the normal REST authentication filter behavior.

## Validation

Executed:

```bash
./mvnw -pl engine-rest/engine-rest -Dskip.frontend.build=true -Dtest=AuthenticationFilterPathMatchingTest test
```

Result:

- `AuthenticationFilterPathMatchingTest` ran 15 parameterized cases twice via the module's configured Surefire executions.
- No failures or errors.

## Attribution

Backported and narrowed from CIBSeven:

- https://github.com/cibseven/cibseven/commit/171f12e124a39c0944d72cea60f4706fad9c982a

Original author:

- Copilot <198982749+Copilot@users.noreply.github.com>

Original co-authors include:

- patrickCIB <204714531+patrickCIB@users.noreply.github.com>
- patrickCIB <patrick.fincke@cib.de>