### PR TITLE
fix(engine): use stored process definition key for MDC

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/ProcessDataContext.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/ProcessDataContext.java
@@ -210,7 +210,7 @@ public class ProcessDataContext {
     }
 
     if (isNotBlank(mdcPropertyDefinitionKey)) {
-      addToStack(execution.getProcessDefinition().getKey(), mdcPropertyDefinitionKey);
+      addToStack(execution.getProcessDefinitionKey(), mdcPropertyDefinitionKey);
     }
 
     sections.sealCurrentSection();

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/interceptor/ProcessDataContextTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/interceptor/ProcessDataContextTest.java
@@ -22,7 +22,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
 import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
 import org.operaton.commons.logging.MdcAccess;
 
@@ -45,18 +44,11 @@ class ProcessDataContextTest {
 
   @Test
   void pushSectionUsesStoredProcessDefinitionKeyForMdc() {
-    ProcessEngineConfigurationImpl configuration = new StandaloneInMemProcessEngineConfiguration()
-        .setLoggingContextActivityId(null)
-        .setLoggingContextActivityName(null)
-        .setLoggingContextApplicationName(null)
-        .setLoggingContextBusinessKey(null)
-        .setLoggingContextProcessDefinitionId(null)
-        .setLoggingContextProcessDefinitionKey(PROCESS_DEFINITION_KEY_MDC_PROPERTY)
-        .setLoggingContextProcessInstanceId(null)
-        .setLoggingContextTenantId(null)
-        .setLoggingContextEngineName(null);
+    ProcessEngineConfigurationImpl configuration = mock(ProcessEngineConfigurationImpl.class);
     ExecutionEntity execution = mock(ExecutionEntity.class);
     ProcessEngine processEngine = mock(ProcessEngine.class);
+
+    when(configuration.getLoggingContextProcessDefinitionKey()).thenReturn(PROCESS_DEFINITION_KEY_MDC_PROPERTY);
     when(execution.getProcessEngine()).thenReturn(processEngine);
     when(processEngine.getName()).thenReturn("engine");
     when(execution.getProcessDefinitionKey()).thenReturn(PROCESS_DEFINITION_KEY);

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/interceptor/ProcessDataContextTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/interceptor/ProcessDataContextTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.interceptor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.operaton.bpm.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
+import org.operaton.bpm.engine.impl.persistence.entity.ExecutionEntity;
+import org.operaton.commons.logging.MdcAccess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessDataContextTest {
+
+  private static final String PROCESS_DEFINITION_KEY_MDC_PROPERTY = "processDefinitionKey";
+  private static final String PROCESS_DEFINITION_KEY = "invoice";
+
+  @AfterEach
+  void clearMdc() {
+    MdcAccess.remove(PROCESS_DEFINITION_KEY_MDC_PROPERTY);
+  }
+
+  @Test
+  void pushSectionUsesStoredProcessDefinitionKeyForMdc() {
+    ProcessEngineConfigurationImpl configuration = new StandaloneInMemProcessEngineConfiguration()
+        .setLoggingContextActivityId(null)
+        .setLoggingContextActivityName(null)
+        .setLoggingContextApplicationName(null)
+        .setLoggingContextBusinessKey(null)
+        .setLoggingContextProcessDefinitionId(null)
+        .setLoggingContextProcessDefinitionKey(PROCESS_DEFINITION_KEY_MDC_PROPERTY)
+        .setLoggingContextProcessInstanceId(null)
+        .setLoggingContextTenantId(null)
+        .setLoggingContextEngineName(null);
+    ExecutionEntity execution = mock(ExecutionEntity.class);
+    ProcessEngine processEngine = mock(ProcessEngine.class);
+    when(execution.getProcessEngine()).thenReturn(processEngine);
+    when(processEngine.getName()).thenReturn("engine");
+    when(execution.getProcessDefinitionKey()).thenReturn(PROCESS_DEFINITION_KEY);
+
+    new ProcessDataContext(configuration).pushSection(execution);
+
+    assertThat(MdcAccess.get(PROCESS_DEFINITION_KEY_MDC_PROPERTY)).isEqualTo(PROCESS_DEFINITION_KEY);
+    verify(execution, never()).getProcessDefinition();
+  }
+}


### PR DESCRIPTION
## Summary

This backports a small Fluxnova engine fix for `ProcessDataContext`: when the MDC logging context needs the process definition key, the engine now reads the already stored execution property via `ExecutionEntity#getProcessDefinitionKey()` instead of resolving the full process definition and then calling `getKey()` on it.

## Problem

Before this change, `ProcessDataContext#pushSection` populated the configured `processDefinitionKey` MDC property through:

```java
execution.getProcessDefinition().getKey()
```

That makes MDC population depend on resolving/loading the process definition even though the execution already carries the process definition key directly. For logging-context setup this is unnecessary work and can cause avoidable process-definition access on a path that should only copy execution metadata into MDC.

## Fix

Use:

```java
execution.getProcessDefinitionKey()
```

This keeps the logging-context behavior the same from the caller's perspective, but avoids resolving the full process definition for the key.

## Test coverage

Added `ProcessDataContextTest#pushSectionUsesStoredProcessDefinitionKeyForMdc`.

The test is intentionally not self-referential: it configures only the `processDefinitionKey` MDC property, stubs `execution.getProcessDefinitionKey()` with a concrete value, asserts that the value is written to MDC, and verifies that `execution.getProcessDefinition()` is never called.

## Backport attribution

Backported and adapted from Fluxnova:

- Source commit: https://github.com/finos/fluxnova-bpm-platform/commit/705979e55288c506eb37e30408910d2ee9ee47ad
- Also seen as the same fix in Fluxnova commit: https://github.com/finos/fluxnova-bpm-platform/commit/9cc0f792c8901f91969c272f599721fa4219f68f
- Original author: Mannuru, ReddyKishore <ReddyKishore.Mannuru@fmr.com>

Adaptation notes:

- Namespace adapted from Fluxnova to Operaton.
- Added an Operaton-owned JUnit 5 unit test with AssertJ/Mockito.

## Verification

- `git diff --check`
- `./mvnw -pl engine -Dskip.frontend.build=true -Dtest=ProcessDataContextTest test`
