### PR TITLE
fix(engine): handle form key evaluation failures

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/EnginePersistenceLogger.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/EnginePersistenceLogger.java
@@ -807,6 +807,16 @@ public class EnginePersistenceLogger extends ProcessEngineLogger {
     );
   }
 
+  public void logFormKeyExpressionEvaluationException(String taskId, String expression, Exception cause) {
+    logWarn(
+      "111",
+      "Failed to evaluate form key expression '{}' for task '{}'. The form key will be set to null. Cause: {}",
+      expression,
+      taskId,
+      cause.getMessage()
+    );
+  }
+
   // exception code 110 is already taken. See requiredOperatonAdminOrPermissionException() for details.
 
   public static List<SQLException> findRelatedSqlExceptions(Throwable exception) {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/persistence/entity/TaskEntity.java
@@ -1451,7 +1451,12 @@ public class TaskEntity extends AbstractVariableScope implements Task, DelegateT
   private void initializeFormKeyFromTaskDefinition(TaskDefinition taskDef) {
     Expression taskDefFormKey = taskDef.getFormKey();
     if (taskDefFormKey != null) {
-      this.formKey = (String) taskDefFormKey.getValue(this);
+      try {
+        this.formKey = (String) taskDefFormKey.getValue(this);
+      } catch (Exception e) {
+        LOG.logFormKeyExpressionEvaluationException(id, taskDefFormKey.getExpressionText(), e);
+        this.formKey = null;
+      }
     } else {
       initializeFormRefFromTaskDefinition(taskDef);
     }

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/task/TaskQueryTest.java
@@ -4969,6 +4969,36 @@ class TaskQueryTest {
       .hasMessage("ENGINE-03052 The form key / form reference is not initialized. You must call initializeFormKeys() on the task query before you can retrieve the form key or the form reference.");
   }
 
+  @Deployment(resources = {"org/operaton/bpm/engine/test/api/task/oneTaskWithInvalidFormKeyExpressionProcess.bpmn20.xml"})
+  @Test
+  void testInitializeFormKeyWithInvalidExpressionReturnsNullForSingleTask() {
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("invalidFormKeyExpressionProcess");
+
+    Task task = taskService.createTaskQuery()
+      .processInstanceId(processInstance.getId())
+      .initializeFormKeys()
+      .singleResult();
+
+    assertThat(task).isNotNull();
+    assertThat(task.getFormKey()).isNull();
+  }
+
+  @Deployment(resources = {"org/operaton/bpm/engine/test/api/task/oneTaskWithInvalidFormKeyExpressionProcess.bpmn20.xml"})
+  @Test
+  void testInitializeFormKeyWithInvalidExpressionDoesNotBlockTaskListRetrieval() {
+    runtimeService.startProcessInstanceByKey("invalidFormKeyExpressionProcess");
+    runtimeService.startProcessInstanceByKey("invalidFormKeyExpressionProcess");
+
+    List<Task> tasks = taskService.createTaskQuery()
+      .processDefinitionKey("invalidFormKeyExpressionProcess")
+      .initializeFormKeys()
+      .list();
+
+    assertThat(tasks)
+      .hasSize(2)
+      .allSatisfy(task -> assertThat(task.getFormKey()).isNull());
+  }
+
   @Test
   @Deployment
   void testInitializeFormKeysOperatonFormRef() {

--- a/engine/src/test/resources/org/operaton/bpm/engine/test/api/task/oneTaskWithInvalidFormKeyExpressionProcess.bpmn20.xml
+++ b/engine/src/test/resources/org/operaton/bpm/engine/test/api/task/oneTaskWithInvalidFormKeyExpressionProcess.bpmn20.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2026 the Operaton contributors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at:
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:operaton="http://operaton.org/schema/1.0/bpmn"
+  targetNamespace="Examples">
+
+  <process id="invalidFormKeyExpressionProcess" name="Invalid Form Key Expression Process" isExecutable="true">
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+    <userTask id="theTask" name="my task" operaton:formKey="${nonExistentVariable}" />
+    <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+  </process>
+
+</definitions>


### PR DESCRIPTION
## Summary

This backports a Fluxnova engine fix for `TaskQuery#initializeFormKeys()`: if evaluating a task `formKey` expression fails, task retrieval continues and the task's form key is initialized as `null`.

## Problem

`TaskEntity#initializeFormKeyFromTaskDefinition` currently evaluates the BPMN user task form key expression directly:

```java
this.formKey = (String) taskDefFormKey.getValue(this);
```

That means a task query using `initializeFormKeys()` can fail while retrieving tasks if one task's form key expression references missing data, for example `${nonExistentVariable}`. This is especially awkward for task-list style queries: the task itself exists and is queryable, but asking the query to initialize form keys can make the whole retrieval fail.

## Fix

Wrap form key expression evaluation in `try/catch`:

- successful expressions keep the existing behavior and set the evaluated form key,
- failed expressions are logged as a warning,
- the task is still returned with `formKey == null`.

The change is intentionally limited to `formKey` expression initialization. Operaton Form Ref handling remains unchanged.

## Test coverage

Added a BPMN process with `operaton:formKey="${nonExistentVariable}"` and two focused `TaskQueryTest` cases:

- `testInitializeFormKeyWithInvalidExpressionReturnsNullForSingleTask`
- `testInitializeFormKeyWithInvalidExpressionDoesNotBlockTaskListRetrieval`

These tests are not self-referential: they deploy an actual BPMN user task whose `operaton:formKey` expression fails at runtime because the referenced variable is absent. The assertions prove that `initializeFormKeys()` returns the task(s) and that `getFormKey()` is initialized to `null` instead of propagating the expression evaluation exception.

Existing positive behavior was also checked with the current form-key/form-ref tests.

## Backport attribution

Backported and adapted from Fluxnova:

- Source commit: https://github.com/finos/fluxnova-bpm-platform/commit/0e8e2ec390e322d8c93bf4e1ef7224fb38f721eb
- Original author: Sowmya, HL <Sowmya.HL@fmr.com>

Adaptation notes:

- Namespace adapted from Fluxnova to Operaton.
- BPMN extension namespace adapted to `operaton:formKey`.
- Tests adapted to Operaton's JUnit 5 + AssertJ style.
- Added an Operaton header to the new BPMN test resource.

## Verification

- `git diff --check`
- `./mvnw -pl engine -Dskip.frontend.build=true -Dtest=TaskQueryTest#testInitializeFormKeyWithInvalidExpressionReturnsNullForSingleTask+testInitializeFormKeyWithInvalidExpressionDoesNotBlockTaskListRetrieval test`
- `./mvnw -pl engine -Dskip.frontend.build=true -Dtest=TaskQueryTest#testInitializeFormKeys+testInitializeFormKeysOperatonFormRef+testInitializeFormKeysForCaseInstance test`
