### PR TITLE
chore(wildfly): remove obsolete sun.jdk module dependencies

### DIFF
--- a/distro/wildfly/modules/src/main/modules/org/apache/groovy/groovy-all/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/apache/groovy/groovy-all/main/module.xml
@@ -11,7 +11,6 @@
 
   <dependencies>
     <module name="javax.api" />
-    <module name="sun.jdk" />
     <module name="org.operaton.spin.operaton-spin-core" />
   </dependencies>
 </module>

--- a/distro/wildfly/modules/src/main/modules/org/camunda/feel/feel-engine/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/camunda/feel/feel-engine/main/module.xml
@@ -4,7 +4,6 @@
   </resources>
 
   <dependencies>
-    <module name="sun.jdk" />
     <module name="org.slf4j" />
     <!-- Needed for feel-engine 1.20.0+ due to jackson-module-scala -->
     <module name="org.scala-lang.scala-library" />

--- a/distro/wildfly/modules/src/main/modules/org/graalvm/js/js-all/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/graalvm/js/js-all/main/module.xml
@@ -19,7 +19,6 @@
     <module name="java.base" />
     <module name="java.management" />
     <module name="jdk.unsupported" />
-    <module name="sun.jdk" />
     <module name="java.scripting" />
     <module name="org.operaton.spin.operaton-spin-core" />
   </dependencies>

--- a/distro/wildfly/modules/src/main/modules/org/operaton/bpm/dmn/operaton-engine-feel-scala/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/operaton/bpm/dmn/operaton-engine-feel-scala/main/module.xml
@@ -5,7 +5,6 @@
 
   <dependencies>
     <module name="org.slf4j" />
-    <module name="sun.jdk" />
     <module name="org.operaton.bpm.dmn.operaton-engine-feel-api" />
     <module name="org.operaton.commons.operaton-commons-typed-values" />
     <module name="org.operaton.commons.operaton-commons-logging" />

--- a/distro/wildfly/modules/src/main/modules/org/operaton/bpm/identity/operaton-identity-ldap/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/operaton/bpm/identity/operaton-identity-ldap/main/module.xml
@@ -5,8 +5,6 @@
 
   <dependencies>
 
-    <module name="sun.jdk" />
-
     <module name="java.base" />
     <module name="java.naming" />
     <module name="org.operaton.bpm.operaton-engine" />

--- a/distro/wildfly/modules/src/main/modules/org/operaton/bpm/operaton-engine/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/operaton/bpm/operaton-engine/main/module.xml
@@ -28,8 +28,6 @@
     <module name="org.apache.groovy.groovy-all" services="import"/>
     <module name="org.graalvm.js.js-all" services="import"/>
 
-    <module name="sun.jdk" services="import"/>
-
     <module name="org.operaton.bpm.model.operaton-xml-model" />
     <module name="org.operaton.bpm.model.operaton-bpmn-model" />
     <module name="org.operaton.bpm.model.operaton-cmmn-model" />

--- a/distro/wildfly/modules/src/main/modules/org/operaton/bpm/wildfly/operaton-wildfly-subsystem/main/module.xml
+++ b/distro/wildfly/modules/src/main/modules/org/operaton/bpm/wildfly/operaton-wildfly-subsystem/main/module.xml
@@ -44,8 +44,5 @@
 
     <module name="org.operaton.bpm.operaton-engine-plugins" optional="true" />
 
-    <!-- for LDAP plugin only -->
-    <module name="sun.jdk" />
-
   </dependencies>
 </module>

--- a/qa/wildfly-runtime/src/main/common/modules/org/jruby/jruby-complete/main/module.xml
+++ b/qa/wildfly-runtime/src/main/common/modules/org/jruby/jruby-complete/main/module.xml
@@ -6,7 +6,7 @@
   <dependencies>
     <module name="java.base" />
     <module name="java.logging" />
-    <module name="sun.jdk" />
+    <module name="jdk.unsupported" />
     <module name="org.operaton.spin.operaton-spin-core" />
   </dependencies>
 </module>

--- a/qa/wildfly-runtime/src/main/common/modules/org/operaton/bpm/operaton-engine/main/module.xml
+++ b/qa/wildfly-runtime/src/main/common/modules/org/operaton/bpm/operaton-engine/main/module.xml
@@ -28,8 +28,6 @@
     <module name="org.jruby.jruby-complete" services="import"/>
     <module name="org.graalvm.js.js-all" services="import"/>
 
-    <module name="sun.jdk" services="import"/>
-
     <module name="org.operaton.bpm.model.operaton-xml-model" />
     <module name="org.operaton.bpm.model.operaton-bpmn-model" />
     <module name="org.operaton.bpm.model.operaton-cmmn-model" />

--- a/qa/wildfly-runtime/src/main/common/modules/org/operaton/bpm/wildfly/operaton-wildfly-subsystem/main/module.xml
+++ b/qa/wildfly-runtime/src/main/common/modules/org/operaton/bpm/wildfly/operaton-wildfly-subsystem/main/module.xml
@@ -47,8 +47,5 @@
     <module name="org.operaton.connect.operaton-connect-http-client" services="import" />
     <module name="org.operaton.connect.operaton-connect-soap-http-client" services="import" />
 
-    <!-- for LDAP plugin only -->
-    <module name="sun.jdk" />
-
   </dependencies>
 </module>


### PR DESCRIPTION
## Summary

This backports and adapts the CIBSeven WildFly cleanup for obsolete `sun.jdk` module dependencies.

The Operaton adaptation is deliberately not a blind `sun.jdk` -> `jdk.unsupported` replacement. Most legacy `sun.jdk` entries were broad stale module dependencies and are removed outright.

## Problem

`sun.jdk` is a legacy JBoss Modules dependency for JDK-internal APIs. Keeping it in module descriptors makes the WildFly module graph look like Operaton depends broadly on old internal JDK packages even where no such dependency is required.

Operaton still had `sun.jdk` references in WildFly distro modules and QA WildFly runtime modules.

## Fix

Removed obsolete `sun.jdk` dependencies from:

- Groovy module
- FEEL engine module
- Operaton FEEL Scala module
- Operaton LDAP module
- Operaton engine module
- Operaton WildFly subsystem module
- consolidated GraalVM JS module
- QA Operaton engine module
- QA Operaton WildFly subsystem module

For QA JRuby only, replaced `sun.jdk` with `jdk.unsupported`.

## Why not replace everything with `jdk.unsupported`?

`jdk.unsupported` is not a clean general-purpose replacement for `sun.jdk`; it should only be declared when the module actually needs APIs such as `sun.misc.Unsafe` or `sun.misc.Signal`.

I checked this with `jdeps`:

- `operaton-engine` does not report JDK-internal API usage.
- Groovy does not report JDK-internal API usage for the checked WildFly module jars.
- `jruby-complete-9.1.17.0.jar` does report `sun.misc.Unsafe`, `sun.misc.Signal`, and `sun.misc.SignalHandler` via `jdeps -jdkinternals`, so the QA JRuby module keeps an explicit `jdk.unsupported` dependency.
- The consolidated GraalVM JS module already had `jdk.unsupported`; this PR only removes its stale additional `sun.jdk` dependency.

## Operaton adaptation notes

CIBSeven has a separate `wildfly28` distribution and a separate `com.ibm.icu.icu4j` module. Operaton does not have `wildfly28`, and its WildFly module layout consolidates GraalVM JS dependencies into `org.graalvm.js.js-all`, where `icu4j` is already a resource root. Therefore this PR does not introduce a new ICU module or a Groovy -> ICU module dependency that would not exist in Operaton's module tree.

## Backport attribution

Backported and adapted from CIBSeven:

- CIBSeven PR: https://github.com/cibseven/cibseven/pull/276
- Source commit: https://github.com/cibseven/cibseven/commit/87e3b58ddaca75d4cc20f804461d7b4596beb817
- Original author: Fernando Mambrilla <fernandom@cib.de>

## Verification

- `rg -n "sun\.jdk" distro/wildfly/modules/src/main/modules qa/wildfly-runtime/src/main/common/modules -S` returns no matches.
- `git diff --check`
- `./mvnw -P distro-wildfly -pl distro/wildfly/modules -DskipTests -Dskip.frontend.build=true verify`
- `find qa/wildfly-runtime/src/main/common/modules -name module.xml -print0 | xargs -0 xmllint --noout`
