### PR TITLE
chore: clean up removed telemetry sending remnants

### DIFF
--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/telemetry/TelemetryConfigurationDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/telemetry/TelemetryConfigurationDto.ftl
@@ -5,7 +5,7 @@
         name = "enableTelemetry"
         type = "boolean"
         last = true
-        desc = "Specifies if the telemetry data should be sent or not."/>
+        desc = "Deprecated. Telemetry sending has been removed; this value is retained only for backwards compatibility and is always false when read."/>
 
 </@lib.dto>
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/telemetry/TelemetryInternalsDto.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/models/org/operaton/bpm/engine/rest/dto/telemetry/TelemetryInternalsDto.ftl
@@ -54,8 +54,7 @@
         format = "date-time"
         nullable = false
         last = true
-        desc = "The date when the engine started to collect dynamic data, such as command executions and metrics. If telemetry sending is enabled, dynamic data resets on sending the data to Operaton.
-                Dynamic data and the date returned by this method are reset in three cases: engine startup, after engine start when sending telemetry data to Operaton is enabled via API, after sending telemetry data to Operaton (only when this was enabled)
+        desc = "The date when the engine started to collect local diagnostics data, such as command executions and metrics. Fetching diagnostics data through the compatibility telemetry endpoint does not reset the counters or this timestamp.
                 The date is in the format <code>YYYY-MM-DD'T'HH:mm:ss.SSSZ</code>."/>
 
 </@lib.dto>

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/telemetry/configuration/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/telemetry/configuration/get.ftl
@@ -4,8 +4,9 @@
   <@lib.endpointInfo
       id = "getTelemetryConfiguration"
       tag = "Telemetry"
+      deprecated = true
       summary = "Fetch Telemetry Configuration"
-      desc = "Fetches Telemetry Configuration." />
+      desc = "Deprecated: The sending telemetry feature is removed. This endpoint is retained for backwards compatibility and always reports telemetry as disabled." />
 
   "parameters" : [],
 
@@ -19,7 +20,7 @@
                        "summary": "Status 200 Response",
                        "description": "The Response content of a status 200",
                        "value": {
-                           "enableTelemetry": true
+                           "enableTelemetry": false
                          }
                      }'] />
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/telemetry/configuration/post.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/telemetry/configuration/post.ftl
@@ -6,7 +6,7 @@
       tag = "Telemetry"
       deprecated = true
       summary = "Configure Telemetry"
-      desc = "Deprecated: The sending telemetry feature is removed. Please remove the endpoint usages as they are no longer needed." />
+      desc = "Deprecated: The sending telemetry feature is removed. This endpoint is retained for backwards compatibility and ignores the requested value." />
 
   "parameters" : [],
 
@@ -17,7 +17,7 @@
                      "summary": "POST /telemetry/configuration",
                      "description": "The content of the Request Body",
                      "value": {
-                         "enableTelemetry": true
+                         "enableTelemetry": false
                        }
                      }'] />
 

--- a/engine-rest/engine-rest-openapi/src/main/templates/paths/telemetry/data/get.ftl
+++ b/engine-rest/engine-rest-openapi/src/main/templates/paths/telemetry/data/get.ftl
@@ -6,7 +6,7 @@
       tag = "Telemetry"
       deprecated = true
       summary = "Fetch Telemetry Data"
-      desc = "Deprecated: Always returns false. The sending telemetry feature is removed. Please remove the endpoint usages as they are no longer needed." />
+      desc = "Deprecated: The sending telemetry feature is removed. This endpoint is retained for diagnostics and returns the data collected locally by the engine." />
 
   "parameters" : [],
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -956,7 +956,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   // OLEs for foreign key constraint violations on databases that rollback on SQL exceptions, e.g. PostgreSQL
   protected boolean enableOptimisticLockingOnForeignKeyViolation = true;
 
-  protected int telemetryRequestTimeout;
   protected TelemetryDataImpl telemetryData;
   protected DiagnosticsRegistry diagnosticsRegistry;
   protected DiagnosticsCollector diagnosticsCollector;
@@ -5242,15 +5241,6 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public ProcessEngineConfigurationImpl setTelemetryData(TelemetryDataImpl telemetryData) {
     this.telemetryData = telemetryData;
-    return this;
-  }
-
-  public int getTelemetryRequestTimeout() {
-    return telemetryRequestTimeout;
-  }
-
-  public ProcessEngineConfigurationImpl setTelemetryRequestTimeout(int telemetryRequestTimeout) {
-    this.telemetryRequestTimeout = telemetryRequestTimeout;
     return this;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/telemetry/ApplicationServer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/telemetry/ApplicationServer.java
@@ -21,7 +21,8 @@ package org.operaton.bpm.engine.telemetry;
  * about the application server.
  *
  * <p>
- * This information is sent to Operaton when telemetry is enabled.
+ * This information is exposed as local diagnostics data through the legacy
+ * telemetry API.
  * </p>
  *
  * @see <a href=

--- a/engine/src/main/java/org/operaton/bpm/engine/telemetry/Command.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/telemetry/Command.java
@@ -20,18 +20,18 @@ import org.operaton.bpm.engine.ManagementService;
 
 /**
  * This class represents the data structure used for collecting information
- * about executed commands for telemetry data. A command is an action usually
+ * about executed commands for diagnostics data. A command is an action usually
  * triggered by a user and performed by the engine. This class counts the number
  * of executions per command.
  *
  * <p>
- * This information is sent to Operaton when telemetry is enabled.
+ * This information is exposed as local diagnostics data through the legacy
+ * telemetry API.
  * </p>
  *
  * <p>
- * When used for telemetry data collection, all command execution counts reset
- * on sending the data. Retrieval through
- * {@link ManagementService#getTelemetryData()} will not reset the counter.
+ * Retrieval through {@link ManagementService#getTelemetryData()} will not reset
+ * the counter.
  * </p>
  *
  * @see <a href=

--- a/engine/src/main/java/org/operaton/bpm/engine/telemetry/Database.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/telemetry/Database.java
@@ -21,7 +21,8 @@ package org.operaton.bpm.engine.telemetry;
  * about the connected database.
  *
  * <p>
- * This information is sent to Operaton when telemetry is enabled.
+ * This information is exposed as local diagnostics data through the legacy
+ * telemetry API.
  * </p>
  *
  * @see <a href=

--- a/engine/src/main/java/org/operaton/bpm/engine/telemetry/Internals.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/telemetry/Internals.java
@@ -27,7 +27,8 @@ import org.operaton.bpm.engine.ManagementService;
  * metrics and the technical environment in which Operaton is set-up.
  *
  * <p>
- * This information is sent to Operaton when telemetry is enabled.
+ * This information is exposed as local diagnostics data through the legacy
+ * telemetry API.
  * </p>
  *
  * @see <a href=
@@ -48,26 +49,11 @@ public interface Internals {
 
   /**
    * The date when the engine started to collect dynamic data, such as command executions
-   * and metrics. If telemetry sending is enabled, dynamic data resets on sending the data
-   * to Operaton.
+   * and metrics.
    *
    * <p>
-   * This method returns a date that represents the date and time when the dynamic data collected
-   * for telemetry is reset. Dynamic data and the date returned by this method are reset in three
-   * cases:
-   * </p>
-   *
-   * <p>
-   * <ul>
-   *   <li>At engine startup, the date is set to the current time, even if telemetry is disabled.
-   *       It is then only used by the telemetry Query API that returns the currently collected
-   *       data but sending telemetry to Operaton is disabled.</li>
-   *   <li>When sending telemetry to Operaton is enabled after engine start via API (e.g.,
-   *       {@link ManagementService#toggleTelemetry(boolean)}. This call causes the engine to wipe
-   *       all dynamic data and therefore the collection date is reset to the current time.</li>
-   *   <li>When sending telemetry to Operaton is enabled, after sending the data, all existing dynamic
-   *       data is wiped and therefore the collection date is reset to the current time.</li>
-   * </ul>
+   * This method returns a date that represents when local diagnostics data
+   * collection started.
    * </p>
    *
    * @return A date that represents the start of the time frame where the current telemetry
@@ -77,9 +63,8 @@ public interface Internals {
 
   /**
    * Information about the number of command executions performed by the Operaton
-   * engine. If telemetry sending is enabled, the number of executions per
-   * command resets on sending the data to Operaton. Retrieving the data through
-   * {@link ManagementService#getTelemetryData()} will not reset the count.
+   * engine. Retrieving the data through {@link ManagementService#getTelemetryData()}
+   * will not reset the count.
    */
   Map<String, Command> getCommands();
 
@@ -92,9 +77,8 @@ public interface Internals {
    *   <li>The number of executed decision instances.</li>
    *   <li>The number of executed decision elements.</li>
    * </ul>
-   * The metrics reset on sending the data to Operaton. Retrieving the data
-   * through {@link ManagementService#getTelemetryData()} will not reset the
-   * count.
+   * Retrieving the data through {@link ManagementService#getTelemetryData()} will
+   * not reset the count.
    */
   Map<String, Metric> getMetrics();
 

--- a/engine/src/main/java/org/operaton/bpm/engine/telemetry/Jdk.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/telemetry/Jdk.java
@@ -21,7 +21,8 @@ package org.operaton.bpm.engine.telemetry;
  * about the installed Java runtime environment.
  *
  * <p>
- * This information is sent to Operaton when telemetry is enabled.
+ * This information is exposed as local diagnostics data through the legacy
+ * telemetry API.
  * </p>
  *
  * @see <a href=

--- a/engine/src/main/java/org/operaton/bpm/engine/telemetry/Metric.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/telemetry/Metric.java
@@ -20,19 +20,18 @@ import org.operaton.bpm.engine.ManagementService;
 
 /**
  * This class represents the data structure used for collecting information
- * about certain internal metrics for telemetry data. A metric is a counter for
+ * about certain internal metrics for diagnostics data. A metric is a counter for
  * a certain action performed by the engine (e.g., start a root
  * process-instance).
  *
  * <p>
- * This information is sent to Operaton when telemetry is enabled.
+ * This information is exposed as local diagnostics data through the legacy
+ * telemetry API.
  * </p>
  *
  * <p>
- * When used for telemetry data collection, all metric counts reset on sending
- * the data. Retrieval through {@link ManagementService#getTelemetryData()} will
- * not reset the counter. Some metrics are used for billing purposes in
- * enterprise setups.
+ * Retrieval through {@link ManagementService#getTelemetryData()} will not reset
+ * the counter.
  * </p>
  *
  * @see <a href=

--- a/engine/src/main/java/org/operaton/bpm/engine/telemetry/Product.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/telemetry/Product.java
@@ -21,7 +21,8 @@ package org.operaton.bpm.engine.telemetry;
  * product.
  *
  * <p>
- * This information is sent to Operaton when telemetry is enabled.
+ * This information is exposed as local diagnostics data through the legacy
+ * telemetry API.
  * </p>
  *
  * @see <a href=

--- a/engine/src/main/java/org/operaton/bpm/engine/telemetry/TelemetryData.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/telemetry/TelemetryData.java
@@ -22,13 +22,14 @@ import org.operaton.bpm.engine.ManagementService;
  * The engine collects information about multiple aspects of the installation.
  *
  * <p>
- * If telemetry is enabled this information is sent to Operaton. If telemetry is
- * disabled, the engine still collects this information and provides it through
- * {@link ManagementService#getTelemetryData()}.
+ * Telemetry sending has been removed. The engine still collects this local
+ * diagnostics information and provides it through
+ * {@link ManagementService#getTelemetryData()} for backwards compatibility.
  * </p>
  *
  * <p>
- * This class represents the data structure used to collect telemetry data.
+ * This class represents the data structure used to expose local diagnostics
+ * data through the legacy telemetry API.
  * </p>
  *
  * @see <a href=

--- a/engine/src/main/java/org/operaton/bpm/engine/telemetry/package-info.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/telemetry/package-info.java
@@ -1,6 +1,6 @@
 /**
- * Data transfer objects for engine telemetry and usage reporting.
+ * Data transfer objects for the legacy telemetry API and local diagnostics data.
  * Contains structured data about product information, metrics, internals, and commands
- * collected by the engine for telemetry purposes.
+ * collected by the engine for diagnostics purposes.
  */
 package org.operaton.bpm.engine.telemetry;

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/baseline/liquibase.db2.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/baseline/liquibase.db2.create.engine.sql
@@ -41,9 +41,6 @@ insert into ACT_GE_PROPERTY
 values ('startup.lock', '0', 1);
 
 insert into ACT_GE_PROPERTY
-values ('telemetry.lock', '0', 1);
-
-insert into ACT_GE_PROPERTY
 values ('installationId.lock', '0', 1);
 
 create table ACT_GE_BYTEARRAY (

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/baseline/liquibase.h2.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/baseline/liquibase.h2.create.engine.sql
@@ -41,9 +41,6 @@ insert into ACT_GE_PROPERTY
 values ('startup.lock', '0', 1);
 
 insert into ACT_GE_PROPERTY
-values ('telemetry.lock', '0', 1);
-
-insert into ACT_GE_PROPERTY
 values ('installationId.lock', '0', 1);
 
 create table ACT_GE_BYTEARRAY (

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/baseline/liquibase.mariadb.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/baseline/liquibase.mariadb.create.engine.sql
@@ -41,9 +41,6 @@ insert into ACT_GE_PROPERTY
 values ('startup.lock', '0', 1);
 
 insert into ACT_GE_PROPERTY
-values ('telemetry.lock', '0', 1);
-
-insert into ACT_GE_PROPERTY
 values ('installationId.lock', '0', 1);
 
 create table ACT_GE_BYTEARRAY (

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/baseline/liquibase.mssql.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/baseline/liquibase.mssql.create.engine.sql
@@ -41,9 +41,6 @@ insert into ACT_GE_PROPERTY
 values ('startup.lock', '0', 1);
 
 insert into ACT_GE_PROPERTY
-values ('telemetry.lock', '0', 1);
-
-insert into ACT_GE_PROPERTY
 values ('installationId.lock', '0', 1);
 
 create table ACT_GE_BYTEARRAY (

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/baseline/liquibase.mysql.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/baseline/liquibase.mysql.create.engine.sql
@@ -41,9 +41,6 @@ insert into ACT_GE_PROPERTY
 values ('startup.lock', '0', 1);
 
 insert into ACT_GE_PROPERTY
-values ('telemetry.lock', '0', 1);
-
-insert into ACT_GE_PROPERTY
 values ('installationId.lock', '0', 1);
 
 create table ACT_GE_BYTEARRAY (

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/baseline/liquibase.oracle.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/baseline/liquibase.oracle.create.engine.sql
@@ -41,9 +41,6 @@ insert into ACT_GE_PROPERTY
 values ('startup.lock', '0', 1);
 
 insert into ACT_GE_PROPERTY
-values ('telemetry.lock', '0', 1);
-
-insert into ACT_GE_PROPERTY
 values ('installationId.lock', '0', 1);
 
 create table ACT_GE_BYTEARRAY (

--- a/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/baseline/liquibase.postgres.create.engine.sql
+++ b/engine/src/main/resources/org/operaton/bpm/engine/db/liquibase/baseline/liquibase.postgres.create.engine.sql
@@ -41,9 +41,6 @@ insert into ACT_GE_PROPERTY
 values ('startup.lock', '0', 1);
 
 insert into ACT_GE_PROPERTY
-values ('telemetry.lock', '0', 1);
-
-insert into ACT_GE_PROPERTY
 values ('installationId.lock', '0', 1);
 
 create table ACT_GE_BYTEARRAY (

--- a/qa/test-old-engine/config/operaton.cfg.xml
+++ b/qa/test-old-engine/config/operaton.cfg.xml
@@ -32,9 +32,6 @@
 
     <property name="jdbcBatchProcessing" value="false"/>
 
-    <!-- telemetry configuration -->
-    <property name="telemetryEndpoint" value="http://localhost:8081/pings"/>
-
     <property name="enforceHistoryTimeToLive" value="false" />
 
   </bean>

--- a/webapps/frontend/operaton-bpm-sdk-js/lib/api-client/resources/telemetry.js
+++ b/webapps/frontend/operaton-bpm-sdk-js/lib/api-client/resources/telemetry.js
@@ -47,10 +47,11 @@ Telemetry.get = function (done) {
 };
 
 /**
- * Configures whether Operaton receives data collection of the process engine setup and usage.
+ * Deprecated. Telemetry sending has been removed; the endpoint is a no-op kept
+ * for backwards compatibility.
  *
  * @param  {Object}   payload                  is an object representation of an authorization
- * @param  {Boolean}  payload.enableTelemetry  Specifies if the data collection should be sent or not.
+ * @param  {Boolean}  payload.enableTelemetry  Deprecated no-op flag.
  * @param  {Function} done
  */
 Telemetry.configure = function (payload, done) {


### PR DESCRIPTION
## Summary
- remove remaining telemetry sending configuration remnants after the sender was removed
- stop creating `telemetry.lock` for fresh Liquibase baseline databases
- mark the legacy telemetry configuration REST endpoint as deprecated/no-op and document local diagnostics data accurately
- remove stale telemetry request timeout configuration and old test telemetry endpoint wiring

## Backport context
- Camunda 7 backport based on https://github.com/camunda/camunda-bpm-platform/issues/4483
- Original upstream PR: https://github.com/camunda/camunda-bpm-platform/pull/4486
- Backport inventory change unit: 4765

## Tests
- `git diff --check`
- `./mvnw -pl engine -DskipTests -Dskip.frontend.build=true -DskipChecks compile -q`
- `./mvnw -pl engine -Dtest=ManagementServiceTest#shouldAlwaysReturnFalseWhenFetchingIsTelemetryEnabled+shouldReturnFalseWhenToggleTelemetry,ManagementServiceGetTelemetryDataTest test -Dskip.frontend.build=true -q`
- `./mvnw -pl engine-rest/engine-rest -Dtest=TelemetryRestServiceTest test -Dskip.frontend.build=true -q`
