### PR TITLE
feat(engine): add root process instance id to MDC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,6 +361,7 @@ Camunda 7 or a Camunda 7-compatible fork.
 - Verify backport with full build: `./mvnw clean install`
 - Run integration tests if dependencies changed
 - License headers in new files MUST be preserved from the source commit
+- New public API classes and methods must be annotated with `@since MAJOR.MINOR`, using MAJOR and MINOR from the version in `/pom.xml`
 
 ## Common Development Workflows
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -947,6 +947,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected String loggingContextProcessDefinitionId = "processDefinitionId";
   protected String loggingContextProcessDefinitionKey;// default == null => disabled by default
   protected String loggingContextProcessInstanceId = "processInstanceId";
+  /**
+   * @since 2.2
+   */
   protected String loggingContextRootProcessInstanceId = "rootProcessInstanceId";
   protected String loggingContextTenantId = "tenantId";
   protected String loggingContextEngineName = "engineName";
@@ -1743,6 +1746,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         return MARIA_DB_PRODUCT_NAME;
       }
     } catch (SQLException ignore) {
+      // ignored
     }
 
     try {
@@ -1751,6 +1755,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
         return MARIA_DB_PRODUCT_NAME;
       }
     } catch (SQLException ignore) {
+      // ignored
     }
 
     String metaDataClassName = databaseMetaData.getClass().getName();
@@ -5167,10 +5172,16 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     return this;
   }
 
+  /**
+   * @since 2.2
+   */
   public String getLoggingContextRootProcessInstanceId() {
     return loggingContextRootProcessInstanceId;
   }
 
+  /**
+   * @since 2.2
+   */
   public ProcessEngineConfigurationImpl setLoggingContextRootProcessInstanceId(String loggingContextRootProcessInstanceId) {
     this.loggingContextRootProcessInstanceId = loggingContextRootProcessInstanceId;
     return this;

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -947,6 +947,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected String loggingContextProcessDefinitionId = "processDefinitionId";
   protected String loggingContextProcessDefinitionKey;// default == null => disabled by default
   protected String loggingContextProcessInstanceId = "processInstanceId";
+  protected String loggingContextRootProcessInstanceId = "rootProcessInstanceId";
   protected String loggingContextTenantId = "tenantId";
   protected String loggingContextEngineName = "engineName";
 
@@ -5163,6 +5164,15 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public ProcessEngineConfigurationImpl setLoggingContextProcessInstanceId(String loggingContextProcessInstanceId) {
     this.loggingContextProcessInstanceId = loggingContextProcessInstanceId;
+    return this;
+  }
+
+  public String getLoggingContextRootProcessInstanceId() {
+    return loggingContextRootProcessInstanceId;
+  }
+
+  public ProcessEngineConfigurationImpl setLoggingContextRootProcessInstanceId(String loggingContextRootProcessInstanceId) {
+    this.loggingContextRootProcessInstanceId = loggingContextRootProcessInstanceId;
     return this;
   }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/ProcessDataContext.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/interceptor/ProcessDataContext.java
@@ -51,6 +51,7 @@ import org.operaton.commons.logging.MdcAccess;
  * <li>loggingContextBusinessKey - the context property for the business key</li>
  * <li>loggingContextDefinitionId - the context property for the definition id</li>
  * <li>loggingContextProcessInstanceId - the context property for the instance id</li>
+ * <li>loggingContextRootProcessInstanceId - the context property for the root process instance id</li>
  * <li>loggingContextTenantId - the context property for the tenant id</li>
  * </ul>
  * </p>
@@ -66,6 +67,7 @@ public class ProcessDataContext {
   protected String mdcPropertyDefinitionId;
   protected String mdcPropertyDefinitionKey;
   protected String mdcPropertyInstanceId;
+  protected String mdcPropertyRootProcessInstanceId;
   protected String mdcPropertyTenantId;
   protected String mdcPropertyEngineName;
 
@@ -115,6 +117,7 @@ public class ProcessDataContext {
     mdcPropertyDefinitionId = initProperty(configuration::getLoggingContextProcessDefinitionId);
     mdcPropertyDefinitionKey = initProperty(configuration::getLoggingContextProcessDefinitionKey);
     mdcPropertyInstanceId = initProperty(configuration::getLoggingContextProcessInstanceId);
+    mdcPropertyRootProcessInstanceId = initProperty(configuration::getLoggingContextRootProcessInstanceId);
     mdcPropertyTenantId = initProperty(configuration::getLoggingContextTenantId);
     mdcPropertyEngineName = initProperty(configuration::getLoggingContextEngineName);
 
@@ -144,6 +147,7 @@ public class ProcessDataContext {
     parkExternalMDCProperty(configuration::getLoggingContextProcessDefinitionId);
     parkExternalMDCProperty(configuration::getLoggingContextProcessDefinitionKey);
     parkExternalMDCProperty(configuration::getLoggingContextProcessInstanceId);
+    parkExternalMDCProperty(configuration::getLoggingContextRootProcessInstanceId);
     parkExternalMDCProperty(configuration::getLoggingContextTenantId);
     parkExternalMDCProperty(configuration::getLoggingContextEngineName);
   }
@@ -195,6 +199,7 @@ public class ProcessDataContext {
     addToStack(execution.getCurrentActivityName(), mdcPropertyActivityName);
     addToStack(execution.getProcessDefinitionId(), mdcPropertyDefinitionId);
     addToStack(execution.getProcessInstanceId(), mdcPropertyInstanceId);
+    addToStack(execution.getRootProcessInstanceId(), mdcPropertyRootProcessInstanceId);
     addToStack(execution.getTenantId(), mdcPropertyTenantId);
     addToStack(execution.getProcessEngine().getName(), mdcPropertyEngineName);
 

--- a/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
@@ -116,6 +116,7 @@ class ProcessDataLoggingContextTest {
       .setLoggingContextBusinessKey("businessKey")
       .setLoggingContextProcessDefinitionId("processDefinitionId")
       .setLoggingContextProcessInstanceId("processInstanceId")
+      .setLoggingContextRootProcessInstanceId("rootProcessInstanceId")
       .setLoggingContextTenantId("tenantId")
       .setLoggingContextEngineName("engineName");
   }
@@ -162,6 +163,42 @@ class ProcessDataLoggingContextTest {
     assertActivityLogsPresent(instance, List.of("start", "waitState", "end"));
     // other logs do not contain MDC properties
     assertActivityLogsPresentWithoutMdc("ENGINE-130");
+  }
+
+  @Test
+  @WatchLogger(loggerNames = PVM_LOGGER, level = "DEBUG")
+  void shouldLogRootProcessInstanceIdInActivityContext() {
+    // given
+    manageDeployment(modelOneTaskProcess());
+
+    // when
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    taskService.complete(taskService.createTaskQuery().singleResult().getId());
+
+    // then
+    assertThat(loggingRule.getFilteredLog("ENGINE-200"))
+        .isNotEmpty()
+        .allSatisfy(logEvent -> assertThat(logEvent.getMDCPropertyMap())
+            .containsEntry("rootProcessInstanceId", instance.getRootProcessInstanceId()));
+  }
+
+  @Test
+  @WatchLogger(loggerNames = PVM_LOGGER, level = "DEBUG")
+  void shouldLogCustomRootProcessInstanceIdMdcProperty() {
+    // given
+    engineRule.getProcessEngineConfiguration().setLoggingContextRootProcessInstanceId("rootInstId");
+    manageDeployment(modelOneTaskProcess());
+
+    // when
+    ProcessInstance instance = runtimeService.startProcessInstanceByKey(PROCESS, B_KEY);
+    taskService.complete(taskService.createTaskQuery().singleResult().getId());
+
+    // then
+    assertThat(loggingRule.getFilteredLog("ENGINE-200"))
+        .isNotEmpty()
+        .allSatisfy(logEvent -> assertThat(logEvent.getMDCPropertyMap())
+            .containsEntry("rootInstId", instance.getRootProcessInstanceId())
+            .doesNotContainKey("rootProcessInstanceId"));
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/logging/ProcessDataLoggingContextTest.java
@@ -96,29 +96,24 @@ class ProcessDataLoggingContextTest {
   }
 
   @AfterEach
-  void resetClock() {
-    ClockUtil.reset();
-    testMDCFacade.clear();
-  }
-
-  @AfterEach
   void tearDown() {
     if (defaultEngineRegistered) {
       runtimeContainerDelegate.unregisterProcessEngine(engineRule.getProcessEngine());
     }
-  }
+    // reset clock
+    ClockUtil.reset();
+    testMDCFacade.clear();
 
-  @AfterEach
-  void resetLogConfiguration() {
+    // resetLogConfiguration
     engineRule.getProcessEngineConfiguration()
-      .setLoggingContextActivityId("activityId")
-      .setLoggingContextApplicationName("applicationName")
-      .setLoggingContextBusinessKey("businessKey")
-      .setLoggingContextProcessDefinitionId("processDefinitionId")
-      .setLoggingContextProcessInstanceId("processInstanceId")
-      .setLoggingContextRootProcessInstanceId("rootProcessInstanceId")
-      .setLoggingContextTenantId("tenantId")
-      .setLoggingContextEngineName("engineName");
+            .setLoggingContextActivityId("activityId")
+            .setLoggingContextApplicationName("applicationName")
+            .setLoggingContextBusinessKey("businessKey")
+            .setLoggingContextProcessDefinitionId("processDefinitionId")
+            .setLoggingContextProcessInstanceId("processInstanceId")
+            .setLoggingContextRootProcessInstanceId("rootProcessInstanceId")
+            .setLoggingContextTenantId("tenantId")
+            .setLoggingContextEngineName("engineName");
   }
 
   @Test


### PR DESCRIPTION

## Summary

Adds `rootProcessInstanceId` to the process-data MDC logging context so engine activity logs can be correlated across call-activity process hierarchies.

## Problem

Operaton already writes process data such as process instance id, process definition id, activity id, business key, tenant id, and engine name into the MDC while process execution logs are emitted. For executions that are part of a called process hierarchy, the local `processInstanceId` alone is not enough to correlate all related log lines back to the top-level process instance.

## Implementation Notes

This backport adds a configurable MDC property `loggingContextRootProcessInstanceId`, defaulting to `rootProcessInstanceId`, and writes `execution.getRootProcessInstanceId()` into the process-data logging context.

The Operaton adaptation also parks and restores externally provided MDC values for the new key, matching the existing behavior for the other process-data MDC properties. Setting the property to `null` disables it in the same way as the existing configurable MDC fields.

## Validation

Executed:

```bash
./mvnw -pl engine -Dskip.frontend.build=true -Dtest="ProcessDataLoggingContextTest#shouldLogRootProcessInstanceIdInActivityContext+shouldLogCustomRootProcessInstanceIdMdcProperty" test
```

Result: 2 tests passed.

Coverage added for:

- default `rootProcessInstanceId` MDC key
- custom MDC key via `setLoggingContextRootProcessInstanceId(...)`
- absence of the default key when a custom key is configured

## Attribution

Backported and adapted from Fluxnova:

- https://github.com/finos/fluxnova-bpm-platform/commit/241c3e1422390c62fcabb1ef4b99f2eb61efbee3
- https://github.com/finos/fluxnova-bpm-platform/commit/2442d26ecad8bc4860ab1f5b27ac7b686e41bd95

Original author:

- Nandan <Nandan.shenoy@fmr.com>

This is adapted for Operaton and is not a byte-for-byte cherry-pick.
