### PR TITLE
fix(engine): register servlet process application deployer

### DIFF
--- a/engine/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
+++ b/engine/src/main/resources/META-INF/services/jakarta.servlet.ServletContainerInitializer
@@ -1,1 +1,2 @@
 org.operaton.bpm.application.impl.JakartaServletProcessApplicationDeployer
+org.operaton.bpm.application.impl.ServletProcessApplicationDeployer

--- a/engine/src/test/java/org/operaton/bpm/application/impl/ServletProcessApplicationDeployerServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/application/impl/ServletProcessApplicationDeployerServiceTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.application.impl;
+
+import java.util.ServiceLoader;
+
+import jakarta.servlet.ServletContainerInitializer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ServletProcessApplicationDeployerServiceTest {
+
+  @Test
+  void shouldRegisterBothJakartaServletContainerInitializers() {
+    assertThat(ServiceLoader.load(ServletContainerInitializer.class))
+        .map(Object::getClass)
+        .contains(JakartaServletProcessApplicationDeployer.class, ServletProcessApplicationDeployer.class);
+  }
+
+}


### PR DESCRIPTION
## Summary

Registers `ServletProcessApplicationDeployer` as a Jakarta `ServletContainerInitializer` service alongside `JakartaServletProcessApplicationDeployer`.

## Problem

After the Jakarta servlet migration, Operaton still has two servlet process application APIs/deployers that both use the `jakarta.servlet.*` namespace:

- `JakartaServletProcessApplication` / `JakartaServletProcessApplicationDeployer`
- `ServletProcessApplication` / `ServletProcessApplicationDeployer`

Both deployers implement `jakarta.servlet.ServletContainerInitializer`, but the service provider file only registered `JakartaServletProcessApplicationDeployer`. Servlet containers that rely on SPI discovery therefore only see one initializer. That means applications extending `ServletProcessApplication` are not discovered through the matching deployer, even though that class is also Jakarta-based in Operaton.

This is not about restoring `javax.servlet.*` support. Operaton has removed the `javax` namespace here; the missing piece is only the SPI registration for the existing `jakarta.servlet`-based `ServletProcessApplicationDeployer` class.

## Implementation Notes

This PR adds the missing service entry:

```text
org.operaton.bpm.application.impl.ServletProcessApplicationDeployer
```

The Operaton backport intentionally extracts only this focused registration fix from the larger EximeeBPMS BPMS-157 dependency/runtime update. No dependency updates or runtime distribution changes are included.

## Validation

Executed:

```bash
./mvnw -pl engine -Dskip.frontend.build=true -Dtest=ServletProcessApplicationDeployerServiceTest test
```

Result: 1 test passed.

Coverage added for:

- `ServiceLoader.load(ServletContainerInitializer.class)` discovers both servlet process application deployers
- the test uses the actual `META-INF/services/jakarta.servlet.ServletContainerInitializer` resource rather than duplicating the production list in test code

## Attribution

Backported and extracted from EximeeBPMS:

- https://github.com/EximeeBPMS/eximeebpms/commit/82d60dfc506cf62c3142d13c701ee6d177ca5131

Original author:

- Robert Mastalerek <robert.mastalerek@gmail.com>

This is adapted for Operaton and keeps only the servlet initializer registration fix from the broader upstream change.