### PR TITLE
chore(build): update Node.js and npm versions

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -54,8 +54,8 @@
     <version.logback>1.5.34</version.logback>
     <version.freemarker>2.3.34</version.freemarker>
     <version.jboss-javaee-spec>3.0.2.Final</version.jboss-javaee-spec>
-    <version.nodejs>22.13.0</version.nodejs>
-    <version.npm>11.0.0</version.npm>
+    <version.nodejs>24.14.0</version.nodejs>
+    <version.npm>11.8.0</version.npm>
     <jacoco.argLine/>
     <surefire.memArgs>-Xmx1024m -XX:MetaspaceSize=128m</surefire.memArgs>
     <surefire.argLine>${jacoco.argLine} ${surefire.memArgs} -Duser.language=en -Duser.region=US -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=${project.build.directory}/heap_dump.hprof</surefire.argLine>


### PR DESCRIPTION
## What changed

Updates the frontend Maven toolchain baseline used by `frontend-maven-plugin`:

- Node.js `22.13.0` -> `24.14.0`
- npm `11.0.0` -> `11.8.0`

This is an Operaton-adapted combined backport: Fluxnova has the newer Node.js 24.14.0 bump, while CIBSeven carries the npm 11.8.0 bump together with Node.js 24.x.

## Why

Keeps the checked-in Maven-managed frontend toolchain aligned with the newer Node.js 24 / npm 11 baseline already adopted by the forks. The change is centralized in `parent/pom.xml`; existing `frontend-maven-plugin` usages continue to consume `v${version.nodejs}` and `${version.npm}` through plugin management.

## Attribution

- Backported/adapted from Fluxnova commit `41e59e89f94679fe813f219f8dbf2d34fbd7ef1b` (`Update nodeJS version from 20.14.0 to 24.14.0`)
  - Related to https://github.com/finos/fluxnova-bpm-platform/issues/122
  - Original author: Bhandari, Prajwol <prajwol.bhandari@fmr.com>
- Backported/adapted from CIBSeven commit `831d0fe0cd4eceaa904c74567bac2cb5b7986c8a` (`chore(dep): update Node.js and npm versions in pom.xml (#256)`)
  - Original author: Dmitry Malkovich <dmitry.malkovich@cib.de>

## Validation

- `./mvnw -pl parent help:evaluate -Dexpression=version.nodejs -q -DforceStdout` -> `24.14.0`
- `./mvnw -pl parent help:evaluate -Dexpression=version.npm -q -DforceStdout` -> `11.8.0`
- `./mvnw -pl webapps com.github.eirslett:frontend-maven-plugin:install-node-and-npm -DskipTests` -> `BUILD SUCCESS`
- Local installed binaries returned `v24.14.0` and `11.8.0`
- `./mvnw -pl webapps -DskipTests -Dskip.frontend.build=true validate` -> `BUILD SUCCESS`
- `git diff --check` -> clean