### PR TITLE
feat(engine): make timer cron syntax configurable

### DIFF
--- a/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/CronTimer.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/CronTimer.java
@@ -28,10 +28,15 @@ import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
 
+import org.operaton.bpm.engine.impl.ProcessEngineLogger;
+import org.operaton.bpm.engine.impl.util.EngineUtilLogger;
+
 /**
  * A cron timer implementation that uses cronutils library for parsing and evaluation.
  */
 public class CronTimer {
+
+  private static final EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
 
   protected final Cron cron;
 
@@ -50,13 +55,60 @@ public class CronTimer {
   }
 
   public static CronTimer parse(final String text) throws ParseException {
+    return parse(text, CronType.SPRING53, true);
+  }
+
+  public static CronTimer parse(
+      final String text,
+      final CronType cronType,
+      final boolean supportLegacyQuartzSyntax) throws ParseException {
     try {
+      String expression = text;
+      if (cronType == CronType.QUARTZ && supportLegacyQuartzSyntax) {
+        String patchedExpression = patchLegacyCronExpression(expression);
+        if (!expression.equals(patchedExpression)) {
+          LOG.warnLegacyCronExpressionPatched(expression, patchedExpression);
+        }
+        expression = patchedExpression;
+      }
+
       final var cron =
-        new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.SPRING53))
-          .parse(text);
+        new CronParser(CronDefinitionBuilder.instanceDefinitionFor(cronType))
+          .parse(expression);
       return new CronTimer(cron);
     } catch (final IllegalArgumentException | NullPointerException ex) {
       throw new ParseException(ex.getMessage(), 0);
     }
+  }
+
+  private static String patchLegacyCronExpression(final String expression) {
+    final String[] parts = expression.split("\\s+");
+    if (parts.length < 6) {
+      return expression;
+    }
+
+    final String dayOfMonth = parts[3];
+    final String dayOfWeek = parts[5];
+
+    boolean dayOfMonthSet = !"?".equals(dayOfMonth) && !"*".equals(dayOfMonth);
+    boolean dayOfWeekSet = !"?".equals(dayOfWeek) && !"*".equals(dayOfWeek);
+
+    if (dayOfMonthSet && dayOfWeekSet) {
+      if (dayOfMonth.contains("W")) {
+        parts[5] = "?";
+      } else {
+        parts[3] = "?";
+      }
+    } else if ("*".equals(dayOfMonth) && dayOfWeekSet) {
+      parts[3] = "?";
+    } else if ("*".equals(dayOfWeek) && dayOfMonthSet) {
+      parts[5] = "?";
+    } else if ("*".equals(dayOfMonth) && "*".equals(dayOfWeek)) {
+      parts[5] = "?";
+    } else if ("?".equals(dayOfMonth) && "?".equals(dayOfWeek)) {
+      parts[3] = "*";
+    }
+
+    return String.join(" ", parts);
   }
 }

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/CycleBusinessCalendar.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/calendar/CycleBusinessCalendar.java
@@ -18,6 +18,8 @@ package org.operaton.bpm.engine.impl.calendar;
 
 import java.util.Date;
 
+import com.cronutils.model.CronType;
+
 import org.operaton.bpm.engine.impl.ProcessEngineLogger;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.engine.impl.util.EngineUtilLogger;
@@ -28,6 +30,18 @@ public class CycleBusinessCalendar implements BusinessCalendar {
   private static final EngineUtilLogger LOG = ProcessEngineLogger.UTIL_LOGGER;
 
   public static final String NAME = "cycle";
+
+  protected final CronType cronType;
+  protected final boolean supportLegacyQuartzSyntax;
+
+  public CycleBusinessCalendar() {
+    this(CronType.SPRING53.name(), true);
+  }
+
+  public CycleBusinessCalendar(String cronType, boolean supportLegacyQuartzSyntax) {
+    this.cronType = CronType.valueOf(cronType);
+    this.supportLegacyQuartzSyntax = supportLegacyQuartzSyntax;
+  }
 
   @Override
   public Date resolveDuedate(String duedateDescription, Task task) {
@@ -51,7 +65,7 @@ public class CycleBusinessCalendar implements BusinessCalendar {
         durationHelper.setRepeatOffset(repeatOffset);
         return durationHelper.getDateAfter(startDate);
       } else {
-        CronTimer cronTimer = CronTimer.parse(duedateDescription);
+        CronTimer cronTimer = CronTimer.parse(duedateDescription, cronType, supportLegacyQuartzSyntax);
         return cronTimer.getDueDate(startDate == null ? ClockUtil.getCurrentTime() : startDate);
       }
 

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/CronProperty.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/CronProperty.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.impl.cfg;
+
+import java.util.Locale;
+
+import com.cronutils.model.CronType;
+
+/**
+ * Configuration properties for cron expression handling in the process engine.
+ */
+public class CronProperty {
+
+  public static final String DEFAULT_TYPE = CronType.SPRING53.name();
+  public static final boolean DEFAULT_SUPPORT_LEGACY_QUARTZ_SYNTAX = true;
+
+  private String type = DEFAULT_TYPE;
+  private boolean supportLegacyQuartzSyntax = DEFAULT_SUPPORT_LEGACY_QUARTZ_SYNTAX;
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    if (type == null || type.trim().isEmpty()) {
+      return;
+    }
+
+    String normalizedType = type.trim().toUpperCase(Locale.ROOT);
+    try {
+      CronType.valueOf(normalizedType);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Invalid cronType: " + type + ". Valid values are: SPRING53, QUARTZ",
+          e);
+    }
+    this.type = normalizedType;
+  }
+
+  public boolean isSupportLegacyQuartzSyntax() {
+    return supportLegacyQuartzSyntax;
+  }
+
+  public void setSupportLegacyQuartzSyntax(boolean supportLegacyQuartzSyntax) {
+    this.supportLegacyQuartzSyntax = supportLegacyQuartzSyntax;
+  }
+
+  @Override
+  public String toString() {
+    return "CronProperty [type=" + type + ", supportLegacyQuartzSyntax=" + supportLegacyQuartzSyntax + "]";
+  }
+}

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -574,6 +574,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected BusinessCalendarManager businessCalendarManager;
 
+  protected CronProperty cron = new CronProperty();
+
   protected String wsSyncFactoryClassName = DEFAULT_WS_SYNC_FACTORY;
 
   protected CommandContextFactory commandContextFactory;
@@ -2649,7 +2651,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       MapBusinessCalendarManager mapBusinessCalendarManager = new MapBusinessCalendarManager();
       mapBusinessCalendarManager.addBusinessCalendar(DurationBusinessCalendar.NAME, new DurationBusinessCalendar());
       mapBusinessCalendarManager.addBusinessCalendar(DueDateBusinessCalendar.NAME, new DueDateBusinessCalendar());
-      mapBusinessCalendarManager.addBusinessCalendar(CycleBusinessCalendar.NAME, new CycleBusinessCalendar());
+      mapBusinessCalendarManager.addBusinessCalendar(
+          CycleBusinessCalendar.NAME,
+          new CycleBusinessCalendar(cron.getType(), cron.isSupportLegacyQuartzSyntax()));
 
       businessCalendarManager = mapBusinessCalendarManager;
     }
@@ -3253,6 +3257,30 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   public ProcessEngineConfigurationImpl setBusinessCalendarManager(BusinessCalendarManager businessCalendarManager) {
     this.businessCalendarManager = businessCalendarManager;
     return this;
+  }
+
+  public String getCronType() {
+    return cron.getType();
+  }
+
+  public void setCronType(String cronType) {
+    cron.setType(cronType);
+  }
+
+  public boolean isSupportLegacyQuartzSyntax() {
+    return cron.isSupportLegacyQuartzSyntax();
+  }
+
+  public void setSupportLegacyQuartzSyntax(boolean supportLegacyQuartzSyntax) {
+    cron.setSupportLegacyQuartzSyntax(supportLegacyQuartzSyntax);
+  }
+
+  public CronProperty getCron() {
+    return cron;
+  }
+
+  public void setCron(CronProperty cron) {
+    this.cron = cron == null ? new CronProperty() : cron;
   }
 
   public CommandContextFactory getCommandContextFactory() {

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/util/EngineUtilLogger.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/util/EngineUtilLogger.java
@@ -272,4 +272,13 @@ public class EngineUtilLogger extends ProcessEngineLogger {
       "049",
       "The URI '{}' is malformed", uri), cause);
   }
+
+  public void warnLegacyCronExpressionPatched(String originalExpression, String patchedExpression) {
+    logWarn(
+        "050",
+        "Legacy cron expression '{}' was automatically patched to '{}' for compatibility with modern Quartz syntax. "
+            + "Consider updating the timer expression to avoid this warning.",
+        originalExpression,
+        patchedExpression);
+  }
 }

--- a/engine/src/test/java/org/operaton/bpm/container/impl/metadata/PropertyHelperTest.java
+++ b/engine/src/test/java/org/operaton/bpm/container/impl/metadata/PropertyHelperTest.java
@@ -43,6 +43,8 @@ class PropertyHelperTest {
   protected static final String MAIL_SERVER_PORT_PROP = "mailServerPort";
   protected static final String JDBC_URL_PROP = "jdbcUrl";
   protected static final String DB_IDENTITY_USED_PROP = "dbIdentityUsed";
+  protected static final String CRON_TYPE_PROP = "cronType";
+  protected static final String SUPPORT_LEGACY_QUARTZ_SYNTAX_PROP = "supportLegacyQuartzSyntax";
 
   // job executor properties
   protected static final String MAX_JOBS_PER_ACQUISITION = "maxJobsPerAcquisition";
@@ -125,6 +127,22 @@ class PropertyHelperTest {
     PropertyHelper.applyProperties(engineConfiguration, propertiesToSet);
 
     assertThat(engineConfiguration.isDbIdentityUsed()).isTrue();
+  }
+
+  @Test
+  void testCronConfigurationProperties() {
+    ProcessEngineConfigurationImpl engineConfiguration = new StandaloneProcessEngineConfiguration();
+
+    assertThat(engineConfiguration.getCronType()).isEqualTo("SPRING53");
+    assertThat(engineConfiguration.isSupportLegacyQuartzSyntax()).isTrue();
+
+    Map<String, String> propertiesToSet = new HashMap<>();
+    propertiesToSet.put(CRON_TYPE_PROP, "QUARTZ");
+    propertiesToSet.put(SUPPORT_LEGACY_QUARTZ_SYNTAX_PROP, "false");
+    PropertyHelper.applyProperties(engineConfiguration, propertiesToSet);
+
+    assertThat(engineConfiguration.getCronType()).isEqualTo("QUARTZ");
+    assertThat(engineConfiguration.isSupportLegacyQuartzSyntax()).isFalse();
   }
 
   @Test

--- a/engine/src/test/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/impl/cfg/ProcessEngineConfigurationTest.java
@@ -74,6 +74,22 @@ public class ProcessEngineConfigurationTest {
   }
 
   @Test
+  void shouldUseSpring53CronTypeByDefault() {
+    // when
+    ProcessEngineConfigurationImpl engineCfg = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createStandaloneProcessEngineConfiguration();
+    // then
+    assertThat(engineCfg.getCronType()).isEqualTo("SPRING53");
+  }
+
+  @Test
+  void shouldEnableLegacyQuartzSyntaxByDefault() {
+    // when
+    ProcessEngineConfigurationImpl engineCfg = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration.createStandaloneProcessEngineConfiguration();
+    // then
+    assertThat(engineCfg.isSupportLegacyQuartzSyntax()).isTrue();
+  }
+
+  @Test
   void validIsolationLevel() {
     // given
     ((PooledDataSource) engineConfiguration.getDataSource()).setDefaultTransactionIsolationLevel(Connection.TRANSACTION_READ_COMMITTED);

--- a/engine/src/test/java/org/operaton/bpm/engine/test/standalone/calendar/CycleBusinessCalendarTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/standalone/calendar/CycleBusinessCalendarTest.java
@@ -162,4 +162,48 @@ class CycleBusinessCalendarTest {
       .hasMessageContaining("Exception while parsing cycle expression");
 
   }
+
+  @Test
+  void shouldResolveQuartzCronExpressionWhenConfigured() throws Exception {
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy MM dd HH:mm");
+    CycleBusinessCalendar cbc = new CycleBusinessCalendar("QUARTZ", true);
+
+    Date startDate = sdf.parse("2025 02 14 12:00");
+
+    assertThat(sdf.format(cbc.resolveDuedate("0 0 12 15 2 ? 2025", startDate))).isEqualTo("2025 02 15 12:00");
+  }
+
+  @Test
+  void shouldRejectQuartzSevenFieldCronExpressionByDefault() throws Exception {
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy MM dd HH:mm");
+    CycleBusinessCalendar cbc = new CycleBusinessCalendar();
+
+    Date startDate = sdf.parse("2025 02 14 12:00");
+
+    assertThatThrownBy(() -> cbc.resolveDuedate("0 0 12 15 2 ? 2025", startDate))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("Exception while parsing cycle expression");
+  }
+
+  @Test
+  void shouldPatchLegacyQuartzCronExpressionWhenEnabled() throws Exception {
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy MM dd HH:mm");
+    CycleBusinessCalendar cbc = new CycleBusinessCalendar("QUARTZ", true);
+
+    Date startDate = sdf.parse("2010 02 11 17:23");
+
+    assertThat(sdf.format(cbc.resolveDuedate("0 0 0 * * *", startDate))).isEqualTo("2010 02 12 00:00");
+  }
+
+  @Test
+  void shouldRejectLegacyQuartzCronExpressionWhenDisabled() throws Exception {
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy MM dd HH:mm");
+    CycleBusinessCalendar cbc = new CycleBusinessCalendar("QUARTZ", false);
+
+    Date startDate = sdf.parse("2010 02 11 17:23");
+
+    assertThatThrownBy(() -> cbc.resolveDuedate("0 0 0 * * *", startDate))
+      .isInstanceOf(ProcessEngineException.class)
+      .hasMessageContaining("Exception while parsing cycle expression");
+  }
 }

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/impl/DefaultProcessEngineConfiguration.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/configuration/impl/DefaultProcessEngineConfiguration.java
@@ -44,6 +44,7 @@ public class DefaultProcessEngineConfiguration extends AbstractOperatonConfigura
     setIdGenerator(configuration);
     setJobExecutorAcquireByPriority(configuration);
     setDefaultNumberOfRetries(configuration);
+    setCronConfiguration(configuration);
   }
 
   private void setIdGenerator(SpringProcessEngineConfiguration configuration) {
@@ -85,5 +86,13 @@ public class DefaultProcessEngineConfiguration extends AbstractOperatonConfigura
   private void setDefaultNumberOfRetries(SpringProcessEngineConfiguration configuration) {
     Optional.ofNullable(operatonBpmProperties.getDefaultNumberOfRetries())
             .ifPresent(configuration::setDefaultNumberOfRetries);
+  }
+
+  private void setCronConfiguration(SpringProcessEngineConfiguration configuration) {
+    String cronType = operatonBpmProperties.getCronType();
+    if (StringUtils.hasText(cronType)) {
+      configuration.setCronType(cronType);
+    }
+    configuration.setSupportLegacyQuartzSyntax(operatonBpmProperties.isSupportLegacyQuartzSyntax());
   }
 }

--- a/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/property/OperatonBpmProperties.java
+++ b/spring-boot-starter/starter/src/main/java/org/operaton/bpm/spring/boot/starter/property/OperatonBpmProperties.java
@@ -28,6 +28,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import org.operaton.bpm.engine.ProcessEngineConfiguration;
 import org.operaton.bpm.engine.ProcessEngines;
+import org.operaton.bpm.engine.impl.cfg.CronProperty;
 import org.operaton.bpm.spring.boot.starter.configuration.id.IdGeneratorConfiguration;
 
 import static org.springframework.core.io.support.ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX;
@@ -106,6 +107,12 @@ public class OperatonBpmProperties {
   private String defaultSerializationFormat = Defaults.INSTANCE.getDefaultSerializationFormat();
 
   private URL licenseFile;
+
+  /**
+   * cron configuration
+   */
+  @NestedConfigurationProperty
+  private CronProperty cron = new CronProperty();
 
   /**
    * deactivate operaton auto configuration
@@ -214,6 +221,30 @@ public class OperatonBpmProperties {
 
   public void setLicenseFile(URL licenseFile) {
     this.licenseFile = licenseFile;
+  }
+
+  public String getCronType() {
+    return cron.getType();
+  }
+
+  public void setCronType(String cronType) {
+    cron.setType(cronType);
+  }
+
+  public boolean isSupportLegacyQuartzSyntax() {
+    return cron.isSupportLegacyQuartzSyntax();
+  }
+
+  public void setSupportLegacyQuartzSyntax(boolean supportLegacyQuartzSyntax) {
+    cron.setSupportLegacyQuartzSyntax(supportLegacyQuartzSyntax);
+  }
+
+  public CronProperty getCron() {
+    return cron;
+  }
+
+  public void setCron(CronProperty cron) {
+    this.cron = cron == null ? new CronProperty() : cron;
   }
 
   public MetricsProperty getMetrics() {
@@ -357,6 +388,7 @@ public class OperatonBpmProperties {
       .add("deploymentResourcePattern=" + Arrays.toString(deploymentResourcePattern))
       .add("defaultSerializationFormat=" + defaultSerializationFormat)
       .add("licenseFile=" + licenseFile)
+      .add("cron=" + cron)
       .add("metrics=" + metrics)
       .add("database=" + database)
       .add("jobExecution=" + jobExecution)

--- a/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/configuration/impl/DefaultProcessEngineConfigurationTest.java
+++ b/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/configuration/impl/DefaultProcessEngineConfigurationTest.java
@@ -109,4 +109,30 @@ class DefaultProcessEngineConfigurationTest {
     assertThat(configuration.getDefaultNumberOfRetries()).isEqualTo(1);
   }
 
+  @Test
+  void setCronType() {
+    instance.preInit(configuration);
+    assertThat(configuration.getCronType()).isEqualTo("SPRING53");
+
+    properties.setCronType("QUARTZ");
+    instance.preInit(configuration);
+    assertThat(configuration.getCronType()).isEqualTo("QUARTZ");
+  }
+
+  @Test
+  void setCronType_ignore_empty() {
+    properties.setCronType(" ");
+    instance.preInit(configuration);
+    assertThat(configuration.getCronType()).isEqualTo("SPRING53");
+  }
+
+  @Test
+  void setSupportLegacyQuartzSyntax() {
+    instance.preInit(configuration);
+    assertThat(configuration.isSupportLegacyQuartzSyntax()).isTrue();
+
+    properties.setSupportLegacyQuartzSyntax(false);
+    instance.preInit(configuration);
+    assertThat(configuration.isSupportLegacyQuartzSyntax()).isFalse();
+  }
 }

--- a/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/property/OperatonBpmPropertiesTest.java
+++ b/spring-boot-starter/starter/src/test/java/org/operaton/bpm/spring/boot/starter/property/OperatonBpmPropertiesTest.java
@@ -48,5 +48,36 @@ class OperatonBpmPropertiesTest {
     assertThatIllegalArgumentException().isThrownBy(() -> databaseProperty.setSchemaUpdate("foo"));
   }
 
+  @Test
+  void cronType_default_is_spring53() {
+    OperatonBpmProperties properties = new OperatonBpmProperties();
+    assertThat(properties.getCronType()).isEqualTo("SPRING53");
+  }
+
+  @Test
+  void cronType_can_be_set_to_quartz() {
+    OperatonBpmProperties properties = new OperatonBpmProperties();
+    properties.setCronType("QUARTZ");
+    assertThat(properties.getCronType()).isEqualTo("QUARTZ");
+  }
+
+  @Test
+  void cronType_rejects_invalid_value() {
+    OperatonBpmProperties properties = new OperatonBpmProperties();
+    assertThatIllegalArgumentException().isThrownBy(() -> properties.setCronType("foo"));
+  }
+
+  @Test
+  void supportLegacyQuartzSyntax_default_is_true() {
+    OperatonBpmProperties properties = new OperatonBpmProperties();
+    assertThat(properties.isSupportLegacyQuartzSyntax()).isTrue();
+  }
+
+  @Test
+  void supportLegacyQuartzSyntax_can_be_disabled() {
+    OperatonBpmProperties properties = new OperatonBpmProperties();
+    properties.setSupportLegacyQuartzSyntax(false);
+    assertThat(properties.isSupportLegacyQuartzSyntax()).isFalse();
+  }
 
 }


### PR DESCRIPTION
## Summary

This PR backports configurable timer cron parsing to Operaton.

It adds:

- a new engine `CronProperty` with `cronType` and `supportLegacyQuartzSyntax`,
- configurable `CycleBusinessCalendar` cron parsing for `SPRING53` and `QUARTZ`,
- optional legacy Quartz expression patching before parsing with modern `cron-utils`,
- a warning when a legacy Quartz expression is patched,
- XML/property-helper compatible setters on `ProcessEngineConfigurationImpl`,
- Spring Boot binding through `operaton.bpm.cron.type` and `operaton.bpm.cron.support-legacy-quartz-syntax`,
- focused engine and Spring Boot tests.

## Reviewer Notes

The other forks disagree on the safest default:

- Fluxnova directly switches `CronTimer` from `SPRING53` to `QUARTZ`.
- CIBSeven makes the parser configurable, but also sets the default to `QUARTZ` with legacy Quartz syntax support enabled.
- Operaton currently defaults to `SPRING53`.

This PR intentionally preserves Operaton's current `SPRING53` default to avoid silently changing timer parsing behavior for existing installations. The Quartz behavior is now available explicitly through configuration:

```properties
cronType=QUARTZ
supportLegacyQuartzSyntax=true
```

or, in Spring Boot:

```yaml
operaton.bpm:
  cron:
    type: QUARTZ
    support-legacy-quartz-syntax: true
```

That gives maintainers a concrete code PR to review while keeping the default-change question visible and reversible. If the team wants CIBSeven's default behavior, the implementation can be adjusted to default `CronProperty.DEFAULT_TYPE` to `QUARTZ` and add distro defaults in a follow-up or during review.

I also did not add the CIBSeven distro config snippets as-is, because those snippets would switch Tomcat/Wildfly/Run defaults to `QUARTZ`. With the current Operaton adaptation, distro files can remain unchanged unless maintainers choose the default switch.

## Backport Attribution

Backported and adapted from CIB Seven and Fluxnova:

- `a984fb2280c31ebf8830324c9fa772c717d80ad6` - CIBSeven `feat(cron): allow to switch between Quartz and SPRING53 cron syntax and add legacy Quartz syntax support (#204)`
- `98fb84743fc7eb3174ae4752a2f2c95970093a95` - Fluxnova `fix(calendar): switch CronTimer from SPRING53 to QUARTZ cron type`

Original CIBSeven PR:

- https://github.com/cibseven/cibseven/pull/204

Original authors:

- Dmitry Malkovich <dmitry.malkovich@cib.de>
- Reddy Kishore Mannuru <kishoremannuru@gmail.com>

## Backport Database

Updated the backport database for these change units:

- `514` -> `pr_opened`, target patch `975dd3e3b9634e33875b3db7c72193ee19bc79cc`
- `1047` -> `pr_opened`, target patch `975dd3e3b9634e33875b3db7c72193ee19bc79cc`

## Verification

- `git diff --check`
- `git diff --cached --check`
- `./mvnw -pl engine -Dtest=CycleBusinessCalendarTest,ProcessEngineConfigurationTest,PropertyHelperTest test`
- `./mvnw -pl engine -DskipTests install`
- `./mvnw -pl spring-boot-starter/starter -Dtest=DefaultProcessEngineConfigurationTest,OperatonBpmPropertiesTest test`
- SQLite `PRAGMA integrity_check` for the backport database

