### PR TITLE
fix(engine-rest): exclude WildFly Jackson modules

### DIFF
--- a/engine-rest/assembly/src/main/runtime/wildfly/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/engine-rest/assembly/src/main/runtime/wildfly/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -4,6 +4,11 @@
     <exclusions>
       <module name="org.jboss.resteasy.resteasy-jackson-provider" />
       <module name="org.jboss.resteasy.resteasy-jettison-provider" />
+      <module name="com.fasterxml.jackson.core.jackson-core" />
+      <module name="com.fasterxml.jackson.core.jackson-annotations" />
+      <module name="com.fasterxml.jackson.core.jackson-databind" />
+      <module name="com.fasterxml.jackson.datatype.jackson-datatype-jsr310" />
+      <module name="org.jboss.resteasy.resteasy-jackson2-provider" />
     </exclusions>
   </deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
## Summary

This PR backports the small, targeted WildFly/Jackson exclusion part from CIBSeven.

It updates the engine-rest WildFly runtime deployment descriptor to exclude the WildFly-provided Jackson/Resteasy Jackson modules so Operaton's packaged versions are used consistently.

## Change unit

- `913` [cibseven:c5d053b5c3b] fix(engine-rest-jakarta/wildfly): exclude jackson modules for old wildfy (cibseven/cibseven#128)

## Attribution

Backported-adapted from CIBSeven commit `c5d053b5c3bfe9f199780a67b5ec14ab5c80a808`.

Original PR: https://github.com/cibseven/cibseven/pull/128

Original author: Fernando Mambrilla <fernandom@cib.de>

## Reviewer notes

This PR intentionally implements only the narrow Jackson/Resteasy exclusion from change unit `913`. The broader WildFly runtime dependency/CVE work and the WildFly 40 upgrade are not part of this code change and should be reviewed separately.

## Verification

- `git diff --check origin/main...HEAD`
- `./mvnw -pl engine-rest/assembly -DskipTests install`