### PR TITLE
feat(engine): support case-insensitive database user lookup

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/identity/impl/UserResourceImpl.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/sub/identity/impl/UserResourceImpl.java
@@ -17,6 +17,7 @@
 package org.operaton.bpm.engine.rest.sub.identity.impl;
 
 import java.net.URI;
+import java.util.List;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.core.Response.Status;
 import jakarta.ws.rs.core.UriBuilder;
@@ -134,12 +135,29 @@ public class UserResourceImpl extends AbstractIdentityResource implements UserRe
 
   protected User findUserObject() {
     try {
-      return identityService.createUserQuery()
+      List<User> users = identityService.createUserQuery()
           .userId(resourceId)
-          .singleResult();
+          .list();
+
+      return selectMatchingUser(users, resourceId);
     } catch(ProcessEngineException e) {
       throw new InvalidRequestException(Status.INTERNAL_SERVER_ERROR, "Exception while performing user query: "+e.getMessage());
     }
+  }
+
+  private User selectMatchingUser(List<User> users, String requestedUserId) {
+    if (users.isEmpty()) {
+      return null;
+    }
+
+    if (users.size() == 1) {
+      return users.get(0);
+    }
+
+    return users.stream()
+        .filter(user -> requestedUserId.equals(user.getId()))
+        .findFirst()
+        .orElse(users.get(0));
   }
 
   @SuppressWarnings("java:S110")

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/UserRestServiceInteractionTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/UserRestServiceInteractionTest.java
@@ -101,7 +101,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
     UserQuery sampleUserQuery = mock(UserQuery.class);
     when(identityServiceMock.createUserQuery()).thenReturn(sampleUserQuery);
     when(sampleUserQuery.userId(MockProvider.EXAMPLE_USER_ID)).thenReturn(sampleUserQuery);
-    when(sampleUserQuery.singleResult()).thenReturn(sampleUser);
+    when(sampleUserQuery.list()).thenReturn(List.of(sampleUser));
 
     var response = given()
         .pathParam("id", MockProvider.EXAMPLE_USER_ID)
@@ -115,6 +115,29 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
         .get(USER_PROFILE_URL);
 
     assertThat(response.contentType()).isEqualTo(ContentType.JSON.toString());
+  }
+
+  @Test
+  void testGetSingleUserProfilePrefersExactMatchForCaseInsensitiveResults() {
+    User inexactUser = mock(User.class);
+    when(inexactUser.getId()).thenReturn(MockProvider.EXAMPLE_USER_ID.toUpperCase());
+
+    User sampleUser = MockProvider.createMockUser();
+    UserQuery sampleUserQuery = mock(UserQuery.class);
+    when(identityServiceMock.createUserQuery()).thenReturn(sampleUserQuery);
+    when(sampleUserQuery.userId(MockProvider.EXAMPLE_USER_ID)).thenReturn(sampleUserQuery);
+    when(sampleUserQuery.list()).thenReturn(List.of(inexactUser, sampleUser));
+
+    given()
+        .pathParam("id", MockProvider.EXAMPLE_USER_ID)
+    .then()
+        .statusCode(Status.OK.getStatusCode())
+        .body("id", equalTo(MockProvider.EXAMPLE_USER_ID))
+        .body("firstName", equalTo(MockProvider.EXAMPLE_USER_FIRST_NAME))
+        .body("lastName", equalTo(MockProvider.EXAMPLE_USER_LAST_NAME))
+        .body("email", equalTo(MockProvider.EXAMPLE_USER_EMAIL))
+    .when()
+        .get(USER_PROFILE_URL);
   }
 
   @Test
@@ -182,7 +205,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
     UserQuery sampleUserQuery = mock(UserQuery.class);
     when(identityServiceMock.createUserQuery()).thenReturn(sampleUserQuery);
     when(sampleUserQuery.userId(MockProvider.EXAMPLE_USER_ID)).thenReturn(sampleUserQuery);
-    when(sampleUserQuery.singleResult()).thenReturn(sampleUser);
+    when(sampleUserQuery.list()).thenReturn(List.of(sampleUser));
     when(identityServiceMock.getCurrentAuthentication()).thenReturn(null);
 
     when(processEngineConfigurationMock.isAuthorizationEnabled()).thenReturn(true);
@@ -219,7 +242,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
     UserQuery sampleUserQuery = mock(UserQuery.class);
     when(identityServiceMock.createUserQuery()).thenReturn(sampleUserQuery);
     when(sampleUserQuery.userId(MockProvider.EXAMPLE_USER_ID)).thenReturn(sampleUserQuery);
-    when(sampleUserQuery.singleResult()).thenReturn(sampleUser);
+    when(sampleUserQuery.list()).thenReturn(List.of(sampleUser));
 
     Authentication authentication = new Authentication(MockProvider.EXAMPLE_USER_ID, null);
     when(identityServiceMock.getCurrentAuthentication()).thenReturn(authentication);
@@ -256,7 +279,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
     UserQuery sampleUserQuery = mock(UserQuery.class);
     when(identityServiceMock.createUserQuery()).thenReturn(sampleUserQuery);
     when(sampleUserQuery.userId(MockProvider.EXAMPLE_USER_ID)).thenReturn(sampleUserQuery);
-    when(sampleUserQuery.singleResult()).thenReturn(sampleUser);
+    when(sampleUserQuery.list()).thenReturn(List.of(sampleUser));
 
     Authentication authentication = new Authentication(MockProvider.EXAMPLE_USER_ID, null);
     when(identityServiceMock.getCurrentAuthentication()).thenReturn(authentication);
@@ -323,7 +346,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
     UserQuery sampleUserQuery = mock(UserQuery.class);
     when(identityServiceMock.createUserQuery()).thenReturn(sampleUserQuery);
     when(sampleUserQuery.userId(anyString())).thenReturn(sampleUserQuery);
-    when(sampleUserQuery.singleResult()).thenReturn(null);
+    when(sampleUserQuery.list()).thenReturn(List.of());
 
     given()
         .pathParam("id", "aNonExistingUser")
@@ -494,7 +517,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
     UserQuery sampleUserQuery = mock(UserQuery.class);
     when(identityServiceMock.createUserQuery()).thenReturn(sampleUserQuery);
     when(sampleUserQuery.userId(MockProvider.EXAMPLE_USER_ID)).thenReturn(sampleUserQuery);
-    when(sampleUserQuery.singleResult()).thenReturn(initialUser);
+    when(sampleUserQuery.list()).thenReturn(List.of(initialUser));
 
     UserCredentialsDto dto = new UserCredentialsDto();
     dto.setPassword("new-password");
@@ -520,7 +543,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
     UserQuery sampleUserQuery = mock(UserQuery.class);
     when(identityServiceMock.createUserQuery()).thenReturn(sampleUserQuery);
     when(sampleUserQuery.userId(MockProvider.EXAMPLE_USER_ID)).thenReturn(sampleUserQuery);
-    when(sampleUserQuery.singleResult()).thenReturn(initialUser);
+    when(sampleUserQuery.list()).thenReturn(List.of(initialUser));
 
     String message = "exception expected";
     doThrow(new AuthorizationException(message)).when(identityServiceMock).saveUser(any(User.class));
@@ -548,7 +571,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
     UserQuery sampleUserQuery = mock(UserQuery.class);
     when(identityServiceMock.createUserQuery()).thenReturn(sampleUserQuery);
     when(sampleUserQuery.userId(MockProvider.EXAMPLE_USER_ID)).thenReturn(sampleUserQuery);
-    when(sampleUserQuery.singleResult()).thenReturn(initialUser);
+    when(sampleUserQuery.list()).thenReturn(List.of(initialUser));
 
     Authentication authentication = MockProvider.createMockAuthentication();
     when(identityServiceMock.getCurrentAuthentication()).thenReturn(authentication);
@@ -585,7 +608,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
     UserQuery sampleUserQuery = mock(UserQuery.class);
     when(identityServiceMock.createUserQuery()).thenReturn(sampleUserQuery);
     when(sampleUserQuery.userId(MockProvider.EXAMPLE_USER_ID)).thenReturn(sampleUserQuery);
-    when(sampleUserQuery.singleResult()).thenReturn(initialUser);
+    when(sampleUserQuery.list()).thenReturn(List.of(initialUser));
 
     Authentication authentication = MockProvider.createMockAuthentication();
     when(identityServiceMock.getCurrentAuthentication()).thenReturn(authentication);
@@ -617,7 +640,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
     UserQuery sampleUserQuery = mock(UserQuery.class);
     when(identityServiceMock.createUserQuery()).thenReturn(sampleUserQuery);
     when(sampleUserQuery.userId("aNonExistingUser")).thenReturn(sampleUserQuery);
-    when(sampleUserQuery.singleResult()).thenReturn(null);
+    when(sampleUserQuery.list()).thenReturn(List.of());
 
     UserCredentialsDto dto = new UserCredentialsDto();
     dto.setPassword("new-password");
@@ -645,7 +668,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
     UserQuery sampleUserQuery = mock(UserQuery.class);
     when(identityServiceMock.createUserQuery()).thenReturn(sampleUserQuery);
     when(sampleUserQuery.userId(MockProvider.EXAMPLE_USER_ID)).thenReturn(sampleUserQuery);
-    when(sampleUserQuery.singleResult()).thenReturn(initialUser);
+    when(sampleUserQuery.list()).thenReturn(List.of(initialUser));
 
     UserProfileDto updateDto = UserProfileDto.fromUser(userUpdate);
 
@@ -674,7 +697,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
     UserQuery sampleUserQuery = mock(UserQuery.class);
     when(identityServiceMock.createUserQuery()).thenReturn(sampleUserQuery);
     when(sampleUserQuery.userId("aNonExistingUser")).thenReturn(sampleUserQuery);
-    when(sampleUserQuery.singleResult()).thenReturn(null);
+    when(sampleUserQuery.list()).thenReturn(List.of());
 
     UserProfileDto updateDto = UserProfileDto.fromUser(userUpdate);
 
@@ -701,7 +724,7 @@ public class UserRestServiceInteractionTest extends AbstractRestServiceTest {
     UserQuery sampleUserQuery = mock(UserQuery.class);
     when(identityServiceMock.createUserQuery()).thenReturn(sampleUserQuery);
     when(sampleUserQuery.userId(MockProvider.EXAMPLE_USER_ID)).thenReturn(sampleUserQuery);
-    when(sampleUserQuery.singleResult()).thenReturn(initialUser);
+    when(sampleUserQuery.list()).thenReturn(List.of(initialUser));
 
     String message = "exception expected";
     doThrow(new AuthorizationException(message)).when(identityServiceMock).saveUser(any(User.class));

--- a/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/DbSqlSession.java
+++ b/engine/src/main/java/org/operaton/bpm/engine/impl/db/sql/DbSqlSession.java
@@ -127,7 +127,7 @@ public abstract class DbSqlSession extends AbstractPersistenceSession {
     String mappedSelectStatement = dbSqlSessionFactory.mapStatement(selectStatement);
     ensureNotNull("no select statement for %s in the ibatis mapping files".formatted(type), "selectStatement", selectStatement);
 
-    Object result = ExceptionUtil.doWithExceptionWrapper(() -> sqlSession.selectOne(mappedSelectStatement, id));
+    Object result = ExceptionUtil.doWithExceptionWrapper(() -> sqlSession.selectList(mappedSelectStatement, id).stream().findFirst().orElse(null));
     fireEntityLoaded(result);
     return (T) result;
   }

--- a/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/User.xml
+++ b/engine/src/main/resources/org/operaton/bpm/engine/impl/mapping/entity/User.xml
@@ -82,7 +82,9 @@
   <!-- USER SELECT -->
 
   <select id="selectUser" parameterType="string" resultMap="userResultMap">
-    select * from ${prefix}ACT_ID_USER where ID_ = #{id,jdbcType=VARCHAR}
+    (select * from ${prefix}ACT_ID_USER where ID_ = #{id,jdbcType=VARCHAR})
+    UNION ALL
+    (select * from ${prefix}ACT_ID_USER where LOWER(ID_) = LOWER(#{id,jdbcType=VARCHAR}))
   </select>
 
   <select id="selectUserByQueryCriteria" parameterType="org.operaton.bpm.engine.impl.UserQueryImpl" resultMap="userResultMap">
@@ -116,7 +118,7 @@
 
     <where>
       <if test="id != null">
-        RES.ID_ = #{id}
+        (RES.ID_ = #{id} OR LOWER(RES.ID_) = LOWER(#{id}))
       </if>
       <if test="ids != null &amp;&amp; ids.length > 0">
         and RES.ID_ in

--- a/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceTest.java
+++ b/engine/src/test/java/org/operaton/bpm/engine/test/api/identity/IdentityServiceTest.java
@@ -235,6 +235,41 @@ class IdentityServiceTest {
   }
 
   @Test
+  void shouldCheckPasswordCaseInsensitiveForDatabaseUsers() {
+    User user = identityService.newUser("johndoe");
+    user.setPassword("s3cret");
+    identityService.saveUser(user);
+
+    assertThat(identityService.checkPassword("JOHNDOE", "s3cret")).isTrue();
+  }
+
+  @Test
+  void shouldQueryDatabaseUserByIdCaseInsensitive() {
+    User user = identityService.newUser("johndoe");
+    identityService.saveUser(user);
+
+    List<User> users = identityService.createUserQuery()
+        .userId("JOHNDOE")
+        .list();
+
+    assertThat(users).extracting(User::getId).containsExactly("johndoe");
+  }
+
+  @Test
+  void shouldPreferExactUserIdWhenCheckingPasswordForSimilarUsers() {
+    User lowerCaseUser = identityService.newUser("johndoe");
+    lowerCaseUser.setPassword("lowerSecret");
+    identityService.saveUser(lowerCaseUser);
+
+    User mixedCaseUser = identityService.newUser("JohnDoe");
+    mixedCaseUser.setPassword("mixedSecret");
+    identityService.saveUser(mixedCaseUser);
+
+    assertThat(identityService.checkPassword("JohnDoe", "mixedSecret")).isTrue();
+    assertThat(identityService.checkPassword("JohnDoe", "lowerSecret")).isFalse();
+  }
+
+  @Test
   void testUserPicture() {
     // First, create a new user
     User user = identityService.newUser("johndoe");

--- a/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/auth/AuthenticationUtil.java
+++ b/webapps/assembly/src/main/java/org/operaton/bpm/webapp/impl/security/auth/AuthenticationUtil.java
@@ -76,11 +76,12 @@ public final class AuthenticationUtil {
 
     String userId = username;
 
-    User user = processEngine.getIdentityService()
+    List<User> users = processEngine.getIdentityService()
       .createUserQuery()
       .userId(username)
-      .singleResult();
+      .list();
 
+    User user = selectMatchingUser(users, username);
     if (user == null) {
       return null;
     }
@@ -124,6 +125,21 @@ public final class AuthenticationUtil {
     newAuthentication.setAuthorizedApps(authorizedApps);
 
     return newAuthentication;
+  }
+
+  private static User selectMatchingUser(List<User> users, String requestedUserId) {
+    if (users.isEmpty()) {
+      return null;
+    }
+
+    if (users.size() == 1) {
+      return users.get(0);
+    }
+
+    return users.stream()
+        .filter(user -> requestedUserId.equals(user.getId()))
+        .findFirst()
+        .orElse(users.get(0));
   }
 
   public static List<String> getTenantsOfUser(ProcessEngine engine, String userId) {

--- a/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/auth/AuthCacheTest.java
+++ b/webapps/assembly/src/test/java/org/operaton/bpm/webapp/impl/security/auth/AuthCacheTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpSession;
 
@@ -34,6 +35,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.identity.User;
+import org.operaton.bpm.engine.identity.UserQuery;
 import org.operaton.bpm.engine.impl.util.ClockUtil;
 import org.operaton.bpm.webapp.impl.IllegalWebAppConfigurationException;
 import org.operaton.bpm.webapp.impl.security.SecurityActions;
@@ -281,12 +283,10 @@ class AuthCacheTest {
     assertThat(nextAuth.getCacheValidationTime()).isEqualTo(addMinutes(5, ClockUtil.getCurrentTime()));
     assertThat(initialAuthentication).isNotSameAs(nextAuth);
 
-    User user = engineMock.getIdentityService()
+    UserQuery userQuery = engineMock.getIdentityService()
       .createUserQuery()
-      .userId("userId1")
-      .singleResult();
-
-    when(user).thenReturn(null);
+      .userId("userId1");
+    when(userQuery.list()).thenReturn(List.of());
 
     Date currentTime = addDays(ClockUtil.getCurrentTime(), 2);
     ClockUtil.setCurrentTime(currentTime);
@@ -394,12 +394,10 @@ class AuthCacheTest {
     assertThat(nextAuthEngineThree.getCacheValidationTime())
       .isEqualTo(datePlus5Minutes);
 
-    User user = engineMocks[1].getIdentityService()
+    UserQuery userQuery = engineMocks[1].getIdentityService()
       .createUserQuery()
-      .userId("userId2")
-      .singleResult();
-
-    when(user).thenReturn(null);
+      .userId("userId2");
+    when(userQuery.list()).thenReturn(List.of());
 
     Date currentTime = addDays(ClockUtil.getCurrentTime(), 2);
     ClockUtil.setCurrentTime(currentTime);
@@ -462,6 +460,20 @@ class AuthCacheTest {
     assertThat(getAuthByEngine(authentications, "engine1").getCacheValidationTime()).isEqualTo(datePlus5Minutes);
   }
 
+  @Test
+  void shouldPreferExactUserIdWhenAuthenticationQueryReturnsSimilarUsers() {
+    ProcessEngine engineMock = setupEngineMock()[0];
+    UserQuery userQuery = engineMock.getIdentityService()
+        .createUserQuery()
+        .userId("UserId1");
+    List<User> users = List.of(createMockUser("userid1"), createMockUser("UserId1"));
+    when(userQuery.list()).thenReturn(users);
+
+    UserAuthentication authentication = AuthenticationUtil.createAuthentication(engineMock, "UserId1");
+
+    assertThat(authentication.getIdentityId()).isEqualTo("UserId1");
+  }
+
   // helpers ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   protected ProcessEngine[] setupEngineMock(String... engines) {
@@ -474,13 +486,26 @@ class AuthCacheTest {
     List<ProcessEngine> processEngines = new ArrayList<>();
     List.of(engines).forEach(engine -> {
       ProcessEngine processEngineMock = mock(ProcessEngine.class, RETURNS_DEEP_STUBS);
+      UserQuery userQuery = mock(UserQuery.class);
+      AtomicReference<String> requestedUserId = new AtomicReference<>();
       processEngines.add(processEngineMock);
 
       when(processEngineMock.getName()).thenReturn(engine);
+      when(processEngineMock.getIdentityService().createUserQuery()).thenReturn(userQuery);
+      when(userQuery.userId(any())).thenAnswer(invocation -> {
+        String userId = invocation.getArgument(0);
+        requestedUserId.set(userId);
+        return userQuery;
+      });
+      when(userQuery.list()).thenAnswer(invocation -> {
+        String userId = requestedUserId.get();
+        return userId == null ? List.of() : List.of(createMockUser(userId));
+      });
       mockedProcessEngineUtil.when(() -> ProcessEngineUtil.lookupProcessEngine(eq(engine))).thenReturn(processEngineMock);
       mockedAuthenticationUtil.when(() -> AuthenticationUtil.updateCache(any(), any(), anyLong())).thenCallRealMethod();
       mockedAuthenticationUtil.when(() -> AuthenticationUtil.getSessionMutex(any())).thenCallRealMethod();
       mockedAuthenticationUtil.when(() -> AuthenticationUtil.createAuthentication(eq(engine), any())).thenCallRealMethod();
+      mockedAuthenticationUtil.when(() -> AuthenticationUtil.createAuthentication(eq(processEngineMock), any())).thenCallRealMethod();
       mockedAuthenticationUtil.when(() -> AuthenticationUtil.createAuthentication(eq(engine), any(), any(), any())).thenCallRealMethod();
       mockedAuthenticationUtil.when(() -> AuthenticationUtil.createAuthentication(eq(processEngineMock), any(), any(), any())).thenCallRealMethod();
     });
@@ -540,5 +565,10 @@ class AuthCacheTest {
     return new Date(currentTime.getTime() + 1000L * 60L * minutes);
   }
 
-}
+  private User createMockUser(String userId) {
+    User user = mock(User.class);
+    when(user.getId()).thenReturn(userId);
+    return user;
+  }
 
+}


### PR DESCRIPTION
## Summary

This PR backports CIBSeven's case-insensitive internal database user lookup to Operaton.

It changes the internal database user lookup so that:

- `IdentityService#checkPassword(...)` can authenticate internal database users even when the supplied user id differs only by case.
- `UserQuery#userId(...)` returns database users case-insensitively.
- REST user profile access and webapp authentication no longer rely on `singleResult()` for user-id lookups that may produce multiple case-insensitive matches.
- When multiple case-insensitive matches exist, REST and webapp authentication prefer the exact requested user id before falling back to the first returned user.

## Reviewer Notes

The original CIBSeven changes intentionally alter internal database identity semantics from exact user-id matching to case-insensitive matching. That means existing databases can theoretically contain two users whose ids differ only by case, for example `john` and `John`.

The risky part is not the lookup itself, but callers that previously expected `singleResult()` semantics. With case-insensitive matching, those callers can see more than one row and fail before they can choose the intended user. This PR adapts the affected Operaton REST and webapp authentication paths to use `.list()` and then choose deterministically:

1. return `null` for no match,
2. return the only user for a single match,
3. prefer an exact id match for duplicate-case results,
4. otherwise fall back to the first result.

The engine password check still uses the low-level `selectById` path. The mapper now returns exact matches first, followed by case-insensitive matches, and `DbSqlSession#selectById` accepts the first row. This preserves exact-case preference for password checks where an exact user id exists.

## Backport Attribution

Backported and adapted from CIB Seven:

- `7646af8afc6dd2be4dfa8497e16298cc48d8dbd0` - `feat(engine): Login with internal database user made case-insensitive (#28)`
- `aa509ee5cf2bf3b4c120703de2f1d3d2b33c7b8b` - `feat(engine): getting user by query case insensitive`
- `e51b54635a61595779e0dbefc5bc923dba07e33c` - `fix(auth) Case-insensitive Login exception with 2 "similar" usernames (#37)`

Original CIBSeven PRs:

- https://github.com/cibseven/cibseven/pull/28
- https://github.com/cibseven/cibseven/pull/37

Original authors:

- Oleg Skrypnyuk <oleg.skrypnyuk@cib.de>
- Serge Krot <serge.krot@cib.de>

## Backport Database

Updated the backport database for these change units:

- `802` -> `pr_opened`, target patch `97f4d842a7cacd555a4d6ab5e8705dcd78c69972`
- `805` -> `pr_opened`, target patch `97f4d842a7cacd555a4d6ab5e8705dcd78c69972`
- `809` -> `pr_opened`, target patch `97f4d842a7cacd555a4d6ab5e8705dcd78c69972`

## Verification

- `git diff --check`
- `git diff --cached --check`
- `./mvnw -pl engine -Dtest=IdentityServiceTest#shouldCheckPasswordCaseInsensitiveForDatabaseUsers+shouldQueryDatabaseUserByIdCaseInsensitive+shouldPreferExactUserIdWhenCheckingPasswordForSimilarUsers test`
- `./mvnw -f engine-rest/engine-rest/pom.xml -Dtest=UserRestServiceInteractionTest test`
- `./mvnw -pl webapps/assembly -Dtest=AuthCacheTest test`
- SQLite `PRAGMA integrity_check` for the backport database

