### PR TITLE
feat(starter-security): secure engine REST as OAuth2 resource server

### DIFF
--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/ProcessEngineAuthenticationFilter.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/ProcessEngineAuthenticationFilter.java
@@ -209,7 +209,7 @@ public class ProcessEngineAuthenticationFilter implements Filter {
     engine.getIdentityService().clearAuthentication();
   }
 
-  protected boolean requiresEngineAuthentication(String requestUrl) {
+  public static boolean requiresEngineAuthentication(String requestUrl) {
     for (Pattern whiteListedUrlPattern : WHITE_LISTED_URL_PATTERNS) {
       Matcher matcher = whiteListedUrlPattern.matcher(requestUrl);
       if (matcher.matches()) {

--- a/spring-boot-starter/starter-security/pom.xml
+++ b/spring-boot-starter/starter-security/pom.xml
@@ -34,6 +34,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+    </dependency>
     <!-- override nimbus-jose-jwt version, consider removal when org.springframework.security:spring-security-oauth2-jose uses this or a newer version -->
     <!-- org.springframework.security:spring-security-oauth2-jose 6.5.3 is using 9.37.3 -->
     <dependency>

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSpringSecurityDisableAutoConfiguration.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSpringSecurityDisableAutoConfiguration.java
@@ -18,26 +18,44 @@ package org.operaton.bpm.spring.boot.starter.security.oauth2;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
+import org.operaton.bpm.spring.boot.starter.property.OperatonBpmProperties;
 import org.operaton.bpm.spring.boot.starter.security.oauth2.impl.ClientsNotConfiguredCondition;
 
 @Conditional(ClientsNotConfiguredCondition.class)
+@ConditionalOnBean(OperatonBpmProperties.class)
+@Configuration(proxyBeanMethods = false)
 public class OperatonBpmSpringSecurityDisableAutoConfiguration {
 
   private static final Logger logger = LoggerFactory.getLogger(OperatonBpmSpringSecurityDisableAutoConfiguration.class);
+  private final String webappPath;
+
+  public OperatonBpmSpringSecurityDisableAutoConfiguration(OperatonBpmProperties properties) {
+    this.webappPath = properties.getWebapp().getApplicationPath();
+  }
 
   @Bean
-  public SecurityFilterChain filterChainPermitAll(HttpSecurity http) {
-    logger.info("Disabling Operaton Spring Security oauth2 integration");
+  public SecurityFilterChain filterChainWebappPermitAll(HttpSecurity http) throws Exception {
+    logger.info("Disabling Operaton Spring Security oauth2 integration for webapps");
 
-    http.authorizeHttpRequests(customizer -> customizer.anyRequest().permitAll())
+    // @formatter:off
+    http.securityMatcher(request -> {
+          String fullPath = request.getServletPath() + (request.getPathInfo() != null ? request.getPathInfo() : "");
+          return fullPath.startsWith(webappPath + "/app/") || fullPath.startsWith(webappPath + "/api/");
+        })
+        .authorizeHttpRequests(customizer -> customizer.anyRequest().permitAll())
+        // disable anonymous access to avoid accessing the OAuth2IdentityProvider
+        .anonymous(AbstractHttpConfigurer::disable)
         .cors(AbstractHttpConfigurer::disable)
         .csrf(AbstractHttpConfigurer::disable);
+    // @formatter:on
     return http.build();
   }
 

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonSpringSecurityOAuth2CommonAutoConfiguration.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonSpringSecurityOAuth2CommonAutoConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.spring.boot.starter.security.oauth2;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+import org.operaton.bpm.engine.spring.SpringProcessEngineServicesConfiguration;
+import org.operaton.bpm.spring.boot.starter.OperatonBpmAutoConfiguration;
+import org.operaton.bpm.spring.boot.starter.property.OperatonBpmProperties;
+import org.operaton.bpm.spring.boot.starter.security.oauth2.impl.ClientsOrResourceServerConfiguredCondition;
+import org.operaton.bpm.spring.boot.starter.security.oauth2.impl.OAuth2IdentityProviderPlugin;
+
+@AutoConfigureOrder(OperatonSpringSecurityOAuth2CommonAutoConfiguration.OPERATON_OAUTH2_ORDER)
+@AutoConfigureAfter({OperatonBpmAutoConfiguration.class, SpringProcessEngineServicesConfiguration.class})
+@ConditionalOnBean(OperatonBpmProperties.class)
+@Conditional(ClientsOrResourceServerConfiguredCondition.class)
+@EnableConfigurationProperties(OAuth2Properties.class)
+@Configuration(proxyBeanMethods = false)
+public class OperatonSpringSecurityOAuth2CommonAutoConfiguration {
+
+  private static final Logger logger = LoggerFactory.getLogger(OperatonSpringSecurityOAuth2CommonAutoConfiguration.class);
+  public static final int OPERATON_OAUTH2_ORDER = Ordered.HIGHEST_PRECEDENCE + 100;
+
+  @Bean
+  @ConditionalOnProperty(name = "identity-provider.enabled", havingValue = "true", prefix = OAuth2Properties.PREFIX, matchIfMissing = true)
+  public OAuth2IdentityProviderPlugin identityProviderPlugin() {
+    logger.debug("Registering OAuth2IdentityProviderPlugin");
+    return new OAuth2IdentityProviderPlugin();
+  }
+}

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonSpringSecurityOAuth2EngineAutoConfiguration.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonSpringSecurityOAuth2EngineAutoConfiguration.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.spring.boot.starter.security.oauth2;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import jakarta.annotation.Nullable;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.jersey.autoconfigure.JerseyApplicationPath;
+import org.springframework.boot.security.autoconfigure.web.servlet.SecurityFilterProperties;
+import org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.web.SecurityFilterChain;
+
+import org.operaton.bpm.engine.rest.security.auth.ProcessEngineAuthenticationFilter;
+import org.operaton.bpm.spring.boot.starter.property.OperatonBpmProperties;
+import org.operaton.bpm.spring.boot.starter.rest.OperatonBpmRestInitializer;
+import org.operaton.bpm.spring.boot.starter.security.oauth2.impl.OAuth2AuthenticationProvider;
+import org.operaton.bpm.spring.boot.starter.security.oauth2.impl.ResourceServerConfiguredCondition;
+
+@AutoConfigureOrder(OperatonSpringSecurityOAuth2CommonAutoConfiguration.OPERATON_OAUTH2_ORDER + 1)
+@AutoConfigureAfter(OperatonSpringSecurityOAuth2CommonAutoConfiguration.class)
+@ConditionalOnBean(OperatonBpmProperties.class)
+@ConditionalOnClass(OperatonBpmRestInitializer.class)
+@Conditional(ResourceServerConfiguredCondition.class)
+@EnableConfigurationProperties({OAuth2Properties.class, OAuth2ResourceServerProperties.class})
+@Configuration(proxyBeanMethods = false)
+public class OperatonSpringSecurityOAuth2EngineAutoConfiguration {
+
+  private static final Logger logger = LoggerFactory.getLogger(OperatonSpringSecurityOAuth2EngineAutoConfiguration.class);
+
+  private final OAuth2Properties oAuth2Properties;
+  private final OAuth2ResourceServerProperties oAuth2ResourceServerProperties;
+
+  public OperatonSpringSecurityOAuth2EngineAutoConfiguration(OAuth2Properties oAuth2Properties,
+                                                            OAuth2ResourceServerProperties oAuth2ResourceServerProperties) {
+    this.oAuth2Properties = oAuth2Properties;
+    this.oAuth2ResourceServerProperties = oAuth2ResourceServerProperties;
+  }
+
+  @Bean
+  public FilterRegistrationBean<Filter> engineRestAuthenticationFilter(JerseyApplicationPath applicationPath) {
+    FilterRegistrationBean<Filter> filterRegistration = new FilterRegistrationBean<>();
+    filterRegistration.setName("Container Based Authentication Filter for engine-rest");
+    filterRegistration.setFilter(new ProcessEngineAuthenticationFilter());
+    filterRegistration.setInitParameters(Map.of(
+        ProcessEngineAuthenticationFilter.AUTHENTICATION_PROVIDER_PARAM, OAuth2AuthenticationProvider.class.getName()));
+    // make sure the filter is registered after the Spring Security Filter Chain
+    filterRegistration.setOrder(SecurityFilterProperties.DEFAULT_FILTER_ORDER + 1);
+    filterRegistration.addUrlPatterns(applicationPath.getPath() + "/*");
+    filterRegistration.setDispatcherTypes(DispatcherType.REQUEST);
+    return filterRegistration;
+  }
+
+  @Bean
+  @ConditionalOnProperty(name = "identity-provider.group-name-attribute", prefix = OAuth2Properties.PREFIX)
+  protected JwtAuthenticationConverter oauth2JwtAuthenticationConverter() {
+    JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+    converter.setJwtGrantedAuthoritiesConverter((Converter<Jwt, Collection<GrantedAuthority>>) jwt -> {
+      var identityProviderProperties = oAuth2Properties.getIdentityProvider();
+      var groupNameAttribute = identityProviderProperties.getGroupNameAttribute();
+
+      List<String> groups = null;
+      try {
+        groups = jwt.getClaimAsStringList(groupNameAttribute);
+      } catch (IllegalArgumentException e) {
+        logger.debug("Claim {} is not a list of strings, trying to parse as single string", groupNameAttribute);
+        String groupsAttribute = jwt.getClaimAsString(groupNameAttribute);
+        if (groupsAttribute != null) {
+          groups = List.of(groupsAttribute.split(identityProviderProperties.getGroupNameDelimiter()));
+        }
+      }
+      if (groups == null) {
+        logger.debug("Claim {} is not available", groupNameAttribute);
+        return List.of();
+      }
+      return groups.stream()
+          .map(group -> (GrantedAuthority) new SimpleGrantedAuthority(group))
+          .toList();
+    });
+
+    String principalClaimName = Optional.ofNullable(oAuth2ResourceServerProperties.getJwt())
+        .map(OAuth2ResourceServerProperties.Jwt::getPrincipalClaimName)
+        .filter(s -> !s.isBlank())
+        .orElse("preferred_username");
+    converter.setPrincipalClaimName(principalClaimName);
+
+    return converter;
+  }
+
+  @Bean
+  @Order(1)
+  public SecurityFilterChain engineRestSecurityFilterChain(HttpSecurity http,
+                                                          JerseyApplicationPath applicationPath,
+                                                          @Nullable JwtAuthenticationConverter jwtAuthenticationConverter) throws Exception {
+    logger.info("Enabling Operaton Spring Security oauth2 integration for engine-rest");
+    String engineRestPath = applicationPath.getPath();
+
+    // @formatter:off
+    http.securityMatcher(request -> {
+          String fullPath = request.getServletPath() + (request.getPathInfo() != null ? request.getPathInfo() : "");
+          String requestUrl = fullPath.startsWith(engineRestPath) ? fullPath.substring(engineRestPath.length()) : fullPath;
+          return fullPath.startsWith(engineRestPath)
+              && ProcessEngineAuthenticationFilter.requiresEngineAuthentication(requestUrl);
+        })
+        .authorizeHttpRequests(c -> c
+          .requestMatchers(engineRestPath + "/**").authenticated())
+        .oauth2ResourceServer(oauth2 -> {
+          if (jwtAuthenticationConverter != null) {
+            oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter));
+          }
+        });
+    // @formatter:on
+
+    return http.build();
+  }
+}

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonSpringSecurityOAuth2WebappAutoConfiguration.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonSpringSecurityOAuth2WebappAutoConfiguration.java
@@ -32,7 +32,8 @@ import org.springframework.boot.security.autoconfigure.web.servlet.SecurityFilte
 import org.springframework.boot.security.oauth2.client.autoconfigure.ConditionalOnOAuth2ClientRegistrationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.Ordered;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -43,31 +44,28 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequest
 import org.springframework.security.web.SecurityFilterChain;
 
 import org.operaton.bpm.engine.rest.security.auth.ProcessEngineAuthenticationFilter;
-import org.operaton.bpm.engine.spring.SpringProcessEngineServicesConfiguration;
-import org.operaton.bpm.spring.boot.starter.OperatonBpmAutoConfiguration;
 import org.operaton.bpm.spring.boot.starter.property.OperatonBpmProperties;
 import org.operaton.bpm.spring.boot.starter.property.WebappProperty;
 import org.operaton.bpm.spring.boot.starter.security.oauth2.impl.AuthorizeTokenFilter;
 import org.operaton.bpm.spring.boot.starter.security.oauth2.impl.OAuth2AuthenticationProvider;
 import org.operaton.bpm.spring.boot.starter.security.oauth2.impl.OAuth2GrantedAuthoritiesMapper;
-import org.operaton.bpm.spring.boot.starter.security.oauth2.impl.OAuth2IdentityProviderPlugin;
 import org.operaton.bpm.spring.boot.starter.security.oauth2.impl.SsoLogoutSuccessHandler;
 import org.operaton.bpm.webapp.impl.security.auth.ContainerBasedAuthenticationFilter;
 
-@AutoConfigureOrder(OperatonSpringSecurityOAuth2AutoConfiguration.OPERATON_OAUTH2_ORDER)
-@AutoConfigureAfter({OperatonBpmAutoConfiguration.class, SpringProcessEngineServicesConfiguration.class})
+@AutoConfigureOrder(OperatonSpringSecurityOAuth2CommonAutoConfiguration.OPERATON_OAUTH2_ORDER + 2)
+@AutoConfigureAfter(OperatonSpringSecurityOAuth2CommonAutoConfiguration.class)
 @ConditionalOnBean(OperatonBpmProperties.class)
 @ConditionalOnOAuth2ClientRegistrationProperties
 @EnableConfigurationProperties(OAuth2Properties.class)
-public class OperatonSpringSecurityOAuth2AutoConfiguration {
+@Configuration(proxyBeanMethods = false)
+public class OperatonSpringSecurityOAuth2WebappAutoConfiguration {
 
-  private static final Logger logger = LoggerFactory.getLogger(OperatonSpringSecurityOAuth2AutoConfiguration.class);
-  public static final int OPERATON_OAUTH2_ORDER = Ordered.HIGHEST_PRECEDENCE + 100;
+  private static final Logger logger = LoggerFactory.getLogger(OperatonSpringSecurityOAuth2WebappAutoConfiguration.class);
   private final OAuth2Properties oAuth2Properties;
   private final String webappPath;
 
-  public OperatonSpringSecurityOAuth2AutoConfiguration(OperatonBpmProperties properties,
-                                                      OAuth2Properties oAuth2Properties) {
+  public OperatonSpringSecurityOAuth2WebappAutoConfiguration(OperatonBpmProperties properties,
+                                                            OAuth2Properties oAuth2Properties) {
     this.oAuth2Properties = oAuth2Properties;
     WebappProperty webapp = properties.getWebapp();
     this.webappPath = webapp.getApplicationPath();
@@ -85,13 +83,6 @@ public class OperatonSpringSecurityOAuth2AutoConfiguration {
     filterRegistration.addUrlPatterns(webappPath + "/app/*", webappPath + "/api/*");
     filterRegistration.setDispatcherTypes(DispatcherType.REQUEST);
     return filterRegistration;
-  }
-
-  @Bean
-  @ConditionalOnProperty(name = "identity-provider.enabled", havingValue = "true", prefix = OAuth2Properties.PREFIX, matchIfMissing = true)
-  public OAuth2IdentityProviderPlugin identityProviderPlugin() {
-    logger.debug("Registering OAuth2IdentityProviderPlugin");
-    return new OAuth2IdentityProviderPlugin();
   }
 
   @Bean
@@ -115,14 +106,22 @@ public class OperatonSpringSecurityOAuth2AutoConfiguration {
   }
 
   @Bean
-  public SecurityFilterChain filterChain(HttpSecurity http,
-                                         AuthorizeTokenFilter authorizeTokenFilter,
-                                         @Nullable SsoLogoutSuccessHandler ssoLogoutSuccessHandler) {
+  @Order(2)
+  public SecurityFilterChain webappSecurityFilterChain(HttpSecurity http,
+                                                       AuthorizeTokenFilter authorizeTokenFilter,
+                                                       @Nullable SsoLogoutSuccessHandler ssoLogoutSuccessHandler) throws Exception {
 
-    logger.info("Enabling Operaton Spring Security oauth2 integration");
+    logger.info("Enabling Operaton Spring Security oauth2 integration for webapps");
 
     // @formatter:off
-    http.authorizeHttpRequests(c -> c
+    http.securityMatcher(request -> {
+          String fullPath = request.getServletPath() + (request.getPathInfo() != null ? request.getPathInfo() : "");
+          return fullPath.startsWith(webappPath)
+              || fullPath.startsWith(OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI)
+              || fullPath.startsWith("/login")
+              || fullPath.startsWith("/logout");
+        })
+        .authorizeHttpRequests(c -> c
             .requestMatchers(webappPath + "/app/**").authenticated()
             .requestMatchers(webappPath + "/api/**").authenticated()
             .anyRequest().permitAll()

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/ClientsNotConfiguredCondition.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/ClientsNotConfiguredCondition.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
- * Condition that matches if no {@code spring.security.oauth2.client.registration} properties are defined
+ * Condition that matches if no OAuth2 client or resource server properties are defined.
  */
 public class ClientsNotConfiguredCondition extends SpringBootCondition {
 
@@ -33,9 +33,13 @@ public class ClientsNotConfiguredCondition extends SpringBootCondition {
 
   @Override
   public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
-    return hasClientRegistrations(context) ?
-        new ConditionOutcome(false, "OAuth2 client is configured") :
-        new ConditionOutcome(true, "No OAuth2 client is configured");
+    if (hasClientRegistrations(context)) {
+      return new ConditionOutcome(false, "OAuth2 client is configured");
+    }
+    if (ResourceServerConfiguredCondition.isResourceServerConfigured(context)) {
+      return new ConditionOutcome(false, "OAuth2 resource server is configured");
+    }
+    return new ConditionOutcome(true, "No OAuth2 client or resource server is configured");
   }
 
   /**
@@ -43,7 +47,7 @@ public class ClientsNotConfiguredCondition extends SpringBootCondition {
    *
    * @return true if at least one client registration is present and set, false otherwise
    */
-  private boolean hasClientRegistrations(ConditionContext context) {
+  static boolean hasClientRegistrations(ConditionContext context) {
     Binder binder = Binder.get(context.getEnvironment());
     return binder.bind(OAUTH2_CLIENT_REGISTRATION_PROPERTY_PREFIX, Map.class)
         .map(map -> !map.isEmpty())

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/ClientsOrResourceServerConfiguredCondition.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/ClientsOrResourceServerConfiguredCondition.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.spring.boot.starter.security.oauth2.impl;
+
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class ClientsOrResourceServerConfiguredCondition extends SpringBootCondition {
+
+  @Override
+  public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+    if (ClientsNotConfiguredCondition.hasClientRegistrations(context)) {
+      return new ConditionOutcome(true, "OAuth2 client is configured");
+    }
+    if (ResourceServerConfiguredCondition.isResourceServerConfigured(context)) {
+      return new ConditionOutcome(true, "OAuth2 resource server is configured");
+    }
+    return new ConditionOutcome(false, "No OAuth2 client or resource server is configured");
+  }
+}

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/OAuth2AuthenticationProvider.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/OAuth2AuthenticationProvider.java
@@ -23,6 +23,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.rest.security.auth.AuthenticationResult;
@@ -43,12 +45,13 @@ public class OAuth2AuthenticationProvider extends ContainerBasedAuthenticationPr
       return AuthenticationResult.unsuccessful();
     }
 
-    if (!(authentication instanceof OAuth2AuthenticationToken)) {
+    if (!(authentication instanceof OAuth2AuthenticationToken) &&
+        !(authentication instanceof JwtAuthenticationToken) &&
+        !(authentication instanceof BearerTokenAuthentication)) {
       logger.debug("Authentication is not OAuth2, it is {}", authentication.getClass());
       return AuthenticationResult.unsuccessful();
     }
-    var oauth2 = (OAuth2AuthenticationToken) authentication;
-    String operatonUserId = oauth2.getName();
+    String operatonUserId = authentication.getName();
     if (!hasText(operatonUserId)) {
       logger.debug("UserId is empty");
       return AuthenticationResult.unsuccessful();

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/OAuth2IdentityProvider.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/OAuth2IdentityProvider.java
@@ -25,8 +25,10 @@ import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
 
 import org.operaton.bpm.engine.identity.*;
 import org.operaton.bpm.engine.impl.GroupQueryImpl;
@@ -94,17 +96,23 @@ public class OAuth2IdentityProvider extends DbIdentityServiceProvider {
       user.setFirstName(oidcUser.getGivenName());
       user.setLastName(oidcUser.getFamilyName());
       user.setEmail(oidcUser.getEmail());
+    } else if (principal instanceof Jwt jwt) {
+      user.setFirstName(jwt.getClaimAsString("given_name"));
+      user.setLastName(jwt.getClaimAsString("family_name"));
+      user.setEmail(jwt.getClaimAsString("email"));
     }
     return user;
   }
 
   protected static List<Group> transformGroups() {
-    return SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream().map(a -> {
-      var group = new GroupEntity();
-      group.setId(a.getAuthority());
-      group.setName(a.getAuthority());
-      return group;
-    }).collect(Collectors.toList());
+    return SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream()
+        .filter(authority -> !(authority instanceof FactorGrantedAuthority))
+        .map(a -> {
+          var group = new GroupEntity();
+          group.setId(a.getAuthority());
+          group.setName(a.getAuthority());
+          return group;
+        }).collect(Collectors.toList());
   }
 
   public static class OAuth2UserQuery extends UserQueryImpl {

--- a/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/ResourceServerConfiguredCondition.java
+++ b/spring-boot-starter/starter-security/src/main/java/org/operaton/bpm/spring/boot/starter/security/oauth2/impl/ResourceServerConfiguredCondition.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.spring.boot.starter.security.oauth2.impl;
+
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class ResourceServerConfiguredCondition extends SpringBootCondition {
+
+  private static final String[] RESOURCE_SERVER_PROPERTIES = {
+      "spring.security.oauth2.resourceserver.jwt.jwk-set-uri",
+      "spring.security.oauth2.resourceserver.jwt.issuer-uri",
+      "spring.security.oauth2.resourceserver.jwt.public-key-location",
+      "spring.security.oauth2.resourceserver.opaquetoken.introspection-uri",
+      "spring.security.oauth2.resourceserver.opaque-token.introspection-uri"
+  };
+
+  @Override
+  public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+    return isResourceServerConfigured(context) ?
+        new ConditionOutcome(true, "OAuth2 resource server is configured") :
+        new ConditionOutcome(false, "No OAuth2 resource server is configured");
+  }
+
+  static boolean isResourceServerConfigured(ConditionContext context) {
+    Environment environment = context.getEnvironment();
+    for (String property : RESOURCE_SERVER_PROPERTIES) {
+      if (environment.containsProperty(property)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/spring-boot-starter/starter-security/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-starter/starter-security/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,4 @@
 org.operaton.bpm.spring.boot.starter.security.oauth2.OperatonBpmSpringSecurityDisableAutoConfiguration
-org.operaton.bpm.spring.boot.starter.security.oauth2.OperatonSpringSecurityOAuth2AutoConfiguration
+org.operaton.bpm.spring.boot.starter.security.oauth2.OperatonSpringSecurityOAuth2CommonAutoConfiguration
+org.operaton.bpm.spring.boot.starter.security.oauth2.OperatonSpringSecurityOAuth2EngineAutoConfiguration
+org.operaton.bpm.spring.boot.starter.security.oauth2.OperatonSpringSecurityOAuth2WebappAutoConfiguration

--- a/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSampleApplicationIT.java
+++ b/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSampleApplicationIT.java
@@ -39,7 +39,9 @@ class OperatonBpmSampleApplicationIT extends AbstractSpringSecurityIT {
   void testSpringSecurityAutoConfigurationCorrectlySet() {
     // given oauth2 client not configured
     // when retrieving config beans then only SpringSecurityDisabledAutoConfiguration is present
-    assertThat(getBeanForClass(OperatonSpringSecurityOAuth2AutoConfiguration.class, webApplicationContext)).isNull();
+    assertThat(getBeanForClass(OperatonSpringSecurityOAuth2CommonAutoConfiguration.class, webApplicationContext)).isNull();
+    assertThat(getBeanForClass(OperatonSpringSecurityOAuth2WebappAutoConfiguration.class, webApplicationContext)).isNull();
+    assertThat(getBeanForClass(OperatonSpringSecurityOAuth2EngineAutoConfiguration.class, webApplicationContext)).isNull();
     assertThat(getBeanForClass(OperatonBpmSpringSecurityDisableAutoConfiguration.class, webApplicationContext)).isNotNull();
   }
 

--- a/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSecurityAutoConfigOauth2ApplicationIT.java
+++ b/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSecurityAutoConfigOauth2ApplicationIT.java
@@ -86,8 +86,12 @@ class OperatonBpmSecurityAutoConfigOauth2ApplicationIT extends AbstractSpringSec
   void testSpringSecurityAutoConfigurationCorrectlySet() {
     // given oauth2 client configured
     // when retrieving config beans then only OAuth2AutoConfiguration is present
-    assertThat(getBeanForClass(OperatonSpringSecurityOAuth2AutoConfiguration.class,
+    assertThat(getBeanForClass(OperatonSpringSecurityOAuth2CommonAutoConfiguration.class,
       mockMvc.getDispatcherServlet().getWebApplicationContext())).isNotNull();
+    assertThat(getBeanForClass(OperatonSpringSecurityOAuth2WebappAutoConfiguration.class,
+      mockMvc.getDispatcherServlet().getWebApplicationContext())).isNotNull();
+    assertThat(getBeanForClass(OperatonSpringSecurityOAuth2EngineAutoConfiguration.class,
+      mockMvc.getDispatcherServlet().getWebApplicationContext())).isNull();
     assertThat(getBeanForClass(OperatonBpmSpringSecurityDisableAutoConfiguration.class,
       mockMvc.getDispatcherServlet().getWebApplicationContext())).isNull();
   }

--- a/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSecurityAutoConfigResourceServerApplicationIT.java
+++ b/spring-boot-starter/starter-security/src/test/java/org/operaton/bpm/spring/boot/starter/security/oauth2/OperatonBpmSecurityAutoConfigResourceServerApplicationIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.spring.boot.starter.security.oauth2;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@AutoConfigureTestRestTemplate
+@TestPropertySource(properties = {
+    "spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost/issuer/jwks",
+    "operaton.bpm.oauth2.identity-provider.group-name-attribute=groups"
+})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class OperatonBpmSecurityAutoConfigResourceServerApplicationIT extends AbstractSpringSecurityIT {
+
+  @Autowired
+  private TestRestTemplate testRestTemplate;
+
+  @Autowired
+  private JwtAuthenticationConverter jwtAuthenticationConverter;
+
+  @Autowired
+  private WebApplicationContext webApplicationContext;
+
+  @MockitoBean
+  private JwtDecoder jwtDecoder;
+
+  @Test
+  void testSpringSecurityAutoConfigurationCorrectlySet() {
+    assertThat(getBeanForClass(OperatonSpringSecurityOAuth2CommonAutoConfiguration.class, webApplicationContext)).isNotNull();
+    assertThat(getBeanForClass(OperatonSpringSecurityOAuth2EngineAutoConfiguration.class, webApplicationContext)).isNotNull();
+    assertThat(getBeanForClass(OperatonSpringSecurityOAuth2WebappAutoConfiguration.class, webApplicationContext)).isNull();
+    assertThat(getBeanForClass(OperatonBpmSpringSecurityDisableAutoConfiguration.class, webApplicationContext)).isNull();
+  }
+
+  @Test
+  void testEngineRestWhitelistRemainsAvailableWithoutAuthentication() {
+    ResponseEntity<String> entity = testRestTemplate.getForEntity(baseUrl + "/engine-rest/engine/", String.class);
+
+    assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(entity.getBody()).isEqualTo(EXPECTED_NAME_DEFAULT);
+  }
+
+  @Test
+  void testEngineRestResourceRequiresAuthentication() {
+    ResponseEntity<String> entity = testRestTemplate.getForEntity(baseUrl + "/engine-rest/user/", String.class);
+
+    assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  void testEngineRestResourceAcceptsJwtAuthentication() {
+    when(jwtDecoder.decode("token")).thenReturn(createJwt(List.of("management")));
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth("token");
+
+    ResponseEntity<String> entity = testRestTemplate.exchange(baseUrl + "/engine-rest/user/",
+        HttpMethod.GET,
+        new HttpEntity<>(headers),
+        String.class);
+
+    assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(entity.getBody()).contains(AUTHORIZED_USER);
+  }
+
+  @Test
+  void testJwtAuthenticationConverterUsesConfiguredGroupClaimAndPreferredUserName() {
+    JwtAuthenticationToken authentication = (JwtAuthenticationToken) jwtAuthenticationConverter.convert(createJwt(List.of("sales", "support")));
+
+    assertThat(authentication.getName()).isEqualTo(AUTHORIZED_USER);
+    assertThat(authentication.getAuthorities())
+        .extracting(authority -> authority.getAuthority())
+        .contains("sales", "support");
+  }
+
+  private static Jwt createJwt(List<String> groups) {
+    return Jwt.withTokenValue("token")
+        .header("alg", "none")
+        .issuedAt(Instant.now())
+        .expiresAt(Instant.now().plusSeconds(60))
+        .subject(AUTHORIZED_USER)
+        .claim("preferred_username", AUTHORIZED_USER)
+        .claim("given_name", "Bob")
+        .claim("family_name", "Builder")
+        .claim("email", "bob@example.org")
+        .claim("groups", groups)
+        .build();
+  }
+}


### PR DESCRIPTION
## Summary

This PR backports the CIBSeven engine-rest OAuth2 resource-server work to Operaton with local adaptations.

The PR splits the starter-security OAuth2 auto-configuration into common, webapp, and engine-rest configuration classes. Webapp OAuth2 login keeps its existing behavior, while engine REST can now be protected by Spring Security's OAuth2 resource-server support when `spring.security.oauth2.resourceserver.*` properties are configured.

## What Changed

- Added `spring-boot-starter-oauth2-resource-server` to the starter-security module.
- Added a dedicated engine-rest `SecurityFilterChain` with resource-server support.
- Registered `ProcessEngineAuthenticationFilter` for engine-rest behind the Spring Security chain, using `OAuth2AuthenticationProvider`.
- Reused `ProcessEngineAuthenticationFilter.requiresEngineAuthentication(...)` in the Spring Security matcher so whitelisted REST endpoints such as `/engine-rest/engine/` remain anonymously reachable.
- Added JWT group/principal mapping from `operaton.bpm.oauth2.identity-provider.group-name-attribute`, with `preferred_username` as the default principal claim when no resource-server principal claim is configured.
- Extended the OAuth2 identity provider to expose user profile attributes from JWT claims.
- Accepted JWT and opaque-token bearer authentications in the Operaton engine authentication provider.
- Filtered Spring Security 7's internal bearer-factor authority out of Operaton group mapping, so `FACTOR_BEARER` does not become an Operaton group.
- Kept the webapp OAuth2 flow separated from the engine-rest resource-server flow.

## Reviewer Notes

This is not a direct cherry-pick. The original CIBSeven code targets Camunda/CIBSeven package names and older Spring Boot package locations. The Operaton version is adapted to current Operaton names, Spring Boot 4 auto-configuration packages, and Spring Security 7 behavior.

The most important behavior to review is the engine-rest matcher. It intentionally applies Spring Security only to REST paths that the existing `ProcessEngineAuthenticationFilter` says require engine authentication. This keeps REST discovery/whitelisted endpoints available without a bearer token, matching the existing REST filter contract.

The webapp login chain is still enabled only when OAuth2 client registrations are configured. The engine-rest chain is enabled only when resource-server properties are configured. The common OAuth2 identity provider plugin is enabled when either of those OAuth2 modes is active.

## Attribution

Backported and adapted from CIBSeven:

- https://github.com/cibseven/cibseven/commit/7fdd7d2df0ff40466d0722a70881904f44086e73
  - Original PR: https://github.com/cibseven/cibseven/pull/161
  - Author: Fernando Mambrilla <fernandom@cib.de>
- https://github.com/cibseven/cibseven/commit/870abf12dde3d0ccf691d4a47b985583787a642c
  - Original PR: https://github.com/cibseven/cibseven/pull/172
  - Author: Fernando Mambrilla <fernandom@cib.de>
- https://github.com/cibseven/cibseven/commit/55228666c6d360683b769838d84b074420f724a8
  - Original PR: https://github.com/cibseven/cibseven/pull/190
  - Author: Fernando Mambrilla <fernandom@cib.de>
  - Co-author: Patrick <patrick.fincke@cib.de>

## Backport Database

Updated change units: `943`, `946`, `1034`.

All three are now marked as `pr_opened` and point to Operaton commit `3a3830840a5af5ce0f8e1f670818574de38cf79b`.

## Verification

- `git diff --check`
- `git diff --cached --check`
- `./mvnw -pl engine-rest/engine-rest -DskipTests install`
- `./mvnw -pl spring-boot-starter/starter-security -Dtest=OperatonBpmSampleApplicationIT,OperatonBpmSecurityAutoConfigOauth2ApplicationIT,OperatonBpmSecurityAutoConfigResourceServerApplicationIT,OAuth2GrantedAuthoritiesMapperIT,OperatonIdentityProviderIT test`
- `./mvnw -pl engine-rest/engine-rest -Dtest=AuthenticationFilterPathMatchingTest test`
- SQLite `PRAGMA integrity_check`

