### PR TITLE
feat(engine-rest): add REST authentication provider extensions

### DIFF
--- a/distro/run/core/src/main/java/org/operaton/bpm/run/OperatonBpmRunRestConfiguration.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/OperatonBpmRunRestConfiguration.java
@@ -31,6 +31,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import org.operaton.bpm.engine.rest.security.auth.ProcessEngineAuthenticationFilter;
+import org.operaton.bpm.engine.rest.security.auth.impl.CompositeAuthenticationProvider;
+import org.operaton.bpm.engine.rest.security.auth.impl.HttpBasicAuthenticationProvider;
+import org.operaton.bpm.engine.rest.security.auth.impl.PseudoAuthenticationProvider;
 import org.operaton.bpm.run.property.OperatonBpmRunAuthenticationProperties;
 import org.operaton.bpm.run.property.OperatonBpmRunCorsProperty;
 import org.operaton.bpm.run.property.OperatonBpmRunProperties;
@@ -77,11 +80,15 @@ public class OperatonBpmRunRestConfiguration {
 
     String restApiPathPattern = applicationPath.getUrlMapping();
     registration.addUrlPatterns(restApiPathPattern);
+    registration.setAsyncSupported(true);
 
-    // if nothing is set, use Http Basic authentication
     OperatonBpmRunAuthenticationProperties properties = operatonBpmRunProperties.getAuth();
-    if (properties.getAuthentication() == null || OperatonBpmRunAuthenticationProperties.DEFAULT_AUTH.equals(properties.getAuthentication())) {
-      registration.addInitParameter("authentication-provider", "org.operaton.bpm.engine.rest.security.auth.impl.HttpBasicAuthenticationProvider");
+    if (properties.getAuthentication() == null || OperatonBpmRunAuthenticationProperties.BASIC_AUTH.equals(properties.getAuthentication())) {
+      registration.addInitParameter(ProcessEngineAuthenticationFilter.AUTHENTICATION_PROVIDER_PARAM, HttpBasicAuthenticationProvider.class.getName());
+    } else if (OperatonBpmRunAuthenticationProperties.COMPOSITE_AUTH.equals(properties.getAuthentication())) {
+      registration.addInitParameter(ProcessEngineAuthenticationFilter.AUTHENTICATION_PROVIDER_PARAM, CompositeAuthenticationProvider.class.getName());
+    } else if (OperatonBpmRunAuthenticationProperties.PSEUDO_AUTH.equals(properties.getAuthentication())) {
+      registration.addInitParameter(ProcessEngineAuthenticationFilter.AUTHENTICATION_PROVIDER_PARAM, PseudoAuthenticationProvider.class.getName());
     }
     return registration;
   }

--- a/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunAuthenticationProperties.java
+++ b/distro/run/core/src/main/java/org/operaton/bpm/run/property/OperatonBpmRunAuthenticationProperties.java
@@ -22,7 +22,10 @@ import java.util.List;
 public class OperatonBpmRunAuthenticationProperties {
   public static final String PREFIX = OperatonBpmRunProperties.PREFIX + ".auth";
   public static final String DEFAULT_AUTH = "basic";
-  private static final List<String> AUTH_METHODS = Arrays.asList(DEFAULT_AUTH);
+  public static final String BASIC_AUTH = DEFAULT_AUTH;
+  public static final String COMPOSITE_AUTH = "composite";
+  public static final String PSEUDO_AUTH = "pseudo";
+  public static final List<String> AUTH_METHODS = Arrays.asList(BASIC_AUTH, COMPOSITE_AUTH, PSEUDO_AUTH);
 
   boolean enabled;
   String authentication = DEFAULT_AUTH;

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/OperatonBpmRunRestConfigurationTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/OperatonBpmRunRestConfigurationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.run;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.jersey.autoconfigure.JerseyApplicationPath;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+
+import org.operaton.bpm.engine.rest.security.auth.ProcessEngineAuthenticationFilter;
+import org.operaton.bpm.engine.rest.security.auth.impl.CompositeAuthenticationProvider;
+import org.operaton.bpm.engine.rest.security.auth.impl.HttpBasicAuthenticationProvider;
+import org.operaton.bpm.engine.rest.security.auth.impl.PseudoAuthenticationProvider;
+import org.operaton.bpm.run.property.OperatonBpmRunAuthenticationProperties;
+import org.operaton.bpm.run.property.OperatonBpmRunProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OperatonBpmRunRestConfigurationTest {
+
+  @Test
+  void shouldUseHttpBasicAuthenticationProviderByDefault() {
+    FilterRegistrationBean<?> registration = createAuthenticationFilterRegistration(null);
+
+    assertThat(registration.getInitParameters())
+        .containsEntry(ProcessEngineAuthenticationFilter.AUTHENTICATION_PROVIDER_PARAM,
+            HttpBasicAuthenticationProvider.class.getName());
+    assertThat(registration.getUrlPatterns()).containsExactly("/engine-rest/*");
+    assertThat(registration.isAsyncSupported()).isTrue();
+  }
+
+  @Test
+  void shouldUseCompositeAuthenticationProviderWhenConfigured() {
+    FilterRegistrationBean<?> registration = createAuthenticationFilterRegistration(
+        OperatonBpmRunAuthenticationProperties.COMPOSITE_AUTH);
+
+    assertThat(registration.getInitParameters())
+        .containsEntry(ProcessEngineAuthenticationFilter.AUTHENTICATION_PROVIDER_PARAM,
+            CompositeAuthenticationProvider.class.getName());
+  }
+
+  @Test
+  void shouldUsePseudoAuthenticationProviderWhenConfigured() {
+    FilterRegistrationBean<?> registration = createAuthenticationFilterRegistration(
+        OperatonBpmRunAuthenticationProperties.PSEUDO_AUTH);
+
+    assertThat(registration.getInitParameters())
+        .containsEntry(ProcessEngineAuthenticationFilter.AUTHENTICATION_PROVIDER_PARAM,
+            PseudoAuthenticationProvider.class.getName());
+  }
+
+  private static FilterRegistrationBean<?> createAuthenticationFilterRegistration(String authentication) {
+    OperatonBpmRunProperties properties = new OperatonBpmRunProperties();
+    properties.getAuth().setAuthentication(authentication);
+    OperatonBpmRunRestConfiguration configuration = new OperatonBpmRunRestConfiguration(properties);
+    JerseyApplicationPath applicationPath = mock(JerseyApplicationPath.class);
+    when(applicationPath.getUrlMapping()).thenReturn("/engine-rest/*");
+    return configuration.processEngineAuthenticationFilter(applicationPath);
+  }
+
+}

--- a/distro/run/core/src/test/java/org/operaton/bpm/run/property/OperatonBpmRunAuthenticationPropertiesTest.java
+++ b/distro/run/core/src/test/java/org/operaton/bpm/run/property/OperatonBpmRunAuthenticationPropertiesTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.run.property;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OperatonBpmRunAuthenticationPropertiesTest {
+
+  @Test
+  void shouldKeepBasicAuthenticationAsDefault() {
+    OperatonBpmRunAuthenticationProperties properties = new OperatonBpmRunAuthenticationProperties();
+
+    assertThat(properties.getAuthentication()).isEqualTo(OperatonBpmRunAuthenticationProperties.BASIC_AUTH);
+  }
+
+  @Test
+  void shouldAcceptSupportedAuthenticationModes() {
+    OperatonBpmRunAuthenticationProperties properties = new OperatonBpmRunAuthenticationProperties();
+
+    properties.setAuthentication(OperatonBpmRunAuthenticationProperties.COMPOSITE_AUTH);
+    assertThat(properties.getAuthentication()).isEqualTo(OperatonBpmRunAuthenticationProperties.COMPOSITE_AUTH);
+
+    properties.setAuthentication(OperatonBpmRunAuthenticationProperties.PSEUDO_AUTH);
+    assertThat(properties.getAuthentication()).isEqualTo(OperatonBpmRunAuthenticationProperties.PSEUDO_AUTH);
+
+    properties.setAuthentication(OperatonBpmRunAuthenticationProperties.BASIC_AUTH);
+    assertThat(properties.getAuthentication()).isEqualTo(OperatonBpmRunAuthenticationProperties.BASIC_AUTH);
+  }
+
+  @Test
+  void shouldRejectUnsupportedAuthenticationMode() {
+    OperatonBpmRunAuthenticationProperties properties = new OperatonBpmRunAuthenticationProperties();
+
+    assertThatThrownBy(() -> properties.setAuthentication("unknown"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("basic", "composite", "pseudo");
+  }
+
+}

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -12,6 +12,7 @@
   <properties>
     <rest.http.port>38080</rest.http.port>
     <surefire.memArgs>-Xmx2g</surefire.memArgs>
+    <version.jjwt>0.12.6</version.jjwt>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -57,6 +58,23 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>${version.jjwt}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>${version.jjwt}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>${version.jjwt}</version>
+      <scope>runtime</scope>
     </dependency>
     <!-- provided deps -->
     <dependency>

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/impl/CompositeAuthenticationProvider.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/impl/CompositeAuthenticationProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.security.auth.impl;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.rest.security.auth.AuthenticationProvider;
+import org.operaton.bpm.engine.rest.security.auth.AuthenticationResult;
+
+/**
+ * Tries JWT bearer authentication first and falls back to HTTP Basic.
+ */
+public class CompositeAuthenticationProvider implements AuthenticationProvider {
+
+  protected final AuthenticationProvider primaryProvider;
+  protected final AuthenticationProvider fallbackProvider;
+
+  public CompositeAuthenticationProvider() {
+    this(new JwtTokenAuthenticationProvider(), new HttpBasicAuthenticationProvider());
+  }
+
+  public CompositeAuthenticationProvider(AuthenticationProvider primaryProvider, AuthenticationProvider fallbackProvider) {
+    this.primaryProvider = primaryProvider;
+    this.fallbackProvider = fallbackProvider;
+  }
+
+  @Override
+  public AuthenticationResult extractAuthenticatedUser(HttpServletRequest request, ProcessEngine engine) {
+    AuthenticationResult result = primaryProvider.extractAuthenticatedUser(request, engine);
+    if (result.isAuthenticated()) {
+      return result;
+    }
+    return fallbackProvider.extractAuthenticatedUser(request, engine);
+  }
+
+  @Override
+  public void augmentResponseByAuthenticationChallenge(HttpServletResponse response, ProcessEngine engine) {
+    primaryProvider.augmentResponseByAuthenticationChallenge(response, engine);
+    fallbackProvider.augmentResponseByAuthenticationChallenge(response, engine);
+  }
+
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/impl/JwtTokenAuthenticationProvider.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/impl/JwtTokenAuthenticationProvider.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.security.auth.impl;
+
+import java.io.IOException;
+import java.util.Base64;
+import javax.crypto.SecretKey;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.HttpHeaders;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import org.operaton.bpm.engine.AuthenticationException;
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.rest.security.auth.AuthenticationProvider;
+import org.operaton.bpm.engine.rest.security.auth.AuthenticationResult;
+import org.operaton.bpm.engine.rest.security.auth.impl.jwt.Configuration;
+import org.operaton.bpm.engine.rest.security.auth.impl.jwt.JwtUser;
+
+public class JwtTokenAuthenticationProvider implements AuthenticationProvider {
+
+  public static final String BEARER_PREFIX = "Bearer ";
+
+  protected final String jwtSecret;
+  protected final ObjectMapper objectMapper;
+
+  public JwtTokenAuthenticationProvider() {
+    this(Configuration.getInstance().getSecret());
+  }
+
+  JwtTokenAuthenticationProvider(String jwtSecret) {
+    this.jwtSecret = jwtSecret;
+    this.objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  }
+
+  @Override
+  public AuthenticationResult extractAuthenticatedUser(HttpServletRequest request, ProcessEngine engine) {
+    String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+    if (authHeader == null || !authHeader.startsWith(BEARER_PREFIX)) {
+      return AuthenticationResult.unsuccessful();
+    }
+    if (jwtSecret == null || jwtSecret.isBlank()) {
+      return AuthenticationResult.unsuccessful();
+    }
+
+    try {
+      JwtUser user = parse(authHeader, jwtSecret);
+      if (user == null || user.getUserID() == null || user.getUserID().isBlank()) {
+        return AuthenticationResult.unsuccessful();
+      }
+      return AuthenticationResult.successful(user.getUserID());
+    } catch (AuthenticationException e) {
+      return AuthenticationResult.unsuccessful();
+    }
+  }
+
+  @Override
+  public void augmentResponseByAuthenticationChallenge(HttpServletResponse response, ProcessEngine engine) {
+    // no additional challenge; composite mode delegates HTTP Basic challenge to the fallback provider
+  }
+
+  JwtUser parse(String tokenHeader, String jwtTokenSecret) {
+    try {
+      String token = tokenHeader.substring(BEARER_PREFIX.length());
+      SecretKey key = Keys.hmacShaKeyFor(Base64.getDecoder().decode(jwtTokenSecret));
+      Claims claims = Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+      Object userClaim = claims.get("user");
+      if (!(userClaim instanceof String userJson)) {
+        throw new AuthenticationException(tokenHeader, "JWT does not contain a serialized user claim");
+      }
+      return deserialize(userJson);
+    } catch (IllegalArgumentException | JwtException e) {
+      throw new AuthenticationException(tokenHeader, e.getMessage());
+    }
+  }
+
+  protected JwtUser deserialize(String json) {
+    try {
+      return objectMapper.readValue(json, JwtUser.class);
+    } catch (IllegalArgumentException | IOException e) {
+      throw new AuthenticationException(json, e.getMessage());
+    }
+  }
+
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/impl/PseudoAuthenticationProvider.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/impl/PseudoAuthenticationProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.security.auth.impl;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.rest.security.auth.AuthenticationProvider;
+import org.operaton.bpm.engine.rest.security.auth.AuthenticationResult;
+
+/**
+ * Trusts a user id supplied by an upstream component in a custom HTTP header.
+ */
+public class PseudoAuthenticationProvider implements AuthenticationProvider {
+
+  public static final String USER_ID_HEADER = "Context-User-ID";
+
+  @Override
+  public AuthenticationResult extractAuthenticatedUser(HttpServletRequest request, ProcessEngine engine) {
+    String userIdHeader = request.getHeader(USER_ID_HEADER);
+    if (userIdHeader == null || userIdHeader.isBlank()) {
+      return AuthenticationResult.unsuccessful();
+    }
+    return AuthenticationResult.successful(userIdHeader);
+  }
+
+  @Override
+  public void augmentResponseByAuthenticationChallenge(HttpServletResponse response, ProcessEngine engine) {
+    // no challenge for trusted-header authentication
+  }
+
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/impl/jwt/Configuration.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/impl/jwt/Configuration.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.security.auth.impl.jwt;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class Configuration {
+
+  public static final String PROPERTIES_FILE = "operaton-plugins.properties";
+  public static final String JWT_SECRET_PROPERTY = "authentication.jwtSecret";
+
+  private static Configuration instance;
+
+  protected final String secret;
+
+  public static synchronized Configuration getInstance() {
+    if (instance == null) {
+      instance = new Configuration();
+    }
+    return instance;
+  }
+
+  Configuration() {
+    this(loadProperties());
+  }
+
+  Configuration(Properties properties) {
+    this.secret = properties.getProperty(JWT_SECRET_PROPERTY);
+  }
+
+  public String getSecret() {
+    return secret;
+  }
+
+  protected static Properties loadProperties() {
+    Properties properties = new Properties();
+    try (InputStream inputStream = Configuration.class.getClassLoader().getResourceAsStream(PROPERTIES_FILE)) {
+      if (inputStream != null) {
+        properties.load(inputStream);
+      }
+      return properties;
+    } catch (IOException e) {
+      throw new IllegalStateException("Unable to load authentication configuration from: " + PROPERTIES_FILE, e);
+    }
+  }
+
+}

--- a/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/impl/jwt/JwtUser.java
+++ b/engine-rest/engine-rest/src/main/java/org/operaton/bpm/engine/rest/security/auth/impl/jwt/JwtUser.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.security.auth.impl.jwt;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JwtUser {
+
+  protected String userID;
+
+  public JwtUser() {
+  }
+
+  public JwtUser(String userID) {
+    this.userID = userID;
+  }
+
+  public String getUserID() {
+    return userID;
+  }
+
+  public void setUserID(String userID) {
+    this.userID = userID;
+  }
+
+  @Override
+  public String toString() {
+    return userID;
+  }
+
+}

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/security/auth/impl/CompositeAuthenticationProviderTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/security/auth/impl/CompositeAuthenticationProviderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.security.auth.impl;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.rest.security.auth.AuthenticationProvider;
+import org.operaton.bpm.engine.rest.security.auth.AuthenticationResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CompositeAuthenticationProviderTest {
+
+  private AuthenticationProvider primaryProvider;
+  private AuthenticationProvider fallbackProvider;
+  private CompositeAuthenticationProvider compositeProvider;
+  private HttpServletRequest request;
+  private ProcessEngine engine;
+
+  @BeforeEach
+  void setUp() {
+    primaryProvider = mock(AuthenticationProvider.class);
+    fallbackProvider = mock(AuthenticationProvider.class);
+    compositeProvider = new CompositeAuthenticationProvider(primaryProvider, fallbackProvider);
+    request = mock(HttpServletRequest.class);
+    engine = mock(ProcessEngine.class);
+  }
+
+  @Test
+  void shouldUsePrimaryProviderWhenItAuthenticates() {
+    when(primaryProvider.extractAuthenticatedUser(request, engine))
+        .thenReturn(AuthenticationResult.successful("jwt-user"));
+
+    AuthenticationResult result = compositeProvider.extractAuthenticatedUser(request, engine);
+
+    assertThat(result.isAuthenticated()).isTrue();
+    assertThat(result.getAuthenticatedUser()).isEqualTo("jwt-user");
+    verify(fallbackProvider, never()).extractAuthenticatedUser(request, engine);
+  }
+
+  @Test
+  void shouldUseFallbackProviderWhenPrimaryProviderFails() {
+    when(primaryProvider.extractAuthenticatedUser(request, engine))
+        .thenReturn(AuthenticationResult.unsuccessful());
+    when(fallbackProvider.extractAuthenticatedUser(request, engine))
+        .thenReturn(AuthenticationResult.successful("basic-user"));
+
+    AuthenticationResult result = compositeProvider.extractAuthenticatedUser(request, engine);
+
+    assertThat(result.isAuthenticated()).isTrue();
+    assertThat(result.getAuthenticatedUser()).isEqualTo("basic-user");
+    verify(fallbackProvider).extractAuthenticatedUser(request, engine);
+  }
+
+  @Test
+  void shouldReturnUnsuccessfulWhenBothProvidersFail() {
+    when(primaryProvider.extractAuthenticatedUser(request, engine))
+        .thenReturn(AuthenticationResult.unsuccessful());
+    when(fallbackProvider.extractAuthenticatedUser(request, engine))
+        .thenReturn(AuthenticationResult.unsuccessful());
+
+    AuthenticationResult result = compositeProvider.extractAuthenticatedUser(request, engine);
+
+    assertThat(result.isAuthenticated()).isFalse();
+  }
+
+  @Test
+  void shouldDelegateAuthenticationChallengeToBothProviders() {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+
+    compositeProvider.augmentResponseByAuthenticationChallenge(response, engine);
+
+    verify(primaryProvider).augmentResponseByAuthenticationChallenge(response, engine);
+    verify(fallbackProvider).augmentResponseByAuthenticationChallenge(response, engine);
+  }
+
+}

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/security/auth/impl/JwtTokenAuthenticationProviderTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/security/auth/impl/JwtTokenAuthenticationProviderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.security.auth.impl;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.HttpHeaders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.Test;
+
+import org.operaton.bpm.engine.rest.security.auth.AuthenticationResult;
+import org.operaton.bpm.engine.rest.security.auth.impl.jwt.JwtUser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JwtTokenAuthenticationProviderTest {
+
+  private static final String USER_ID = "demo";
+  private static final String JWT_SECRET = Base64.getEncoder()
+      .encodeToString("01234567890123456789012345678901".getBytes(StandardCharsets.UTF_8));
+
+  @Test
+  void shouldAuthenticateBearerJwt() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn(JwtTokenAuthenticationProvider.BEARER_PREFIX + createToken(USER_ID));
+    JwtTokenAuthenticationProvider provider = new JwtTokenAuthenticationProvider(JWT_SECRET);
+
+    AuthenticationResult result = provider.extractAuthenticatedUser(request, null);
+
+    assertThat(result.isAuthenticated()).isTrue();
+    assertThat(result.getAuthenticatedUser()).isEqualTo(USER_ID);
+  }
+
+  @Test
+  void shouldRejectMissingBearerToken() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    JwtTokenAuthenticationProvider provider = new JwtTokenAuthenticationProvider(JWT_SECRET);
+
+    AuthenticationResult result = provider.extractAuthenticatedUser(request, null);
+
+    assertThat(result.isAuthenticated()).isFalse();
+  }
+
+  @Test
+  void shouldRejectJwtWhenSecretIsMissing() throws Exception {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn(JwtTokenAuthenticationProvider.BEARER_PREFIX + createToken(USER_ID));
+    JwtTokenAuthenticationProvider provider = new JwtTokenAuthenticationProvider(null);
+
+    AuthenticationResult result = provider.extractAuthenticatedUser(request, null);
+
+    assertThat(result.isAuthenticated()).isFalse();
+  }
+
+  @Test
+  void shouldRejectInvalidJwt() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn(JwtTokenAuthenticationProvider.BEARER_PREFIX + "invalid");
+    JwtTokenAuthenticationProvider provider = new JwtTokenAuthenticationProvider(JWT_SECRET);
+
+    AuthenticationResult result = provider.extractAuthenticatedUser(request, null);
+
+    assertThat(result.isAuthenticated()).isFalse();
+  }
+
+  private static String createToken(String userId) throws Exception {
+    JwtUser user = new JwtUser(userId);
+    SecretKey key = Keys.hmacShaKeyFor(Base64.getDecoder().decode(JWT_SECRET));
+    return Jwts.builder()
+        .subject(userId)
+        .expiration(new Date(System.currentTimeMillis() + 60000L))
+        .issuedAt(new Date())
+        .claim("user", new ObjectMapper().writeValueAsString(user))
+        .signWith(key)
+        .compact();
+  }
+
+}

--- a/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/security/auth/impl/PseudoAuthenticationProviderTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/operaton/bpm/engine/rest/security/auth/impl/PseudoAuthenticationProviderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.engine.rest.security.auth.impl;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.Test;
+
+import org.operaton.bpm.engine.rest.security.auth.AuthenticationResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PseudoAuthenticationProviderTest {
+
+  private final PseudoAuthenticationProvider provider = new PseudoAuthenticationProvider();
+
+  @Test
+  void shouldAuthenticateUserFromContextHeader() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeader(PseudoAuthenticationProvider.USER_ID_HEADER)).thenReturn("trusted-user");
+
+    AuthenticationResult result = provider.extractAuthenticatedUser(request, null);
+
+    assertThat(result.isAuthenticated()).isTrue();
+    assertThat(result.getAuthenticatedUser()).isEqualTo("trusted-user");
+  }
+
+  @Test
+  void shouldRejectMissingContextHeader() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+
+    AuthenticationResult result = provider.extractAuthenticatedUser(request, null);
+
+    assertThat(result.isAuthenticated()).isFalse();
+  }
+
+  @Test
+  void shouldRejectBlankContextHeader() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeader(PseudoAuthenticationProvider.USER_ID_HEADER)).thenReturn(" ");
+
+    AuthenticationResult result = provider.extractAuthenticatedUser(request, null);
+
+    assertThat(result.isAuthenticated()).isFalse();
+  }
+
+}


### PR DESCRIPTION
## Summary

Backports and adapts CIBSeven's REST authentication provider extensions for Operaton.

This adds two additional authentication modes to the engine REST authentication infrastructure:

- `CompositeAuthenticationProvider`: tries JWT bearer authentication first and falls back to HTTP Basic.
- `PseudoAuthenticationProvider`: authenticates a user id supplied by a trusted upstream component in the `Context-User-ID` header.

Operaton Run can now select these providers through `operaton.bpm.run.auth.authentication`, while keeping `basic` as the default mode.

## What Changed

- Added `CompositeAuthenticationProvider` for JWT-first / Basic-fallback authentication.
- Added `JwtTokenAuthenticationProvider` using JJWT 0.12.6.
- Added `JwtUser` and JWT configuration loading from optional classpath resource `operaton-plugins.properties` with key `authentication.jwtSecret`.
- Added `PseudoAuthenticationProvider` for trusted-header authentication via `Context-User-ID`.
- Extended `OperatonBpmRunAuthenticationProperties` to accept `basic`, `composite`, and `pseudo`.
- Updated `OperatonBpmRunRestConfiguration` to register the selected provider class explicitly.
- Added JUnit 5/AssertJ tests for composite auth, JWT auth, pseudo auth, Run auth properties, and Run provider registration.

## Reviewer Notes

- This is intentionally not a blind cherry-pick.
- Operaton keeps HTTP Basic as the default Run authentication mode. CIBSeven changed its default to pseudo auth; this PR does **not** do that.
- `pseudo` must be selected explicitly. Missing or blank `Context-User-ID` returns an unsuccessful authentication result in Operaton. CIBSeven's later follow-up allowed a missing header through as `successful(null)`; that behavior is not carried over because it would make this trusted-header mode too easy to misconfigure.
- This PR does not enable new filters in packaged `web.xml` files. It adds provider classes and Run wiring; deployments that use static web.xml configuration can opt in by setting the authentication provider class themselves.
- JWT secrets are not shipped with a product default value. The default JWT provider reads `authentication.jwtSecret` from `operaton-plugins.properties` if present. In composite mode, missing or invalid JWT configuration simply makes the JWT provider fail and the Basic fallback can still authenticate the request.
- The CIBSeven multi-engine follow-up mainly changed URL-pattern handling for their Run/web.xml setup. Operaton Run already registers the auth filter on the Jersey REST mapping; the new tests verify provider selection while preserving that existing mapping behavior.
- Identity/setup whitelist changes are intentionally not part of this PR. They are handled separately in #3108 and #3123.
- For Spring Security OAuth2 resource-server setups, see #3121. This PR is for the standalone REST `AuthenticationProvider` extension point.

## Attribution

Backported and adapted from CIB Seven:

- Commit: https://github.com/cibseven/cibseven/commit/e9a960e34bab7d086123cb859915b447a4197283
  - Original PR: https://github.com/cibseven/cibseven/pull/49
  - Original author: Oleg Skrypnyuk <oleg.skrypnyuk@cib.de>
- Commit: https://github.com/cibseven/cibseven/commit/86f3b3aa697b4e166a351b6c1cda0fc49fbc610b
  - Original PR: https://github.com/cibseven/cibseven/pull/73
  - Original author: Oleg Skrypnyuk <oleg.skrypnyuk@cib.de>
  - Original co-authors include Dmitry Malkovich <dmitry.malkovich@cib.de> and Patrick Fincke <patrick.fincke@cib.de>
- Commit: https://github.com/cibseven/cibseven/commit/7a646eae13116bb49838df6952abf938ff7071e6
  - Original PR: https://github.com/cibseven/cibseven/pull/243
  - Original author: Oleg Skrypnyuk <oleg.skrypnyuk@cib.de>
  - Original commit also includes Copilot/cibdmitrym/OlegCIB co-author trailers

## Backport Database

- Change units: `820`, `879`, `1061`
- Source fork: CIBSeven
- Target commit: `dc739a0420ab13fc499ab8f3a11a4990d25ab889`

## Verification

- `git diff --check`
- `git diff --cached --check`
- `./mvnw -pl engine-rest/engine-rest -Dtest=CompositeAuthenticationProviderTest,JwtTokenAuthenticationProviderTest,PseudoAuthenticationProviderTest,HttpBasicAuthenticationProviderTest test`
- `./mvnw -pl engine-rest/engine-rest -DskipTests install`
- `./mvnw -pl distro/run/core -Dtest=OperatonBpmRunAuthenticationPropertiesTest,OperatonBpmRunRestConfigurationTest test`
