### PR TITLE
feat(external-task-client): support OAuth2 client credentials

### DIFF
--- a/clients/java/client/pom.xml
+++ b/clients/java/client/pom.xml
@@ -65,6 +65,24 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>${version.jjwt}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>${version.jjwt}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>${version.jjwt}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
       <scope>test</scope>

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/impl/ExternalTaskClientLogger.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/impl/ExternalTaskClientLogger.java
@@ -245,4 +245,19 @@ public class ExternalTaskClientLogger extends BaseLogger {
         "030", "Null value is not allowed as '{}'", parameterName));
   }
 
+  public ExternalTaskClientException oauth2TokenUriNullException() {
+    return new ExternalTaskClientException(exceptionMessage(
+        "032", "OAuth2 token URI cannot be null or empty"));
+  }
+
+  public ExternalTaskClientException oauth2ClientIdNullException() {
+    return new ExternalTaskClientException(exceptionMessage(
+        "033", "OAuth2 client ID cannot be null or empty"));
+  }
+
+  public ExternalTaskClientException oauth2TokenAcquisitionFailedException(Throwable cause) {
+    return new ExternalTaskClientException(exceptionMessage(
+        "034", "Failed to acquire OAuth2 access token from token endpoint"), cause);
+  }
+
 }

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/impl/RequestExecutor.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/impl/RequestExecutor.java
@@ -127,7 +127,14 @@ public class RequestExecutor {
         final HttpEntity entity = response.getEntity();
         if (statusLine.getStatusCode() >= 300) {
           try {
-            RestException engineException = deserializeResponse(entity, EngineRestExceptionDto.class).toRestException();
+            RestException engineException;
+            if (entity == null || entity.getContentLength() == 0) {
+              EngineRestExceptionDto dto = new EngineRestExceptionDto();
+              dto.setMessage("No body in response, unable to parse error message");
+              engineException = dto.toRestException();
+            } else {
+              engineException = deserializeResponse(entity, EngineRestExceptionDto.class).toRestException();
+            }
 
             int statusCode = statusLine.getStatusCode();
             engineException.setHttpStatusCode(statusCode);
@@ -135,7 +142,9 @@ public class RequestExecutor {
             throw engineException;
 
           } finally {
-            EntityUtils.consume(entity);
+            if (entity != null) {
+              EntityUtils.consume(entity);
+            }
           }
         }
         return entity == null ? null : handleEntity(entity);

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/interceptor/auth/AzureWorkloadIdentityAssertionProvider.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/interceptor/auth/AzureWorkloadIdentityAssertionProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.client.interceptor.auth;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.operaton.bpm.client.exception.ExternalTaskClientException;
+
+/**
+ * Supplies Azure Workload Identity federated tokens as OAuth2 client assertions.
+ */
+public class AzureWorkloadIdentityAssertionProvider implements ClientAssertionProvider {
+
+  protected static final String ENV_FEDERATED_TOKEN_FILE = "AZURE_FEDERATED_TOKEN_FILE";
+
+  @Override
+  public String getAssertion() {
+    String tokenFilePath = System.getenv(ENV_FEDERATED_TOKEN_FILE);
+    if (tokenFilePath == null || tokenFilePath.isBlank()) {
+      throw new ExternalTaskClientException(
+          "Environment variable '" + ENV_FEDERATED_TOKEN_FILE + "' is not set. "
+              + "Ensure the Azure Workload Identity webhook has been applied to this workload.");
+    }
+
+    try {
+      return Files.readString(Path.of(tokenFilePath), StandardCharsets.UTF_8).strip();
+    } catch (IOException e) {
+      throw new ExternalTaskClientException(
+          "Failed to read Azure federated identity token from file '" + tokenFilePath + "'", e);
+    }
+  }
+
+}

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/interceptor/auth/ClientAssertionProvider.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/interceptor/auth/ClientAssertionProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.client.interceptor.auth;
+
+/**
+ * Supplies a client assertion JWT for OAuth2 client credentials authentication.
+ */
+@FunctionalInterface
+public interface ClientAssertionProvider {
+
+  /**
+   * Returns a serialized client assertion JWT.
+   */
+  String getAssertion();
+
+}

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/interceptor/auth/JjwtClientAssertionProvider.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/interceptor/auth/JjwtClientAssertionProvider.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.client.interceptor.auth;
+
+import java.security.PrivateKey;
+import java.util.Date;
+import java.util.UUID;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+
+import org.operaton.bpm.client.exception.ExternalTaskClientException;
+
+/**
+ * Creates signed RFC 7523 client assertion JWTs with JJWT.
+ */
+public class JjwtClientAssertionProvider implements ClientAssertionProvider {
+
+  protected static final long ASSERTION_LIFETIME_MS = 5 * 60 * 1000L;
+
+  protected final String clientId;
+  protected final String audience;
+  protected final PrivateKey privateKey;
+
+  public JjwtClientAssertionProvider(String clientId, String audience, PrivateKey privateKey) {
+    this.clientId = clientId;
+    this.audience = audience;
+    this.privateKey = privateKey;
+  }
+
+  @Override
+  public String getAssertion() {
+    Date now = new Date();
+    Date exp = new Date(now.getTime() + ASSERTION_LIFETIME_MS);
+
+    try {
+      return Jwts.builder()
+          .issuer(clientId)
+          .subject(clientId)
+          .audience().add(audience).and()
+          .id(UUID.randomUUID().toString())
+          .issuedAt(now)
+          .expiration(exp)
+          .signWith(privateKey)
+          .compact();
+    } catch (JwtException e) {
+      throw new ExternalTaskClientException("Failed to sign client assertion JWT", e);
+    }
+  }
+
+}

--- a/clients/java/client/src/main/java/org/operaton/bpm/client/interceptor/auth/OAuth2ClientCredentialsProvider.java
+++ b/clients/java/client/src/main/java/org/operaton/bpm/client/interceptor/auth/OAuth2ClientCredentialsProvider.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.client.interceptor.auth;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
+
+import org.operaton.bpm.client.exception.ExternalTaskClientException;
+import org.operaton.bpm.client.impl.ExternalTaskClientLogger;
+import org.operaton.bpm.client.interceptor.ClientRequestContext;
+import org.operaton.bpm.client.interceptor.ClientRequestInterceptor;
+
+import static org.apache.hc.core5.http.HttpHeaders.AUTHORIZATION;
+
+/**
+ * OAuth2 client credentials request interceptor for the external task client.
+ */
+public class OAuth2ClientCredentialsProvider implements ClientRequestInterceptor, Closeable {
+
+  protected static final ExternalTaskClientLogger LOG = ExternalTaskClientLogger.CLIENT_LOGGER;
+
+  protected static final String GRANT_TYPE_CLIENT_CREDENTIALS = "client_credentials";
+  protected static final String ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+
+  protected final String tokenUri;
+  protected final String clientId;
+  protected final String clientSecret;
+  protected final ClientAssertionProvider clientAssertionProvider;
+  protected final String scope;
+  protected final String audience;
+  protected final String resource;
+  protected final Map<String, String> additionalParameters;
+  protected final Duration expiryBuffer;
+
+  protected final CloseableHttpClient httpClient;
+  protected final ObjectMapper objectMapper;
+
+  protected volatile String cachedToken;
+  protected volatile Instant tokenExpiry = Instant.EPOCH;
+
+  protected OAuth2ClientCredentialsProvider(Builder builder) {
+    this.tokenUri = builder.tokenUri;
+    this.clientId = builder.clientId;
+    this.clientSecret = builder.clientSecret;
+    this.clientAssertionProvider = builder.clientAssertionProvider;
+    this.scope = builder.scope;
+    this.audience = builder.audience;
+    this.resource = builder.resource;
+    this.additionalParameters = builder.additionalParameters.isEmpty()
+        ? Collections.emptyMap()
+        : Collections.unmodifiableMap(new LinkedHashMap<>(builder.additionalParameters));
+    this.expiryBuffer = builder.expiryBuffer;
+    this.httpClient = builder.httpClient != null ? builder.httpClient : HttpClients.createDefault();
+    this.objectMapper = builder.objectMapper != null ? builder.objectMapper : new ObjectMapper();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public void intercept(ClientRequestContext requestContext) {
+    requestContext.addHeader(AUTHORIZATION, "Bearer " + getValidToken());
+  }
+
+  @Override
+  public void close() throws IOException {
+    httpClient.close();
+  }
+
+  protected String getValidToken() {
+    if (cachedToken != null && Instant.now().isBefore(tokenExpiry.minus(expiryBuffer))) {
+      return cachedToken;
+    }
+    synchronized (this) {
+      if (cachedToken != null && Instant.now().isBefore(tokenExpiry.minus(expiryBuffer))) {
+        return cachedToken;
+      }
+      fetchAndCacheToken();
+      return cachedToken;
+    }
+  }
+
+  protected void fetchAndCacheToken() {
+    List<BasicNameValuePair> params = new ArrayList<>();
+    params.add(new BasicNameValuePair("grant_type", GRANT_TYPE_CLIENT_CREDENTIALS));
+    params.add(new BasicNameValuePair("client_id", clientId));
+
+    if (clientSecret != null && !clientSecret.isBlank()) {
+      params.add(new BasicNameValuePair("client_secret", clientSecret));
+    } else {
+      params.add(new BasicNameValuePair("client_assertion_type", ASSERTION_TYPE));
+      params.add(new BasicNameValuePair("client_assertion", clientAssertionProvider.getAssertion()));
+    }
+
+    if (scope != null && !scope.isBlank()) {
+      params.add(new BasicNameValuePair("scope", scope));
+    }
+    if (audience != null && !audience.isBlank()) {
+      params.add(new BasicNameValuePair("audience", audience));
+    }
+    if (resource != null && !resource.isBlank()) {
+      params.add(new BasicNameValuePair("resource", resource));
+    }
+    additionalParameters.forEach((key, value) -> {
+      if (key != null && !key.isBlank() && value != null) {
+        params.add(new BasicNameValuePair(key, value));
+      }
+    });
+
+    HttpPost request = new HttpPost(tokenUri);
+    request.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
+
+    try {
+      String body = httpClient.execute(request, response -> {
+        int statusCode = response.getCode();
+        String responseBody = response.getEntity() != null
+            ? EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8)
+            : "";
+
+        if (statusCode != 200) {
+          JsonNode errorJson = parseJsonSilently(responseBody);
+          String error = errorJson != null ? errorJson.path("error").asText("unknown_error") : "unknown_error";
+          String description = errorJson != null ? errorJson.path("error_description").asText("") : "";
+          throw new ExternalTaskClientException(
+              "Token endpoint returned HTTP " + statusCode + ": " + error
+                  + (description.isBlank() ? "" : " - " + description));
+        }
+        return responseBody;
+      });
+
+      JsonNode json = objectMapper.readTree(body);
+      String accessToken = json.path("access_token").asText();
+      if (accessToken == null || accessToken.isBlank()) {
+        throw new ExternalTaskClientException(
+            "Token endpoint response did not contain a valid access_token");
+      }
+
+      cachedToken = accessToken;
+      tokenExpiry = Instant.now().plusSeconds(json.path("expires_in").asLong(3600L));
+    } catch (ExternalTaskClientException | IOException e) {
+      throw LOG.oauth2TokenAcquisitionFailedException(e);
+    }
+  }
+
+  private JsonNode parseJsonSilently(String body) {
+    try {
+      return objectMapper.readTree(body);
+    } catch (JsonProcessingException | RuntimeException ignored) {
+      return null;
+    }
+  }
+
+  public static class Builder {
+
+    private String tokenUri;
+    private String clientId;
+    private String clientSecret;
+    private ClientAssertionProvider clientAssertionProvider;
+    private String scope;
+    private String audience;
+    private String resource;
+    private Map<String, String> additionalParameters = new LinkedHashMap<>();
+    private Duration expiryBuffer = Duration.ofSeconds(30);
+    private CloseableHttpClient httpClient;
+    private ObjectMapper objectMapper;
+
+    public Builder tokenUri(String tokenUri) {
+      this.tokenUri = tokenUri;
+      return this;
+    }
+
+    public Builder clientId(String clientId) {
+      this.clientId = clientId;
+      return this;
+    }
+
+    public Builder clientSecret(String clientSecret) {
+      this.clientSecret = clientSecret;
+      return this;
+    }
+
+    public Builder clientAssertionProvider(ClientAssertionProvider clientAssertionProvider) {
+      this.clientAssertionProvider = clientAssertionProvider;
+      return this;
+    }
+
+    public Builder scope(String scope) {
+      this.scope = scope;
+      return this;
+    }
+
+    public Builder audience(String audience) {
+      this.audience = audience;
+      return this;
+    }
+
+    public Builder resource(String resource) {
+      this.resource = resource;
+      return this;
+    }
+
+    public Builder additionalParameter(String key, String value) {
+      this.additionalParameters.put(key, value);
+      return this;
+    }
+
+    public Builder additionalParameters(Map<String, String> additionalParameters) {
+      this.additionalParameters = additionalParameters != null
+          ? new LinkedHashMap<>(additionalParameters)
+          : new LinkedHashMap<>();
+      return this;
+    }
+
+    public Builder expiryBuffer(Duration expiryBuffer) {
+      this.expiryBuffer = expiryBuffer;
+      return this;
+    }
+
+    public Builder httpClient(CloseableHttpClient httpClient) {
+      this.httpClient = httpClient;
+      return this;
+    }
+
+    public Builder objectMapper(ObjectMapper objectMapper) {
+      this.objectMapper = objectMapper;
+      return this;
+    }
+
+    public OAuth2ClientCredentialsProvider build() {
+      if (tokenUri == null || tokenUri.isBlank()) {
+        throw LOG.oauth2TokenUriNullException();
+      }
+      if (clientId == null || clientId.isBlank()) {
+        throw LOG.oauth2ClientIdNullException();
+      }
+      if ((clientSecret == null || clientSecret.isBlank()) && clientAssertionProvider == null) {
+        throw new ExternalTaskClientException(
+            "Either clientSecret or clientAssertionProvider must be configured on OAuth2ClientCredentialsProvider");
+      }
+      if (clientSecret != null && clientAssertionProvider != null) {
+        throw new ExternalTaskClientException(
+            "Only one of clientSecret or clientAssertionProvider may be set on OAuth2ClientCredentialsProvider, not both");
+      }
+      if (expiryBuffer != null && expiryBuffer.isNegative()) {
+        throw new ExternalTaskClientException(
+            "expiryBuffer must not be negative on OAuth2ClientCredentialsProvider");
+      }
+      if (expiryBuffer == null) {
+        expiryBuffer = Duration.ZERO;
+      }
+      return new OAuth2ClientCredentialsProvider(this);
+    }
+  }
+
+}

--- a/clients/java/client/src/test/java/org/operaton/bpm/client/impl/RequestExecutorTest.java
+++ b/clients/java/client/src/test/java/org/operaton/bpm/client/impl/RequestExecutorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.client.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.impl.io.DefaultClassicHttpResponseFactory;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+import org.junit.jupiter.api.Test;
+
+import org.operaton.bpm.client.exception.RestException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+
+class RequestExecutorTest {
+
+  private final RequestExecutor requestExecutor = new RequestExecutor(null, new ObjectMapper());
+
+  @Test
+  void shouldCreateRestExceptionForErrorResponseWithoutBody() throws Exception {
+    ClassicHttpResponse response = DefaultClassicHttpResponseFactory.INSTANCE.newHttpResponse(500);
+
+    RestException exception = catchThrowableOfType(
+        () -> requestExecutor.handleResponse(Void.class).handleResponse(response),
+        RestException.class);
+
+    assertThat(exception.getHttpStatusCode()).isEqualTo(500);
+    assertThat(exception.getMessage()).isEqualTo("No body in response, unable to parse error message");
+  }
+
+  @Test
+  void shouldCreateRestExceptionForErrorResponseWithEmptyBody() throws Exception {
+    ClassicHttpResponse response = DefaultClassicHttpResponseFactory.INSTANCE.newHttpResponse(401);
+    response.setEntity(new ByteArrayEntity(new byte[0], ContentType.APPLICATION_JSON));
+
+    RestException exception = catchThrowableOfType(
+        () -> requestExecutor.handleResponse(Void.class).handleResponse(response),
+        RestException.class);
+
+    assertThat(exception.getHttpStatusCode()).isEqualTo(401);
+    assertThat(exception.getMessage()).isEqualTo("No body in response, unable to parse error message");
+  }
+
+}

--- a/clients/java/client/src/test/java/org/operaton/bpm/client/interceptor/auth/OAuth2ClientCredentialsProviderTest.java
+++ b/clients/java/client/src/test/java/org/operaton/bpm/client/interceptor/auth/OAuth2ClientCredentialsProviderTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.client.interceptor.auth;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.operaton.bpm.client.exception.ExternalTaskClientException;
+import org.operaton.bpm.client.interceptor.ClientRequestContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OAuth2ClientCredentialsProviderTest {
+
+  private HttpServer tokenServer;
+  private final AtomicInteger requestCount = new AtomicInteger();
+  private final AtomicReference<String> requestBody = new AtomicReference<>();
+
+  @AfterEach
+  void tearDown() {
+    if (tokenServer != null) {
+      tokenServer.stop(0);
+    }
+  }
+
+  @Test
+  void shouldFetchClientCredentialsTokenAndReuseCachedToken() throws Exception {
+    String tokenUri = startTokenServer(200, "{\"access_token\":\"access-token\",\"expires_in\":3600}");
+    OAuth2ClientCredentialsProvider provider = OAuth2ClientCredentialsProvider.builder()
+        .tokenUri(tokenUri)
+        .clientId("external-task-client")
+        .clientSecret("secret")
+        .scope("engine-rest/.default")
+        .audience("engine-rest")
+        .resource("api://engine-rest")
+        .additionalParameter("tenant", "demo")
+        .build();
+
+    RecordingClientRequestContext firstRequest = new RecordingClientRequestContext();
+    RecordingClientRequestContext secondRequest = new RecordingClientRequestContext();
+    provider.intercept(firstRequest);
+    provider.intercept(secondRequest);
+
+    assertThat(firstRequest.headers).containsEntry("Authorization", "Bearer access-token");
+    assertThat(secondRequest.headers).containsEntry("Authorization", "Bearer access-token");
+    assertThat(requestCount).hasValue(1);
+    assertThat(parseForm(requestBody.get()))
+        .containsEntry("grant_type", "client_credentials")
+        .containsEntry("client_id", "external-task-client")
+        .containsEntry("client_secret", "secret")
+        .containsEntry("scope", "engine-rest/.default")
+        .containsEntry("audience", "engine-rest")
+        .containsEntry("resource", "api://engine-rest")
+        .containsEntry("tenant", "demo");
+  }
+
+  @Test
+  void shouldSendClientAssertionWhenNoClientSecretIsConfigured() throws Exception {
+    String tokenUri = startTokenServer(200, "{\"access_token\":\"assertion-token\",\"expires_in\":3600}");
+    OAuth2ClientCredentialsProvider provider = OAuth2ClientCredentialsProvider.builder()
+        .tokenUri(tokenUri)
+        .clientId("external-task-client")
+        .clientAssertionProvider(() -> "signed-client-assertion")
+        .build();
+
+    provider.intercept(new RecordingClientRequestContext());
+
+    assertThat(parseForm(requestBody.get()))
+        .containsEntry("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+        .containsEntry("client_assertion", "signed-client-assertion");
+  }
+
+  @Test
+  void shouldRejectInvalidOAuth2Configuration() {
+    assertThatThrownBy(() -> OAuth2ClientCredentialsProvider.builder()
+        .clientId("client")
+        .clientSecret("secret")
+        .build())
+        .isInstanceOf(ExternalTaskClientException.class)
+        .hasMessageContaining("OAuth2 token URI");
+
+    assertThatThrownBy(() -> OAuth2ClientCredentialsProvider.builder()
+        .tokenUri("http://localhost/token")
+        .clientSecret("secret")
+        .build())
+        .isInstanceOf(ExternalTaskClientException.class)
+        .hasMessageContaining("OAuth2 client ID");
+
+    assertThatThrownBy(() -> OAuth2ClientCredentialsProvider.builder()
+        .tokenUri("http://localhost/token")
+        .clientId("client")
+        .build())
+        .isInstanceOf(ExternalTaskClientException.class)
+        .hasMessageContaining("Either clientSecret or clientAssertionProvider");
+  }
+
+  @Test
+  void shouldWrapTokenEndpointErrors() throws Exception {
+    String tokenUri = startTokenServer(401, "{\"error\":\"invalid_client\",\"error_description\":\"bad credentials\"}");
+    OAuth2ClientCredentialsProvider provider = OAuth2ClientCredentialsProvider.builder()
+        .tokenUri(tokenUri)
+        .clientId("external-task-client")
+        .clientSecret("secret")
+        .build();
+
+    assertThatThrownBy(() -> provider.intercept(new RecordingClientRequestContext()))
+        .isInstanceOf(ExternalTaskClientException.class)
+        .hasMessageContaining("Failed to acquire OAuth2 access token")
+        .hasRootCauseMessage("Token endpoint returned HTTP 401: invalid_client - bad credentials");
+  }
+
+  private String startTokenServer(int statusCode, String responseBody) throws IOException {
+    tokenServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    tokenServer.createContext("/token", exchange -> {
+      requestCount.incrementAndGet();
+      requestBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+      byte[] bytes = responseBody.getBytes(StandardCharsets.UTF_8);
+      exchange.getResponseHeaders().add("Content-Type", "application/json");
+      exchange.sendResponseHeaders(statusCode, bytes.length);
+      exchange.getResponseBody().write(bytes);
+      exchange.close();
+    });
+    tokenServer.start();
+    return "http://127.0.0.1:" + tokenServer.getAddress().getPort() + "/token";
+  }
+
+  private static Map<String, String> parseForm(String body) {
+    Map<String, String> params = new HashMap<>();
+    for (String pair : body.split("&")) {
+      String[] keyValue = pair.split("=", 2);
+      params.put(
+          URLDecoder.decode(keyValue[0], StandardCharsets.UTF_8),
+          URLDecoder.decode(keyValue[1], StandardCharsets.UTF_8));
+    }
+    return params;
+  }
+
+  private static class RecordingClientRequestContext implements ClientRequestContext {
+
+    private final Map<String, String> headers = new HashMap<>();
+
+    @Override
+    public void addHeader(String name, String value) {
+      headers.put(name, value);
+    }
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -32,6 +32,7 @@
     <version.gson>2.14.0</version.gson>
     <version.hibernate>6.6.10.Final</version.hibernate>
     <version.jackson>2.21.4</version.jackson>
+    <version.jjwt>0.12.6</version.jjwt>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpclient5>5.6.1</version.httpclient5>
     <version.httpcore5>5.4</version.httpcore5>

--- a/spring-boot-starter/starter-client/spring-boot/pom.xml
+++ b/spring-boot-starter/starter-client/spring-boot/pom.xml
@@ -31,6 +31,24 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>${version.jjwt}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>${version.jjwt}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>${version.jjwt}</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/spring-boot-starter/starter-client/spring-boot/src/main/java/org/operaton/bpm/client/spring/boot/starter/ClientProperties.java
+++ b/spring-boot-starter/starter-client/spring-boot/src/main/java/org/operaton/bpm/client/spring/boot/starter/ClientProperties.java
@@ -34,6 +34,9 @@ public class ClientProperties extends ClientConfiguration {
   @NestedConfigurationProperty
   protected BasicAuthProperties basicAuth;
 
+  @NestedConfigurationProperty
+  protected OAuth2Properties oauth2;
+
   public SubscriptionConfiguration findSubscriptionPropsByTopicName(String topic) {
     return subscriptions.get(topic);
   }
@@ -52,6 +55,14 @@ public class ClientProperties extends ClientConfiguration {
 
   public void setBasicAuth(BasicAuthProperties basicAuth) {
     this.basicAuth = basicAuth;
+  }
+
+  public OAuth2Properties getOauth2() {
+    return oauth2;
+  }
+
+  public void setOauth2(OAuth2Properties oauth2) {
+    this.oauth2 = oauth2;
   }
 
 }

--- a/spring-boot-starter/starter-client/spring-boot/src/main/java/org/operaton/bpm/client/spring/boot/starter/OAuth2Properties.java
+++ b/spring-boot-starter/starter-client/spring-boot/src/main/java/org/operaton/bpm/client/spring/boot/starter/OAuth2Properties.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.client.spring.boot.starter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+/**
+ * OAuth2 client credentials flow settings under {@code operaton.bpm.client.oauth2}.
+ */
+public class OAuth2Properties {
+
+  private String tokenUri;
+  private String clientId;
+  private String clientSecret;
+  private String scope;
+  private String audience;
+  private String resource;
+  private Map<String, String> additionalParameters = new LinkedHashMap<>();
+  private long expiryBufferSeconds = 30L;
+
+  @NestedConfigurationProperty
+  private AssertionProperties assertion;
+
+  public String getTokenUri() {
+    return tokenUri;
+  }
+
+  public void setTokenUri(String tokenUri) {
+    this.tokenUri = tokenUri;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public void setClientId(String clientId) {
+    this.clientId = clientId;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
+  public void setClientSecret(String clientSecret) {
+    this.clientSecret = clientSecret;
+  }
+
+  public String getScope() {
+    return scope;
+  }
+
+  public void setScope(String scope) {
+    this.scope = scope;
+  }
+
+  public String getAudience() {
+    return audience;
+  }
+
+  public void setAudience(String audience) {
+    this.audience = audience;
+  }
+
+  public String getResource() {
+    return resource;
+  }
+
+  public void setResource(String resource) {
+    this.resource = resource;
+  }
+
+  public Map<String, String> getAdditionalParameters() {
+    return additionalParameters;
+  }
+
+  public void setAdditionalParameters(Map<String, String> additionalParameters) {
+    this.additionalParameters = additionalParameters != null ? additionalParameters : new LinkedHashMap<>();
+  }
+
+  public long getExpiryBufferSeconds() {
+    return expiryBufferSeconds;
+  }
+
+  public void setExpiryBufferSeconds(long expiryBufferSeconds) {
+    this.expiryBufferSeconds = expiryBufferSeconds;
+  }
+
+  public AssertionProperties getAssertion() {
+    return assertion;
+  }
+
+  public void setAssertion(AssertionProperties assertion) {
+    this.assertion = assertion;
+  }
+
+  public static class AssertionProperties {
+
+    private AssertionType type;
+    private String keyLocation;
+
+    public AssertionType getType() {
+      return type;
+    }
+
+    public void setType(AssertionType type) {
+      this.type = type;
+    }
+
+    public String getKeyLocation() {
+      return keyLocation;
+    }
+
+    public void setKeyLocation(String keyLocation) {
+      this.keyLocation = keyLocation;
+    }
+
+    public enum AssertionType {
+      JJWT,
+      AZURE_WORKLOAD_IDENTITY
+    }
+  }
+
+}

--- a/spring-boot-starter/starter-client/spring-boot/src/main/java/org/operaton/bpm/client/spring/boot/starter/impl/PropertiesAwareClientFactory.java
+++ b/spring-boot-starter/starter-client/spring-boot/src/main/java/org/operaton/bpm/client/spring/boot/starter/impl/PropertiesAwareClientFactory.java
@@ -16,17 +16,37 @@
  */
 package org.operaton.bpm.client.spring.boot.starter.impl;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import java.io.InputStream;
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.time.Duration;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ssl.pem.PemContent;
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+import org.operaton.bpm.client.interceptor.auth.AzureWorkloadIdentityAssertionProvider;
 import org.operaton.bpm.client.interceptor.auth.BasicAuthProvider;
+import org.operaton.bpm.client.interceptor.auth.ClientAssertionProvider;
+import org.operaton.bpm.client.interceptor.auth.JjwtClientAssertionProvider;
+import org.operaton.bpm.client.interceptor.auth.OAuth2ClientCredentialsProvider;
 import org.operaton.bpm.client.spring.boot.starter.BasicAuthProperties;
 import org.operaton.bpm.client.spring.boot.starter.ClientProperties;
+import org.operaton.bpm.client.spring.boot.starter.OAuth2Properties;
+import org.operaton.bpm.client.spring.boot.starter.OAuth2Properties.AssertionProperties;
+import org.operaton.bpm.client.spring.boot.starter.OAuth2Properties.AssertionProperties.AssertionType;
 import org.operaton.bpm.client.spring.impl.client.ClientConfiguration;
 import org.operaton.bpm.client.spring.impl.client.ClientFactory;
 
-public class PropertiesAwareClientFactory extends ClientFactory {
+public class PropertiesAwareClientFactory extends ClientFactory implements ResourceLoaderAware {
 
   protected ClientProperties clientProperties;
+  protected ResourceLoader resourceLoader = new DefaultResourceLoader();
 
   @Autowired
   public PropertiesAwareClientFactory(ClientProperties clientProperties) {
@@ -34,9 +54,15 @@ public class PropertiesAwareClientFactory extends ClientFactory {
   }
 
   @Override
+  public void setResourceLoader(ResourceLoader resourceLoader) {
+    this.resourceLoader = resourceLoader;
+  }
+
+  @Override
   public void afterPropertiesSet() {
     applyPropertiesFrom(clientProperties);
     addBasicAuthInterceptor();
+    addOAuth2Interceptor();
     super.afterPropertiesSet();
   }
 
@@ -50,6 +76,70 @@ public class PropertiesAwareClientFactory extends ClientFactory {
 
       getRequestInterceptors().add(basicAuthProvider);
     }
+  }
+
+  protected void addOAuth2Interceptor() {
+    OAuth2Properties oauth2 = clientProperties.getOauth2();
+    if (oauth2 == null) {
+      return;
+    }
+
+    OAuth2ClientCredentialsProvider.Builder builder = OAuth2ClientCredentialsProvider.builder()
+        .tokenUri(oauth2.getTokenUri())
+        .clientId(oauth2.getClientId())
+        .scope(oauth2.getScope())
+        .audience(oauth2.getAudience())
+        .resource(oauth2.getResource())
+        .additionalParameters(oauth2.getAdditionalParameters())
+        .expiryBuffer(Duration.ofSeconds(oauth2.getExpiryBufferSeconds()));
+
+    if (oauth2.getClientSecret() != null && !oauth2.getClientSecret().isBlank()) {
+      builder.clientSecret(oauth2.getClientSecret());
+    } else {
+      builder.clientAssertionProvider(buildAssertionProvider(oauth2));
+    }
+
+    getRequestInterceptors().add(builder.build());
+  }
+
+  protected ClientAssertionProvider buildAssertionProvider(OAuth2Properties oauth2) {
+    AssertionProperties assertion = oauth2.getAssertion();
+    if (assertion == null || assertion.getType() == null) {
+      throw new IllegalStateException(
+          "operaton.bpm.client.oauth2.assertion.type must be set when no clientSecret is configured. "
+              + "Valid values: JJWT, AZURE_WORKLOAD_IDENTITY");
+    }
+
+    AssertionType type = assertion.getType();
+    if (type == AssertionType.AZURE_WORKLOAD_IDENTITY) {
+      return new AzureWorkloadIdentityAssertionProvider();
+    }
+
+    String keyLocation = assertion.getKeyLocation();
+    if (keyLocation == null || keyLocation.isBlank()) {
+      throw new IllegalStateException(
+          "operaton.bpm.client.oauth2.assertion.key-location must be set for assertion type " + type);
+    }
+
+    Resource resource = resourceLoader.getResource(keyLocation);
+    PrivateKey privateKey;
+    try (InputStream inputStream = resource.getInputStream()) {
+      privateKey = PemContent.load(inputStream).getPrivateKey();
+    } catch (IOException e) {
+      throw new IllegalStateException("Cannot load OAuth2 client assertion private key from '" + keyLocation + "'", e);
+    }
+
+    if (privateKey == null) {
+      throw new IllegalStateException("No private key found in PEM content at '" + keyLocation + "'");
+    }
+    if (!(privateKey instanceof RSAPrivateKey) && !(privateKey instanceof ECPrivateKey)) {
+      throw new IllegalStateException(
+          "Unsupported private key type '" + privateKey.getAlgorithm()
+              + "' (" + privateKey.getClass().getName() + ") loaded from '" + keyLocation
+              + "'. Expected RSA or EC key.");
+    }
+
+    return new JjwtClientAssertionProvider(oauth2.getClientId(), oauth2.getTokenUri(), privateKey);
   }
 
   public void applyPropertiesFrom(ClientProperties clientConfigurationProps) {

--- a/spring-boot-starter/starter-client/spring-boot/src/test/java/org/operaton/bpm/client/spring/boot/starter/OAuth2PropertiesTest.java
+++ b/spring-boot-starter/starter-client/spring-boot/src/test/java/org/operaton/bpm/client/spring/boot/starter/OAuth2PropertiesTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the Operaton contributors.
+ *
+ * Licensed under the Apache License, Version 2.0; you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.operaton.bpm.client.spring.boot.starter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import org.operaton.bpm.client.spring.boot.starter.OAuth2Properties.AssertionProperties.AssertionType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {
+  "operaton.bpm.client.oauth2.token-uri=https://idp.example.test/token",
+  "operaton.bpm.client.oauth2.client-id=external-task-client",
+  "operaton.bpm.client.oauth2.client-secret=secret",
+  "operaton.bpm.client.oauth2.scope=engine-rest/.default",
+  "operaton.bpm.client.oauth2.audience=engine-rest",
+  "operaton.bpm.client.oauth2.resource=api://engine-rest",
+  "operaton.bpm.client.oauth2.expiry-buffer-seconds=45",
+  "operaton.bpm.client.oauth2.additional-parameters.tenant=demo",
+  "operaton.bpm.client.oauth2.assertion.type=jjwt",
+  "operaton.bpm.client.oauth2.assertion.key-location=classpath:client-key.pem"
+})
+@ExtendWith(SpringExtension.class)
+class OAuth2PropertiesTest extends ParsePropertiesHelper {
+
+  @Test
+  void shouldBindOAuth2Properties() {
+    OAuth2Properties oauth2 = properties.getOauth2();
+
+    assertThat(oauth2.getTokenUri()).isEqualTo("https://idp.example.test/token");
+    assertThat(oauth2.getClientId()).isEqualTo("external-task-client");
+    assertThat(oauth2.getClientSecret()).isEqualTo("secret");
+    assertThat(oauth2.getScope()).isEqualTo("engine-rest/.default");
+    assertThat(oauth2.getAudience()).isEqualTo("engine-rest");
+    assertThat(oauth2.getResource()).isEqualTo("api://engine-rest");
+    assertThat(oauth2.getExpiryBufferSeconds()).isEqualTo(45L);
+    assertThat(oauth2.getAdditionalParameters()).containsEntry("tenant", "demo");
+    assertThat(oauth2.getAssertion().getType()).isEqualTo(AssertionType.JJWT);
+    assertThat(oauth2.getAssertion().getKeyLocation()).isEqualTo("classpath:client-key.pem");
+  }
+}

--- a/spring-boot-starter/starter-client/spring-boot/src/test/java/org/operaton/bpm/client/spring/boot/starter/impl/PropertiesAwareClientFactoryTest.java
+++ b/spring-boot-starter/starter-client/spring-boot/src/test/java/org/operaton/bpm/client/spring/boot/starter/impl/PropertiesAwareClientFactoryTest.java
@@ -23,6 +23,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import org.operaton.bpm.client.spring.boot.starter.ClientProperties;
+import org.operaton.bpm.client.interceptor.auth.OAuth2ClientCredentialsProvider;
+import org.operaton.bpm.client.spring.boot.starter.OAuth2Properties;
 import org.operaton.bpm.client.spring.exception.SpringExternalTaskClientException;
 import org.operaton.bpm.client.spring.impl.client.ClientConfiguration;
 
@@ -100,5 +102,39 @@ class PropertiesAwareClientFactoryTest {
     assertThatThrownBy(() -> clientFactory.applyPropertiesFrom(clientProperties))
       .isInstanceOf(SpringExternalTaskClientException.class)
       .hasMessageContainingAll("useCreateTime", "orderByCreateTime");
+  }
+
+  @Test
+  void shouldAddOAuth2ClientCredentialsInterceptor() throws Exception {
+    ClientProperties properties = new ClientProperties();
+    OAuth2Properties oauth2 = new OAuth2Properties();
+    oauth2.setTokenUri("https://idp.example.test/token");
+    oauth2.setClientId("external-task-client");
+    oauth2.setClientSecret("secret");
+    oauth2.setScope("engine-rest/.default");
+    properties.setOauth2(oauth2);
+    PropertiesAwareClientFactory factory = new PropertiesAwareClientFactory(properties);
+
+    factory.afterPropertiesSet();
+
+    assertThat(factory.getRequestInterceptors())
+        .singleElement()
+        .isInstanceOf(OAuth2ClientCredentialsProvider.class)
+        .extracting("tokenUri", "clientId", "clientSecret", "scope")
+        .containsExactly("https://idp.example.test/token", "external-task-client", "secret", "engine-rest/.default");
+  }
+
+  @Test
+  void shouldRequireAssertionTypeWhenNoOAuth2ClientSecretIsConfigured() {
+    ClientProperties properties = new ClientProperties();
+    OAuth2Properties oauth2 = new OAuth2Properties();
+    oauth2.setTokenUri("https://idp.example.test/token");
+    oauth2.setClientId("external-task-client");
+    properties.setOauth2(oauth2);
+    PropertiesAwareClientFactory factory = new PropertiesAwareClientFactory(properties);
+
+    assertThatThrownBy(factory::afterPropertiesSet)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("operaton.bpm.client.oauth2.assertion.type");
   }
 }

--- a/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/client/ClientFactory.java
+++ b/spring-boot-starter/starter-client/spring/src/main/java/org/operaton/bpm/client/spring/impl/client/ClientFactory.java
@@ -16,11 +16,14 @@
  */
 package org.operaton.bpm.client.spring.impl.client;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.env.PropertyResolver;
@@ -41,7 +44,7 @@ import static java.lang.Boolean.TRUE;
 import static java.util.Optional.ofNullable;
 
 public class ClientFactory
-  implements FactoryBean<ExternalTaskClient>, InitializingBean {
+  implements FactoryBean<ExternalTaskClient>, InitializingBean, DisposableBean {
 
   protected static final ClientLoggerUtil LOG = LoggerUtil.CLIENT_LOGGER;
 
@@ -201,6 +204,20 @@ public class ClientFactory
 
   public List<ClientRequestInterceptor> getRequestInterceptors() {
     return requestInterceptors;
+  }
+
+  @Override
+  public void destroy() {
+    close();
+    for (ClientRequestInterceptor interceptor : requestInterceptors) {
+      if (interceptor instanceof Closeable closeable) {
+        try {
+          closeable.close();
+        } catch (IOException ignored) {
+          // best-effort cleanup during shutdown
+        }
+      }
+    }
   }
 
   protected void close() {


### PR DESCRIPTION
## Summary

Backports and adapts CIBSeven's OAuth2 client-credentials support for the Java external task client and the Spring Boot external-task-client starter.

The external task client can now obtain a bearer token from an OAuth2 token endpoint and attach it to outgoing engine-rest requests via `Authorization: Bearer ...`. The Spring Boot starter exposes this through `operaton.bpm.client.oauth2.*` properties.

## What Changed

- Added `OAuth2ClientCredentialsProvider` as a client request interceptor with in-memory token caching and refresh-before-expiry behavior.
- Supports `client_secret_post` via `clientSecret`.
- Supports JWT client assertions via a pluggable `ClientAssertionProvider`:
  - `JjwtClientAssertionProvider` signs private-key JWT assertions with JJWT.
  - `AzureWorkloadIdentityAssertionProvider` reads the federated token from `AZURE_FEDERATED_TOKEN_FILE`.
- Added Spring Boot property binding under `operaton.bpm.client.oauth2.*` and automatic interceptor registration in `PropertiesAwareClientFactory`.
- Ensures closeable request interceptors are closed when the Spring client factory is destroyed.
- Makes `RequestExecutor` resilient when engine-rest returns an HTTP error response without a body or with an empty body.
- Adds focused tests for token requests, token caching, assertion mode, configuration validation, Spring Boot property binding, auto-registration, and empty REST error bodies.

## Reviewer Notes

- This is not a pure cherry-pick. It is adapted for Operaton package names and for the Operaton property prefix `operaton.bpm.client.oauth2`.
- The CIBSeven commit also touched engine-rest/security auto-configuration. That part is intentionally not included here because the Operaton resource-server work is handled separately in #3121; this PR stays scoped to the external task client and starter-client modules.
- JJWT dependencies are added as optional dependencies. The client-secret flow does not require JJWT at runtime; users only need the JJWT artifacts when they configure the JJWT assertion provider.
- `RequestExecutor` now preserves the HTTP status code even when the error response has no parseable body. The new test verifies this behavior directly.
- New source files use the Operaton contributors header because the implementation was adapted for Operaton rather than copied as unmodified Camunda-owned files.

## Attribution

Backported and adapted from CIB Seven:

- Commit: https://github.com/cibseven/cibseven/commit/c97459268474ee42a9f38797b26473772878dd39
- Original PR: https://github.com/cibseven/cibseven/pull/321
- Original author: Patrick Fincke <patrick.fincke@cib.de>
- Original PR description: `CIB7-1310`
- Original commit also lists: `Co-authored-by: Copilot <copilot@github.com>`

## Backport Database

- Change unit: `1113`
- Source fork: CIBSeven
- Source commit: `c97459268474ee42a9f38797b26473772878dd39`
- Target commit: `0b7630c75a9cbc45212b8bbcd9c8b9c97f4b3b23`

## Verification

- `git diff --check`
- `git diff --cached --check`
- `./mvnw -pl clients/java/client -Dtest=OAuth2ClientCredentialsProviderTest,RequestExecutorTest test`
- `./mvnw -pl clients/java/client -DskipTests install`
- `./mvnw -pl spring-boot-starter/starter-client/spring -DskipTests install`
- `./mvnw -pl spring-boot-starter/starter-client/spring-boot -Dtest=BasicAuthConfigurationTest,BasicAuthAndInterceptorConfigurationTest,PropertiesAwareClientFactoryTest,OAuth2PropertiesTest test`
